### PR TITLE
Fix locator length calculation in the get_locator test

### DIFF
--- a/chainstate/src/detail/tests/syncing_tests.rs
+++ b/chainstate/src/detail/tests/syncing_tests.rs
@@ -43,7 +43,7 @@ fn get_locator() {
 
             // Check the locator length.
             let locator = btf.chainstate().get_locator().unwrap();
-            assert_eq!(locator.len(), (blocks as f64).log2().floor() as usize + 2);
+            assert_eq!(locator.len(), (blocks as f64).log2().ceil() as usize + 1);
 
             // Check the locator headers.
             let height = btf


### PR DESCRIPTION
The previous formula gives a wrong result on some edge-cases.