### PR TITLE
Refactor `PubSubMessageHandler`

### DIFF
--- a/chainstate/src/chainstate_interface.rs
+++ b/chainstate/src/chainstate_interface.rs
@@ -13,7 +13,7 @@ use crate::{detail::BlockSource, ChainstateError, ChainstateEvent};
 pub trait ChainstateInterface: Send {
     fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(ChainstateEvent) + Send + Sync>);
     fn process_block(&mut self, block: Block, source: BlockSource) -> Result<(), ChainstateError>;
-    fn preliminary_block_check(&self, block: Block) -> Result<(), ChainstateError>;
+    fn preliminary_block_check(&self, block: Block) -> Result<Block, ChainstateError>;
     fn get_best_block_id(&self) -> Result<Id<Block>, ChainstateError>;
     fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError>;
     fn get_block_height_in_main_chain(

--- a/chainstate/src/chainstate_interface/mock.rs
+++ b/chainstate/src/chainstate_interface/mock.rs
@@ -15,7 +15,7 @@ mockall::mock! {
     impl ChainstateInterface for ChainstateInterfaceMock {
         fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(ChainstateEvent) + Send + Sync>);
         fn process_block(&mut self, block: Block, source: BlockSource) -> Result<(), ChainstateError>;
-        fn preliminary_block_check(&self, block: Block) -> Result<(), ChainstateError>;
+        fn preliminary_block_check(&self, block: Block) -> Result<Block, ChainstateError>;
         fn get_best_block_id(&self) -> Result<Id<Block>, ChainstateError>;
         fn get_best_block_height(&self) -> Result<BlockHeight, ChainstateError>;
         fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError>;

--- a/chainstate/src/chainstate_interface_impl.rs
+++ b/chainstate/src/chainstate_interface_impl.rs
@@ -31,7 +31,7 @@ impl ChainstateInterface for ChainstateInterfaceImpl {
         Ok(())
     }
 
-    fn preliminary_block_check(&self, block: Block) -> Result<(), ChainstateError> {
+    fn preliminary_block_check(&self, block: Block) -> Result<Block, ChainstateError> {
         self.chainstate
             .preliminary_block_check(block)
             .map_err(ChainstateError::ProcessBlockError)

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -262,10 +262,10 @@ impl Chainstate {
         self.attempt_to_process_block(block, block_source, 0)
     }
 
-    pub fn preliminary_block_check(&self, block: Block) -> Result<(), BlockError> {
+    pub fn preliminary_block_check(&self, block: Block) -> Result<Block, BlockError> {
         let chainstate_ref = self.make_db_tx_ro();
         chainstate_ref.check_block(&block)?;
-        Ok(())
+        Ok(block)
     }
 
     pub fn get_best_block_id(&self) -> Result<Option<Id<Block>>, PropertyQueryError> {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -164,7 +164,6 @@ where
                 P2pError::ConversionError(ConversionError::InvalidAddress(bind_addr))
             })?,
             &[],
-            &[net::types::PubSubTopic::Blocks],
             Arc::clone(&config),
             TIMEOUT,
         )
@@ -207,10 +206,15 @@ where
 
         // TODO: merge with syncmanager when appropriate
         tokio::spawn(async move {
-            if let Err(e) =
-                pubsub::PubSubMessageHandler::<T>::new(config, pubsub, consensus_handle, rx_pubsub)
-                    .run()
-                    .await
+            if let Err(e) = pubsub::PubSubMessageHandler::<T>::new(
+                config,
+                pubsub,
+                consensus_handle,
+                rx_pubsub,
+                &[net::types::PubSubTopic::Blocks],
+            )
+            .run()
+            .await
             {
                 log::error!("PubSubMessageHandler failed: {:?}", e);
             }

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -333,6 +333,15 @@ impl Backend {
                     channel.send(res).map_err(|_| P2pError::ChannelClosed)
                 }
             },
+            types::Command::Subscribe { topics, response } => {
+                for topic in topics {
+                    if let Err(err) = self.swarm.behaviour_mut().gossipsub.subscribe(&topic) {
+                        return response.send(Err(err.into())).map_err(|_| P2pError::ChannelClosed);
+                    }
+                }
+
+                response.send(Ok(())).map_err(|_| P2pError::ChannelClosed)
+            }
         }
     }
 }

--- a/p2p/src/net/libp2p/behaviour.rs
+++ b/p2p/src/net/libp2p/behaviour.rs
@@ -26,7 +26,6 @@ use crate::{
             sync::*,
             types::{self, ConnectivityEvent, Libp2pBehaviourEvent, PubSubEvent},
         },
-        types::PubSubTopic,
     },
 };
 use common::chain::config::ChainConfig;
