### PR TITLE
proof of work based on bitcoin.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
  "blockchain-storage",
  "common",
  "logging",
+ "num",
  "rand 0.8.4",
 ]
 

--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -1,5 +1,5 @@
+use crate::chain::block::ConsensusData;
 use crate::chain::transaction::Transaction;
-use crate::primitives::consensus_data::ConsensusData;
 use crate::primitives::{id, Id, Idable, H256};
 use parity_scale_codec_derive::{Decode as DecodeDer, Encode as EncodeDer};
 

--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -38,7 +38,7 @@ impl BlockV1 {
         self.header.consensus_data = consensus_data;
     }
 
-    pub fn get_consensus_data(&self) -> &ConsensusData {
+    pub fn consensus_data(&self) -> &ConsensusData {
         &self.header.consensus_data
     }
 

--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -38,6 +38,10 @@ impl BlockV1 {
         self.header.consensus_data = consensus_data;
     }
 
+    pub fn get_consensus_data(&self) -> &ConsensusData {
+        &self.header.consensus_data
+    }
+
     pub fn get_block_time(&self) -> u32 {
         self.header.time
     }

--- a/common/src/chain/block/consensus_data.rs
+++ b/common/src/chain/block/consensus_data.rs
@@ -1,3 +1,4 @@
+use crate::chain::TxOutput;
 use crate::primitives::Compact;
 use parity_scale_codec::{Decode, Encode};
 
@@ -13,11 +14,17 @@ pub enum ConsensusData {
 pub struct PoWData {
     bits: Compact,
     nonce: u128,
+    /// contains the block reward
+    outputs: Vec<TxOutput>,
 }
 
 impl PoWData {
-    pub fn new(bits: Compact, nonce: u128) -> Self {
-        PoWData { bits, nonce }
+    pub fn new(bits: Compact, nonce: u128, outputs: Vec<TxOutput>) -> Self {
+        PoWData {
+            bits,
+            nonce,
+            outputs,
+        }
     }
     pub fn bits(&self) -> Compact {
         self.bits
@@ -25,5 +32,13 @@ impl PoWData {
 
     pub fn nonce(&self) -> u128 {
         self.nonce
+    }
+
+    pub fn outputs(&self) -> &[TxOutput] {
+        &self.outputs
+    }
+
+    pub fn update_nonce(&mut self, nonce: u128) {
+        self.nonce = nonce;
     }
 }

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -21,10 +21,11 @@ use crate::primitives::merkle::MerkleTreeFormError;
 use crate::primitives::H256;
 use crate::primitives::{Id, Idable};
 mod block_v1;
+pub mod consensus_data;
 
-use crate::primitives::consensus_data::ConsensusData;
 use block_v1::BlockHeader;
 use block_v1::BlockV1;
+pub use consensus_data::ConsensusData;
 use parity_scale_codec::{Decode, Encode};
 
 pub fn calculate_tx_merkle_root(

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -114,9 +114,9 @@ impl Block {
         }
     }
 
-    pub fn get_consensus_data(&self) -> &ConsensusData {
+    pub fn consensus_data(&self) -> &ConsensusData {
         match self {
-            Block::V1(blk) => blk.get_consensus_data()
+            Block::V1(blk) => blk.consensus_data()
         }
     }
 

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -114,6 +114,12 @@ impl Block {
         }
     }
 
+    pub fn get_consensus_data(&self) -> &ConsensusData {
+        match self {
+            Block::V1(blk) => blk.get_consensus_data()
+        }
+    }
+
     pub fn get_merkle_root(&self) -> H256 {
         match &self {
             Block::V1(blk) => blk.get_tx_merkle_root(),

--- a/common/src/chain/config.rs
+++ b/common/src/chain/config.rs
@@ -1,9 +1,9 @@
 use crate::address::Address;
 use crate::chain::block::Block;
+use crate::chain::block::ConsensusData;
 use crate::chain::transaction::Transaction;
 use crate::chain::upgrades::NetUpgrades;
 use crate::chain::{PoWChainConfig, UpgradeVersion};
-use crate::primitives::consensus_data::ConsensusData;
 use crate::primitives::id::{Id, H256};
 use crate::primitives::{version::SemVer, BlockHeight};
 use std::collections::BTreeMap;

--- a/common/src/chain/pow.rs
+++ b/common/src/chain/pow.rs
@@ -121,7 +121,7 @@ mod tests {
             0
         );
 
-        assert_eq!(&ConsensusData::None, cfg.genesis_block().get_consensus_data());
+        assert_eq!(&ConsensusData::None, cfg.genesis_block().consensus_data());
 
         if !mainnet_cfg.no_retargeting() {
             let target_max = Uint256([

--- a/common/src/chain/pow.rs
+++ b/common/src/chain/pow.rs
@@ -92,8 +92,10 @@ const fn limit(chain_type: ChainType) -> Uint256 {
 
 #[cfg(test)]
 mod tests {
+    use crate::chain::block::ConsensusData;
     use crate::chain::config::{create_mainnet, ChainType};
     use crate::chain::pow::{allow_min_difficulty_blocks, limit, no_retargeting};
+    use crate::Uint256;
 
     #[test]
     fn check_mainnet_powconfig() {
@@ -113,5 +115,26 @@ mod tests {
 
         assert!(!mainnet_cfg.no_retargeting());
         assert!(!mainnet_cfg.allow_min_difficulty_blocks());
+
+        assert_eq!(
+            mainnet_cfg.target_timespan().as_secs() % mainnet_cfg.target_spacing().as_secs(),
+            0
+        );
+
+        assert_eq!(&ConsensusData::None, cfg.genesis_block().get_consensus_data());
+
+        if !mainnet_cfg.no_retargeting() {
+            let target_max = Uint256([
+                0xFFFFFFFFFFFFFFFF,
+                0xFFFFFFFFFFFFFFFF,
+                0xFFFFFFFFFFFFFFFF,
+                0xFFFFFFFFFFFFFFFF,
+            ]);
+
+            let target_max = target_max
+                / Uint256::from_u64(mainnet_cfg.target_timespan().as_secs() * 4)
+                    .expect("should be okay");
+            assert!(mainnet_cfg.limit() < target_max);
+        }
     }
 }

--- a/common/src/primitives/compact.rs
+++ b/common/src/primitives/compact.rs
@@ -127,5 +127,6 @@ mod tests {
 
         err_conversion(0x04923456);
         err_conversion(0x01fedcba);
+        err_conversion(!0x00800000); // overflow
     }
 }

--- a/common/src/primitives/consensus_data.rs
+++ b/common/src/primitives/consensus_data.rs
@@ -14,3 +14,16 @@ pub struct PoWData {
     bits: Compact,
     nonce: u128,
 }
+
+impl PoWData {
+    pub fn new(bits: Compact, nonce: u128) -> Self {
+        PoWData { bits, nonce }
+    }
+    pub fn bits(&self) -> Compact {
+        self.bits
+    }
+
+    pub fn nonce(&self) -> u128 {
+        self.nonce
+    }
+}

--- a/common/src/primitives/mod.rs
+++ b/common/src/primitives/mod.rs
@@ -25,7 +25,6 @@ pub mod id;
 pub mod merkle;
 pub mod time;
 
-pub mod consensus_data;
 pub mod version;
 
 pub use amount::Amount;

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -9,5 +9,6 @@ license = "MIT"
 [dependencies]
 blockchain-storage = { path = '../blockchain_storage'}
 common = { path = '../common'}
+num = "0.4.0"
 rand = "0.8.4"
 logging = { path = '../logging'}

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -3,6 +3,10 @@
 // use common::chain::block::Block;
 
 mod orphan_blocks;
+mod pow;
+
+pub use pow::{work::check_proof_of_work, Error as PoWError};
+
 // use orphan_blocks::OrphanBlocks;
 
 // struct Consensus<S: BlockchainStorage> {

--- a/consensus/src/orphan_blocks.rs
+++ b/consensus/src/orphan_blocks.rs
@@ -195,8 +195,8 @@ mod tests {
 
     mod helpers {
         use super::*;
+        use common::chain::block::ConsensusData;
         use common::chain::transaction::Transaction;
-        use common::primitives::consensus_data::ConsensusData;
         use rand::Rng;
 
         pub fn gen_random_blocks(count: u32) -> Vec<Block> {

--- a/consensus/src/pow/helpers.rs
+++ b/consensus/src/pow/helpers.rs
@@ -1,0 +1,110 @@
+use crate::pow::temp::BlockIndex;
+use crate::pow::Error;
+use common::primitives::{BlockHeight, Compact, H256};
+use common::Uint256;
+
+/// checks if retargeting is due for the provided block_height
+pub fn is_for_retarget(difficulty_adjustment_interval: u64, block_height: BlockHeight) -> bool {
+    block_height.inner() % difficulty_adjustment_interval == 0
+}
+
+/// The block time of the nth block, based on the difficulty adjustment interval,
+/// where nth block = height of given block - difficulty adjustment interval - 1 (off by one)
+pub fn retarget_block_time(difficulty_adjustment_interval: u64, block_index: &BlockIndex) -> u32 {
+    let retarget_height = {
+        // Go back by what we want to be 14 days worth of blocks (the last 2015 blocks)
+        let old_block_height = block_index.height.inner() - (difficulty_adjustment_interval - 1);
+        BlockHeight::new(old_block_height)
+    };
+
+    let retarget_block_index = block_index.get_ancestor(retarget_height);
+
+    retarget_block_index.get_block_time()
+}
+
+/// Returns a calculated new target as Compact datatype.
+/// See Bitcoin's Protocol rules of [Difficulty change](https://en.bitcoin.it/wiki/Protocol_rules)
+/// # Arguments
+/// `actual_timespan_of_last_interval` - the actual timespan or the difference between the current block
+/// and the 2016th block before it. This should be in seconds.
+/// `target_timespan` - found in the `PoWChainConfig`. This should be in seconds.
+/// `old_target` - Coming from the last block, this is the `bits` of the PoWData.
+/// `difficulty_limit` - found in the PoWChainConfig, as `limit`
+pub fn calculate_new_target(
+    actual_timespan_of_last_interval: u64,
+    target_timespan: u64,
+    old_target: Compact,
+    difficulty_limit: Uint256,
+) -> Result<Compact, Error> {
+    let actual_timespan = Uint256::from_u64(actual_timespan_of_last_interval).ok_or_else(|| {
+        Error::ConversionError(format!(
+            "conversion of actual timespan {:?} to Uint256 type failed.",
+            actual_timespan_of_last_interval
+        ))
+    })?;
+
+    let target_timespan = Uint256::from_u64(target_timespan).ok_or_else(|| {
+        Error::ConversionError(format!(
+            "conversion of target timespan {:?} to Uint256 type failed.",
+            target_timespan
+        ))
+    })?;
+
+    let old_target = Uint256::try_from(old_target).map_err(|e| {
+        Error::ConversionError(format!(
+            "conversion of bits {:?} to Uint256 type: {:?}",
+            old_target, e
+        ))
+    })?;
+
+    // new target is coputed by  multiplying the old target by ratio of the actual timespan / target timespan.
+    // see Bitcoin's Protocol rules of Difficulty change: https://en.bitcoin.it/wiki/Protocol_rules
+    let mut new_target = old_target * actual_timespan;
+    new_target = new_target / target_timespan;
+
+    new_target = if new_target > difficulty_limit {
+        difficulty_limit
+    } else {
+        new_target
+    };
+
+    Ok(Compact::from(new_target))
+}
+
+pub fn check_difficulty(block_hash: H256, difficulty: &Uint256) -> bool {
+    let id: Uint256 = block_hash.into(); //TODO: needs to be tested
+
+    id <= *difficulty
+}
+
+pub mod special_rules {
+    use super::*;
+
+    /// Checks if it took > 20 minutes to find a block
+    pub fn is_restart_difficulty(
+        target_spacing_in_secs: u64,
+        new_block_time: u32,
+        prev_block_time: u32,
+    ) -> bool {
+        new_block_time as u64 > (prev_block_time as u64 + (target_spacing_in_secs * 2))
+    }
+
+    pub fn last_non_special_min_difficulty(_block_index: &BlockIndex) -> Compact {
+        // Return the last non-special-min-difficulty-rules-block
+        // let mut ctr_index = block_index.clone();
+        // loop {
+        //     let block_bits = ctr_index.data.bits();
+        //     if ctr_index.height == BlockHeight::zero() {
+        //         return block_bits;
+        //     }
+        //
+        //     if is_for_retarget(pow_cfg, ctr_index.height) && block_bits == pow_cfg.limit() {
+        //         match ctr_index.prev() {
+        //             None => { return block_bits; }
+        //             Some(id) => {   }
+        //         }
+        //     }
+        // }
+        todo!()
+    }
+}

--- a/consensus/src/pow/helpers.rs
+++ b/consensus/src/pow/helpers.rs
@@ -4,7 +4,7 @@ use common::primitives::{BlockHeight, Compact};
 use common::Uint256;
 
 /// checks if retargeting is due for the provided block_height
-pub fn is_for_retarget(difficulty_adjustment_interval: u64, block_height: BlockHeight) -> bool {
+pub fn due_for_retarget(difficulty_adjustment_interval: u64, block_height: BlockHeight) -> bool {
     block_height.inner() % difficulty_adjustment_interval == 0
 }
 
@@ -78,7 +78,7 @@ pub mod special_rules {
     use super::*;
 
     /// Checks if it took > 20 minutes to find a block
-    pub fn is_restart_difficulty(
+    pub fn block_production_stalled(
         target_spacing_in_secs: u64,
         new_block_time: u32,
         prev_block_time: u32,
@@ -95,7 +95,7 @@ pub mod special_rules {
         //         return block_bits;
         //     }
         //
-        //     if is_for_retarget(pow_cfg, ctr_index.height) && block_bits == pow_cfg.limit() {
+        //     if due_for_retarget(pow_cfg, ctr_index.height) && block_bits == pow_cfg.limit() {
         //         match ctr_index.prev() {
         //             None => { return block_bits; }
         //             Some(id) => {   }
@@ -108,13 +108,13 @@ pub mod special_rules {
 
 #[cfg(test)]
 mod tests {
-    use crate::pow::helpers::is_for_retarget;
+    use crate::pow::helpers::due_for_retarget;
     use common::primitives::BlockHeight;
 
     #[test]
-    fn is_for_retarget_test() {
+    fn due_for_retarget_test() {
         let interval = 2016;
-        let test = |h: BlockHeight| is_for_retarget(interval, h);
+        let test = |h: BlockHeight| due_for_retarget(interval, h);
 
         assert!(test(BlockHeight::zero()));
         assert!(!test(BlockHeight::one()));

--- a/consensus/src/pow/helpers.rs
+++ b/consensus/src/pow/helpers.rs
@@ -1,6 +1,6 @@
 use crate::pow::temp::BlockIndex;
 use crate::pow::Error;
-use common::primitives::{BlockHeight, Compact, H256};
+use common::primitives::{BlockHeight, Compact};
 use common::Uint256;
 
 /// checks if retargeting is due for the provided block_height
@@ -8,9 +8,12 @@ pub fn is_for_retarget(difficulty_adjustment_interval: u64, block_height: BlockH
     block_height.inner() % difficulty_adjustment_interval == 0
 }
 
-/// The block time of the nth block, based on the difficulty adjustment interval,
-/// where nth block = height of given block - difficulty adjustment interval - 1 (off by one)
-pub fn retarget_block_time(difficulty_adjustment_interval: u64, block_index: &BlockIndex) -> u32 {
+/// The block time of the first block, based on the difficulty adjustment interval,
+/// where first block = height of given block - difficulty adjustment interval - 1 (off by one)
+pub fn get_starting_block_time(
+    difficulty_adjustment_interval: u64,
+    block_index: &BlockIndex,
+) -> u32 {
     let retarget_height = {
         // Go back by what we want to be 14 days worth of blocks (the last 2015 blocks)
         let old_block_height = block_index.height.inner() - (difficulty_adjustment_interval - 1);
@@ -57,7 +60,7 @@ pub fn calculate_new_target(
         ))
     })?;
 
-    // new target is coputed by  multiplying the old target by ratio of the actual timespan / target timespan.
+    // new target is computed by  multiplying the old target by ratio of the actual timespan / target timespan.
     // see Bitcoin's Protocol rules of Difficulty change: https://en.bitcoin.it/wiki/Protocol_rules
     let mut new_target = old_target * actual_timespan;
     new_target = new_target / target_timespan;
@@ -69,12 +72,6 @@ pub fn calculate_new_target(
     };
 
     Ok(Compact::from(new_target))
-}
-
-pub fn check_difficulty(block_hash: H256, difficulty: &Uint256) -> bool {
-    let id: Uint256 = block_hash.into(); //TODO: needs to be tested
-
-    id <= *difficulty
 }
 
 pub mod special_rules {

--- a/consensus/src/pow/helpers.rs
+++ b/consensus/src/pow/helpers.rs
@@ -105,3 +105,25 @@ pub mod special_rules {
         todo!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::pow::helpers::is_for_retarget;
+    use common::primitives::BlockHeight;
+
+    #[test]
+    fn is_for_retarget_test() {
+        let interval = 2016;
+        let test = |h: BlockHeight| is_for_retarget(interval, h);
+
+        assert!(test(BlockHeight::zero()));
+        assert!(!test(BlockHeight::one()));
+        assert!(test(BlockHeight::new(interval)));
+        assert!(!test(BlockHeight::new(interval + 1)));
+        assert!(test(BlockHeight::new(interval * 2)));
+        assert!(test(BlockHeight::new(interval * 5)));
+        assert!(test(BlockHeight::new(interval * 10)));
+        assert!(!test(BlockHeight::new((interval * 10) + 1)));
+        assert!(!test(BlockHeight::new((interval * 10) - 1)));
+    }
+}

--- a/consensus/src/pow/mod.rs
+++ b/consensus/src/pow/mod.rs
@@ -1,5 +1,6 @@
 use common::chain::PoWChainConfig;
 use common::Uint256;
+use std::time::Duration;
 
 mod helpers;
 mod temp;
@@ -27,8 +28,8 @@ impl PoW {
         self.0.allow_min_difficulty_blocks()
     }
 
-    pub fn target_spacing_in_secs(&self) -> u64 {
-        self.0.target_spacing().as_secs()
+    pub fn target_spacing(&self) -> Duration {
+        self.0.target_spacing()
     }
 
     pub fn max_retarget_factor(&self) -> u64 {
@@ -53,6 +54,6 @@ impl PoW {
 
     pub fn difficulty_adjustment_interval(&self) -> u64 {
         // or a total of 2016 blocks
-        self.target_timespan_in_secs() / self.target_spacing_in_secs()
+        self.target_timespan_in_secs() / self.target_spacing().as_secs()
     }
 }

--- a/consensus/src/pow/mod.rs
+++ b/consensus/src/pow/mod.rs
@@ -5,6 +5,7 @@ mod helpers;
 mod temp;
 pub mod work;
 
+#[derive(Debug)]
 pub enum Error {
     BlockToMineError(String),
     ConversionError(String),

--- a/consensus/src/pow/mod.rs
+++ b/consensus/src/pow/mod.rs
@@ -1,0 +1,53 @@
+use common::chain::PoWChainConfig;
+use common::Uint256;
+
+mod helpers;
+mod temp;
+pub mod work;
+
+pub enum Error {
+    BlockToMineError(String),
+    ConversionError(String),
+    OutofBounds(String),
+}
+
+pub struct PoW(PoWChainConfig);
+
+impl PoW {
+    pub fn difficulty_limit(&self) -> Uint256 {
+        self.0.limit()
+    }
+
+    pub fn no_retargeting(&self) -> bool {
+        self.0.no_retargeting()
+    }
+
+    pub fn allow_min_difficulty_blocks(&self) -> bool {
+        self.0.allow_min_difficulty_blocks()
+    }
+
+    pub fn target_spacing_in_secs(&self) -> u64 {
+        self.0.target_spacing().as_secs()
+    }
+
+    pub fn max_retarget_factor(&self) -> u64 {
+        self.0.max_retarget_factor()
+    }
+
+    pub fn target_timespan_in_secs(&self) -> u64 {
+        self.0.target_timespan().as_secs()
+    }
+
+    pub fn max_target_timespan_in_secs(&self) -> u64 {
+        self.target_timespan_in_secs() * self.max_retarget_factor()
+    }
+
+    pub fn min_target_timespan_in_secs(&self) -> u64 {
+        self.target_timespan_in_secs() / self.max_retarget_factor()
+    }
+
+    pub fn difficulty_adjustment_interval(&self) -> u64 {
+        // or a total of 2016 blocks
+        self.target_timespan_in_secs() / self.target_spacing_in_secs()
+    }
+}

--- a/consensus/src/pow/mod.rs
+++ b/consensus/src/pow/mod.rs
@@ -38,10 +38,14 @@ impl PoW {
         self.0.target_timespan().as_secs()
     }
 
+    /// Follows the upper bound of the target timespan (2 weeks * 4) of Bitcoin.
+    /// See Bitcoin's Protocol rules on [Difficulty change](https://en.bitcoin.it/wiki/Protocol_rules)
     pub fn max_target_timespan_in_secs(&self) -> u64 {
         self.target_timespan_in_secs() * self.max_retarget_factor()
     }
 
+    /// Follows the lower bound of the target timespan  (2 weeks / 4) of Bitcoin.
+    /// See Bitcoin's Protocol rules on [Difficulty change](https://en.bitcoin.it/wiki/Protocol_rules)
     pub fn min_target_timespan_in_secs(&self) -> u64 {
         self.target_timespan_in_secs() / self.max_retarget_factor()
     }

--- a/consensus/src/pow/temp.rs
+++ b/consensus/src/pow/temp.rs
@@ -1,0 +1,31 @@
+#![allow(dead_code, unused_variables)]
+// Temporary placeholders. Should be deleted once an actual representation/implementation is ready.
+
+use common::chain::block::Block;
+use common::primitives::consensus_data::PoWData;
+use common::primitives::{BlockHeight, Id};
+
+pub struct BlockIndex {
+    pub height: BlockHeight,
+    pub data: PoWData,
+}
+
+impl BlockIndex {
+    pub fn get_block_time(&self) -> u32 {
+        todo!()
+    }
+
+    pub fn get_ancestor(&self, height: BlockHeight) -> BlockIndex {
+        todo!()
+    }
+
+    pub fn prev(&self) -> Option<Id<Block>> {
+        todo!()
+    }
+}
+
+impl From<Block> for BlockIndex {
+    fn from(_: Block) -> Self {
+        todo!()
+    }
+}

--- a/consensus/src/pow/temp.rs
+++ b/consensus/src/pow/temp.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, unused_variables)]
-// Temporary placeholders. Should be deleted once an actual representation/implementation is ready.
+// TODO: Temporary placeholders. Should be deleted once an actual representation/implementation is ready.
 
 use common::chain::block::consensus_data::PoWData;
 use common::chain::block::Block;

--- a/consensus/src/pow/temp.rs
+++ b/consensus/src/pow/temp.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code, unused_variables)]
 // Temporary placeholders. Should be deleted once an actual representation/implementation is ready.
 
+use common::chain::block::consensus_data::PoWData;
 use common::chain::block::Block;
-use common::primitives::consensus_data::PoWData;
 use common::primitives::{BlockHeight, Id};
 
 pub struct BlockIndex {

--- a/consensus/src/pow/work.rs
+++ b/consensus/src/pow/work.rs
@@ -1,0 +1,133 @@
+#![allow(dead_code)]
+
+use crate::pow::helpers::{
+    calculate_new_target, check_difficulty, is_for_retarget, retarget_block_time, special_rules,
+};
+use crate::pow::temp::BlockIndex;
+use crate::pow::{Error, PoW};
+use common::chain::block::Block;
+use common::primitives::consensus_data::{ConsensusData, PoWData};
+use common::primitives::{Compact, Idable};
+use common::Uint256;
+
+pub fn check_proof_of_work(hash: Uint256, bits: Compact) -> bool {
+    if let Ok(target) = Uint256::try_from(bits) {
+        hash > target
+    } else {
+        false
+    }
+}
+
+impl PoW {
+    /// The difference (in block time) between the current block and 2016th block before the current one.
+    /// This difference should be inclusive between (2 weeks/4) and (2 weeks*4).
+    /// See Bitcoin's Protocol rules on [Difficulty change](https://en.bitcoin.it/wiki/Protocol_rules)
+    pub fn actual_timespan(&self, prev_block_blocktime: u32, retarget_blocktime: u32) -> u64 {
+        let actual_timespan = (prev_block_blocktime - retarget_blocktime) as u64;
+
+        // 2 weeks / 4
+        let lower_bound = self.min_target_timespan_in_secs();
+        // 2 wees * 4
+        let upper_bound = self.max_target_timespan_in_secs();
+
+        if actual_timespan < lower_bound {
+            lower_bound
+        } else if actual_timespan > upper_bound {
+            upper_bound
+        } else {
+            actual_timespan
+        }
+    }
+
+    pub fn get_work_required(
+        &self,
+        prev_block_index: &BlockIndex,
+        new_block_time: u32,
+    ) -> Result<Compact, Error> {
+        //TODO: check prev_block_index exists
+        let prev_block_bits = prev_block_index.data.bits();
+
+        if self.no_retargeting() {
+            return Ok(prev_block_bits);
+        }
+
+        let current_height = prev_block_index
+            .height
+            .checked_add(1)
+            .ok_or_else(|| Error::OutofBounds("max block height has been reached.".to_string()))?;
+        let adjustment_interval = self.difficulty_adjustment_interval();
+
+        if is_for_retarget(adjustment_interval, current_height) {
+            let retarget_block_time = retarget_block_time(adjustment_interval, prev_block_index);
+            self.next_work_required(retarget_block_time, prev_block_index)
+        }
+        // special difficulty rules
+        else if self.allow_min_difficulty_blocks() {
+            Ok(self.next_work_required_for_min_difficulty(new_block_time, prev_block_index))
+        } else {
+            Ok(prev_block_bits)
+        }
+    }
+
+    /// retargeting proof of work
+    fn next_work_required(
+        &self,
+        retarget_block_time: u32,
+        prev_block_index: &BlockIndex,
+    ) -> Result<Compact, Error> {
+        // limit adjustment step
+        let actual_timespan_of_last_interval =
+            self.actual_timespan(prev_block_index.get_block_time(), retarget_block_time);
+
+        calculate_new_target(
+            actual_timespan_of_last_interval,
+            self.target_timespan_in_secs(),
+            prev_block_index.data.bits(),
+            self.difficulty_limit(),
+        )
+    }
+
+    fn next_work_required_for_min_difficulty(
+        &self,
+        new_block_time: u32,
+        prev_block_index: &BlockIndex,
+    ) -> Compact {
+        // If the new block's timestamp is more than 2 * 10 minutes
+        // then allow mining of a min-difficulty block.
+        if special_rules::is_restart_difficulty(
+            self.target_spacing_in_secs(),
+            new_block_time,
+            prev_block_index.get_block_time(),
+        ) {
+            return Compact::from(self.difficulty_limit());
+        }
+
+        // Return the last non-special-min-difficulty-rules-block
+        special_rules::last_non_special_min_difficulty(prev_block_index)
+    }
+}
+
+pub fn mine(block: &mut Block, max_nonce: u128, bits: Compact) -> Result<(), Error> {
+    match Uint256::try_from(bits) {
+        Ok(difficulty) => {
+            for nonce in 0..max_nonce {
+                let data = PoWData::new(bits, nonce);
+
+                block.update_consensus_data(ConsensusData::PoW(data));
+
+                if check_difficulty(block.get_id().get(), &difficulty) {
+                    return Ok(());
+                }
+            }
+        }
+        Err(e) => {
+            return Err(Error::ConversionError(format!(
+                "conversion of bits {:?} to Uint256 type: {:?}",
+                bits, e
+            )));
+        }
+    }
+
+    let err = format!("max nonce {} has been reached.", max_nonce);
+    Err(Error::BlockToMineError(err))
+}


### PR DESCRIPTION
continue from: https://github.com/mintlayer/mintlayer-core/pull/62

address comments: 
https://github.com/mintlayer/mintlayer-core/pull/62#discussion_r801266191
> I don't think the UpgradeVersion is necessary here.

https://github.com/mintlayer/mintlayer-core/pull/62#discussion_r801268578
> Whenever you take a link from github, make sure you use a permalink, which contains the commit hash. You can do this by clicking on the ... on the left of the line number. Why? Because the master branch can always change.

https://github.com/mintlayer/mintlayer-core/pull/62#discussion_r801270588
> This whole file should probably go into ChainConfig. 
TARGET_TIMESPAN_SECS should be in ChainConfig, and should be returned as rust Duration.
Uint256 version should be derived from that, and not hardcoded.
TARGET_SPACING should certainly be in ChainConfig.
DIFFICULTY_ADJUSTMENT_INTERVAL should be a function.
TIMESPAN_ADJUSTMENT_FACTOR: This should be called MAX_DIFFICULTY_ADJUSTMENT_PER_INTERVAL, which is basically the max increase/decrease in work that can happen. This protects from having huge swings in difficulty. Also should go into ChainConfig
Finally, the upper and lower things also should be functions.
Preferably, find a way to group them all under PoW in ChainConfig instead of having them scattered. Maybe just prefix? Maybe substruct? I don't know. Please propose something.


https://github.com/mintlayer/mintlayer-core/pull/62#discussion_r801282932
> The block index contains the height

https://github.com/mintlayer/mintlayer-core/pull/62#discussion_r801283521
> call it "interval" instead of 2016 blocks

https://github.com/mintlayer/mintlayer-core/pull/62#discussion_r801284291
> So why do we have a separate function for testnet if we do this check which is true anyway for testnet? Please combine both functions into one function and make them depend on ChainConfig.

~~Another TODO:~~ To be created in another PR.
https://github.com/mintlayer/mintlayer-core/pull/62#discussion_r801260163
> Sam: This isn't an operation I'm particularly happy about and I think we should discuss the reason why this is necessary. Since we're starting from scratch, let's try to make both H256 and Uint256 use the same order. No need to reverse things every time. This can get very confusing and error-prone very quickly.  

> Ben: As we briefly discussed earlier I think forking fixed_hash is the best way to approach this, my 30s peak makes it look like we should be dandy dependency wise so it's just a case of fixing the macros and tests and we should be good to go.