### PR TITLE
Allow webpki in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,7 @@ skip = [{name = "quick-error"},
         {name = "rand"},
         {name = "getrandom"},
         {name = "byteorder"},
+        {name = "webpki"},
         ]
 
 [licenses]
@@ -31,9 +32,25 @@ allow = [
     "MPL-2.0",
     "CC0-1.0",
     "Zlib",
+    "LicenseRef-ring",
+    "LicenseRef-webpki",
     "Unlicense",#this is a specific license rather than no license at all
 ] #deny a license not in this set of licenses
 
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "LicenseRef-webpki"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+    
 [advisories]
 db-path = "~/.cargo/advisory-dbs"
 db-urls = [ "https://github.com/RustSec/advisory-db" ]


### PR DESCRIPTION
According to the Github repository it's licensed under custom, ISC-style license. The author says that some of the files in `tests/` are not under ISC but doesn't mention what the license is. Anyway, it's not like we have a choice with this because it's a dependency of libp2p 

https://github.com/briansmith/webpki
https://github.com/briansmith/webpki/issues/246#issuecomment-970833491