### PR TITLE
p2p: Create new message format

### DIFF
--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -21,48 +21,99 @@ use common::{
 use serialization::{Decode, Encode};
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub enum SyncingRequest {
-    #[codec(index = 0)]
-    GetHeaders { locator: Vec<BlockHeader> },
-    #[codec(index = 1)]
-    GetBlocks { block_ids: Vec<Id<Block>> },
+pub struct HeaderRequest {
+    locator: Vec<BlockHeader>,
+}
+
+impl HeaderRequest {
+    pub fn new(locator: Vec<BlockHeader>) -> Self {
+        HeaderRequest { locator }
+    }
+
+    pub fn locator(&self) -> &Vec<BlockHeader> {
+        &self.locator
+    }
+
+    pub fn into_locator(self) -> Vec<BlockHeader> {
+        self.locator
+    }
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub enum SyncingResponse {
-    #[codec(index = 0)]
-    Headers { headers: Vec<BlockHeader> },
-    #[codec(index = 1)]
-    Blocks { blocks: Vec<Block> },
+pub struct BlockRequest {
+    block_ids: Vec<Id<Block>>,
+}
+
+impl BlockRequest {
+    pub fn new(block_ids: Vec<Id<Block>>) -> Self {
+        Self { block_ids }
+    }
+
+    pub fn block_ids(&self) -> &Vec<Id<Block>> {
+        &self.block_ids
+    }
+
+    pub fn into_block_ids(self) -> Vec<Id<Block>> {
+        self.block_ids
+    }
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub enum PubSubMessage {
+pub enum Request {
+    #[codec(index = 0)]
+    HeaderRequest(HeaderRequest),
+    #[codec(index = 1)]
+    BlockRequest(BlockRequest),
+}
+
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct HeaderResponse {
+    headers: Vec<BlockHeader>,
+}
+
+impl HeaderResponse {
+    pub fn new(headers: Vec<BlockHeader>) -> Self {
+        Self { headers }
+    }
+
+    pub fn headers(&self) -> &Vec<BlockHeader> {
+        &self.headers
+    }
+
+    pub fn into_headers(self) -> Vec<BlockHeader> {
+        self.headers
+    }
+}
+
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct BlockResponse {
+    blocks: Vec<Block>,
+}
+
+impl BlockResponse {
+    pub fn new(blocks: Vec<Block>) -> Self {
+        Self { blocks }
+    }
+
+    pub fn blocks(&self) -> &Vec<Block> {
+        &self.blocks
+    }
+
+    pub fn into_blocks(self) -> Vec<Block> {
+        self.blocks
+    }
+}
+
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub enum Response {
+    #[codec(index = 0)]
+    HeaderResponse(HeaderResponse),
+    #[codec(index = 1)]
+    BlockResponse(BlockResponse),
+}
+
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub enum Announcement {
     #[codec(index = 0)]
     Block(Block),
-}
-
-#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub enum SyncingMessage {
-    #[codec(index = 0)]
-    Request(SyncingRequest),
-    #[codec(index = 1)]
-    Response(SyncingResponse),
-}
-
-#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub enum MessageType {
-    #[codec(index = 0)]
-    Syncing(SyncingMessage),
-    #[codec(index = 1)]
-    PubSub(PubSubMessage),
-}
-
-#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct Message {
-    /// Magic number identifying mainnet, testnet
-    pub magic: [u8; 4],
-
-    /// Message (GetHeaders, Blocks, etc.)
-    pub msg: MessageType,
 }

--- a/p2p/src/net/libp2p/behaviour.rs
+++ b/p2p/src/net/libp2p/behaviour.rs
@@ -317,7 +317,7 @@ impl NetworkBehaviourEventProcess<gossipsub::GossipsubEvent> for Libp2pBehaviour
                     propagation_source
                 );
 
-                let message = match message::Message::decode(&mut &message.data[..]) {
+                let announcement = match message::Announcement::decode(&mut &message.data[..]) {
                     Ok(data) => data,
                     Err(_) => {
                         log::warn!(
@@ -335,10 +335,10 @@ impl NetworkBehaviourEventProcess<gossipsub::GossipsubEvent> for Libp2pBehaviour
                     }
                 };
 
-                self.add_event(Libp2pBehaviourEvent::PubSub(PubSubEvent::MessageReceived {
+                self.add_event(Libp2pBehaviourEvent::PubSub(PubSubEvent::Announcement {
                     peer_id: propagation_source,
-                    message,
                     message_id,
+                    announcement,
                 }));
             }
         }

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -408,8 +408,8 @@ impl<T> PubSubService<T> for Libp2pPubSubHandle<T>
 where
     T: NetworkingService<PeerId = PeerId, MessageId = MessageId> + Send,
 {
-    async fn publish(&mut self, message: message::Message) -> crate::Result<()> {
-        let encoded = message.encode();
+    async fn publish(&mut self, announcement: message::Announcement) -> crate::Result<()> {
+        let encoded = announcement.encode();
         ensure!(
             encoded.len() <= constants::GOSSIPSUB_MAX_TRANSMIT_SIZE,
             P2pError::PublishError(PublishError::MessageTooLarge(
@@ -418,13 +418,10 @@ where
             ))
         );
 
-        // TODO: add support for transactions in the future
-        let topic =
-            if let message::MessageType::PubSub(message::PubSubMessage::Block(_)) = message.msg {
-                net::types::PubSubTopic::Blocks
-            } else {
-                return Err(P2pError::ProtocolError(ProtocolError::InvalidMessage));
-            };
+        // TODO: transactions
+        let topic = match &announcement {
+            message::Announcement::Block(_) => net::types::PubSubTopic::Blocks,
+        };
 
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
@@ -477,14 +474,14 @@ where
 
     async fn poll_next(&mut self) -> crate::Result<PubSubEvent<T>> {
         match self.gossip_rx.recv().await.ok_or(P2pError::ChannelClosed)? {
-            types::PubSubEvent::MessageReceived {
+            types::PubSubEvent::Announcement {
                 peer_id,
-                message,
                 message_id,
-            } => Ok(PubSubEvent::MessageReceived {
+                announcement,
+            } => Ok(PubSubEvent::Announcement {
                 peer_id,
-                message,
                 message_id,
+                announcement,
             }),
         }
     }
@@ -498,13 +495,13 @@ where
     async fn send_request(
         &mut self,
         peer_id: T::PeerId,
-        message: message::Message,
+        request: message::Request,
     ) -> crate::Result<T::RequestId> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(types::Command::SendRequest {
                 peer_id,
-                request: Box::new(SyncRequest::new(message.encode())),
+                request: Box::new(SyncRequest::new(request.encode())),
                 response: tx,
             })
             .await?;
@@ -517,13 +514,13 @@ where
     async fn send_response(
         &mut self,
         request_id: T::RequestId,
-        message: message::Message,
+        response: message::Response,
     ) -> crate::Result<()> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(types::Command::SendResponse {
                 request_id,
-                response: Box::new(SyncResponse::new(message.encode())),
+                response: Box::new(SyncResponse::new(response.encode())),
                 channel: tx,
             })
             .await?;
@@ -540,12 +537,9 @@ where
                 request_id,
                 request,
             } => {
-                let request = message::Message::decode(&mut &(*request)[..]).map_err(|err| {
-                    log::error!(
-                        "invalid request received from peer {:?}: {:?}",
-                        peer_id,
-                        err
-                    );
+                // TODO: decode  on libp2p side!
+                let request = message::Request::decode(&mut &(*request)[..]).map_err(|err| {
+                    log::error!("invalid request received from peer {}: {}", peer_id, err);
                     P2pError::ProtocolError(ProtocolError::InvalidMessage)
                 })?;
 
@@ -560,12 +554,9 @@ where
                 request_id,
                 response,
             } => {
-                let response = message::Message::decode(&mut &(*response)[..]).map_err(|err| {
-                    log::error!(
-                        "invalid response received from peer {:?}: {:?}",
-                        peer_id,
-                        err
-                    );
+                // TODO: decode  on libp2p side!
+                let response = message::Response::decode(&mut &(*response)[..]).map_err(|err| {
+                    log::error!("invalid response received from peer {}: {}", peer_id, err);
                     P2pError::ProtocolError(ProtocolError::InvalidMessage)
                 })?;
 

--- a/p2p/src/net/libp2p/tests/gossipsub.rs
+++ b/p2p/src/net/libp2p/tests/gossipsub.rs
@@ -23,15 +23,15 @@ use serialization::Encode;
 
 impl PartialEq for types::PubSubEvent {
     fn eq(&self, other: &Self) -> bool {
-        let types::PubSubEvent::MessageReceived {
+        let types::PubSubEvent::Announcement {
             peer_id: p1,
             message_id: m1,
-            message: msg1,
+            announcement: msg1,
         } = self;
-        let types::PubSubEvent::MessageReceived {
+        let types::PubSubEvent::Announcement {
             peer_id: p2,
             message_id: m2,
-            message: msg2,
+            announcement: msg2,
         } = other;
 
         (p1 == p2) && (m1 == m2) && (msg1 == msg2)

--- a/p2p/src/net/libp2p/types.rs
+++ b/p2p/src/net/libp2p/types.rs
@@ -133,13 +133,10 @@ pub enum ConnectivityEvent {
 
 #[derive(Debug, Clone)]
 pub enum PubSubEvent {
-    // TODO: rethink this event
-    // TODO: box?
-    // Message received from one of the PubSub topics
-    MessageReceived {
+    Announcement {
         peer_id: PeerId,
         message_id: MessageId,
-        message: message::Message,
+        announcement: message::Announcement,
     },
 }
 

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -195,7 +195,7 @@ impl<T> PubSubService<T> for MockPubSubHandle<T>
 where
     T: NetworkingService<PeerId = SocketAddr> + Send,
 {
-    async fn publish(&mut self, _message: message::Message) -> crate::Result<()> {
+    async fn publish(&mut self, _announcement: message::Announcement) -> crate::Result<()> {
         todo!();
     }
 
@@ -225,7 +225,7 @@ where
     async fn send_request(
         &mut self,
         _peer_id: T::PeerId,
-        _message: message::Message,
+        _request: message::Request,
     ) -> crate::Result<T::RequestId> {
         todo!();
     }
@@ -233,7 +233,7 @@ where
     async fn send_response(
         &mut self,
         _request_id: T::RequestId,
-        _message: message::Message,
+        _response: message::Response,
     ) -> crate::Result<()> {
         todo!();
     }

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -35,10 +35,10 @@ pub enum ConnectivityEvent {
 // TODO: use two events, one for txs and one for blocks?
 pub enum PubSubEvent {
     /// Message received from one of the pubsub topics
-    MessageReceived {
+    Announcement {
         peer_id: SocketAddr,
         topic: net::types::PubSubTopic,
-        message: message::Message,
+        message: message::Announcement,
     },
 }
 

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -134,20 +134,18 @@ pub trait PubSubService<T>
 where
     T: NetworkingService,
 {
-    /// Publish data to the network
+    /// Publish a data announcement on the network
     ///
     /// # Arguments
-    /// `message` - message to be sent
-    async fn publish(&mut self, message: message::Message) -> crate::Result<()>;
+    /// `announcement` - SCALE-encodable block or transaction
+    async fn publish(&mut self, announcement: message::Announcement) -> crate::Result<()>;
 
     /// Report message validation result back to the backend
     ///
     /// # Arguments
-    /// `source` - source of the message
-    ///
-    /// `msg_id` - unique ID of the message
-    ///
-    /// `result` - result of validation, see [types::ValidationResult] for more details
+    /// * `source` - source of the message
+    /// * `msg_id` - unique ID of the message
+    /// * `result` - result of validation, see [types::ValidationResult] for more details
     async fn report_validation_result(
         &mut self,
         source: T::PeerId,
@@ -180,25 +178,23 @@ where
     /// Send block/header request to remote
     ///
     /// # Arguments
-    /// `peer_id` - Unique ID of the peer the request is sent to
-    ///
-    /// `message` - request to be sent
+    /// * `peer_id` - Unique ID of the peer the request is sent to
+    /// * `request` - Request to be sent
     async fn send_request(
         &mut self,
         peer_id: T::PeerId,
-        message: message::Message,
+        request: message::Request,
     ) -> crate::Result<T::RequestId>;
 
     /// Send block/header response to remote
     ///
     /// # Arguments
-    /// `request_id` - ID of the request this is a response to
-    ///
-    /// `message` - response to be sent
+    /// * `request_id` - ID of the request this is a response to
+    /// * `message` - Response to be sent
     async fn send_response(
         &mut self,
         request_id: T::RequestId,
-        message: message::Message,
+        response: message::Response,
     ) -> crate::Result<()>;
 
     /// Poll syncing-related event from the networking service

--- a/p2p/src/net/types.rs
+++ b/p2p/src/net/types.rs
@@ -154,20 +154,17 @@ pub enum ConnectivityEvent<T: NetworkingService> {
 
 /// Publish-subscribe related events
 #[derive(Debug)]
-pub enum PubSubEvent<T>
-where
-    T: NetworkingService,
-{
-    /// Message received from a PubSub topic
-    MessageReceived {
+pub enum PubSubEvent<T: NetworkingService> {
+    /// Block announcement received from peer
+    Announcement {
         /// Unique ID of the sender
         peer_id: T::PeerId,
 
         /// Unique ID of the message
         message_id: T::MessageId,
 
-        /// Received PubSub message
-        message: message::Message,
+        /// Received data, block/transaction
+        announcement: message::Announcement,
     },
 }
 
@@ -197,7 +194,7 @@ where
         request_id: T::RequestId,
 
         /// Received request
-        request: message::Message,
+        request: message::Request,
     },
 
     /// Incoming response to a sent request
@@ -209,7 +206,7 @@ where
         request_id: T::RequestId,
 
         /// Received response
-        response: message::Message,
+        response: message::Response,
     },
 
     /// Error occurred with syncing codec

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -16,8 +16,7 @@
 // Author(s): A. Altonen
 use crate::{
     error::{P2pError, PeerError, ProtocolError},
-    event,
-    message::{Message, MessageType, SyncingMessage, SyncingRequest, SyncingResponse},
+    event, message,
     net::{self, types::SyncingEvent, NetworkingService, SyncingCodecService},
 };
 use chainstate::{
@@ -476,65 +475,65 @@ where
                     SyncingEvent::Request {
                         peer_id,
                         request_id,
-                        request:
-                            Message {
-                                msg: MessageType::Syncing(SyncingMessage::Request(message)),
-                                magic: _,
-                            },
-                    } => {
-                        match message {
-                            SyncingRequest::GetHeaders { locator } => {
-                                log::debug!(
-                                    "process header request (id {:?}) from peer {}",
-                                    request_id, peer_id
-                                );
-                                log::trace!("locator: {:#?}", locator);
+                        request,
+                    } => match request {
+                        message::Request::HeaderRequest(request) => {
+                            log::debug!(
+                                "process header request (id {:?}) from peer {}",
+                                request_id, peer_id
+                            );
+                            log::trace!("locator: {:#?}", request.locator());
 
-                                let result = self.process_header_request(peer_id, request_id, locator).await;
-                                self.handle_error(peer_id, result).await?;
-                            }
-                            SyncingRequest::GetBlocks { block_ids } => {
-                                log::debug!(
-                                    "process block request (id {:?}) from peer {}",
-                                    request_id, peer_id
-                                );
-                                log::trace!("requested block ids: {:#?}", block_ids);
-
-                                let result = self.process_block_request(peer_id, request_id, block_ids).await;
-                                self.handle_error(peer_id, result).await?;
-                            }
+                            let result = self.process_header_request(
+                                peer_id,
+                                request_id,
+                                request.into_locator(),
+                            ).await;
+                            self.handle_error(peer_id, result).await?;
                         }
-                    }
+                        message::Request::BlockRequest(request) => {
+                            log::debug!(
+                                "process block request (id {:?}) from peer {}",
+                                request_id, peer_id
+                            );
+                            log::trace!("requested block ids: {:#?}", request.block_ids());
+
+                            let result = self.process_block_request(
+                                peer_id,
+                                request_id,
+                                request.into_block_ids(),
+                            ).await;
+                            self.handle_error(peer_id, result).await?;
+                        }
+                    },
                     SyncingEvent::Response {
                         peer_id,
                         request_id,
-                        response:
-                            Message {
-                                msg: MessageType::Syncing(SyncingMessage::Response(message)),
-                                magic: _,
-                            },
-                    } => {
-                        match message {
-                            SyncingResponse::Headers { headers } => {
-                                log::debug!(
-                                    "process header response (id {:?}) from peer {}",
-                                    request_id, peer_id
-                                );
-                                log::trace!("received headers: {:#?}", headers);
+                        response,
+                    } => match response {
+                        message::Response::HeaderResponse(response) => {
+                            log::debug!(
+                                "process header response (id {:?}) from peer {}",
+                                request_id, peer_id
+                            );
+                            log::trace!("received headers: {:#?}", response.headers());
 
-                                let result = self.process_header_response(peer_id, headers).await;
-                                self.handle_error(peer_id, result).await?;
-                            }
-                            SyncingResponse::Blocks { blocks } => {
-                                log::debug!(
-                                    "process block response (id {:?}) from peer {}",
-                                    request_id, peer_id
-                                );
-                                log::trace!("# of received blocks: {:#?}", blocks.len());
+                            let result = self.process_header_response(peer_id, response.into_headers()).await;
+                            self.handle_error(peer_id, result).await?;
+                        }
+                        message::Response::BlockResponse(response) => {
+                            log::debug!(
+                                "process block response (id {:?}) from peer {}",
+                                request_id, peer_id
+                            );
+                            log::trace!(
+                                "# of received blocks: {}, block ids: {:#?}",
+                                response.blocks().len(),
+                                response.blocks().iter().map(|block| block.get_id()).collect::<Vec<_>>(),
+                            );
 
-                                let result = self.process_block_response(peer_id, blocks).await;
-                                self.handle_error(peer_id, result).await?;
-                            }
+                            let result = self.process_block_response(peer_id, response.into_blocks()).await;
+                            self.handle_error(peer_id, result).await?;
                         }
                     },
                     SyncingEvent::Error {
@@ -545,13 +544,6 @@ where
                         let result = self.process_error(peer_id, request_id, error).await;
                         self.handle_error(peer_id, result).await?;
                     },
-                    SyncingEvent::Request { peer_id, .. } | SyncingEvent::Response { peer_id, .. } => {
-                        log::error!("received an invalid message from peer {}", peer_id);
-                        self.handle_error(
-                            peer_id,
-                            Err(P2pError::ProtocolError(ProtocolError::InvalidMessage))
-                        ).await?;
-                    }
                 },
                 event = self.rx_sync.recv().fuse() => match event.ok_or(P2pError::ChannelClosed)? {
                     event::SyncControlEvent::Connected(peer_id) => {


### PR DESCRIPTION
Remove global message type and use task-specific types that prevent
publish-subscribe messages to be received by `SyncManager` or header
requests to be received from one of the Gossipsub topics.

The magic numbers of the nodes are exchanged during handshaking, meaning
if the connection is not closed during handshaking, the magic numbers
are going to match for the entire duration of the session.