### PR TITLE
Use env_logger everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "lazy_static",
+ "logging",
  "loom",
  "merkletree",
  "parity-scale-codec",
@@ -1988,6 +1989,9 @@ dependencies = [
 [[package]]
 name = "node"
 version = "0.1.0"
+dependencies = [
+ "logging",
+]
 
 [[package]]
 name = "nohash-hasher"
@@ -2867,6 +2871,7 @@ dependencies = [
  "flate2",
  "hex",
  "hex-literal",
+ "logging",
  "parity-scale-codec",
  "parity-scale-codec-derive",
  "proptest",
@@ -3586,6 +3591,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 [[package]]
 name = "wallet"
 version = "0.1.0"
+dependencies = [
+ "logging",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,9 +3083,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sscanf"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513162b19ce2aa5347d36a1d9cbc8ba2b20c63e0e82080b52d2cade9fb3a8cb7"
+checksum = "6311683a27f16025db4f8bcf0732662f5fecd1406f53f0aab9adbf6f396f1189"
 dependencies = [
  "const_format",
  "lazy_static",
@@ -3095,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "sscanf_macro"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d697834866afffd34330ee55f6dbb2cf1eedd44b33cc63b8fdfd87bc3268eeac"
+checksum = "0d1d364d856d72a52b518c7669df864bdf177de242bcb5b45369ec33190c91c3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,6 +1671,7 @@ name = "logging"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "lazy_static",
  "log",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,6 +22,7 @@ parity-scale-codec = {version = "2.3.1", features = ["derive", "chain-error"]}
 parity-scale-codec-derive = "2.3.1"
 sscanf = "0.1.4"
 lazy_static = "1.4.0"
+logging = { path = "../logging/" }
 
 # for fixed_hash
 arbitrary = "1.1.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,7 +20,7 @@ rand = "0.8.4"
 anyhow = "1.0.51"
 parity-scale-codec = {version = "2.3.1", features = ["derive", "chain-error"]}
 parity-scale-codec-derive = "2.3.1"
-sscanf = "0.1.4"
+sscanf = "0.2.1"
 lazy_static = "1.4.0"
 logging = { path = "../logging/" }
 

--- a/common/src/primitives/encoding.rs
+++ b/common/src/primitives/encoding.rs
@@ -96,6 +96,7 @@ mod tests {
     use super::*;
     use bitcoin_bech32::WitnessProgram;
     use hex::FromHex;
+    use logging::log;
 
     #[test]
     fn check_encode() {
@@ -106,7 +107,7 @@ mod tests {
         assert_eq!(encoded, "bech321qqqsyktsg0l".to_string());
 
         let decoded = decode(&encoded).expect("should decode okay");
-        println!("value of decoded: {:?}", decoded);
+        log::info!("value of decoded: {:?}", decoded);
 
         let base32_data: Vec<u8> = data.to_base32().into_iter().map(|x| x.to_u8()).collect();
         assert_eq!(base32_data, decoded.get_base32_data());

--- a/common/src/primitives/encoding.rs
+++ b/common/src/primitives/encoding.rs
@@ -100,6 +100,8 @@ mod tests {
 
     #[test]
     fn check_encode() {
+        logging::init_logging::<&std::path::Path>(None);
+
         let data = vec![0x00, 0x01, 0x02];
         let hrp = "bech32";
 

--- a/common/src/primitives/time.rs
+++ b/common/src/primitives/time.rs
@@ -16,6 +16,7 @@
 // Author(s): A. Altonen
 #![allow(unused, dead_code)]
 use lazy_static::lazy_static;
+use logging::log;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::SystemTime;
 
@@ -68,29 +69,29 @@ mod tests {
     #[test]
     fn test_time() {
         let handle = std::thread::spawn(move || {
-            println!("p2p time: {}", get());
+            log::info!("p2p time: {}", get());
             std::thread::sleep(std::time::Duration::from_secs(1));
 
-            println!("p2p time: {}", get());
+            log::info!("p2p time: {}", get());
             assert_eq!(get(), 1337);
             std::thread::sleep(std::time::Duration::from_secs(1));
 
-            println!("p2p time: {}", get());
+            log::info!("p2p time: {}", get());
             assert_ne!(get(), 1337);
         });
 
         std::thread::spawn(move || {
-            println!("rpc time: {}", get());
+            log::info!("rpc time: {}", get());
             std::thread::sleep(std::time::Duration::from_millis(500));
 
             set(1337);
             assert_eq!(get(), 1337);
-            println!("rpc time: {}", get());
+            log::info!("rpc time: {}", get());
             std::thread::sleep(std::time::Duration::from_millis(500));
 
             reset();
             assert_ne!(get(), 1337);
-            println!("rpc time: {}", get());
+            log::info!("rpc time: {}", get());
         });
 
         handle.join();

--- a/common/src/primitives/time.rs
+++ b/common/src/primitives/time.rs
@@ -68,6 +68,8 @@ mod tests {
 
     #[test]
     fn test_time() {
+        logging::init_logging::<&std::path::Path>(None);
+
         let handle = std::thread::spawn(move || {
             log::info!("p2p time: {}", get());
             std::thread::sleep(std::time::Duration::from_secs(1));

--- a/common/src/primitives/version.rs
+++ b/common/src/primitives/version.rs
@@ -44,8 +44,8 @@ impl TryFrom<&str> for SemVer {
 
     fn try_from(v: &str) -> Result<SemVer, Self::Error> {
         match sscanf::scanf!(v, "{}.{}.{}", u8, u8, u16) {
-            None => Err("String does not contain SemVer"),
-            Some((ma, mi, pa)) => Ok(SemVer::new(ma, mi, pa)),
+            Err(_) => Err("String does not contain SemVer"),
+            Ok((ma, mi, pa)) => Ok(SemVer::new(ma, mi, pa)),
         }
     }
 }
@@ -55,8 +55,8 @@ impl TryFrom<String> for SemVer {
 
     fn try_from(v: String) -> Result<SemVer, Self::Error> {
         match sscanf::scanf!(v, "{}.{}.{}", u8, u8, u16) {
-            None => Err("String does not contain SemVer"),
-            Some((ma, mi, pa)) => Ok(SemVer::new(ma, mi, pa)),
+            Err(_) => Err("String does not contain SemVer"),
+            Ok((ma, mi, pa)) => Ok(SemVer::new(ma, mi, pa)),
         }
     }
 }

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -9,3 +9,4 @@ license = "MIT"
 [dependencies]
 log = "0.4.14"
 env_logger = "0.9.0"
+lazy_static = "1.4.0"

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -11,7 +11,7 @@ pub fn is_file_output_supported() -> bool {
 static INITIALIZE_LOGGER_ONCE_FLAG: std::sync::Once = std::sync::Once::new();
 
 pub fn init_logging<P: AsRef<std::path::Path>>(_log_file_path: Option<P>) {
-    INITIALIZE_LOGGER_ONCE_FLAG.call_once(|| env_logger::init());
+    INITIALIZE_LOGGER_ONCE_FLAG.call_once(env_logger::init);
 }
 
 #[cfg(test)]

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -8,15 +8,20 @@ pub fn is_file_output_supported() -> bool {
     false
 }
 
+static INITIALIZE_LOGGER_ONCE_FLAG: std::sync::Once = std::sync::Once::new();
+
 pub fn init_logging<P: AsRef<std::path::Path>>(_log_file_path: Option<P>) {
-    env_logger::init();
+    INITIALIZE_LOGGER_ONCE_FLAG.call_once(|| env_logger::init());
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     #[allow(clippy::eq_op)]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn initialize_twice() {
+        init_logging::<&std::path::Path>(None);
+        init_logging::<&std::path::Path>(None);
     }
 }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,3 +7,4 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+logging = { path = "../logging/" }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    logging::log::info!("Hello, world!");
 }

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -16,6 +16,7 @@ flate2 = "1.0.22"
 hex = "0.4.3"
 hex-literal = "0.3.1"
 proptest = "1.0.0"
+logging = { path = '../logging' }
 
 [features]
 default = ['testcontext']

--- a/script/src/test/mod.rs
+++ b/script/src/test/mod.rs
@@ -16,6 +16,7 @@
 // Author(s): L. Kuklinek
 
 use crate::*;
+use logging::log;
 
 // Test the interpreter on all 4-byte combinations of non-trivial opcodes.
 #[test]
@@ -62,7 +63,7 @@ fn test_4opc_sequences() {
         // Run the script and record mismatches between expected and actual outputs.
         let result = run_script(&TestContext::default(), &script, vec![].into()).ok();
         if expected != result {
-            eprintln!("FAIL {:?}: {:?} vs. {:?}", script, result, expected);
+            log::error!("FAIL {:?}: {:?} vs. {:?}", script, result, expected);
             fails += 1;
         }
     }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -7,3 +7,4 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+logging = { path = "../logging/" }

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    logging::log::info!("Hello, world!");
 }


### PR DESCRIPTION
P2P is not fixed in this commit as the prints were converted to use env_logger in the syncing PR