### PR TITLE
Port allocation fix

### DIFF
--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -26,7 +26,10 @@ use crate::{
     },
 };
 use futures::StreamExt;
-use libp2p::swarm::{Swarm, SwarmEvent};
+use libp2p::{
+    swarm::{Swarm, SwarmEvent},
+    Multiaddr,
+};
 use logging::log;
 use tokio::sync::mpsc;
 
@@ -45,6 +48,9 @@ pub struct Backend {
 
     /// Sender for outgoing syncing events
     pub(super) sync_tx: mpsc::Sender<types::SyncingEvent>,
+
+    /// Active listen address of the backend
+    listen_addr: Option<Multiaddr>,
 }
 
 impl Backend {
@@ -61,6 +67,7 @@ impl Backend {
             conn_tx,
             gossip_tx,
             sync_tx,
+            listen_addr: None,
         }
     }
 
@@ -71,7 +78,8 @@ impl Backend {
             tokio::select! {
                 event = self.swarm.select_next_some() => match event {
                     SwarmEvent::NewListenAddr { address, .. } => {
-                        log::trace!("new listen address {:?}", address);
+                        let peer_id = *self.swarm.local_peer_id();
+                        self.listen_addr = Some(address.with(libp2p::multiaddr::Protocol::P2p(peer_id.into())));
                     }
                     SwarmEvent::Behaviour(Libp2pBehaviourEvent::Connectivity(event)) => {
                         self.conn_tx.send(event).await.map_err(P2pError::from)?;
@@ -223,6 +231,9 @@ impl Backend {
 
                 response.send(Ok(())).map_err(|_| P2pError::ChannelClosed)
             }
+            types::Command::ListenAddress { response } => {
+                response.send(self.listen_addr.clone()).map_err(|_| P2pError::ChannelClosed)
+            }
         }
     }
 }
@@ -242,7 +253,7 @@ mod tests {
         request_response::{ProtocolSupport, RequestResponse, RequestResponseConfig},
         swarm::SwarmBuilder,
         tcp::TcpConfig,
-        Multiaddr, Transport,
+        Transport,
     };
     use std::{
         collections::{HashMap, VecDeque},
@@ -318,7 +329,7 @@ mod tests {
         let (tx, rx) = oneshot::channel();
         let res = cmd_tx
             .send(types::Command::Listen {
-                addr: test_utils::make_address("/ip6/::1/tcp/"),
+                addr: test_utils::make_libp2p_addr(),
                 response: tx,
             })
             .await;
@@ -342,11 +353,10 @@ mod tests {
 
         tokio::spawn(async move { backend.run().await });
 
-        let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
         let (tx, rx) = oneshot::channel();
         let res = cmd_tx
             .send(types::Command::Listen {
-                addr: addr.clone(),
+                addr: test_utils::make_libp2p_addr(),
                 response: tx,
             })
             .await;
@@ -358,7 +368,12 @@ mod tests {
 
         // try to bind to the same interface again
         let (tx, rx) = oneshot::channel();
-        let res = cmd_tx.send(types::Command::Listen { addr, response: tx }).await;
+        let res = cmd_tx
+            .send(types::Command::Listen {
+                addr: test_utils::make_libp2p_addr(),
+                response: tx,
+            })
+            .await;
         assert!(res.is_ok());
 
         let res = rx.await;

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -38,7 +38,7 @@ struct Transaction {
 async fn test_connect_new() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let service = Libp2pService::start(
-        test_utils::make_address("/ip6/::1/tcp/"),
+        test_utils::make_libp2p_addr(),
         &[],
         config,
         Duration::from_secs(10),
@@ -53,7 +53,7 @@ async fn test_connect_new() {
 async fn test_connect_new_addrinuse() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let service = Libp2pService::start(
-        test_utils::make_address("/ip6/::1/tcp/"),
+        test_utils::make_libp2p_addr(),
         &[],
         Arc::clone(&config),
         Duration::from_secs(10),
@@ -62,7 +62,7 @@ async fn test_connect_new_addrinuse() {
     assert!(service.is_ok());
 
     let service = Libp2pService::start(
-        test_utils::make_address("/ip6/::1/tcp/"),
+        test_utils::make_libp2p_addr(),
         &[],
         config,
         Duration::from_secs(10),
@@ -86,14 +86,14 @@ async fn test_connect_new_addrinuse() {
 async fn test_connect_accept() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let service1 = Libp2pService::start(
-        test_utils::make_address("/ip6/::1/tcp/"),
+        test_utils::make_libp2p_addr(),
         &[],
         Arc::clone(&config),
         Duration::from_secs(10),
     )
     .await;
     let service2 = Libp2pService::start(
-        test_utils::make_address("/ip6/::1/tcp/"),
+        test_utils::make_libp2p_addr(),
         &[],
         Arc::clone(&config),
         Duration::from_secs(10),
@@ -104,7 +104,7 @@ async fn test_connect_accept() {
 
     let (mut service1, _, _) = service1.unwrap();
     let (mut service2, _, _) = service2.unwrap();
-    let conn_addr = service1.local_addr().clone();
+    let conn_addr = service1.local_addr().await.unwrap().unwrap();
 
     let (res1, res2): (crate::Result<ConnectivityEvent<Libp2pService>>, _) =
         tokio::join!(service1.poll_next(), service2.connect(conn_addr));
@@ -120,7 +120,7 @@ async fn test_connect_peer_id_missing() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let addr: Multiaddr = "/ip6/::1/tcp/8904".parse().unwrap();
     let (mut service, _, _) = Libp2pService::start(
-        test_utils::make_address("/ip6/::1/tcp/"),
+        test_utils::make_libp2p_addr(),
         &[],
         config,
         Duration::from_secs(10),
@@ -306,7 +306,7 @@ fn test_parse_peers_valid_3_peers_1_valid() {
 async fn test_connect_with_timeout() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let (mut service, _, _) = Libp2pService::start(
-        test_utils::make_address("/ip6/::1/tcp/"),
+        test_utils::make_libp2p_addr(),
         &[],
         config,
         Duration::from_secs(2),

--- a/p2p/src/net/libp2p/tests/identify.rs
+++ b/p2p/src/net/libp2p/tests/identify.rs
@@ -16,15 +16,14 @@
 // // Author(s): A. Altonen
 use super::*;
 use crate::net::libp2p::behaviour;
-use libp2p::{ping, Multiaddr};
+use libp2p::ping;
 use std::time::Duration;
 
 #[tokio::test]
 async fn test_identify_not_supported() {
     let config = common::chain::config::create_mainnet();
-    let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
     let (mut backend1, _cmd1, _conn1, _gossip1, _sync1) =
-        make_libp2p(config.clone(), addr.clone(), &[], false).await;
+        make_libp2p(config.clone(), test_utils::make_libp2p_addr(), &[], false).await;
 
     let (transport, peer_id, _id_keys) = make_transport_and_keys();
     let mut swarm = SwarmBuilder::new(
@@ -38,12 +37,8 @@ async fn test_identify_not_supported() {
     )
     .build();
 
-    connect_swarms::<behaviour::Libp2pBehaviour, ping::Behaviour>(
-        addr,
-        &mut backend1.swarm,
-        &mut swarm,
-    )
-    .await;
+    connect_swarms::<behaviour::Libp2pBehaviour, ping::Behaviour>(&mut backend1.swarm, &mut swarm)
+        .await;
 
     loop {
         tokio::select! {

--- a/p2p/src/net/libp2p/tests/mdns.rs
+++ b/p2p/src/net/libp2p/tests/mdns.rs
@@ -15,18 +15,19 @@
 //
 // Author(s): A. Altonen
 use super::*;
-use crate::net::libp2p::behaviour;
-use crate::net::libp2p::types::{ConnectivityEvent, Libp2pBehaviourEvent};
+use crate::net::libp2p::{
+    behaviour,
+    types::{ConnectivityEvent, Libp2pBehaviourEvent},
+};
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
-use libp2p::Multiaddr;
+use test_utils::make_libp2p_addr;
 
 #[tokio::test]
 async fn test_discovered_and_expired() {
-    let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
     let (mut backend1, _, _conn_rx, _, _) = make_libp2p(
         common::chain::config::create_mainnet(),
-        addr.clone(),
+        make_libp2p_addr(),
         &[],
         true,
     )
@@ -34,14 +35,13 @@ async fn test_discovered_and_expired() {
 
     let (mut backend2, _, _, _, _) = make_libp2p(
         common::chain::config::create_mainnet(),
-        test_utils::make_address("/ip6/::1/tcp/"),
+        make_libp2p_addr(),
         &[],
         true,
     )
     .await;
 
     connect_swarms::<behaviour::Libp2pBehaviour, behaviour::Libp2pBehaviour>(
-        addr,
         &mut backend1.swarm,
         &mut backend2.swarm,
     )
@@ -52,7 +52,7 @@ async fn test_discovered_and_expired() {
             event = backend1.swarm.select_next_some() => match event {
                 SwarmEvent::Behaviour(Libp2pBehaviourEvent::Connectivity(ConnectivityEvent::Discovered { peers })) => {
                     if peers.iter().any(|(peer_id, _)| peer_id == backend2.swarm.local_peer_id()) {
-                        backend1.swarm.disconnect_peer_id(*backend2.swarm.local_peer_id()).unwrap();
+                        let _ = backend1.swarm.disconnect_peer_id(*backend2.swarm.local_peer_id());
                     }
                 }
                 SwarmEvent::Behaviour(Libp2pBehaviourEvent::Connectivity(ConnectivityEvent::Expired { peers })) => {

--- a/p2p/src/net/libp2p/tests/mod.rs
+++ b/p2p/src/net/libp2p/tests/mod.rs
@@ -244,12 +244,21 @@ pub async fn make_libp2p_with_ping(
     )
 }
 
+async fn get_address<T: NetworkBehaviour>(swarm: &mut Swarm<T>) -> Multiaddr {
+    loop {
+        if let SwarmEvent::NewListenAddr { address, .. } = swarm.select_next_some().await {
+            return address;
+        }
+    }
+}
+
 #[allow(dead_code)]
-pub async fn connect_swarms<A, B>(addr: Multiaddr, swarm1: &mut Swarm<A>, swarm2: &mut Swarm<B>)
+pub async fn connect_swarms<A, B>(swarm1: &mut Swarm<A>, swarm2: &mut Swarm<B>)
 where
     A: NetworkBehaviour,
     B: NetworkBehaviour,
 {
+    let addr = get_address::<A>(swarm1).await;
     swarm2.dial(addr).expect("swarm dial failed");
 
     loop {

--- a/p2p/src/net/libp2p/tests/ping.rs
+++ b/p2p/src/net/libp2p/tests/ping.rs
@@ -20,16 +20,15 @@ use futures::StreamExt;
 use libp2p::{
     ping,
     swarm::{SwarmBuilder, SwarmEvent},
-    Multiaddr,
 };
 use std::time::Duration;
+use test_utils::make_libp2p_addr;
 
 #[tokio::test]
 async fn test_remote_doesnt_respond() {
-    let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
     let (mut backend1, _cmd, _conn_rx, _gossip_rx, _sync_rx) = make_libp2p_with_ping(
         common::chain::config::create_mainnet(),
-        addr.clone(),
+        make_libp2p_addr(),
         &[],
         make_ping(
             Some(Duration::from_secs(2)),
@@ -52,12 +51,8 @@ async fn test_remote_doesnt_respond() {
     )
     .build();
 
-    connect_swarms::<behaviour::Libp2pBehaviour, ping::Behaviour>(
-        addr,
-        &mut backend1.swarm,
-        &mut swarm,
-    )
-    .await;
+    connect_swarms::<behaviour::Libp2pBehaviour, ping::Behaviour>(&mut backend1.swarm, &mut swarm)
+        .await;
 
     loop {
         tokio::select! {
@@ -71,11 +66,10 @@ async fn test_remote_doesnt_respond() {
 
 #[tokio::test]
 async fn test_ping_not_supported() {
-    let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
     let config = common::chain::config::create_mainnet();
     let (mut backend1, _cmd, _conn_rx, _gossip_rx, _) = make_libp2p_with_ping(
         config.clone(),
-        addr.clone(),
+        make_libp2p_addr(),
         &[],
         make_ping(
             Some(Duration::from_secs(2)),
@@ -90,7 +84,6 @@ async fn test_ping_not_supported() {
     let mut swarm = SwarmBuilder::new(transport, make_identify(config, id_keys), peer_id).build();
 
     connect_swarms::<behaviour::Libp2pBehaviour, libp2p::identify::Identify>(
-        addr,
         &mut backend1.swarm,
         &mut swarm,
     )

--- a/p2p/src/net/libp2p/tests/swarm.rs
+++ b/p2p/src/net/libp2p/tests/swarm.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
+use super::*;
 use crate::error::P2pError;
 use futures::StreamExt;
 use libp2p::{
@@ -21,8 +22,9 @@ use libp2p::{
     identify, identity, mplex, noise,
     swarm::{SwarmBuilder, SwarmEvent},
     tcp::TcpConfig,
-    Multiaddr, PeerId, Swarm, Transport,
+    PeerId, Swarm, Transport,
 };
+use test_utils::make_libp2p_addr;
 
 // TODO: add more tests at some point
 
@@ -60,8 +62,9 @@ fn make_dummy_swarm() -> (PeerId, Swarm<identify::Identify>) {
 async fn dial_then_disconnect() {
     let (_peer_id1, mut swarm1) = make_dummy_swarm();
     let (peer_id2, mut swarm2) = make_dummy_swarm();
-    let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
-    swarm2.listen_on(addr.clone()).unwrap();
+
+    swarm2.listen_on(make_libp2p_addr()).unwrap();
+    let addr = get_address::<identify::Identify>(&mut swarm2).await;
 
     tokio::spawn(async move {
         loop {
@@ -86,8 +89,9 @@ async fn dial_then_disconnect() {
 async fn diconnect_closing_connection() {
     let (_peer_id1, mut swarm1) = make_dummy_swarm();
     let (peer_id2, mut swarm2) = make_dummy_swarm();
-    let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
-    swarm2.listen_on(addr.clone()).unwrap();
+
+    swarm2.listen_on(make_libp2p_addr()).unwrap();
+    let addr = get_address(&mut swarm2).await;
 
     tokio::spawn(async move {
         loop {

--- a/p2p/src/net/libp2p/types.rs
+++ b/p2p/src/net/libp2p/types.rs
@@ -117,6 +117,11 @@ pub enum Command {
         topics: Vec<Topic>,
         response: oneshot::Sender<crate::Result<()>>,
     },
+
+    /// Get the active listen address
+    ListenAddress {
+        response: oneshot::Sender<Option<Multiaddr>>,
+    },
 }
 
 #[derive(Debug)]

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -166,8 +166,8 @@ where
         todo!();
     }
 
-    fn local_addr(&self) -> &T::Address {
-        &self.addr
+    async fn local_addr(&self) -> crate::Result<Option<T::Address>> {
+        Ok(Some(self.addr))
     }
 
     fn peer_id(&self) -> &T::PeerId {

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -113,7 +113,9 @@ where
     async fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()>;
 
     /// Return the socket address of the network service provider
-    fn local_addr(&self) -> &T::Address;
+    ///
+    /// If the address isn't available yet, `None` is returned
+    async fn local_addr(&self) -> crate::Result<Option<T::Address>>;
 
     /// Return peer id of the local node
     fn peer_id(&self) -> &T::PeerId;

--- a/p2p/src/swarm/mod.rs
+++ b/p2p/src/swarm/mod.rs
@@ -400,9 +400,11 @@ where
                     event::SwarmEvent::GetPeerCount(response) => {
                         response.send(self.peers.len()).map_err(|_| P2pError::ChannelClosed)
                     }
-                    event::SwarmEvent::GetBindAddress(response) => response
-                        .send(self.handle.local_addr().to_string())
-                        .map_err(|_| P2pError::ChannelClosed),
+                    event::SwarmEvent::GetBindAddress(response) => {
+                        let addr = self.handle.local_addr();
+                        let addr = addr.await?.map_or("<unavailable>".to_string(), |addr| addr.to_string());
+                        response.send(addr).map_err(|_| P2pError::ChannelClosed)
+                    }
                     event::SwarmEvent::GetPeerId(response) => response
                         .send(self.handle.peer_id().to_string())
                         .map_err(|_| P2pError::ChannelClosed),

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -122,7 +122,7 @@ mod tests {
     use std::net::SocketAddr;
 
     fn new_mock_peersyncstate() -> PeerContext<MockService> {
-        let addr: SocketAddr = test_utils::make_address("[::1]:");
+        let addr: SocketAddr = "[::1]:0".parse().unwrap();
         PeerContext::<MockService>::new(addr)
     }
 

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -17,12 +17,13 @@
 use super::*;
 use chainstate::ChainstateError;
 use common::chain::block::consensus_data::PoWData;
+use test_utils::make_libp2p_addr;
 
 // peer doesn't exist
 #[tokio::test]
 async fn peer_doesnt_exist() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     assert_eq!(
         mgr.validate_header_response(&PeerId::random(), vec![]).await,
@@ -36,7 +37,7 @@ async fn valid_block() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -59,7 +60,7 @@ async fn valid_block_invalid_state() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -77,7 +78,7 @@ async fn valid_block_resubmitted_chainstate() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -104,7 +105,7 @@ async fn invalid_block() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 

--- a/p2p/src/sync/tests/connection.rs
+++ b/p2p/src/sync/tests/connection.rs
@@ -15,12 +15,13 @@
 //
 // Author(s): A. Altonen
 use super::*;
+use test_utils::make_libp2p_addr;
 
 // handle peer connection event
 #[tokio::test]
 async fn test_peer_connected() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     assert_eq!(mgr.register_peer(PeerId::random()).await, Ok(()));
     assert_eq!(mgr.peers.len(), 1);
@@ -30,7 +31,7 @@ async fn test_peer_connected() {
 #[tokio::test]
 async fn test_peer_reconnected() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     let peer_id = PeerId::random();
     assert_eq!(mgr.register_peer(peer_id).await, Ok(()));
@@ -45,7 +46,7 @@ async fn test_peer_reconnected() {
 #[tokio::test]
 async fn test_peer_disconnected() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     // send Connected event to SyncManager
     let peer_id = PeerId::random();

--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -16,13 +16,14 @@
 // Author(s): A. Altonen
 use super::*;
 use crypto::random::{Rng, SliceRandom};
+use test_utils::make_libp2p_addr;
 
 // response contains more than 2000 headers
 #[tokio::test]
 async fn too_many_headers() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -41,7 +42,7 @@ async fn too_many_headers() {
 #[tokio::test]
 async fn empty_response() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -58,7 +59,7 @@ async fn valid_response() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -83,7 +84,7 @@ async fn valid_response() {
 async fn prev_block_is_none() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -101,7 +102,7 @@ async fn header_doesnt_attach_to_local_chain() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -127,7 +128,7 @@ async fn headers_not_in_order() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -154,7 +155,7 @@ async fn invalid_state() {
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
     mgr.register_peer(peer_id).await.unwrap();
 
@@ -179,7 +180,7 @@ async fn invalid_state() {
 #[tokio::test]
 async fn peer_doesnt_exist() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     assert_eq!(
         mgr.validate_header_response(&PeerId::random(), vec![]).await,

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -17,14 +17,15 @@
 use super::*;
 use crate::message::*;
 use std::{collections::HashSet, time::Duration};
+use test_utils::make_libp2p_addr;
 use tokio::time::timeout;
 
 #[tokio::test]
 async fn test_request_response() {
     let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
@@ -60,9 +61,9 @@ async fn test_request_response() {
 #[tokio::test]
 async fn test_multiple_requests_and_responses() {
     let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
@@ -128,9 +129,9 @@ async fn test_multiple_requests_and_responses() {
 #[tokio::test]
 async fn test_request_timeout_error() {
     let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
@@ -185,9 +186,9 @@ async fn test_request_timeout_error() {
 #[tokio::test]
 async fn request_timeout() {
     let (mut mgr1, mut conn1, _sync1, _pubsub1, mut swarm_rx) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/")).await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -29,10 +29,15 @@ use common::{
     primitives::{time, Amount, Id, Idable, H256},
 };
 use crypto::random::SliceRandom;
+use libp2p::Multiaddr;
 use p2p::net::{mock::MockService, NetworkingService};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
+
+pub fn make_libp2p_addr() -> Multiaddr {
+    "/ip6/::1/tcp/0".parse().unwrap()
+}
 
 pub async fn get_tcp_socket() -> TcpStream {
     let port: u16 = portpicker::pick_unused_port().expect("No ports free");
@@ -46,16 +51,6 @@ pub async fn get_tcp_socket() -> TcpStream {
     });
 
     TcpStream::connect(addr).await.unwrap()
-}
-
-/// Allocate a port and create a socket address for given NetworkingService
-pub fn make_address<T>(addr: &str) -> T
-where
-    T: std::str::FromStr,
-    <T as std::str::FromStr>::Err: std::fmt::Debug,
-{
-    let port: u16 = portpicker::pick_unused_port().expect("No ports free");
-    format!("{}{}", addr, port).parse().unwrap()
 }
 
 pub fn get_mock_id() -> <MockService as NetworkingService>::PeerId {

--- a/p2p/tests/libp2p-mdns.rs
+++ b/p2p/tests/libp2p-mdns.rs
@@ -14,23 +14,22 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
-extern crate test_utils;
 
-use libp2p::{multiaddr::Protocol, Multiaddr};
+use libp2p::multiaddr::Protocol;
 use p2p::net::{
     libp2p::{Libp2pDiscoveryStrategy, Libp2pService},
     types::ConnectivityEvent,
     ConnectivityService, NetworkingService,
 };
 use std::sync::Arc;
+use test_utils::make_libp2p_addr;
 
 // verify that libp2p mdns peer discovery works
 #[tokio::test]
 async fn test_libp2p_peer_discovery() {
     let config = Arc::new(common::chain::config::create_mainnet());
-    let addr: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
     let (mut serv, _, _) = Libp2pService::start(
-        addr.clone(),
+        make_libp2p_addr(),
         &[Libp2pDiscoveryStrategy::MulticastDns],
         Arc::clone(&config),
         std::time::Duration::from_secs(10),
@@ -38,9 +37,8 @@ async fn test_libp2p_peer_discovery() {
     .await
     .unwrap();
 
-    let addr2: Multiaddr = test_utils::make_address("/ip6/::1/tcp/");
     let (mut serv2, _, _) = Libp2pService::start(
-        addr2.clone(),
+        make_libp2p_addr(),
         &[Libp2pDiscoveryStrategy::MulticastDns],
         Arc::clone(&config),
         std::time::Duration::from_secs(10),

--- a/p2p/tests/sync.rs
+++ b/p2p/tests/sync.rs
@@ -34,6 +34,7 @@ use std::{
     collections::{HashSet, VecDeque},
     sync::Arc,
 };
+use test_utils::make_libp2p_addr;
 use tokio::sync::mpsc;
 
 async fn make_sync_manager<T>(
@@ -81,13 +82,25 @@ where
     )
 }
 
+async fn get_address<T>(handle: &mut T::ConnectivityHandle) -> T::Address
+where
+    T: NetworkingService,
+    T::ConnectivityHandle: ConnectivityService<T>,
+{
+    loop {
+        if let Some(addr) = handle.local_addr().await.unwrap() {
+            return addr;
+        }
+    }
+}
+
 async fn connect_services<T>(conn1: &mut T::ConnectivityHandle, conn2: &mut T::ConnectivityHandle)
 where
     T: NetworkingService,
     T::ConnectivityHandle: ConnectivityService<T>,
 {
-    let (_conn1_res, conn2_res) =
-        tokio::join!(conn1.connect(conn2.local_addr().clone()), conn2.poll_next());
+    let addr = get_address::<T>(conn2).await;
+    let (_conn1_res, conn2_res) = tokio::join!(conn1.connect(addr), conn2.poll_next());
     let conn2_res: ConnectivityEvent<T> = conn2_res.unwrap();
     let _conn1_id = match conn2_res {
         ConnectivityEvent::IncomingConnection { peer_info, .. } => peer_info.peer_id,
@@ -229,11 +242,9 @@ async fn local_and_remote_in_sync() {
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, mut pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
@@ -269,11 +280,9 @@ async fn remote_ahead_by_7_blocks() {
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, mut pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
 
     // add 7 more blocks on top of the best block (which is also known by mgr1)
     assert!(same_tip(&mgr1_handle, &mgr2_handle).await);
@@ -362,11 +371,9 @@ async fn local_ahead_by_12_blocks() {
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, mut pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _pubsub2, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
 
     // add 12 more blocks on top of the best block (which is also known by mgr2)
     assert!(same_tip(&mgr1_handle, &mgr2_handle).await);
@@ -481,11 +488,9 @@ async fn remote_local_diff_chains_local_higher() {
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, mut pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
 
     // add 14 more blocks to local chain and 7 more blocks to remote chain
     assert!(same_tip(&mgr1_handle, &mgr2_handle).await);
@@ -625,11 +630,9 @@ async fn remote_local_diff_chains_remote_higher() {
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, mut pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _pubsub2, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
 
     // add 5 more blocks to local chain and 12 more blocks to remote chain
     assert!(same_tip(&mgr1_handle, &mgr2_handle).await);
@@ -768,14 +771,11 @@ async fn two_remote_nodes_different_chains() {
     let mgr3_handle = handle3.clone();
 
     let (mut mgr1, mut conn1, _, mut pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
     let (mut mgr3, mut conn3, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle3)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle3).await;
 
     // add 5 more blocks for first remote and 7 blocks to second remote
     test_utils::add_more_blocks(Arc::clone(&config), &mgr2_handle, 5).await;
@@ -877,14 +877,11 @@ async fn two_remote_nodes_same_chains() {
     let mgr3_handle = handle3.clone();
 
     let (mut mgr1, mut conn1, _, mut pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
     let (mut mgr3, mut conn3, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle3)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle3).await;
 
     // add the same 32 new blocks for both mgr2 and mgr3
     let id = mgr2_handle.call(move |this| this.get_best_block_id()).await.unwrap().unwrap();
@@ -1000,14 +997,11 @@ async fn two_remote_nodes_same_chains_new_blocks() {
     let mgr3_handle = handle3.clone();
 
     let (mut mgr1, mut conn1, _, mut pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
     let (mut mgr3, mut conn3, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle3)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle3).await;
 
     // add the same 32 new blocks for both mgr2 and mgr3
     let id = mgr2_handle.call(move |this| this.get_best_block_id()).await.unwrap().unwrap();
@@ -1138,11 +1132,9 @@ async fn test_connect_disconnect_resyncing() {
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, _pubsub, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle1)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle1).await;
     let (mut mgr2, mut conn2, _, _, _) =
-        make_sync_manager::<Libp2pService>(test_utils::make_address("/ip6/::1/tcp/"), handle2)
-            .await;
+        make_sync_manager::<Libp2pService>(make_libp2p_addr(), handle2).await;
 
     connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
     assert_eq!(mgr1.register_peer(*conn2.peer_id()).await, Ok(()));


### PR DESCRIPTION
Listen to `SwarmEvent::NewListenAddr` event and return the address advertised by that event when a call to `ConnectivityService::local_addr()` is made. This allows tests to use port 0 which tells the operating system to allocate a free port.