### PR TITLE
storage: Add a convenience macro for defining schema

### DIFF
--- a/blockchain_storage/src/store.rs
+++ b/blockchain_storage/src/store.rs
@@ -31,38 +31,19 @@ mod well_known {
     declare_entry!(BestBlockId: Id<Block>);
 }
 
-// Type-level tags for individual key-value stores:
-// Store tag for individual values.
-pub struct DBValues;
-// Store tag for blocks.
-pub struct DBBlocks;
-// Store tag for transaction indices.
-pub struct DBTxIndices;
-// Store for block IDs indexed by block height.
-pub struct DBBlockByHeight;
-
-impl storage::schema::Column for DBValues {
-    const NAME: &'static str = "ValuesV0";
-    type Kind = storage::schema::Single;
+storage::decl_schema! {
+    // Database schema for blockchain storage
+    Schema {
+        // Storage for individual values.
+        pub DBValues: Single,
+        // Storage for blocks.
+        pub DBBlocks: Single,
+        // Storage for transaction indices.
+        pub DBTxIndices: Single,
+        // Storage for block IDs indexed by block height.
+        pub DBBlockByHeight: Single,
+    }
 }
-
-impl storage::schema::Column for DBBlocks {
-    const NAME: &'static str = "BlocksV0";
-    type Kind = storage::schema::Single;
-}
-
-impl storage::schema::Column for DBTxIndices {
-    const NAME: &'static str = "TxIndicesV0";
-    type Kind = storage::schema::Single;
-}
-
-impl storage::schema::Column for DBBlockByHeight {
-    const NAME: &'static str = "BlkByHgtV0";
-    type Kind = storage::schema::Single;
-}
-
-// Complete database schema
-type Schema = (DBValues, (DBBlocks, (DBTxIndices, (DBBlockByHeight, ()))));
 
 type StoreImpl = storage::Store<Schema>;
 type RoTxImpl<'tx> = <StoreImpl as traits::Transactional<'tx, Schema>>::TransactionRo;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -15,16 +15,11 @@
 //! // Delcare a schema. Schema specifies which columns are present,
 //! // name of each column and its kind. Columns are identified by types.
 //! // Here, we create just one column.
-//!
-//! struct MyColumn;
-//! impl schema::Column for MyColumn {
-//!     const NAME: &'static str = "MyColumnV1";
-//!     type Kind = schema::Single;
+//! storage::decl_schema! {
+//!     Schema {
+//!         MyColumn: Single,
+//!     }
 //! }
-//!
-//! // Schema is a bunch of nested tuples listing the columns.
-//! // The format is (Column1, (Column2, ())) etc.
-//! type Schema = (MyColumn, ());
 //!
 //! // Our store type is parametrized by the schema.
 //! type MyStore = storage::Store<Schema>;
@@ -84,15 +79,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
 mod test {
-    use crate::{schema, traits::*};
+    use crate::traits::*;
 
-    struct MyColumn;
-    impl schema::Column for MyColumn {
-        const NAME: &'static str = "MyColumnV1";
-        type Kind = schema::Single;
+    crate::decl_schema! {
+        MySchema {
+            MyColumn: Single,
+        }
     }
 
-    type MySchema = (MyColumn, ());
     type MyStore = crate::Store<MySchema>;
 
     fn generic_aborted_write<St: Backend<MySchema>>(store: &St) -> crate::Result<()> {


### PR DESCRIPTION
This is to avoid having to manually write nested tuples and other boilerplate. Also, to provide a more friendly syntax independent of underlying encoding in terms of types and trait instances.