### PR TITLE
p2p: Enable timeouts for outbound connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,6 +2148,7 @@ dependencies = [
  "libp2p",
  "logging",
  "parity-scale-codec",
+ "portpicker",
  "rand 0.8.4",
  "test-utils",
  "tokio",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -26,12 +26,15 @@ features = ["floodsub", "mdns", "mplex", "noise", "streaming", "tcp-async-io"]
 
 [dependencies.tokio]
 version = "1"
-features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync"]
+features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"]
 
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
 version = '2.0.0'
+
+[dev-dependencies]
+portpicker = "0.1.1"
 
 [dev-dependencies.test-utils]
 version = "0.1.0"

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -60,7 +60,7 @@ where
         addr: T::Address,
         config: Arc<ChainConfig>,
     ) -> error::Result<Self> {
-        let (conn, flood) = T::start(addr, &[], &[]).await?;
+        let (conn, flood) = T::start(addr, &[], &[], std::time::Duration::from_secs(10)).await?;
         let (tx_swarm, rx_swarm) = mpsc::channel(16);
         let (tx_sync, rx_sync) = mpsc::channel(16);
         let (tx_peer, rx_peer) = mpsc::channel(16);

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -110,10 +110,12 @@ pub trait NetworkService {
     /// `addr` - socket address for incoming P2P traffic
     /// `strategies` - list of strategies that are used for peer discovery
     /// `topics` - list of floodsub topics that the implementation should subscribe to
+    /// `timeout` - timeout for outbound connections
     async fn start(
         addr: Self::Address,
         strategies: &[Self::Strategy],
         topics: &[FloodsubTopic],
+        timeout: std::time::Duration,
     ) -> error::Result<(Self::ConnectivityHandle, Self::FloodsubHandle)>;
 }
 

--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -414,7 +414,7 @@ mod tests {
         T::ConnectivityHandle: ConnectivityService<T>,
     {
         let config = Arc::new(config::create_mainnet());
-        let (conn, _) = T::start(addr, &[], &[]).await.unwrap();
+        let (conn, _) = T::start(addr, &[], &[], std::time::Duration::from_secs(10)).await.unwrap();
         let (_, rx) = tokio::sync::mpsc::channel(16);
         let (tx_sync, mut rx_sync) = tokio::sync::mpsc::channel(16);
         let (tx_peer, _) = tokio::sync::mpsc::channel(16);

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -194,7 +194,8 @@ mod tests {
         T::FloodsubHandle: FloodsubService<T>,
     {
         let config = Arc::new(config::create_mainnet());
-        let (_, flood) = T::start(addr, &[], &[]).await.unwrap();
+        let (_, flood) =
+            T::start(addr, &[], &[], std::time::Duration::from_secs(10)).await.unwrap();
         let (tx_sync, rx_sync) = tokio::sync::mpsc::channel(16);
         let (tx_peer, rx_peer) = tokio::sync::mpsc::channel(16);
 

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -65,7 +65,7 @@ pub async fn create_two_mock_peers(
     config: Arc<ChainConfig>,
 ) -> (Peer<MockService>, Peer<MockService>) {
     let addr: SocketAddr = make_address("[::1]:");
-    let (mut server, _) = MockService::start(addr, &[], &[]).await.unwrap();
+    let (mut server, _) = MockService::start(addr, &[], &[], std::time::Duration::from_secs(10)).await.unwrap();
     let peer_fut = TcpStream::connect(addr);
 
     let (remote_res, local_res) = tokio::join!(server.poll_next(), peer_fut);
@@ -117,10 +117,10 @@ pub async fn create_two_libp2p_peers(
     config: Arc<ChainConfig>,
 ) -> (Peer<Libp2pService>, Peer<Libp2pService>) {
     let addr1: Multiaddr = make_address("/ip6/::1/tcp/");
-    let (mut server1, _) = Libp2pService::start(addr1, &[], &[]).await.unwrap();
+    let (mut server1, _) = Libp2pService::start(addr1, &[], &[], std::time::Duration::from_secs(10)).await.unwrap();
 
     let addr2: Multiaddr = make_address("/ip6/::1/tcp/");
-    let (mut server2, _) = Libp2pService::start(addr2, &[], &[]).await.unwrap();
+    let (mut server2, _) = Libp2pService::start(addr2, &[], &[], std::time::Duration::from_secs(10)).await.unwrap();
 
     let server1_conn_fut = server1.connect(server2.local_addr().clone());
 

--- a/p2p/tests/libp2p.rs
+++ b/p2p/tests/libp2p.rs
@@ -33,14 +33,24 @@ use p2p::{
 #[tokio::test]
 async fn test_libp2p_peer_discovery() {
     let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
-    let (mut serv, _) = Libp2pService::start(addr.clone(), &[Libp2pStrategy::MulticastDns], &[])
-        .await
-        .unwrap();
+    let (mut serv, _) = Libp2pService::start(
+        addr.clone(),
+        &[Libp2pStrategy::MulticastDns],
+        &[],
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .unwrap();
 
     let addr2: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
-    let (mut serv2, _) = Libp2pService::start(addr2.clone(), &[Libp2pStrategy::MulticastDns], &[])
-        .await
-        .unwrap();
+    let (mut serv2, _) = Libp2pService::start(
+        addr2.clone(),
+        &[Libp2pStrategy::MulticastDns],
+        &[],
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .unwrap();
 
     loop {
         let (serv_res, _) = tokio::join!(serv.poll_next(), serv2.poll_next());
@@ -74,12 +84,24 @@ async fn test_libp2p_peer_discovery() {
 #[tokio::test]
 async fn test_libp2p_floodsub() {
     let addr1: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
-    let (mut conn1, mut flood1) =
-        Libp2pService::start(addr1, &[], &[FloodsubTopic::Transactions]).await.unwrap();
+    let (mut conn1, mut flood1) = Libp2pService::start(
+        addr1,
+        &[],
+        &[FloodsubTopic::Transactions],
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .unwrap();
 
     let addr2: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
-    let (mut conn2, mut flood2) =
-        Libp2pService::start(addr2, &[], &[FloodsubTopic::Transactions]).await.unwrap();
+    let (mut conn2, mut flood2) = Libp2pService::start(
+        addr2,
+        &[],
+        &[FloodsubTopic::Transactions],
+        std::time::Duration::from_secs(10),
+    )
+    .await
+    .unwrap();
 
     let (conn1_res, conn2_res) =
         tokio::join!(conn1.connect(conn2.local_addr().clone()), conn2.poll_next());

--- a/p2p/tests/peer.rs
+++ b/p2p/tests/peer.rs
@@ -32,7 +32,9 @@ use tokio::net::TcpStream;
 async fn test_peer_new_mock() {
     let config = Arc::new(config::create_mainnet());
     let addr: SocketAddr = test_utils::make_address("[::1]:");
-    let (mut server, _) = MockService::start(addr, &[], &[]).await.unwrap();
+    let (mut server, _) = MockService::start(addr, &[], &[], std::time::Duration::from_secs(10))
+        .await
+        .unwrap();
     let peer_fut = TcpStream::connect(addr);
 
     let (server_res, peer_res) = tokio::join!(server.poll_next(), peer_fut);
@@ -64,11 +66,17 @@ async fn test_peer_new_mock() {
 async fn test_peer_new_libp2p() {
     let config = Arc::new(config::create_mainnet());
     let addr1: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
-    let (mut server1, _) = Libp2pService::start(addr1.clone(), &[], &[]).await.unwrap();
+    let (mut server1, _) =
+        Libp2pService::start(addr1.clone(), &[], &[], std::time::Duration::from_secs(10))
+            .await
+            .unwrap();
 
     let conn_addr = server1.local_addr().clone();
     let addr2: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
-    let (mut server2, _) = Libp2pService::start(addr2, &[], &[]).await.unwrap();
+    let (mut server2, _) =
+        Libp2pService::start(addr2, &[], &[], std::time::Duration::from_secs(10))
+            .await
+            .unwrap();
 
     let (server1_res, server2_res) = tokio::join!(server1.poll_next(), server2.connect(conn_addr));
     assert!(server1_res.is_ok());


### PR DESCRIPTION
Previously, the SwarmManager could be DoS'ed by advertising an address
that didn't have an active listener and forcing the SwarmManager to
wait on that connection to succeeds.

Mock inteface's test might be a little unreliable because it's surprisingly hard to create a connection test that timeouts in localhost. If for some reason the code doesn't time out in CI/your computer/on Windows, I'll just disable it for now. It works on my computer so the actual timeout mechanisms works for both libp2p and mock.