### PR TITLE
Fix drop checks

### DIFF
--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -45,7 +45,7 @@ impl From<Uint256> for H256 {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct Id<T: ?Sized> {
     id: H256,
-    _shadow: std::marker::PhantomData<T>,
+    _shadow: std::marker::PhantomData<fn() -> T>,
 }
 
 // We implement Ord manually to avoid it getting inherited to T through PhantomData, because Id having Ord doesn't mean T requiring Ord

--- a/storage/src/basic.rs
+++ b/storage/src/basic.rs
@@ -58,7 +58,7 @@ impl DeltaMap {
 /// Store is a collection of key-(multi)value maps
 pub struct Store<Sch: Schema> {
     maps: sync::Arc<sync::RwLock<StoreMapSet>>,
-    _phantom: std::marker::PhantomData<Sch>,
+    _phantom: std::marker::PhantomData<fn() -> Sch>,
 }
 
 impl<Sch: Schema> Clone for Store<Sch> {


### PR DESCRIPTION
Signal to the compiler that `Id<T>` and `storage::basic::Store<Sch>` do not drop any `T`s or `Sch`s respectively. This makes the compiler less restrictive when using these types if the generic parameters are types that implement `Drop`.