### PR TITLE
consensus: Make OrphanBlocksPool usable in async code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ version = "0.1.0"
 dependencies = [
  "blockchain-storage",
  "common",
+ "crypto",
  "logging",
  "num",
  "parity-scale-codec",
@@ -591,6 +592,7 @@ dependencies = [
  "rand 0.8.4",
  "replace_with",
  "slave-pool",
+ "static_assertions",
  "thiserror",
 ]
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -7,14 +7,18 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blockchain-storage = { path = '../blockchain_storage'}
-common = { path = '../common'}
+blockchain-storage = { path = '../blockchain_storage' }
+common = { path = '../common' }
+crypto = { path = '../crypto' }
 num = "0.4.0"
 rand = "0.8.4"
-logging = { path = '../logging'}
+logging = { path = '../logging' }
 thiserror = "1.0.30"
 proptest = "1.0.0"
 parity-scale-codec-derive = "2.3.1"
 parity-scale-codec = {version = "2.3.1", features = ["derive", "chain-error"]}
 replace_with = "0.1.7"
 slave-pool = "0.2.3"
+
+[dev-dependencies]
+static_assertions = "1.1"

--- a/consensus/src/detail/orphan_blocks.rs
+++ b/consensus/src/detail/orphan_blocks.rs
@@ -38,7 +38,6 @@ pub enum OrphanAddError {
 }
 
 impl OrphanBlocksPool {
-    #[allow(dead_code)]
     pub fn new_default() -> Self {
         OrphanBlocksPool {
             orphan_ids: Vec::new(),
@@ -60,7 +59,6 @@ impl OrphanBlocksPool {
         }
     }
 
-    #[allow(dead_code)]
     fn drop_block(&mut self, block_id: &H256) {
         let block = self
             .orphan_by_id
@@ -115,7 +113,6 @@ impl OrphanBlocksPool {
     }
 
     // keep digging in the orphans tree until we find a block that has no children, then delete that
-    #[allow(dead_code)]
     fn del_one_deepest_child(&mut self, block_id: &H256) {
         let next_block = self
             .orphan_by_prev_id
@@ -130,7 +127,6 @@ impl OrphanBlocksPool {
         }
     }
 
-    #[allow(dead_code)]
     fn prune(&mut self) {
         if self.orphan_by_id.len() < self.max_orphans {
             return;
@@ -141,7 +137,6 @@ impl OrphanBlocksPool {
         self.del_one_deepest_child(&id);
     }
 
-    #[allow(dead_code)]
     pub fn add_block(&mut self, block: Block) -> Result<(), OrphanAddError> {
         self.prune();
         let block_id = block.get_id();

--- a/consensus/src/test.rs
+++ b/consensus/src/test.rs
@@ -1,1 +1,6 @@
+use super::*;
+use static_assertions::*;
+
+assert_impl_all!(ConsensusInterface: Send);
+
 // TODO: write tests for consensus crate


### PR DESCRIPTION
For `consensus` to be usable as a subsystem, it has to be able to oparate in async constexts. In multithreaded runtimes, it means the type has to implement `Send`.

There are many ways to achieve this. This PR goes with the most straightforward approach. Alternative suggestions are welcome.
