### PR TITLE
Fix typo in RistrettoSignatureError

### DIFF
--- a/crypto/src/key/mod.rs
+++ b/crypto/src/key/mod.rs
@@ -6,7 +6,7 @@ use serialization::{Decode, Encode};
 use crate::random::make_true_rng;
 pub use signature::Signature;
 
-use self::rschnorr::RistrittoSignatureError;
+use self::rschnorr::RistrettoSignatureError;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum SignatureError {
@@ -40,10 +40,10 @@ pub(crate) enum PublicKeyHolder {
     RistrettoSchnorr(rschnorr::MLRistrettoPublicKey),
 }
 
-impl From<RistrittoSignatureError> for SignatureError {
-    fn from(e: RistrittoSignatureError) -> Self {
+impl From<RistrettoSignatureError> for SignatureError {
+    fn from(e: RistrettoSignatureError) -> Self {
         match e {
-            RistrittoSignatureError::ByteConversionError(s) => {
+            RistrettoSignatureError::ByteConversionError(s) => {
                 SignatureError::DataConversionError(s)
             }
         }

--- a/crypto/src/key/rschnorr/mod.rs
+++ b/crypto/src/key/rschnorr/mod.rs
@@ -16,7 +16,7 @@ pub enum RistrettoKeyError {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub enum RistrittoSignatureError {
+pub enum RistrettoSignatureError {
     ByteConversionError(String),
 }
 
@@ -94,7 +94,7 @@ impl MLRistrettoPrivateKey {
         &self,
         rng: &mut R,
         msg: &[u8],
-    ) -> Result<RistrettoSchnorrSignature, RistrittoSignatureError> {
+    ) -> Result<RistrettoSchnorrSignature, RistrettoSignatureError> {
         let (r, r_pub) = RistrettoPublicKey::random_keypair(rng);
         let k = &self.key_data;
         let e = Self::construct_challenge_from_message(msg);


### PR DESCRIPTION
Fixes a typo in the crypto subsystem. 