### PR TITLE
testing: Make loom optional on per-package basis

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         submodules: recursive
     - name: Run permutation tests
-      run: cargo test --tests --release --workspace
+      run: cargo test --tests --release -p storage -p blockchain-storage

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-#![cfg(not(loom))]
 
 use crate::net::{ConnectivityService, FloodsubService, NetworkService};
 use common::chain::ChainConfig;

--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -15,7 +15,6 @@
 //
 // Author(s): A. Altonen
 #![allow(unused, dead_code)]
-#![cfg(not(loom))]
 
 ///! Swarm manager
 ///!

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-#![cfg(not(loom))]
 #![allow(unused)]
 
 use crate::{

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-#![cfg(not(loom))]
 
 use common::chain::ChainConfig;
 use libp2p::Multiaddr;

--- a/p2p/tests/connectivity.rs
+++ b/p2p/tests/connectivity.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-#![cfg(not(loom))]
 
 use common::{
     chain::{config, ChainConfig},

--- a/p2p/tests/handshake.rs
+++ b/p2p/tests/handshake.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-#![cfg(not(loom))]
 
 use common::{
     chain::config,

--- a/p2p/tests/libp2p.rs
+++ b/p2p/tests/libp2p.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-#![cfg(not(loom))]
 extern crate test_utils;
 
 use libp2p::{multiaddr::Protocol, Multiaddr};

--- a/p2p/tests/p2p.rs
+++ b/p2p/tests/p2p.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-#![cfg(not(loom))]
 extern crate test_utils;
 
 use common::{chain::config, sync::Arc};

--- a/p2p/tests/peer.rs
+++ b/p2p/tests/peer.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-#![cfg(not(loom))]
 extern crate test_utils;
 
 use common::chain::config;

--- a/script/src/interpreter.rs
+++ b/script/src/interpreter.rs
@@ -526,7 +526,7 @@ fn op_hash<T: AsRef<[u8]>>(stack: &mut Stack, f: impl FnOnce(&[u8]) -> T) -> cra
     Ok(())
 }
 
-#[cfg(all(test, not(loom)))]
+#[cfg(test)]
 mod test {
     use super::*;
     use crate::opcodes::all as opc;

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -55,7 +55,7 @@ mod interpreter;
 pub mod opcodes;
 pub mod script;
 pub mod sighash;
-#[cfg(all(test, not(loom)))]
+#[cfg(test)]
 mod test;
 
 pub use crate::script::{Builder, Script};


### PR DESCRIPTION
For now, loom is only enabled for `storage` and `blockchain-storage`.