@@ -96,7 +95,6 @@ impl Libp2pBehaviour {
     pub async fn new(
         config: Arc<ChainConfig>,
         id_keys: identity::Keypair,
-        topics: &[PubSubTopic],
         relay_mdns: bool,
     ) -> Self {
         let gossipsub_config = GossipsubConfigBuilder::default()
@@ -118,7 +116,7 @@ impl Libp2pBehaviour {
         let mut req_cfg = RequestResponseConfig::default();
         req_cfg.set_request_timeout(REQ_RESP_TIMEOUT);
 
-        let mut behaviour = Libp2pBehaviour {
+        let behaviour = Libp2pBehaviour {
             mdns: mdns::Mdns::new(Default::default()).await.expect("mDNS to succeed"),
             ping: ping::Behaviour::new(
                 ping::Config::new()
@@ -149,13 +147,6 @@ impl Libp2pBehaviour {
             pending_conns: HashMap::new(),
             waker: None,
         };
-
-        // subscribes to our topic
-        // TODO: subscribe only after initial block download is done
-        for topic in topics.iter() {
-            log::debug!("subscribing to gossipsub topic {:?}", topic);
-            behaviour.gossipsub.subscribe(&topic.into()).expect("subscription to work");
-        }
 
         behaviour
     }

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -230,7 +230,6 @@ impl NetworkingService for Libp2pService {
     async fn start(
         bind_addr: Self::Address,
         strategies: &[Self::DiscoveryStrategy],
-        topics: &[PubSubTopic],
         chain_config: Arc<common::chain::ChainConfig>,
         timeout: std::time::Duration,
     ) -> crate::Result<(
@@ -259,8 +258,7 @@ impl NetworkingService for Libp2pService {
 
         let swarm = SwarmBuilder::new(
             transport,
-            behaviour::Libp2pBehaviour::new(Arc::clone(&chain_config), id_keys, topics, relay_mdns)
-                .await,
+            behaviour::Libp2pBehaviour::new(Arc::clone(&chain_config), id_keys, relay_mdns).await,
             peer_id,
         )
         .build();

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -40,7 +40,6 @@ async fn test_connect_new() {
     let service = Libp2pService::start(
         test_utils::make_address("/ip6/::1/tcp/"),
         &[],
-        &[],
         config,
         Duration::from_secs(10),
     )
@@ -56,7 +55,6 @@ async fn test_connect_new_addrinuse() {
     let service = Libp2pService::start(
         test_utils::make_address("/ip6/::1/tcp/"),
         &[],
-        &[],
         Arc::clone(&config),
         Duration::from_secs(10),
     )
@@ -65,7 +63,6 @@ async fn test_connect_new_addrinuse() {
 
     let service = Libp2pService::start(
         test_utils::make_address("/ip6/::1/tcp/"),
-        &[],
         &[],
         config,
         Duration::from_secs(10),
@@ -91,14 +88,12 @@ async fn test_connect_accept() {
     let service1 = Libp2pService::start(
         test_utils::make_address("/ip6/::1/tcp/"),
         &[],
-        &[],
         Arc::clone(&config),
         Duration::from_secs(10),
     )
     .await;
     let service2 = Libp2pService::start(
         test_utils::make_address("/ip6/::1/tcp/"),
-        &[],
         &[],
         Arc::clone(&config),
         Duration::from_secs(10),
@@ -126,7 +121,6 @@ async fn test_connect_peer_id_missing() {
     let addr: Multiaddr = "/ip6/::1/tcp/8904".parse().unwrap();
     let (mut service, _, _) = Libp2pService::start(
         test_utils::make_address("/ip6/::1/tcp/"),
-        &[],
         &[],
         config,
         Duration::from_secs(10),
@@ -313,7 +307,6 @@ async fn test_connect_with_timeout() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let (mut service, _, _) = Libp2pService::start(
         test_utils::make_address("/ip6/::1/tcp/"),
-        &[],
         &[],
         config,
         Duration::from_secs(2),

--- a/p2p/src/net/libp2p/types.rs
+++ b/p2p/src/net/libp2p/types.rs
@@ -81,6 +81,12 @@ pub enum Command {
         response: Box<SyncResponse>,
         channel: oneshot::Sender<crate::Result<()>>,
     },
+
+    /// Subscribe to gossipsub topics
+    Subscribe {
+        topics: Vec<Topic>,
+        response: oneshot::Sender<crate::Result<()>>,
+    },
 }
 
 #[derive(Debug)]

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -209,6 +209,10 @@ where
         todo!();
     }
 
+    async fn subscribe(&mut self, _topics: &[PubSubTopic]) -> crate::Result<()> {
+        todo!();
+    }
+
     async fn poll_next(&mut self) -> crate::Result<PubSubEvent<T>> {
         todo!();
     }

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -97,7 +97,6 @@ impl NetworkingService for MockService {
     async fn start(
         addr: Self::Address,
         _strategies: &[Self::DiscoveryStrategy],
-        _topics: &[PubSubTopic],
         _config: Arc<common::chain::ChainConfig>,
         timeout: std::time::Duration,
     ) -> crate::Result<(

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -156,6 +156,12 @@ where
         result: types::ValidationResult,
     ) -> crate::Result<()>;
 
+    /// Subscribe to publish-subscribe topics
+    ///
+    /// # Arguments
+    /// * `topics` - list of topics
+    async fn subscribe(&mut self, topics: &[types::PubSubTopic]) -> crate::Result<()>;
+
     /// Poll unvalidated pubsub messages
     ///
     /// The message must be validated by the application layer and the validation

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -80,7 +80,6 @@ pub trait NetworkingService {
     async fn start(
         bind_addr: Self::Address,
         strategies: &[Self::DiscoveryStrategy],
-        topics: &[types::PubSubTopic],
         chain_config: Arc<common::chain::ChainConfig>,
         timeout: std::time::Duration,
     ) -> crate::Result<(

--- a/p2p/src/swarm/tests/mod.rs
+++ b/p2p/src/swarm/tests/mod.rs
@@ -36,7 +36,6 @@ where
     let (conn, _, _) = T::start(
         addr,
         &[],
-        &[],
         Arc::clone(&config),
         std::time::Duration::from_secs(10),
     )

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -57,7 +57,6 @@ where
     let (conn, _, sync) = T::start(
         addr,
         &[],
-        &[],
         Arc::clone(&config),
         std::time::Duration::from_secs(10),
     )

--- a/p2p/tests/libp2p-gossipsub.rs
+++ b/p2p/tests/libp2p-gossipsub.rs
@@ -205,8 +205,6 @@ async fn test_libp2p_gossipsub_3_peers() {
     peer2.1.subscribe(&[PubSubTopic::Blocks]).await.unwrap();
     peer3.1.subscribe(&[PubSubTopic::Blocks]).await.unwrap();
 
-    println!("here");
-
     // spam the message on the pubsubsub until it succeeds (= until we have a peer)
     loop {
         let res = pubsub1

--- a/p2p/tests/libp2p-mdns.rs
+++ b/p2p/tests/libp2p-mdns.rs
@@ -32,7 +32,6 @@ async fn test_libp2p_peer_discovery() {
     let (mut serv, _, _) = Libp2pService::start(
         addr.clone(),
         &[Libp2pDiscoveryStrategy::MulticastDns],
-        &[],
         Arc::clone(&config),
         std::time::Duration::from_secs(10),
     )
@@ -43,7 +42,6 @@ async fn test_libp2p_peer_discovery() {
     let (mut serv2, _, _) = Libp2pService::start(
         addr2.clone(),
         &[Libp2pDiscoveryStrategy::MulticastDns],
-        &[],
         Arc::clone(&config),
         std::time::Duration::from_secs(10),
     )

--- a/p2p/tests/sync.rs
+++ b/p2p/tests/sync.rs
@@ -62,7 +62,6 @@ where
     let (conn, _, sync) = T::start(
         addr,
         &[],
-        &[],
         Arc::clone(&config),
         std::time::Duration::from_secs(10),
     )


### PR DESCRIPTION
Remove code duplication, add documentation, improve error handling, and subscribe to pubsub topics only after the initial block download.

Let me know your opinions on what are the appropriate responses to various errors the message handler might receive from chainstate. 