### PR TITLE
Update `construct_fixed_hash!` to use little-endian

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
+name = "arbitrary"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db55d72333851e17d572bec876e390cd3b11eb1ef53ae821dd9f3b653d2b4569"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,12 +599,13 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "bech32",
  "bitcoin-bech32",
+ "byteorder 1.4.3",
  "crypto",
  "displaydoc",
  "expect-test",
- "fixed-hash",
  "generic-array",
  "hex",
  "hex-literal",
@@ -607,7 +614,9 @@ dependencies = [
  "merkletree",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "quickcheck",
  "rand 0.8.4",
+ "rustc-hex",
  "script",
  "sscanf",
  "static_assertions",
@@ -1015,6 +1024,16 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
@@ -1059,18 +1078,6 @@ checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder 1.4.3",
- "rand 0.8.4",
- "rustc-hex",
- "static_assertions",
 ]
 
 [[package]]
@@ -2168,7 +2175,7 @@ dependencies = [
 name = "logging"
 version = "0.1.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.0",
  "log",
 ]
 
@@ -3082,6 +3089,18 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quickcheck"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+]
 
 [[package]]
 name = "quicksink"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "arbitrary"
-version = "0.4.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db55d72333851e17d572bec876e390cd3b11eb1ef53ae821dd9f3b653d2b4569"
+checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
 
 [[package]]
 name = "arrayref"
@@ -614,7 +614,6 @@ dependencies = [
  "merkletree",
  "parity-scale-codec",
  "parity-scale-codec-derive",
- "quickcheck",
  "rand 0.8.4",
  "rustc-hex",
  "script",
@@ -1020,16 +1019,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "log",
- "regex",
 ]
 
 [[package]]
@@ -2175,7 +2164,7 @@ dependencies = [
 name = "logging"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.9.0",
+ "env_logger",
  "log",
 ]
 
@@ -3089,18 +3078,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quickcheck"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
-dependencies = [
- "env_logger 0.7.1",
- "log",
- "rand 0.7.3",
- "rand_core 0.5.1",
-]
 
 [[package]]
 name = "quicksink"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -24,10 +24,9 @@ sscanf = "0.1.4"
 lazy_static = "1.4.0"
 
 # for fixed_hash
-arbitrary = "0.4"
-byteorder = "1.3.2"
-quickcheck = "0.9.0"
-rustc-hex = "2.0.1"
+arbitrary = "1.1.0"
+byteorder = "1.4.3"
+rustc-hex = "2.1.0"
 
 [dev-dependencies]
 bitcoin-bech32 = "0.12.1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fixed-hash = { version = "0.7.0", default-features = true, features = ["std"] }
 bech32 = "0.8.1"
 thiserror = "1.0.30"
 displaydoc = { default-features = false, version = "0.2" }
@@ -23,6 +22,12 @@ parity-scale-codec = {version = "2.3.1", features = ["derive", "chain-error"]}
 parity-scale-codec-derive = "2.3.1"
 sscanf = "0.1.4"
 lazy_static = "1.4.0"
+
+# for fixed_hash
+arbitrary = "0.4"
+byteorder = "1.3.2"
+quickcheck = "0.9.0"
+rustc-hex = "2.0.1"
 
 [dev-dependencies]
 bitcoin-bech32 = "0.12.1"

