### PR TITLE
Functional test utils

### DIFF
--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -29,6 +29,9 @@ pub enum SwarmEvent<T: NetworkingService> {
 
     /// Get the total number of peers local node has a connection with
     GetPeerCount(oneshot::Sender<usize>),
+
+    /// Get the bind address of the local node
+    GetBindAddress(oneshot::Sender<String>),
 }
 
 #[derive(Debug)]

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -27,6 +27,9 @@ pub enum SwarmEvent<T: NetworkingService> {
     /// Try to establish connection with a remote peer
     Connect(T::Address, oneshot::Sender<error::Result<()>>),
 
+    /// Disconnect node using peer ID
+    Disconnect(T::PeerId),
+
     /// Get the total number of peers local node has a connection with
     GetPeerCount(oneshot::Sender<usize>),
 

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -16,7 +16,7 @@
 // Author(s): A. Altonen
 #![allow(unused)]
 
-use crate::{message, net::NetworkingService};
+use crate::{error, message, net::NetworkingService};
 use common::chain::block::{Block, BlockHeader};
 use serialization::{Decode, Encode};
 use std::sync::Arc;
@@ -25,7 +25,7 @@ use tokio::sync::{mpsc, oneshot};
 #[derive(Debug)]
 pub enum SwarmEvent<T: NetworkingService> {
     /// Try to establish connection with a remote peer
-    Connect(T::Address),
+    Connect(T::Address, oneshot::Sender<error::Result<()>>),
 
     /// Get the total number of peers local node has a connection with
     GetPeerCount(oneshot::Sender<usize>),

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -145,12 +145,19 @@ where
         });
 
         let sync_handle = consensus_handle.clone();
+        let swarm_tx = tx_swarm.clone();
         let sync_config = Arc::clone(&config);
         tokio::spawn(async move {
-            if let Err(e) =
-                sync::SyncManager::<T>::new(sync_config, sync, sync_handle, rx_p2p_sync, tx_pubsub)
-                    .run()
-                    .await
+            if let Err(e) = sync::SyncManager::<T>::new(
+                sync_config,
+                sync,
+                sync_handle,
+                rx_p2p_sync,
+                swarm_tx,
+                tx_pubsub,
+            )
+            .run()
+            .await
             {
                 log::error!("SyncManager failed: {:?}", e);
             }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -78,6 +78,16 @@ where
             .map_err(P2pError::from)?;
         rx.await.map_err(P2pError::from)
     }
+
+    pub async fn get_bind_address(&self) -> error::Result<String> {
+        let (tx, rx) = oneshot::channel();
+        self.p2p
+            .tx_swarm
+            .send(event::SwarmEvent::GetBindAddress(tx))
+            .await
+            .map_err(P2pError::from)?;
+        rx.await.map_err(P2pError::from)
+    }
 }
 
 #[allow(unused)]

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -17,6 +17,8 @@
 // Author(s): A. Altonen
 #![allow(unused)]
 
+// TODO: think about connection management
+
 use crate::{
     error::{self, Libp2pError, P2pError},
     message,
@@ -81,6 +83,9 @@ pub struct Backend {
     /// Set of pending connections
     pub(super) pending_conns: HashMap<PeerId, PendingState>,
 
+    /// Set of established connections
+    pub(super) established_conns: HashSet<PeerId>,
+
     /// Set of pending requests
     pub(super) pending_reqs: HashMap<RequestId, ResponseChannel<SyncResponse>>,
 
@@ -104,6 +109,7 @@ impl Backend {
             gossip_tx,
             sync_tx,
             pending_conns: HashMap::new(),
+            established_conns: HashSet::new(),
             pending_reqs: HashMap::new(),
             relay_mdns,
         }

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -594,7 +594,7 @@ where
 
     async fn poll_next(&mut self) -> error::Result<SyncingEvent<T>> {
         match self.sync_rx.recv().await.ok_or(P2pError::ChannelClosed)? {
-            types::SyncingEvent::SyncRequest {
+            types::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request,
@@ -610,7 +610,7 @@ where
                     request,
                 })
             }
-            types::SyncingEvent::SyncResponse {
+            types::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response,
@@ -626,6 +626,15 @@ where
                     response,
                 })
             }
