### PR TITLE
script: Use `thiserror` instead of `displaydoc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,6 @@ dependencies = [
  "bitcoin-bech32",
  "byteorder 1.4.3",
  "crypto",
- "displaydoc",
  "expect-test",
  "generic-array",
  "hex",
@@ -926,17 +925,6 @@ dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3394,7 +3382,6 @@ name = "script"
 version = "0.1.0"
 dependencies = [
  "crypto",
- "displaydoc",
  "flate2",
  "hex",
  "hex-literal",
@@ -3402,6 +3389,7 @@ dependencies = [
  "parity-scale-codec",
  "proptest",
  "serialization",
+ "thiserror",
  "utils",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,6 @@ logging = { path = "../logging/" }
 
 anyhow = "1.0.51"
 bech32 = "0.9.0"
-displaydoc = { default-features = false, version = "0.2" }
 generic-array = "0.14.4"
 hex-literal = "0.3.4"
 lazy_static = "1.4.0"

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -43,7 +43,7 @@ pub async fn initialize(opts: Options) -> anyhow::Result<subsystem::Manager> {
             opts.p2p_addr,
         )
         .await
-        .unwrap(),
+        .expect("The p2p subsystem initialization failed"),
     );
 
     // RPC subsystem

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -9,8 +9,8 @@ crypto = { path = '../crypto' }
 serialization = { path = "../serialization" }
 utils = { path = '../utils' }
 
-displaydoc = { default-features = false, version = "0.2" }
 parity-scale-codec = "3.1.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 flate2 = "1.0.22"

--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -17,53 +17,49 @@
 
 //! Listing of all the error states
 
-use displaydoc::Display;
-
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
 /// would help you.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Display)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, thiserror::Error)]
 pub enum Error {
-    /// Something did a non-minimal push
+    #[error("Something did a non-minimal push")]
     NonMinimalPush,
-    /// Some opcode expected a parameter, but it was missing or truncated
+    #[error("Some opcode expected a parameter, but it was missing or truncated")]
     EarlyEndOfScript,
-    /// Tried to read an array off the stack as a number when it was more than 4 bytes
+    #[error("Tried to read an array off the stack as a number when it was more than 4 bytes")]
     NumericOverflow,
-    /// Illegal instruction executed
+    #[error("Illegal instruction executed")]
     IllegalOp,
-    /// Syntactically incorrect OP_(NOT)IF/OP_ELSE/OP_ENDIF
+    #[error("Syntactically incorrect OP_(NOT)IF/OP_ELSE/OP_ENDIF")]
     UnbalancedIfElse,
-    /// Stack has insufficient number of elements in it
+    #[error("Stack has insufficient number of elements in it")]
     NotEnoughElementsOnStack,
-    /// Invalid operand to a script operation.
+    #[error("Invalid operand to a script operation.")]
     InvalidOperand,
-    /// OP_*VERIFY failed verification or OP_RETURN was executed.
+    #[error("OP_*VERIFY failed verification or OP_RETURN was executed.")]
     VerifyFail,
-    /// Stack not clean after a script run.
+    #[error("Stack not clean after a script run.")]
     StackNotClean,
-    /// Signature is not in correct format.
+    #[error("Signature is not in correct format.")]
     SignatureFormat,
-    /// Pubkey is not in correct format.
+    #[error("Pubkey is not in correct format.")]
     PubkeyFormat,
-    /// Push data too large.
+    #[error("Push data too large.")]
     PushSize,
-    /// Non-push operation present in context where only data push opcodes are allowed.
+    #[error("Non-push operation present in context where only data push opcodes are allowed.")]
     PushOnly,
-    /// Maximum stack size exceeded.
+    #[error("Maximum stack size exceeded.")]
     StackSize,
-    /// Maximum script size exceeded.
+    #[error("Maximum script size exceeded.")]
     ScriptSize,
-    /// Incorrect number of public keys for multisig
+    #[error("Incorrect number of public keys for multisig")]
     PubkeyCount,
-    /// Incorrect number of signatures for multisig
+    #[error("Incorrect number of signatures for multisig")]
     SigCount,
-    /// Time lock interval not elapsed yet
+    #[error("Time lock interval not elapsed yet")]
     TimeLock,
-    /// Multisig lacks extra 0 dummy.
+    #[error("Multisig lacks extra 0 dummy.")]
     NullDummy,
 }
-
-impl ::std::error::Error for Error {}
 
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
This removes the last remaining occurrences of `displaydoc`, slightly reducing dependency footprint.