--- a/common/src/fixed_hash.rs
+++ b/common/src/fixed_hash.rs
@@ -1,0 +1,805 @@
+// Copyright 2020 Parity Technologies
+//
+// Modified in 2022 by
+//   Carla Yap <carla.yap@rbblab.com>
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Construct a fixed-size hash type.
+///
+/// # Examples
+///
+/// Create a public unformatted hash type with 32 bytes size.
+///
+/// ```
+/// use common::construct_fixed_hash;
+///
+/// construct_fixed_hash!{ pub struct H256(32); }
+/// assert_eq!(std::mem::size_of::<H256>(), 32);
+/// ```
+///
+/// With additional attributes and doc comments.
+///
+/// ```
+/// use common::construct_fixed_hash;
+/// construct_fixed_hash!{
+///     /// My unformatted 160 bytes sized hash type.
+///     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+///     pub struct H160(20);
+/// }
+/// assert_eq!(std::mem::size_of::<H160>(), 20);
+/// ```
+///
+/// The visibility modifier is optional and you can create a private hash type.
+///
+/// ```
+/// use common::construct_fixed_hash;
+/// construct_fixed_hash!{ struct H512(64); }
+/// assert_eq!(std::mem::size_of::<H512>(), 64);
+/// ```
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! construct_fixed_hash {
+	( $(#[$attr:meta])* $visibility:vis struct $name:ident ( $n_bytes:expr ); ) => {
+		#[repr(C)]
+		$(#[$attr])*
+		$visibility struct $name (pub [u8; $n_bytes]);
+
+		impl From<[u8; $n_bytes]> for $name {
+			/// Constructs a hash type from the given bytes array of fixed length.
+            ///
+            /// # Note
+            ///
+            /// The given bytes are interpreted in little endian order.
+			#[inline]
+			fn from(bytes: [u8; $n_bytes]) -> Self {
+				$name(bytes)
+			}
+		}
+
+		impl<'a> From<&'a [u8; $n_bytes]> for $name {
+			/// Constructs a hash type from the given reference
+            /// to the bytes array of fixed length.
+            ///
+            /// # Note
+            ///
+            /// The given bytes are interpreted in little endian order.
+			#[inline]
+			fn from(bytes: &'a [u8; $n_bytes]) -> Self {
+				$name(*bytes)
+			}
+		}
+
+		impl<'a> From<&'a mut [u8; $n_bytes]> for $name {
+			/// Constructs a hash type from the given reference
+            /// to the mutable bytes array of fixed length.
+            ///
+            /// # Note
+            ///
+            /// The given bytes are interpreted in little endian order.
+			#[inline]
+			fn from(bytes: &'a mut [u8; $n_bytes]) -> Self {
+				$name(*bytes)
+			}
+		}
+
+		impl From<$name> for [u8; $n_bytes] {
+			#[inline]
+			fn from(s: $name) -> Self {
+				s.0
+			}
+		}
+
+		impl AsRef<[u8]> for $name {
+			#[inline]
+			fn as_ref(&self) -> &[u8] {
+				self.as_bytes()
+			}
+		}
+
+		impl AsMut<[u8]> for $name {
+			#[inline]
+			fn as_mut(&mut self) -> &mut [u8] {
+				self.as_bytes_mut()
+			}
+		}
+
+		impl $name {
+			/// Returns a new fixed hash where all bits are set to the given byte.
+			#[inline]
+			pub const fn repeat_byte(byte: u8) -> $name {
+				$name([byte; $n_bytes])
+			}
+
+			/// Returns a new zero-initialized fixed hash.
+			#[inline]
+			pub const fn zero() -> $name {
+				$name::repeat_byte(0u8)
+			}
+
+			/// Returns the size of this hash in bytes.
+			#[inline]
+			pub const fn len_bytes() -> usize {
+				$n_bytes
+			}
+
+			/// Extracts a byte slice containing the entire fixed hash.
+			#[inline]
+			pub fn as_bytes(&self) -> &[u8] {
+				&self.0
+			}
+
+			/// Extracts a mutable byte slice containing the entire fixed hash.
+			#[inline]
+			pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+				&mut self.0
+			}
+
+			/// Extracts a reference to the byte array containing the entire fixed hash.
+			#[inline]
+			pub const fn as_fixed_bytes(&self) -> &[u8; $n_bytes] {
+				&self.0
+			}
+
+			/// Extracts a reference to the byte array containing the entire fixed hash.
+			#[inline]
+			pub fn as_fixed_bytes_mut(&mut self) -> &mut [u8; $n_bytes] {
+				&mut self.0
+			}
+
+			/// Returns the inner bytes array.
+			#[inline]
+			pub const fn to_fixed_bytes(self) -> [u8; $n_bytes] {
+				self.0
+			}
+
+			/// Returns a constant raw pointer to the value.
+			#[inline]
+			pub fn as_ptr(&self) -> *const u8 {
+				self.as_bytes().as_ptr()
+			}
+
+			/// Returns a mutable raw pointer to the value.
+			#[inline]
+			pub fn as_mut_ptr(&mut self) -> *mut u8 {
+				self.as_bytes_mut().as_mut_ptr()
+			}
+
+			/// Assign the bytes from the byte slice `src` to `self`.
+            ///
+            /// # Note
+            ///
+            /// The given bytes are interpreted in little endian order.
+            ///
+            /// # Panics
+            ///
+            /// If the length of `src` and the number of bytes in `self` do not match.
+			pub fn assign_from_slice(&mut self, src: &[u8]) {
+				core::assert_eq!(src.len(), $n_bytes);
+				self.as_bytes_mut().copy_from_slice(src);
+			}
+
+			/// Create a new fixed-hash from the given slice `src`.
+            ///
+            /// # Note
+            ///
+            /// The given bytes are interpreted in little endian order.
+            ///
+            /// # Panics
+            ///
+            /// If the length of `src` and the number of bytes in `Self` do not match.
+			pub fn from_slice(src: &[u8]) -> Self {
+				core::assert_eq!(src.len(), $n_bytes);
+				let mut ret = Self::zero();
+				ret.assign_from_slice(src);
+				ret
+			}
+
+			/// Returns `true` if all bits set in `b` are also set in `self`.
+			#[inline]
+			pub fn covers(&self, b: &Self) -> bool {
+				&(b & self) == b
+			}
+
+			/// Returns `true` if no bits are set.
+			#[inline]
+			pub fn is_zero(&self) -> bool {
+				self.as_bytes().iter().all(|&byte| byte == 0u8)
+			}
+		}
+
+		/// Returns the big-endian format
+		impl core::fmt::Debug for $name {
+			fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+				let mut inner = self.0;
+				inner.reverse();
+				core::write!(f, "{:#x}", $name(inner))
+			}
+		}
+
+		/// Returns the little endian format
+		impl core::fmt::Display for $name {
+			fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+				core::write!(f, "0x")?;
+				for i in &self.0[0..2] {
+					core::write!(f, "{:02x}", i)?;
+				}
+				core::write!(f, "…")?;
+				for i in &self.0[$n_bytes - 2..$n_bytes] {
+					core::write!(f, "{:02x}", i)?;
+				}
+				Ok(())
+			}
+		}
+
+		impl core::fmt::LowerHex for $name {
+			fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+				if f.alternate() {
+					core::write!(f, "0x")?;
+				}
+				for i in &self.0[..] {
+					core::write!(f, "{:02x}", i)?;
+				}
+				Ok(())
+			}
+		}
+
+		impl core::fmt::UpperHex for $name {
+			fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+				if f.alternate() {
+					core::write!(f, "0X")?;
+				}
+				for i in &self.0[..] {
+					core::write!(f, "{:02X}", i)?;
+				}
+				Ok(())
+			}
+		}
+
+		impl core::marker::Copy for $name {}
+
+		#[cfg_attr(feature = "dev", allow(expl_impl_clone_on_copy))]
+		impl core::clone::Clone for $name {
+			fn clone(&self) -> $name {
+				let mut ret = $name::zero();
+				ret.0.copy_from_slice(&self.0);
+				ret
+			}
+		}
+
+		impl core::cmp::Eq for $name {}
+
+		impl core::cmp::PartialOrd for $name {
+			fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+				Some(self.cmp(other))
+			}
+		}
+
+		impl core::hash::Hash for $name {
+			fn hash<H>(&self, state: &mut H) where H: core::hash::Hasher {
+				state.write(&self.0);
+				state.finish();
+			}
+		}
+
+		impl<I> core::ops::Index<I> for $name
+		where
+			I: core::slice::SliceIndex<[u8]>
+		{
+			type Output = I::Output;
+
+			#[inline]
+			fn index(&self, index: I) -> &I::Output {
+				&self.as_bytes()[index]
+			}
+		}
+
+		impl<I> core::ops::IndexMut<I> for $name
+		where
+			I: core::slice::SliceIndex<[u8], Output = [u8]>
+		{
+			#[inline]
+			fn index_mut(&mut self, index: I) -> &mut I::Output {
+				&mut self.as_bytes_mut()[index]
+			}
+		}
+
+		impl core::default::Default for $name {
+			#[inline]
+			fn default() -> Self {
+				Self::zero()
+			}
+		}
+
+		impl_ops_for_hash!($name, BitOr, bitor, BitOrAssign, bitor_assign, |, |=);
+		impl_ops_for_hash!($name, BitAnd, bitand, BitAndAssign, bitand_assign, &, &=);
+		impl_ops_for_hash!($name, BitXor, bitxor, BitXorAssign, bitxor_assign, ^, ^=);
+
+		impl_byteorder_for_fixed_hash!($name);
+		impl_rand_for_fixed_hash!($name);
+		impl_cmp_for_fixed_hash!($name);
+		impl_rustc_hex_for_fixed_hash!($name);
+		impl_quickcheck_for_fixed_hash!($name);
+		impl_arbitrary_for_fixed_hash!($name);
+	}
+}
+
+// // Implementation for disabled byteorder crate support.
+// //
+// // # Note
+// //
+// // Feature guarded macro definitions instead of feature guarded impl blocks
+// // to work around the problems of introducing `byteorder` crate feature in
+// // a user crate.
+// #[cfg(not(feature = "byteorder"))]
+// #[macro_export]
+// #[doc(hidden)]
+// macro_rules! impl_byteorder_for_fixed_hash {
+// 	( $name:ident ) => {};
+// }
+
+// Implementation for enabled byteorder crate support.
+//
+// # Note
+//
+// Feature guarded macro definitions instead of feature guarded impl blocks
+// to work around the problems of introducing `byteorder` crate feature in
+// a user crate.
+// #[cfg(feature = "byteorder")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_byteorder_for_fixed_hash {
+    ( $name:ident ) => {
+        /// Utilities using the `byteorder` crate.
+        impl $name {
+            /// Returns the least significant `n` bytes as slice.
+            ///
+            /// # Panics
+            ///
+            /// If `n` is greater than the number of bytes in `self`.
+            #[inline]
+            fn least_significant_bytes(&self, n: usize) -> &[u8] {
+                core::assert_eq!(true, n <= Self::len_bytes());
+                &self[(Self::len_bytes() - n)..]
+            }
+
+            fn to_low_u64_with_byteorder<B>(self) -> u64
+            where
+                B: byteorder::ByteOrder,
+            {
+                let mut buf = [0x0; 8];
+                let capped = core::cmp::min(Self::len_bytes(), 8);
+                buf[(8 - capped)..].copy_from_slice(self.least_significant_bytes(capped));
+                B::read_u64(&buf)
+            }
+
+            /// Returns the lowest 8 bytes interpreted as little-endian.
+            ///
+            /// # Note
+            ///
+            /// For hash type with less than 8 bytes the missing bytes
+            /// are interpreted as being zero.
+            #[inline]
+            pub fn to_low_u64_be(&self) -> u64 {
+                self.to_low_u64_with_byteorder::<byteorder::BigEndian>()
+            }
+
+            /// Returns the lowest 8 bytes interpreted as little-endian.
+            ///
+            /// # Note
+            ///
+            /// For hash type with less than 8 bytes the missing bytes
+            /// are interpreted as being zero.
+            #[inline]
+            pub fn to_low_u64_le(&self) -> u64 {
+                self.to_low_u64_with_byteorder::<byteorder::LittleEndian>()
+            }
+
+            /// Returns the lowest 8 bytes interpreted as native-endian.
+            ///
+            /// # Note
+            ///
+            /// For hash type with less than 8 bytes the missing bytes
+            /// are interpreted as being zero.
+            #[inline]
+            pub fn to_low_u64_ne(&self) -> u64 {
+                self.to_low_u64_with_byteorder::<byteorder::NativeEndian>()
+            }
+
+            fn from_low_u64_with_byteorder<B>(val: u64) -> Self
+            where
+                B: byteorder::ByteOrder,
+            {
+                let mut buf = [0x0; 8];
+                B::write_u64(&mut buf, val);
+
+                let capped = core::cmp::min(Self::len_bytes(), 8);
+                let mut bytes = [0x0; core::mem::size_of::<Self>()];
+                bytes[(Self::len_bytes() - capped)..].copy_from_slice(&buf[..capped]);
+                bytes.reverse();
+                Self::from_slice(&bytes)
+            }
+
+            /// Creates a new hash type from the given `u64` value.
+            ///
+            /// # Note
+            ///
+            /// - The given `u64` value is interpreted as big endian.
+            /// - Ignores the most significant bits of the given value
+            ///   if the hash type has less than 8 bytes.
+            #[inline]
+            pub fn from_low_u64_be(val: u64) -> Self {
+                Self::from_low_u64_with_byteorder::<byteorder::BigEndian>(val)
+            }
+
+            /// Creates a new hash type from the given `u64` value.
+            ///
+            /// # Note
+            ///
+            /// - The given `u64` value is interpreted as little endian.
+            /// - Ignores the most significant bits of the given value
+            ///   if the hash type has less than 8 bytes.
+            #[inline]
+            pub fn from_low_u64_le(val: u64) -> Self {
+                Self::from_low_u64_with_byteorder::<byteorder::LittleEndian>(val)
+            }
+
+            /// Creates a new hash type from the given `u64` value.
+            ///
+            /// # Note
+            ///
+            /// - The given `u64` value is interpreted as native endian.
+            /// - Ignores the most significant bits of the given value
+            ///   if the hash type has less than 8 bytes.
+            #[inline]
+            pub fn from_low_u64_ne(val: u64) -> Self {
+                Self::from_low_u64_with_byteorder::<byteorder::NativeEndian>(val)
+            }
+        }
+    };
+}
+
+// // Implementation for disabled rand crate support.
+// //
+// // # Note
+// //
+// // Feature guarded macro definitions instead of feature guarded impl blocks
+// // to work around the problems of introducing `rand` crate feature in
+// // a user crate.
+// #[cfg(not(feature = "rand"))]
+// #[macro_export]
+// #[doc(hidden)]
+// macro_rules! impl_rand_for_fixed_hash {
+// 	( $name:ident ) => {};
+// }
+
+// Implementation for enabled rand crate support.
+//
+// # Note
+//
+// Feature guarded macro definitions instead of feature guarded impl blocks
+// to work around the problems of introducing `rand` crate feature in
+// a user crate.
+// #[cfg(feature = "rand")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_rand_for_fixed_hash {
+    ( $name:ident ) => {
+        impl rand::distributions::Distribution<$name> for rand::distributions::Standard {
+            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> $name {
+                let mut ret = $name::zero();
+                for byte in ret.as_bytes_mut().iter_mut() {
+                    *byte = rng.gen();
+                }
+                ret
+            }
+        }
+
+        /// Utilities using the `rand` crate.
+        impl $name {
+            /// Assign `self` to a cryptographically random value using the
+            /// given random number generator.
+            pub fn randomize_using<R>(&mut self, rng: &mut R)
+            where
+                R: rand::Rng + ?Sized,
+            {
+                use rand::distributions::Distribution;
+                *self = rand::distributions::Standard.sample(rng);
+            }
+
+            /// Assign `self` to a cryptographically random value.
+            pub fn randomize(&mut self) {
+                let mut rng = rand::rngs::OsRng;
+                self.randomize_using(&mut rng);
+            }
+
+            /// Create a new hash with cryptographically random content using the
+            /// given random number generator.
+            pub fn random_using<R>(rng: &mut R) -> Self
+            where
+                R: rand::Rng + ?Sized,
+            {
+                let mut ret = Self::zero();
+                ret.randomize_using(rng);
+                ret
+            }
+
+            /// Create a new hash with cryptographically random content.
+            pub fn random() -> Self {
+                let mut hash = Self::zero();
+                hash.randomize();
+                hash
+            }
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_cmp_for_fixed_hash {
+    ( $name:ident ) => {
+        impl core::cmp::PartialEq for $name {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                self.as_bytes() == other.as_bytes()
+            }
+        }
+
+        impl core::cmp::Ord for $name {
+            #[inline]
+            fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+                self.as_bytes().cmp(other.as_bytes())
+            }
+        }
+    };
+}
+
+// // Implementation for disabled rustc-hex crate support.
+// //
+// // # Note
+// //
+// // Feature guarded macro definitions instead of feature guarded impl blocks
+// // to work around the problems of introducing `rustc-hex` crate feature in
+// // a user crate.
+// #[cfg(not(feature = "rustc-hex"))]
+// #[macro_export]
+// #[doc(hidden)]
+// macro_rules! impl_rustc_hex_for_fixed_hash {
+// 	( $name:ident ) => {};
+// }
+
+// Implementation for enabled rustc-hex crate support.
+//
+// # Note
+//
+// Feature guarded macro definitions instead of feature guarded impl blocks
+// to work around the problems of introducing `rustc-hex` crate feature in
+// a user crate.
+// #[cfg(feature = "rustc-hex")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_rustc_hex_for_fixed_hash {
+    ( $name:ident ) => {
+        impl core::str::FromStr for $name {
+            type Err = rustc_hex::FromHexError;
+
+            /// Creates a hash type instance from the given string.
+            ///
+            /// # Note
+            ///
+            /// The given input string is interpreted in little endian.
+            ///
+            /// # Errors
+            ///
+            /// - When encountering invalid non hex-digits
+            /// - Upon empty string input or invalid input length in general
+            fn from_str(input: &str) -> core::result::Result<$name, rustc_hex::FromHexError> {
+                let input = input.strip_prefix("0x").unwrap_or(input);
+                let mut iter = rustc_hex::FromHexIter::new(input);
+
+                let mut result = Self::zero();
+
+                for byte in result.as_mut().iter_mut().rev() {
+                    *byte = iter.next().ok_or(Self::Err::InvalidHexLength)??;
+                }
+
+                if iter.next().is_some() {
+                    return Err(Self::Err::InvalidHexLength);
+                }
+                Ok(result)
+            }
+        }
+    };
+}
+
+// // Implementation for disabled quickcheck crate support.
+// //
+// // # Note
+// //
+// // Feature guarded macro definitions instead of feature guarded impl blocks
+// // to work around the problems of introducing `quickcheck` crate feature in
+// // a user crate.
+// #[cfg(not(feature = "quickcheck"))]
+// #[macro_export]
+// #[doc(hidden)]
+// macro_rules! impl_quickcheck_for_fixed_hash {
+// 	( $name:ident ) => {};
+// }
+
+// Implementation for enabled quickcheck crate support.
+//
+// # Note
+//
+// Feature guarded macro definitions instead of feature guarded impl blocks
+// to work around the problems of introducing `quickcheck` crate feature in
+// a user crate.
+// #[cfg(feature = "quickcheck")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_quickcheck_for_fixed_hash {
+    ( $name:ident ) => {
+        impl quickcheck::Arbitrary for $name {
+            fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+                let mut res = [0u8; core::mem::size_of::<Self>()];
+                g.fill_bytes(&mut res[..Self::len_bytes()]);
+                Self::from(res)
+            }
+        }
+    };
+}
+
+// // When the `arbitrary` feature is disabled.
+// //
+// // # Note
+// //
+// // Feature guarded macro definitions instead of feature guarded impl blocks
+// // to work around the problems of introducing `arbitrary` crate feature in
+// // a user crate.
+// #[cfg(not(feature = "arbitrary"))]
+// #[macro_export]
+// #[doc(hidden)]
+// macro_rules! impl_arbitrary_for_fixed_hash {
+// 	( $name:ident ) => {};
+// }
+
+// When the `arbitrary` feature is enabled.
+//
+// # Note
+//
+// Feature guarded macro definitions instead of feature guarded impl blocks
+// to work around the problems of introducing `arbitrary` crate feature in
+// a user crate.
+// #[cfg(feature = "arbitrary")]
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! impl_arbitrary_for_fixed_hash {
+    ( $name:ident ) => {
+        impl arbitrary::Arbitrary for $name {
+            fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                let mut res = Self::zero();
+                u.fill_buffer(&mut res.0)?;
+                Ok(Self::from(res))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_ops_for_hash {
+	(
+		$impl_for:ident,
+		$ops_trait_name:ident,
+		$ops_fn_name:ident,
+		$ops_assign_trait_name:ident,
+		$ops_assign_fn_name:ident,
+		$ops_tok:tt,
+		$ops_assign_tok:tt
+	) => {
+		impl<'r> core::ops::$ops_assign_trait_name<&'r $impl_for> for $impl_for {
+			fn $ops_assign_fn_name(&mut self, rhs: &'r $impl_for) {
+				for (lhs, rhs) in self.as_bytes_mut().iter_mut().zip(rhs.as_bytes()) {
+					*lhs $ops_assign_tok rhs;
+				}
+			}
+		}
+
+		impl core::ops::$ops_assign_trait_name<$impl_for> for $impl_for {
+			#[inline]
+			fn $ops_assign_fn_name(&mut self, rhs: $impl_for) {
+				*self $ops_assign_tok &rhs;
+			}
+		}
+
+		impl<'l, 'r> core::ops::$ops_trait_name<&'r $impl_for> for &'l $impl_for {
+			type Output = $impl_for;
+
+			fn $ops_fn_name(self, rhs: &'r $impl_for) -> Self::Output {
+				let mut ret = self.clone();
+				ret $ops_assign_tok rhs;
+				ret
+			}
+		}
+
+		impl core::ops::$ops_trait_name<$impl_for> for $impl_for {
+			type Output = $impl_for;
+
+			#[inline]
+			fn $ops_fn_name(self, rhs: Self) -> Self::Output {
+				&self $ops_tok &rhs
+			}
+		}
+	};
+}
+
+/// Implements lossy conversions between the given types.
+///
+/// # Note
+///
+/// - Both types must be of different sizes.
+/// - Type `large_ty` must have a larger memory footprint compared to `small_ty`.
+///
+/// # Panics
+///
+/// Both `From` implementations will panic if sizes of the given types
+/// do not meet the requirements stated above.
+///
+/// # Example
+///
+/// ```
+/// use common::{construct_fixed_hash, impl_fixed_hash_conversions};
+///
+/// construct_fixed_hash!{ struct H160(20); }
+/// construct_fixed_hash!{ struct H256(32); }
+/// impl_fixed_hash_conversions!(H256, H160);
+/// // now use it!
+/// assert_eq!(H256::from(H160::zero()), H256::zero());
+/// assert_eq!(H160::from(H256::zero()), H160::zero());
+/// ```
+#[macro_export]
+macro_rules! impl_fixed_hash_conversions {
+    ($large_ty:ident, $small_ty:ident) => {
+        static_assertions::const_assert!(
+            core::mem::size_of::<$small_ty>() < core::mem::size_of::<$large_ty>()
+        );
+
+        impl From<$small_ty> for $large_ty {
+            fn from(value: $small_ty) -> $large_ty {
+                let large_ty_size = $large_ty::len_bytes();
+                let small_ty_size = $small_ty::len_bytes();
+
+                core::debug_assert!(
+                    large_ty_size > small_ty_size
+                        && large_ty_size % 2 == 0
+                        && small_ty_size % 2 == 0
+                );
+
+                let mut ret = $large_ty::zero();
+                ret.as_bytes_mut()[(large_ty_size - small_ty_size)..large_ty_size]
+                    .copy_from_slice(value.as_bytes());
+                ret
+            }
+        }
+
+        impl From<$large_ty> for $small_ty {
+            fn from(value: $large_ty) -> $small_ty {
+                let large_ty_size = $large_ty::len_bytes();
+                let small_ty_size = $small_ty::len_bytes();
+
+                core::debug_assert!(
+                    large_ty_size > small_ty_size
+                        && large_ty_size % 2 == 0
+                        && small_ty_size % 2 == 0
+                );
+
+                let mut ret = $small_ty::zero();
+                ret.as_bytes_mut()
+                    .copy_from_slice(&value[(large_ty_size - small_ty_size)..large_ty_size]);
+                ret
+            }
+        }
+    };
+}

--- a/common/src/fixed_hash.rs
+++ b/common/src/fixed_hash.rs
@@ -322,33 +322,12 @@ macro_rules! construct_fixed_hash {
 		impl_rand_for_fixed_hash!($name);
 		impl_cmp_for_fixed_hash!($name);
 		impl_rustc_hex_for_fixed_hash!($name);
-		impl_quickcheck_for_fixed_hash!($name);
+		// impl_quickcheck_for_fixed_hash!($name);
 		impl_arbitrary_for_fixed_hash!($name);
 	}
 }
 
-// // Implementation for disabled byteorder crate support.
-// //
-// // # Note
-// //
-// // Feature guarded macro definitions instead of feature guarded impl blocks
-// // to work around the problems of introducing `byteorder` crate feature in
-// // a user crate.
-// #[cfg(not(feature = "byteorder"))]
-// #[macro_export]
-// #[doc(hidden)]
-// macro_rules! impl_byteorder_for_fixed_hash {
-// 	( $name:ident ) => {};
-// }
-
 // Implementation for enabled byteorder crate support.
-//
-// # Note
-//
-// Feature guarded macro definitions instead of feature guarded impl blocks
-// to work around the problems of introducing `byteorder` crate feature in
-// a user crate.
-// #[cfg(feature = "byteorder")]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_byteorder_for_fixed_hash {
@@ -462,28 +441,7 @@ macro_rules! impl_byteorder_for_fixed_hash {
     };
 }
 
-// // Implementation for disabled rand crate support.
-// //
-// // # Note
-// //
-// // Feature guarded macro definitions instead of feature guarded impl blocks
-// // to work around the problems of introducing `rand` crate feature in
-// // a user crate.
-// #[cfg(not(feature = "rand"))]
-// #[macro_export]
-// #[doc(hidden)]
-// macro_rules! impl_rand_for_fixed_hash {
-// 	( $name:ident ) => {};
-// }
-
-// Implementation for enabled rand crate support.
-//
-// # Note
-//
-// Feature guarded macro definitions instead of feature guarded impl blocks
-// to work around the problems of introducing `rand` crate feature in
-// a user crate.
-// #[cfg(feature = "rand")]
+// Implementation for rand crate support.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_rand_for_fixed_hash {
@@ -557,28 +515,7 @@ macro_rules! impl_cmp_for_fixed_hash {
     };
 }
 