+            types::SyncingEvent::Error {
+                peer_id,
+                request_id,
+                error,
+            } => Ok(SyncingEvent::Error {
+                peer_id,
+                request_id,
+                error,
+            }),
         }
     }
 }

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     message,
     net::{
         self, libp2p::sync::*, ConnectivityEvent, ConnectivityService, NetworkingService,
-        PubSubEvent, PubSubService, PubSubTopic, SyncingCodecService, SyncingMessage,
+        PubSubEvent, PubSubService, PubSubTopic, SyncingCodecService, SyncingEvent,
     },
 };
 use async_trait::async_trait;
@@ -592,7 +592,7 @@ where
             .map_err(|e| e) // command failure
     }
 
-    async fn poll_next(&mut self) -> error::Result<SyncingMessage<T>> {
+    async fn poll_next(&mut self) -> error::Result<SyncingEvent<T>> {
         match self.sync_rx.recv().await.ok_or(P2pError::ChannelClosed)? {
             types::SyncingEvent::SyncRequest {
                 peer_id,
@@ -604,7 +604,7 @@ where
                     P2pError::ProtocolError(ProtocolError::InvalidMessage)
                 })?;
 
-                Ok(SyncingMessage::Request {
+                Ok(SyncingEvent::Request {
                     peer_id,
                     request_id,
                     request,
@@ -620,7 +620,7 @@ where
                     P2pError::ProtocolError(ProtocolError::InvalidMessage)
                 })?;
 
-                Ok(SyncingMessage::Response {
+                Ok(SyncingEvent::Response {
                     peer_id,
                     request_id,
                     response,

--- a/p2p/src/net/libp2p/proto/util.rs
+++ b/p2p/src/net/libp2p/proto/util.rs
@@ -22,7 +22,7 @@ use crate::{
         libp2p::sync::*,
         libp2p::{backend::Backend, types},
         ConnectivityEvent, ConnectivityService, NetworkingService, PubSubEvent, PubSubService,
-        PubSubTopic, SyncingCodecService, SyncingMessage,
+        PubSubTopic, SyncingCodecService, SyncingEvent,
     },
 };
 use async_trait::async_trait;

--- a/p2p/src/net/libp2p/types.rs
+++ b/p2p/src/net/libp2p/types.rs
@@ -138,15 +138,20 @@ pub enum PubSubEvent {
 }
 
 pub enum SyncingEvent {
-    SyncRequest {
+    Request {
         peer_id: PeerId,
         request_id: RequestId,
         request: Box<SyncRequest>,
     },
-    SyncResponse {
+    Response {
         peer_id: PeerId,
         request_id: RequestId,
         response: Box<SyncResponse>,
+    },
+    Error {
+        peer_id: PeerId,
+        request_id: RequestId,
+        error: net::RequestResponseError,
     },
 }
 

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -51,7 +51,7 @@ pub struct MockService;
 #[derive(Debug, Copy, Clone)]
 pub struct MockMessageId(u64);
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct MockRequestId(u64);
 
 pub struct MockConnectivityHandle<T>

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     message,
     net::{
         ConnectivityEvent, ConnectivityService, NetworkingService, PeerInfo, PubSubEvent,
-        PubSubService, PubSubTopic, SyncingCodecService, SyncingMessage, ValidationResult,
+        PubSubService, PubSubTopic, SyncingCodecService, SyncingEvent, ValidationResult,
     },
 };
 use async_trait::async_trait;
@@ -245,7 +245,7 @@ where
         todo!();
     }
 
-    async fn poll_next(&mut self) -> error::Result<SyncingMessage<T>> {
+    async fn poll_next(&mut self) -> error::Result<SyncingEvent<T>> {
         todo!();
     }
 }

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -133,7 +133,7 @@ where
 }
 
 #[derive(Debug)]
-pub enum SyncingMessage<T>
+pub enum SyncingEvent<T>
 where
     T: NetworkingService,
 {
@@ -309,5 +309,5 @@ where
     ) -> error::Result<()>;
 
     // TODO:
-    async fn poll_next(&mut self) -> error::Result<SyncingMessage<T>>;
+    async fn poll_next(&mut self) -> error::Result<SyncingEvent<T>>;
 }

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -132,6 +132,15 @@ where
     },
 }
 
+#[derive(Debug, PartialEq)]
+pub enum RequestResponseError {
+    /// Request timed out
+    Timeout,
+
+    /// Connection was closed by remote
+    ConnectionClosed,
+}
+
 #[derive(Debug)]
 pub enum SyncingEvent<T>
 where
@@ -146,6 +155,11 @@ where
         peer_id: T::PeerId,
         request_id: T::RequestId,
         response: message::Message,
+    },
+    Error {
+        peer_id: T::PeerId,
+        request_id: T::RequestId,
+        error: RequestResponseError,
     },
 }
 
@@ -182,10 +196,10 @@ pub trait NetworkingService {
     type Address: Send + Sync + Debug + PartialEq + Eq + Hash + Clone + ToString;
 
     /// Unique ID assigned to a peer on the network
-    type PeerId: Send + Copy + PartialEq + Eq + Hash + Debug;
+    type PeerId: Send + Copy + PartialEq + Eq + Hash + Debug + Sync;
 
     // TODO:
-    type RequestId: Send + Debug;
+    type RequestId: Send + Debug + Eq + Hash + Sync;
 
     /// Enum of different peer discovery strategies that the implementation provides
     type DiscoveryStrategy;

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -179,7 +179,7 @@ pub trait NetworkingService {
     ///
     /// For an implementation built on libp2p, the address format is:
     ///     `/ip4/0.0.0.0/tcp/8888/p2p/<peer ID>`
-    type Address: Send + Sync + Debug + PartialEq + Eq + Hash + Clone;
+    type Address: Send + Sync + Debug + PartialEq + Eq + Hash + Clone + ToString;
 
     /// Unique ID assigned to a peer on the network
     type PeerId: Send + Copy + PartialEq + Eq + Hash + Debug;

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -29,6 +29,10 @@ trait P2pRpc {
     /// Get the number of peers
     #[method(name = "get_peer_count")]
     async fn get_peer_count(&self) -> rpc::Result<usize>;
+
+    /// Get bind address of the local node
+    #[method(name = "get_bind_address")]
+    async fn get_bind_address(&self) -> rpc::Result<String>;
 }
 
 #[async_trait::async_trait]
@@ -45,6 +49,11 @@ where
 
     async fn get_peer_count(&self) -> rpc::Result<usize> {
         let res = self.call_async(|this| Box::pin(this.get_peer_count())).await;
+        handle_error(res)
+    }
+
+    async fn get_bind_address(&self) -> rpc::Result<String> {
+        let res = self.call_async(|this| Box::pin(this.get_bind_address())).await;
         handle_error(res)
     }
 }

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -43,11 +43,17 @@ pub mod peer;
 // TODO: from config? global constant?
 const HEADER_LIMIT: usize = 2000;
 
+// TODO: this comes from spec?
+const RETRY_LIMIT: usize = 3;
+
 // TODO: add more tests
 // TODO: split syncing into separate files
 // TODO: match against error in `run()` and deal with `ProtocolError`
 // TODO: use ensure
 // TODO: create better api for request/response codec
+// TODO: create helper function for creating requests/responses
+// TODO: cache locator and invalidate it when `NewTip` event is received
+// TODO: simplify code: remove code duplication, move code to submodules, add req/resp api, etc.
 
 // Define which errors are fatal for the sync manager as the error is bubbled
 // up to the main event loop which then decides how to act on errors.
@@ -71,6 +77,17 @@ impl<T> FatalError for error::Result<T> {
 
         Ok(())
     }
+}
+
+enum RequestType {
+    GetHeaders,
+    GetBlocks(Vec<Id<Block>>),
+}
+
+struct PendingRequest<T: NetworkingService> {
+    peer_id: T::PeerId,
+    request_type: RequestType,
+    retry_count: usize,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -109,6 +126,9 @@ where
     /// RX channel for receiving control events
     rx_sync: mpsc::Receiver<event::SyncControlEvent<T>>,
 
+    /// TX channel for sending control events to swarm
+    tx_swarm: mpsc::Sender<event::SwarmEvent<T>>,
+
     /// TX channel for sending control events to pubsub
     tx_pubsub: mpsc::Sender<event::PubSubControlEvent>,
 
@@ -117,7 +137,9 @@ where
 
     /// Subsystem handle to Consensus
     consensus_handle: subsystem::Handle<Box<dyn consensus_interface::ConsensusInterface>>,
-    // TODO: cache locator and invalidate it when `NewTip` event is received
+
+    /// Pending requests
+    requests: HashMap<T::RequestId, PendingRequest<T>>,
 }
 
 // TODO: refactor this code
@@ -131,15 +153,18 @@ where
         handle: T::SyncingCodecHandle,
         consensus_handle: subsystem::Handle<Box<dyn consensus_interface::ConsensusInterface>>,
         rx_sync: mpsc::Receiver<event::SyncControlEvent<T>>,
+        tx_swarm: mpsc::Sender<event::SwarmEvent<T>>,
         tx_pubsub: mpsc::Sender<event::PubSubControlEvent>,
     ) -> Self {
         Self {
             config,
             handle,
             rx_sync,
+            tx_swarm,
             tx_pubsub,
             consensus_handle,
             peers: Default::default(),
+            requests: HashMap::new(),
             state: SyncState::Uninitialized,
         }
     }
