### PR TITLE
Get rid of all thread-related testing in time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "serial_test",
  "serialization",
  "sscanf",
  "static_assertions",
@@ -3574,6 +3575,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe196827aea34242c314d2f0dd49ed00a129225e80dda71b0dbf65d54d25628d"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+dependencies = [
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -38,6 +38,7 @@ serde_test = "1.0"
 serde_json = "1.0"
 rand = "0.8.5"
 itertools = "0.10"
+serial_test = "0.8"
 
 [target.'cfg(loom)'.dependencies]
 loom = "0.5"

--- a/common/src/primitives/time.rs
+++ b/common/src/primitives/time.rs
@@ -75,25 +75,19 @@ mod tests {
         logging::init_logging::<&std::path::Path>(None);
         set(Duration::from_secs(1337));
 
-        let handle = std::thread::spawn(move || {
-            log::info!("p2p time: {}", get().as_secs());
-            std::thread::sleep(Duration::from_secs(1));
+        log::info!("p2p time: {}", get().as_secs());
+        std::thread::sleep(Duration::from_secs(1));
 
-            log::info!("p2p time: {}", get().as_secs());
-            assert_eq!(get().as_secs(), 1337);
-            std::thread::sleep(Duration::from_secs(1));
-        });
+        log::info!("p2p time: {}", get().as_secs());
+        assert_eq!(get().as_secs(), 1337);
+        std::thread::sleep(Duration::from_secs(1));
 
-        std::thread::spawn(move || {
-            log::info!("rpc time: {}", get().as_secs());
-            std::thread::sleep(Duration::from_millis(500));
+        log::info!("rpc time: {}", get().as_secs());
+        std::thread::sleep(Duration::from_millis(500));
 
-            assert_eq!(get().as_secs(), 1337);
-            log::info!("rpc time: {}", get().as_secs());
-            std::thread::sleep(Duration::from_millis(500));
-        });
-
-        handle.join();
+        assert_eq!(get().as_secs(), 1337);
+        log::info!("rpc time: {}", get().as_secs());
+        std::thread::sleep(Duration::from_millis(500));
 
         reset();
         assert_ne!(get().as_secs(), 1337);

--- a/common/src/primitives/time.rs
+++ b/common/src/primitives/time.rs
@@ -71,6 +71,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[serial_test::serial]
     fn test_time() {
         logging::init_logging::<&std::path::Path>(None);
         set(Duration::from_secs(1337));
@@ -95,6 +96,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_mocked() {
         assert_eq!(get_mocked(), None);
 


### PR DESCRIPTION
Given that rust tests run in parallel, testing time with a global state in multiple threads is basically undefined behavior. No more multi-threading.