### PR TITLE
net/libp2p: Disable mDNS tests

### DIFF
--- a/p2p/src/net/libp2p/proto/mdns.rs
+++ b/p2p/src/net/libp2p/proto/mdns.rs
@@ -69,6 +69,7 @@ mod tests {
     };
     use std::collections::HashMap;
 
+    #[ignore]
     #[tokio::test]
     async fn test_on_discovered() {
         let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
@@ -112,6 +113,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_on_discovered_no_relay() {
         let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
@@ -158,6 +160,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_on_expired() {
         let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
@@ -211,6 +214,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_on_expired_no_relay() {
         let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
@@ -255,6 +259,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_mdns_not_supported() {
         let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -415,6 +415,7 @@ mod tests {
             .unwrap();
 
         assert_ne!(req_id1, req_id2);
+        let mut first_req_id = req_id1;
 
         let (recv_req1_id, request1) = if let Ok(net::SyncingMessage::Request {
             peer_id: _,
@@ -426,8 +427,6 @@ mod tests {
         } else {
             panic!("invalid data received");
         };
-
-        // TODO: force order?
 
         let (recv_req2_id, request2) = if let Ok(net::SyncingMessage::Request {
             peer_id: _,
@@ -459,7 +458,8 @@ mod tests {
             response,
         }) = mgr1.handle.poll_next().await
         {
-            assert_eq!(request_id, req_id2);
+            first_req_id = request_id;
+            assert!(request_id == req_id2 || request_id == req_id1);
             assert_eq!(
                 response,
                 Message {
@@ -492,7 +492,12 @@ mod tests {
             response,
         }) = mgr1.handle.poll_next().await
         {
-            assert_eq!(request_id, req_id1);
+            if first_req_id == req_id1 {
+                assert_eq!(request_id, req_id2);
+            } else {
+                assert_eq!(request_id, req_id1);
+            }
+
             assert_eq!(
                 response,
                 Message {


### PR DESCRIPTION
Because all Libp2pService objects are automatically configured to
have mDNS on, it creates a large amount of spam which seemingly causes
the expected mDNS advertisement to be dropped every now and then.

Disable the test for now and enable it later when proper libp2p
NetworkBehaviour mocking capabilities have been implemented.

Also relax the requirement for syncing requests to be received in
certain order in syncing tests.