### PR TITLE
Include block version in header and use header for block id and some little refactoring

### DIFF
--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -1,6 +1,8 @@
 use crate::chain::block::Block;
 use crate::chain::block::ConsensusData;
 use crate::chain::transaction::Transaction;
+use crate::primitives::id;
+use crate::primitives::id::Idable;
 use crate::primitives::{Id, H256};
 
 use serialization::{Decode, Encode};
@@ -27,6 +29,24 @@ pub struct BlockV1 {
 
 impl BlockVersion for BlockV1 {
     const BLOCK_VERSION: u32 = 1;
+}
+
+impl Idable<BlockHeader> for BlockHeader {
+    fn get_id(&self) -> Id<Self> {
+        Id::new(&id::hash_encoded(self))
+    }
+}
+
+impl From<&Id<BlockHeader>> for Id<Block> {
+    fn from(id: &Id<BlockHeader>) -> Self {
+        Id::new(&id.get())
+    }
+}
+
+impl From<Id<BlockHeader>> for Id<Block> {
+    fn from(id: Id<BlockHeader>) -> Self {
+        Id::new(&id.get())
+    }
 }
 
 impl BlockV1 {

--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -31,7 +31,8 @@ impl BlockVersion for BlockV1 {
     const BLOCK_VERSION: u32 = 1;
 }
 
-impl Idable<Block> for BlockHeader {
+impl Idable for BlockHeader {
+    type Tag = Block;
     fn get_id(&self) -> Id<Block> {
         Id::new(&id::hash_encoded(self))
     }

--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -32,7 +32,7 @@ impl BlockVersion for BlockV1 {
 impl BlockV1 {
     pub fn check_version(&self) -> Result<(), super::BlockConsistencyError> {
         let a = self.header.block_version;
-        let b = <Self as BlockVersion>::static_version(&self);
+        let b = <Self as BlockVersion>::static_version(self);
         if a != b {
             return Err(super::BlockConsistencyError::VersionMismatch(a, b));
         }

--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -5,13 +5,18 @@ use crate::primitives::{Id, H256};
 
 use serialization::{Decode, Encode};
 
+use super::BlockVersion;
+
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub struct BlockHeader {
+    #[codec(compact)]
+    pub(super) block_version: u32,
     pub(super) prev_block_hash: Option<Id<Block>>,
     pub(super) tx_merkle_root: Option<H256>,
     pub(super) witness_merkle_root: Option<H256>,
+    #[codec(compact)]
     pub(super) time: u32,
-    pub(super) consensus_data_inner: ConsensusData,
+    pub(super) consensus_data: ConsensusData,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
@@ -20,7 +25,24 @@ pub struct BlockV1 {
     pub(super) transactions: Vec<Transaction>,
 }
 
+impl BlockVersion for BlockV1 {
+    const BLOCK_VERSION: u32 = 1;
+}
+
 impl BlockV1 {
+    pub fn check_version(&self) -> Result<(), super::BlockConsistencyError> {
+        let a = self.header.block_version;
+        let b = <Self as BlockVersion>::static_version(&self);
+        if a != b {
+            return Err(super::BlockConsistencyError::VersionMismatch(a, b));
+        }
+        Ok(())
+    }
+
+    pub fn version(&self) -> u32 {
+        self.header.block_version
+    }
+
     pub fn tx_merkle_root(&self) -> Option<H256> {
         self.header.tx_merkle_root
     }
@@ -34,11 +56,11 @@ impl BlockV1 {
     }
 
     pub fn update_consensus_data(&mut self, consensus_data: ConsensusData) {
-        self.header.consensus_data_inner = consensus_data;
+        self.header.consensus_data = consensus_data;
     }
 
     pub fn consensus_data(&self) -> &ConsensusData {
-        &self.header.consensus_data_inner
+        &self.header.consensus_data
     }
 
     pub fn block_time(&self) -> u32 {

--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -31,21 +31,9 @@ impl BlockVersion for BlockV1 {
     const BLOCK_VERSION: u32 = 1;
 }
 
-impl Idable<BlockHeader> for BlockHeader {
-    fn get_id(&self) -> Id<Self> {
+impl Idable<Block> for BlockHeader {
+    fn get_id(&self) -> Id<Block> {
         Id::new(&id::hash_encoded(self))
-    }
-}
-
-impl From<&Id<BlockHeader>> for Id<Block> {
-    fn from(id: &Id<BlockHeader>) -> Self {
-        Id::new(&id.get())
-    }
-}
-
-impl From<Id<BlockHeader>> for Id<Block> {
-    fn from(id: Id<BlockHeader>) -> Self {
-        Id::new(&id.get())
     }
 }
 

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -16,10 +16,9 @@
 // Author(s): S. Afach
 
 use crate::chain::transaction::Transaction;
+use crate::primitives::merkle;
 use crate::primitives::merkle::MerkleTreeFormError;
-use crate::primitives::H256;
-use crate::primitives::{id, merkle};
-use crate::primitives::{Id, Idable};
+use crate::primitives::{Id, Idable, H256};
 pub mod block_index;
 pub use block_index::*;
 mod block_v1;
@@ -240,7 +239,7 @@ impl Idable<Block> for Block {
     fn get_id(&self) -> Id<Self> {
         // Block ID is just the hash of its header. The transaction list is committed to by the
         // inclusion of transaction Merkle root in the header. We also include the version number.
-        Id::new(&id::hash_encoded(self.header()))
+        self.header().get_id().into()
     }
 }
 

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -223,7 +223,8 @@ impl Block {
     }
 }
 
-impl Idable<Block> for Block {
+impl Idable for Block {
+    type Tag = Block;
     fn get_id(&self) -> Id<Self> {
         // Block ID is just the hash of its header. The transaction list is committed to by the
         // inclusion of transaction Merkle root in the header. We also include the version number.

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -227,7 +227,7 @@ impl Idable<Block> for Block {
     fn get_id(&self) -> Id<Self> {
         // Block ID is just the hash of its header. The transaction list is committed to by the
         // inclusion of transaction Merkle root in the header. We also include the version number.
-        self.header().get_id().into()
+        self.header().get_id()
     }
 }
 

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -93,18 +93,6 @@ pub enum Block {
     V1(BlockV1),
 }
 
-impl From<&Id<BlockV1>> for Id<Block> {
-    fn from(id_block_v1: &Id<BlockV1>) -> Self {
-        Id::new(&id_block_v1.get())
-    }
-}
-
-impl From<Id<BlockV1>> for Id<Block> {
-    fn from(id_block_v1: Id<BlockV1>) -> Self {
-        Id::new(&id_block_v1.get())
-    }
-}
-
 impl Block {
     pub fn new(
         transactions: Vec<Transaction>,

--- a/common/src/chain/transaction.rs
+++ b/common/src/chain/transaction.rs
@@ -43,7 +43,8 @@ impl From<Id<TransactionV1>> for Id<Transaction> {
     }
 }
 
-impl Idable<Transaction> for Transaction {
+impl Idable for Transaction {
+    type Tag = Transaction;
     fn get_id(&self) -> Id<Transaction> {
         match &self {
             Transaction::V1(tx) => tx.get_id().into(),

--- a/common/src/chain/transaction.rs
+++ b/common/src/chain/transaction.rs
@@ -47,7 +47,7 @@ impl Idable for Transaction {
     type Tag = Transaction;
     fn get_id(&self) -> Id<Transaction> {
         match &self {
-            Transaction::V1(tx) => tx.get_id().into(),
+            Transaction::V1(tx) => tx.get_id(),
         }
     }
 }

--- a/common/src/chain/transaction/transaction_v1.rs
+++ b/common/src/chain/transaction/transaction_v1.rs
@@ -59,8 +59,9 @@ impl TransactionV1 {
     }
 }
 
-impl Idable<TransactionV1> for TransactionV1 {
-    fn get_id(&self) -> Id<Self> {
+impl Idable for TransactionV1 {
+    type Tag = Transaction;
+    fn get_id(&self) -> Id<Transaction> {
         let mut hash_stream = id::DefaultHashAlgoStream::new();
 
         // Collect data from inputs, excluding witnesses

--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -113,7 +113,7 @@ impl<T> AsRef<[u8]> for Id<T> {
 
 /// a trait for objects that deserve having a unique id with implementations to how to ID them
 pub trait Idable<T: ?Sized> {
-    fn get_id(&self) -> Id<Self>;
+    fn get_id(&self) -> Id<T>;
 }
 
 #[allow(dead_code)]

--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -112,8 +112,9 @@ impl<T> AsRef<[u8]> for Id<T> {
 }
 
 /// a trait for objects that deserve having a unique id with implementations to how to ID them
-pub trait Idable<T: ?Sized> {
-    fn get_id(&self) -> Id<T>;
+pub trait Idable {
+    type Tag: ?Sized;
+    fn get_id(&self) -> Id<Self::Tag>;
 }
 
 #[allow(dead_code)]

--- a/consensus/src/detail/error.rs
+++ b/consensus/src/detail/error.rs
@@ -16,7 +16,10 @@
 // Author(s): S. Afach, A. Sinitsyn
 
 use common::{
-    chain::{block::Block, SpendError, Spender, Transaction, TxMainChainIndexError},
+    chain::{
+        block::{Block, BlockConsistencyError},
+        SpendError, Spender, Transaction, TxMainChainIndexError,
+    },
     primitives::{Amount, BlockHeight, Id},
 };
 use thiserror::Error;
@@ -81,6 +84,8 @@ pub enum BlockError {
     SerializationInvariantError(Id<Block>),
     #[error("Unexpected numeric type conversion error `{0:?}`")]
     InternalNumTypeConversionError(Id<Block>),
+    #[error("Internal block representation is invalid `{0:?}`")]
+    BlockConsistencyError(BlockConsistencyError),
     // To be expanded
 }
 
@@ -99,6 +104,12 @@ impl From<SpendError> for BlockError {
             SpendError::AlreadyUnspent => BlockError::InvariantBrokenAlreadyUnspent,
             SpendError::OutOfRange => BlockError::OutputIndexOutOfRange,
         }
+    }
+}
+
+impl From<BlockConsistencyError> for BlockError {
+    fn from(err: BlockConsistencyError) -> Self {
+        BlockError::BlockConsistencyError(err)
     }
 }
 

--- a/consensus/src/detail/error.rs
+++ b/consensus/src/detail/error.rs
@@ -84,7 +84,7 @@ pub enum BlockError {
     SerializationInvariantError(Id<Block>),
     #[error("Unexpected numeric type conversion error `{0:?}`")]
     InternalNumTypeConversionError(Id<Block>),
-    #[error("Internal block representation is invalid `{0:?}`")]
+    #[error("Internal block representation is invalid `{0}`")]
     BlockConsistencyError(BlockConsistencyError),
     // To be expanded
 }

--- a/consensus/src/detail/mod.rs
+++ b/consensus/src/detail/mod.rs
@@ -506,6 +506,8 @@ impl<'a> ConsensusRef<'a> {
         block: &Block,
         block_source: BlockSource,
     ) -> Result<(), BlockError> {
+        block.check_version()?;
+
         // Allows the previous block to be None only if the block hash is genesis
         if !block.is_genesis(self.chain_config) && block.prev_block_id().is_none() {
             return Err(BlockError::Unknown);


### PR DESCRIPTION
There are two issues here I try to address:

1. Scale doesn't seem to provide a way to extract the enum index byte value from an enum object
2. The header is the source of a block hash, yet there's no way for it to know the enum index number

My solutions are probably not the best. But I'm hoping I created something consistent that prevents both malicious behavior and mistakes in the future.

Please take a look, and if you can find a better solution, let's talk.

In addition to this, I'll be (somehow) moving the idable implementation to the header. I still am working on that.