### PR TITLE
Implement missing functionality for `PeerDb`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "env_logger"
@@ -2602,6 +2602,7 @@ dependencies = [
  "chainstate-storage",
  "common",
  "crypto",
+ "either",
  "futures",
  "itertools",
  "jsonrpsee",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -6,13 +6,13 @@ license = "MIT"
 
 [dependencies]
 async-trait = "0.1"
+either = "1.7"
 futures = "0.3"
 itertools = "0.10"
 parity-scale-codec = "3.1"
 sscanf = "0.2"
 thiserror = "1.0"
 void = "1.0"
-serde = { version = "1", features = ["derive"] }
 
 # local dependencies
 common = { path = "../common/" }
@@ -31,6 +31,10 @@ features = ["macros"]
 version = "0.45"
 default-features = false
 features = ["gossipsub", "identify", "mdns", "mplex", "noise", "ping", "request-response", "tcp-async-io"]
+
+[dependencies.serde]
+version = "1"
+features = ["derive"]
 
 [dependencies.tokio]
 version = "1"

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -136,13 +136,13 @@ where
 {
     fn from_iter<I: IntoIterator<Item = (PeerId, Multiaddr)>>(iter: I) -> Self {
         let mut entry = net::types::AddrInfo {
-            id: PeerId::random(),
+            peer_id: PeerId::random(),
             ip4: Vec::new(),
             ip6: Vec::new(),
         };
 
         iter.into_iter().for_each(|(id, addr)| {
-            entry.id = id;
+            entry.peer_id = id;
             match get_addr_from_multiaddr(&addr) {
                 Some(Protocol::Ip4(_)) => entry.ip4.push(addr),
                 Some(Protocol::Ip6(_)) => entry.ip6.push(addr),
@@ -152,7 +152,7 @@ where
 
         log::trace!(
             "id {:?}, ipv4 {:#?}, ipv6 {:#?}",
-            entry.id,
+            entry.peer_id,
             entry.ip4,
             entry.ip6
         );

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -211,18 +211,18 @@ impl<T: NetworkingService> PartialEq for net::types::PeerInfo<T> {
 // verify that vector of address (that all belong to one peer) parse into one `net::types::Peer` entry
 #[test]
 fn test_parse_peers_valid_1_peer() {
-    let id = PeerId::random();
+    let peer_id = PeerId::random();
     let ip4: Multiaddr = "/ip4/127.0.0.1/tcp/9090".parse().unwrap();
     let ip6: Multiaddr = "/ip6/::1/tcp/9091".parse().unwrap();
-    let addrs = vec![(id, ip4.clone()), (id, ip6.clone())];
+    let addrs = vec![(peer_id, ip4.clone()), (peer_id, ip6.clone())];
 
     let parsed: Vec<net::types::AddrInfo<Libp2pService>> = parse_peers(addrs);
     assert_eq!(
         parsed,
         vec![net::types::AddrInfo {
-            id,
-            ip4: vec![ip4.with(Protocol::P2p(id.into()))],
-            ip6: vec![ip6.with(Protocol::P2p(id.into()))],
+            peer_id,
+            ip4: vec![ip4.with(Protocol::P2p(peer_id.into()))],
+            ip6: vec![ip6.with(Protocol::P2p(peer_id.into()))],
         }]
     );
 }
@@ -251,18 +251,18 @@ fn test_parse_peers_valid_2_peers() {
     ];
 
     let mut parsed: Vec<net::types::AddrInfo<Libp2pService>> = parse_peers(addrs);
-    parsed.sort_by(|a, b| a.id.cmp(&b.id));
+    parsed.sort_by(|a, b| a.peer_id.cmp(&b.peer_id));
 
     assert_eq!(
         parsed,
         vec![
             net::types::AddrInfo {
-                id: id_2,
+                peer_id: id_2,
                 ip4: vec![ip4_2.with(Protocol::P2p(id_2.into()))],
                 ip6: vec![ip6_2.with(Protocol::P2p(id_2.into()))],
             },
             net::types::AddrInfo {
-                id: id_1,
+                peer_id: id_1,
                 ip4: vec![ip4_1.with(Protocol::P2p(id_1.into()))],
                 ip6: vec![ip6_1.with(Protocol::P2p(id_1.into()))],
             },
@@ -289,7 +289,7 @@ fn test_parse_peers_valid_3_peers_1_valid() {
     assert_eq!(
         parsed,
         vec![net::types::AddrInfo {
-            id: id_1,
+            peer_id: id_1,
             ip4: vec![ip4.with(Protocol::P2p(id_1.into()))],
             ip6: vec![],
         }]

--- a/p2p/src/net/types.rs
+++ b/p2p/src/net/types.rs
@@ -20,7 +20,7 @@ use super::*;
 #[derive(Debug, PartialEq, Eq)]
 pub struct AddrInfo<T: NetworkingService> {
     /// Unique ID of the peer
-    pub id: T::PeerId,
+    pub peer_id: T::PeerId,
 
     /// List of discovered IPv4 addresses
     pub ip4: Vec<T::Address>,

--- a/p2p/src/swarm/mod.rs
+++ b/p2p/src/swarm/mod.rs
@@ -361,7 +361,7 @@ where
         );
 
         for _ in 0..npeers {
-            if let Some(addr) = self.peerdb.best_peer_addr() {
+            if let Some(addr) = self.peerdb.best_peer_addr()? {
                 match self.connect(addr.clone()).await {
                     Ok(_) => {
                         self.pending.insert(addr, None);

--- a/p2p/src/swarm/mod.rs
+++ b/p2p/src/swarm/mod.rs
@@ -103,7 +103,9 @@ where
 
     /// Update the list of known peers or known peer's list of addresses
     fn peer_discovered(&mut self, peers: &[net::types::AddrInfo<T>]) {
-        self.peerdb.discover_peers(peers)
+        peers.iter().for_each(|peer| {
+            self.peerdb.peer_discovered(peer);
+        })
     }
 
     /// Update the list of known peers or known peer's list of addresses

--- a/p2p/src/swarm/peerdb.rs
+++ b/p2p/src/swarm/peerdb.rs
@@ -194,32 +194,30 @@ impl<T: NetworkingService> PeerDb<T> {
     }
 
     /// Discover new peer addresses
-    pub fn discover_peers(&mut self, peers: &[types::AddrInfo<T>]) {
-        for info in peers.iter() {
-            match self.peers.entry(info.peer_id) {
-                Entry::Occupied(mut entry) => match entry.get_mut() {
-                    Peer::Discovered(addr_info) => {
-                        // TODO: duplicates
-                        addr_info.extend(info.ip6.clone());
-                        addr_info.extend(info.ip4.clone());
-                    }
-                    Peer::Idle(_info) | Peer::Active(_info) => {
-                        // TODO: update existing information of a known peer
-                    }
-                    Peer::Banned(_info) => {
-                        // TODO: update existing information of a known peer
-                    }
-                },
-                Entry::Vacant(entry) => {
-                    entry.insert(Peer::Discovered(VecDeque::from_iter(
-                        info.ip6
-                            .iter()
-                            .cloned()
-                            .chain(info.ip4.iter().cloned())
-                            .collect::<Vec<_>>(),
-                    )));
-                    self.available.insert(info.peer_id);
+    pub fn peer_discovered(&mut self, info: &types::AddrInfo<T>) {
+        match self.peers.entry(info.peer_id) {
+            Entry::Occupied(mut entry) => match entry.get_mut() {
+                Peer::Discovered(addr_info) => {
+                    // TODO: duplicates
+                    addr_info.extend(info.ip6.clone());
+                    addr_info.extend(info.ip4.clone());
                 }
+                Peer::Idle(_info) | Peer::Active(_info) => {
+                    // TODO: update existing information of a known peer
+                }
+                Peer::Banned(_info) => {
+                    // TODO: update existing information of a known peer
+                }
+            },
+            Entry::Vacant(entry) => {
+                entry.insert(Peer::Discovered(VecDeque::from_iter(
+                    info.ip6
+                        .iter()
+                        .cloned()
+                        .chain(info.ip4.iter().cloned())
+                        .collect::<Vec<_>>(),
+                )));
+                self.available.insert(info.peer_id);
             }
         }
     }

--- a/p2p/src/swarm/tests/ban.rs
+++ b/p2p/src/swarm/tests/ban.rs
@@ -139,20 +139,23 @@ async fn validate_invalid_outbound_connection() {
     // valid connection
     let peer_id = libp2p::PeerId::random();
     let res = swarm
-        .accept_connection(net::types::PeerInfo::<Libp2pService> {
-            peer_id,
-            magic_bytes: *config.magic_bytes(),
-            version: common::primitives::semver::SemVer::new(0, 1, 0),
-            agent: None,
-            protocols: vec![
-                "/meshsub/1.1.0".to_string(),
-                "/meshsub/1.0.0".to_string(),
-                "/ipfs/ping/1.0.0".to_string(),
-                "/ipfs/id/1.0.0".to_string(),
-                "/ipfs/id/push/1.0.0".to_string(),
-                "/mintlayer/sync/0.1.0".to_string(),
-            ],
-        })
+        .accept_connection(
+            Multiaddr::empty(),
+            net::types::PeerInfo::<Libp2pService> {
+                peer_id,
+                magic_bytes: *config.magic_bytes(),
+                version: common::primitives::semver::SemVer::new(0, 1, 0),
+                agent: None,
+                protocols: vec![
+                    "/meshsub/1.1.0".to_string(),
+                    "/meshsub/1.0.0".to_string(),
+                    "/ipfs/ping/1.0.0".to_string(),
+                    "/ipfs/id/1.0.0".to_string(),
+                    "/ipfs/id/push/1.0.0".to_string(),
+                    "/mintlayer/sync/0.1.0".to_string(),
+                ],
+            },
+        )
         .await;
     assert_eq!(swarm.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!swarm.peerdb.is_id_banned(&peer_id));
@@ -160,20 +163,23 @@ async fn validate_invalid_outbound_connection() {
     // invalid magic bytes
     let peer_id = libp2p::PeerId::random();
     let res = swarm
-        .accept_connection(net::types::PeerInfo::<Libp2pService> {
-            peer_id,
-            magic_bytes: [1, 2, 3, 4],
-            version: common::primitives::semver::SemVer::new(0, 1, 0),
-            agent: None,
-            protocols: vec![
-                "/meshsub/1.1.0".to_string(),
-                "/meshsub/1.0.0".to_string(),
-                "/ipfs/ping/1.0.0".to_string(),
-                "/ipfs/id/1.0.0".to_string(),
-                "/ipfs/id/push/1.0.0".to_string(),
-                "/mintlayer/sync/0.1.0".to_string(),
-            ],
-        })
+        .accept_connection(
+            Multiaddr::empty(),
+            net::types::PeerInfo::<Libp2pService> {
+                peer_id,
+                magic_bytes: [1, 2, 3, 4],
+                version: common::primitives::semver::SemVer::new(0, 1, 0),
+                agent: None,
+                protocols: vec![
+                    "/meshsub/1.1.0".to_string(),
+                    "/meshsub/1.0.0".to_string(),
+                    "/ipfs/ping/1.0.0".to_string(),
+                    "/ipfs/id/1.0.0".to_string(),
+                    "/ipfs/id/push/1.0.0".to_string(),
+                    "/mintlayer/sync/0.1.0".to_string(),
+                ],
+            },
+        )
         .await;
     assert_eq!(swarm.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(swarm.peerdb.is_id_banned(&peer_id));
@@ -181,20 +187,23 @@ async fn validate_invalid_outbound_connection() {
     // invalid version
     let peer_id = libp2p::PeerId::random();
     let res = swarm
-        .accept_connection(net::types::PeerInfo::<Libp2pService> {
-            peer_id,
-            magic_bytes: *config.magic_bytes(),
-            version: common::primitives::semver::SemVer::new(1, 1, 1),
-            agent: None,
-            protocols: vec![
-                "/meshsub/1.1.0".to_string(),
-                "/meshsub/1.0.0".to_string(),
-                "/ipfs/ping/1.0.0".to_string(),
-                "/ipfs/id/1.0.0".to_string(),
-                "/ipfs/id/push/1.0.0".to_string(),
-                "/mintlayer/sync/0.1.0".to_string(),
-            ],
-        })
+        .accept_connection(
+            Multiaddr::empty(),
+            net::types::PeerInfo::<Libp2pService> {
+                peer_id,
+                magic_bytes: *config.magic_bytes(),
+                version: common::primitives::semver::SemVer::new(1, 1, 1),
+                agent: None,
+                protocols: vec![
+                    "/meshsub/1.1.0".to_string(),
+                    "/meshsub/1.0.0".to_string(),
+                    "/ipfs/ping/1.0.0".to_string(),
+                    "/ipfs/id/1.0.0".to_string(),
+                    "/ipfs/id/push/1.0.0".to_string(),
+                    "/mintlayer/sync/0.1.0".to_string(),
+                ],
+            },
+        )
         .await;
     assert_eq!(swarm.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(swarm.peerdb.is_id_banned(&peer_id));
@@ -202,19 +211,22 @@ async fn validate_invalid_outbound_connection() {
     // protocol missing
     let peer_id = libp2p::PeerId::random();
     let res = swarm
-        .accept_connection(net::types::PeerInfo::<Libp2pService> {
-            peer_id,
-            magic_bytes: *config.magic_bytes(),
-            version: common::primitives::semver::SemVer::new(0, 1, 0),
-            agent: None,
-            protocols: vec![
-                "/meshsub/1.1.0".to_string(),
-                "/meshsub/1.0.0".to_string(),
-                "/ipfs/ping/1.0.0".to_string(),
-                "/ipfs/id/push/1.0.0".to_string(),
-                "/mintlayer/sync/0.1.0".to_string(),
-            ],
-        })
+        .accept_connection(
+            Multiaddr::empty(),
+            net::types::PeerInfo::<Libp2pService> {
+                peer_id,
+                magic_bytes: *config.magic_bytes(),
+                version: common::primitives::semver::SemVer::new(0, 1, 0),
+                agent: None,
+                protocols: vec![
+                    "/meshsub/1.1.0".to_string(),
+                    "/meshsub/1.0.0".to_string(),
+                    "/ipfs/ping/1.0.0".to_string(),
+                    "/ipfs/id/push/1.0.0".to_string(),
+                    "/mintlayer/sync/0.1.0".to_string(),
+                ],
+            },
+        )
         .await;
     assert_eq!(swarm.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(swarm.peerdb.is_id_banned(&peer_id));

--- a/p2p/src/swarm/tests/mod.rs
+++ b/p2p/src/swarm/tests/mod.rs
@@ -15,6 +15,7 @@
 //
 // Author(s): A. Altonen
 mod ban;
+mod peerdb;
 mod tmp;
 
 use crate::{

--- a/p2p/src/swarm/tests/peerdb.rs
+++ b/p2p/src/swarm/tests/peerdb.rs
@@ -1,0 +1,581 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): A. Altonen
+
+use super::*;
+use crate::{
+    config,
+    net::{libp2p::Libp2pService, types},
+    swarm::peerdb::{Peer, PeerContext, PeerDb},
+};
+use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
+use std::collections::{HashMap, VecDeque};
+
+fn make_peer_info() -> (PeerId, types::PeerInfo<Libp2pService>) {
+    let peer_id = PeerId::random();
+
+    (
+        peer_id,
+        types::PeerInfo::<Libp2pService> {
+            peer_id,
+            magic_bytes: [1, 2, 3, 4],
+            version: common::primitives::semver::SemVer::new(0, 1, 0),
+            agent: None,
+            protocols: vec![
+                "/meshsub/1.1.0".to_string(),
+                "/meshsub/1.0.0".to_string(),
+                "/ipfs/ping/1.0.0".to_string(),
+                "/ipfs/id/push/1.0.0".to_string(),
+                "/mintlayer/sync/0.1.0".to_string(),
+            ],
+        },
+    )
+}
+
+fn make_peer_ctx() -> (PeerId, PeerContext<Libp2pService>) {
+    let (peer_id, info) = make_peer_info();
+
+    (
+        peer_id,
+        PeerContext {
+            info,
+            address: None,
+            addresses: Default::default(),
+            score: 0,
+        },
+    )
+}
+
+#[test]
+fn num_active_peers() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+    assert_eq!(peerdb.idle_peer_count(), 0);
+    assert_eq!(peerdb.active_peer_count(), 0);
+
+    // add three active peers
+    for _ in 0..3 {
+        let (id, ctx) = make_peer_ctx();
+        peerdb.peers().insert(id, Peer::Active(ctx));
+    }
+    assert_eq!(peerdb.idle_peer_count(), 0);
+    assert_eq!(peerdb.active_peer_count(), 3);
+    assert_eq!(peerdb.peers().len(), 3);
+
+    // add 2 idle peers
+    for _ in 0..2 {
+        let (id, ctx) = make_peer_ctx();
+        peerdb.peers().insert(id, Peer::Idle(ctx));
+        peerdb.available().insert(id);
+    }
+    assert_eq!(peerdb.idle_peer_count(), 2);
+    assert_eq!(peerdb.active_peer_count(), 3);
+    assert_eq!(peerdb.peers().len(), 5);
+
+    // add 4 discovered peers
+    for _ in 0..2 {
+        let id = PeerId::random();
+        peerdb.peers().insert(id, Peer::Discovered(Default::default()));
+        peerdb.available().insert(id);
+    }
+    assert_eq!(peerdb.idle_peer_count(), 4);
+    assert_eq!(peerdb.active_peer_count(), 3);
+    assert_eq!(peerdb.peers().len(), 7);
+
+    // add 5 banned peers
+    for _ in 0..5 {
+        let (id, ctx) = make_peer_ctx();
+        peerdb.peers().insert(id, Peer::Banned(either::Left(ctx)));
+        peerdb.banned().insert(id);
+    }
+    assert_eq!(peerdb.idle_peer_count(), 4);
+    assert_eq!(peerdb.active_peer_count(), 3);
+    assert_eq!(peerdb.peers().len(), 12);
+}
+
+#[test]
+fn is_active_peer() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+    let (id1, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id1, Peer::Active(ctx));
+    assert!(peerdb.is_active_peer(&id1));
+
+    let (id2, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id2, Peer::Idle(ctx));
+    assert!(!peerdb.is_active_peer(&id2));
+
+    let id3 = PeerId::random();
+    peerdb.peers().insert(id3, Peer::Discovered(Default::default()));
+    assert!(!peerdb.is_active_peer(&id3));
+
+    let (id4, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id4, Peer::Banned(either::Left(ctx)));
+    assert!(!peerdb.is_active_peer(&id4));
+}
+
+#[test]
+fn adjust_peer_score() {
+    // peer banned after adjustment
+    {
+        let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+        let (id, ctx) = make_peer_ctx();
+        peerdb.peers().insert(id, Peer::Active(ctx));
+        peerdb.available().insert(id);
+        assert!(peerdb.adjust_peer_score(&id, 100));
+        assert!(peerdb.banned().contains(&id));
+    }
+
+    // higher threshold, no ban
+    {
+        let mut config = config::P2pConfig::new();
+        config.ban_threshold = 200;
+        let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config));
+
+        let (id, ctx) = make_peer_ctx();
+        peerdb.peers().insert(id, Peer::Active(ctx));
+        peerdb.available().insert(id);
+        assert!(!peerdb.adjust_peer_score(&id, 100));
+        assert!(!peerdb.banned().contains(&id));
+    }
+
+    // lower threshold, ban for more minor offense
+    {
+        let mut config = config::P2pConfig::new();
+        config.ban_threshold = 20;
+        let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config));
+
+        let (id, ctx) = make_peer_ctx();
+        peerdb.peers().insert(id, Peer::Active(ctx));
+        peerdb.available().insert(id);
+        assert!(peerdb.adjust_peer_score(&id, 30));
+        assert!(peerdb.banned().contains(&id));
+    }
+}
+
+#[test]
+fn ban_peer() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+    // unknown peer only updates the `banned` set
+    assert_eq!(peerdb.banned().len(), 0);
+    peerdb.ban_peer(&PeerId::random());
+    assert_eq!(peerdb.banned().len(), 1);
+
+    // idle peer
+    let (id, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Idle(ctx));
+    peerdb.available().insert(id);
+    peerdb.ban_peer(&id);
+
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Banned(_))
+    ));
+    assert!(peerdb.banned().contains(&id));
+    assert!(!peerdb.available().contains(&id));
+
+    // active peer
+    let (id, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Active(ctx));
+    peerdb.available().insert(id);
+    peerdb.ban_peer(&id);
+
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Banned(_))
+    ));
+    assert!(peerdb.banned().contains(&id));
+    assert!(!peerdb.available().contains(&id));
+
+    // discovered peer
+    let (id, _ctx) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Discovered(Default::default()));
+    peerdb.available().insert(id);
+    peerdb.ban_peer(&id);
+
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Banned(_))
+    ));
+    assert!(peerdb.banned().contains(&id));
+    assert!(!peerdb.available().contains(&id));
+}
+
+#[test]
+fn peer_disconnected() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+    // unknown peer doesn't cause any changes
+    assert_eq!(peerdb.peers().len(), 0);
+    peerdb.peer_disconnected(&PeerId::random());
+    assert_eq!(peerdb.peers().len(), 0);
+
+    // idle peer
+    let (id, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Idle(ctx));
+    peerdb.available().insert(id);
+    peerdb.peer_disconnected(&id);
+    assert!(std::matches!(peerdb.peers().get(&id), Some(Peer::Idle(_))));
+    assert!(peerdb.available().contains(&id));
+
+    // discovered peer
+    let (id, _ctx) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Discovered(Default::default()));
+    peerdb.available().insert(id);
+    peerdb.peer_disconnected(&id);
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Discovered(_))
+    ));
+    assert!(peerdb.available().contains(&id));
+
+    // banned peer
+    let (id, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Banned(either::Left(ctx)));
+    peerdb.peer_disconnected(&id);
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Banned(_))
+    ));
+
+    // active peer
+    let (id, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Active(ctx));
+    peerdb.peer_disconnected(&id);
+    assert!(std::matches!(peerdb.peers().get(&id), Some(Peer::Idle(_))));
+    assert!(peerdb.available().contains(&id));
+}
+
+#[test]
+fn peer_connected_discovered() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+    let remote_addr: Multiaddr = "/ip6/::1/tcp/8888".parse().unwrap();
+
+    // register information for a discovered peer
+    let (id, info) = make_peer_info();
+    peerdb.peers().insert(
+        id,
+        Peer::Discovered(VecDeque::from([
+            remote_addr.clone(),
+            "/ip6/::1/tcp/8889".parse().unwrap(),
+        ])),
+    );
+    peerdb.pending().insert(remote_addr.clone(), id);
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Discovered(_))
+    ));
+
+    assert!(peerdb.pending().contains_key(&remote_addr));
+    peerdb.peer_connected(remote_addr.clone(), info);
+
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Active(_))
+    ));
+    assert!(!peerdb.available().contains(&id));
+    assert!(!peerdb.pending().contains_key(&remote_addr));
+}
+
+#[test]
+fn peer_connected_idle() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+    let remote_addr: Multiaddr = "/ip6/::1/tcp/8888".parse().unwrap();
+
+    // register information for a discovered peer
+    let (id, info) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Idle(info));
+
+    peerdb.pending().insert(remote_addr.clone(), id);
+    assert!(std::matches!(peerdb.peers().get(&id), Some(Peer::Idle(_))));
+
+    let (_id, mut info) = make_peer_info();
+    info.peer_id = id;
+
+    assert!(peerdb.pending().contains_key(&remote_addr));
+    peerdb.peer_connected(remote_addr.clone(), info);
+
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Active(_))
+    ));
+    assert!(!peerdb.available().contains(&id));
+    assert!(!peerdb.pending().contains_key(&remote_addr));
+}
+
+#[test]
+fn peer_connected_unknown() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+    let remote_addr: Multiaddr = "/ip6/::1/tcp/8888".parse().unwrap();
+
+    let (id, info) = make_peer_info();
+
+    assert!(!peerdb.available().contains(&id));
+    assert!(!peerdb.peers().contains_key(&id));
+    assert!(!peerdb.pending().contains_key(&remote_addr));
+
+    peerdb.peer_connected(remote_addr.clone(), info);
+
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Active(_))
+    ));
+    assert!(!peerdb.available().contains(&id));
+    assert!(!peerdb.pending().contains_key(&remote_addr));
+}
+
+// update is ignored for banned and active peers
+#[test]
+fn peer_connected_banned_and_active() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+    // active peer
+    let (id1, ctx1) = make_peer_ctx();
+    let (_id, info1) = make_peer_info();
+
+    peerdb.peers().insert(id1, Peer::Active(ctx1));
+    peerdb.peer_connected(Multiaddr::empty(), info1);
+    assert!(std::matches!(
+        peerdb.peers().get(&id1),
+        Some(Peer::Active(_))
+    ));
+    assert!(!peerdb.available().contains(&id1));
+
+    // banned peer
+    let (id2, ctx2) = make_peer_ctx();
+    let (_id, info2) = make_peer_info();
+
+    peerdb.peers().insert(id2, Peer::Banned(either::Left(ctx2)));
+    peerdb.peer_connected(Multiaddr::empty(), info2);
+    assert!(std::matches!(
+        peerdb.peers().get(&id2),
+        Some(Peer::Banned(_))
+    ));
+    assert!(!peerdb.available().contains(&id1));
+}
+
+#[test]
+fn register_peer_info_discovered_peer() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+    let remote_addr: Multiaddr = "/ip6/::1/tcp/8888".parse().unwrap();
+
+    // register information for a discovered peer
+    let (id, info) = make_peer_info();
+    peerdb.peers().insert(
+        id,
+        Peer::Discovered(VecDeque::from([
+            remote_addr.clone(),
+            "/ip6/::1/tcp/8889".parse().unwrap(),
+        ])),
+    );
+    peerdb.pending().insert(remote_addr.clone(), id);
+    assert!(std::matches!(
+        peerdb.peers().get(&id),
+        Some(Peer::Discovered(_))
+    ));
+
+    assert!(peerdb.pending().get(&remote_addr).is_some());
+    peerdb.register_peer_info(remote_addr, info);
+    assert!(std::matches!(peerdb.peers().get(&id), Some(Peer::Idle(_))));
+    assert!(peerdb.available().contains(&id));
+}
+
+// for idle peers the information is updated
+#[test]
+fn register_peer_info_idle_peer() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+    let (id, ctx) = make_peer_ctx();
+    peerdb.peers().insert(id, Peer::Idle(ctx));
+    if let Some(Peer::Idle(ctx)) = peerdb.peers().get(&id) {
+        assert_eq!(ctx.info.magic_bytes, [1, 2, 3, 4]);
+    } else {
+        panic!("invalid peer type");
+    }
+
+    let (_id, mut info) = make_peer_info();
+    info.peer_id = id;
+    info.magic_bytes = [13, 37, 13, 38];
+    peerdb.register_peer_info("/ip6/::1/tcp/8888".parse().unwrap(), info);
+
+    // verify that the information has been updated for an idle peer
+    if let Some(Peer::Idle(ctx)) = peerdb.peers().get(&id) {
+        assert_eq!(ctx.info.magic_bytes, [13, 37, 13, 38]);
+    } else {
+        panic!("invalid peer type");
+    }
+    assert!(peerdb.available().contains(&id));
+}
+
+#[test]
+fn register_peer_info_unknown_peer() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+    let (id, info) = make_peer_info();
+    assert!(peerdb.peers().get(&id).is_none());
+    peerdb.register_peer_info("/ip6/::1/tcp/8888".parse().unwrap(), info);
+    assert!(std::matches!(peerdb.peers().get(&id), Some(Peer::Idle(_))));
+    assert!(peerdb.available().contains(&id));
+}
+
+// update is ignored for banned and active peers
+#[test]
+fn register_peer_info_banned_and_active() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(config::P2pConfig::new()));
+
+    // active peer
+    let (id1, ctx1) = make_peer_ctx();
+    let (_id, info1) = make_peer_info();
+
+    peerdb.peers().insert(id1, Peer::Active(ctx1));
+    peerdb.register_peer_info(Multiaddr::empty(), info1);
+    assert!(std::matches!(
+        peerdb.peers().get(&id1),
+        Some(Peer::Active(_))
+    ));
+    assert!(!peerdb.available().contains(&id1));
+
+    // banned peer
+    let (id2, ctx2) = make_peer_ctx();
+    let (_id, info2) = make_peer_info();
+
+    peerdb.peers().insert(id2, Peer::Banned(either::Left(ctx2)));
+    peerdb.register_peer_info(Multiaddr::empty(), info2);
+    assert!(std::matches!(
+        peerdb.peers().get(&id2),
+        Some(Peer::Banned(_))
+    ));
+    assert!(!peerdb.available().contains(&id1));
+}
+
+#[test]
+fn peer_discovered_libp2p() {
+    let mut peerdb = PeerDb::new(Arc::new(config::P2pConfig::new()));
+
+    let id_1: libp2p::PeerId = PeerId::random();
+    let id_2: libp2p::PeerId = PeerId::random();
+    let id_3: libp2p::PeerId = PeerId::random();
+
+    // check that peer with `id` has the correct ipv4 and ipv6 addresses
+    let check_peer =
+        |peers: &HashMap<<Libp2pService as NetworkingService>::PeerId, Peer<Libp2pService>>,
+         peer_id: PeerId,
+         ip4: Vec<Multiaddr>,
+         ip6: Vec<Multiaddr>| {
+            let (p_ip4, p_ip6) = {
+                match peers.get(&peer_id).unwrap() {
+                    Peer::Idle(_) => panic!("invalid peer type"),
+                    Peer::Active(_) => panic!("invalid peer type"),
+                    Peer::Banned(_) => panic!("invalid peer type"),
+                    Peer::Discovered(info) => {
+                        let mut ip4 = vec![];
+                        let mut ip6 = vec![];
+
+                        for addr in info {
+                            let components = addr.iter().collect::<Vec<_>>();
+                            if std::matches!(components[0], Protocol::Ip6(_)) {
+                                ip6.push(addr.clone());
+                            } else {
+                                ip4.push(addr.clone());
+                            }
+                        }
+
+                        (ip4, ip6)
+                    }
+                }
+            };
+
+            assert_eq!(ip4.len(), p_ip4.len());
+            assert_eq!(ip6.len(), p_ip6.len());
+
+            for ip in ip4.iter() {
+                assert!(p_ip4.contains(ip));
+            }
+
+            for ip in ip6.iter() {
+                assert!(p_ip6.contains(ip));
+            }
+        };
+
+    // first add two new peers, both with ipv4 and ipv6 address
+    peerdb.discover_peers(&[
+        types::AddrInfo {
+            peer_id: id_1,
+            ip4: vec!["/ip4/127.0.0.1/tcp/9090".parse().unwrap()],
+            ip6: vec!["/ip6/::1/tcp/9091".parse().unwrap()],
+        },
+        types::AddrInfo {
+            peer_id: id_2,
+            ip4: vec!["/ip4/127.0.0.1/tcp/9092".parse().unwrap()],
+            ip6: vec!["/ip6/::1/tcp/9093".parse().unwrap()],
+        },
+    ]);
+
+    assert_eq!(peerdb.peers().len(), 2);
+    assert_eq!(
+        peerdb.peers().iter().filter(|x| std::matches!(x.1, Peer::Idle(_))).count(),
+        0
+    );
+    assert_eq!(peerdb.available().len(), 2);
+
+    check_peer(
+        peerdb.peers(),
+        id_1,
+        vec!["/ip4/127.0.0.1/tcp/9090".parse().unwrap()],
+        vec!["/ip6/::1/tcp/9091".parse().unwrap()],
+    );
+
+    check_peer(
+        peerdb.peers(),
+        id_2,
+        vec!["/ip4/127.0.0.1/tcp/9092".parse().unwrap()],
+        vec!["/ip6/::1/tcp/9093".parse().unwrap()],
+    );
+
+    // then discover one new peer and two additional ipv6 addresses for peer 1
+    peerdb.discover_peers(&[
+        types::AddrInfo {
+            peer_id: id_1,
+            ip4: vec![],
+            ip6: vec!["/ip6/::1/tcp/9094".parse().unwrap(), "/ip6/::1/tcp/9095".parse().unwrap()],
+        },
+        types::AddrInfo {
+            peer_id: id_3,
+            ip4: vec!["/ip4/127.0.0.1/tcp/9096".parse().unwrap()],
+            ip6: vec!["/ip6/::1/tcp/9097".parse().unwrap()],
+        },
+    ]);
+
+    check_peer(
+        peerdb.peers(),
+        id_1,
+        vec!["/ip4/127.0.0.1/tcp/9090".parse().unwrap()],
+        vec![
+            "/ip6/::1/tcp/9091".parse().unwrap(),
+            "/ip6/::1/tcp/9094".parse().unwrap(),
+            "/ip6/::1/tcp/9095".parse().unwrap(),
+        ],
+    );
+
+    check_peer(
+        peerdb.peers(),
+        id_3,
+        vec!["/ip4/127.0.0.1/tcp/9096".parse().unwrap()],
+        vec!["/ip6/::1/tcp/9097".parse().unwrap()],
+    );
+}

