### PR TITLE
[DRAFT] Subsystems wrapper

### DIFF
--- a/node/src/future_utils.rs
+++ b/node/src/future_utils.rs
@@ -1,0 +1,98 @@
+use {
+    futures::{
+        future::{BoxFuture, FutureExt},
+        task::{waker_ref, ArcWake},
+        //lock::Mutex,
+    },
+    std::{
+        future::Future,
+        sync::mpsc::{sync_channel, Receiver, SyncSender},
+        sync::{Arc, Mutex},
+        task::{Context, Poll},
+        time::Duration,
+    },
+};
+
+/// A future that can reschedule itself to be polled by an `Executor`.
+pub struct Task {
+    /// In-progress future that should be pushed to completion.
+    ///
+    /// The `Mutex` is not necessary for correctness, since we only have
+    /// one thread executing tasks at once. However, Rust isn't smart
+    /// enough to know that `future` is only mutated from one thread,
+    /// so we need to use the `Mutex` to prove thread-safety. A production
+    /// executor would not need this, and could use `UnsafeCell` instead.
+    /// BoxFuture : An owned dynamically typed Future for use in cases where
+    /// we can't statically type our result or need to add some indirection.
+    future: Mutex<Option<BoxFuture<'static, ()>>>,
+
+    /// Handle to place the task itself back onto the task queue.
+    task_sender: SyncSender<Arc<Task>>,
+}
+
+/// Task executor that receives tasks off of a channel and runs them.
+pub struct Executor {
+    ready_queue: Receiver<Arc<Task>>,
+}
+
+/// `Spawner` spawns new futures onto the task channel.
+#[derive(Clone)]
+pub struct Spawner {
+    task_sender: SyncSender<Arc<Task>>,
+}
+
+impl Spawner {
+    pub fn spawn(&self, future: impl Future<Output = ()> + 'static + Send) {
+        let future = future.boxed();
+        let task = Arc::new(Task {
+            future: Mutex::new(Some(future)),
+            task_sender: self.task_sender.clone(),
+        });
+        self.task_sender.send(task).expect("too many tasks queued");
+    }
+}
+
+impl ArcWake for Task {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        // Implement `wake` by sending this task back onto the task channel
+        // so that it will be polled again by the executor.
+        let cloned = arc_self.clone();
+        arc_self
+            .task_sender
+            .send(cloned)
+            .expect("too many tasks queued");
+    }
+}
+
+impl Executor {
+    pub fn run(&self) {
+        while let Ok(task) = self.ready_queue.recv() {
+            // Take the future, and if it has not yet completed (is still Some),
+            // poll it in an attempt to complete it.
+            let mut future_slot = task.future.lock().unwrap();
+            if let Some(mut future) = future_slot.take() {
+                // Create a `LocalWaker` from the task itself
+                let waker = waker_ref(&task);
+                let context = &mut Context::from_waker(&*waker);
+                // `BoxFuture<T>` is a type alias for
+                // `Pin<Box<dyn Future<Output = T> + Send + 'static>>`.
+                // We can get a `Pin<&mut dyn Future + Send + 'static>`
+                // from it by calling the `Pin::as_mut` method.
+                if future.as_mut().poll(context).is_pending() {
+                    // We're not done processing the future, so put it
+                    // back in its task to be run again in the future.
+                    *future_slot = Some(future);
+                }
+            }
+        }
+    }
+}
+
+pub fn new_executor_and_spawner() -> (Executor, Spawner) {
+    // Maximum number of tasks to allow queueing in the channel at once.
+    // This is just to make `sync_channel` happy, and wouldn't be present in
+    // a real executor.
+    const MAX_QUEUED_TASKS: usize = 100;
+    let (task_sender, ready_queue) = sync_channel(MAX_QUEUED_TASKS);
+    (Executor { ready_queue }, Spawner { task_sender })
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -15,23 +15,22 @@ struct Subsystem1 {
     block_hash: Vec<u128>,
 }
 
-struct Subsystem2 {
-    tx_count: u32,
-    mempool: Vec<u128>,
-}
+// struct Subsystem2 {
+//     tx_count: u32,
+//     mempool: Vec<u128>,
+// }
 
 impl Subsystem1 {
-    pub fn add_them(&self, x: i32, y: i32) -> i32 {
+    pub fn simple_add(&mut self, x: i32, y: i32) -> i32 {
         x + y
     }
 
-    pub fn add_block(&mut self, hash: &u128) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn add_block(&mut self, hash: &u128) -> u128 {
         self.block_counter += 1;
         self.block_hash.push(hash.clone());
-        todo!()
+        *hash ^ 0x87654321FEDCBA90
     }
 
-    /// Create a new Subsystem Future
     pub fn init() -> Self {
         let block_counter = 0;
         let block_hash: Vec<u128> = vec![0]; // GENESIS
@@ -41,91 +40,122 @@ impl Subsystem1 {
             block_hash,
         }
     }
-}
 
-impl Subsystem2 {
-    pub fn submit_transaction(
-        &mut self,
-        tx: &Transaction,
-        timestamp: i64,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        todo!();
-    }
-
-    /// Create a new Subsystem Future
-    pub fn init() -> Self {
-        let tx_count = 0;
-        let mempool: Vec<u128> = vec![0]; // GENESIS
-
-        Subsystem2 { tx_count, mempool }
-    }
+    pub fn shutdown() {}
 }
 
 struct Wrap {
-    sender: Sender<(for<'r> fn(&'r Subsystem1, i32, i32) -> i32, i32, i32)>,
+    call: Sender<Subsystem1Callables>,
     handle: JoinHandle<()>,
-    result_rx: Receiver<i32>,
+    result_rx: Receiver<Subsystem1Returnable>,
 }
 
 impl Wrap {
-    fn Launch(func: fn() -> Subsystem1) -> Self {
-        type F = (for<'r> fn(&'r Subsystem1, i32, i32) -> i32, i32, i32);
+    fn launch(func: fn() -> Subsystem1) -> Self {
+        type F = (for<'r> fn(&'r mut Subsystem1, i32, i32) -> i32, i32, i32);
 
-        let (tx, rx) = mpsc::channel::<F>();
-        let (tx2, rx2) = mpsc::channel();
+        let (tx, rx) = mpsc::channel::<Subsystem1Callables>();
+        let (tx2, rx2) = mpsc::channel::<Subsystem1Returnable>();
 
         let handle = thread::spawn(move || {
             // TODO SOMETHING HERER
-            let instance = func();
+            let instance: &mut Subsystem1 = &mut func();
             loop {
                 let t = rx.recv().unwrap();
-                let result = (t.0)(&instance, t.1, t.2);
+                let result = t.call(instance);
                 tx2.send(result).unwrap();
             }
         });
 
         Wrap {
-            sender: tx,
+            call: tx,
             handle: handle,
             result_rx: rx2,
         }
     }
 }
 