@@ -156,9 +181,10 @@ where
         &mut self,
         peer_id: T::PeerId,
         locator: Vec<BlockHeader>,
+        retry_count: usize,
     ) -> error::Result<()> {
-        // TODO: save request id somewhere?
-        let _request_id = self
+        let peer = self.peers.get_mut(&peer_id).ok_or(P2pError::PeerDoesntExist)?;
+        let request_id = self
             .handle
             .send_request(
                 peer_id,
@@ -170,6 +196,48 @@ where
                 },
             )
             .await?;
+        self.requests.insert(
+            request_id,
+            PendingRequest {
+                peer_id,
+                request_type: RequestType::GetHeaders,
+                retry_count,
+            },
+        );
+        peer.set_state(peer::PeerSyncState::UploadingHeaders);
+
+        Ok(())
+    }
+
+    pub async fn send_block_request(
+        &mut self,
+        peer_id: T::PeerId,
+        block_id: Id<Block>,
+        retry_count: usize,
+    ) -> error::Result<()> {
+        let peer = self.peers.get_mut(&peer_id).ok_or(P2pError::PeerDoesntExist)?;
+        let request_id = self
+            .handle
+            .send_request(
+                peer_id,
+                Message {
+                    magic: *self.config.magic_bytes(),
+                    msg: MessageType::Syncing(SyncingMessage::Request(SyncingRequest::GetBlocks {
+                        block_ids: vec![block_id.clone()],
+                    })),
+                },
+            )
+            .await?;
+        self.requests.insert(
+            request_id,
+            PendingRequest {
+                peer_id,
+                request_type: RequestType::GetBlocks(vec![block_id.clone()]),
+                retry_count,
+            },
+        );
+        peer.set_state(peer::PeerSyncState::UploadingBlocks(block_id));
+
         Ok(())
     }
 
