### PR TITLE
net: Split NetworkService into two separate services

### DIFF
--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -19,7 +19,7 @@
 #![allow(unused)]
 use crate::{
     error::{self, Libp2pError, P2pError},
-    net::{self, Event, FloodsubTopic, NetworkService, SocketService},
+    net::{self, FloodsubTopic, NetworkService, SocketService},
 };
 use async_trait::async_trait;
 use futures::prelude::*;

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -42,27 +42,29 @@ where
     T: NetworkService,
 {
     /// Incoming connection from remote peer
-    IncomingConnection(T::PeerId, T::Socket),
+    IncomingConnection {
+        peer_id: T::PeerId,
+        socket: T::Socket,
+    },
 
     /// One or more peers discovered
-    PeerDiscovered(Vec<AddrInfo<T>>),
+    PeerDiscovered { peers: Vec<AddrInfo<T>> },
 
     /// One one more peers have expired
-    PeerExpired(Vec<AddrInfo<T>>),
+    PeerExpired { peers: Vec<AddrInfo<T>> },
 }
 
 // TODO: separate events for blocks and transactions?
-pub enum FloodsubEvent {
-    /// Message received from a Floodsub topic
-    MessageReceived(FloodsubTopic, message::Message),
-}
-
-pub enum Event<T>
+pub enum FloodsubEvent<T>
 where
     T: NetworkService,
 {
-    Connectivity(ConnectivityEvent<T>),
-    Floodsub(FloodsubEvent),
+    /// Message received from a Floodsub topic
+    MessageReceived {
+        peer_id: T::PeerId,
+        topic: FloodsubTopic,
+        message: message::Message,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -94,20 +96,32 @@ pub trait NetworkService {
     // Enum of different peer discovery strategies that the implementation provides
     type Strategy;
 
+    /// Handle for sending/receiving connecitivity-related events
+    type ConnectivityHandle: Send;
+
+    /// Handle for sending/receiving floodsub-related events
+    type FloodsubHandle: Send;
+
     /// Initialize the network service provider
     ///
     /// # Arguments
     /// `addr` - socket address for incoming P2P traffic
     /// `strategies` - list of strategies that are used for peer discovery
     /// `topics` - list of floodsub topics that the implementation should subscribe to
-    async fn new(
+    async fn start(
         addr: Self::Address,
         strategies: &[Self::Strategy],
         topics: &[FloodsubTopic],
-    ) -> error::Result<Self>
-    where
-        Self: Sized;
+    ) -> error::Result<(Self::ConnectivityHandle, Self::FloodsubHandle)>;
+}
 
+/// ConnectivityService provides an interface through which objects can send
+/// and receive connectivity-related events to/from the network service provider
+#[async_trait]
+pub trait ConnectivityService<T>
+where
+    T: NetworkService,
+{
     /// Connect to a remote node
     ///
     /// If the connection succeeds, the socket object is returned
@@ -115,33 +129,41 @@ pub trait NetworkService {
     ///
     /// # Arguments
     /// `addr` - socket address of the peer
-    async fn connect(&mut self, addr: Self::Address)
-        -> error::Result<(Self::PeerId, Self::Socket)>;
+    async fn connect(&mut self, address: T::Address) -> error::Result<(T::PeerId, T::Socket)>;
 
     /// Poll events from the network service provider
     ///
     /// There are three types of events that can be received:
     /// - incoming peer connections
-    /// - incoming messages from floodsub topics
     /// - new discovered peers
-    async fn poll_next<T>(&mut self) -> error::Result<Event<T>>
-    where
-        T: NetworkService<Socket = Self::Socket, Address = Self::Address, PeerId = Self::PeerId>;
+    /// - peer expiration events
+    async fn poll_next(&mut self) -> error::Result<ConnectivityEvent<T>>;
 
+    /// Register peer to the network service provider
+    async fn register_peer(&mut self, peer: T::PeerId) -> error::Result<()>;
+
+    /// Unregister peer from the network service provider
+    async fn unregister_peer(&mut self, peer: T::PeerId) -> error::Result<()>;
+}
+
+/// FloodsubService provides an interface through which objects can send
+/// and receive floodsub-related events to/from the network service provider
+#[async_trait]
+pub trait FloodsubService<T>
+where
+    T: NetworkService,
+{
     /// Publish data in a given floodsub topic
     ///
     /// # Arguments
     /// `topic` - identifier for the topic
     /// `data` - generic data to send
-    async fn publish<T>(&mut self, topic: FloodsubTopic, data: &T) -> error::Result<()>
+    async fn publish<U>(&mut self, topic: FloodsubTopic, data: &U) -> error::Result<()>
     where
-        T: Sync + Send + Encode;
+        U: Sync + Send + Encode;
 
-    /// Register peer to the network service provider
-    async fn register_peer(&mut self, peer: Self::PeerId) -> error::Result<()>;
-
-    /// Unregister peer from the network service provider
-    async fn unregister_peer(&mut self, peer: Self::PeerId) -> error::Result<()>;
+    /// Poll floodsub-related events from the network service provider
+    async fn poll_next(&mut self) -> error::Result<FloodsubEvent<T>>;
 }
 
 /// `SocketService` provides the low-level socket interface that

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -23,7 +23,7 @@ use p2p::{
         // libp2p::Libp2pService,
         mock::{MockService, MockSocket},
         ConnectivityEvent,
-        Event,
+        ConnectivityService,
         NetworkService,
     },
     peer::*,
@@ -67,13 +67,13 @@ pub async fn create_two_mock_peers(
     config: Arc<ChainConfig>,
 ) -> (Peer<MockService>, Peer<MockService>) {
     let addr: SocketAddr = make_address("[::1]:");
-    let mut server = MockService::new(addr, &[], &[]).await.unwrap();
+    let (mut server, _) = MockService::start(addr, &[], &[]).await.unwrap();
     let peer_fut = TcpStream::connect(addr);
 
     let (remote_res, local_res) = tokio::join!(server.poll_next(), peer_fut);
-    let remote_res: Event<MockService> = remote_res.unwrap();
+    let remote_res: ConnectivityEvent<MockService> = remote_res.unwrap();
     let remote_res = match remote_res {
-        Event::Connectivity(ConnectivityEvent::IncomingConnection(_, socket)) => socket,
+        ConnectivityEvent::IncomingConnection { peer_id: _, socket } => socket,
         _ => panic!("invalid event received, expected incoming connection"),
     };
     let local_res = local_res.unwrap();


### PR DESCRIPTION
Split NetworkService into ConnectivityService and FloodsubService
and instead of returning the NetworkService object, return two handles
which can be used to exchange connectivity and floodsub-related events
with the network service provider.

The ultimate goal is separate P2P object into Sync and Swarm-like
objects that handle syncing and connectivity-related events,
respectively. This requires that multiple objects can communicate with
the network service provider and as RefCell/Mutex/RwLock are not optimal
solutions, the cleanest way to implement this is to take advantage of
the frontend/backend split and acquire two handles to the network service
provider and have each handle provide only some of the functionality of
selected network service.

Depending on how the subsystem communication is introduced to P2P,
it may be worthwhile to implement the FloodsubHandle using
tokio::broadcast and provide the handle for both Sync and P2P objects.