### PR TITLE
Change BlockTimestamp internal integer to u64

### DIFF
--- a/chainstate/src/detail/block_index_history_iter.rs
+++ b/chainstate/src/detail/block_index_history_iter.rs
@@ -98,7 +98,7 @@ mod tests {
             let block1 = Block::new(
                 vec![],
                 Some(Id::new(chainstate.chain_config.genesis_block_id().get())),
-                BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+                BlockTimestamp::from_duration_since_epoch(time::get()),
                 ConsensusData::None,
             )
             .expect("Block creation failed");
@@ -107,7 +107,7 @@ mod tests {
             let block2 = Block::new(
                 vec![],
                 Some(block1.get_id()),
-                BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+                BlockTimestamp::from_duration_since_epoch(time::get()),
                 ConsensusData::None,
             )
             .expect("Block creation failed");
@@ -116,7 +116,7 @@ mod tests {
             let block3 = Block::new(
                 vec![],
                 Some(block2.get_id()),
-                BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+                BlockTimestamp::from_duration_since_epoch(time::get()),
                 ConsensusData::None,
             )
             .expect("Block creation failed");

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -48,7 +48,10 @@ mod test {
     use chainstate_storage::Store;
     use common::{
         chain::{
-            block::{timestamp::BlockTimestamp, ConsensusData},
+            block::{
+                timestamp::{BlockTimestamp, BlockTimestampInternalType},
+                ConsensusData,
+            },
             config::create_unit_test_config,
         },
         primitives::{time, Idable},
@@ -58,7 +61,7 @@ mod test {
         time::Duration,
     };
 
-    fn make_block(prev_block: Id<Block>, time: u32) -> Block {
+    fn make_block(prev_block: Id<Block>, time: BlockTimestampInternalType) -> Block {
         Block::new(
             vec![],
             Some(prev_block),
@@ -68,7 +71,11 @@ mod test {
         .expect("Block creation failed")
     }
 
-    fn chain_blocks(count: usize, initial_prev: Id<Block>, initial_time: u32) -> Vec<Block> {
+    fn chain_blocks(
+        count: usize,
+        initial_prev: Id<Block>,
+        initial_time: BlockTimestampInternalType,
+    ) -> Vec<Block> {
         let mut res = vec![];
         let mut prev = initial_prev;
         let mut time = initial_time;
@@ -102,7 +109,7 @@ mod test {
             let blocks = chain_blocks(
                 block_count,
                 chainstate.chain_config.genesis_block_id(),
-                time::get().as_secs() as u32,
+                time::get().as_secs(),
             );
 
             for block in &blocks {
@@ -164,11 +171,11 @@ mod test {
                     .unwrap();
 
             // we use unordered block times, and ensure that the median will be in the right spot
-            let block1_time = current_time.load(Ordering::SeqCst) as u32 + 1;
-            let block2_time = current_time.load(Ordering::SeqCst) as u32 + 20;
-            let block3_time = current_time.load(Ordering::SeqCst) as u32 + 10;
-            let block4_time = current_time.load(Ordering::SeqCst) as u32 + 18;
-            let block5_time = current_time.load(Ordering::SeqCst) as u32 + 17;
+            let block1_time = current_time.load(Ordering::SeqCst) + 1;
+            let block2_time = current_time.load(Ordering::SeqCst) + 20;
+            let block3_time = current_time.load(Ordering::SeqCst) + 10;
+            let block4_time = current_time.load(Ordering::SeqCst) + 18;
+            let block5_time = current_time.load(Ordering::SeqCst) + 17;
 
             let block1 = make_block(chainstate.chain_config.genesis_block_id(), block1_time);
             let block2 = make_block(block1.get_id(), block2_time);

--- a/chainstate/src/detail/pow/helpers.rs
+++ b/chainstate/src/detail/pow/helpers.rs
@@ -96,8 +96,8 @@ pub mod special_rules {
     /// Checks if it took > 20 minutes to find a block
     pub fn block_production_stalled(
         target_spacing_in_secs: u64,
-        new_block_time: u32,
-        prev_block_time: u32,
+        new_block_time: u64,
+        prev_block_time: u64,
     ) -> bool {
         new_block_time as u64 > (prev_block_time as u64 + (target_spacing_in_secs * 2))
     }

--- a/chainstate/src/detail/pow/work.rs
+++ b/chainstate/src/detail/pow/work.rs
@@ -103,7 +103,7 @@ fn calculate_work_required<H: BlockIndexHandle>(
 
 impl PoW {
     /// The difference (in block time) between the current block and 2016th block before the current one.
-    fn actual_timespan(&self, prev_block_blocktime: u32, retarget_blocktime: u32) -> u64 {
+    fn actual_timespan(&self, prev_block_blocktime: u64, retarget_blocktime: u64) -> u64 {
         // TODO: this needs to be fixed because it could suffer from an underflow
         let actual_timespan = (prev_block_blocktime - retarget_blocktime) as u64;
 
@@ -186,7 +186,7 @@ impl PoW {
 
     fn next_work_required_for_min_difficulty(
         &self,
-        new_block_time: u32,
+        new_block_time: u64,
         prev_block_index: &BlockIndex,
         prev_block_bits: Compact,
     ) -> Compact {

--- a/chainstate/src/detail/tests/double_spend_tests.rs
+++ b/chainstate/src/detail/tests/double_spend_tests.rs
@@ -49,7 +49,7 @@ fn spend_output_in_the_same_block() {
         let block = Block::new(
             vec![first_tx, second_tx],
             Some(Id::new(chainstate.chain_config.genesis_block_id().get())),
-            BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+            BlockTimestamp::from_duration_since_epoch(time::get()),
             ConsensusData::None,
         )
         .expect(ERR_CREATE_BLOCK_FAIL);
@@ -90,7 +90,7 @@ fn spend_output_in_the_same_block_invalid_order() {
         let block = Block::new(
             vec![second_tx, first_tx],
             Some(Id::new(chainstate.chain_config.genesis_block_id().get())),
-            BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+            BlockTimestamp::from_duration_since_epoch(time::get()),
             ConsensusData::None,
         )
         .expect(ERR_CREATE_BLOCK_FAIL);
@@ -137,7 +137,7 @@ fn double_spend_tx_in_the_same_block() {
         let block = Block::new(
             vec![first_tx, second_tx, third_tx],
             Some(Id::new(chainstate.chain_config.genesis_block_id().get())),
-            BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+            BlockTimestamp::from_duration_since_epoch(time::get()),
             ConsensusData::None,
         )
         .expect(ERR_CREATE_BLOCK_FAIL);
@@ -185,7 +185,7 @@ fn double_spend_tx_in_another_block() {
         let first_block = Block::new(
             vec![first_tx.clone()],
             Some(Id::new(chainstate.chain_config.genesis_block_id().get())),
-            BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+            BlockTimestamp::from_duration_since_epoch(time::get()),
             ConsensusData::None,
         )
         .expect(ERR_CREATE_BLOCK_FAIL);
@@ -203,7 +203,7 @@ fn double_spend_tx_in_another_block() {
         let second_block = Block::new(
             vec![second_tx],
             Some(first_block_id.clone()),
-            BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+            BlockTimestamp::from_duration_since_epoch(time::get()),
             ConsensusData::None,
         )
         .expect(ERR_CREATE_BLOCK_FAIL);

--- a/chainstate/src/detail/tests/events_tests.rs
+++ b/chainstate/src/detail/tests/events_tests.rs
@@ -169,7 +169,7 @@ fn custom_orphan_error_hook() {
         let first_block = produce_test_block(chainstate.chain_config.genesis_block(), false);
         // Produce a block with a bad timestamp.
         let timestamp = chainstate.chain_config.genesis_block().timestamp().as_int_seconds()
-            + chainstate.chain_config.max_future_block_time_offset().as_secs() as u32;
+            + chainstate.chain_config.max_future_block_time_offset().as_secs();
         let second_block = Block::new(
             vec![],
             Some(first_block.get_id()),

--- a/chainstate/src/detail/tests/mod.rs
+++ b/chainstate/src/detail/tests/mod.rs
@@ -120,7 +120,7 @@ fn produce_test_block_with_consensus_data(
         } else {
             Some(Id::new(prev_block.get_id().get()))
         },
-        BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+        BlockTimestamp::from_duration_since_epoch(time::get()),
         consensus_data,
     )
     .expect(ERR_CREATE_BLOCK_FAIL)

--- a/chainstate/src/detail/tests/processing_tests.rs
+++ b/chainstate/src/detail/tests/processing_tests.rs
@@ -744,13 +744,13 @@ fn blocks_from_the_future() {
         {
             // submit a block on the threshold of being rejected for being from the future
             let max_future_offset =
-                chainstate.chain_config.max_future_block_time_offset().as_secs() as u32;
+                chainstate.chain_config.max_future_block_time_offset().as_secs();
 
             let good_block = Block::new(
                 vec![],
                 Some(chainstate.chain_config.genesis_block_id()),
                 BlockTimestamp::from_int_seconds(
-                    current_time.load(Ordering::SeqCst) as u32 + max_future_offset,
+                    current_time.load(Ordering::SeqCst) + max_future_offset,
                 ),
                 ConsensusData::None,
             )
@@ -762,13 +762,13 @@ fn blocks_from_the_future() {
         {
             // submit a block a second after the allowed threshold in the future
             let max_future_offset =
-                chainstate.chain_config.max_future_block_time_offset().as_secs() as u32;
+                chainstate.chain_config.max_future_block_time_offset().as_secs();
 
             let bad_block_in_future = Block::new(
                 vec![],
                 Some(chainstate.chain_config.genesis_block_id()),
                 BlockTimestamp::from_int_seconds(
-                    current_time.load(Ordering::SeqCst) as u32 + max_future_offset + 1,
+                    current_time.load(Ordering::SeqCst) + max_future_offset + 1,
                 ),
                 ConsensusData::None,
             )
@@ -785,7 +785,7 @@ fn blocks_from_the_future() {
             let bad_block_from_past = Block::new(
                 vec![],
                 Some(chainstate.chain_config.genesis_block_id()),
-                BlockTimestamp::from_int_seconds(current_time.load(Ordering::SeqCst) as u32 - 1),
+                BlockTimestamp::from_int_seconds(current_time.load(Ordering::SeqCst) - 1),
                 ConsensusData::None,
             )
             .expect(ERR_CREATE_BLOCK_FAIL);

--- a/chainstate/src/detail/tests/signature_tests.rs
+++ b/chainstate/src/detail/tests/signature_tests.rs
@@ -78,7 +78,7 @@ fn signed_tx() {
         let block = Block::new(
             vec![tx_1, tx_2],
             Some(chainstate.chain_config.genesis_block().get_id()),
-            BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+            BlockTimestamp::from_duration_since_epoch(time::get()),
             ConsensusData::None,
         )
         .unwrap();

--- a/chainstate/src/detail/tests/test_framework.rs
+++ b/chainstate/src/detail/tests/test_framework.rs
@@ -98,7 +98,7 @@ impl BlockTestFramework {
         Block::new(
             vec![Transaction::new(0, inputs, outputs, 0).expect(ERR_CREATE_TX_FAIL)],
             Some(prev_block_hash),
-            BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+            BlockTimestamp::from_duration_since_epoch(time::get()),
             ConsensusData::None,
         )
         .expect(ERR_CREATE_BLOCK_FAIL)

--- a/common/src/chain/block/timestamp.rs
+++ b/common/src/chain/block/timestamp.rs
@@ -15,7 +15,6 @@
 
 use parity_scale_codec::{Decode, Encode};
 use std::time::Duration;
-use thiserror::Error;
 
 pub type BlockTimestampInternalType = u64;
 
@@ -31,22 +30,16 @@ impl std::fmt::Display for BlockTimestamp {
     }
 }
 
-#[derive(Error, Debug, PartialEq, Eq, Clone)]
-pub enum TimestampError {
-    #[error("Duration cannot fit in a timestamp: {0:?}")]
-    DurationTooLargeForTimestamp(Duration),
-}
-
 impl BlockTimestamp {
     pub fn from_int_seconds(timestamp: BlockTimestampInternalType) -> Self {
         Self { timestamp }
     }
 
-    pub fn from_duration_since_epoch(duration: Duration) -> Result<Self, TimestampError> {
+    pub fn from_duration_since_epoch(duration: Duration) -> Self {
         let result = Self {
             timestamp: duration.as_secs(),
         };
-        Ok(result)
+        result
     }
 
     pub fn as_duration_since_epoch(&self) -> Duration {

--- a/common/src/chain/block/timestamp.rs
+++ b/common/src/chain/block/timestamp.rs
@@ -36,10 +36,9 @@ impl BlockTimestamp {
     }
 
     pub fn from_duration_since_epoch(duration: Duration) -> Self {
-        let result = Self {
+        Self {
             timestamp: duration.as_secs(),
-        };
-        result
+        }
     }
 
     pub fn as_duration_since_epoch(&self) -> Duration {

--- a/common/src/chain/block/timestamp.rs
+++ b/common/src/chain/block/timestamp.rs
@@ -17,10 +17,12 @@ use parity_scale_codec::{Decode, Encode};
 use std::time::Duration;
 use thiserror::Error;
 
+pub type BlockTimestampInternalType = u64;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, PartialOrd, Ord)]
 pub struct BlockTimestamp {
     #[codec(compact)]
-    timestamp: u32,
+    timestamp: BlockTimestampInternalType,
 }
 
 impl std::fmt::Display for BlockTimestamp {
@@ -31,12 +33,12 @@ impl std::fmt::Display for BlockTimestamp {
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum TimestampError {
-    #[error("Duration cannot fit in a u32: {0:?}")]
-    DurationTooLargeForU32(Duration),
+    #[error("Duration cannot fit in a timestamp: {0:?}")]
+    DurationTooLargeForTimestamp(Duration),
 }
 
 impl BlockTimestamp {
-    pub fn from_int_seconds(timestamp: u32) -> Self {
+    pub fn from_int_seconds(timestamp: BlockTimestampInternalType) -> Self {
         Self { timestamp }
     }
 
@@ -45,7 +47,7 @@ impl BlockTimestamp {
             timestamp: duration
                 .as_secs()
                 .try_into()
-                .map_err(|_| TimestampError::DurationTooLargeForU32(duration))?,
+                .map_err(|_| TimestampError::DurationTooLargeForTimestamp(duration))?,
         };
         Ok(result)
     }
@@ -54,7 +56,7 @@ impl BlockTimestamp {
         Duration::from_secs(self.timestamp as u64)
     }
 
-    pub fn as_int_seconds(&self) -> u32 {
+    pub fn as_int_seconds(&self) -> BlockTimestampInternalType {
         self.timestamp
     }
 }

--- a/common/src/chain/block/timestamp.rs
+++ b/common/src/chain/block/timestamp.rs
@@ -44,10 +44,7 @@ impl BlockTimestamp {
 
     pub fn from_duration_since_epoch(duration: Duration) -> Result<Self, TimestampError> {
         let result = Self {
-            timestamp: duration
-                .as_secs()
-                .try_into()
-                .map_err(|_| TimestampError::DurationTooLargeForTimestamp(duration))?,
+            timestamp: duration.as_secs(),
         };
         Ok(result)
     }

--- a/common/src/chain/transaction/transaction_index/tests.rs
+++ b/common/src/chain/transaction/transaction_index/tests.rs
@@ -273,7 +273,7 @@ fn generate_random_invalid_block() -> Block {
             .map(|_| generate_random_invalid_transaction(&mut rng))
             .collect::<Vec<_>>()
     };
-    let time = rng.next_u32();
+    let time = rng.next_u64();
     let prev_id = Some(Id::new(generate_random_h256(&mut rng)));
 
     Block::new(

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -139,7 +139,7 @@ mod tests {
         let header = Block::new(
             vec![],
             None,
-            BlockTimestamp::from_int_seconds(1337u32),
+            BlockTimestamp::from_int_seconds(1337u64),
             ConsensusData::None,
         )
         .unwrap()

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -108,7 +108,7 @@ fn produce_test_block_with_consensus_data(
         } else {
             Some(Id::new(prev_block.get_id().get()))
         },
-        BlockTimestamp::from_duration_since_epoch(time::get()).unwrap(),
+        BlockTimestamp::from_duration_since_epoch(time::get()),
         consensus_data,
     )
     .expect("not to fail")

--- a/p2p/tests/libp2p-gossipsub.rs
+++ b/p2p/tests/libp2p-gossipsub.rs
@@ -75,7 +75,7 @@ async fn test_libp2p_gossipsub() {
                 Block::new(
                     vec![],
                     None,
-                    BlockTimestamp::from_int_seconds(1337u32),
+                    BlockTimestamp::from_int_seconds(1337u64),
                     ConsensusData::None,
                 )
                 .unwrap(),
@@ -99,13 +99,13 @@ async fn test_libp2p_gossipsub() {
         message_id: _,
         announcement: Announcement::Block(block),
     } = res2.unwrap();
-    assert_eq!(block.timestamp().as_int_seconds(), 1337u32);
+    assert_eq!(block.timestamp().as_int_seconds(), 1337u64);
     pubsub2
         .publish(Announcement::Block(
             Block::new(
                 vec![],
                 None,
-                BlockTimestamp::from_int_seconds(1338u32),
+                BlockTimestamp::from_int_seconds(1338u64),
                 ConsensusData::None,
             )
             .unwrap(),
@@ -119,7 +119,7 @@ async fn test_libp2p_gossipsub() {
         message_id: _,
         announcement: Announcement::Block(block),
     } = res1.unwrap();
-    assert_eq!(block.timestamp(), BlockTimestamp::from_int_seconds(1338u32));
+    assert_eq!(block.timestamp(), BlockTimestamp::from_int_seconds(1338u64));
 }
 
 async fn connect_peers(
@@ -188,7 +188,7 @@ async fn test_libp2p_gossipsub_3_peers() {
                 Block::new(
                     vec![],
                     None,
-                    BlockTimestamp::from_int_seconds(1337u32),
+                    BlockTimestamp::from_int_seconds(1337u64),
                     ConsensusData::None,
                 )
                 .unwrap(),
@@ -320,7 +320,7 @@ async fn test_libp2p_gossipsub_too_big_message() {
         Block::new(
             txs,
             None,
-            BlockTimestamp::from_int_seconds(1337u32),
+            BlockTimestamp::from_int_seconds(1337u64),
             ConsensusData::None,
         )
         .unwrap(),


### PR DESCRIPTION
Since we're using compact encoding, there's zero harm in using u64 for block timestamps. It's even beneficial so that we don't worry about running out of time in the future. It also simplify Duration usage since seconds there are also u64.