### PR TITLE
utils: Introduce the `ensure!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,6 +3252,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-scale-codec-derive",
  "proptest",
+ "utils",
 ]
 
 [[package]]

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 [dependencies]
 displaydoc = { default-features = false, version = "0.2" }
 crypto = { path = '../crypto' }
+utils = { path = '../utils' }
 
 parity-scale-codec = {version = "2.3.1", features = ["derive", "chain-error"]}
 parity-scale-codec-derive = "2.3.1"

--- a/script/src/interpreter.rs
+++ b/script/src/interpreter.rs
@@ -25,6 +25,7 @@ use crate::{
     util,
 };
 use std::{borrow::Cow, cmp, ops, ops::Range};
+use utils::ensure;
 
 /// Item on the data stack.
 ///

--- a/script/src/util.rs
+++ b/script/src/util.rs
@@ -84,15 +84,6 @@ macro_rules! hex_script {
     };
 }
 
-macro_rules! ensure {
-    ($cond:expr, $err:expr) => {
-        ($cond).then(|| ()).ok_or_else(|| ($err))?
-    };
-    ($cond:expr) => {
-        ($cond).then(|| ())?
-    };
-}
-
 // Export some hash functions.
 pub use crypto::hash;
 

--- a/utils/src/ensure.rs
+++ b/utils/src/ensure.rs
@@ -1,0 +1,114 @@
+//! Tools for interrupting function flow unless some condition holds.
+
+/// Early exit if given condition is not satisfied.
+///
+/// There are two variants:
+/// * `ensure!(cond)` returns from the enclosing function with [`None`] if `cond` fails
+/// * `ensure!(cond, err)` returns from the function with [`Err`]`(err)` if `cond` fails
+///
+/// Example with [Option]:
+/// ```
+/// # use utils::ensure;
+/// fn safe_div(x: u32, y: u32) -> Option<u32> {
+///     ensure!(y != 0);
+///     Some(x / y)
+/// }
+///
+/// assert_eq!(safe_div(6, 2), Some(3));
+/// assert_eq!(safe_div(0, 3), Some(0));
+/// assert_eq!(safe_div(8, 0), None);
+/// ```
+///
+/// Example with [Result]:
+/// ```
+/// # use utils::ensure;
+/// # #[derive(PartialEq, Eq, Debug)]
+/// enum DivError {
+///     DivByZero,
+///     NotIntegral,
+/// }
+///
+/// fn integral_div(x: u32, y: u32) -> Result<u32, DivError> {
+///     ensure!(y != 0, DivError::DivByZero);
+///     ensure!(x % y == 0, DivError::NotIntegral);
+///     Ok(x / y)
+/// }
+///
+/// assert_eq!(integral_div(6, 2), Ok(3));
+/// assert_eq!(integral_div(0, 3), Ok(0));
+/// assert_eq!(integral_div(5, 3), Err(DivError::NotIntegral));
+/// assert_eq!(integral_div(8, 0), Err(DivError::DivByZero));
+/// ```
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr $(,)?) => {
+        $cond.then(|| ())?
+    };
+    ($cond:expr, $err:expr $(,)?) => {
+        $cond.then(|| ()).ok_or_else(|| $err)?
+    };
+}
+
+/// Alternative design for ensure
+pub mod func_style {
+    /// Return `None` if given condition is not satisfied.
+    ///
+    /// Maps `true` to `Some(())`, `false` to `None`.
+    ///
+    /// Example:
+    /// ```
+    /// # use utils::ensure::func_style::*;
+    /// fn safe_div(x: u32, y: u32) -> Option<u32> {
+    ///     ensure_some(y != 0)?;
+    ///     Some(x / y)
+    /// }
+    ///
+    /// assert_eq!(safe_div(6, 2), Some(3));
+    /// assert_eq!(safe_div(0, 3), Some(0));
+    /// assert_eq!(safe_div(8, 0), None);
+    /// ```
+    #[must_use = "Result of ensure_some not used. Use the `?` operator for early exit."]
+    pub fn ensure_some(cond: bool) -> Option<()> {
+        cond.then(|| ())
+    }
+
+    /// Return `Err` if given condition is not satisfied.
+    ///
+    /// Maps `true` to `Ok(())`, `false` to `Err(err)`.
+    ///
+    /// Example:
+    /// ```
+    /// # use utils::ensure::func_style::*;
+    /// # #[derive(PartialEq, Eq, Debug)]
+    /// enum DivError {
+    ///     DivByZero,
+    ///     NotIntegral,
+    /// }
+    ///
+    /// fn integral_div(x: u32, y: u32) -> Result<u32, DivError> {
+    ///     ensure(y != 0, DivError::DivByZero)?;
+    ///     ensure(x % y == 0, DivError::NotIntegral)?;
+    ///     Ok(x / y)
+    /// }
+    ///
+    /// assert_eq!(integral_div(6, 2), Ok(3));
+    /// assert_eq!(integral_div(0, 3), Ok(0));
+    /// assert_eq!(integral_div(5, 3), Err(DivError::NotIntegral));
+    /// assert_eq!(integral_div(8, 0), Err(DivError::DivByZero));
+    /// ```
+    #[must_use = "Result of ensure not used. Use the `?` operator for early exit."]
+    pub fn ensure<E>(cond: bool, err: E) -> Result<(), E> {
+        ensure_some(cond).ok_or(err)
+    }
+
+    /// Return `Err` if given condition is not satisfied.
+    ///
+    /// Maps `true` to `Ok(())`, `false` to `Err(err_fn())`.
+    ///
+    /// Same as [ensure()] but takes a closure to calculate the error lazily.
+    /// Useful if a non-trivial computation is needed to obtain the error value.
+    #[must_use = "Result of ensure_fn not used. Use the `?` operator for early exit."]
+    pub fn ensure_fn<E>(cond: bool, err_fn: impl FnOnce() -> E) -> Result<(), E> {
+        ensure_some(cond).ok_or_else(err_fn)
+    }
+}

