### PR TITLE
net/libp2p: Implement mDNS peer discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,6 +2481,7 @@ dependencies = [
  "rand 0.8.4",
  "test-utils",
  "tokio",
+ "void",
 ]
 
 [[package]]

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1.51"
 futures = "0.3.15"
 futures-timer = "3.0.2"
 rand = "0.8.4"
+void = "1.0.2"
 
 [dependencies.common]
 path = "../common/"

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -128,6 +128,16 @@ where
         Ok(())
     }
 
+    fn peer_discovered(&mut self, peers: &[NetworkingBackend::Address]) -> error::Result<()> {
+        println!("peers discovered: {:#?}", peers);
+        Ok(())
+    }
+
+    fn peer_expired(&mut self, peers: &[NetworkingBackend::Address]) -> error::Result<()> {
+        println!("peers expired: {:#?}", peers);
+        Ok(())
+    }
+
     /// Handle network event received from the network service provider
     async fn on_network_event(
         &mut self,
@@ -137,6 +147,8 @@ where
             net::Event::IncomingConnection(socket) => {
                 self.on_connectivity_event(ConnectivityEvent::Accept(socket)).await
             }
+            net::Event::PeerDiscovered(peers) => self.peer_discovered(&peers),
+            net::Event::PeerExpired(peers) => self.peer_expired(&peers),
         }
     }
 

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -222,7 +222,10 @@ mod tests {
         assert!(remote_res.is_ok());
 
         let server_res: Event<MockService> = server_res.unwrap();
-        let Event::IncomingConnection(server_res) = server_res;
+        let server_res = match server_res {
+            Event::IncomingConnection(server_res) => server_res,
+            _ => panic!("invalid event received, expected incoming connection"),
+        };
 
         let config = Arc::new(config::create_mainnet());
         let (peer_tx, _peer_rx) = tokio::sync::mpsc::channel(1);
@@ -264,7 +267,10 @@ mod tests {
         assert!(remote_res.is_ok());
 
         let server_res: Event<MockService> = server_res.unwrap();
-        let Event::IncomingConnection(server_res) = server_res;
+        let server_res = match server_res {
+            Event::IncomingConnection(server_res) => server_res,
+            _ => panic!("invalid event received, expected incoming connection"),
+        };
 
         let config = Arc::new(config::create_mainnet());
         let (peer_tx, _peer_rx) = tokio::sync::mpsc::channel(1);

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -28,6 +28,12 @@ where
 {
     /// Incoming connection from remote peer
     IncomingConnection(T::Socket),
+
+    /// One or more peers discovered
+    PeerDiscovered(Vec<T::Address>),
+
+    /// One one more peers have expired
+    PeerExpired(Vec<T::Address>),
 }
 
 #[derive(Debug)]
@@ -48,7 +54,7 @@ pub trait NetworkService {
     ///
     /// For an implementation built on libp2p, the address format is:
     ///     `/ip4/0.0.0.0/tcp/8888/p2p/<peer ID>`
-    type Address;
+    type Address: std::fmt::Debug;
 
     /// Generic socket object that the underlying implementation uses
     type Socket: SocketService + Send;
@@ -87,7 +93,7 @@ pub trait NetworkService {
     /// - new discovered peers
     async fn poll_next<T>(&mut self) -> error::Result<Event<T>>
     where
-        T: NetworkService<Socket = Self::Socket>;
+        T: NetworkService<Socket = Self::Socket, Address = Self::Address>;
 
     /// Publish data in a given gossip topic
     ///

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -61,7 +61,10 @@ pub async fn create_two_mock_peers(
 
     let (remote_res, local_res) = tokio::join!(server.poll_next(), peer_fut);
     let remote_res: Event<MockService> = remote_res.unwrap();
-    let Event::IncomingConnection(remote_res) = remote_res;
+    let remote_res = match remote_res {
+        Event::IncomingConnection(remote_res) => remote_res,
+        _ => panic!("invalid event received, expected incoming connection"),
+    };
     let local_res = local_res.unwrap();
 
     let (peer_tx, _peer_rx) = tokio::sync::mpsc::channel(1);

--- a/p2p/tests/libp2p.rs
+++ b/p2p/tests/libp2p.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): A. Altonen
+#![cfg(not(loom))]
+extern crate test_utils;
+
+use common::{chain::config, sync::Arc};
+use libp2p::{multiaddr::Protocol, Multiaddr};
+use p2p::{
+    net::{
+        libp2p::{Libp2pService, Libp2pStrategy},
+        Event, NetworkService,
+    },
+    P2P,
+};
+
+// verify that libp2p mdns peer discovery works
+#[tokio::test(flavor = "multi_thread")]
+async fn test_libp2p_peer_discovery() {
+    let config = Arc::new(config::create_mainnet());
+    let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
+    let mut serv = Libp2pService::new(addr.clone(), &[Libp2pStrategy::MulticastDns], &[])
+        .await
+        .unwrap();
+
+    tokio::spawn(async move {
+        let mut p2p = P2P::<Libp2pService>::new(256, 32, addr, Arc::clone(&config)).await.unwrap();
+        let _ = p2p.run().await;
+    });
+
+    loop {
+        let serv_res: Event<Libp2pService> = serv.poll_next().await.unwrap();
+        match serv_res {
+            Event::PeerDiscovered(peers) => {
+                for addr in peers.iter() {
+                    let components = addr.iter().collect::<Vec<Protocol>>();
+
+                    assert_eq!(components.len(), 3);
+                    assert!(matches!(components[0], Protocol::Ip4(_) | Protocol::Ip6(_)));
+                    assert!(matches!(components[1], Protocol::Tcp(_)));
+                    assert!(matches!(components[2], Protocol::P2p(_)));
+                }
+                return;
+            }
+            e => panic!("unexpected event: {:?}", e),
+        }
+    }
+}

--- a/p2p/tests/p2p.rs
+++ b/p2p/tests/p2p.rs
@@ -19,7 +19,10 @@ extern crate test_utils;
 
 use common::{chain::config, sync::Arc};
 use libp2p::Multiaddr;
-use p2p::{net::libp2p::Libp2pService, net::mock::MockService, P2P};
+use p2p::{
+    net::{libp2p::Libp2pService, mock::MockService},
+    P2P,
+};
 use std::net::SocketAddr;
 
 // create new p2p object with mock service

--- a/p2p/tests/peer.rs
+++ b/p2p/tests/peer.rs
@@ -38,7 +38,10 @@ async fn test_peer_new_mock() {
     assert!(peer_res.is_ok());
 
     let server_res: net::Event<MockService> = server_res.unwrap();
-    let net::Event::IncomingConnection(server_res) = server_res;
+    let server_res = match server_res {
+        net::Event::IncomingConnection(server_res) => server_res,
+        _ => panic!("invalid event received, expected incoming connection"),
+    };
 
     let (peer_tx, _peer_rx) = tokio::sync::mpsc::channel(1);
     let (_tx, rx) = tokio::sync::mpsc::channel(1);
@@ -68,7 +71,10 @@ async fn test_peer_new_libp2p() {
     assert!(server2_res.is_ok());
 
     let server1_res: net::Event<Libp2pService> = server1_res.unwrap();
-    let net::Event::IncomingConnection(server1_res) = server1_res;
+    let server1_res = match server1_res {
+        net::Event::IncomingConnection(server1_res) => server1_res,
+        _ => panic!("invalid event received, expected incoming connection"),
+    };
 
     let (peer_tx, _peer_rx) = tokio::sync::mpsc::channel(1);
     let (_tx, rx) = tokio::sync::mpsc::channel(1);


### PR DESCRIPTION
This PR implements mDNS peer discovery and essentially allows the Mintlayer node to find other nodes in the local network. It adds `mdns` field to the `NetworkBehaviour` struct, waits for incoming mDNS events from the network and sends them to the P2P object for further processing. This PR does not implement any peer management so currently the P2P object receives the mDNS events and discards the records.

An unfortunate thing about `libp2p-mdns` is that there is no way during runtime to enable/disable it so it's either always on or never on and that decision is made when the code is compiled and there is no way to shut down the mDNS object or tell it to no longer query the network. It's not an attack vector or performance concern but "disabling" mDNS is not quite as elegant as one could hope: we basically just ignore incoming events and that's it. If `Libp2pStrategy::MulticastDns` is provided when the network service provider is being created, the P2P object will receive mDNS events and if the mDNS strategy is not specified, those events are still received by the libp2p backend but they are not relayed to the P2P object for further processing.

I don't know if there ever a use-case where you'd need to disable mDNS though. You'd have to nodes running locally at the same time and you wouldn't want them to connect to each other?