### PR TITLE
storage: Categorize errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "mockall",
  "parity-scale-codec",
  "storage",
+ "thiserror",
 ]
 
 [[package]]
@@ -3273,6 +3274,7 @@ name = "storage"
 version = "0.1.0"
 dependencies = [
  "common",
+ "logging",
  "serialization",
  "thiserror",
 ]

--- a/blockchain_storage/Cargo.toml
+++ b/blockchain_storage/Cargo.toml
@@ -7,10 +7,11 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-storage = { path = '../storage'}
 common = { path = '../common' }
+storage = { path = '../storage'}
 mockall = { version = "0.11", optional = true }
 parity-scale-codec = { version = "2.3.1", features = ["chain-error"] }
+thiserror = "1.0"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/blockchain_storage/src/lib.rs
+++ b/blockchain_storage/src/lib.rs
@@ -11,10 +11,16 @@ mod store;
 pub use store::{Store, StoreTx};
 
 /// Blockchain storage error
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug)]
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, thiserror::Error)]
 pub enum Error {
-    RecoverableError(storage::Error),
-    UnrecoverableError(storage::Error),
+    #[error("Storage error: {0}")]
+    Storage(storage::error::Recoverable),
+}
+
+impl From<storage::Error> for Error {
+    fn from(e: storage::Error) -> Self {
+        Error::Storage(e.recoverable())
+    }
 }
 
 /// Possibly failing result of blockchain storage query

--- a/blockchain_storage/src/mock.rs
+++ b/blockchain_storage/src/mock.rs
@@ -122,7 +122,8 @@ mod tests {
     pub use common::primitives::{Idable, H256};
     pub use storage::Transactional;
 
-    const TXFAIL: crate::Error = crate::Error::RecoverableError(storage::Error::TransactionFailed);
+    const TXFAIL: crate::Error =
+        crate::Error::Storage(storage::error::Recoverable::TransactionFailed);
     const HASH1: H256 = H256([0x01; 32]);
     const HASH2: H256 = H256([0x02; 32]);
 
@@ -212,13 +213,13 @@ mod tests {
             storage::commit("ok")
         });
         res.unwrap_or_else(|e| {
-            let e = match e {
-                crate::Error::RecoverableError(e) => e,
-                crate::Error::UnrecoverableError(e) => e,
-            };
+            #[allow(unreachable_patterns)]
             match e {
-                storage::Error::TransactionFailed => "tx failed",
-                _ => "other",
+                crate::Error::Storage(e) => match e {
+                    storage::error::Recoverable::TransactionFailed => "tx failed",
+                    _ => "other storage error",
+                },
+                _ => "other error",
             }
         })
     }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-serialization = { path = "../serialization"}
 common = { path = "../common"}
+serialization = { path = "../serialization"}
+logging = { path = '../logging' }
 thiserror = "1.0"

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -1,0 +1,56 @@
+//! Storage errors
+
+/// Recoverable database error
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, thiserror::Error)]
+pub enum Recoverable {
+    /// Transaction has failed top execute and its effecs have not taken place. This could be e.g.
+    /// because of a conflicting transaction front-running this one.
+    #[error("Transaction failed")]
+    TransactionFailed,
+
+    /// Some resource is temporarily exhausted so the transaction did not succeed.
+    /// This could be e.g. exceeding the max number of concurrent readers.
+    #[error("The database has temporarily exhausted some resource")]
+    TemporarilyUnavailable,
+
+    /// Other recoverable error
+    #[error("Unknown database error")]
+    Unknown,
+}
+
+/// Fatal database error
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, thiserror::Error)]
+pub enum Fatal {
+    #[error("Out of storage space")]
+    OutOfSpace,
+    #[error("Database has been corrupted")]
+    DatabaseCorrupted,
+    #[error("Database internal error")]
+    InternalError,
+    #[error("Database schema does not match database settings or contents")]
+    SchemaMismatch,
+    #[error("Unknown fatal database error")]
+    Unknown,
+}
+
+/// Database error
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Recoverable(Recoverable),
+    #[error("{0}")]
+    Fatal(Fatal),
+}
+
+impl Error {
+    /// Get recoverable error, panicking if this is a fatal error.
+    pub fn recoverable(self) -> Recoverable {
+        match self {
+            Self::Recoverable(e) => e,
+            Self::Fatal(e) => {
+                logging::log::error!("Fatal database error: {}", e);
+                panic!("Fatal database error: {}", e)
+            },
+        }
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -69,19 +69,13 @@
 //! ```
 
 mod basic;
+pub mod error;
 pub mod schema;
 pub mod transaction;
 
 // Reexport items from the temporary basic implementation.
 pub use basic::{SingleMap, Store, Transaction};
+pub use error::Error;
 pub use transaction::{abort, commit, DbTransaction, Transactional};
-
-#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, thiserror::Error)]
-pub enum Error {
-    #[error("Transaction failed")]
-    TransactionFailed,
-    #[error("Unknown database error")]
-    Unknown,
-}
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
* Split storage layer errors between recoverable and fatal
* Better coverage of possible errors (not necessarily final)
* Handle fatal errors by panicking in the blockchain_storage layer