### PR TITLE
service: Add message format for Mintlayer core services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,14 @@ name = "serialization"
 version = "0.1.0"
 
 [[package]]
+name = "service"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "rand 0.8.4",
+]
+
+[[package]]
 name = "sha1"
 version = "0.9.8"
 source = "git+https://github.com/mintlayer/hashing.git?branch=master#5af66c334a78e87b688cc47caed38012275f3f7e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "serialization", # serialization interfaces and implementations
   "node",          # node executable
   "wallet",        # wallet executable
+  "service",       # mintayer core services
 #  "test",          # integration tests
 ]
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "service"
+version = "0.1.0"
+edition = "2018"
+license = "MIT"
+
+[dependencies]
+rand = "0.8.4"
+common = { path = "../common" }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): A. Altonen
+pub mod message;

--- a/service/src/message.rs
+++ b/service/src/message.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): A. Altonen
+use rand::Rng;
+use common::primitives::H256;
+use common::chain::block::BlockHeader;
+
+pub enum System {
+    P2p,
+    Rpc,
+    Consensus,
+    ChainInfo,
+    Mempool,
+}
+
+pub enum MessageType {
+    GetHeaders(H256, usize),
+    Headers(Vec<BlockHeader>),
+}
+
+pub struct Message {
+    /// Unique ID of the message, used to link requests with responses
+    id: u128,
+
+    /// System where the message originated from
+    src: System,
+
+    /// System where the message is destined to go
+    dst: System,
+
+    /// Request or response
+    /// If `msg` is None, the requested resource was not found
+    msg: Option<MessageType>,
+}
+
+impl Message {
+    pub fn new(src: System, dst: System, msg: Option<MessageType>) -> Self {
+        Self {
+            id: rand::thread_rng().gen(),
+            src,
+            dst,
+            msg,
+        }
+    }
+}


### PR DESCRIPTION
Add initial message format that different subsystems of Mintlayer use to communicate with each other via Mintlayer core services. I'm not married to this format but I need to add something so that I can design the P2P interface properly.