### PR TITLE
storage: Cleaner db transaction interface

### DIFF
--- a/storage/src/basic.rs
+++ b/storage/src/basic.rs
@@ -178,9 +178,8 @@ impl<'st, Sch: Schema> crate::transaction::DbTransaction for Transaction<'st, Sc
     }
 
     /// Abort a transaction.
-    fn abort(&mut self) -> Result<(), Self::Error> {
-        self.delta = Default::default();
-        Err(crate::Error::Aborted)
+    fn abort(self) -> Result<(), Self::Error> {
+        Ok(())
     }
 }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -45,27 +45,26 @@
 //!     assert_eq!(val, Some(&b"bar"[..]));
 //!
 //!     // End the transaction
-//!     Ok(())
+//!     storage::commit(())
 //! });
 //!
 //! // Try writing a value but abort the transaction afterwards.
 //! store.transaction(|tx| {
 //!     tx.get::<MyColumn, ()>().put(b"baz".to_vec(), b"xyz".to_vec())?;
-//!     tx.abort()?;
-//!     Ok(())
+//!     storage::abort(())
 //! });
 //!
 //! // Transaction can return data. Values taken from the database have to be cloned
 //! // in order for them to be available after the transaction terminates.
 //! let result = store.transaction(|tx| {
-//!     Ok(tx.get::<MyColumn, ()>().get(b"baz")?.map(ToOwned::to_owned))
+//!     storage::commit(tx.get::<MyColumn, ()>().get(b"baz")?.map(ToOwned::to_owned))
 //! });
 //! assert_eq!(result, Ok(None));
 //!
 //! // Check the value we first inserted is still there.
 //! let result = store.transaction(|tx| {
 //!     assert_eq!(tx.get::<MyColumn, ()>().get(b"foo")?, Some(&b"bar"[..]));
-//!     Ok(())
+//!     storage::commit(())
 //! });
 //! ```
 
@@ -75,12 +74,10 @@ pub mod transaction;
 
 // Reexport items from the temporary basic implementation.
 pub use basic::{SingleMap, Store, Transaction};
-pub use transaction::{DbTransaction, Transactional};
+pub use transaction::{DbTransaction, Transactional, abort, commit};
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("Transaction aborted by the user")]
-    Aborted,
     #[error("Unknown database error")]
     Unknown,
 }


### PR DESCRIPTION
* Cleaner distinction between transaction error and user-triggered abort of a transaction.
* The interface is way more specific on whether a transaction is committed or aborted.
* More consistent life cycle of the transaction object.