@@ -184,12 +252,12 @@ where
             Entry::Vacant(entry) => {
                 let locator = self.consensus_handle.call(|this| this.get_locator()).await??;
                 entry.insert(peer::PeerContext::new(peer_id, locator.clone()));
-                self.send_header_request(peer_id, locator).await
+                self.send_header_request(peer_id, locator, 0).await
             }
         }
     }
 
-    pub async fn unregister_peer(&mut self, peer_id: T::PeerId) -> error::Result<()> {
+    pub fn unregister_peer(&mut self, peer_id: T::PeerId) -> error::Result<()> {
         log::info!("unregister peer {:?}", peer_id);
 
         self.peers.remove(&peer_id);
@@ -208,9 +276,7 @@ where
             locator
         );
 
-        let peer = self.peers.get_mut(&peer_id).ok_or(P2pError::PeerDoesntExist)?;
         let headers = self.consensus_handle.call(move |this| this.get_headers(locator)).await??;
-
         self.handle
             .send_response(
                 request_id,
@@ -271,6 +337,7 @@ where
     }
 
     // TODO: get rid of the awful `set_state()` calls
+    // TODO: simplify this code massively
     async fn process_header_response(
         &mut self,
         peer_id: T::PeerId,
@@ -278,7 +345,7 @@ where
     ) -> error::Result<()> {
         let peer = self.peers.get_mut(&peer_id).ok_or(P2pError::PeerDoesntExist)?;
 
-        log::debug!(
+        log::info!(
             "initialize peer {:?} state, headers: {:#?}",
             peer_id,
             headers
@@ -331,7 +398,6 @@ where
             prev_id = header.get_id();
         }
 
-        // TODO: fetch unique headers from chainstate
         let unknown_headers = self
             .consensus_handle
             .call(|this| this.filter_already_existing_blocks(headers))
@@ -339,9 +405,7 @@ where
 
         peer.register_header_response(&unknown_headers);
         if let Some(header) = peer.get_header_for_download() {
-            // TODO: create helper function for this message
-            // TODO: save request ids somewhere?
-            let _ = self
+            let request_id = self
                 .handle
                 .send_request(
                     peer_id,
@@ -354,8 +418,16 @@ where
                         )),
                     },
                 )
-                .await;
-            peer.set_state(peer::PeerSyncState::UploadingBlocks(header));
+                .await?;
+            self.requests.insert(
+                request_id,
+                PendingRequest {
+                    peer_id,
+                    request_type: RequestType::GetBlocks(vec![header.get_id()]),
+                    retry_count: 0,
+                },
+            );
+            peer.set_state(peer::PeerSyncState::UploadingBlocks(header.get_id()));
         } else {
             peer.set_state(peer::PeerSyncState::Idle);
         }
