### PR TITLE
Fix new Clippy lints (Rust 1.62)

### DIFF
--- a/common/src/uint/impls.rs
+++ b/common/src/uint/impls.rs
@@ -272,21 +272,21 @@ macro_rules! construct_uint {
             }
         }
 
-        impl<'a> From<u64> for $name {
+        impl From<u64> for $name {
             #[inline]
             fn from(n: u64) -> Self {
                 Self::from_u64(n)
             }
         }
 
-        impl<'a> From<u128> for $name {
+        impl From<u128> for $name {
             #[inline]
             fn from(n: u128) -> Self {
                 Self::from_u128(n)
             }
         }
 
-        impl<'a> From<Amount> for $name {
+        impl From<Amount> for $name {
             #[inline]
             fn from(n: Amount) -> Self {
                 Self::from_amount(n)

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -435,9 +435,8 @@ where
             })
             .await?;
 
-        rx.await
-            .map_err(|e| e)? // channel closed
-            .map_err(|e| e) // command failure
+        // The first error indicates the channel being closed and the second one is a p2p error.
+        rx.await?
     }
 
     async fn report_validation_result(
@@ -456,9 +455,8 @@ where
             })
             .await?;
 
-        rx.await
-            .map_err(|e| e)? // channel closed
-            .map_err(|e| e) // command failure
+        // The first error indicates the channel being closed and the second one is a p2p error.
+        rx.await?
     }
 
     async fn subscribe(&mut self, topics: &[PubSubTopic]) -> crate::Result<()> {
@@ -470,9 +468,8 @@ where
             })
             .await?;
 
-        rx.await
-            .map_err(|e| e)? // channel closed
-            .map_err(|e| e) // command failure
+        // The first error indicates the channel being closed and the second one is a p2p error.
+        rx.await?
     }
 
     async fn poll_next(&mut self) -> crate::Result<PubSubEvent<T>> {
@@ -509,9 +506,8 @@ where
             })
             .await?;
 
-        rx.await
-            .map_err(|e| e)? // channel closed
-            .map_err(|e| e) // command failure
+        // The first error indicates the channel being closed and the second one is a p2p error.
+        rx.await?
     }
 
     async fn send_response(
@@ -528,9 +524,8 @@ where
             })
             .await?;
 
-        rx.await
-            .map_err(|e| e)? // channel closed
-            .map_err(|e| e) // command failure
+        // The first error indicates the channel being closed and the second one is a p2p error.
+        rx.await?
     }
 
     async fn poll_next(&mut self) -> crate::Result<SyncingEvent<T>> {

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -148,10 +148,7 @@ where
         let (tx, rx) = oneshot::channel();
         self.cmd_tx.send(types::Command::Connect { addr, response: tx }).await?;
 
-        let _ = rx
-            .await
-            .map_err(|e| e)? // channel closed
-            .map_err(|e| e)?; // command failure
+        let _ = rx.await??;
 
         todo!();
         // Ok(


### PR DESCRIPTION
Actually, new lints aren't triggered for the code-base, but some of the old ones were improved, too.