### PR TITLE
storage: Separate mutable and immutable interfaces

### DIFF
--- a/blockchain_storage/src/lib.rs
+++ b/blockchain_storage/src/lib.rs
@@ -3,6 +3,7 @@
 use common::chain::block::Block;
 use common::chain::transaction::{Transaction, TxMainChainIndex, TxMainChainPosition};
 use common::primitives::{BlockHeight, Id};
+use storage::traits;
 
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
@@ -26,22 +27,40 @@ impl From<storage::Error> for Error {
 /// Possibly failing result of blockchain storage query
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// Operations on persistent blockchain data
-pub trait BlockchainStorage {
+/// Queries on persistent blockchain data
+pub trait BlockchainStorageRead {
     /// Get storage version
     fn get_storage_version(&self) -> crate::Result<u32>;
-
-    /// Set storage version
-    fn set_storage_version(&mut self, version: u32) -> crate::Result<()>;
 
     /// Get the hash of the best block
     fn get_best_block_id(&self) -> crate::Result<Option<Id<Block>>>;
 
-    /// Set the hash of the best block
-    fn set_best_block_id(&mut self, id: &Id<Block>) -> crate::Result<()>;
-
     /// Get block by its hash
     fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
+
+    /// Get outputs state for given transaction in the mainchain
+    fn get_mainchain_tx_index(
+        &self,
+        tx_id: &Id<Transaction>,
+    ) -> crate::Result<Option<TxMainChainIndex>>;
+
+    /// Get transaction by block ID and position
+    fn get_mainchain_tx_by_position(
+        &self,
+        tx_index: &TxMainChainPosition,
+    ) -> crate::Result<Option<Transaction>>;
+
+    /// Get mainchain block by its height
+    fn get_block_id_by_height(&self, height: &BlockHeight) -> crate::Result<Option<Id<Block>>>;
+}
+
+/// Modifying operations on persistent blockchain data
+pub trait BlockchainStorageWrite: BlockchainStorageRead {
+    /// Set storage version
+    fn set_storage_version(&mut self, version: u32) -> crate::Result<()>;
+
+    /// Set the hash of the best block
+    fn set_best_block_id(&mut self, id: &Id<Block>) -> crate::Result<()>;
 
     /// Add a new block into the database
     fn add_block(&mut self, block: &Block) -> crate::Result<()>;
@@ -56,23 +75,8 @@ pub trait BlockchainStorage {
         tx_index: &TxMainChainIndex,
     ) -> crate::Result<()>;
 
-    /// Get outputs state for given transaction in the mainchain
-    fn get_mainchain_tx_index(
-        &self,
-        tx_id: &Id<Transaction>,
-    ) -> crate::Result<Option<TxMainChainIndex>>;
-
     /// Delete outputs state index associated with given transaction
     fn del_mainchain_tx_index(&mut self, tx_id: &Id<Transaction>) -> crate::Result<()>;
-
-    /// Get transaction by block ID and position
-    fn get_mainchain_tx_by_position(
-        &self,
-        tx_index: &TxMainChainPosition,
-    ) -> crate::Result<Option<Transaction>>;
-
-    /// Get mainchain block by its height
-    fn get_block_id_by_height(&self, height: &BlockHeight) -> crate::Result<Option<Id<Block>>>;
 
     /// Set the mainchain block at given height to be given block.
     fn set_block_id_at_height(
@@ -84,3 +88,20 @@ pub trait BlockchainStorage {
     /// Remove block id from given mainchain height
     fn del_block_id_at_height(&mut self, height: &BlockHeight) -> crate::Result<()>;
 }
+
+/// Support for transactions over blockchain storage
+pub trait Transactional<'t> {
+    /// Associated read-only transaction type.
+    type TransactionRo: traits::TransactionRo<Error = crate::Error> + BlockchainStorageRead + 't;
+
+    /// Associated read-write transaction type.
+    type TransactionRw: traits::TransactionRw<Error = crate::Error> + BlockchainStorageWrite + 't;
+
+    /// Start a read-only transaction.
+    fn transaction_ro<'s: 't>(&'s self) -> Self::TransactionRo;
+
+    /// Start a read-write transaction.
+    fn transaction_rw<'s: 't>(&'s self) -> Self::TransactionRw;
+}
+
+pub trait BlockchainStorage: BlockchainStorageWrite + for<'tx> Transactional<'tx> {}

--- a/blockchain_storage/src/mock.rs
+++ b/blockchain_storage/src/mock.rs
@@ -8,26 +8,16 @@ mockall::mock! {
     /// A mock object for blockchain storage
     pub Store {}
 
-    impl crate::BlockchainStorage for Store {
+    impl crate::BlockchainStorageRead for Store {
         fn get_storage_version(&self) -> crate::Result<u32>;
-        fn set_storage_version(&mut self, version: u32) -> crate::Result<()>;
         fn get_best_block_id(&self) -> crate::Result<Option<Id<Block>>>;
-        fn set_best_block_id(&mut self, id: &Id<Block>) -> crate::Result<()>;
-        fn add_block(&mut self, block: &Block) -> crate::Result<()>;
         fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
-        fn del_block(&mut self, id: Id<Block>) -> crate::Result<()>;
-        fn set_mainchain_tx_index(
-            &mut self,
-            tx_id: &Id<Transaction>,
-            tx_index: &TxMainChainIndex,
-        ) -> crate::Result<()>;
 
         fn get_mainchain_tx_index(
             &self,
             tx_id: &Id<Transaction>,
         ) -> crate::Result<Option<TxMainChainIndex>>;
 
-        fn del_mainchain_tx_index(&mut self, tx_id: &Id<Transaction>) -> crate::Result<()>;
 
         fn get_mainchain_tx_by_position(
             &self,
@@ -38,6 +28,19 @@ mockall::mock! {
             &self,
             height: &BlockHeight,
         ) -> crate::Result<Option<Id<Block>>>;
+    }
+
+    impl crate::BlockchainStorageWrite for Store {
+        fn set_storage_version(&mut self, version: u32) -> crate::Result<()>;
+        fn set_best_block_id(&mut self, id: &Id<Block>) -> crate::Result<()>;
+        fn add_block(&mut self, block: &Block) -> crate::Result<()>;
+        fn del_block(&mut self, id: Id<Block>) -> crate::Result<()>;
+        fn set_mainchain_tx_index(
+            &mut self,
+            tx_id: &Id<Transaction>,
+            tx_index: &TxMainChainIndex,
+        ) -> crate::Result<()>;
+        fn del_mainchain_tx_index(&mut self, tx_id: &Id<Transaction>) -> crate::Result<()>;
 
         fn set_block_id_at_height(
             &mut self,
@@ -48,38 +51,60 @@ mockall::mock! {
         fn del_block_id_at_height(&mut self, height: &BlockHeight) -> crate::Result<()>;
     }
 
-    impl storage::traits::Transactional<'_> for Store {
-        type TransactionRo = MockStoreTx;
-        type TransactionRw = MockStoreTx;
-        fn start_transaction_ro(&self) -> MockStoreTx;
-        fn start_transaction_rw(&self) -> MockStoreTx;
+    impl<'tx> crate::Transactional<'tx> for Store {
+        type TransactionRo = MockStoreTxRo;
+        type TransactionRw = MockStoreTxRw;
+        fn transaction_ro<'st>(&'st self) -> MockStoreTxRo where 'st: 'tx;
+        fn transaction_rw<'st>(&'st self) -> MockStoreTxRw where 'st: 'tx;
+    }
+
+    impl crate::BlockchainStorage for Store {}
+}
+
+mockall::mock! {
+    /// A mock object for blockcain storage transaction
+    pub StoreTxRo {}
+
+    impl crate::BlockchainStorageRead for StoreTxRo {
+        fn get_storage_version(&self) -> crate::Result<u32>;
+        fn get_best_block_id(&self) -> crate::Result<Option<Id<Block>>>;
+        fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
+
+        fn get_mainchain_tx_index(
+            &self,
+            tx_id: &Id<Transaction>,
+        ) -> crate::Result<Option<TxMainChainIndex>>;
+
+        fn get_mainchain_tx_by_position(
+            &self,
+            tx_index: &TxMainChainPosition,
+        ) -> crate::Result<Option<Transaction>>;
+
+        fn get_block_id_by_height(
+            &self,
+            height: &BlockHeight,
+        ) -> crate::Result<Option<Id<Block>>>;
+    }
+
+    impl storage::traits::TransactionRo for StoreTxRo {
+        type Error = crate::Error;
+        fn finalize(self) -> crate::Result<()>;
     }
 }
 
 mockall::mock! {
     /// A mock object for blockcain storage transaction
-    pub StoreTx {}
+    pub StoreTxRw {}
 
-    impl crate::BlockchainStorage for StoreTx {
+    impl crate::BlockchainStorageRead for StoreTxRw {
         fn get_storage_version(&self) -> crate::Result<u32>;
-        fn set_storage_version(&mut self, version: u32) -> crate::Result<()>;
         fn get_best_block_id(&self) -> crate::Result<Option<Id<Block>>>;
-        fn set_best_block_id(&mut self, id: &Id<Block>) -> crate::Result<()>;
-        fn add_block(&mut self, block: &Block) -> crate::Result<()>;
         fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
-        fn del_block(&mut self, id: Id<Block>) -> crate::Result<()>;
-        fn set_mainchain_tx_index(
-            &mut self,
-            tx_id: &Id<Transaction>,
-            tx_index: &TxMainChainIndex,
-        ) -> crate::Result<()>;
 
         fn get_mainchain_tx_index(
             &self,
             tx_id: &Id<Transaction>,
         ) -> crate::Result<Option<TxMainChainIndex>>;
-
-        fn del_mainchain_tx_index(&mut self, tx_id: &Id<Transaction>) -> crate::Result<()>;
 
         fn get_mainchain_tx_by_position(
             &self,
@@ -90,6 +115,20 @@ mockall::mock! {
             &self,
             height: &BlockHeight,
         ) -> crate::Result<Option<Id<Block>>>;
+    }
+
+    impl crate::BlockchainStorageWrite for StoreTxRw {
+        fn set_storage_version(&mut self, version: u32) -> crate::Result<()>;
+        fn set_best_block_id(&mut self, id: &Id<Block>) -> crate::Result<()>;
+        fn add_block(&mut self, block: &Block) -> crate::Result<()>;
+        fn del_block(&mut self, id: Id<Block>) -> crate::Result<()>;
+        fn set_mainchain_tx_index(
+            &mut self,
+            tx_id: &Id<Transaction>,
+            tx_index: &TxMainChainIndex,
+        ) -> crate::Result<()>;
+
+        fn del_mainchain_tx_index(&mut self, tx_id: &Id<Transaction>) -> crate::Result<()>;
 
         fn set_block_id_at_height(
             &mut self,
@@ -100,12 +139,7 @@ mockall::mock! {
         fn del_block_id_at_height(&mut self, height: &BlockHeight) -> crate::Result<()>;
     }
 
-    impl storage::traits::TransactionRo for StoreTx {
-        type Error = crate::Error;
-        fn finalize(self) -> crate::Result<()>;
-    }
-
-    impl storage::traits::TransactionRw for StoreTx {
+    impl storage::traits::TransactionRw for StoreTxRw {
         type Error = crate::Error;
         fn abort(self) -> crate::Result<()>;
         fn commit(self) -> crate::Result<()>;
@@ -114,11 +148,11 @@ mockall::mock! {
 
 #[cfg(test)]
 mod tests {
-    pub use super::*;
-    pub use crate::BlockchainStorage;
+    use super::*;
+    use crate::{BlockchainStorageRead, BlockchainStorageWrite, Transactional};
     use common::primitives::consensus_data::ConsensusData;
-    pub use common::primitives::{Idable, H256};
-    pub use storage::traits::Transactional;
+    use common::primitives::{Idable, H256};
+    use storage::traits::{TransactionRo, TransactionRw};
 
     const TXFAIL: crate::Error =
         crate::Error::Storage(storage::error::Recoverable::TransactionFailed);
@@ -166,8 +200,8 @@ mod tests {
     fn mock_transaction() {
         // Set up the mock store
         let mut store = MockStore::new();
-        store.expect_start_transaction_rw().returning(|| {
-            let mut mock_tx = MockStoreTx::new();
+        store.expect_transaction_rw().returning(|| {
+            let mut mock_tx = MockStoreTxRw::new();
             mock_tx.expect_get_storage_version().return_const(Ok(3));
             mock_tx
                 .expect_set_storage_version()
@@ -178,7 +212,7 @@ mod tests {
         });
 
         // Test some code against the mock
-        let tx_result = store.transaction_rw(|tx| {
+        let tx_result = store.transaction_rw().run(|tx| {
             let v = tx.get_storage_version()?;
             tx.set_storage_version(v + 1)?;
             storage::commit(())
@@ -186,13 +220,26 @@ mod tests {
         assert_eq!(tx_result, Ok(()))
     }
 
+    fn generic_test<BS: crate::BlockchainStorage>(store: &BS) {
+        let tx = store.transaction_ro();
+        let _ = tx.get_best_block_id();
+        let _ = tx.finalize();
+    }
+
+    #[test]
+    fn use_generic_test() {
+        common::concurrency::model(|| {
+            let store: crate::Store = crate::Store::new_empty().unwrap();
+            generic_test(&store);
+        });
+    }
+
     // A sample function under test
-    fn attach_block_to_top<'a, BS>(store: &'a mut BS, block: &Block) -> &'static str
-    where
-        BS: Transactional<'a>,
-        BS::TransactionRw: storage::traits::TransactionRw<Error = crate::Error> + BlockchainStorage,
-    {
-        let res: crate::Result<&'static str> = store.transaction_rw(|tx| {
+    fn attach_block_to_top<BS: crate::BlockchainStorage>(
+        store: &mut BS,
+        block: &Block,
+    ) -> &'static str {
+        let res: crate::Result<&'static str> = store.transaction_rw().run(|tx| {
             // Get current best block ID
             let _best_id = match tx.get_best_block_id()? {
                 None => return storage::abort("top not set"),
@@ -238,12 +285,21 @@ mod tests {
     }
 
     #[test]
+    fn attach_to_top_real_storage() {
+        common::concurrency::model(|| {
+            let mut store = crate::Store::new_empty().unwrap();
+            let (_block0, block1) = sample_data();
+            let _result = attach_block_to_top(&mut store, &block1);
+        });
+    }
+
+    #[test]
     fn attach_to_top_ok() {
         let (block0, block1) = sample_data();
         let block1_id = block1.get_id();
         let mut store = MockStore::new();
-        store.expect_start_transaction_rw().returning(move || {
-            let mut tx = MockStoreTx::new();
+        store.expect_transaction_rw().returning(move || {
+            let mut tx = MockStoreTxRw::new();
             tx.expect_get_best_block_id().return_const(Ok(Some(block0.get_id())));
             tx.expect_add_block().return_const(Ok(()));
             tx.expect_set_best_block_id()
@@ -261,8 +317,8 @@ mod tests {
     fn attach_to_top_no_best_block() {
         let (_block0, block1) = sample_data();
         let mut store = MockStore::new();
-        store.expect_start_transaction_rw().returning(move || {
-            let mut tx = MockStoreTx::new();
+        store.expect_transaction_rw().returning(move || {
+            let mut tx = MockStoreTxRw::new();
             tx.expect_get_best_block_id().return_const(Ok(None));
             tx.expect_abort().return_const(Ok(()));
             tx
@@ -277,8 +333,8 @@ mod tests {
         let (_block0, block1) = sample_data();
         let top_id = Id::new(&H256([0x99; 32]));
         let mut store = MockStore::new();
-        store.expect_start_transaction_rw().returning(move || {
-            let mut tx = MockStoreTx::new();
+        store.expect_transaction_rw().returning(move || {
+            let mut tx = MockStoreTxRw::new();
             tx.expect_get_best_block_id().return_const(Ok(Some(top_id.clone())));
             tx.expect_abort().return_const(Ok(()));
             tx
@@ -293,8 +349,8 @@ mod tests {
         let (block0, block1) = sample_data();
         let block1_id = block1.get_id();
         let mut store = MockStore::new();
-        store.expect_start_transaction_rw().returning(move || {
-            let mut tx = MockStoreTx::new();
+        store.expect_transaction_rw().returning(move || {
+            let mut tx = MockStoreTxRw::new();
             tx.expect_get_best_block_id().return_const(Ok(Some(block0.get_id())));
             tx.expect_add_block().return_const(Ok(()));
             tx.expect_set_best_block_id()

--- a/storage/src/transaction.rs
+++ b/storage/src/transaction.rs
@@ -7,11 +7,31 @@ pub trait TransactionRo: Sized {
 
     /// Finalize the transaction.
     fn finalize(self) -> Result<(), Self::Error>;
-}
 
-#[allow(type_alias_bounds)]
-pub type RoTxResult<'s, R, T: Transactional<'s>> =
-    Result<R, <T::TransactionRo as TransactionRo>::Error>;
+    /// Run a read-only transaction.
+    ///
+    /// High-level convenience method. Prefer this over using a transaction directly.
+    ///
+    /// ```
+    /// # use storage::traits::*;
+    /// # fn foo<'a, S: storage::schema::Schema, T: Transactional<'a, S>>(foo: &'a T) {
+    /// let result = foo.transaction_ro().run(|tx| {
+    ///     // Your transaction operations go here
+    ///     Ok(42) // this will be the result
+    /// });
+    /// # }
+    /// ```
+    ///
+    /// Implementations are allowed to override this method provided semantics are preserved.
+    fn run<R>(
+        self,
+        tx_body: impl FnOnce(&Self) -> Result<R, Self::Error>,
+    ) -> Result<R, Self::Error> {
+        let result = tx_body(&self);
+        self.finalize()?;
+        result
+    }
+}
 
 /// Low-level interface for read-write database transactions
 pub trait TransactionRw: Sized {
@@ -23,6 +43,34 @@ pub trait TransactionRw: Sized {
 
     /// Abort a transaction.
     fn abort(self) -> Result<(), Self::Error>;
+
+    /// Run a read-write transaction.
+    ///
+    /// High-level convenience method. Prefer this over using the transaction directly.
+    ///
+    /// ```
+    /// # use storage::traits::*;
+    /// # fn foo<'a, S: storage::schema::Schema, T: Transactional<'a, S>>(foo: &'a mut T) {
+    /// let result = foo.transaction_rw().run(|tx| {
+    ///     // Your transaction operations go here
+    ///     storage::commit(42) // this will be the result
+    /// });
+    /// # }
+    /// ```
+    ///
+    /// Implementations are allowed to override this method provided semantics are preserved.
+    fn run<R>(
+        mut self,
+        tx_body: impl FnOnce(&mut Self) -> Result<Response<R>, Self::Error>,
+    ) -> Result<R, Self::Error> {
+        let result = tx_body(&mut self);
+        match result {
+            Ok(Response::Commit(_)) => self.commit()?,
+            Ok(Response::Abort(_)) => self.abort()?,
+            Err(_) => (),
+        };
+        result.map(Response::value)
+    }
 }
 
 /// Transaction response
@@ -54,83 +102,4 @@ pub fn commit<T, E>(ret: T) -> Result<Response<T>, E> {
 #[must_use = "abort must be returned from the transaction"]
 pub fn abort<T, E>(ret: T) -> Result<Response<T>, E> {
     Ok(Response::Abort(ret))
-}
-
-#[allow(type_alias_bounds)]
-pub type RwTxResult<'s, R, T: Transactional<'s>> =
-    Result<R, <T::TransactionRw as TransactionRw>::Error>;
-
-/// Type where some operations can be grouped into atomic transactions.
-pub trait Transactional<'s> {
-    /// Associated read-only transaction type.
-    type TransactionRo: TransactionRo;
-
-    /// Associated read-write transaction type.
-    type TransactionRw: TransactionRw;
-
-    /// Start a read-only transaction.
-    ///
-    /// Prefer the [Self::read] convenience function over this.
-    fn start_transaction_ro(&'s self) -> Self::TransactionRo;
-
-    /// Run a read-only transaction.
-    ///
-    /// High-level convenience method. Prefer this over a combination of
-    /// [Self::start_transaction_ro], [TransactionRo::finalize].
-    ///
-    /// ```
-    /// # use storage::transaction::Transactional;
-    /// # fn foo<'a, T: Transactional<'a>>(foo: &'a mut T) {
-    /// let result = foo.transaction_ro(|tx| {
-    ///     // Your transaction operations go here
-    ///     Ok(42) // this will be the result
-    /// });
-    /// # }
-    /// ```
-    ///
-    /// Implementations are allowed to override this method provided semantics are preserved.
-    fn transaction_ro<R>(
-        &'s self,
-        tx_body: impl FnOnce(&Self::TransactionRo) -> RoTxResult<'s, R, Self>,
-    ) -> RoTxResult<R, Self> {
-        let tx = self.start_transaction_ro();
-        let result = tx_body(&tx);
-        tx.finalize()?;
-        result
-    }
-
-    /// Start a read-write transaction.
-    ///
-    /// Prefer the [Self::write] convenience function over this.
-    fn start_transaction_rw(&'s self) -> Self::TransactionRw;
-
-    /// Run a read-write transaction.
-    ///
-    /// High-level convenience method. Prefer this over a combination of
-    /// [Self::start_transaction_rw], [TransactionRw::commit], [TransactionRw::abort].
-    ///
-    /// ```
-    /// # use storage::transaction::Transactional;
-    /// # fn foo<'a, T: Transactional<'a>>(foo: &'a mut T) {
-    /// let result = foo.transaction_rw(|tx| {
-    ///     // Your transaction operations go here
-    ///     storage::commit(42) // this will be the result
-    /// });
-    /// # }
-    /// ```
-    ///
-    /// Implementations are allowed to override this method provided semantics are preserved.
-    fn transaction_rw<F, R>(&'s self, tx_body: F) -> RwTxResult<'s, R, Self>
-    where
-        F: FnOnce(&mut Self::TransactionRw) -> RwTxResult<'s, Response<R>, Self>,
-    {
-        let mut tx = self.start_transaction_rw();
-        let result = tx_body(&mut tx);
-        match result {
-            Ok(Response::Commit(_)) => tx.commit()?,
-            Ok(Response::Abort(_)) => tx.abort()?,
-            Err(_) => (),
-        };
-        result.map(Response::value)
-    }
 }


### PR DESCRIPTION
* The blockchain_storage crate now takes advantage of the immutabl/mutable separation in the low-level storage framework
* Add traits defining an abstraction over mutiple storage backends
* Add traits abstracting over real and mock implementations of the application-level blockchain storage.
* It is now easier to write generic backend-agnostic and mockery-agnostic (?) code

Comments regarding the PR review process:
* Sorry for a big PR. It conceptually contains two changes but both touch the same bits of code and would take some effort to separate at this point.
* This is a result of many iterations on the design and trait definitions. There may be some residual artefacts from the previous iterations that I might have overlooked. Please have a look and point them out.

## API changes

There have been some changes to the way database transactions are used.

When using transaction objects, this:

```rust
let tx = storage.start_transaction_rw();
// stuff
tx.commit();
```

becomes:

```rust
let tx = storage.transaction_rw();
// stuff
tx.commit();
```

When using scoped transactions, this:

```rust
let result = storage.transaction_rw(|tx| {
    // stuff
    storage::commit(res)
});
```

becomes:

```rust
let result = storage.transaction_rw().run(|tx| {
    // stuff
    storage::commit(res)
});
```

Same applies to read-only transactions.