### PR TITLE
storage: Separate out mutable and immutable operations

### DIFF
--- a/blockchain_storage/src/lib.rs
+++ b/blockchain_storage/src/lib.rs
@@ -8,7 +8,7 @@ use common::primitives::{BlockHeight, Id};
 pub mod mock;
 mod store;
 
-pub use store::{Store, StoreTx};
+pub use store::Store;
 
 /// Blockchain storage error
 #[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, thiserror::Error)]
@@ -29,22 +29,22 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// Operations on persistent blockchain data
 pub trait BlockchainStorage {
     /// Get storage version
-    fn get_storage_version(&mut self) -> crate::Result<u32>;
+    fn get_storage_version(&self) -> crate::Result<u32>;
 
     /// Set storage version
     fn set_storage_version(&mut self, version: u32) -> crate::Result<()>;
 
     /// Get the hash of the best block
-    fn get_best_block_id(&mut self) -> crate::Result<Option<Id<Block>>>;
+    fn get_best_block_id(&self) -> crate::Result<Option<Id<Block>>>;
 
     /// Set the hash of the best block
     fn set_best_block_id(&mut self, id: &Id<Block>) -> crate::Result<()>;
 
+    /// Get block by its hash
+    fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
+
     /// Add a new block into the database
     fn add_block(&mut self, block: &Block) -> crate::Result<()>;
-
-    /// Get block by its hash
-    fn get_block(&mut self, id: Id<Block>) -> crate::Result<Option<Block>>;
 
     /// Remove block from the database
     fn del_block(&mut self, id: Id<Block>) -> crate::Result<()>;
@@ -58,7 +58,7 @@ pub trait BlockchainStorage {
 
     /// Get outputs state for given transaction in the mainchain
     fn get_mainchain_tx_index(
-        &mut self,
+        &self,
         tx_id: &Id<Transaction>,
     ) -> crate::Result<Option<TxMainChainIndex>>;
 
@@ -67,15 +67,15 @@ pub trait BlockchainStorage {
 
     /// Get transaction by block ID and position
     fn get_mainchain_tx_by_position(
-        &mut self,
+        &self,
         tx_index: &TxMainChainPosition,
     ) -> crate::Result<Option<Transaction>>;
 
     /// Get transaction by transaction ID. Transaction must be in the index.
-    fn get_mainchain_tx(&mut self, txid: &Id<Transaction>) -> crate::Result<Option<Transaction>>;
+    fn get_mainchain_tx(&self, txid: &Id<Transaction>) -> crate::Result<Option<Transaction>>;
 
     /// Get mainchain block by its height
-    fn get_block_id_by_height(&mut self, height: &BlockHeight) -> crate::Result<Option<Id<Block>>>;
+    fn get_block_id_by_height(&self, height: &BlockHeight) -> crate::Result<Option<Id<Block>>>;
 
     /// Set the mainchain block at given height to be given block.
     fn set_block_id_at_height(

--- a/common/src/chain/transaction.rs
+++ b/common/src/chain/transaction.rs
@@ -132,6 +132,10 @@ mod tests {
         let tx1 = Transaction::new(0x00, vec![input], vec![], 0x00).expect("tx1 bad");
         assert_ne!(tx0, tx1);
 
-        assert_ne!(tx0.get_id(), tx1.get_id(), "Different transactions with the same ID!");
+        assert_ne!(
+            tx0.get_id(),
+            tx1.get_id(),
+            "Different transactions with the same ID!"
+        );
     }
 }

--- a/storage/src/basic.rs
+++ b/storage/src/basic.rs
@@ -1,8 +1,7 @@
 use crate::schema::{self, Schema};
+use crate::Data;
 use common::sync;
 use std::collections::BTreeMap;
-
-type Data = Vec<u8>;
 
 // These store the data
 type StoreMapSingle = BTreeMap<Data, Data>;
@@ -58,7 +57,7 @@ impl DeltaMap {
 
 /// Store is a collection of key-(multi)value maps
 pub struct Store<Sch: Schema> {
-    maps: sync::Arc<sync::Mutex<StoreMapSet>>,
+    maps: sync::Arc<sync::RwLock<StoreMapSet>>,
     _phantom: std::marker::PhantomData<Sch>,
 }
 
@@ -95,17 +94,22 @@ impl<Sch: InitStore> Store<Sch> {
     /// New empty store
     pub fn new() -> Self {
         Self {
-            maps: sync::Arc::new(sync::Mutex::new(Sch::init())),
+            maps: sync::Arc::new(sync::RwLock::new(Sch::init())),
             _phantom: Default::default(),
         }
     }
 }
 
-impl<'st, Sch: Schema> crate::transaction::Transactional<'st> for Store<Sch> {
-    type Transaction = Transaction<'st, Sch>;
+impl<'st, Sch: 'static + Schema> crate::transaction::Transactional<'st> for Store<Sch> {
+    type TransactionRo = TransactionRo<'st, Sch>;
+    type TransactionRw = TransactionRw<'st, Sch>;
 
-    fn start_transaction(&'st mut self) -> Self::Transaction {
-        Transaction::start(self)
+    fn start_transaction_ro(&'st self) -> Self::TransactionRo {
+        TransactionRo::start(self)
+    }
+
+    fn start_transaction_rw(&'st self) -> Self::TransactionRw {
+        TransactionRw::start(self)
     }
 }
 
@@ -115,21 +119,51 @@ impl<Sch: InitStore> Default for Store<Sch> {
     }
 }
 
+// Read-only transaction is a read-write transaction internally for now.
+// TODO: We can get some code clarity and efficiency gains by making this a separate type.
+pub struct TransactionRo<'st, Sch> {
+    store: sync::RwLockReadGuard<'st, StoreMapSet>,
+    _phantom: std::marker::PhantomData<fn() -> Sch>,
+}
+
+impl<'st, Sch: Schema> TransactionRo<'st, Sch> {
+    // Start a transaction on given store
+    fn start(store: &'st Store<Sch>) -> Self {
+        let store = store.maps.read().expect("Mutex locked by a crashed thread");
+        Self {
+            store,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<'st, Sch: Schema> crate::traits::GetMapRef<'st, Sch> for TransactionRo<'st, Sch> {
+    type MapRef = SingleMapView<'st>;
+
+    fn get<Col: schema::Column, I>(&self) -> SingleMapView<'_> {
+        if let Some(StoreMap::Single(store)) = self.store.get(Col::NAME) {
+            SingleMapView::new(store)
+        } else {
+            panic!("Unexpected map kind")
+        }
+    }
+}
+
 /// Store transaction.
 ///
 /// Contains a pointer to the original store and a set of changes to it. If the transaction is
 /// commited, the changes are flushed to the store. If the transaction is aborted, the changes are
 /// discarded.
-pub struct Transaction<'st, Sch: Schema> {
-    store: sync::MutexGuard<'st, StoreMapSet>,
+pub struct TransactionRw<'st, Sch: Schema> {
+    store: sync::RwLockWriteGuard<'st, StoreMapSet>,
     delta: DeltaMapSet,
-    _phantom: std::marker::PhantomData<Sch>,
+    _phantom: std::marker::PhantomData<fn() -> Sch>,
 }
 
-impl<'st, Sch: Schema> Transaction<'st, Sch> {
+impl<'st, Sch: Schema> TransactionRw<'st, Sch> {
     // Start a transaction on given store
     fn start(store: &'st Store<Sch>) -> Self {
-        let store = store.maps.lock().expect("Mutex locked by a crashed thread");
+        let store = store.maps.write().expect("Mutex locked by a crashed thread");
         let delta = store
             .iter()
             .map(|(&k, v)| {
@@ -147,23 +181,43 @@ impl<'st, Sch: Schema> Transaction<'st, Sch> {
             _phantom,
         }
     }
+}
 
-    /// Get key-value store for given column (key-to-single-value only for now)
-    pub fn get<Col, I>(&mut self) -> SingleMap<'_>
-    where
-        Col: schema::Column<Kind = schema::Single>,
-        Sch: schema::HasColumn<Col, I>,
-    {
-        match (self.store.get(Col::NAME), self.delta.get_mut(Col::NAME)) {
+impl<'st, Sch: Schema> crate::traits::GetMapRef<'st, Sch> for TransactionRw<'st, Sch> {
+    type MapRef = SingleMapRef<'st>;
+
+    fn get<Col: schema::Column, I>(&self) -> SingleMapRef<'_> {
+        match (self.store.get(Col::NAME), self.delta.get(Col::NAME)) {
             (Some(StoreMap::Single(store)), Some(DeltaMap::Single(delta))) => {
-                SingleMap::new(store, delta)
+                SingleMapRef::new(store, delta)
             }
             _ => panic!("Unexpected map kind"),
         }
     }
 }
 
-impl<'st, Sch: Schema> crate::transaction::DbTransaction for Transaction<'st, Sch> {
+impl<'tx, 'st: 'tx, Sch: Schema> crate::traits::GetMapMut<'tx, Sch> for TransactionRw<'st, Sch> {
+    type MapMut = SingleMapMut<'tx>;
+
+    fn get_mut<Col: schema::Column, I>(&'tx mut self) -> SingleMapMut<'tx> {
+        match (self.store.get(Col::NAME), self.delta.get_mut(Col::NAME)) {
+            (Some(StoreMap::Single(store)), Some(DeltaMap::Single(delta))) => {
+                SingleMapMut::new(store, delta)
+            }
+            _ => panic!("Unexpected map kind"),
+        }
+    }
+}
+
+impl<'st, Sch: Schema> crate::transaction::TransactionRo for TransactionRo<'st, Sch> {
+    type Error = crate::Error;
+
+    fn finalize(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'st, Sch: Schema> crate::transaction::TransactionRw for TransactionRw<'st, Sch> {
     type Error = crate::Error;
 
     /// Commit a transaction
@@ -183,35 +237,73 @@ impl<'st, Sch: Schema> crate::transaction::DbTransaction for Transaction<'st, Sc
     }
 }
 
-/// Represents a key-value store with keys mapping to one value.
-pub struct SingleMap<'tx> {
+/// Represents an immutable store with keys mapping to one value inside a read-only transaction.
+pub struct SingleMapView<'tx>(&'tx StoreMapSingle);
+
+impl<'tx> SingleMapView<'tx> {
+    fn new(store: &'tx StoreMapSingle) -> Self {
+        Self(store)
+    }
+}
+
+impl crate::traits::MapRef for SingleMapView<'_> {
+    fn get(&self, key: &[u8]) -> crate::Result<Option<&[u8]>> {
+        Ok(self.0.get(key).map(AsRef::as_ref))
+    }
+}
+
+/// Represents an immutable key-value store with keys mapping to one value.
+pub struct SingleMapRef<'tx> {
+    store: &'tx StoreMapSingle,
+    delta: &'tx DeltaMapSingle,
+}
+
+impl<'tx> SingleMapRef<'tx> {
+    fn new(store: &'tx StoreMapSingle, delta: &'tx DeltaMapSingle) -> Self {
+        Self { store, delta }
+    }
+}
+
+impl crate::traits::MapRef for SingleMapRef<'_> {
+    fn get(&self, key: &[u8]) -> crate::Result<Option<&[u8]>> {
+        let res = match &self.delta.get(key) {
+            Some(val) => val.as_ref(),
+            None => self.store.get(key),
+        };
+        Ok(res.map(AsRef::as_ref))
+    }
+}
+
+/// Represents a mutable key-value store with keys mapping to one value.
+pub struct SingleMapMut<'tx> {
     store: &'tx StoreMapSingle,
     delta: &'tx mut DeltaMapSingle,
 }
 
-impl<'tx> SingleMap<'tx> {
+impl<'tx> SingleMapMut<'tx> {
     fn new(store: &'tx StoreMapSingle, delta: &'tx mut DeltaMapSingle) -> Self {
         Self { store, delta }
     }
+}
 
-    /// Get value associated with given key
-    pub fn get(&self, key: impl AsRef<[u8]>) -> crate::Result<Option<&[u8]>> {
-        let res = match &self.delta.get(key.as_ref()) {
+impl crate::traits::MapRef for SingleMapMut<'_> {
+    fn get(&self, key: &[u8]) -> crate::Result<Option<&[u8]>> {
+        let res = match &self.delta.get(key) {
             Some(val) => val.as_ref(),
-            None => self.store.get(key.as_ref()),
+            None => self.store.get(key),
         };
         Ok(res.map(AsRef::as_ref))
     }
+}
 
-    /// Insert a value associated with given key, overwriting the original one.
-    pub fn put(&mut self, key: Data, val: Data) -> crate::Result<()> {
+impl crate::traits::MapMut for SingleMapMut<'_> {
+    fn put(&mut self, key: Data, val: Data) -> crate::Result<()> {
         self.delta.insert(key, Some(val));
         Ok(())
     }
 
-    /// Delete the value associated with given key.
-    pub fn del(&mut self, key: impl AsRef<[u8]>) -> crate::Result<()> {
-        self.delta.insert(key.as_ref().to_vec(), None);
+    fn del(&mut self, key: &[u8]) -> crate::Result<()> {
+        self.delta.insert(key.to_vec(), None);
         Ok(())
     }
 }

--- a/storage/src/traits.rs
+++ b/storage/src/traits.rs
@@ -1,0 +1,51 @@
+//! Traits that constitute storage interface.
+
+use crate::schema;
+pub use crate::transaction::{TransactionRo, TransactionRw, Transactional};
+
+/// Get a reference to given single-valued column
+pub trait GetMapRef<'tx, Sch: schema::Schema> {
+    /// Type representing the map reference
+    type MapRef: MapRef;
+
+    /// Get key-value store for given column mutably (key-to-single-value only for now)
+    fn get<Col, I>(&'tx self) -> Self::MapRef
+    where
+        Col: schema::Column<Kind = schema::Single>,
+        Sch: schema::HasColumn<Col, I>;
+}
+
+/// Get a mutable reference to given single-valued column
+pub trait GetMapMut<'tx, Sch: schema::Schema> {
+    /// Type representing the map reference
+    type MapMut: MapMut;
+
+    /// Get key-value store for given column mutably (key-to-single-value only for now)
+    fn get_mut<Col, I>(&'tx mut self) -> Self::MapMut
+    where
+        Col: schema::Column<Kind = schema::Single>,
+        Sch: schema::HasColumn<Col, I>;
+}
+
+/// Read operations on a single-valued map
+pub trait MapRef {
+    /// Get value associated with given key
+    fn get(&self, key: &[u8]) -> crate::Result<Option<&[u8]>>;
+}
+
+/// Modifying operations on a single-valued map
+pub trait MapMut: MapRef {
+    /// Insert a value associated with given key, overwriting the original one.
+    fn put(&mut self, key: crate::Data, val: crate::Data) -> crate::Result<()>;
+
+    /// Delete the value associated with given key.
+    fn del(&mut self, key: &[u8]) -> crate::Result<()>;
+}
+
+/// A transaction over an immutable store
+pub trait StoreTxRo<'tx, Sch: schema::Schema>: TransactionRo + GetMapRef<'tx, Sch> {}
+impl<'tx, S: schema::Schema, T: TransactionRo + GetMapRef<'tx, S>> StoreTxRo<'tx, S> for T {}
+
+/// A transaction over a mutable store
+pub trait StoreTxRw<'tx, Sch: schema::Schema>: TransactionRw + GetMapMut<'tx, Sch> {}
+impl<'tx, S: schema::Schema, T: TransactionRw + GetMapMut<'tx, S>> StoreTxRw<'tx, S> for T {}


### PR DESCRIPTION
* Method signature specifies mutability in a more precise way
* Database transactions distinguish between read-only transactions and read-write transactions
* Introduced traits abstracting over low-level storage operations

TODO:

- [x] In-memory storage could now use `RwLock` rather than `Mutex`
- [ ] Blockchain storage still uses one transaction type, not taking
       advantage of the separation between ro and rw transactions.
- [x] Update docs