### PR TITLE
node: RPC command to shutdown the node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "clap 3.1.18",
  "common",
  "consensus",
+ "jsonrpsee",
  "logging",
  "rpc",
  "strum",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,6 +18,7 @@ subsystem = { path = "../subsystem/" }
 # External dependencies
 anyhow = "1.0"
 clap = { version = "3.1", features = ["derive"] }
+jsonrpsee = { version = "0.13", features = ["macros"] }
 strum = "0.24"
 tokio = { version = "1.17", default-features = false }
 thiserror = "1.0"

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,7 +1,7 @@
 //! Top-level node binary
 
-mod runner;
 mod options;
+mod runner;
 
 async fn run() -> anyhow::Result<()> {
     let opts = options::Options::from_args(std::env::args_os());


### PR DESCRIPTION
* Subsystem manager is now able to listen to external shutdown requests
* Add RPC command to shutdown the node
* Add RPC query to get node version

Useful for functional tests among other things