### PR TITLE
Introduce ban score

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -5,6 +5,8 @@ use super::{
     CheckBlockTransactionsError, ConsensusVerificationError, OrphanCheckError,
 };
 
+// TODO: use a ban_score macro in a form similar to thiserror in order to define the ban score value of an error
+
 pub trait BanScore {
     fn ban_score(&self) -> u32;
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -5,7 +5,7 @@ use super::{
     CheckBlockTransactionsError, ConsensusVerificationError, OrphanCheckError,
 };
 
-trait BanScore {
+pub trait BanScore {
     fn ban_score(&self) -> u32;
 }
 

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -5,7 +5,8 @@ use super::{
     CheckBlockTransactionsError, ConsensusVerificationError, OrphanCheckError,
 };
 
-// TODO: use a ban_score macro in a form similar to thiserror in order to define the ban score value of an error
+// TODO: use a ban_score macro in a form similar to thiserror::Error in order to define the ban score
+//       value of an error on the error enum arms instead of separately like in this file
 
 pub trait BanScore {
     fn ban_score(&self) -> u32;

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -1,0 +1,143 @@
+use crate::BlockError;
+
+use super::{
+    pow::error::ConsensusPoWError, spend_cache::error::StateUpdateError, CheckBlockError,
+    CheckBlockTransactionsError, ConsensusVerificationError, OrphanCheckError,
+};
+
+trait BanScoreFromError {
+    fn ban_score(&self) -> u32;
+}
+
+impl BanScoreFromError for BlockError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            BlockError::StorageError(_) => 0,
+            BlockError::OrphanCheckFailed(err) => err.ban_score(),
+            BlockError::CheckBlockFailed(err) => err.ban_score(),
+            BlockError::StateUpdateFailed(err) => err.ban_score(),
+            BlockError::BestBlockLoadError(_) => 0,
+            BlockError::InvariantErrorFailedToFindNewChainPath(_, _, _) => 0,
+            BlockError::InvariantErrorInvalidTip => 0,
+            BlockError::InvariantErrorPrevBlockNotFound => 0,
+            // Even though this should've been caught by orphans check, its mere presence means a peer sent a block they're not supposed to send
+            BlockError::PrevBlockNotFound => 100,
+            BlockError::InvalidBlockSource => 100,
+            BlockError::BlockAlreadyExists(_) => 0,
+            BlockError::DatabaseCommitError(_, _, _) => 0,
+        }
+    }
+}
+
+impl BanScoreFromError for OrphanCheckError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            OrphanCheckError::StorageError(_) => 0,
+            OrphanCheckError::PrevBlockIdNotFound => 100,
+            OrphanCheckError::PrevBlockIndexNotFound(_) => 100,
+            OrphanCheckError::LocalOrphan => 0,
+        }
+    }
+}
+
+impl BanScoreFromError for StateUpdateError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            StateUpdateError::StorageError(_) => 0,
+            StateUpdateError::TxNumWrongInBlockOnConnect(_, _) => 100,
+            StateUpdateError::TxNumWrongInBlockOnDisconnect(_, _) => 0,
+            // this is zero because it's used when we add the outputs whose transactions we tested beforehand
+            StateUpdateError::InvariantErrorTxNumWrongInBlock(_, _) => 0,
+            StateUpdateError::OutputAlreadyPresentInInputsCache => 100,
+            StateUpdateError::ImmatureBlockRewardSpend => 100,
+            StateUpdateError::PreviouslyCachedInputNotFound => 0,
+            StateUpdateError::PreviouslyCachedInputWasErased => 100,
+            StateUpdateError::InvariantBrokenAlreadyUnspent => 0,
+            // Even though this is an invariant error, it stems from referencing a block for reward that doesn't exist
+            StateUpdateError::InvariantBrokenSourceBlockIndexNotFound => 100,
+            StateUpdateError::MissingOutputOrSpent => 100,
+            StateUpdateError::MissingOutputOrSpentOutputErasedOnConnect => 100,
+            StateUpdateError::MissingOutputOrSpentOutputErasedOnDisconnect => 0,
+            StateUpdateError::AttemptToPrintMoney(_, _) => 100,
+            StateUpdateError::TxFeeTotalCalcFailed(_, _) => 100,
+            StateUpdateError::OutputAdditionError => 100,
+            StateUpdateError::SignatureVerificationFailed => 100,
+            StateUpdateError::InvalidOutputCount => 100,
+            StateUpdateError::BlockHeightArithmeticError => 100,
+            StateUpdateError::InputAdditionError => 100,
+            StateUpdateError::DoubleSpendAttempt(_) => 100,
+            StateUpdateError::OutputIndexOutOfRange {
+                tx_id: _,
+                source_output_index: _,
+            } => 100,
+            // Even though this is an invariant error, it stems from a transaction that doesn't exist
+            StateUpdateError::InvariantErrorTransactionCouldNotBeLoaded(_) => 100,
+            // Even though this is an invariant error, it stems from a block reward that doesn't exist
+            StateUpdateError::InvariantErrorHeaderCouldNotBeLoaded(_) => 100,
+            StateUpdateError::FailedToAddAllFeesOfBlock(_) => 100,
+            StateUpdateError::RewardAdditionError(_) => 100,
+            // Even though this is an invariant, we consider it a violation to be overly cautious
+            StateUpdateError::SerializationInvariantError(_) => 100,
+        }
+    }
+}
+
+impl BanScoreFromError for CheckBlockError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            CheckBlockError::StorageError(_) => 0,
+            CheckBlockError::MerkleRootMismatch => 100,
+            CheckBlockError::WitnessMerkleRootMismatch => 100,
+            CheckBlockError::BlockConsistencyError(_) => 100,
+            CheckBlockError::InvalidBlockNoPrevBlock => 100,
+            // even though this may be an invariant error, we treat it strictly
+            CheckBlockError::PrevBlockNotFound(_, _) => 100,
+            CheckBlockError::BlockTimeOrderInvalid => 100,
+            CheckBlockError::BlockFromTheFuture => 100,
+            CheckBlockError::BlockTooLarge => 100,
+            CheckBlockError::CheckTransactionFailed(err) => err.ban_score(),
+            CheckBlockError::ConsensusVerificationFailed(err) => err.ban_score(),
+        }
+    }
+}
+
+impl BanScoreFromError for CheckBlockTransactionsError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            CheckBlockTransactionsError::StorageError(_) => 0,
+            CheckBlockTransactionsError::DuplicateInputInTransaction(_, _) => 100,
+            CheckBlockTransactionsError::DuplicateInputInBlock(_) => 100,
+            CheckBlockTransactionsError::DuplicatedTransactionInBlock(_, _) => 100,
+        }
+    }
+}
+
+impl BanScoreFromError for ConsensusVerificationError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            ConsensusVerificationError::StorageError(_) => 0,
+            ConsensusVerificationError::PrevBlockLoadError(_, _, _) => 0,
+            ConsensusVerificationError::PrevBlockNotFound(_, _) => 100,
+            ConsensusVerificationError::ConsensusTypeMismatch(_) => 100,
+            ConsensusVerificationError::PoWError(err) => err.ban_score(),
+            ConsensusVerificationError::UnsupportedConsensusType => 100,
+        }
+    }
+}
+
+impl BanScoreFromError for ConsensusPoWError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            ConsensusPoWError::StorageError(_) => 0,
+            ConsensusPoWError::InvalidPoW(_) => 100,
+            ConsensusPoWError::PrevBlockLoadError(_, _, _) => 0,
+            ConsensusPoWError::PrevBlockNotFound(_, _) => 100,
+            ConsensusPoWError::AncestorAtHeightNotFound(_, _, _) => 0,
+            ConsensusPoWError::NoPowDataInPreviousBlock => 100,
+            ConsensusPoWError::DecodingBitsFailed(_) => 100,
+            ConsensusPoWError::PreviousBitsDecodingFailed(_) => 0,
+        }
+    }
+}
+
+// TODO: tests in which we simulate every possible case and test the score

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -131,7 +131,6 @@ impl BanScore for ConsensusVerificationError {
 impl BanScore for ConsensusPoWError {
     fn ban_score(&self) -> u32 {
         match self {
-            ConsensusPoWError::StorageError(_) => 0,
             ConsensusPoWError::InvalidPoW(_) => 100,
             ConsensusPoWError::PrevBlockLoadError(_, _, _) => 0,
             ConsensusPoWError::PrevBlockNotFound(_, _) => 100,

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -5,11 +5,11 @@ use super::{
     CheckBlockTransactionsError, ConsensusVerificationError, OrphanCheckError,
 };
 
-trait BanScoreFromError {
+trait BanScore {
     fn ban_score(&self) -> u32;
 }
 
-impl BanScoreFromError for BlockError {
+impl BanScore for BlockError {
     fn ban_score(&self) -> u32 {
         match self {
             BlockError::StorageError(_) => 0,
@@ -29,7 +29,7 @@ impl BanScoreFromError for BlockError {
     }
 }
 
-impl BanScoreFromError for OrphanCheckError {
+impl BanScore for OrphanCheckError {
     fn ban_score(&self) -> u32 {
         match self {
             OrphanCheckError::StorageError(_) => 0,
@@ -40,7 +40,7 @@ impl BanScoreFromError for OrphanCheckError {
     }
 }
 
-impl BanScoreFromError for StateUpdateError {
+impl BanScore for StateUpdateError {
     fn ban_score(&self) -> u32 {
         match self {
             StateUpdateError::StorageError(_) => 0,
@@ -82,7 +82,7 @@ impl BanScoreFromError for StateUpdateError {
     }
 }
 
-impl BanScoreFromError for CheckBlockError {
+impl BanScore for CheckBlockError {
     fn ban_score(&self) -> u32 {
         match self {
             CheckBlockError::StorageError(_) => 0,
@@ -101,7 +101,7 @@ impl BanScoreFromError for CheckBlockError {
     }
 }
 
-impl BanScoreFromError for CheckBlockTransactionsError {
+impl BanScore for CheckBlockTransactionsError {
     fn ban_score(&self) -> u32 {
         match self {
             CheckBlockTransactionsError::StorageError(_) => 0,
@@ -112,7 +112,7 @@ impl BanScoreFromError for CheckBlockTransactionsError {
     }
 }
 
-impl BanScoreFromError for ConsensusVerificationError {
+impl BanScore for ConsensusVerificationError {
     fn ban_score(&self) -> u32 {
         match self {
             ConsensusVerificationError::StorageError(_) => 0,
@@ -125,7 +125,7 @@ impl BanScoreFromError for ConsensusVerificationError {
     }
 }
 
-impl BanScoreFromError for ConsensusPoWError {
+impl BanScore for ConsensusPoWError {
     fn ban_score(&self) -> u32 {
         match self {
             ConsensusPoWError::StorageError(_) => 0,

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -291,7 +291,9 @@ impl<'a, S: BlockchainStorageRead> ChainstateRef<'a, S> {
                     return Err(CheckBlockError::BlockTimeOrderInvalid);
                 }
 
-                if i64::from(block.block_time()) > time::get() {
+                let max_future_offset = self.chain_config.max_future_block_time_offset();
+                if i64::from(block.block_time()) > time::get() + max_future_offset.as_secs() as i64
+                {
                     // TODO: test submitting a block that fails this
                     return Err(CheckBlockError::BlockFromTheFuture);
                 }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -33,6 +33,7 @@ mod error;
 pub use error::*;
 mod pow;
 
+pub mod ban_score;
 mod block_index_history_iter;
 
 mod chainstateref;

--- a/chainstate/src/detail/spend_cache/cached_operation.rs
+++ b/chainstate/src/detail/spend_cache/cached_operation.rs
@@ -32,7 +32,7 @@ impl CachedInputsOperation {
                 tx_index.spend(output_index, spender).map_err(StateUpdateError::from)?
             }
             CachedInputsOperation::Erase => {
-                return Err(StateUpdateError::MissingOutputOrSpentOutputErased)
+                return Err(StateUpdateError::MissingOutputOrSpentOutputErasedOnConnect)
             }
         }
 
@@ -48,7 +48,7 @@ impl CachedInputsOperation {
                 tx_index.unspend(output_index).map_err(StateUpdateError::from)?
             }
             CachedInputsOperation::Erase => {
-                return Err(StateUpdateError::MissingOutputOrSpentOutputErased)
+                return Err(StateUpdateError::MissingOutputOrSpentOutputErasedOnDisconnect)
             }
         }
 

--- a/chainstate/src/detail/spend_cache/error.rs
+++ b/chainstate/src/detail/spend_cache/error.rs
@@ -8,8 +8,12 @@ use thiserror::Error;
 pub enum StateUpdateError {
     #[error("Blockchain storage error: {0}")]
     StorageError(blockchain_storage::Error),
-    #[error("Transaction number `{0}` does not exist in block `{1}`")]
-    TxNumWrongInBlock(usize, Id<Block>),
+    #[error("While connecting a block, transaction number `{0}` does not exist in block `{1}`")]
+    TxNumWrongInBlockOnConnect(usize, Id<Block>),
+    #[error("While disconnecting a block, transaction number `{0}` does not exist in block `{1}`")]
+    TxNumWrongInBlockOnDisconnect(usize, Id<Block>),
+    #[error("While disconnecting a block, transaction number `{0}` does not exist in block `{1}`")]
+    InvariantErrorTxNumWrongInBlock(usize, Id<Block>),
     #[error("Outputs already in the inputs cache")]
     OutputAlreadyPresentInInputsCache,
     #[error("Block reward spent immaturely")]
@@ -24,8 +28,10 @@ pub enum StateUpdateError {
     InvariantBrokenSourceBlockIndexNotFound,
     #[error("Output is not found in the cache or database")]
     MissingOutputOrSpent,
-    #[error("Output was erased in a previous step (possible in reorgs with no cache flushing)")]
-    MissingOutputOrSpentOutputErased,
+    #[error("While connecting a block, output was erased in a previous step (possible in reorgs with no cache flushing)")]
+    MissingOutputOrSpentOutputErasedOnConnect,
+    #[error("While disconnecting a block, output was erased in a previous step (possible in reorgs with no cache flushing)")]
+    MissingOutputOrSpentOutputErasedOnDisconnect,
     #[error("Attempt to print money (total inputs: `{0:?}` vs total outputs `{1:?}`")]
     AttemptToPrintMoney(Amount, Amount),
     #[error("Fee calculation failed (total inputs: `{0:?}` vs total outputs `{1:?}`")]
@@ -91,7 +97,7 @@ impl From<TxMainChainIndexError> for StateUpdateError {
                 StateUpdateError::SerializationInvariantError(block_id)
             }
             TxMainChainIndexError::InvalidTxNumberForBlock(tx_num, block_id) => {
-                StateUpdateError::TxNumWrongInBlock(tx_num, block_id)
+                StateUpdateError::InvariantErrorTxNumWrongInBlock(tx_num, block_id)
             }
         }
     }

--- a/chainstate/src/detail/spend_cache/mod.rs
+++ b/chainstate/src/detail/spend_cache/mod.rs
@@ -66,10 +66,9 @@ impl<'a, S: BlockchainStorageRead> CachedInputs<'a, S> {
     ) -> Result<OutPointSourceId, StateUpdateError> {
         let outpoint_source_id = match spend_ref {
             BlockTransactableRef::Transaction(block, tx_num) => {
-                let tx = block
-                    .transactions()
-                    .get(tx_num)
-                    .ok_or_else(|| StateUpdateError::TxNumWrongInBlock(tx_num, block.get_id()))?;
+                let tx = block.transactions().get(tx_num).ok_or_else(|| {
+                    StateUpdateError::InvariantErrorTxNumWrongInBlock(tx_num, block.get_id())
+                })?;
                 let tx_id = tx.get_id();
                 OutPointSourceId::from(tx_id)
             }
@@ -410,10 +409,9 @@ impl<'a, S: BlockchainStorageRead> CachedInputs<'a, S> {
     ) -> Result<(), StateUpdateError> {
         match spend_ref {
             BlockTransactableRef::Transaction(block, tx_num) => {
-                let tx = block
-                    .transactions()
-                    .get(tx_num)
-                    .ok_or_else(|| StateUpdateError::TxNumWrongInBlock(tx_num, block.get_id()))?;
+                let tx = block.transactions().get(tx_num).ok_or_else(|| {
+                    StateUpdateError::TxNumWrongInBlockOnConnect(tx_num, block.get_id())
+                })?;
 
                 // pre-cache all inputs
                 self.precache_inputs(tx.get_inputs())?;
@@ -459,10 +457,9 @@ impl<'a, S: BlockchainStorageRead> CachedInputs<'a, S> {
 
         match spend_ref {
             BlockTransactableRef::Transaction(block, tx_num) => {
-                let tx = block
-                    .transactions()
-                    .get(tx_num)
-                    .ok_or_else(|| StateUpdateError::TxNumWrongInBlock(tx_num, block.get_id()))?;
+                let tx = block.transactions().get(tx_num).ok_or_else(|| {
+                    StateUpdateError::TxNumWrongInBlockOnDisconnect(tx_num, block.get_id())
+                })?;
 
                 // pre-cache all inputs
                 self.precache_inputs(tx.get_inputs())?;

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -23,6 +23,8 @@ pub mod chainstate_interface_impl;
 
 pub mod chainstate_interface;
 
+pub use detail::ban_score;
+
 use std::sync::Arc;
 
 use chainstate_interface::ChainstateInterface;

--- a/common/src/chain/config.rs
+++ b/common/src/chain/config.rs
@@ -20,6 +20,8 @@ const MAINNET_COIN_DECIMALS: u8 = 11;
 const MAINNET_COIN_PREMINE: &str = "400_000_000";
 const MAINNET_TOTAL_SUPPLY: &str = "599_990_800";
 
+const DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET: Duration = Duration::from_secs(60 * 60);
+
 const DEFAULT_TARGET_BLOCK_SPACING: Duration = Duration::from_secs(120);
 
 #[derive(
@@ -54,6 +56,7 @@ pub struct ChainConfig {
     genesis_block: Block,
     genesis_block_id: Id<Block>,
     blockreward_maturity: BlockDistance,
+    max_future_block_time_offset: Duration,
     version: SemVer,
     target_block_spacing: Duration,
     coin_decimals: u8,
@@ -116,6 +119,10 @@ impl ChainConfig {
 
     pub fn coin_decimals(&self) -> u8 {
         self.coin_decimals
+    }
+
+    pub fn max_future_block_time_offset(&self) -> &Duration {
+        &self.max_future_block_time_offset
     }
 
     pub fn block_subsidy_at_height(&self, height_in: &BlockHeight) -> Amount {
@@ -333,6 +340,7 @@ pub fn create_mainnet() -> ChainConfig {
         genesis_block_id,
         version: SemVer::new(0, 1, 0),
         blockreward_maturity: MAINNET_BLOCKREWARD_MATURITY,
+        max_future_block_time_offset: DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET,
         target_block_spacing,
         coin_decimals,
         emission_schedule,
@@ -401,6 +409,7 @@ pub fn create_regtest() -> ChainConfig {
         version: SemVer::new(0, 1, 0),
         target_block_spacing,
         blockreward_maturity: MAINNET_BLOCKREWARD_MATURITY,
+        max_future_block_time_offset: DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET,
         coin_decimals: MAINNET_COIN_DECIMALS,
         emission_schedule,
     }
@@ -452,6 +461,7 @@ pub fn create_unit_test_config() -> ChainConfig {
         version: SemVer::new(0, 1, 0),
         target_block_spacing,
         blockreward_maturity: MAINNET_BLOCKREWARD_MATURITY,
+        max_future_block_time_offset: DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET,
         coin_decimals,
         emission_schedule,
     }
@@ -532,6 +542,7 @@ impl TestChainConfig {
             version: SemVer::new(0, 1, 0),
             target_block_spacing,
             blockreward_maturity: MAINNET_BLOCKREWARD_MATURITY,
+            max_future_block_time_offset: DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET,
             coin_decimals,
             emission_schedule,
         }


### PR DESCRIPTION
This PR basically maps every error from updating the chainstate to a ban score. I encourage scrutinizing the decisions I made as much as possible. Also please understand that we prefer to be more conservative and hostile towards errors. Some times it's difficult to make a decision on whether to consider something malicious. In that case, we just consider it malicious.

A ban score follows the bitcoin definition. A peer has a maximum ban score of 100. We ban peers that reach 100. Nodes are free to define their own max, which is why we don't define a "max" and assign it to all values. Nodes can choose to tolerate malicious behavior. 