### PR TITLE
net: Redesign the network interface

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 RBB S.r.l
+// Copyright (c) 2021-2022 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -41,7 +41,7 @@ pub enum ConnectivityEvent<T>
 where
     T: NetworkService,
 {
-    Accept(error::Result<T::Socket>),
+    Accept(T::Socket),
     Connect(T::Address),
 }
 
@@ -82,7 +82,7 @@ where
         config: Arc<ChainConfig>,
     ) -> error::Result<Self> {
         Ok(Self {
-            network: NetworkingBackend::new(addr).await?,
+            network: NetworkingBackend::new(addr, &[], &[]).await?,
             config,
             peer_cnt: AtomicU64::default(),
             peer_backlock,
@@ -114,9 +114,7 @@ where
         event: ConnectivityEvent<NetworkingBackend>,
     ) -> error::Result<()> {
         match event {
-            ConnectivityEvent::Accept(res) => {
-                res.map(|socket| self.create_peer(socket, PeerRole::Inbound))?
-            }
+            ConnectivityEvent::Accept(socket) => self.create_peer(socket, PeerRole::Inbound),
             ConnectivityEvent::Connect(address) => self
                 .network
                 .connect(address)
@@ -127,17 +125,27 @@ where
         Ok(())
     }
 
+    /// Handle network event received from the network service provider
+    async fn on_network_event(
+        &mut self,
+        event: net::Event<NetworkingBackend>,
+    ) -> error::Result<()> {
+        match event {
+            net::Event::IncomingConnection(socket) => {
+                self.on_connectivity_event(ConnectivityEvent::Accept(socket)).await
+            }
+        }
+    }
+
     /// Run the `P2P` event loop.
-    ///
-    /// This event loop has three responsibilities:
-    ///  - accept incoming connections
-    ///  - listen to messages from peers
     pub async fn run(&mut self) -> error::Result<()> {
         loop {
             tokio::select! {
-                res = self.network.accept() => {
-                    self.on_connectivity_event(ConnectivityEvent::Accept(res)).await?;
-                },
+                res = self.network.poll_next() => {
+                    res.map(|event| async {
+                        self.on_network_event(event).await
+                    })?;
+                }
                 event = self.mgr_chan.1.recv().fuse() => {
                     self.on_peer_event(event).await?;
                 }

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 RBB S.r.l
+// Copyright (c) 2021-2022 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -16,13 +16,16 @@
 // Author(s): A. Altonen
 use crate::{
     error,
-    net::{NetworkService, SocketService},
+    net::{Event, GossipSubTopic, NetworkService, SocketService},
 };
 use async_trait::async_trait;
 use libp2p::Multiaddr;
 use parity_scale_codec::{Decode, Encode};
 
 /// This file provides the libp2p implementation of the network service.
+
+#[derive(Debug)]
+pub enum LibP2pStrategy {}
 
 #[derive(Debug)]
 pub struct Libp2pService {}
@@ -34,8 +37,13 @@ pub struct Libp2pSocket {}
 impl NetworkService for Libp2pService {
     type Address = Multiaddr;
     type Socket = Libp2pSocket;
+    type Strategy = LibP2pStrategy;
 
-    async fn new(_addr: Self::Address) -> error::Result<Self> {
+    async fn new(
+        _addr: Self::Address,
+        _strategies: &[Self::Strategy],
+        _topics: &[GossipSubTopic],
+    ) -> error::Result<Self> {
         todo!();
     }
 
@@ -43,20 +51,16 @@ impl NetworkService for Libp2pService {
         todo!();
     }
 
-    async fn accept(&mut self) -> error::Result<Self::Socket> {
-        todo!();
-    }
-
-    async fn publish<T>(&mut self, _topic: &'static str, _data: &T)
+    async fn poll_next<T>(&mut self) -> error::Result<Event<T>>
     where
-        T: Sync + Send + Encode,
+        T: NetworkService,
     {
         todo!();
     }
 
-    async fn subscribe<T>(&mut self, _topic: &'static str, _tx: tokio::sync::mpsc::Sender<T>)
+    async fn publish<T>(&mut self, _topic: GossipSubTopic, _data: &T)
     where
-        T: Send + Sync + Decode,
+        T: Sync + Send + Encode,
     {
         todo!();
     }

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 RBB S.r.l
+// Copyright (c) 2021-2022 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -15,19 +15,28 @@
 //
 // Author(s): A. Altonen
 #![allow(dead_code, unused_variables, unused_imports)]
-use crate::error::{self, P2pError};
-use crate::net::{NetworkService, SocketService};
-use crate::peer::Peer;
+use crate::{
+    error::{self, P2pError},
+    net::{Event, GossipSubTopic, NetworkService, SocketService},
+    peer::Peer,
+};
 use async_trait::async_trait;
 use parity_scale_codec::{Decode, Encode};
-use std::collections::HashMap;
-use std::io::{Error, ErrorKind};
-use std::net::SocketAddr;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use std::{
+    collections::HashMap,
+    io::{Error, ErrorKind},
+    net::SocketAddr,
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
 
 /// This file provides a mock implementation of the network service.
 /// It implements the `NetworkService` trait on top of `tokio::net::TcpListener`
+
+#[derive(Debug)]
+pub enum MockStrategy {}
 
 #[derive(Debug)]
 pub struct MockService {
@@ -53,8 +62,13 @@ impl MockSocket {
 impl NetworkService for MockService {
     type Address = SocketAddr;
     type Socket = MockSocket;
+    type Strategy = MockStrategy;
 
-    async fn new(addr: Self::Address) -> error::Result<Self> {
+    async fn new(
+        addr: Self::Address,
+        _strategies: &[Self::Strategy],
+        _topics: &[GossipSubTopic],
+    ) -> error::Result<Self> {
         Ok(Self {
             addr,
             socket: TcpListener::bind(addr).await?,
@@ -71,23 +85,18 @@ impl NetworkService for MockService {
         })
     }
 
-    async fn accept(&mut self) -> error::Result<Self::Socket> {
-        // 0 is `TcpStream`, 1 is `SocketAddr`
-        Ok(MockSocket {
+    async fn poll_next<T>(&mut self) -> error::Result<Event<T>>
+    where
+        T: NetworkService<Socket = MockSocket>,
+    {
+        Ok(Event::IncomingConnection(MockSocket {
             socket: self.socket.accept().await?.0,
-        })
+        }))
     }
 
-    async fn publish<T>(&mut self, topic: &'static str, data: &T)
+    async fn publish<T>(&mut self, topic: GossipSubTopic, data: &T)
     where
         T: Sync + Send + Encode,
-    {
-        todo!();
-    }
-
-    async fn subscribe<T>(&mut self, topic: &'static str, tx: tokio::sync::mpsc::Sender<T>)
-    where
-        T: Send + Sync + Decode,
     {
         todo!();
     }
@@ -122,6 +131,7 @@ impl SocketService for MockSocket {
 mod tests {
     use super::*;
     use crate::net::mock::MockService;
+    use crate::net::Event;
     use crate::peer::{Peer, PeerRole};
     use common::chain::config;
     use parity_scale_codec::{Decode, Encode};
@@ -138,19 +148,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_new() {
-        let srv_ipv4 = MockService::new("127.0.0.1:5555".parse().unwrap()).await;
+        let srv_ipv4 = MockService::new("127.0.0.1:5555".parse().unwrap(), &[], &[]).await;
         assert!(srv_ipv4.is_ok());
 
         // address already in use
-        let err = MockService::new("127.0.0.1:5555".parse().unwrap()).await;
+        let err = MockService::new("127.0.0.1:5555".parse().unwrap(), &[], &[]).await;
         assert!(err.is_err());
 
         // bind to IPv6 localhost
-        let srv_ipv6 = MockService::new("[::1]:5555".parse().unwrap()).await;
+        let srv_ipv6 = MockService::new("[::1]:5555".parse().unwrap(), &[], &[]).await;
         assert!(srv_ipv6.is_ok());
 
         // address already in use
-        let s_ipv6 = MockService::new("[::1]:5555".parse().unwrap()).await;
+        let s_ipv6 = MockService::new("[::1]:5555".parse().unwrap(), &[], &[]).await;
         assert!(s_ipv6.is_err());
     }
 
@@ -169,7 +179,7 @@ mod tests {
         });
 
         // create service that is used for testing `connect()`
-        let srv = MockService::new("127.0.0.1:7777".parse().unwrap()).await;
+        let srv = MockService::new("127.0.0.1:7777".parse().unwrap(), &[], &[]).await;
         assert!(srv.is_ok());
         let mut srv = srv.unwrap();
 
@@ -191,11 +201,12 @@ mod tests {
     async fn test_accept() {
         // create service that is used for testing `accept()`
         let addr: SocketAddr = "[::1]:9999".parse().unwrap();
-        let mut srv = MockService::new("[::1]:9999".parse().unwrap()).await.unwrap();
+        let mut srv = MockService::new("[::1]:9999".parse().unwrap(), &[], &[]).await.unwrap();
 
-        let (acc, con) = tokio::join!(srv.accept(), TcpStream::connect(addr));
+        let (acc, con) = tokio::join!(srv.poll_next(), TcpStream::connect(addr));
         assert!(acc.is_ok());
         assert!(con.is_ok());
+        let acc: Event<MockService> = acc.unwrap();
 
         // TODO: is there any sensible way to make `accept()` fail?
     }
@@ -203,12 +214,15 @@ mod tests {
     #[tokio::test]
     async fn test_peer_send() {
         let addr: SocketAddr = "[::1]:11112".parse().unwrap();
-        let mut server = MockService::new(addr).await.unwrap();
+        let mut server = MockService::new(addr, &[], &[]).await.unwrap();
         let remote_fut = TcpStream::connect(addr);
 
-        let (server_res, remote_res) = tokio::join!(server.accept(), remote_fut);
+        let (server_res, remote_res) = tokio::join!(server.poll_next(), remote_fut);
         assert!(server_res.is_ok());
         assert!(remote_res.is_ok());
+
+        let server_res: Event<MockService> = server_res.unwrap();
+        let Event::IncomingConnection(server_res) = server_res;
 
         let config = Arc::new(config::create_mainnet());
         let (peer_tx, _peer_rx) = tokio::sync::mpsc::channel(1);
@@ -217,7 +231,7 @@ mod tests {
             1,
             PeerRole::Outbound,
             config.clone(),
-            server_res.unwrap(),
+            server_res,
             peer_tx,
             rx,
         );
@@ -242,12 +256,15 @@ mod tests {
     async fn test_peer_recv() {
         // create a `MockService`, connect to it with a `TcpStream` and exchange data
         let addr: SocketAddr = "[::1]:11113".parse().unwrap();
-        let mut server = MockService::new(addr).await.unwrap();
+        let mut server = MockService::new(addr, &[], &[]).await.unwrap();
         let remote_fut = TcpStream::connect(addr);
 
-        let (server_res, remote_res) = tokio::join!(server.accept(), remote_fut);
+        let (server_res, remote_res) = tokio::join!(server.poll_next(), remote_fut);
         assert!(server_res.is_ok());
         assert!(remote_res.is_ok());
+
+        let server_res: Event<MockService> = server_res.unwrap();
+        let Event::IncomingConnection(server_res) = server_res;
 
         let config = Arc::new(config::create_mainnet());
         let (peer_tx, _peer_rx) = tokio::sync::mpsc::channel(1);
@@ -256,7 +273,7 @@ mod tests {
             1,
             PeerRole::Outbound,
             config.clone(),
-            server_res.unwrap(),
+            server_res,
             peer_tx,
             rx,
         );

--- a/p2p/src/proto/connectivity.rs
+++ b/p2p/src/proto/connectivity.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 RBB S.r.l
+// Copyright (c) 2022 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -301,6 +301,7 @@ mod tests {
     use crate::{
         message::HandshakeMessage,
         net::mock::{MockService, MockSocket},
+        net::Event,
         peer::PeerRole,
         proto::handshake::{HandshakeState, OutboundHandshakeState},
     };
@@ -312,11 +313,12 @@ mod tests {
         config: Arc<ChainConfig>,
         addr: std::net::SocketAddr,
     ) -> (Peer<MockService>, Peer<MockService>) {
-        let mut server = MockService::new(addr).await.unwrap();
+        let mut server = MockService::new(addr, &[], &[]).await.unwrap();
         let peer_fut = TcpStream::connect(addr);
 
-        let (remote_res, local_res) = tokio::join!(server.accept(), peer_fut);
-        let remote_res = remote_res.unwrap();
+        let (remote_res, local_res) = tokio::join!(server.poll_next(), peer_fut);
+        let remote_res: Event<MockService> = remote_res.unwrap();
+        let Event::IncomingConnection(remote_res) = remote_res;
         let local_res = local_res.unwrap();
 
         let (peer_tx, _peer_rx) = tokio::sync::mpsc::channel(1);


### PR DESCRIPTION
This PR introduces two changes to the API:
- specify peer discovery strategies and gossipsub topics during start-up
- replace accept() with poll_next()

Both of these changes are required in order to get libp2p working as a
networking backend for Mintlayer. What happens during start-up is that
the network backend is forked into background and it performs the peer
discovery using provided strategies and starts listening to the gossipsub
topics for incoming events.

accept() is replaced with poll_next() which in addition to listening
to incoming connections also listens to gossipsub and peer discovery
events from the network backend.

Peer discovery is network backend specific because different backends
may implement different mechanisms and they each may have, e.g., different
address formats which means it's cleaner to provide the strategies as
part of the selected network service.

Also adjust copyright years of all the files this commit touched