--- a/utils/src/ensure.rs
+++ b/utils/src/ensure.rs
@@ -42,73 +42,9 @@
 #[macro_export]
 macro_rules! ensure {
     ($cond:expr $(,)?) => {
-        $cond.then(|| ())?
+        ::core::primitive::bool::then($cond, || ())?
     };
     ($cond:expr, $err:expr $(,)?) => {
-        $cond.then(|| ()).ok_or_else(|| $err)?
+        ::core::primitive::bool::then($cond, || ()).ok_or_else(|| $err)?
     };
-}
-
-/// Alternative design for ensure
-pub mod func_style {
-    /// Return `None` if given condition is not satisfied.
-    ///
-    /// Maps `true` to `Some(())`, `false` to `None`.
-    ///
-    /// Example:
-    /// ```
-    /// # use utils::ensure::func_style::*;
-    /// fn safe_div(x: u32, y: u32) -> Option<u32> {
-    ///     ensure_some(y != 0)?;
-    ///     Some(x / y)
-    /// }
-    ///
-    /// assert_eq!(safe_div(6, 2), Some(3));
-    /// assert_eq!(safe_div(0, 3), Some(0));
-    /// assert_eq!(safe_div(8, 0), None);
-    /// ```
-    #[must_use = "Result of ensure_some not used. Use the `?` operator for early exit."]
-    pub fn ensure_some(cond: bool) -> Option<()> {
-        cond.then(|| ())
-    }
-
-    /// Return `Err` if given condition is not satisfied.
-    ///
-    /// Maps `true` to `Ok(())`, `false` to `Err(err)`.
-    ///
-    /// Example:
-    /// ```
-    /// # use utils::ensure::func_style::*;
-    /// # #[derive(PartialEq, Eq, Debug)]
-    /// enum DivError {
-    ///     DivByZero,
-    ///     NotIntegral,
-    /// }
-    ///
-    /// fn integral_div(x: u32, y: u32) -> Result<u32, DivError> {
-    ///     ensure(y != 0, DivError::DivByZero)?;
-    ///     ensure(x % y == 0, DivError::NotIntegral)?;
-    ///     Ok(x / y)
-    /// }
-    ///
-    /// assert_eq!(integral_div(6, 2), Ok(3));
-    /// assert_eq!(integral_div(0, 3), Ok(0));
-    /// assert_eq!(integral_div(5, 3), Err(DivError::NotIntegral));
-    /// assert_eq!(integral_div(8, 0), Err(DivError::DivByZero));
-    /// ```
-    #[must_use = "Result of ensure not used. Use the `?` operator for early exit."]
-    pub fn ensure<E>(cond: bool, err: E) -> Result<(), E> {
-        ensure_some(cond).ok_or(err)
-    }
-
-    /// Return `Err` if given condition is not satisfied.
-    ///
-    /// Maps `true` to `Ok(())`, `false` to `Err(err_fn())`.
-    ///
-    /// Same as [ensure()] but takes a closure to calculate the error lazily.
-    /// Useful if a non-trivial computation is needed to obtain the error value.
-    #[must_use = "Result of ensure_fn not used. Use the `?` operator for early exit."]
-    pub fn ensure_fn<E>(cond: bool, err_fn: impl FnOnce() -> E) -> Result<(), E> {
-        ensure_some(cond).ok_or_else(err_fn)
-    }
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod ensure;
 pub mod newtype;


### PR DESCRIPTION
Resurrect `ensure!` form Substrate. Used for the common pattern where function exits early with an error if some condition is not satisfied.

<s>The `func_style` submodule is an altenative design that does not use macros. Its advantage is less magic and no unusual behaviour (like interrupting function flow). The disadvantage is that it requires more functions and creating error is not lazy by default, so a bit more clumsy to use in certain cases.</s>

Any preferences between the two? Either the macro or the functions in the `func_style` module will be deleted before finalising this PR. **Going for the macro version**