### PR TITLE
Add a test to ensure our sk is zeroed correctly

### DIFF
--- a/crypto/src/key/rschnorr/mod.rs
+++ b/crypto/src/key/rschnorr/mod.rs
@@ -290,4 +290,19 @@ mod test {
         let sig = sk.sign_message(&mut rng, &msg).unwrap();
         assert!(pk.verify_message(&sig, &msg));
     }
+
+    #[test]
+    fn sk_zeroed() {
+        use std::slice;
+        let mut rng = rand::rngs::StdRng::from_entropy();
+        let zero_sk = &vec![0u8; 32][..];
+        unsafe {
+            let hldr;
+            {
+                let (sk, _pk) = MLRistrettoPrivateKey::new(&mut rng);
+                hldr = sk.as_bytes().as_ptr();
+            }
+            assert_eq!(slice::from_raw_parts(hldr, 32), zero_sk);
+        }
+    }
 }

--- a/crypto/src/key/rschnorr/mod.rs
+++ b/crypto/src/key/rschnorr/mod.rs
@@ -197,12 +197,12 @@ impl std::ops::Add for &MLRistrettoPublicKey {
 mod test {
     use super::*;
     use hex::ToHex;
-    use rand::SeedableRng;
     use tari_crypto::tari_utilities::message_format::MessageFormat;
+    use crate::random::make_true_rng;
 
     #[test]
     fn basic() {
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = make_true_rng();
         let (sk, pk) = MLRistrettoPrivateKey::new(&mut rng);
         let pk2 = MLRistrettoPublicKey::from_private_key(&sk);
         assert_eq!(pk, pk2);
@@ -210,7 +210,7 @@ mod test {
 
     #[test]
     fn import_from_short_key() {
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = make_true_rng();
         let (sk, pk) = MLRistrettoPrivateKey::new(&mut rng);
         {
             let sk_bytes = sk.as_bytes();
@@ -230,7 +230,7 @@ mod test {
 
     #[test]
     fn serialize() {
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = make_true_rng();
         let (sk, pk) = MLRistrettoPrivateKey::new(&mut rng);
         let sk_encoded = sk.encode();
         let pk_encoded = pk.encode();
@@ -274,7 +274,7 @@ mod test {
 
     #[test]
     fn sign_and_verify() {
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = make_true_rng();
         let msg_size = 1 + rand::random::<usize>() % 10000;
         let msg: Vec<u8> = (0..msg_size).map(|_| rand::random::<u8>()).collect();
         let (sk, pk) = MLRistrettoPrivateKey::new(&mut rng);
@@ -284,7 +284,7 @@ mod test {
 
     #[test]
     fn sign_empty() {
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = make_true_rng();
         let msg: Vec<u8> = Vec::new();
         let (sk, pk) = MLRistrettoPrivateKey::new(&mut rng);
         let sig = sk.sign_message(&mut rng, &msg).unwrap();
@@ -294,7 +294,7 @@ mod test {
     #[test]
     fn sk_zeroed() {
         use std::slice;
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = make_true_rng();
         let zero_sk = &vec![0u8; 32][..];
         unsafe {
             let hldr;

--- a/crypto/src/key/rschnorr/mod.rs
+++ b/crypto/src/key/rschnorr/mod.rs
@@ -296,12 +296,12 @@ mod test {
         use std::slice;
         let mut rng = make_true_rng();
         let zero_sk = &vec![0u8; 32][..];
+        let hldr;
+        {
+            let (sk, _pk) = MLRistrettoPrivateKey::new(&mut rng);
+            hldr = sk.as_bytes().as_ptr();
+        }
         unsafe {
-            let hldr;
-            {
-                let (sk, _pk) = MLRistrettoPrivateKey::new(&mut rng);
-                hldr = sk.as_bytes().as_ptr();
-            }
             assert_eq!(slice::from_raw_parts(hldr, 32), zero_sk);
         }
     }


### PR DESCRIPTION
This test is somewhat superfluous while we rely on `Tari` for our sks but on the assumption it's viable (likely?) that someone will refactor this to work with an "in house" implementation at some point in time it makes me happier to have tests to catch these annoying little things rather than just the raw functionality of the sigs like we currently have. 
I've started thinking about the key storage so there may be a few more of these over the next few days adding small tests to make life "easier" in the long run. 