-// // Implementation for disabled rustc-hex crate support.
-// //
-// // # Note
-// //
-// // Feature guarded macro definitions instead of feature guarded impl blocks
-// // to work around the problems of introducing `rustc-hex` crate feature in
-// // a user crate.
-// #[cfg(not(feature = "rustc-hex"))]
-// #[macro_export]
-// #[doc(hidden)]
-// macro_rules! impl_rustc_hex_for_fixed_hash {
-// 	( $name:ident ) => {};
-// }
-
-// Implementation for enabled rustc-hex crate support.
-//
-// # Note
-//
-// Feature guarded macro definitions instead of feature guarded impl blocks
-// to work around the problems of introducing `rustc-hex` crate feature in
-// a user crate.
-// #[cfg(feature = "rustc-hex")]
+// Implementation for rustc-hex crate support.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_rustc_hex_for_fixed_hash {
@@ -615,71 +552,33 @@ macro_rules! impl_rustc_hex_for_fixed_hash {
     };
 }
 
-// // Implementation for disabled quickcheck crate support.
-// //
-// // # Note
-// //
-// // Feature guarded macro definitions instead of feature guarded impl blocks
-// // to work around the problems of introducing `quickcheck` crate feature in
-// // a user crate.
-// #[cfg(not(feature = "quickcheck"))]
+//
+// TODO: works on version 0.9.0. But has version conflicts with env_logger.
+// Upgrading the quickcheck version also removes the `fill_bytes` method.
+// See issue: [missing fill_bytes](https://github.com/BurntSushi/quickcheck/issues/291)
+//
+//Implementation for quickcheck crate support.
 // #[macro_export]
 // #[doc(hidden)]
 // macro_rules! impl_quickcheck_for_fixed_hash {
