### PR TITLE
Cargo deny fixes

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,17 @@ skip = [{name = "quick-error"},
         {name = "rand"},
         {name = "getrandom"},
         {name = "byteorder"},
+        {name = "socket2"},
+        {name = "arrayvec"},
+        {name = "pin-project"},
+        {name = "pin-project-internal"},
+        {name = "pin-project-lite"},
+        {name = "digest"},
+        {name = "block-buffer"},
+        {name = "sha-1"},
+        {name = "sha2"},
+        {name = "sha3"},
+        {name = "blake2"},
         ]
 
 [licenses]


### PR DESCRIPTION
Fix cargo-deny problems by adding license exceptions for two crates (webpki, ring) and ignoring duplicate crates where fixing the duplicate would be impossible (external crates) or too much work (crypto).