### PR TITLE
Proof of Work Config from ChainConfig

### DIFF
--- a/common/src/chain/config.rs
+++ b/common/src/chain/config.rs
@@ -40,6 +40,10 @@ pub struct ChainConfig {
 }
 
 impl ChainConfig {
+    pub fn chain_type(&self) -> ChainType {
+        self.chain_type
+    }
+
     pub fn address_prefix(&self) -> &str {
         &self.address_prefix
     }
@@ -102,6 +106,7 @@ pub fn create_mainnet() -> ChainConfig {
     }
 }
 
+#[cfg(test)]
 mod tests {
 
     #[test]

--- a/common/src/chain/config.rs
+++ b/common/src/chain/config.rs
@@ -2,7 +2,7 @@ use crate::address::Address;
 use crate::chain::block::Block;
 use crate::chain::transaction::Transaction;
 use crate::chain::upgrades::NetUpgrades;
-use crate::chain::UpgradeVersion;
+use crate::chain::{PoWChainConfig, UpgradeVersion};
 use crate::primitives::consensus_data::ConsensusData;
 use crate::primitives::id::{Id, H256};
 use crate::primitives::{version::SemVer, BlockHeight};
@@ -40,10 +40,6 @@ pub struct ChainConfig {
 }
 
 impl ChainConfig {
-    pub fn chain_type(&self) -> ChainType {
-        self.chain_type
-    }
-
     pub fn address_prefix(&self) -> &str {
         &self.address_prefix
     }
@@ -62,6 +58,10 @@ impl ChainConfig {
 
     pub fn net_upgrade(&self) -> &NetUpgrades<UpgradeVersion> {
         &self.net_upgrades
+    }
+
+    pub const fn get_proof_of_work_config(&self) -> PoWChainConfig {
+        PoWChainConfig::new(self.chain_type)
     }
 }
 

--- a/common/src/chain/mod.rs
+++ b/common/src/chain/mod.rs
@@ -1,9 +1,11 @@
 pub mod block;
 pub mod config;
+mod pow;
 pub mod transaction;
 mod upgrades;
 
 pub use transaction::*;
 
 pub use config::ChainConfig;
+pub use pow::PoWChainConfig;
 pub use upgrades::*;

--- a/common/src/chain/pow.rs
+++ b/common/src/chain/pow.rs
@@ -1,68 +1,73 @@
 use crate::chain::config::ChainType;
-use crate::chain::ChainConfig;
 use crate::Uint256;
 use std::time::Duration;
 
-/// Chain Parameters for Proof of Work, as found in
-/// https://github.com/bitcoin/bitcoin/blob/eca694a4e78d54ce4e29b388b3e81b06e55c2293/src/chainparams.cpp
+/// Chain Parameters for Proof of Work.
+///
+/// See in Bitcoin's [chainparams.cpp](https://github.com/bitcoin/bitcoin/blob/eca694a4e78d54ce4e29b388b3e81b06e55c2293/src/chainparams.cpp)
+#[derive(Debug)]
 pub struct PoWChainConfig {
     no_retargeting: bool,
+    /// Checks whether minimum difficulty can be used for the block
     allow_min_difficulty_blocks: bool,
+    /// The lowest possible difficulty
     limit: Uint256,
 }
 
-impl ChainConfig {
-    pub fn get_pow_config(&self) -> PoWChainConfig {
+impl PoWChainConfig {
+    pub(crate) const fn new(chain_type: ChainType) -> Self {
         PoWChainConfig {
-            no_retargeting: no_retargeting(&self.chain_type()),
-            allow_min_difficulty_blocks: allow_min_difficulty_blocks(&self.chain_type()),
-            limit: limit(&self.chain_type()),
+            no_retargeting: no_retargeting(chain_type),
+            allow_min_difficulty_blocks: allow_min_difficulty_blocks(chain_type),
+            limit: limit(chain_type),
         }
     }
-}
 
-impl PoWChainConfig {
-    pub fn no_retargeting(&self) -> bool {
+    pub const fn no_retargeting(&self) -> bool {
         self.no_retargeting
     }
 
-    pub fn allow_min_difficulty_blocks(&self) -> bool {
+    pub const fn allow_min_difficulty_blocks(&self) -> bool {
         self.allow_min_difficulty_blocks
     }
 
-    pub fn limit(&self) -> Uint256 {
+    pub const fn limit(&self) -> Uint256 {
         self.limit
     }
 
-    pub fn target_timespan(&self) -> Duration {
+    /// The difficulty changes every 2016 blocks, or approximately 2 weeks.
+    /// See Bitcoin's Protocol Rules of [Difficulty change](https://en.bitcoin.it/wiki/Protocol_rules)
+    pub const fn target_timespan(&self) -> Duration {
         Duration::new(14 * 24 * 60 * 60, 0)
     }
 
-    pub fn target_spacing(&self) -> Duration {
+    /// The average rate of generating a block is set to every 10 minutes
+    pub const fn target_spacing(&self) -> Duration {
         Duration::new(10 * 60, 0)
     }
 
-    /// https://github.com/bitcoin/bitcoin/blob/eca694a4e78d54ce4e29b388b3e81b06e55c2293/src/pow.cpp#L56
-    pub fn max_difficulty_adjustment_per_interval(&self) -> u64 {
+    /// A single retarget never changes the target by more than a factor of 4.
+    /// See Bitcoin's [Target](https://en.bitcoin.it/wiki/Target) article.
+    pub const fn max_retarget_factor(&self) -> u64 {
         4
     }
 }
 
-fn no_retargeting(chain_type: &ChainType) -> bool {
+const fn no_retargeting(chain_type: ChainType) -> bool {
     match chain_type {
         ChainType::Mainnet | ChainType::Testnet | ChainType::Signet => false,
         ChainType::Regtest => true,
     }
 }
 
-fn allow_min_difficulty_blocks(chain_type: &ChainType) -> bool {
+const fn allow_min_difficulty_blocks(chain_type: ChainType) -> bool {
     match chain_type {
         ChainType::Mainnet | ChainType::Signet => false,
         ChainType::Testnet | ChainType::Regtest => true,
     }
 }
 
-fn limit(chain_type: &ChainType) -> Uint256 {
+const fn limit(chain_type: ChainType) -> Uint256 {
     match chain_type {
         ChainType::Mainnet | ChainType::Testnet => Uint256([
             0xFFFFFFFFFFFFFFFF,
@@ -87,26 +92,26 @@ fn limit(chain_type: &ChainType) -> Uint256 {
 
 #[cfg(test)]
 mod tests {
-    use crate::chain::config::create_mainnet;
+    use crate::chain::config::{create_mainnet, ChainType};
     use crate::chain::pow::{allow_min_difficulty_blocks, limit, no_retargeting};
 
     #[test]
     fn check_mainnet_powconfig() {
         let cfg = create_mainnet();
 
-        let mainnet_cfg = cfg.get_pow_config();
+        let mainnet_cfg = cfg.get_proof_of_work_config();
 
         assert_eq!(
-            mainnet_cfg.no_retargeting,
-            no_retargeting(&cfg.chain_type())
+            mainnet_cfg.no_retargeting(),
+            no_retargeting(ChainType::Mainnet)
         );
         assert_eq!(
-            mainnet_cfg.allow_min_difficulty_blocks,
-            allow_min_difficulty_blocks(&cfg.chain_type())
+            mainnet_cfg.allow_min_difficulty_blocks(),
+            allow_min_difficulty_blocks(ChainType::Mainnet)
         );
-        assert_eq!(mainnet_cfg.limit, limit(&cfg.chain_type()));
+        assert_eq!(mainnet_cfg.limit(), limit(ChainType::Mainnet));
 
-        assert_eq!(mainnet_cfg.no_retargeting, false);
-        assert_eq!(mainnet_cfg.allow_min_difficulty_blocks, false);
+        assert!(!mainnet_cfg.no_retargeting());
+        assert!(!mainnet_cfg.allow_min_difficulty_blocks());
     }
 }

--- a/common/src/chain/pow.rs
+++ b/common/src/chain/pow.rs
@@ -1,0 +1,112 @@
+use crate::chain::config::ChainType;
+use crate::chain::ChainConfig;
+use crate::Uint256;
+use std::time::Duration;
+
+/// Chain Parameters for Proof of Work, as found in
+/// https://github.com/bitcoin/bitcoin/blob/eca694a4e78d54ce4e29b388b3e81b06e55c2293/src/chainparams.cpp
+pub struct PoWChainConfig {
+    no_retargeting: bool,
+    allow_min_difficulty_blocks: bool,
+    limit: Uint256,
+}
+
+impl ChainConfig {
+    pub fn get_pow_config(&self) -> PoWChainConfig {
+        PoWChainConfig {
+            no_retargeting: no_retargeting(&self.chain_type()),
+            allow_min_difficulty_blocks: allow_min_difficulty_blocks(&self.chain_type()),
+            limit: limit(&self.chain_type()),
+        }
+    }
+}
+
+impl PoWChainConfig {
+    pub fn no_retargeting(&self) -> bool {
+        self.no_retargeting
+    }
+
+    pub fn allow_min_difficulty_blocks(&self) -> bool {
+        self.allow_min_difficulty_blocks
+    }
+
+    pub fn limit(&self) -> Uint256 {
+        self.limit
+    }
+
+    pub fn target_timespan(&self) -> Duration {
+        Duration::new(14 * 24 * 60 * 60, 0)
+    }
+
+    pub fn target_spacing(&self) -> Duration {
+        Duration::new(10 * 60, 0)
+    }
+
+    /// https://github.com/bitcoin/bitcoin/blob/eca694a4e78d54ce4e29b388b3e81b06e55c2293/src/pow.cpp#L56
+    pub fn max_difficulty_adjustment_per_interval(&self) -> u64 {
+        4
+    }
+}
+
+fn no_retargeting(chain_type: &ChainType) -> bool {
+    match chain_type {
+        ChainType::Mainnet | ChainType::Testnet | ChainType::Signet => false,
+        ChainType::Regtest => true,
+    }
+}
+
+fn allow_min_difficulty_blocks(chain_type: &ChainType) -> bool {
+    match chain_type {
+        ChainType::Mainnet | ChainType::Signet => false,
+        ChainType::Testnet | ChainType::Regtest => true,
+    }
+}
+
+fn limit(chain_type: &ChainType) -> Uint256 {
+    match chain_type {
+        ChainType::Mainnet | ChainType::Testnet => Uint256([
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0x00000000FFFFFFFF,
+        ]),
+        ChainType::Signet => Uint256([
+            0x0000000000000000,
+            0x0000000000000000,
+            0x0000000000000000,
+            0x00000377AE000000,
+        ]),
+        ChainType::Regtest => Uint256([
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0x7FFFFFFFFFFFFFFF,
+        ]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::chain::config::create_mainnet;
+    use crate::chain::pow::{allow_min_difficulty_blocks, limit, no_retargeting};
+
+    #[test]
+    fn check_mainnet_powconfig() {
+        let cfg = create_mainnet();
+
+        let mainnet_cfg = cfg.get_pow_config();
+
+        assert_eq!(
+            mainnet_cfg.no_retargeting,
+            no_retargeting(&cfg.chain_type())
+        );
+        assert_eq!(
+            mainnet_cfg.allow_min_difficulty_blocks,
+            allow_min_difficulty_blocks(&cfg.chain_type())
+        );
+        assert_eq!(mainnet_cfg.limit, limit(&cfg.chain_type()));
+
+        assert_eq!(mainnet_cfg.no_retargeting, false);
+        assert_eq!(mainnet_cfg.allow_min_difficulty_blocks, false);
+    }
+}


### PR DESCRIPTION
Based on the comment: https://github.com/mintlayer/mintlayer-core/pull/62/files#r801270588
Removed all `const`.
All PoW related config can be derived from `ChainConfig`, using the `chain_type` field. 

Computed values like the `UPPER_TARGET_TIMESPAN_SECS` and `LOWER_TARGET_TIMESPAN_SECS` and `DIFFICULTY_ADJUSTMENT_INTERVAL` will be functions in the PoW package of consensus module.