### PR TITLE
Move to rust 2021 in all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "MIT"
 version = "0.1.0"
 authors = ["Samer Afach <samer.afach@mintlayer.org>", "Ben Marsh <benjamin.marsh@mintlayer.org>", "Enrico Rubboli <enrico.rubboli@mintlayer.org>"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = [

--- a/blockchain_storage/Cargo.toml
+++ b/blockchain_storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blockchain-storage"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "common"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "consensus"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crypto"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 authors = ["Samer Afach <samer.afach@mintlayer.org>", "Ben Marsh <benjamin.marsh@mintlayer.org>", "Enrico Rubboli <enrico.rubboli@mintlayer.org>"]
 

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "logging"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "network"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "node"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "p2p"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rpc"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,4 +5,4 @@ array_width = 80
 chain_width = 80
 single_line_if_else_max_width = 50
 newline_style = "Unix"
-edition = "2018"
+edition = "2021"

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "script"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/serialization/Cargo.toml
+++ b/serialization/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "serialization"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "storage"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wallet"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
There doesn't seem to be a reason to stay on 2018, especially that rust guarantees interoperability between 2021 and 2018.

Here's a blog post on what's new in 2021: https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html

