### PR TITLE
Make P2P generic over the network service provider

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -14,40 +14,85 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
+use crate::error::P2pError;
+use crate::net::NetworkService;
+
 pub mod error;
 pub mod net;
 pub mod peer;
 
 #[allow(unused)]
-struct NetworkManager {}
+struct NetworkManager<NetworkingBackend> {
+    network: NetworkingBackend,
+}
 
 #[allow(unused)]
-impl NetworkManager {
-    pub fn new() -> Self {
-        Self {}
+impl<NetworkingBackend: NetworkService> NetworkManager<NetworkingBackend> {
+    /// Create new NetworkManager
+    ///
+    /// # Arguments
+    /// `addr` - socket address where the local node binds itself to
+    pub async fn new(addr: NetworkingBackend::Address) -> Result<Self, P2pError> {
+        Ok(Self {
+            network: NetworkingBackend::new(addr).await?,
+        })
     }
 }
 
 #[allow(unused)]
-struct P2P {
-    mgr: NetworkManager,
+struct P2P<NetworkingBackend> {
+    mgr: NetworkManager<NetworkingBackend>,
 }
 
 #[allow(unused)]
-impl P2P {
-    pub fn new() -> Self {
-        Self {
-            mgr: NetworkManager::new(),
-        }
+impl<NetworkingBackend: NetworkService> P2P<NetworkingBackend> {
+    /// Create new P2P object
+    ///
+    /// # Arguments
+    /// `addr` - socket address where the local node binds itself to
+    pub async fn new(addr: NetworkingBackend::Address) -> Result<Self, P2pError> {
+        Ok(Self {
+            mgr: NetworkManager::new(addr).await?,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use net::mock::MockService;
 
-    #[test]
-    fn it_works() {
-        let _p2p = P2P::new();
+    #[tokio::test]
+    async fn test_p2p_new() {
+        let addr: <MockService as NetworkService>::Address = "[::1]:8888".parse().unwrap();
+        let res = P2P::<MockService>::new(addr).await;
+        assert_eq!(res.is_ok(), true);
+
+        // try to create new P2P object to the same address, should fail
+        let addr: <MockService as NetworkService>::Address = "[::1]:8888".parse().unwrap();
+        let res = P2P::<MockService>::new(addr).await;
+        assert_eq!(res.is_err(), true);
+
+        // try to create new P2P object to different address, should succeed
+        let addr: <MockService as NetworkService>::Address = "127.0.0.1:8888".parse().unwrap();
+        let res = P2P::<MockService>::new(addr).await;
+        assert_eq!(res.is_ok(), true);
+    }
+
+    #[tokio::test]
+    async fn test_network_manager_new() {
+        let addr: <MockService as NetworkService>::Address = "[::1]:1111".parse().unwrap();
+        let res = NetworkManager::<MockService>::new(addr).await;
+        assert_eq!(res.is_ok(), true);
+
+        // try to create new NetworkManager to the same address, should fail
+        let addr: <MockService as NetworkService>::Address = "[::1]:1111".parse().unwrap();
+        let res = NetworkManager::<MockService>::new(addr).await;
+        assert_eq!(res.is_err(), true);
+
+        // try to create new NetworkManager to different address, should succeed
+        let addr: <MockService as NetworkService>::Address = "127.0.0.1:1111".parse().unwrap();
+        let res = NetworkManager::<MockService>::new(addr).await;
+        assert_eq!(res.is_ok(), true);
     }
 }

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -84,7 +84,7 @@ impl NetworkService for MockService {
 }
 
 #[async_trait]
-impl PeerService for Peer {
+impl<P: NetworkService> PeerService for Peer<P> {
     async fn send<T>(&mut self, data: &T) -> Result<(), P2pError>
     where
         T: Sync + Send + Encode,

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -36,7 +36,7 @@ pub trait NetworkService {
     type Address;
 
     /// Generic socket object that the underlying implementation uses
-    type Socket;
+    type Socket: Sync + Send;
 
     /// Initialize the network service provider
     ///


### PR DESCRIPTION
This PR makes the P2P subsystem generic over the network service provider. This means that you can provide different network implementations for the network stack when you running the node and when you're running the tests. In theory this also allows us to replace libp2p with some other p2p library without major rewrites.