@@ -397,8 +469,7 @@ where
         let next_header = peer.register_block_response(&header);
         match next_header {
             Ok(Some(next_block)) => {
-                // TODO: save request ids somewhere?
-                let _ = self
+                let request_id = self
                     .handle
                     .send_request(
                         peer_id,
@@ -412,15 +483,22 @@ where
                         },
                     )
                     .await?;
-                peer.set_state(peer::PeerSyncState::UploadingBlocks(next_block));
+                self.requests.insert(
+                    request_id,
+                    PendingRequest {
+                        peer_id,
+                        request_type: RequestType::GetBlocks(vec![next_block.get_id()]),
+                        retry_count: 0,
+                    },
+                );
+                peer.set_state(peer::PeerSyncState::UploadingBlocks(next_block.get_id()));
                 Ok(())
             }
             Ok(None) => {
                 // last block from peer, ask if peer knows of any new headers
                 let locator = self.consensus_handle.call(|this| this.get_locator()).await??;
                 peer.set_locator(locator.clone());
-                // TODO: save request ids somewhere?
-                let _ = self
+                let request_id = self
                     .handle
                     .send_request(
                         peer_id,
@@ -432,6 +510,14 @@ where
                         },
                     )
                     .await?;
+                self.requests.insert(
+                    request_id,
+                    PendingRequest {
+                        peer_id,
+                        request_type: RequestType::GetHeaders,
+                        retry_count: 0,
+                    },
+                );
                 peer.set_state(peer::PeerSyncState::UploadingHeaders);
                 Ok(())
             }
@@ -502,6 +588,60 @@ where
         }
     }
 
