### PR TITLE
Ignore the 'mixed_sighash_types' test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,9 @@ jobs:
       run: cargo build --release
     - name: Run tests
       run: cargo test --release --workspace
+    # This test is ignored, so it needs to run separately.
+    - name: Run mixed_sighash_types test
+      run: cargo test mixed_sighash_types
     - name: Run functional tests
       run: cargo test --release -p mintlayer-test --test functional -- --ignored
 
@@ -79,6 +82,9 @@ jobs:
       run: cargo build --release
     - name: Run tests
       run: cargo test --release --workspace
+    # This test is ignored, so it needs to run separately.
+    - name: Run mixed_sighash_types test
+      run: cargo test mixed_sighash_types
     - name: Run functional tests
       run: cargo test --release -p mintlayer-test --test functional -- --ignored
 
@@ -101,5 +107,8 @@ jobs:
       run: cargo build --release
     - name: Run tests
       run: cargo test --release --workspace
+    # This test is ignored, so it needs to run separately.
+    - name: Run mixed_sighash_types test
+      run: cargo test mixed_sighash_types
     - name: Run functional tests
       run: cargo test --release -p mintlayer-test --test functional -- --ignored

--- a/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
+++ b/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
@@ -6,8 +6,10 @@ use super::utils::*;
 use crate::chain::Destination;
 
 // Create a transaction with a different signature hash type for every input.
+// This test takes a long time to finish, so it is ignored by default.
+#[ignore]
 #[test]
-fn mixed_sighas_types() {
+fn mixed_sighash_types() {
     let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
 


### PR DESCRIPTION
The `mixed_sighash_types` runs for more than 9 minutes on my (weak) laptop, so marking it as ignored can save a lot of time for everyone, but we still have it on CI.

I am worried that we have a performance regression in some of the latest commits because previously this test took about a minute (which is probably also a little bit too long).

By the way, I can add a lightweight version of the test to run every time if it makes sense.