### PR TITLE
Reorganize Subsystem traits a bit

### DIFF
--- a/subsystem/src/manager.rs
+++ b/subsystem/src/manager.rs
@@ -167,7 +167,7 @@ impl Manager {
     /// A passive subsystem does not interact with the environment on its own. It only serves calls
     /// from other subsystems. A hook to be invoked on shutdown can be specified by means of the
     /// [Subsystem] trait.
-    pub fn start_with_config<S: 'static + Send + Subsystem>(
+    pub fn start_with_config<S: Subsystem>(
         &self,
         config: SubsystemConfig,
         mut subsys: S,
@@ -193,7 +193,7 @@ impl Manager {
     }
 
     /// Start a passive subsystem. See [Manager::start_with_config].
-    pub fn start<S: 'static + Send + Subsystem>(&self, name: &'static str, subsys: S) -> Handle<S> {
+    pub fn start<S: Subsystem>(&self, name: &'static str, subsys: S) -> Handle<S> {
         self.start_with_config(SubsystemConfig::named(name), subsys)
     }
 

--- a/subsystem/src/subsystem.rs
+++ b/subsystem/src/subsystem.rs
@@ -61,7 +61,7 @@ type Action<T, R> = Box<dyn Send + for<'a> FnOnce(&'a mut T) -> BoxFuture<'a, R>
 /// Call request
 pub struct CallRequest<T>(pub(crate) mpsc::Receiver<Action<T, ()>>);
 
-impl<T: 'static + Send> CallRequest<T> {
+impl<T: 'static> CallRequest<T> {
     /// Receive an external call to this subsystem.
     pub async fn recv(&mut self) -> Action<T, ()> {
         match self.0.recv().await {

--- a/subsystem/src/subsystem.rs
+++ b/subsystem/src/subsystem.rs
@@ -20,7 +20,7 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 
 /// Defines hooks into a subsystem lifecycle.
 #[async_trait::async_trait]
-pub trait Subsystem: Sized {
+pub trait Subsystem: 'static + Send + Sized {
     /// Custom shutdown procedure.
     async fn shutdown(self) {}
 }


### PR DESCRIPTION
Some tiny changes to make subsystems that don't adhere to required constraints be flagged up earlier by the compiler.