### PR TITLE
chainstate: Make locator a list of block IDs

### DIFF
--- a/chainstate-types/src/lib.rs
+++ b/chainstate-types/src/lib.rs
@@ -15,3 +15,4 @@
 
 pub mod block_index;
 pub mod height_skip;
+pub mod locator;

--- a/chainstate-types/src/locator.rs
+++ b/chainstate-types/src/locator.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+use common::chain::block::Block;
+use common::primitives::Id;
+use serialization::{Decode, Encode};
+
+/// Locator is a list of block IDs at exponentially increasing distance from the tip
+#[derive(PartialEq, Eq, Clone, Debug, Encode, Decode)]
+pub struct Locator(Vec<Id<Block>>);
+
+impl Locator {
+    /// A new locator
+    pub fn new(entries: Vec<Id<Block>>) -> Locator {
+        Locator(entries)
+    }
+
+    /// Get iterator over locator entries
+    pub fn iter(&self) -> impl Iterator<Item = &Id<Block>> + ExactSizeIterator {
+        self.0.iter()
+    }
+
+    /// Get number of entries in the locator
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Convert into a vector.
+    pub fn into_vec(self) -> Vec<Id<Block>> {
+        self.0
+    }
+}
+
+impl std::ops::Index<usize> for Locator {
+    type Output = Id<Block>;
+    fn index(&self, i: usize) -> &Id<Block> {
+        &self.0[i]
+    }
+}

--- a/chainstate/src/chainstate_interface.rs
+++ b/chainstate/src/chainstate_interface.rs
@@ -23,7 +23,7 @@ use common::{
     primitives::{BlockHeight, Id},
 };
 
-use crate::{detail::BlockSource, ChainstateError, ChainstateEvent};
+use crate::{detail::BlockSource, ChainstateError, ChainstateEvent, Locator};
 
 pub trait ChainstateInterface: Send {
     fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(ChainstateEvent) + Send + Sync>);