--- a/p2p/src/swarm/tests/peerdb.rs
+++ b/p2p/src/swarm/tests/peerdb.rs
@@ -513,18 +513,20 @@ fn peer_discovered_libp2p() {
         };
 
     // first add two new peers, both with ipv4 and ipv6 address
-    peerdb.discover_peers(&[
-        types::AddrInfo {
+    peerdb.peer_discovered(
+        &types::AddrInfo {
             peer_id: id_1,
             ip4: vec!["/ip4/127.0.0.1/tcp/9090".parse().unwrap()],
             ip6: vec!["/ip6/::1/tcp/9091".parse().unwrap()],
         },
-        types::AddrInfo {
+    );
+    peerdb.peer_discovered(
+        &types::AddrInfo {
             peer_id: id_2,
             ip4: vec!["/ip4/127.0.0.1/tcp/9092".parse().unwrap()],
             ip6: vec!["/ip6/::1/tcp/9093".parse().unwrap()],
         },
-    ]);
+    );
 
     assert_eq!(peerdb.peers().len(), 2);
     assert_eq!(
@@ -548,18 +550,20 @@ fn peer_discovered_libp2p() {
     );
 
     // then discover one new peer and two additional ipv6 addresses for peer 1
-    peerdb.discover_peers(&[
-        types::AddrInfo {
+    peerdb.peer_discovered(
+        &types::AddrInfo {
             peer_id: id_1,
             ip4: vec![],
             ip6: vec!["/ip6/::1/tcp/9094".parse().unwrap(), "/ip6/::1/tcp/9095".parse().unwrap()],
         },
-        types::AddrInfo {
+    );
+    peerdb.peer_discovered(
+        &types::AddrInfo {
             peer_id: id_3,
             ip4: vec!["/ip4/127.0.0.1/tcp/9096".parse().unwrap()],
             ip6: vec!["/ip6/::1/tcp/9097".parse().unwrap()],
         },
-    ]);
+    );
 
     check_peer(
         peerdb.peers(),

--- a/p2p/src/swarm/tests/tmp.rs
+++ b/p2p/src/swarm/tests/tmp.rs
@@ -23,8 +23,8 @@ use crate::{
 use common::chain::config;
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use logging::log;
-use std::{net::SocketAddr, sync::Arc};
 use p2p_test_utils::make_libp2p_addr;
+use std::{net::SocketAddr, sync::Arc};
 
 // try to connect to an address that no one listening on and verify it fails
 #[tokio::test]

--- a/p2p/src/swarm/tests/tmp.rs
+++ b/p2p/src/swarm/tests/tmp.rs
@@ -23,8 +23,8 @@ use crate::{
 use common::chain::config;
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use logging::log;
+use std::{collections::HashSet, net::SocketAddr, sync::Arc};
 use p2p_test_utils::make_libp2p_addr;
-use std::{net::SocketAddr, sync::Arc};
 
 // try to connect to an address that no one listening on and verify it fails
 #[tokio::test]
@@ -278,7 +278,7 @@ async fn inbound_connection_too_many_peers() {
     for _ in 0..swarm::MAX_ACTIVE_CONNECTIONS {
         let peer_id = PeerId::random();
         let info = swarm::peerdb::PeerContext {
-            _info: net::types::PeerInfo {
+            info: net::types::PeerInfo {
                 peer_id,
                 magic_bytes: *config.magic_bytes(),
                 version: common::primitives::semver::SemVer::new(0, 1, 0),
@@ -293,6 +293,8 @@ async fn inbound_connection_too_many_peers() {
                 ],
             },
             score: 0,
+            address: None,
+            addresses: HashSet::new(),
         };
 
         swarm1.peers.insert(peer_id, info);

--- a/p2p/src/swarm/tests/tmp.rs
+++ b/p2p/src/swarm/tests/tmp.rs
@@ -67,7 +67,7 @@ async fn test_auto_connect_libp2p() {
     let mut swarm2 = make_peer_manager::<Libp2pService>(make_libp2p_addr(), config).await;
 
     let addr = swarm2.handle.local_addr().await.unwrap().unwrap();
-    let id: PeerId = if let Some(Protocol::P2p(peer)) = addr.iter().last() {
+    let peer_id: PeerId = if let Some(Protocol::P2p(peer)) = addr.iter().last() {
         PeerId::from_multihash(peer).unwrap()
     } else {
         panic!("invalid multiaddr");
@@ -82,7 +82,7 @@ async fn test_auto_connect_libp2p() {
 
     // "discover" the other libp2p service
     swarm.peer_discovered(&[net::types::AddrInfo {
-        id,
+        peer_id,
         ip4: vec![],
         ip6: vec![addr],
     }]);


### PR DESCRIPTION
Previously there was an awkward split between `PeerManager` and `PeerDb` as the implementation for the latter was mostly missing but it was heading towards the right direction so implementing, e.g., peer info logging for banned peers would've resulted in an ugly and temporary hack. This PR implements the needed functionality to make both `PeerManager` and `PeerDb` deal with tasks that they're supposed to be concerned with.