### PR TITLE
net/mock: Split mock interface into front and backend

### DIFF
--- a/p2p/src/net/mock/README.md
+++ b/p2p/src/net/mock/README.md
@@ -1,3 +1,0 @@
-# mock network service
-
-TODO

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): A. Altonen
+#![allow(dead_code, unused_variables, unused_imports)]
+use crate::{
+    error::{self, P2pError},
+    net::mock::types,
+    net::{Event, FloodsubTopic, NetworkService, SocketService},
+    peer::Peer,
+};
+use async_trait::async_trait;
+use futures::FutureExt;
+use logging::log;
+use parity_scale_codec::{Decode, Encode};
+use std::{
+    collections::HashMap,
+    io::{Error, ErrorKind},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    sync::mpsc,
+};
+
+pub struct Backend {
+    /// Socket for listening to incoming connections
+    socket: TcpListener,
+
+    /// RX channel for receiving commands from the frontend
+    cmd_rx: mpsc::Receiver<types::Command>,
+
+    /// TX channel for sending events to the frontend
+    event_tx: mpsc::Sender<types::Event>,
+}
+
+impl Backend {
+    pub fn new(
+        socket: TcpListener,
+        cmd_rx: mpsc::Receiver<types::Command>,
+        event_tx: mpsc::Sender<types::Event>,
+    ) -> Self {
+        Self {
+            socket,
+            cmd_rx,
+            event_tx,
+        }
+    }
+
+    pub async fn run(&mut self) -> error::Result<()> {
+        loop {
+            tokio::select! {
+                event = self.socket.accept() => match event {
+                    Ok(socket) => self.event_tx.send(types::Event::IncomingConnection {
+                        peer_id: socket.1,
+                        socket: socket.0,
+                    }).await?,
+                    Err(e) => {
+                        log::error!("accept() failed: {:?}", e);
+                        return Err(P2pError::SocketError(e.kind()));
+                    }
+                },
+                event = self.cmd_rx.recv().fuse() => match event.ok_or(P2pError::ChannelClosed)? {
+                    types::Command::Connect { addr, response } => {
+                        let _ = match TcpStream::connect(addr).await {
+                            Ok(socket) => response.send(Ok(socket)),
+                            Err(e) => response.send(Err(e.into())),
+                        };
+                    }
+                }
+            }
+        }
+    }
+}

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -31,21 +31,25 @@ use std::{
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
+    sync::{mpsc, oneshot},
 };
 
-/// This file provides a mock implementation of the network service.
-/// It implements the `NetworkService` trait on top of `tokio::net::TcpListener`
+pub mod backend;
+pub mod types;
 
 #[derive(Debug)]
 pub enum MockStrategy {}
 
 #[derive(Debug)]
 pub struct MockService {
-    /// Local node's TCP socket for listening to incoming connections
-    socket: TcpListener,
-
-    /// Address the local node has bind itself to
+    /// Address the mock service has been bind to
     addr: SocketAddr,
+
+    /// TX channel for sending commands to mock backend
+    cmd_tx: mpsc::Sender<types::Command>,
+
+    /// RX channel for receiving events from mock backend
+    event_rx: mpsc::Receiver<types::Event>,
 }
 
 #[derive(Debug)]
@@ -71,9 +75,19 @@ impl NetworkService for MockService {
         _strategies: &[Self::Strategy],
         _topics: &[FloodsubTopic],
     ) -> error::Result<Self> {
+        let (cmd_tx, cmd_rx) = mpsc::channel(16);
+        let (event_tx, event_rx) = mpsc::channel(16);
+        let socket = TcpListener::bind(addr).await?;
+
+        tokio::spawn(async move {
+            let mut mock = backend::Backend::new(socket, cmd_rx, event_tx);
+            let _ = mock.run().await;
+        });
+
         Ok(Self {
             addr,
-            socket: TcpListener::bind(addr).await?,
+            cmd_tx,
+            event_rx,
         })
     }
 
@@ -87,26 +101,26 @@ impl NetworkService for MockService {
             return Err(P2pError::SocketError(ErrorKind::AddrNotAvailable));
         }
 
-        Ok((
-            addr,
-            MockSocket {
-                socket: TcpStream::connect(addr).await?,
-            },
-        ))
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx.send(types::Command::Connect { addr, response: tx }).await?;
+
+        let socket = rx
+            .await
+            .map_err(|e| e)? // channel closed
+            .map_err(|e| e)?; // command failure
+
+        Ok((addr, MockSocket::new(socket)))
     }
 
     async fn poll_next<T>(&mut self) -> error::Result<Event<T>>
     where
         T: NetworkService<Socket = MockSocket, PeerId = SocketAddr>,
     {
-        let connection = self.socket.accept().await?;
-
-        Ok(Event::IncomingConnection(
-            connection.1,
-            MockSocket {
-                socket: connection.0,
-            },
-        ))
+        match self.event_rx.recv().await.ok_or(P2pError::ChannelClosed)? {
+            types::Event::IncomingConnection { peer_id, socket } => {
+                Ok(Event::IncomingConnection(peer_id, MockSocket { socket }))
+            }
+        }
     }
 
     async fn publish<T>(&mut self, topic: FloodsubTopic, data: &T) -> error::Result<()>

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): A. Altonen
+use crate::error;
+use std::net::SocketAddr;
+use tokio::{net::TcpStream, sync::oneshot};
+
+pub enum Command {
+    Connect {
+        addr: SocketAddr,
+        response: oneshot::Sender<error::Result<TcpStream>>,
+    },
+}
+
+pub enum Event {
+    IncomingConnection {
+        peer_id: SocketAddr,
+        socket: TcpStream,
+    },
+}


### PR DESCRIPTION
This is a change which was anyway going to happen (floodsub support) but introducing the split now makes it easier to review the upcoming changes to the network service provider trait as they split the functionality even further. Most of the tests (both unit and integration) are implemented for mock service so this allows to introduce the upcoming changes gradually (so no +1500,-1200 PR that touch 13 different files :smiley: )