@@ -47,14 +47,14 @@ pub trait ChainstateInterface: Send {
     ///
     /// This returns a relatively short sequence even for a long chain. Such sequence can be used
     /// to quickly find a common ancestor between different chains.
-    fn get_locator(&self) -> Result<Vec<BlockHeader>, ChainstateError>;
+    fn get_locator(&self) -> Result<Locator, ChainstateError>;
 
     /// Returns a list of block headers starting from the last locator's block that is in the main
     /// chain.
     ///
     /// The number of returned headers is limited by the `HEADER_LIMIT` constant. The genesis block
     /// header is returned in case there is no common ancestor with a better block height.
-    fn get_headers(&self, locator: Vec<BlockHeader>) -> Result<Vec<BlockHeader>, ChainstateError>;
+    fn get_headers(&self, locator: Locator) -> Result<Vec<BlockHeader>, ChainstateError>;
 
     /// Removes all headers that are already known to the chain from the given vector.
     fn filter_already_existing_blocks(

--- a/chainstate/src/chainstate_interface/mock.rs
+++ b/chainstate/src/chainstate_interface/mock.rs
@@ -20,7 +20,7 @@ use common::{
     primitives::{BlockHeight, Id},
 };
 
-use crate::{detail::BlockSource, ChainstateError, ChainstateEvent};
+use crate::{detail::BlockSource, ChainstateError, ChainstateEvent, Locator};
 
 use super::ChainstateInterface;
 
@@ -43,10 +43,10 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> Result<Option<Id<Block>>, ChainstateError>;
         fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, ChainstateError>;
-        fn get_locator(&self) -> Result<Vec<BlockHeader>, ChainstateError>;
+        fn get_locator(&self) -> Result<Locator, ChainstateError>;
         fn get_headers(
             &self,
-            locator: Vec<BlockHeader>,
+            locator: Locator,
         ) -> Result<Vec<BlockHeader>, ChainstateError>;
         fn filter_already_existing_blocks(
             &self,

--- a/chainstate/src/chainstate_interface_impl.rs
+++ b/chainstate/src/chainstate_interface_impl.rs
@@ -21,7 +21,7 @@ use utils::eventhandler::EventHandler;
 
 use crate::{
     detail::{self, BlockSource},
-    ChainstateError, ChainstateEvent, ChainstateInterface,
+    ChainstateError, ChainstateEvent, ChainstateInterface, Locator,
 };
 
 pub struct ChainstateInterfaceImpl {
@@ -92,11 +92,11 @@ impl ChainstateInterface for ChainstateInterfaceImpl {
             .map_err(ChainstateError::FailedToReadProperty)
     }
 
-    fn get_locator(&self) -> Result<Vec<BlockHeader>, ChainstateError> {
+    fn get_locator(&self) -> Result<Locator, ChainstateError> {
         self.chainstate.get_locator().map_err(ChainstateError::FailedToReadProperty)
     }
 
-    fn get_headers(&self, locator: Vec<BlockHeader>) -> Result<Vec<BlockHeader>, ChainstateError> {
+    fn get_headers(&self, locator: Locator) -> Result<Vec<BlockHeader>, ChainstateError> {
         self.chainstate
             .get_headers(locator)
             .map_err(ChainstateError::FailedToReadProperty)

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -39,6 +39,8 @@ pub mod ban_score;
 mod block_index_history_iter;
 mod median_time;
 
+pub use chainstate_types::locator::Locator;
+
 mod chainstateref;
 
 type TxRw<'a> = <chainstate_storage::Store as Transactional<'a>>::TransactionRw;
@@ -305,22 +307,23 @@ impl Chainstate {
         self.make_db_tx_ro().get_best_block_index()
     }
 
-    pub fn get_locator(&self) -> Result<Vec<BlockHeader>, PropertyQueryError> {
+    fn locator_tip_distances() -> impl Iterator<Item = BlockDistance> {
+        itertools::iterate(0, |&i| std::cmp::max(1, i * 2)).map(BlockDistance::new)
+    }
+
+    pub fn get_locator(&self) -> Result<Locator, PropertyQueryError> {
         let chainstate_ref = self.make_db_tx_ro();
         let best_block_index = chainstate_ref
             .get_best_block_index()?
             .ok_or(PropertyQueryError::BestBlockIndexNotFound)?;
         let height = best_block_index.block_height();
 
-        let headers = itertools::iterate(0, |&i| if i == 0 { 1 } else { i * 2 })
-            .take_while(|i| (height - BlockDistance::new(*i)).is_some())
-            .map(|i| {
-                chainstate_ref.get_header_from_height(
-                    &(height - BlockDistance::new(i)).expect("distance to be valid"),
-                )
-            });
+        let headers = Self::locator_tip_distances()
+            .map_while(|dist| height - dist)
+            .map(|ht| chainstate_ref.get_block_id_by_height(&ht));
 
         itertools::process_results(headers, |iter| iter.flatten().collect::<Vec<_>>())
+            .map(Locator::new)
     }
 
     pub fn get_block_height_in_main_chain(
@@ -330,16 +333,13 @@ impl Chainstate {
         self.make_db_tx_ro().get_block_height_in_main_chain(id)
     }
 
-    pub fn get_headers(
-        &self,
-        locator: Vec<BlockHeader>,
-    ) -> Result<Vec<BlockHeader>, PropertyQueryError> {
+    pub fn get_headers(&self, locator: Locator) -> Result<Vec<BlockHeader>, PropertyQueryError> {
         // use genesis block if no common ancestor with better block height is found
         let chainstate_ref = self.make_db_tx_ro();
         let mut best = BlockHeight::new(0);
 
-        for header in locator.iter() {
-            if let Some(block_index) = chainstate_ref.get_block_index(&header.get_id())? {
+        for header_id in locator.iter() {
+            if let Some(block_index) = chainstate_ref.get_block_index(header_id)? {
                 if chainstate_ref.is_block_in_main_chain(&block_index)? {
                     best = block_index.block_height();
                     break;

--- a/chainstate/src/detail/tests/syncing_tests.rs
+++ b/chainstate/src/detail/tests/syncing_tests.rs
@@ -21,6 +21,12 @@ use crate::detail::tests::{test_framework::BlockTestFramework, *};
 use chainstate_storage::BlockchainStorageRead;
 use crypto::random::{self, Rng};
 
+#[test]
+fn locator_distances() {
+    let distances: Vec<i64> = Chainstate::locator_tip_distances().take(7).map(From::from).collect();
+    assert_eq!(distances, vec![0, 1, 2, 4, 8, 16, 32]);
+}
+
 // Generate some blocks and check that a locator is of expected length.
 #[test]
 fn get_locator() {
@@ -30,7 +36,7 @@ fn get_locator() {
         // There is only one (genesis) block.
         let locator = btf.chainstate().get_locator().unwrap();
         assert_eq!(locator.len(), 1);
-        assert_eq!(btf.genesis().header(), &locator[0]);
+        assert_eq!(&btf.genesis().get_id(), &locator[0]);
 
         // Expand the chain several times.
         let mut rng = random::make_pseudo_rng();
@@ -51,11 +57,11 @@ fn get_locator() {
                 .get_block_height_in_main_chain(&last_block.get_id())
                 .unwrap()
                 .unwrap();
-            assert_eq!(&locator[0], last_block.header());
+            assert_eq!(&locator[0], &last_block.get_id());
             for (i, header) in locator.iter().skip(1).enumerate() {
                 let idx = height - BlockDistance::new(2i64.pow(i as u32));
                 let expected =
-                    btf.chainstate().get_header_from_height(&idx.unwrap()).unwrap().unwrap();
+                    btf.chainstate().get_block_id_from_height(&idx.unwrap()).unwrap().unwrap();
                 assert_eq!(&expected, header);
             }
         }
@@ -97,7 +103,7 @@ fn get_headers() {
         assert_eq!(headers, expected);
         // Because both the locator and chainstate are tracking the same chain, the first header of
         // the locator is always the parent of the first new block.
-        assert_eq!(expected[0].prev_block_id(), &Some(locator[0].get_id()));
+        assert_eq!(expected[0].prev_block_id(), &Some(locator[0].clone()));
 
         // Produce more blocks than `HEADER_LIMIT`, so get_headers is truncated.
         btf.create_chain(&last_block.get_id(), header_limit - expected.len()).unwrap();

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -25,7 +25,7 @@ pub mod rpc;
 pub use crate::{
     chainstate_interface_impl::ChainstateInterfaceImpl,
     config::ChainstateConfig,
-    detail::{ban_score, BlockError, BlockSource, Chainstate},
+    detail::{ban_score, BlockError, BlockSource, Chainstate, Locator},
 };
 
 use std::sync::Arc;

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 // Author(s): A. Altonen
+use chainstate::Locator;
 use common::{
     chain::block::{Block, BlockHeader},
     primitives::Id,
@@ -22,19 +23,19 @@ use serialization::{Decode, Encode};
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct HeaderRequest {
-    locator: Vec<BlockHeader>,
+    locator: Locator,
 }
 
 impl HeaderRequest {
-    pub fn new(locator: Vec<BlockHeader>) -> Self {
+    pub fn new(locator: Locator) -> Self {
         HeaderRequest { locator }
     }
 
-    pub fn locator(&self) -> &Vec<BlockHeader> {
+    pub fn locator(&self) -> &Locator {
         &self.locator
     }
 
-    pub fn into_locator(self) -> Vec<BlockHeader> {
+    pub fn into_locator(self) -> Locator {
         self.locator
     }
 }

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use chainstate::{
     ban_score::BanScore, chainstate_interface, BlockError, ChainstateError::ProcessBlockError,
+    Locator,
 };
 use common::{
     chain::{
@@ -162,7 +163,7 @@ where
         &mut self,
         _peer_id: T::PeerId,
         request_id: T::RequestId,
-        locator: Vec<BlockHeader>,
+        locator: Locator,
     ) -> crate::Result<()> {
         // TODO: check if remote has already asked for these headers?
         let headers = self.chainstate_handle.call(move |this| this.get_headers(locator)).await??;
@@ -228,7 +229,7 @@ where
                 ensure!(
                     locator
                         .iter()
-                        .any(|header| &Some(header.get_id()) == headers[0].prev_block_id())
+                        .any(|header_id| &Some(header_id.clone()) == headers[0].prev_block_id())
                         || &Some(self.config.genesis_block_id()) == headers[0].prev_block_id(),
                     P2pError::ProtocolError(ProtocolError::InvalidMessage),
                 );

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -18,6 +18,7 @@ use crate::{
     error::{P2pError, ProtocolError},
     net::NetworkingService,
 };
+use chainstate::Locator;
 use common::{
     chain::block::{Block, BlockHeader},
     primitives::{Id, Idable},
@@ -35,7 +36,7 @@ pub enum PeerSyncState {
     UploadingBlocks(Id<Block>),
 
     /// Peer is uploading headers to local node
-    UploadingHeaders(Vec<BlockHeader>),
+    UploadingHeaders(Locator),
 
     /// Peer is idling and can be used for block requests
     Idle,
@@ -66,7 +67,7 @@ impl<T: NetworkingService> PeerContext<T> {
         }
     }
 
-    pub fn new_with_locator(_peer_id: T::PeerId, locator: Vec<BlockHeader>) -> Self {
+    pub fn new_with_locator(_peer_id: T::PeerId, locator: Locator) -> Self {
         Self {
             _peer_id,
             state: PeerSyncState::UploadingHeaders(locator),

--- a/p2p/src/sync/request.rs
+++ b/p2p/src/sync/request.rs
@@ -66,10 +66,7 @@ where
     ///
     /// # Arguments
     /// * `locator` - locator object that shows the state of the local node
-    pub fn make_header_request(
-        &self,
-        locator: Vec<BlockHeader>,
-    ) -> (message::Request, RequestType) {
+    pub fn make_header_request(&self, locator: Locator) -> (message::Request, RequestType) {
         (
             message::Request::HeaderRequest(message::HeaderRequest::new(locator)),
             RequestType::GetHeaders,
@@ -165,7 +162,7 @@ where
     pub async fn send_header_request(
         &mut self,
         peer_id: T::PeerId,
-        locator: Vec<BlockHeader>,
+        locator: Locator,
         retry_count: usize,
     ) -> crate::Result<()> {
         ensure!(

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -33,7 +33,7 @@ async fn test_request_response() {
     mgr1.handle
         .send_request(
             *conn2.peer_id(),
-            Request::HeaderRequest(HeaderRequest::new(vec![])),
+            Request::HeaderRequest(HeaderRequest::new(Locator::new(vec![]))),
         )
         .await
         .unwrap();
@@ -44,7 +44,10 @@ async fn test_request_response() {
         request,
     }) = mgr2.handle.poll_next().await
     {
-        assert_eq!(request, Request::HeaderRequest(HeaderRequest::new(vec![])));
+        assert_eq!(
+            request,
+            Request::HeaderRequest(HeaderRequest::new(Locator::new(vec![])))
+        );
 
         mgr2.handle
             .send_response(
@@ -73,7 +76,7 @@ async fn test_multiple_requests_and_responses() {
         .handle
         .send_request(
             *conn2.peer_id(),
-            Request::HeaderRequest(HeaderRequest::new(vec![])),
+            Request::HeaderRequest(HeaderRequest::new(Locator::new(vec![]))),
         )
         .await
         .unwrap();
@@ -83,7 +86,7 @@ async fn test_multiple_requests_and_responses() {
         .handle
         .send_request(
             *conn2.peer_id(),
-            Request::HeaderRequest(HeaderRequest::new(vec![])),
+            Request::HeaderRequest(HeaderRequest::new(Locator::new(vec![]))),
         )
         .await
         .unwrap();


### PR DESCRIPTION
* Block IDs are more compact than headers and more in line with what Bitcoin does
* Also introduced a new separate `Locator` type rather in place of using `Vec<_>` directly