### PR TITLE
Add rustfmt as its own check in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,24 @@ jobs:
       with:
         arguments: --all-features --workspace
 
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install rust stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          default: true
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Run rustfmt
+        run: carfo fmt --all -- --check
+
   build_windows:
     runs-on: windows-latest
     # if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,6 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
-        components: rustfmt
         default: true
     - name: Checkout repository and submodules
       uses: actions/checkout@v2
@@ -53,7 +52,6 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
-        components: rustfmt
         default: true
     - name: Checkout repository and submodules
       uses: actions/checkout@v2
@@ -76,7 +74,6 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
-        components: rustfmt
         default: true
     - name: Checkout repository and submodules
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           submodules: recursive
       - name: Run rustfmt
-        run: carfo fmt --all -- --check
+        run: cargo fmt --all -- --check
 
   build_windows:
     runs-on: windows-latest

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -21,7 +21,6 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
-        components: rustfmt
         default: true
     - name: Checkout repository and submodules
       uses: actions/checkout@v2

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -215,7 +215,7 @@ impl Backend {
         }
     }
 
-	// TODO: design p2p global command system
+    // TODO: design p2p global command system
     /// Handle command received from the libp2p front-end
     async fn on_command(&mut self, cmd: types::Command) -> crate::Result<()> {
         log::debug!("handle incoming command {:?}", cmd);


### PR DESCRIPTION
As far as I can see, we are not using rustfmt on CI, so there is no reason to install it.