-// 	( $name:ident ) => {};
+//     ( $name:ident ) => {
+//         impl quickcheck::Arbitrary for $name {
+//             fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+//                 let mut res = [0u8; core::mem::size_of::<Self>()];
+//                 g.fill_bytes(&mut res[..Self::len_bytes()]);
+//                 Self::from(res)
+//             }
+//         }
+//     };
 // }
 
-// Implementation for enabled quickcheck crate support.
-//
-// # Note
-//
-// Feature guarded macro definitions instead of feature guarded impl blocks
-// to work around the problems of introducing `quickcheck` crate feature in
-// a user crate.
-// #[cfg(feature = "quickcheck")]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! impl_quickcheck_for_fixed_hash {
-    ( $name:ident ) => {
-        impl quickcheck::Arbitrary for $name {
-            fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
-                let mut res = [0u8; core::mem::size_of::<Self>()];
-                g.fill_bytes(&mut res[..Self::len_bytes()]);
-                Self::from(res)
-            }
-        }
-    };
-}
-
-// // When the `arbitrary` feature is disabled.
-// //
-// // # Note
-// //
-// // Feature guarded macro definitions instead of feature guarded impl blocks
-// // to work around the problems of introducing `arbitrary` crate feature in
-// // a user crate.
-// #[cfg(not(feature = "arbitrary"))]
-// #[macro_export]
-// #[doc(hidden)]
-// macro_rules! impl_arbitrary_for_fixed_hash {
-// 	( $name:ident ) => {};
-// }
-
-// When the `arbitrary` feature is enabled.
-//
-// # Note
-//
-// Feature guarded macro definitions instead of feature guarded impl blocks
-// to work around the problems of introducing `arbitrary` crate feature in
-// a user crate.
-// #[cfg(feature = "arbitrary")]
-
+// Implementation for arbitrary crate support
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_arbitrary_for_fixed_hash {
     ( $name:ident ) => {
-        impl arbitrary::Arbitrary for $name {
-            fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        impl<'a> arbitrary::Arbitrary<'a> for $name {
+            fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
                 let mut res = Self::zero();
                 u.fill_buffer(&mut res.0)?;
                 Ok(Self::from(res))

--- a/common/src/fixed_hash.rs
+++ b/common/src/fixed_hash.rs
@@ -211,7 +211,7 @@ macro_rules! construct_fixed_hash {
 			}
 		}
 
-		/// Returns the big-endian format
+		/// Returns the big endian format
 		impl core::fmt::Debug for $name {
 			fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
 				let mut inner = self.0;
@@ -327,7 +327,7 @@ macro_rules! construct_fixed_hash {
 	}
 }
 
-// Implementation for enabled byteorder crate support.
+// Implementation for byteorder crate support.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_byteorder_for_fixed_hash {
@@ -355,7 +355,7 @@ macro_rules! impl_byteorder_for_fixed_hash {
                 B::read_u64(&buf)
             }
 
-            /// Returns the lowest 8 bytes interpreted as little-endian.
+            /// Returns the lowest 8 bytes interpreted as little endian.
             ///
             /// # Note
             ///
@@ -366,7 +366,7 @@ macro_rules! impl_byteorder_for_fixed_hash {
                 self.to_low_u64_with_byteorder::<byteorder::BigEndian>()
             }
 
-            /// Returns the lowest 8 bytes interpreted as little-endian.
+            /// Returns the lowest 8 bytes interpreted as little endian.
             ///
             /// # Note
             ///

--- a/common/src/fixed_hash.rs
+++ b/common/src/fixed_hash.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Parity Technologies
 //
 // Modified in 2022 by
-//   Carla Yap <carla.yap@rbblab.com>
+//   Carla Yap <carla.yap@mintlayer.org>
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -21,8 +21,11 @@ pub mod primitives;
 pub mod uint;
 
 mod concurrency_impl;
-pub use concurrency_impl::*;
 
+#[macro_use]
+mod fixed_hash;
+
+pub use concurrency_impl::*;
 pub use uint::{Uint128, Uint256};
 
 #[cfg(test)]

--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -36,6 +36,12 @@ impl From<H256> for Uint256 {
     }
 }
 
+impl From<Uint256> for H256 {
+    fn from(val: Uint256) -> Self {
+        H256(val.to_bytes())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
 pub struct Id<T: ?Sized> {
     id: H256,
@@ -120,7 +126,7 @@ mod tests {
     }
 
     #[test]
-    fn h256_to_uint256() {
+    fn h256_to_uint256_and_vice_versa() {
         fn check(value: &str) {
             let hash_value = H256::from_str(value).expect("nothing wrong");
             let uint_value = Uint256::from(hash_value);
@@ -129,9 +135,9 @@ mod tests {
             let uint_str = format!("{:?}", uint_value);
             assert_eq!(hash_str, uint_str);
 
-            let uint_bytes: [u8; 32] = uint_value.into();
-            let hash_bytes = hash_value.0;
-            assert_eq!(hash_bytes, uint_bytes);
+            // make sure the position of the bytes are the same.
+            assert_eq!(hash_value.0, uint_value.to_bytes());
+            assert_eq!(hash_value, H256::from(uint_value));
         }
 
         check("000000000000000000059fa50103b9683e51e5aba83b8a34c9b98ce67d66136c");

--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -32,7 +32,7 @@ impl From<GenericArray<u8, typenum::U32>> for H256 {
 
 impl From<H256> for Uint256 {
     fn from(hash: H256) -> Self {
-        Uint256::from_le_bytes(hash.0)
+        Uint256::from(hash.0)
     }
 }
 
@@ -123,13 +123,13 @@ mod tests {
     fn h256_to_uint256() {
         fn check(value: &str) {
             let hash_value = H256::from_str(value).expect("nothing wrong");
-            let uint_value = Uint256::from(hash_value.clone());
+            let uint_value = Uint256::from(hash_value);
 
             let hash_str = format!("{:?}", hash_value);
             let uint_str = format!("{:?}", uint_value);
             assert_eq!(hash_str, uint_str);
 
-            let uint_bytes = uint_value.to_le_bytes();
+            let uint_bytes: [u8; 32] = uint_value.into();
             let hash_bytes = hash_value.0;
             assert_eq!(hash_bytes, uint_bytes);
         }

--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -106,6 +106,7 @@ pub fn hash_encoded<T: Encode>(value: &T) -> H256 {
 mod tests {
     use super::*;
     use crypto::hash::StreamHasher;
+    use hex::FromHex;
     use std::str::FromStr;
 
     #[test]
@@ -143,5 +144,27 @@ mod tests {
         check("000000000000000000059fa50103b9683e51e5aba83b8a34c9b98ce67d66136c");
         check("000000000000000004ec466ce4732fe6f1ed1cddc2ed4b328fff5224276e3f6f");
         check("000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd");
+    }
+
+    #[test]
+    fn h256_and_uint256_from_bytes_and_bytes_form() {
+        fn check(hex: &str) {
+            // reverse pairs of bytes as hex
+            let hex_reversed =
+                String::from_utf8(hex.as_bytes().chunks(2).rev().collect::<Vec<&[u8]>>().concat())
+                    .unwrap();
+
+            let bytes: Vec<u8> = FromHex::from_hex(hex_reversed).unwrap();
+            let bytes = bytes.as_slice();
+            let h = H256::from_str(hex).unwrap();
+            let u = Uint256::from_bytes(bytes.try_into().unwrap());
+            assert_eq!(h.as_bytes(), bytes);
+            assert_eq!(u.to_bytes(), bytes);
+        }
+        check("0000000000000000000000000000000000000000000000000000000000000000");
+        check("0000000000000000000000000000000000000000000000000000000000000001");
+        check("000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd");
+        check("02f0000ff000000004ec466ce4732fe6f1ed1cddc2ed4b328fff5224276e3f6f");
+        check("000000000000000000059fa50103b9683e51e5aba83b8a34c9b98ce67d66136c");
     }
 }

--- a/common/src/uint/impls.rs
+++ b/common/src/uint/impls.rs
@@ -3,7 +3,7 @@
 //     Andrew Poelstra <apoelstra@wpsoftware.net>
 //
 // Modified in 2022 by
-//     Carla Yap <carla.yap@rbblab.com>
+//     Carla Yap <carla.yap@mintlayer.org>
 // To the extent possible under law, the author(s) have dedicated all
 // copyright and related and neighboring rights to this software to
 // the public domain worldwide. This software is distributed without

--- a/common/src/uint/impls.rs
+++ b/common/src/uint/impls.rs
@@ -2,7 +2,7 @@
 // Written in 2014 by
 //     Andrew Poelstra <apoelstra@wpsoftware.net>
 //
-// Modified by
+// Modified in 2022 by
 //     Carla Yap <carla.yap@rbblab.com>
 // To the extent possible under law, the author(s) have dedicated all
 // copyright and related and neighboring rights to this software to
@@ -131,6 +131,42 @@ macro_rules! construct_uint {
                     let start = i * 8;
                     res[start..start + 8]
                         .copy_from_slice(&u64_to_array_be(self.0[$n_words - (i + 1)]));
+                }
+                res
+            }
+
+            pub fn from_le_bytes(bytes: [u8; $n_words * 8]) -> $name {
+                Self::_from_le_slice(&bytes)
+            }
+
+            pub fn from_le_slice(bytes: &[u8]) -> Result<$name, ParseLengthError> {
+                if bytes.len() != $n_words * 8 {
+                    Err(ParseLengthError {
+                        actual: bytes.len(),
+                        expected: $n_words * 8,
+                    })
+                } else {
+                    Ok(Self::_from_le_slice(bytes))
+                }
+            }
+
+            fn _from_le_slice(bytes: &[u8]) -> $name {
+                use crate::uint::endian::slice_to_u64_le;
+                let mut slice = [0u64; $n_words];
+                slice
+                    .iter_mut()
+                    .zip(bytes.chunks(8))
+                    .for_each(|(word, bytes)| *word = slice_to_u64_le(bytes));
+                $name(slice)
+            }
+
+            /// Convert a big integer into a byte array using little-endian encoding
+            pub fn to_le_bytes(&self) -> [u8; $n_words * 8] {
+                use crate::uint::endian::u64_to_array_le;
+                let mut res = [0; $n_words * 8];
+                for i in 0..$n_words {
+                    let start = i * 8;
+                    res[start..start + 8].copy_from_slice(&u64_to_array_le(self.0[i]));
                 }
                 res
             }
@@ -588,6 +624,57 @@ mod tests {
                 0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xaf, 0xba, 0xbe, 0x2b, 0xed,
                 0xfe, 0xed, 0xba, 0xad, 0xf0, 0x0d, 0xde, 0xfa, 0xce, 0xda, 0x11, 0xfe, 0xd2, 0xba,
                 0xd1, 0xc0, 0xff, 0xe0
+            ]
+        );
+    }
+
+    #[test]
+    pub fn uint_from_le_bytes() {
+        assert_eq!(
+            Uint128::from_le_bytes([
+                0xed, 0xfe, 0xed, 0x2b, 0xbe, 0xba, 0xaf, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca,
+                0xad, 0x1b
+            ]),
+            Uint128([0xdeafbabe2bedfeed, 0x1badcafedeadbeef])
+        );
+
+        assert_eq!(
+            Uint256::from_le_bytes([
+                0xe0, 0xff, 0xc0, 0xd1, 0xba, 0xd2, 0xfe, 0x11, 0xda, 0xce, 0xfa, 0xde, 0x0d, 0xf0,
+                0xad, 0xba, 0xed, 0xfe, 0xed, 0x2b, 0xbe, 0xba, 0xaf, 0xde, 0xef, 0xbe, 0xad, 0xde,
+                0xfe, 0xca, 0xad, 0x1b,
+            ]),
+            Uint256([
+                0x11fed2bad1c0ffe0,
+                0xbaadf00ddefaceda,
+                0xdeafbabe2bedfeed,
+                0x1badcafedeadbeef
+            ])
+        );
+    }
+
+    #[test]
+    pub fn uint_to_le_bytes() {
+        assert_eq!(
+            Uint128([0xdeafbabe2bedfeed, 0x1badcafedeadbeef]).to_le_bytes(),
+            [
+                0xed, 0xfe, 0xed, 0x2b, 0xbe, 0xba, 0xaf, 0xde, 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca,
+                0xad, 0x1b
+            ]
+        );
+
+        assert_eq!(
+            Uint256([
+                0x11fed2bad1c0ffe0,
+                0xbaadf00ddefaceda,
+                0xdeafbabe2bedfeed,
+                0x1badcafedeadbeef
+            ])
+            .to_le_bytes(),
+            [
+                0xe0, 0xff, 0xc0, 0xd1, 0xba, 0xd2, 0xfe, 0x11, 0xda, 0xce, 0xfa, 0xde, 0x0d, 0xf0,
+                0xad, 0xba, 0xed, 0xfe, 0xed, 0x2b, 0xbe, 0xba, 0xaf, 0xde, 0xef, 0xbe, 0xad, 0xde,
+                0xfe, 0xca, 0xad, 0x1b,
             ]
         );
     }

--- a/common/src/uint/internal_macros.rs
+++ b/common/src/uint/internal_macros.rs
@@ -2,6 +2,8 @@
 // Written in 2014 by
 //     Andrew Poelstra <apoelstra@wpsoftware.net>
 //
+// Modified in 2022 by
+//     Carla Yap <carla.yap@mintlayer.org>
 // To the extent possible under law, the author(s) have dedicated all
 // copyright and related and neighboring rights to this software to
 // the public domain worldwide. This software is distributed without
@@ -45,19 +47,19 @@ macro_rules! impl_array_newtype {
 
             #[inline]
             /// Returns the underlying bytes.
-            pub fn as_bytes(&self) -> &[$ty; $len] {
+            pub fn as_inner(&self) -> &[$ty; $len] {
                 &self.0
             }
 
             #[inline]
             /// Returns the underlying bytes.
-            pub fn to_bytes(&self) -> [$ty; $len] {
+            pub fn inner(&self) -> [$ty; $len] {
                 self.0.clone()
             }
 
             #[inline]
             /// Returns the underlying bytes.
-            pub fn into_bytes(self) -> [$ty; $len] {
+            pub fn into_inner(self) -> [$ty; $len] {
                 self.0
             }
         }

--- a/common/tests/transaction.rs
+++ b/common/tests/transaction.rs
@@ -19,37 +19,37 @@ fn transaction_id_snapshots() {
 
     let tx = Transaction::new(0x00, vec![], vec![], 0x01).unwrap();
     expect![[r#"
-        0xa87e4adcb5a356a3247b699d2c36cf217a135b43a29c3883f46eaed72abbd128
+        0x28d1bb2ad7ae6ef483389ca2435b137a21cf362c9d697b24a356a3b5dc4a7ea8
     "#]]
     .assert_debug_eq(&tx.get_id().get());
 
     let tx = Transaction::new(0x00, vec![], vec![], 0x02).unwrap();
     expect![[r#"
-        0x228fea54993e15647ec580ccabde223444b43bd52c82579a2d99ffcfb756c662
+        0x62c656b7cfff992d9a57822cd53bb4443422deabcc80c57e64153e9954ea8f22
     "#]]
     .assert_debug_eq(&tx.get_id().get());
 
     let tx = Transaction::new(0x00, ins0.clone(), vec![], 0x00).unwrap();
     expect![[r#"
-        0xf94788524c18ef1fc4b402398f7dc75a42bc6cba31465c14d3fcc1c25bd71a2e
+        0x2e1ad75bc2c1fcd3145c4631ba6cbc425ac77d8f3902b4c41fef184c528847f9
     "#]]
     .assert_debug_eq(&tx.get_id().get());
 
     let tx = Transaction::new(0x00, ins1.clone(), vec![], 0x00).unwrap();
     expect![[r#"
-        0xdfe2df919b4eab0ee3d10fff2f1f964f33c6a50c9b2e3a18fd9297088b64576e
+        0x6e57648b089792fd183a2e9b0ca5c6334f961f2fff0fd1e30eab4e9b91dfe2df
     "#]]
     .assert_debug_eq(&tx.get_id().get());
 
     let tx = Transaction::new(0x00, ins0, outs0.clone(), 0x123456).unwrap();
     expect![[r#"
-        0xd6361975b7013da6a67a449bfd2d5beddcd02ed86aabfa04fd25f8a15443f7ad
+        0xadf74354a1f825fd04faab6ad82ed0dced5b2dfd9b447aa6a63d01b7751936d6
     "#]]
     .assert_debug_eq(&tx.get_id().get());
 
     let tx = Transaction::new(0x00, ins1, outs0, 0x00).unwrap();
     expect![[r#"
-        0xab0e6bfe8878d893f153ba10846fb965373f6aa09c998ab8b61260e2c23affd5
+        0xd5ff3ac2e26012b6b88a999ca06a3f3765b96f8410ba53f193d87888fe6b0eab
     "#]]
     .assert_debug_eq(&tx.get_id().get());
 }


### PR DESCRIPTION
Forking from [parity's fixed_hash](https://github.com/paritytech/parity-common/blob/bcb2e48a7f0e1594b97fdd9086973f046d6bdd5d/fixed-hash/src/hash.rs), only the **_debug_** is in _big-endian_. 


The value stored in the constructed structure (like the `[u8;32]` of `H256`)  follows little-endian format. 
This assumes that the 32-byte array parameter (especially when calling for example `H256::from(...)` or  initializing `H256(...)` ) is  in little-endian format.

To convert H256 to Uint256, I added the `from_le_bytes` and `to_le_bytes`.
Also updated test cases in the `transaction.rs`