### PR TITLE
Consensus should take ChainConfig in an Arc

### DIFF
--- a/consensus/src/detail/mod.rs
+++ b/consensus/src/detail/mod.rs
@@ -48,7 +48,7 @@ use spend_cache::CachedInputs;
 
 // TODO: ISSUE #129 - https://github.com/mintlayer/mintlayer-core/issues/129
 pub struct Consensus {
-    chain_config: ChainConfig,
+    chain_config: Arc<ChainConfig>,
     blockchain_storage: blockchain_storage::Store,
     orphan_blocks: OrphanBlocksPool,
     event_subscribers: Vec<EventHandler>,
@@ -85,7 +85,7 @@ impl Consensus {
     }
 
     pub fn new(
-        chain_config: ChainConfig,
+        chain_config: Arc<ChainConfig>,
         blockchain_storage: blockchain_storage::Store,
     ) -> Result<Self, crate::ConsensusError> {
         use crate::ConsensusError;
@@ -110,7 +110,7 @@ impl Consensus {
     }
 
     fn new_no_genesis(
-        chain_config: ChainConfig,
+        chain_config: Arc<ChainConfig>,
         blockchain_storage: blockchain_storage::Store,
     ) -> Result<Self, crate::ConsensusError> {
         let event_broadcaster = slave_pool::ThreadPool::new();

--- a/consensus/src/detail/tests/events_tests.rs
+++ b/consensus/src/detail/tests/events_tests.rs
@@ -117,7 +117,7 @@ fn test_events_a_bunch_of_events() {
     const COUNT_EVENTS: usize = 100;
 
     common::concurrency::model(|| {
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let mut consensus = Consensus::new(config, storage).unwrap();
 
@@ -169,7 +169,7 @@ fn test_events_orphan_block() {
     use std::sync::Arc;
 
     common::concurrency::model(|| {
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let mut consensus = Consensus::new(config, storage).unwrap();
 

--- a/consensus/src/detail/tests/mod.rs
+++ b/consensus/src/detail/tests/mod.rs
@@ -62,7 +62,7 @@ pub(in crate::detail::tests) enum TestSpentStatus {
 }
 
 fn setup_consensus() -> Consensus {
-    let config = create_mainnet();
+    let config = Arc::new(create_mainnet());
     let storage = Store::new_empty().unwrap();
     Consensus::new(config, storage).unwrap()
 }

--- a/consensus/src/detail/tests/processing_tests.rs
+++ b/consensus/src/detail/tests/processing_tests.rs
@@ -23,7 +23,7 @@ use common::chain::{config::create_mainnet, OutputSpentState};
 fn test_process_genesis_block_wrong_block_source() {
     common::concurrency::model(|| {
         // Genesis can't be from Peer, test it
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let mut consensus = Consensus::new_no_genesis(config.clone(), storage).unwrap();
 
@@ -38,7 +38,7 @@ fn test_process_genesis_block_wrong_block_source() {
 fn test_process_genesis_block() {
     common::concurrency::model(|| {
         // This test process only Genesis block
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let mut consensus = Consensus::new_no_genesis(config, storage).unwrap();
 
@@ -65,7 +65,7 @@ fn test_process_genesis_block() {
 #[test]
 fn test_orphans_chains() {
     common::concurrency::model(|| {
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let mut consensus = Consensus::new(config, storage).unwrap();
 
@@ -85,7 +85,7 @@ fn test_orphans_chains() {
 fn test_empty_consensus() {
     common::concurrency::model(|| {
         // No genesis
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let consensus = Consensus::new_no_genesis(config, storage).unwrap();
         assert!(consensus.get_best_block_id().unwrap().is_none());
@@ -95,7 +95,7 @@ fn test_empty_consensus() {
             .unwrap()
             .is_none());
         // Let's add genesis
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let consensus = Consensus::new(config, storage).unwrap();
         assert!(consensus.get_best_block_id().unwrap().is_some());
@@ -180,7 +180,7 @@ fn test_straight_chain() {
     common::concurrency::model(|| {
         const COUNT_BLOCKS: usize = 255;
         // In this test, processing a few correct blocks in a single chain
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let mut consensus = Consensus::new_no_genesis(config, storage).unwrap();
 

--- a/consensus/src/detail/tests/reorgs_tests.rs
+++ b/consensus/src/detail/tests/reorgs_tests.rs
@@ -25,7 +25,7 @@ use common::chain::config::create_mainnet;
 #[test]
 fn test_reorg_simple() {
     common::concurrency::model(|| {
-        let config = create_mainnet();
+        let config = Arc::new(create_mainnet());
         let storage = Store::new_empty().unwrap();
         let mut consensus = Consensus::new_no_genesis(config, storage).unwrap();
 

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -107,7 +107,7 @@ impl subsystem::Subsystem for ConsensusInterface {}
 type ConsensusHandle = subsystem::Handle<ConsensusInterface>;
 
 pub fn make_consensus(
-    chain_config: ChainConfig,
+    chain_config: Arc<ChainConfig>,
     blockchain_storage: blockchain_storage::Store,
 ) -> Result<ConsensusInterface, ConsensusError> {
     let cons = Consensus::new(chain_config, blockchain_storage)?;

--- a/consensus/src/rpc.rs
+++ b/consensus/src/rpc.rs
@@ -38,13 +38,13 @@ fn handle_error<T>(e: Result<Result<T, ConsensusError>, CallError>) -> rpc::Resu
 mod test {
     use super::*;
     use serde_json::Value;
-    use std::future::Future;
+    use std::{future::Future, sync::Arc};
 
     async fn with_consensus<F: 'static + Send + Future<Output = ()>>(
         proc: impl 'static + Send + FnOnce(crate::ConsensusHandle) -> F,
     ) {
         let storage = blockchain_storage::Store::new_empty().unwrap();
-        let cfg = common::chain::config::create_mainnet();
+        let cfg = Arc::new(common::chain::config::create_mainnet());
         let mut man = subsystem::Manager::new("rpctest");
         let handle = man.add_subsystem("consensus", crate::make_consensus(cfg, storage).unwrap());
         let _ = man.add_raw_subsystem(

--- a/node/src/initialize.rs
+++ b/node/src/initialize.rs
@@ -3,6 +3,7 @@
 use crate::options::Options;
 use common::chain::config::ChainType;
 use consensus::rpc::ConsensusRpcServer;
+use std::sync::Arc;
 
 #[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, thiserror::Error)]
 enum Error {
@@ -16,7 +17,7 @@ pub async fn initialize(opts: Options) -> anyhow::Result<subsystem::Manager> {
 
     // Chain configuration
     let chain_config = match opts.net {
-        ChainType::Mainnet => common::chain::config::create_mainnet(),
+        ChainType::Mainnet => Arc::new(common::chain::config::create_mainnet()),
         chain_ty => return Err(Error::UnsupportedChain(chain_ty).into()),
     };
 


### PR DESCRIPTION
ChainConfig should be always passed as a Arc. No need to clone it by value.