### PR TITLE
p2p: Implement port allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,7 +2553,6 @@ dependencies = [
  "libp2p",
  "logging",
  "parity-scale-codec",
- "portpicker",
  "rpc",
  "serialization",
  "sscanf",
@@ -2742,15 +2741,6 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
-]
-
-[[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -3953,9 +3943,9 @@ dependencies = [
  "chainstate-storage",
  "common",
  "crypto",
+ "lazy_static",
  "libp2p",
  "p2p",
- "portpicker",
  "subsystem",
  "tokio",
 ]

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -37,7 +37,6 @@ default-features = false
 features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"]
 
 [dev-dependencies]
-portpicker = "0.1"
 chainstate-storage = { path = "../chainstate-storage" }
 crypto = { path = "../crypto/" }
 

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -314,7 +314,7 @@ async fn test_connect_with_timeout() {
     .await
     .unwrap();
 
-    let port = portpicker::pick_unused_port().unwrap();
+    let port = test_utils::get_free_port();
     let mut addr: Multiaddr = format!("/ip6/::1/tcp/{}", port).parse().unwrap();
     addr.push(Protocol::P2p(PeerId::random().into()));
 

--- a/p2p/test-utils/Cargo.toml
+++ b/p2p/test-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-portpicker = "0.1"
+lazy_static = "1.4"
 
 # local dependencies
 chainstate-storage = { path = "../../chainstate-storage" }


### PR DESCRIPTION
Both `portpicker-rs` and `port-selector` have problems with thread-safe
allocation which result in the same port to be allocated for multiple
different threads causing unit tests to fail.

Implement simple allocator that internally uses `AtomicU16` to keep track
of the allocated ports.

NOTE: this is only used in tests