### PR TITLE
Network event updates

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -380,8 +380,8 @@ mod tests {
     use super::*;
     use crate::error::P2pError;
     use common::chain::config;
-    use libp2p::Multiaddr;
-    use net::{libp2p::Libp2pService, mock::MockService};
+    // use libp2p::Multiaddr;
+    use net::mock::MockService;
     use std::net::SocketAddr;
     use tokio::net::TcpListener;
 
@@ -400,6 +400,7 @@ mod tests {
         );
     }
 
+    /*
     // try to connect to an address that no one listening on and verify it fails
     #[tokio::test]
     async fn test_p2p_connect_libp2p() {
@@ -417,6 +418,7 @@ mod tests {
             Err(P2pError::SocketError(std::io::ErrorKind::ConnectionRefused))
         );
     }
+    */
 
     // verify that if handshake succeeds, peer state is set to `Active`
     #[tokio::test]
@@ -482,6 +484,7 @@ mod tests {
         assert_eq!(p2p.peers.len(), 0);
     }
 
+    /*
     #[tokio::test]
     async fn test_peer_discovered_libp2p() {
         let config = Arc::new(config::create_mainnet());
@@ -615,6 +618,7 @@ mod tests {
             vec![Arc::new("/ip6/::1/tcp/9097".parse().unwrap())],
         );
     }
+    */
 
     // verify that if the node is aware of any peers on the network,
     // call to `auto_connect()` will establish a connection with them

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -320,12 +320,17 @@ where
         event: net::Event<NetworkingBackend>,
     ) -> error::Result<()> {
         match event {
-            net::Event::IncomingConnection(peer_id, socket) => {
-                self.on_connectivity_event(ConnectivityEvent::Accept(peer_id, socket)).await
+            net::Event::Connectivity(event) => match event {
+                net::ConnectivityEvent::IncomingConnection(peer_id, socket) => {
+                    self.on_connectivity_event(ConnectivityEvent::Accept(peer_id, socket)).await
+                }
+                net::ConnectivityEvent::PeerDiscovered(peers) => self.peer_discovered(&peers),
+                net::ConnectivityEvent::PeerExpired(peers) => self.peer_expired(&peers),
+            },
+            net::Event::Floodsub(event) => {
+                let net::FloodsubEvent::MessageReceived(topic, message) = event;
+                self.on_floodsub_event(topic, message)
             }
-            net::Event::PeerDiscovered(peers) => self.peer_discovered(&peers),
-            net::Event::PeerExpired(peers) => self.peer_expired(&peers),
-            net::Event::MessageReceived(topic, message) => self.on_floodsub_event(topic, message),
         }
     }
 

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -15,6 +15,7 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
+/*
 use crate::{
     error::{self, Libp2pError, P2pError},
     message,
@@ -501,3 +502,4 @@ mod tests {
         assert_eq!(backend.run().await, Err(P2pError::ChannelClosed));
     }
 }
+*/

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
+#![allow(unused)]
 use crate::{
     error::{self, Libp2pError, P2pError},
     net::{self, Event, FloodsubTopic, NetworkService, SocketService},
@@ -161,6 +162,7 @@ where
         .collect::<Vec<net::AddrInfo<T>>>()
 }
 
+/*
 #[async_trait]
 impl NetworkService for Libp2pService {
     type Address = Multiaddr;
@@ -777,3 +779,4 @@ mod tests {
         );
     }
 }
+*/

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -44,19 +44,24 @@ pub struct Backend {
     cmd_rx: mpsc::Receiver<types::Command>,
 
     /// TX channel for sending events to the frontend
-    event_tx: mpsc::Sender<types::Event>,
+    conn_tx: mpsc::Sender<types::ConnectivityEvent>,
+
+    /// TX channel for sending events to the frontend
+    _flood_tx: mpsc::Sender<types::FloodsubEvent>,
 }
 
 impl Backend {
     pub fn new(
         socket: TcpListener,
         cmd_rx: mpsc::Receiver<types::Command>,
-        event_tx: mpsc::Sender<types::Event>,
+        conn_tx: mpsc::Sender<types::ConnectivityEvent>,
+        _flood_tx: mpsc::Sender<types::FloodsubEvent>,
     ) -> Self {
         Self {
             socket,
             cmd_rx,
-            event_tx,
+            conn_tx,
+            _flood_tx,
         }
     }
 
@@ -64,7 +69,7 @@ impl Backend {
         loop {
             tokio::select! {
                 event = self.socket.accept() => match event {
-                    Ok(socket) => self.event_tx.send(types::Event::IncomingConnection {
+                    Ok(socket) => self.conn_tx.send(types::ConnectivityEvent::IncomingConnection {
                         peer_id: socket.1,
                         socket: socket.0,
                     }).await?,

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-use crate::error;
+use crate::{error, message, net};
 use std::net::SocketAddr;
 use tokio::{net::TcpStream, sync::oneshot};
 
@@ -25,9 +25,19 @@ pub enum Command {
     },
 }
 
-pub enum Event {
+pub enum ConnectivityEvent {
     IncomingConnection {
         peer_id: SocketAddr,
         socket: TcpStream,
+    },
+}
+
+// TODO: use two events, one for txs and one for blocks?
+pub enum FloodsubEvent {
+    /// Message received from one of the floodsub topics
+    MessageReceived {
+        peer_id: SocketAddr,
+        topic: net::FloodsubTopic,
+        message: message::Message,
     },
 }

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -37,8 +37,7 @@ where
     pub ip6: Vec<Arc<T::Address>>,
 }
 
-#[derive(Debug)]
-pub enum Event<T>
+pub enum ConnectivityEvent<T>
 where
     T: NetworkService,
 {
@@ -50,9 +49,20 @@ where
 
     /// One one more peers have expired
     PeerExpired(Vec<AddrInfo<T>>),
+}
 
+// TODO: separate events for blocks and transactions?
+pub enum FloodsubEvent {
     /// Message received from a Floodsub topic
     MessageReceived(FloodsubTopic, message::Message),
+}
+
+pub enum Event<T>
+where
+    T: NetworkService,
+{
+    Connectivity(ConnectivityEvent<T>),
+    Floodsub(FloodsubEvent),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -17,12 +17,13 @@
 #![cfg(not(loom))]
 
 use common::chain::ChainConfig;
-use libp2p::Multiaddr;
+// use libp2p::Multiaddr;
 use p2p::{
     net::{
-        libp2p::Libp2pService,
+        // libp2p::Libp2pService,
         mock::{MockService, MockSocket},
-        Event, NetworkService,
+        Event,
+        NetworkService,
     },
     peer::*,
 };
@@ -109,6 +110,7 @@ pub async fn create_two_mock_peers(
     (local, remote)
 }
 
+/*
 // create two libp2p peers that are connected to each other
 pub async fn create_two_libp2p_peers(
     config: Arc<ChainConfig>,
@@ -161,3 +163,4 @@ pub async fn create_two_libp2p_peers(
 
     (local, remote)
 }
+*/

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -22,6 +22,7 @@ use p2p::{
     net::{
         // libp2p::Libp2pService,
         mock::{MockService, MockSocket},
+        ConnectivityEvent,
         Event,
         NetworkService,
     },
@@ -72,7 +73,7 @@ pub async fn create_two_mock_peers(
     let (remote_res, local_res) = tokio::join!(server.poll_next(), peer_fut);
     let remote_res: Event<MockService> = remote_res.unwrap();
     let remote_res = match remote_res {
-        Event::IncomingConnection(_, socket) => socket,
+        Event::Connectivity(ConnectivityEvent::IncomingConnection(_, socket)) => socket,
         _ => panic!("invalid event received, expected incoming connection"),
     };
     let local_res = local_res.unwrap();

--- a/p2p/tests/libp2p.rs
+++ b/p2p/tests/libp2p.rs
@@ -17,6 +17,7 @@
 #![cfg(not(loom))]
 extern crate test_utils;
 
+/*
 use common::{chain::config, sync::Arc};
 use libp2p::{multiaddr::Protocol, Multiaddr};
 use p2p::{
@@ -149,3 +150,4 @@ async fn test_libp2p_floodsub() {
         panic!("invalid event received for server1, expected floodsub message");
     }
 }
+*/

--- a/p2p/tests/p2p.rs
+++ b/p2p/tests/p2p.rs
@@ -18,11 +18,8 @@
 extern crate test_utils;
 
 use common::{chain::config, sync::Arc};
-use libp2p::Multiaddr;
-use p2p::{
-    net::{libp2p::Libp2pService, mock::MockService},
-    P2P,
-};
+// use libp2p::Multiaddr;
+use p2p::{net::mock::MockService, P2P};
 use std::net::SocketAddr;
 
 // create new p2p object with mock service
@@ -43,6 +40,7 @@ async fn test_p2p_new_mock() {
     assert!(res.is_ok());
 }
 
+/*
 // create new p2p object with libp2p service
 #[ignore]
 #[tokio::test]
@@ -61,3 +59,4 @@ async fn test_p2p_new_libp2p() {
     let res = P2P::<Libp2pService>::new(256, 32, addr, Arc::clone(&config)).await;
     assert!(res.is_ok());
 }
+*/

--- a/p2p/tests/peer.rs
+++ b/p2p/tests/peer.rs
@@ -18,8 +18,8 @@
 extern crate test_utils;
 
 use common::chain::config;
-use libp2p::Multiaddr;
-use p2p::net::{self, libp2p::Libp2pService, mock::MockService, NetworkService};
+// use libp2p::Multiaddr;
+use p2p::net::{self, /*libp2p::Libp2pService, */ mock::MockService, NetworkService};
 use p2p::peer::{Peer, PeerRole};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -55,6 +55,7 @@ async fn test_peer_new_mock() {
     );
 }
 
+/*
 // connect two libp2p service peers together
 #[tokio::test]
 async fn test_peer_new_libp2p() {
@@ -87,3 +88,4 @@ async fn test_peer_new_libp2p() {
         rx,
     );
 }
+*/

--- a/p2p/tests/peer.rs
+++ b/p2p/tests/peer.rs
@@ -39,7 +39,7 @@ async fn test_peer_new_mock() {
 
     let server_res: net::Event<MockService> = server_res.unwrap();
     let server_res = match server_res {
-        net::Event::IncomingConnection(_, socket) => socket,
+        net::Event::Connectivity(net::ConnectivityEvent::IncomingConnection(_, socket)) => socket,
         _ => panic!("invalid event received, expected incoming connection"),
     };
 


### PR DESCRIPTION
This PR splits the `net::Event` enum into two separate enums, `net::ConnectivityEvent` and `net::FloodsubEvent`, which is required for the implementation of separated connectivity and floodsub handling in application-level code. It also temporarily disables libp2p as a network service provider because it's easier to demonstrate the changes I wish to make to the network interface if they are first introduced only to the mock interface which is significantly simpler.

The reason why we want to split these two is that code becomes easier to maintain, especially in the future when all of the peer and syncing-related features have been implemented. Without the split they would all be in `src/lib.rs` which would grow into a very long and unmaintainable file.