### PR TITLE
Only start subsystems when `Manager::main` is invoked

### DIFF
--- a/crypto/src/key/rschnorr/mod.rs
+++ b/crypto/src/key/rschnorr/mod.rs
@@ -196,9 +196,9 @@ impl std::ops::Add for &MLRistrettoPublicKey {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::random::make_true_rng;
     use hex::ToHex;
     use tari_crypto::tari_utilities::message_format::MessageFormat;
-    use crate::random::make_true_rng;
 
     #[test]
     fn basic() {

--- a/rpc/examples/simple_server.rs
+++ b/rpc/examples/simple_server.rs
@@ -62,12 +62,12 @@ async fn main() -> anyhow::Result<()> {
 
     let mut app = subsystem::Manager::new("rpc-example");
     app.install_signal_handlers();
-    let some_subsystem = app.start("some_subsys", SomeSubsystem(0));
-    let _rpc_subsystem = app.start(
+    let some_subsystem = app.add_subsystem("some_subsys", SomeSubsystem(0));
+    let _rpc_subsystem = app.add_subsystem(
         "rpc",
         rpc::Builder::new("127.0.0.1:3030".parse().unwrap())
             .register(some_subsystem.clone().into_rpc())
-            .start()
+            .build()
             .await?,
     );
 

--- a/rpc/examples/simple_server.rs
+++ b/rpc/examples/simple_server.rs
@@ -60,7 +60,7 @@ impl SomeSubsystemRpcServer for SomeSubsystemHandle {
 async fn main() -> anyhow::Result<()> {
     logging::init_logging::<&std::path::Path>(None);
 
-    let app = subsystem::Manager::new("rpc-example");
+    let mut app = subsystem::Manager::new("rpc-example");
     app.install_signal_handlers();
     let some_subsystem = app.start("some_subsys", SomeSubsystem(0));
     let _rpc_subsystem = app.start(

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -49,8 +49,8 @@ impl Builder {
         self
     }
 
-    /// Start the RPC server and get the RPC object
-    pub async fn start(self) -> anyhow::Result<Rpc> {
+    /// Build the RPC server and get the RPC object
+    pub async fn build(self) -> anyhow::Result<Rpc> {
         Rpc::new(&self.address, self.methods).await
     }
 }
@@ -116,7 +116,7 @@ mod tests {
     async fn rpc_server() -> anyhow::Result<()> {
         let rpc = Builder::new("127.0.0.1:3030".parse().unwrap())
             .register(SubsystemRpcImpl.into_rpc())
-            .start()
+            .build()
             .await?;
 
         let url = format!("http://{}", rpc.address());

--- a/subsystem/examples/stopwatch.rs
+++ b/subsystem/examples/stopwatch.rs
@@ -38,6 +38,6 @@ async fn main() {
 
     let mut app = subsystem::Manager::new("toplevel");
     app.install_signal_handlers();
-    app.start_raw("watch", Stopwatch::start);
+    app.add_raw_subsystem("watch", Stopwatch::start);
     app.main().await
 }

--- a/subsystem/examples/stopwatch.rs
+++ b/subsystem/examples/stopwatch.rs
@@ -36,7 +36,7 @@ impl Stopwatch {
 async fn main() {
     logging::init_logging::<&std::path::Path>(None);
 
-    let app = subsystem::Manager::new("toplevel");
+    let mut app = subsystem::Manager::new("toplevel");
     app.install_signal_handlers();
     app.start_raw("watch", Stopwatch::start);
     app.main().await

--- a/subsystem/tests/async_calls.rs
+++ b/subsystem/tests/async_calls.rs
@@ -65,7 +65,7 @@ fn async_calls() {
     let runtime = helpers::init_test_runtime();
     common::concurrency::model(move || {
         runtime.block_on(async {
-            let app = subsystem::Manager::new("app");
+            let mut app = subsystem::Manager::new("app");
             let logger = app.start("logger", Logger::new("logging".to_string()));
             let counter = app.start("counter", Counter::new(logger.clone()));
 

--- a/subsystem/tests/async_calls.rs
+++ b/subsystem/tests/async_calls.rs
@@ -66,10 +66,10 @@ fn async_calls() {
     common::concurrency::model(move || {
         runtime.block_on(async {
             let mut app = subsystem::Manager::new("app");
-            let logger = app.start("logger", Logger::new("logging".to_string()));
-            let counter = app.start("counter", Counter::new(logger.clone()));
+            let logger = app.add_subsystem("logger", Logger::new("logging".to_string()));
+            let counter = app.add_subsystem("counter", Counter::new(logger.clone()));
 
-            app.start_raw("test", |_call_rq: CallRequest<()>, _shut_rq| async move {
+            app.add_raw_subsystem("test", |_call_rq: CallRequest<()>, _shut_rq| async move {
                 logger.call(|l| l.write("starting")).await.unwrap();
 
                 // Bump the counter twice

--- a/subsystem/tests/passive.rs
+++ b/subsystem/tests/passive.rs
@@ -107,7 +107,7 @@ fn basic_passive_subsystem() {
     let runtime = helpers::init_test_runtime();
     common::concurrency::model(move || {
         runtime.block_on(async {
-            let app = subsystem::Manager::new("app");
+            let mut app = subsystem::Manager::new("app");
 
             let substr = app.start("substr", Substringer::new("abc".into()));
             let counter = app.start("counter", Counter::new());
@@ -127,7 +127,7 @@ fn basic_passive_shutdown() {
     let runtime = helpers::init_test_runtime();
     common::concurrency::model(move || {
         runtime.block_on(async {
-            let app = subsystem::Manager::new("app");
+            let mut app = subsystem::Manager::new("app");
 
             let _substr = app.start("substr", Substringer::new("abc".into()));
             let _counter = app.start("counter", Counter::new());

--- a/subsystem/tests/passive.rs
+++ b/subsystem/tests/passive.rs
@@ -109,11 +109,11 @@ fn basic_passive_subsystem() {
         runtime.block_on(async {
             let mut app = subsystem::Manager::new("app");
 
-            let substr = app.start("substr", Substringer::new("abc".into()));
-            let counter = app.start("counter", Counter::new());
+            let substr = app.add_subsystem("substr", Substringer::new("abc".into()));
+            let counter = app.add_subsystem("counter", Counter::new());
 
             let tester = Tester::new(substr, counter);
-            app.start_raw("test", |call_rq, shut_rq| async move {
+            app.add_raw_subsystem("test", |call_rq, shut_rq| async move {
                 tester.run(call_rq, shut_rq).await
             });
 
@@ -129,12 +129,12 @@ fn basic_passive_shutdown() {
         runtime.block_on(async {
             let mut app = subsystem::Manager::new("app");
 
-            let _substr = app.start("substr", Substringer::new("abc".into()));
-            let _counter = app.start("counter", Counter::new());
+            let _substr = app.add_subsystem("substr", Substringer::new("abc".into()));
+            let _counter = app.add_subsystem("counter", Counter::new());
 
             // Start a subsystem that immediately terminates, instructing the remaining subsystems
             // to terminate too.
-            let _shut: subsystem::Handle<()> = app.start_raw("terminator", |_, _| async {});
+            let _shut: subsystem::Handle<()> = app.add_raw_subsystem("terminator", |_, _| async {});
 
             app.main().await
         })

--- a/subsystem/tests/trivial.rs
+++ b/subsystem/tests/trivial.rs
@@ -37,7 +37,7 @@ fn empty() {
 fn shortlived() {
     let rt = helpers::init_test_runtime();
     rt.block_on(async {
-        let app = subsystem::Manager::new("shortlived");
+        let mut app = subsystem::Manager::new("shortlived");
         app.start_raw("nop", |_: CallRequest<()>, _| async {});
         app.main().await;
     });
@@ -48,7 +48,7 @@ fn shortlived() {
 fn trivial() {
     let rt = helpers::init_test_runtime();
     rt.block_on(async {
-        let app = subsystem::Manager::new("trivial");
+        let mut app = subsystem::Manager::new("trivial");
         app.start("trivial", Trivial);
         app.start_raw("nop", |_: CallRequest<()>, _| async {});
         app.main().await;

--- a/subsystem/tests/trivial.rs
+++ b/subsystem/tests/trivial.rs
@@ -38,7 +38,7 @@ fn shortlived() {
     let rt = helpers::init_test_runtime();
     rt.block_on(async {
         let mut app = subsystem::Manager::new("shortlived");
-        app.start_raw("nop", |_: CallRequest<()>, _| async {});
+        app.add_raw_subsystem("nop", |_: CallRequest<()>, _| async {});
         app.main().await;
     });
 }
@@ -49,8 +49,8 @@ fn trivial() {
     let rt = helpers::init_test_runtime();
     rt.block_on(async {
         let mut app = subsystem::Manager::new("trivial");
-        app.start("trivial", Trivial);
-        app.start_raw("nop", |_: CallRequest<()>, _| async {});
+        app.add_subsystem("trivial", Trivial);
+        app.add_raw_subsystem("nop", |_: CallRequest<()>, _| async {});
         app.main().await;
     });
 }


### PR DESCRIPTION
Previously, subsystems started immediately as soon as they were registered with the `Manager`. With this change, the subsystems are collected by the `Manager` when registered and started when the `main` method on `Manager` is invoked. This is a less surprising behaviour, giving a cleaner separation between initialisation and startup stages. It will also give the opportunity to subsystems to set up all event handlers and communication channels before startup, avoiding certain race conditions.