+    async fn process_error(
+        &mut self,
+        peer_id: T::PeerId,
+        request_id: T::RequestId,
+        error: net::RequestResponseError,
+    ) -> error::Result<()> {
+        match error {
+            net::RequestResponseError::ConnectionClosed => {
+                self.unregister_peer(peer_id);
+            }
+            net::RequestResponseError::Timeout => {
+                if let Some(request) = self.requests.remove(&request_id) {
+                    log::warn!(
+                        "outbound request {:?} for peer {:?} timed out",
+                        request_id,
+                        peer_id
+                    );
+
+                    if request.retry_count == RETRY_LIMIT {
+                        log::error!(
+                            "peer {:?} failed to respond to request, close connection",
+                            peer_id
+                        );
+                        self.unregister_peer(peer_id);
+                        return self
+                            .tx_swarm
+                            .send(event::SwarmEvent::Disconnect(peer_id))
+                            .await
+                            .map_err(P2pError::from);
+                    }
+
+                    match request.request_type {
+                        RequestType::GetHeaders => {
+                            let locator =
+                                self.consensus_handle.call(|this| this.get_locator()).await??;
+                            self.send_header_request(peer_id, locator, request.retry_count + 1)
+                                .await?;
+                        }
+                        RequestType::GetBlocks(block_ids) => {
+                            assert_eq!(block_ids.len(), 1);
+                            self.send_block_request(
+                                peer_id,
+                                block_ids.get(0).expect("block id to exist").clone(),
+                                request.retry_count + 1,
+                            )
+                            .await?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Handle incoming block/header request/response
     pub async fn on_syncing_event(&mut self, event: net::SyncingEvent<T>) -> error::Result<()> {
         match event {
@@ -537,6 +677,11 @@ where
                 );
                 self.process_response(peer_id, message).await
             }
+            net::SyncingEvent::Error {
+                peer_id,
+                request_id,
+                error,
+            } => self.process_error(peer_id, request_id, error).await,
             net::SyncingEvent::Request { peer_id, .. }
             | net::SyncingEvent::Response { peer_id, .. } => {
                 log::error!("received an invalid message from peer {:?}", peer_id);
@@ -551,7 +696,7 @@ where
     async fn on_control_event(&mut self, event: event::SyncControlEvent<T>) -> error::Result<()> {
         match event {
             event::SyncControlEvent::Connected(peer_id) => self.register_peer(peer_id).await,
-            event::SyncControlEvent::Disconnected(peer_id) => self.unregister_peer(peer_id).await,
+            event::SyncControlEvent::Disconnected(peer_id) => self.unregister_peer(peer_id),
         }
     }
 
@@ -578,7 +723,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        event::{PubSubControlEvent, SyncControlEvent},
+        event::{PubSubControlEvent, SwarmEvent, SyncControlEvent},
         net::{libp2p::Libp2pService, ConnectivityEvent, ConnectivityService},
     };
     use consensus::make_consensus;
@@ -591,6 +736,7 @@ mod tests {
         T::ConnectivityHandle,
         mpsc::Sender<SyncControlEvent<T>>,
         mpsc::Receiver<PubSubControlEvent>,
+        mpsc::Receiver<SwarmEvent<T>>,
     )
     where
         T: NetworkingService,
@@ -599,6 +745,7 @@ mod tests {
     {
         let (tx_p2p_sync, rx_p2p_sync) = mpsc::channel(16);
         let (tx_pubsub, rx_pubsub) = mpsc::channel(16);
+        let (tx_swarm, rx_swarm) = mpsc::channel(16);
         let storage = blockchain_storage::Store::new_empty().unwrap();
         let cfg = Arc::new(common::chain::config::create_unit_test_config());
         let mut man = subsystem::Manager::new("TODO");
@@ -617,10 +764,18 @@ mod tests {
         .unwrap();
 
         (
-            SyncManager::<T>::new(Arc::clone(&config), sync, handle, rx_p2p_sync, tx_pubsub),
+            SyncManager::<T>::new(
+                Arc::clone(&config),
+                sync,
+                handle,
+                rx_p2p_sync,
+                tx_swarm,
+                tx_pubsub,
+            ),
             conn,
             tx_p2p_sync,
             rx_pubsub,
+            rx_swarm,
         )
     }
 
@@ -643,7 +798,7 @@ mod tests {
     // handle peer connection event
     #[tokio::test]
     async fn test_peer_connected() {
-        let (mut mgr, _, _, _) =
+        let (mut mgr, _, _, _, _) =
             make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
 
         assert_eq!(
@@ -656,7 +811,7 @@ mod tests {
     // handle peer disconnection event
     #[tokio::test]
     async fn test_peer_disconnected() {
-        let (mut mgr, _, _, _) =
+        let (mut mgr, _, _, _, _) =
             make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
 
         // send Connected event to SyncManager
@@ -685,9 +840,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_response() {
-        let (mut mgr1, mut conn1, _, _) =
+        let (mut mgr1, mut conn1, _, _, _) =
             make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
-        let (mut mgr2, mut conn2, _, _) =
+        let (mut mgr2, mut conn2, _, _, _) =
             make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
 
         // connect the two managers together so that they can exchange messages
@@ -742,9 +897,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_requests_and_responses() {
-        let (mut mgr1, mut conn1, _, _) =
+        let (mut mgr1, mut conn1, _, _, _) =
             make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
-        let (mut mgr2, mut conn2, _, _) =
+        let (mut mgr2, mut conn2, _, _, _) =
             make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
 
         // connect the two managers together so that they can exchange messages
@@ -840,5 +995,99 @@ mod tests {
         }
 
         assert_eq!(magic_seen, 2);
+    }
+
+    // receive getheaders before receiving `Connected` event from swarm manager
+    // which makes the request to be rejected and to time out in the sender end
+    #[tokio::test]
+    async fn test_out_of_order_events() {
+        let (mut mgr1, mut conn1, _, _, _) =
+            make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        let (mut mgr2, mut conn2, _, _, _) =
+            make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+
+        // connect the two managers together so that they can exchange messages
+        connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
+        let peer2_id = *conn2.peer_id();
+
+        tokio::spawn(async move {
+            mgr1.register_peer(peer2_id).await.unwrap();
+
+            match mgr1.handle.poll_next().await.unwrap() {
+                net::SyncingEvent::Error {
+                    peer_id,
+                    request_id,
+                    error,
+                } => {
+                    assert_eq!(error, net::RequestResponseError::Timeout);
+                    mgr1.process_error(peer_id, request_id, error).await.unwrap();
+                }
+                _ => panic!("invalid event received"),
+            }
+        });
+
+        assert!(std::matches!(
+            mgr2.handle.poll_next().await,
+            Ok(net::SyncingEvent::Request { .. })
+        ));
+        assert!(std::matches!(
+            mgr2.handle.poll_next().await,
+            Ok(net::SyncingEvent::Error { .. })
+        ));
+        assert!(std::matches!(
+            mgr2.handle.poll_next().await,
+            Ok(net::SyncingEvent::Request { .. })
+        ));
+    }
+
+    // verify that if after three retries the remote peer still
+    // hasn't responded to our request, the connection is closed
+    //
+    // marked as ignored as it takes quite a long time to complete
+    #[ignore]
+    #[tokio::test]
+    async fn request_timeout() {
+        let (mut mgr1, mut conn1, _, _, mut swarm_rx) =
+            make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        let (mut mgr2, mut conn2, _, _, _) =
+            make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+
+        // connect the two managers together so that they can exchange messages
+        connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
+        let peer2_id = *conn2.peer_id();
+
+        tokio::spawn(async move {
+            mgr1.register_peer(peer2_id).await.unwrap();
+
+            for i in 0..4 {
+                match mgr1.handle.poll_next().await.unwrap() {
+                    net::SyncingEvent::Error {
+                        peer_id,
+                        request_id,
+                        error,
+                    } => {
+                        assert_eq!(error, net::RequestResponseError::Timeout);
+                        mgr1.process_error(peer_id, request_id, error).await.unwrap();
+                    }
+                    _ => panic!("invalid event received"),
+                }
+            }
+
+            assert!(std::matches!(
+                swarm_rx.try_recv(),
+                Ok(SwarmEvent::Disconnect(peer2_id))
+            ));
+        });
+
+        for i in 0..4 {
+            assert!(std::matches!(
+                mgr2.handle.poll_next().await,
+                Ok(net::SyncingEvent::Request { .. })
+            ));
+            assert!(std::matches!(
+                mgr2.handle.poll_next().await,
+                Ok(net::SyncingEvent::Error { .. })
+            ));
+        }
     }
 }

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -37,7 +37,7 @@ pub enum PeerSyncState {
     Unknown,
 
     /// Peer is uploading blocks to local node
-    UploadingBlocks(BlockHeader),
+    UploadingBlocks(Id<Block>),
 
     /// Peer is uploading headers to local node
     UploadingHeaders,
@@ -94,7 +94,7 @@ where
     ) -> error::Result<Option<BlockHeader>> {
         match &self.state {
             PeerSyncState::UploadingBlocks(expected) => {
-                if expected != header {
+                if expected != &header.get_id() {
                     log::error!(
                         "peer sent us the wrong header, expected {:?}, got {:?}",
                         expected,
@@ -160,7 +160,7 @@ mod tests {
             Block::new(vec![], None, 1337u32, ConsensusData::None).unwrap().header().clone();
 
         assert_eq!(peer.state, PeerSyncState::Unknown);
-        peer.set_state(PeerSyncState::UploadingBlocks(header.clone()));
-        assert_eq!(peer.state, PeerSyncState::UploadingBlocks(header));
+        peer.set_state(PeerSyncState::UploadingBlocks(header.get_id()));
+        assert_eq!(peer.state, PeerSyncState::UploadingBlocks(header.get_id()));
     }
 }

--- a/p2p/tests/sync.rs
+++ b/p2p/tests/sync.rs
@@ -157,7 +157,7 @@ where
     T::SyncingCodecHandle: SyncingCodecService<T>,
 {
     match mgr.handle_mut().poll_next().await.unwrap() {
-        net::SyncingMessage::Request {
+        net::SyncingEvent::Request {
             peer_id,
             request_id,
             request:
@@ -274,7 +274,7 @@ async fn remote_ahead_by_7_blocks() {
 
     for i in 0..9 {
         match mgr2.handle_mut().poll_next().await.unwrap() {
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -301,7 +301,7 @@ async fn remote_ahead_by_7_blocks() {
                     .await
                     .unwrap()
             }
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -334,7 +334,7 @@ async fn remote_ahead_by_7_blocks() {
                     .await
                     .unwrap();
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -400,7 +400,7 @@ async fn local_ahead_by_12_blocks() {
 
     loop {
         match mgr2.handle_mut().poll_next().await.unwrap() {
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -427,7 +427,7 @@ async fn local_ahead_by_12_blocks() {
                     .await
                     .unwrap()
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -467,7 +467,7 @@ async fn local_ahead_by_12_blocks() {
                     break;
                 }
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -564,7 +564,7 @@ async fn remote_local_diff_chains_local_higher() {
 
     for i in 0..24 {
         match mgr2.handle_mut().poll_next().await.unwrap() {
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -591,7 +591,7 @@ async fn remote_local_diff_chains_local_higher() {
                     .await
                     .unwrap()
             }
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -624,7 +624,7 @@ async fn remote_local_diff_chains_local_higher() {
                     .await
                     .unwrap();
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -661,7 +661,7 @@ async fn remote_local_diff_chains_local_higher() {
                         .unwrap();
                 }
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -759,7 +759,7 @@ async fn remote_local_diff_chains_remote_higher() {
 
     for i in 0..20 {
         match mgr2.handle_mut().poll_next().await.unwrap() {
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -786,7 +786,7 @@ async fn remote_local_diff_chains_remote_higher() {
                     .await
                     .unwrap()
             }
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -819,7 +819,7 @@ async fn remote_local_diff_chains_remote_higher() {
                     .await
                     .unwrap();
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -856,7 +856,7 @@ async fn remote_local_diff_chains_remote_higher() {
                         .unwrap();
                 }
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -961,7 +961,7 @@ async fn two_remote_nodes_different_chains() {
         };
 
         match event {
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -988,7 +988,7 @@ async fn two_remote_nodes_different_chains() {
                     mgr3.handle_mut().send_response(request_id, msg).await.unwrap()
                 }
             }
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -1020,7 +1020,7 @@ async fn two_remote_nodes_different_chains() {
                     mgr3.handle_mut().send_response(request_id, msg).await.unwrap();
                 }
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -1115,7 +1115,7 @@ async fn two_remote_nodes_same_chains() {
         };
 
         match event {
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -1142,7 +1142,7 @@ async fn two_remote_nodes_same_chains() {
                     mgr3.handle_mut().send_response(request_id, msg).await.unwrap()
                 }
             }
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -1174,7 +1174,7 @@ async fn two_remote_nodes_same_chains() {
                     mgr3.handle_mut().send_response(request_id, msg).await.unwrap();
                 }
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:
@@ -1264,7 +1264,7 @@ async fn two_remote_nodes_same_chains_new_blocks() {
         };
 
         match event {
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -1308,7 +1308,7 @@ async fn two_remote_nodes_same_chains_new_blocks() {
                     }
                 }
             }
-            net::SyncingMessage::Request {
+            net::SyncingEvent::Request {
                 peer_id,
                 request_id,
                 request:
@@ -1340,7 +1340,7 @@ async fn two_remote_nodes_same_chains_new_blocks() {
                     mgr3.handle_mut().send_response(request_id, msg).await.unwrap();
                 }
             }
-            net::SyncingMessage::Response {
+            net::SyncingEvent::Response {
                 peer_id,
                 request_id,
                 response:


### PR DESCRIPTION
This PR fixes the `SwarmControlEvent::Connect` to a working state so connections to other peers can be established with the RPC command `connect`. It also adds a new RPC command called `get_bind_address` which allows the caller to get the full bind address of the local node (including the peer ID).

In functional tests, establishing connection with other node would be something like:
```python
node1 = create_node()
node2 = create_node()

node1_addr = rpc.call(node1, "get_bind_address")
rpc.call(node2, "connect", node1_addr)
```
Probably some RPC command has to be implemented so that we can verify that both peers have a connection. I'll play around with it when both this and #191 are in master