### PR TITLE
Replace iter_tool dependency with itertools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,15 +1507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
-name = "iter_tools"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee1f87ffbdadd88f99d74b86f5139a74b37b4a8d3d08b18e227a96147e27151"
-dependencies = [
- "itertools",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,7 +4247,7 @@ version = "0.1.0"
 dependencies = [
  "common",
  "crypto",
- "iter_tools",
+ "itertools",
  "logging",
  "parity-scale-codec",
  "serialization",

--- a/utxo/Cargo.toml
+++ b/utxo/Cargo.toml
@@ -13,5 +13,5 @@ logging = { path = "../logging/" }
 serialization = { path = "../serialization" }
 
 parity-scale-codec = { version = "3.1.2", features = ["chain-error"] }
-iter_tools = "0.1.0"
+itertools = "0.10"
 thiserror = "1.0.30"

--- a/utxo/src/utxo_impl/test.rs
+++ b/utxo/src/utxo_impl/test.rs
@@ -11,7 +11,7 @@ use crate::utxo_impl::test_helper::{
 use crate::utxo_impl::{UtxoSource, UtxoStatus};
 use common::chain::{OutPoint, OutPointSourceId, Transaction, TxInput};
 use crypto::random::{make_pseudo_rng, seq};
-use iter_tools::Itertools;
+use itertools::Itertools;
 use std::collections::BTreeMap;
 
 /// Checks `add_utxo` method behaviour.

--- a/utxo/src/utxo_impl/test_helper.rs
+++ b/utxo/src/utxo_impl/test_helper.rs
@@ -4,7 +4,7 @@ use common::chain::{Destination, OutPoint, OutPointSourceId, Transaction, TxInpu
 use common::primitives::{Amount, BlockHeight, Id, H256};
 use crypto::key::{KeyKind, PrivateKey};
 use crypto::random::{make_pseudo_rng, seq, Rng};
-use iter_tools::Itertools;
+use itertools::Itertools;
 
 pub const FRESH: u8 = 1;
 pub const DIRTY: u8 = 2;

--- a/utxo/src/utxo_impl/utxo_storage.rs
+++ b/utxo/src/utxo_impl/utxo_storage.rs
@@ -180,7 +180,7 @@ mod test {
     use common::primitives::{Amount, BlockHeight, Idable};
     use common::primitives::{Id, H256};
     use crypto::random::{make_pseudo_rng, seq, Rng};
-    use iter_tools::Itertools;
+    use itertools::Itertools;
     use std::collections::BTreeMap;
 
     fn create_transactions(


### PR DESCRIPTION
The `iter_tools` library simply reexports `itertools` and we already have the second one, so it makes sense to remove the first one.