+/* For polymorphism we used enum instead of traits, both for parameters and return types
+https://www.mattkennedy.io/blog/rust_polymorphism/
+ */
+
+/* Type encompassing : The variants of enums are not considered types in their own right,
+meaning one cannot create functions that only work with an individual variant from the enum.
+This can be solved by creating the types using structs and wrapping them in an enum
+*/
+
+/*Higher-Rank Trait Bounds (HRTBs)
+for<'a> F can be read as "for all choices of 'a",
+and basically produces an infinite list of trait bounds that F must satisfy.
+*/
+
 enum Subsystem1Callables {
-    add_them((for<'r> fn(&'r Subsystem1, i32, i32) -> i32, i32, i32)),
-    add_block(
-        (
-            for<'r> fn(&'r mut Subsystem1, &u128) -> Result<(), Box<dyn std::error::Error>>,
-            u128,
-        ),
-    ),
-    init,
-    shutdown,
+    SimpleAdd {
+        func: for<'r> fn(&'r mut Subsystem1, i32, i32) -> i32,
+        A: i32,
+        B: i32,
+    },
+
+    AddBlock {
+        func: for<'r> fn(&'r mut Subsystem1, &u128) -> u128,
+        H: u128,
+    },
+
+    Init,
+    Shutdown,
+}
+
+#[derive(Debug)]
+enum Subsystem1Returnable {
+    R1(i32),
+    R2(u128),
+    R3(i32),
+    R4(i32),
+}
+
+impl Subsystem1Callables {
+    fn call(&self, S: &mut Subsystem1) -> Subsystem1Returnable {
+        match self {
+            Subsystem1Callables::SimpleAdd { func, A, B } => {
+                Subsystem1Returnable::R1(func(S, *A, *B))
+            }
+            Subsystem1Callables::AddBlock { func, H } => Subsystem1Returnable::R2(func(S, H)),
+            Subsystem1Callables::Init {} => Subsystem1Returnable::R3(1),
+            Subsystem1Callables::Shutdown {} => Subsystem1Returnable::R4(0),
+        }
+    }
 }
 
 fn main() {
     // create a thread in each Subsystem and return a future
-    let wrapper_s1 = Wrap::Launch(Subsystem1::init);
+    let wrapper_s1 = Wrap::launch(Subsystem1::init);
 
-    let hash = 0;
+    let hash = 0x123456789ABCDEF;
 
     // Channels
     wrapper_s1
-        .sender
-        .send((Subsystem1::add_them, 3, 4))
+        .call
+        .send(Subsystem1Callables::SimpleAdd {
+            func: Subsystem1::simple_add,
+            A: 3,
+            B: 4,
+        })
+        .unwrap();
+
+    wrapper_s1
+        .call
+        .send(Subsystem1Callables::AddBlock {
+            func: Subsystem1::add_block,
+            H: hash,
+        })
         .unwrap();
 
     let y = wrapper_s1.result_rx.recv().unwrap();
+    let z = wrapper_s1.result_rx.recv().unwrap();
 
-    println!("{}", y);
+    println!("ADD = {:?}, BLOCK = {:?} ", y, z);
 
     wrapper_s1.handle.join().unwrap();
-
-    // make "CALL" function which gets enum
-
-    //let result1 = wrapper_s1.call(&Subsystem1::add_block, hash);
-    //let result2 = wrapper_s2.call(&Subsystem1::submit_transaction, 0x555666666);
 
     // what happens inside wrapper when one does wrapper_s1.call(...)
     // s2.submit_transaction(&Transaction, 55566666);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,3 +1,107 @@
+use std::array;
+
+/******************* IDEA
+
+Core <--> Trait <--> Tunnel <--> Some other core
+
+fn get_tip() -> Id<Block>;
+fn get_block(id: &Id<Block>) -> Block;
+
+template <typename Func, typename ReturnType, typename Params...>
+ReturnType Call(Func&& func, Params... params)
+{
+    return func(params...);
+}
+
+
+[External]
+fn get_tip() -> Id<Block>;
+
+*/
+
+/******************* The Technique
+
+Lets assume you have an ordered list of N sets of types (“specialization levels”), e.g. (0) Subsystem1, (1) T: Subsystem2, (2) T: Subsystem3.
+You want calls of your method foo to dispatch via the first (in the order of your list) set of types that contains the receiver type of the method call,
+e.g. String dispatches via (0), while u32 dispatches via (1).
+
+To make this happen, you have to:
+
+- Create the type struct Wrap<T>(T).
+- For each specialization level with index i in your list:
+- Create a trait Via⟨desc⟩ where ⟨desc⟩ is a good description of that level (e.g. ViaSubsystem2). Add the method foo to this trait.
+- Implement that trait for ⟨refs⟩ Wrap<⟨set⟩> where ⟨refs⟩ is simply N - i - 1 times &,
+  and ⟨set⟩ describes the set of types for this specialization level. E.g. impl ViaSubsystem1 for &&Wrap<Subsystem1> or impl<T: Subsystem2> ViaSubsystem2 for &Wrap<T>.
+
+For your method call:
+- Make sure all Via* traits are in scope.
+- Wrap your receiver type ( ⟨refs⟩ Wrap<⟨receiver⟩> ).method() where ⟨refs⟩ is N times & and ⟨receiver⟩ is the original receiver. E.g. (&&&Wrap(r)).method().
+
+https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html
+https://stackoverflow.com/questions/28519997/what-are-rusts-exact-auto-dereferencing-rules
+
+*/
+
+/*******************  Tagging (complementary technique)
+
+Tagged dispatch strategy with a pair of method calls,
+the first using autoderef-based specialization with a reference argument to select a tag,
+and the second based on that tag which takes ownership of the original argument.
+
+https://github.com/dtolnay/case-studies/tree/master/autoref-specialization#realistic-application
+
+*/
+
+use std::fmt::{Debug, Display};
+
+struct Wrap<T>(T);
+
+// Subsystem traits
+trait Subsystem1 {}
+trait Subsystem2 {}
+trait Subsystem3 {}
+
+// Specialization trick
+trait ViaSubsystem1 {
+    fn foo(&self);
+}
+
+impl ViaSubsystem1 for &&Wrap<String> {
+    fn foo(&self) {
+        println!("Via Subsystem1");
+    }
+}
+
+trait ViaSubsystem2 {
+    fn foo(&self);
+}
+
+impl<T: Display> ViaSubsystem2 for &Wrap<T> {
+    fn foo(&self) {
+        println!("Via Subsystem2");
+    }
+}
+
+trait ViaSubsystem3 {
+    fn foo(&self);
+}
+
+impl<T: Debug> ViaSubsystem3 for Wrap<T> {
+    fn foo(&self) {
+        println!("Via Subsystem3");
+    }
+}
+
 fn main() {
-    println!("Hello, world!");
+    // Test method calls
+    (&&&Wrap(String::from("hi"))).foo();
+    (&&&Wrap(3)).foo();
+    (&&&Wrap(['a', 'b'])).foo();
+
+    // TODO
+    // Replace STRING, DISPLAY and DEBUG with Subsystems
+
+    //(&&&Wrap(Subsystem1)).foo();
+    //(&&&Wrap(Subsystem2)).foo();
+    //(&&&Wrap(Subsystem3)).foo();
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,5 +1,3 @@
-use std::array;
-
 /******************* IDEA
 
 Core <--> Trait <--> Tunnel <--> Some other core
@@ -57,16 +55,22 @@ use std::fmt::{Debug, Display};
 struct Wrap<T>(T);
 
 // Subsystem traits
-trait Subsystem1 {}
-trait Subsystem2 {}
-trait Subsystem3 {}
+struct Subsystem1 {
+    num: u8,
+}
+struct Subsystem2 {
+    vec: Vec<u8>,
+}
+struct Subsystem3 {
+    str: String,
+}
 
 // Specialization trick
 trait ViaSubsystem1 {
     fn foo(&self);
 }
 
-impl ViaSubsystem1 for &&Wrap<String> {
+impl ViaSubsystem1 for &&Wrap<Subsystem1> {
     fn foo(&self) {
         println!("Via Subsystem1");
     }
@@ -76,7 +80,7 @@ trait ViaSubsystem2 {
     fn foo(&self);
 }
 
-impl<T: Display> ViaSubsystem2 for &Wrap<T> {
+impl ViaSubsystem2 for &Wrap<Subsystem2> {
     fn foo(&self) {
         println!("Via Subsystem2");
     }
@@ -86,22 +90,19 @@ trait ViaSubsystem3 {
     fn foo(&self);
 }
 
-impl<T: Debug> ViaSubsystem3 for Wrap<T> {
+impl ViaSubsystem3 for Wrap<Subsystem3> {
     fn foo(&self) {
         println!("Via Subsystem3");
     }
 }
 
 fn main() {
-    // Test method calls
-    (&&&Wrap(String::from("hi"))).foo();
-    (&&&Wrap(3)).foo();
-    (&&&Wrap(['a', 'b'])).foo();
-
     // TODO
-    // Replace STRING, DISPLAY and DEBUG with Subsystems
+    // Include Tagging Method
+    // Simplify with Macro
+    // PoC with Thread
 
-    //(&&&Wrap(Subsystem1)).foo();
-    //(&&&Wrap(Subsystem2)).foo();
-    //(&&&Wrap(Subsystem3)).foo();
+    (&&&Wrap(Subsystem1 { num: 8 })).foo();
+    (&&&Wrap(Subsystem2 { vec: Vec::new() })).foo();
+    (&&&Wrap(Subsystem3 { str: String::new() })).foo();
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,4 +1,4 @@
-/******************* IDEA
+/******************* IDEA : Compile time deterministic generic specialization for subsystems interfacing
 
 Core <--> Trait <--> Tunnel <--> Some other core
 
@@ -38,13 +38,16 @@ For your method call:
 https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html
 https://stackoverflow.com/questions/28519997/what-are-rusts-exact-auto-dereferencing-rules
 
+Real-World example :
+https://github.com/sagebind/castaway
+
 */
 
 /*******************  Tagging (complementary technique)
 
-Tagged dispatch strategy with a pair of method calls,
-the first using autoderef-based specialization with a reference argument to select a tag,
-and the second based on that tag which takes ownership of the original argument.
+Tagged dispatch strategy with a pair of method calls :
+- the first using autoderef-based specialization with a reference argument to select a tag, and
+- the second based on that tag which takes ownership of the original argument.
 
 https://github.com/dtolnay/case-studies/tree/master/autoref-specialization#realistic-application
 
@@ -54,7 +57,7 @@ use std::fmt::{Debug, Display};
 
 struct Wrap<T>(T);
 
-// Subsystem traits
+// Subsystem Types
 struct Subsystem1 {
     num: u8,
 }
@@ -96,11 +99,13 @@ impl ViaSubsystem3 for Wrap<Subsystem3> {
     }
 }
 
+
 fn main() {
     // TODO
-    // Include Tagging Method
-    // Simplify with Macro
-    // PoC with Thread
+    // Add Tagging for conflict resolution
+    // Simplify specialization with macro
+    // Thread
+    // proc_macro 
 
     (&&&Wrap(Subsystem1 { num: 8 })).foo();
     (&&&Wrap(Subsystem2 { vec: Vec::new() })).foo();

--- a/node/src/main.rs.specialization
+++ b/node/src/main.rs.specialization
@@ -1,0 +1,113 @@
+/******************* IDEA : Compile time deterministic generic specialization for subsystems interfacing
+
+Core <--> Trait <--> Tunnel <--> Some other core
+
+fn get_tip() -> Id<Block>;
+fn get_block(id: &Id<Block>) -> Block;
+
+template <typename Func, typename ReturnType, typename Params...>
+ReturnType Call(Func&& func, Params... params)
+{
+    return func(params...);
+}
+
+
+[External]
+fn get_tip() -> Id<Block>;
+
+*/
+
+/******************* The Technique
+
+Lets assume you have an ordered list of N sets of types (“specialization levels”), e.g. (0) Subsystem1, (1) T: Subsystem2, (2) T: Subsystem3.
+You want calls of your method foo to dispatch via the first (in the order of your list) set of types that contains the receiver type of the method call,
+e.g. String dispatches via (0), while u32 dispatches via (1).
+
+To make this happen, you have to:
+
+- Create the type struct Wrap<T>(T).
+- For each specialization level with index i in your list:
+- Create a trait Via⟨desc⟩ where ⟨desc⟩ is a good description of that level (e.g. ViaSubsystem2). Add the method foo to this trait.
+- Implement that trait for ⟨refs⟩ Wrap<⟨set⟩> where ⟨refs⟩ is simply N - i - 1 times &,
+  and ⟨set⟩ describes the set of types for this specialization level. E.g. impl ViaSubsystem1 for &&Wrap<Subsystem1> or impl<T: Subsystem2> ViaSubsystem2 for &Wrap<T>.
+
+For your method call:
+- Make sure all Via* traits are in scope.
+- Wrap your receiver type ( ⟨refs⟩ Wrap<⟨receiver⟩> ).method() where ⟨refs⟩ is N times & and ⟨receiver⟩ is the original receiver. E.g. (&&&Wrap(r)).method().
+
+https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html
+https://stackoverflow.com/questions/28519997/what-are-rusts-exact-auto-dereferencing-rules
+
+Real-World example :
+https://github.com/sagebind/castaway
+
+*/
+
+/*******************  Tagging (complementary technique)
+
+Tagged dispatch strategy with a pair of method calls :
+- the first using autoderef-based specialization with a reference argument to select a tag, and
+- the second based on that tag which takes ownership of the original argument.
+
+https://github.com/dtolnay/case-studies/tree/master/autoref-specialization#realistic-application
+
+*/
+
+use std::fmt::{Debug, Display};
+
+struct Wrap<T>(T);
+
+// Subsystem Types
+struct Subsystem1 {
+    num: u8,
+}
+struct Subsystem2 {
+    vec: Vec<u8>,
+}
+struct Subsystem3 {
+    str: String,
+}
+
+// Specialization trick
+trait ViaSubsystem1 {
+    fn foo(&self);
+}
+
+impl ViaSubsystem1 for &&Wrap<Subsystem1> {
+    fn foo(&self) {
+        println!("Via Subsystem1");
+    }
+}
+
+trait ViaSubsystem2 {
+    fn foo(&self);
+}
+
+impl ViaSubsystem2 for &Wrap<Subsystem2> {
+    fn foo(&self) {
+        println!("Via Subsystem2");
+    }
+}
+
+trait ViaSubsystem3 {
+    fn foo(&self);
+}
+
+impl ViaSubsystem3 for Wrap<Subsystem3> {
+    fn foo(&self) {
+        println!("Via Subsystem3");
+    }
+}
+
+
+fn main() {
+    // TODO
+    // Add Tagging for conflict resolution
+    // Simplify specialization with macro
+    // Thread
+    // proc_macro 
+
+    (&&&Wrap(Subsystem1 { num: 8 })).foo();
+    (&&&Wrap(Subsystem2 { vec: Vec::new() })).foo();
+    (&&&Wrap(Subsystem3 { str: String::new() })).foo();
+}

--- a/node/src/v1.rs
+++ b/node/src/v1.rs
@@ -1,0 +1,137 @@
+
+use std::collections::HashMap;
+//mod future_utils;
+use std::thread;
+//use std::thread::JoinHandle;
+use std::time::Duration;
+use tokio::task;
+use tokio::task::JoinHandle;
+
+//use future_utils::{new_executor_and_spawner, Executor, Spawner};
+
+// Definitions
+struct Transaction;
+struct Subsystem1 {
+    block_counter: u64,
+    block_hash: Vec<u128>,
+}
+struct Subsystem2 {
+    tx_count: u32,
+    mempool: Vec<u128>,
+}
+
+trait Launch {
+    fn init(&mut self) -> JoinHandle<()>;
+    fn call<F: Fn(U) -> (), U>(&mut self, func: F, arg: U);
+}
+
+// Implementation of Subsystem1
+impl Subsystem1 {
+    pub fn add_block(&mut self, hash: &u128) -> Result<(), Box<dyn std::error::Error>> {
+        self.block_counter += 1;
+        self.block_hash.push(*hash);
+        println!("Hash {} added as block num {}", *hash, self.block_counter);
+        Ok(())
+    }
+}
+
+impl Launch for Subsystem1 {
+    fn init(&mut self) -> JoinHandle<()> {
+        task::spawn(async {
+            self.block_counter = 0;
+            self.block_hash = Vec::new();
+            println!("Init Subsystem1 Thread");
+        })
+    }
+
+    fn call<F, U>(&mut self, func: F, arg: U)
+    where
+        F: Fn(U) -> (),
+    {
+        func(arg);
+    }
+}
+
+// Implementation of Subsystem2
+impl Subsystem2 {
+    pub fn submit_transaction(
+        &self,
+        tx: &Transaction,
+        timestamp: i64,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        todo!();
+    }
+}
+
+impl Launch for Subsystem2 {
+    fn init(&mut self) -> JoinHandle<()> {
+        task::spawn(async {
+            println!("Init Subsystem2 Thread");
+        })
+    }
+
+    fn call<F, U>(&mut self, func: F, arg: U) {
+        todo!()
+    }
+}
+
+// Implement Wrapper
+
+struct Wrap;
+
+impl Wrap {
+    fn instantiate<T: Launch>() -> JoinHandle<()> {
+        T::init()
+    }
+}
+#[tokio::main]
+async fn main() {
+    // -----------------------Template-------------------------------
+    //let s1 = Subsystem1;
+    //let s2 = Subsystem2;
+
+    // Future for Subsystem Thread
+    //let wrapper_s1 = Wrap::Launch::<Subsystem1>(&Subsystem1::init);
+    //let wrapper_s2 = Wrap::Launch::<Subsystem2>(&Subsystem2::init);
+
+    let hash = 0;
+    let value = 0x55566666;
+
+    //let result = wrapper_s1.call(&Subsystem1::add_block, hash);
+    // Internally does :  s1.add_block(&0);
+    // what happens inside wrapper when one does wrapper_s1.call(...)
+    /*
+    let func = Subsystem1::add_block; // this is the first param
+    let result = func(&s1, &hash); // this result is returned through the channel
+    */
+
+    //let result = wrapper_s1.call(&Subsystem2::submit_transaction, 55566666);
+    // Internally Does s2.submit_transaction(&Transaction, 55566666);
+
+    // ----------------------------RAW--------------------------------
+
+    //let (executor, spawner) = new_executor_and_spawner();
+
+    // Spawn a task to print before and after waiting on a timer.
+    /*
+    spawner.spawn(async {
+        println!("howdy!");
+        println!("done!");
+    });
+    */
+    // Drop the spawner so that our executor knows it is finished and won't
+    // receive more incoming tasks to run.
+    //drop(&spawner);
+
+    // Run the executor until the task queue is empty.
+    // This will print "howdy!", then print "done!".
+    //executor.run();
+
+    // -----------------------Wrapped-------------------------------
+
+    let wrap_sys1 = Wrap::instantiate::<Subsystem1>();
+    let wrap_sys2 = Wrap::instantiate::<Subsystem2>();
+
+    //let result1 = wrap_sys1.call::<Subsystem1>(&Subsystem1::add_block, hash);
+    //let result2 = wrap_sys1.call::<Subsystem2>(&Subsystem2::submit_transaction, value);
+}

--- a/node/src/v2.rs
+++ b/node/src/v2.rs
@@ -1,0 +1,111 @@
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::task;
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
+
+// Definitions
+struct Transaction;
+struct Subsystem1 {
+    block_counter: u64,
+    block_hash: Vec<u128>,
+}
+struct Subsystem2 {
+    tx_count: u32,
+    mempool: Vec<u128>,
+}
+
+trait Launch {
+    fn init(tx: mpsc::Sender<&'static str>) -> JoinHandle<()>;
+    fn call<T>(func: impl Fn(T) -> T);
+}
+
+// Implementation of Subsystem1
+impl Subsystem1 {
+    pub fn init(tx: mpsc::Sender<&'static str>) -> JoinHandle<()> {
+        task::spawn(async move {
+            tx.send("Init Subsystem1 Thread").await;
+            sleep(Duration::from_millis(200)).await;
+        })
+    }
+
+    pub fn add_block(/*&mut self, */ hash: &u128) -> Result<(), Box<dyn std::error::Error>> {
+        /*
+        self.block_counter += 1;
+        self.block_hash.push(*hash);
+        println!("Hash {} added as block num {}", *hash, self.block_counter);
+        */
+        println!("Hash {} added as block num {}", 1, 2);
+        Ok(())
+    }
+}
+
+impl Launch for Subsystem1 {
+    fn init(tx: mpsc::Sender<&'static str>) -> JoinHandle<()> {
+        Subsystem1::init(tx)
+    }
+
+    fn call<T>(func: impl Fn(T) -> T) {}
+}
+
+// Implementation of Subsystem2
+impl Subsystem2 {
+    pub fn init(tx: mpsc::Sender<&'static str>) -> JoinHandle<()> {
+        task::spawn(async move {
+            tx.send("Init Subsystem2 Thread").await;
+            sleep(Duration::from_millis(100)).await;
+        })
+    }
+
+    pub fn submit_transaction(
+        &self,
+        tx: &Transaction,
+        timestamp: i64,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        todo!();
+    }
+}
+
+impl Launch for Subsystem2 {
+    fn init(tx: mpsc::Sender<&'static str>) -> JoinHandle<()> {
+        Subsystem2::init(tx)
+    }
+
+    fn call<T>(func: impl Fn(T) -> T) {}
+}
+
+// Implement Wrapper
+
+struct Wrap;
+
+impl Wrap {
+    fn new<T: Launch>(tx: mpsc::Sender<&'static str>) -> JoinHandle<()> {
+        T::init(tx)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let hash = 0;
+    let value = 0x55566666;
+
+    // Channels
+    let (tx1, mut rx) = mpsc::channel(32);
+    let tx2 = tx1.clone();
+    tx1.abc();
+
+    // Subsystem Initialization
+    let wrap_sys1 = Wrap::new::<Subsystem1>(tx1);
+    let wrap_sys2 = Wrap::new::<Subsystem2>(tx2);
+
+    wrap_sys1.await;
+    wrap_sys2.await;
+
+    while let Some(message) = rx.recv().await {
+        println!("GOT = {}", message);
+    }
+
+    // Subsystem Call
+    //let result1 = wrap_sys1.call::<Subsystem1>(&Subsystem1::add_block, hash);
+    //let result2 = wrap_sys1.call::<Subsystem2>(&Subsystem2::submit_transaction, value);
+}


### PR DESCRIPTION
In this draft, we are trying to create a flexible interface between different subsystems of Mintlayer Core. This wrapper should be statically typed with compile time specialization. Wrapper has a function named "Launcher" to create each Subsystem in a single thread, an object named "Caller" to execute a range of functions with different argumnets.

We started with this template,  :  

    let wrapper_s1 = Wrap::Launch::<Subsystem1>(&Subsystem1::init);
    let wrapper_s2 = Wrap::Launch::<Subsystem2>(&Subsystem2::init);

    let hash = 0;
    let result = wrapper_s1.call(&Subsystem1::add_block, hash);

Techniques, 

For polymorphism we used enum instead of traits, both for parameters and return types, and consequently
Type encompassing : The variants of enums are not considered types in their own right,
meaning one cannot create functions that only work with an individual variant from the enum.
This can be solved by creating the types using structs and wrapping them in an enum

Higher-Rank Trait Bounds (HRTBs) : for<'a> F can be read as "for all choices of 'a",
and basically produces an infinite list of trait bounds that F must satisfy.

