### PR TITLE
Make `Id` copyable

### DIFF
--- a/chainstate-storage/src/mock.rs
+++ b/chainstate-storage/src/mock.rs
@@ -334,7 +334,7 @@ mod tests {
             let mut tx = MockStoreTxRw::new();
             tx.expect_get_best_block_id().return_const(Ok(Some(block0.get_id().into())));
             tx.expect_add_block().return_const(Ok(()));
-            let expected_id: Id<GenBlock> = block1_id.clone().into();
+            let expected_id: Id<GenBlock> = block1_id.into();
             tx.expect_set_best_block_id()
                 .with(mockall::predicate::eq(expected_id))
                 .return_const(Ok(()));
@@ -368,7 +368,7 @@ mod tests {
         let mut store = MockStore::new();
         store.expect_transaction_rw().returning(move || {
             let mut tx = MockStoreTxRw::new();
-            tx.expect_get_best_block_id().return_const(Ok(Some(top_id.clone())));
+            tx.expect_get_best_block_id().return_const(Ok(Some(top_id)));
             tx.expect_abort().return_const(Ok(()));
             tx
         });
@@ -386,7 +386,7 @@ mod tests {
             let mut tx = MockStoreTxRw::new();
             tx.expect_get_best_block_id().return_const(Ok(Some(block0.get_id().into())));
             tx.expect_add_block().return_const(Ok(()));
-            let expected_id: Id<GenBlock> = block1_id.clone().into();
+            let expected_id: Id<GenBlock> = block1_id.into();
             tx.expect_set_best_block_id()
                 .with(mockall::predicate::eq(expected_id))
                 .return_const(Ok(()));

--- a/chainstate-storage/src/store.rs
+++ b/chainstate-storage/src/store.rs
@@ -699,12 +699,12 @@ pub(crate) mod test {
         let mut store = Store::new_empty().unwrap();
 
         // store is empty, so no undo data should be found.
-        assert_eq!(store.get_undo_data(id0.clone()), Ok(None));
+        assert_eq!(store.get_undo_data(id0), Ok(None));
 
         // add undo data and check if it is there
-        assert_eq!(store.add_undo_data(id0.clone(), &block_undo0), Ok(()));
+        assert_eq!(store.add_undo_data(id0, &block_undo0), Ok(()));
         assert_eq!(
-            store.get_undo_data(id0.clone()).unwrap().unwrap(),
+            store.get_undo_data(id0).unwrap().unwrap(),
             block_undo0.clone()
         );
 
@@ -714,19 +714,19 @@ pub(crate) mod test {
         // create id:
         let id1: Id<Block> = Id::new(H256::random());
 
-        assert_eq!(store.get_undo_data(id1.clone()), Ok(None));
-        assert_eq!(store.add_undo_data(id1.clone(), &block_undo1), Ok(()));
-        assert_eq!(
-            store.get_undo_data(id0.clone()).unwrap().unwrap(),
-            block_undo0.clone()
-        );
-        assert_eq!(store.del_undo_data(id1.clone()), Ok(()));
-        assert_eq!(store.get_undo_data(id1.clone()), Ok(None));
+        assert_eq!(store.get_undo_data(id1), Ok(None));
+        assert_eq!(store.add_undo_data(id1, &block_undo1), Ok(()));
         assert_eq!(
             store.get_undo_data(id0).unwrap().unwrap(),
             block_undo0.clone()
         );
-        assert_eq!(store.add_undo_data(id1.clone(), &block_undo1), Ok(()));
+        assert_eq!(store.del_undo_data(id1), Ok(()));
+        assert_eq!(store.get_undo_data(id1), Ok(None));
+        assert_eq!(
+            store.get_undo_data(id0).unwrap().unwrap(),
+            block_undo0.clone()
+        );
+        assert_eq!(store.add_undo_data(id1, &block_undo1), Ok(()));
         assert_eq!(store.get_undo_data(id1).unwrap().unwrap(), block_undo1);
     }
 }

--- a/chainstate-storage/src/utxo_db.rs
+++ b/chainstate-storage/src/utxo_db.rs
@@ -122,9 +122,9 @@ mod test {
         // undo checking
         let undo = create_rand_block_undo(10, 10, BlockHeight::new(10));
 
-        assert!(db_interface.set_undo_data(block_id.clone(), &undo).is_ok());
-        assert_eq!(db_interface.get_undo_data(block_id.clone()), Ok(Some(undo)));
-        assert!(db_interface.del_undo_data(block_id.clone()).is_ok());
+        assert!(db_interface.set_undo_data(block_id, &undo).is_ok());
+        assert_eq!(db_interface.get_undo_data(block_id), Ok(Some(undo)));
+        assert!(db_interface.del_undo_data(block_id).is_ok());
         assert_eq!(db_interface.get_undo_data(block_id), Ok(None));
     }
 }

--- a/chainstate/src/chainstate_interface_impl.rs
+++ b/chainstate/src/chainstate_interface_impl.rs
@@ -60,7 +60,7 @@ impl ChainstateInterface for ChainstateInterfaceImpl {
 
     fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError> {
         self.chainstate
-            .get_block_height_in_main_chain(&block_id.clone().into())
+            .get_block_height_in_main_chain(&(*block_id).into())
             .map_err(ChainstateError::FailedToReadProperty)
             .map(|ht| ht.is_some())
     }

--- a/chainstate/src/detail/block_index_history_iter.rs
+++ b/chainstate/src/detail/block_index_history_iter.rs
@@ -52,7 +52,7 @@ impl<'a, H: BlockIndexHandle> Iterator for BlockIndexHistoryIterator<'a, H> {
 
         self.next_id = match &block_index {
             GenBlockIndex::Genesis(_) => None,
-            GenBlockIndex::Block(blkidx) => Some(blkidx.prev_block_id().clone()),
+            GenBlockIndex::Block(blkidx) => Some(*blkidx.prev_block_id()),
         };
 
         Some(block_index)

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -196,7 +196,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
             Some(ht) => ht,
         };
         let bid = self.get_block_id_by_height(&ht)?;
-        Ok(bid == Some(block_id.clone()))
+        Ok(bid == Some(*block_id))
     }
 
     /// Allow to read from storage the previous block and return itself BlockIndex
@@ -206,7 +206,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     ) -> Result<GenBlockIndex<'a>, PropertyQueryError> {
         let prev_block_id = block_index.prev_block_id();
         self.get_gen_block_index(prev_block_id)?
-            .ok_or_else(|| PropertyQueryError::PrevBlockIndexNotFound(prev_block_id.clone()))
+            .ok_or(PropertyQueryError::PrevBlockIndexNotFound(*prev_block_id))
     }
 
     pub fn get_ancestor(
@@ -319,8 +319,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
             GenBlockId::Genesis(_) => return Ok(Some(BlockHeight::zero())),
         };
         let block_index = self.get_block_index(&id)?;
-        let block_index =
-            block_index.ok_or_else(|| PropertyQueryError::BlockNotFound(id.clone()))?;
+        let block_index = block_index.ok_or(PropertyQueryError::BlockNotFound(id))?;
         if block_index.block_id() == &id {
             Ok(Some(block_index.block_height()))
         } else {
@@ -335,7 +334,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     ) -> Result<Vec<BlockIndex>, PropertyQueryError> {
         let mut result = Vec::new();
         let mut block_index = new_tip_block_index.clone();
-        while !self.is_block_in_main_chain(&block_index.block_id().clone().into())? {
+        while !self.is_block_in_main_chain(&(*block_index.block_id()).into())? {
             result.push(block_index.clone());
             block_index = match self.get_previous_block_index(&block_index)? {
                 GenBlockIndex::Genesis(_) => break,
@@ -350,9 +349,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     fn check_block_index(&self, block_index: &BlockIndex) -> Result<(), BlockError> {
         // BlockIndex is already known or block exists
         if self.db_tx.get_block_index(block_index.block_id())?.is_some() {
-            return Err(BlockError::BlockAlreadyExists(
-                block_index.block_id().clone(),
-            ));
+            return Err(BlockError::BlockAlreadyExists(*block_index.block_id()));
         }
         // TODO: Will be expanded
         Ok(())
@@ -483,7 +480,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     }
 
     fn get_block_from_index(&self, block_index: &BlockIndex) -> Result<Option<Block>, BlockError> {
-        Ok(self.db_tx.get_block(block_index.block_id().clone())?)
+        Ok(self.db_tx.get_block(*block_index.block_id())?)
     }
 
     pub fn check_block(&self, block: &Block) -> Result<(), CheckBlockError> {
@@ -568,7 +565,7 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut> ChainstateRef<'a, S, O> 
         last_to_remain_connected: &Id<GenBlock>,
     ) -> Result<(), BlockError> {
         let mut to_disconnect = GenBlockIndex::Block(to_disconnect.clone());
-        while to_disconnect.block_id().clone() != *last_to_remain_connected {
+        while to_disconnect.block_id() != *last_to_remain_connected {
             let to_disconnect_block = match to_disconnect {
                 GenBlockIndex::Genesis(_) => panic!("Attempt to disconnect genesis"),
                 GenBlockIndex::Block(block_index) => block_index,
@@ -585,8 +582,8 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut> ChainstateRef<'a, S, O> 
     ) -> Result<(), BlockError> {
         let new_chain = self.get_new_chain(new_block_index).map_err(|e| {
             BlockError::InvariantErrorFailedToFindNewChainPath(
-                new_block_index.block_id().clone(),
-                best_block_id.clone(),
+                *new_block_index.block_id(),
+                *best_block_id,
                 e,
             )
         })?;
@@ -655,9 +652,9 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut> ChainstateRef<'a, S, O> 
 
         self.db_tx.set_block_id_at_height(
             &new_tip_block_index.block_height(),
-            &new_tip_block_index.block_id().clone().into(),
+            &(*new_tip_block_index.block_id()).into(),
         )?;
-        self.db_tx.set_best_block_id(&new_tip_block_index.block_id().clone().into())?;
+        self.db_tx.set_best_block_id(&(*new_tip_block_index.block_id()).into())?;
         Ok(())
     }
 

--- a/chainstate/src/detail/consensus_validator/mod.rs
+++ b/chainstate/src/detail/consensus_validator/mod.rs
@@ -34,15 +34,12 @@ pub(crate) fn validate_consensus<H: BlockIndexHandle>(
     header: &BlockHeader,
     block_index_handle: &H,
 ) -> Result<(), ConsensusVerificationError> {
-    let prev_block_id = header.prev_block_id().clone();
+    let prev_block_id = *header.prev_block_id();
 
     let prev_block_height = block_index_handle
         .get_gen_block_index(&prev_block_id)
-        .map_err({
-            let prev_block_id = prev_block_id.clone();
-            |err| {
-                ConsensusVerificationError::PrevBlockLoadError(prev_block_id, header.get_id(), err)
-            }
+        .map_err(|err| {
+            ConsensusVerificationError::PrevBlockLoadError(prev_block_id, header.get_id(), err)
         })?
         .ok_or_else(|| {
             ConsensusVerificationError::PrevBlockNotFound(prev_block_id, header.get_id())

--- a/chainstate/src/detail/gen_block_index.rs
+++ b/chainstate/src/detail/gen_block_index.rs
@@ -31,7 +31,7 @@ pub enum GenBlockIndex<'a> {
 impl<'a> GenBlockIndex<'a> {
     pub fn block_id(&self) -> Id<GenBlock> {
         match self {
-            GenBlockIndex::Block(b) => b.block_id().clone().into(),
+            GenBlockIndex::Block(b) => (*b.block_id()).into(),
             GenBlockIndex::Genesis(c) => c.genesis_block_id(),
         }
     }

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -30,7 +30,7 @@ pub fn calculate_median_time_past<H: BlockIndexHandle>(
     block_index_handle: &H,
     starting_block: &Id<GenBlock>,
 ) -> BlockTimestamp {
-    let iter = BlockIndexHistoryIterator::new(starting_block.clone(), block_index_handle);
+    let iter = BlockIndexHistoryIterator::new(*starting_block, block_index_handle);
     let time_values = iter
         .take(MEDIAN_TIME_SPAN)
         .map(|bi| bi.block_timestamp())

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -162,7 +162,7 @@ impl Chainstate {
         match new_block_index {
             Some(ref new_block_index) => {
                 let new_height = new_block_index.block_height();
-                let new_id = new_block_index.block_id().clone();
+                let new_id = *new_block_index.block_id();
                 self.events_controller.broadcast(ChainstateEvent::NewTip(new_id, new_height))
             }
             None => (),
@@ -171,7 +171,7 @@ impl Chainstate {
 
     /// returns the new block index, which is the new tip, if any
     fn process_orphans(&mut self, last_processed_block: &Id<Block>) -> Option<BlockIndex> {
-        let orphans = self.orphan_blocks.take_all_children_of(&last_processed_block.clone().into());
+        let orphans = self.orphan_blocks.take_all_children_of(&(*last_processed_block).into());
         let (block_indexes, block_errors): (Vec<Option<BlockIndex>>, Vec<BlockError>) = orphans
             .into_iter()
             .map(|blk| self.process_block(blk, BlockSource::Local))
@@ -268,9 +268,8 @@ impl Chainstate {
         let genesis = self.chain_config.genesis_block();
         let genesis_id = self.chain_config.genesis_block_id();
         let utxo_count = genesis.utxos().len() as u32;
-        let genesis_index =
-            common::chain::TxMainChainIndex::new(genesis_id.clone().into(), utxo_count)
-                .expect("Genesis not constructed correctly");
+        let genesis_index = common::chain::TxMainChainIndex::new(genesis_id.into(), utxo_count)
+            .expect("Genesis not constructed correctly");
 
         // Initialize storage with given info
         let mut db_tx = self.chainstate_storage.transaction_rw();
@@ -393,7 +392,7 @@ impl Chainstate {
         if let Some(id) = first_block.prev_block_id().classify(config).chain_block_id() {
             utils::ensure!(
                 self.get_block_index(&id)?.is_some(),
-                PropertyQueryError::BlockNotFound(id.clone())
+                PropertyQueryError::BlockNotFound(id)
             );
         }
 

--- a/chainstate/src/detail/orphan_blocks/pool.rs
+++ b/chainstate/src/detail/orphan_blocks/pool.rs
@@ -75,7 +75,7 @@ impl OrphanBlocksPool {
     fn del_one_deepest_child(&mut self, block_id: &Id<Block>) {
         let next_block = self
             .orphan_by_prev_id
-            .get(&block_id.clone().into())
+            .get(&(*block_id).into())
             .map(|v| v.get(0).expect("This list should never be empty as we always delete empty vectors from the map"))
             .cloned();
         match next_block {
@@ -91,7 +91,7 @@ impl OrphanBlocksPool {
             return;
         }
         let id = self.orphan_ids.choose(&mut crypto::random::make_pseudo_rng());
-        let id = id.expect("As orphans can never be empty, this should always return").clone();
+        let id = *id.expect("As orphans can never be empty, this should always return");
 
         self.del_one_deepest_child(&id);
     }
@@ -104,7 +104,7 @@ impl OrphanBlocksPool {
         }
 
         let rc_block = Arc::new(block);
-        self.orphan_by_id.insert(block_id.clone(), rc_block.clone());
+        self.orphan_by_id.insert(block_id, rc_block.clone());
         self.orphan_ids.push(block_id);
         self.orphan_by_prev_id
             .entry(rc_block.prev_block_id())
@@ -230,7 +230,7 @@ mod tests {
 
             (0..count)
                 .into_iter()
-                .map(|_| gen_block_from_id(Some(prev_block_id.clone().into())))
+                .map(|_| gen_block_from_id(Some(prev_block_id.into())))
                 .collect()
         }
     }

--- a/chainstate/src/detail/pow/helpers.rs
+++ b/chainstate/src/detail/pow/helpers.rs
@@ -46,7 +46,7 @@ pub(crate) fn get_starting_block_time(
         Ok(bi) => bi,
         Err(err) => {
             return Err(ConsensusPoWError::AncestorAtHeightNotFound(
-                block_index.block_id().clone(),
+                *block_index.block_id(),
                 retarget_height,
                 err,
             ))

--- a/chainstate/src/detail/spend_cache/mod.rs
+++ b/chainstate/src/detail/spend_cache/mod.rs
@@ -245,7 +245,7 @@ impl<'a, S: BlockchainStorageRead> CachedInputs<'a, S> {
                     let rewards_tx = block_index.block_reward_transactable();
 
                     let outputs = rewards_tx.outputs().unwrap_or(&[]);
-                    Self::get_output_amount(outputs, output_index, block_id.clone().into())?
+                    Self::get_output_amount(outputs, output_index, (*block_id).into())?
                 }
             };
             total = (total + output_amount).ok_or(StateUpdateError::InputAdditionError)?;

--- a/chainstate/src/detail/tests/double_spend_tests.rs
+++ b/chainstate/src/detail/tests/double_spend_tests.rs
@@ -196,13 +196,13 @@ fn double_spend_tx_in_another_block() {
                 .chainstate_storage
                 .get_best_block_id()
                 .expect(ERR_BEST_BLOCK_NOT_FOUND),
-            Some(first_block_id.clone().into())
+            Some(first_block_id.into())
         );
 
         let second_tx = tx_from_genesis(&chainstate);
         let second_block = Block::new(
             vec![second_tx],
-            first_block_id.clone().into(),
+            first_block_id.into(),
             BlockTimestamp::from_duration_since_epoch(time::get()),
             ConsensusData::None,
         )

--- a/chainstate/src/detail/tests/mod.rs
+++ b/chainstate/src/detail/tests/mod.rs
@@ -116,7 +116,7 @@ impl TestBlockInfo {
 
     fn from_genesis(genesis: &Genesis) -> Self {
         let id: Id<GenBlock> = genesis.get_id().into();
-        let outsrc = OutPointSourceId::BlockReward(id.clone());
+        let outsrc = OutPointSourceId::BlockReward(id);
         let txns = vec![(outsrc, genesis.utxos().to_vec())];
         Self { txns, id }
     }

--- a/chainstate/src/detail/tests/processing_tests.rs
+++ b/chainstate/src/detail/tests/processing_tests.rs
@@ -56,7 +56,7 @@ fn process_genesis_block() {
         let chainstate = chainstate.make_db_tx_ro();
 
         // Check the genesis block is properly set up
-        assert_eq!(chainstate.get_best_block_id(), Ok(genesis_id.clone()));
+        assert_eq!(chainstate.get_best_block_id(), Ok(genesis_id));
         let genesis_index = chainstate.get_gen_block_index(&genesis_id).unwrap().unwrap();
         assert_eq!(genesis_index.block_height(), BlockHeight::from(0));
         assert_eq!(genesis_index.block_id(), genesis_id.clone());
@@ -304,7 +304,7 @@ fn get_ancestor() {
     // we aggressively test the simple ancestor calculation for all previous heights up to genesis
     for i in 1..=split.block_height().into() {
         assert_eq!(
-            <Id<GenBlock>>::from(btf.index_at(i as usize).block_id().clone()),
+            <Id<GenBlock>>::from(*btf.index_at(i as usize).block_id()),
             btf.chainstate
                 .make_db_tx()
                 .get_ancestor(&split, i.into())
@@ -510,9 +510,7 @@ fn consensus_type() {
     // The next block will be at height 5, so it is expected to be a PoW block. Let's crate a block
     // with ConsensusData::None and see that adding it fails
     let block_without_consensus_data = produce_test_block_with_consensus_data(
-        TestBlockInfo::from_block(
-            &btf.get_block(btf.index_at(4).block_id().clone()).unwrap().unwrap(),
-        ),
+        TestBlockInfo::from_block(&btf.get_block(*btf.index_at(4).block_id()).unwrap().unwrap()),
         ConsensusData::None,
     );
 
@@ -525,7 +523,7 @@ fn consensus_type() {
 
     // Mine blocks 5-9 with minimal difficulty, as expected by net upgrades
     for i in 5..10 {
-        let prev_block = btf.get_block(btf.index_at(i - 1).block_id().clone()).unwrap().unwrap();
+        let prev_block = btf.get_block(*btf.index_at(i - 1).block_id()).unwrap().unwrap();
         let mut mined_block = btf.random_block(TestBlockInfo::from_block(&prev_block), None);
         let bits = min_difficulty.into();
         let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
@@ -544,7 +542,7 @@ fn consensus_type() {
 
     // Block 10 should ignore consensus according to net upgrades. The following Pow block should
     // fail.
-    let prev_block = btf.get_block(btf.index_at(9).block_id().clone()).unwrap().unwrap();
+    let prev_block = btf.get_block(*btf.index_at(9).block_id()).unwrap().unwrap();
     let mut mined_block = btf.random_block(TestBlockInfo::from_block(&prev_block), None);
     let bits = min_difficulty.into();
     assert!(
@@ -563,7 +561,7 @@ fn consensus_type() {
     btf.create_chain(&prev_block.get_id().into(), 5).expect("chain creation");
 
     // At height 15 we are again proof of work, ignoring consensus should fail
-    let prev_block = btf.get_block(btf.index_at(14).block_id().clone()).unwrap().unwrap();
+    let prev_block = btf.get_block(*btf.index_at(14).block_id()).unwrap().unwrap();
     let block_without_consensus_data = produce_test_block_with_consensus_data(
         TestBlockInfo::from_block(&prev_block),
         ConsensusData::None,
@@ -578,7 +576,7 @@ fn consensus_type() {
 
     // Mining should work
     for i in 15..20 {
-        let prev_block = btf.get_block(btf.index_at(i - 1).block_id().clone()).unwrap().unwrap();
+        let prev_block = btf.get_block(*btf.index_at(i - 1).block_id()).unwrap().unwrap();
         let mut mined_block = btf.random_block(TestBlockInfo::from_block(&prev_block), None);
         let bits = min_difficulty.into();
         let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);

--- a/chainstate/src/detail/tests/reorgs_tests.rs
+++ b/chainstate/src/detail/tests/reorgs_tests.rs
@@ -139,27 +139,24 @@ fn check_spend_tx_in_failed_block(btf: &mut BlockTestFramework, events: &EventLi
     const NEW_CHAIN_END_ON: usize = 11;
 
     assert!(btf
-        .create_chain(
-            &btf.index_at(NEW_CHAIN_START_ON).block_id().clone().into(),
-            5,
-        )
+        .create_chain(&(*btf.index_at(NEW_CHAIN_START_ON).block_id()).into(), 5,)
         .is_ok());
     check_last_event(btf, events);
 
     let block = btf
         .chainstate
         .chainstate_storage
-        .get_block(btf.index_at(NEW_CHAIN_END_ON - 1).block_id().clone())
+        .get_block(*btf.index_at(NEW_CHAIN_END_ON - 1).block_id())
         .unwrap()
         .unwrap();
 
     let double_spend_block = btf.random_block(
         TestBlockInfo::from_block(&block),
-        Some(&[TestBlockParams::SpendFrom(btf.index_at(NEW_CHAIN_END_ON).block_id().clone())]),
+        Some(&[TestBlockParams::SpendFrom(*btf.index_at(NEW_CHAIN_END_ON).block_id())]),
     );
     assert!(btf.add_special_block(double_spend_block).is_ok());
     // Cause reorg on a failed block
-    assert!(btf.create_chain(&btf.index_at(12).block_id().clone().into(), 1).is_err());
+    assert!(btf.create_chain(&(*btf.index_at(12).block_id()).into(), 1).is_err());
 }
 
 fn check_spend_tx_in_other_fork(btf: &mut BlockTestFramework) {
@@ -176,20 +173,17 @@ fn check_spend_tx_in_other_fork(btf: &mut BlockTestFramework) {
     const NEW_CHAIN_START_ON: usize = 5;
     const NEW_CHAIN_END_ON: usize = 9;
     assert!(btf
-        .create_chain(
-            &btf.index_at(NEW_CHAIN_START_ON).block_id().clone().into(),
-            1
-        )
+        .create_chain(&(*btf.index_at(NEW_CHAIN_START_ON).block_id()).into(), 1)
         .is_ok());
     let block = btf
         .chainstate
         .chainstate_storage
-        .get_block(btf.index_at(NEW_CHAIN_END_ON).block_id().clone())
+        .get_block(*btf.index_at(NEW_CHAIN_END_ON).block_id())
         .unwrap()
         .unwrap();
     let double_spend_block = btf.random_block(
         TestBlockInfo::from_block(&block),
-        Some(&[TestBlockParams::SpendFrom(btf.index_at(3).block_id().clone())]),
+        Some(&[TestBlockParams::SpendFrom(*btf.index_at(3).block_id())]),
     );
     let block_id = double_spend_block.get_id();
     assert!(btf.add_special_block(double_spend_block).is_ok());
@@ -213,12 +207,12 @@ fn check_fork_that_double_spends(btf: &mut BlockTestFramework) {
     let block = btf
         .chainstate
         .chainstate_storage
-        .get_block(btf.block_indexes.last().unwrap().block_id().clone())
+        .get_block(*btf.block_indexes.last().unwrap().block_id())
         .unwrap()
         .unwrap();
     let double_spend_block = btf.random_block(
         TestBlockInfo::from_block(&block),
-        Some(&[TestBlockParams::SpendFrom(btf.index_at(6).block_id().clone())]),
+        Some(&[TestBlockParams::SpendFrom(*btf.index_at(6).block_id())]),
     );
     assert!(btf.add_special_block(double_spend_block).is_err());
 }
@@ -235,14 +229,14 @@ fn check_reorg_to_first_chain(btf: &mut BlockTestFramework, events: &EventList) 
     //                         +-- 0x67fd…6419 (H:3,B:4))
     // > H - Height, M - main chain, B - block
     //
-    let block_id: Id<GenBlock> = btf.index_at(2).block_id().clone().into();
+    let block_id: Id<GenBlock> = (*btf.index_at(2).block_id()).into();
     assert!(btf.create_chain(&block_id, 2).is_ok());
     check_last_event(btf, events);
 
     // b3
     btf.test_block(
         btf.index_at(3).block_id(),
-        &btf.index_at(1).block_id().clone().into(),
+        &(*btf.index_at(1).block_id()).into(),
         None,
         2,
         TestSpentStatus::NotInMainchain,
@@ -251,7 +245,7 @@ fn check_reorg_to_first_chain(btf: &mut BlockTestFramework, events: &EventList) 
     // b4
     btf.test_block(
         btf.index_at(4).block_id(),
-        &btf.index_at(3).block_id().clone().into(),
+        &(*btf.index_at(3).block_id()).into(),
         None,
         3,
         TestSpentStatus::NotInMainchain,
@@ -260,7 +254,7 @@ fn check_reorg_to_first_chain(btf: &mut BlockTestFramework, events: &EventList) 
     // b5
     btf.test_block(
         btf.index_at(5).block_id(),
-        &btf.index_at(2).block_id().clone().into(),
+        &(*btf.index_at(2).block_id()).into(),
         Some(btf.index_at(6).block_id()),
         3,
         TestSpentStatus::Spent,
@@ -269,7 +263,7 @@ fn check_reorg_to_first_chain(btf: &mut BlockTestFramework, events: &EventList) 
     // b6
     btf.test_block(
         btf.index_at(6).block_id(),
-        &btf.index_at(5).block_id().clone().into(),
+        &(*btf.index_at(5).block_id()).into(),
         None,
         4,
         TestSpentStatus::Unspent,
@@ -292,7 +286,7 @@ fn check_make_alternative_chain_longer(btf: &mut BlockTestFramework, events: &Ev
     let block = btf
         .chainstate
         .chainstate_storage
-        .get_block(btf.block_indexes.last().unwrap().block_id().clone())
+        .get_block(*btf.block_indexes.last().unwrap().block_id())
         .unwrap()
         .unwrap();
     let block = btf.random_block(TestBlockInfo::from_block(&block), None);
@@ -301,7 +295,7 @@ fn check_make_alternative_chain_longer(btf: &mut BlockTestFramework, events: &Ev
     // b3
     btf.test_block(
         btf.index_at(3).block_id(),
-        &btf.index_at(1).block_id().clone().into(),
+        &(*btf.index_at(1).block_id()).into(),
         Some(btf.index_at(4).block_id()),
         2,
         TestSpentStatus::Spent,
@@ -310,7 +304,7 @@ fn check_make_alternative_chain_longer(btf: &mut BlockTestFramework, events: &Ev
     // b4
     btf.test_block(
         btf.index_at(4).block_id(),
-        &btf.index_at(3).block_id().clone().into(),
+        &(*btf.index_at(3).block_id()).into(),
         None,
         3,
         TestSpentStatus::Unspent,
@@ -331,7 +325,7 @@ fn check_simple_fork(btf: &mut BlockTestFramework, events: &EventList) {
     // Don't reorg to a chain of the same length
     assert!(btf.create_chain(&btf.genesis().get_id().into(), 2).is_ok());
     check_last_event(btf, events);
-    assert!(btf.create_chain(&btf.index_at(1).block_id().clone().into(), 1).is_ok());
+    assert!(btf.create_chain(&(*btf.index_at(1).block_id()).into(), 1).is_ok());
     check_last_event(btf, events);
 
     btf.test_block(
@@ -345,7 +339,7 @@ fn check_simple_fork(btf: &mut BlockTestFramework, events: &EventList) {
     // b2
     btf.test_block(
         btf.index_at(2).block_id(),
-        &btf.index_at(1).block_id().clone().into(),
+        &(*btf.index_at(1).block_id()).into(),
         None,
         2,
         TestSpentStatus::Unspent,
@@ -354,7 +348,7 @@ fn check_simple_fork(btf: &mut BlockTestFramework, events: &EventList) {
     // b3
     btf.test_block(
         btf.index_at(3).block_id(),
-        &btf.index_at(1).block_id().clone().into(),
+        &(*btf.index_at(1).block_id()).into(),
         None,
         2,
         TestSpentStatus::NotInMainchain,

--- a/chainstate/src/detail/tests/syncing_tests.rs
+++ b/chainstate/src/detail/tests/syncing_tests.rs
@@ -95,10 +95,7 @@ fn get_headers() {
 
         // Produce more blocks. Now `get_headers` should return these blocks.
         let expected: Vec<_> = iter::from_fn(|| {
-            let block = produce_test_block(TestBlockInfo::from_id(
-                btf.chainstate(),
-                last_block_id.clone(),
-            ));
+            let block = produce_test_block(TestBlockInfo::from_id(btf.chainstate(), last_block_id));
             last_block_id = block.get_id().into();
             let header = block.header().clone();
             btf.chainstate().process_block(block, BlockSource::Peer).unwrap().unwrap();
@@ -195,12 +192,12 @@ fn get_headers_different_chains() {
 
         let locator = btf1.chainstate.get_locator().unwrap();
         let headers = btf2.chainstate.get_headers(locator).unwrap();
-        let id = headers[0].prev_block_id().clone();
+        let id = *headers[0].prev_block_id();
         let _ = btf1.get_block_index(&id); // This panics if the ID is not found
 
         let locator = btf2.chainstate.get_locator().unwrap();
         let headers = btf1.chainstate.get_headers(locator).unwrap();
-        let id = headers[0].prev_block_id().clone();
+        let id = *headers[0].prev_block_id();
         let _ = btf2.get_block_index(&id); // This panics if the ID is not found
     });
 }

--- a/chainstate/src/detail/tests/test_framework.rs
+++ b/chainstate/src/detail/tests/test_framework.rs
@@ -79,7 +79,7 @@ impl BlockTestFramework {
                         let block = self
                             .chainstate
                             .chainstate_storage
-                            .get_block(block_id.clone())
+                            .get_block(*block_id)
                             .unwrap()
                             .unwrap();
 
@@ -120,7 +120,7 @@ impl BlockTestFramework {
         parent_block_id: &Id<GenBlock>,
         count_blocks: usize,
     ) -> Result<Id<GenBlock>, BlockError> {
-        let mut test_block_info = TestBlockInfo::from_id(&self.chainstate, parent_block_id.clone());
+        let mut test_block_info = TestBlockInfo::from_id(&self.chainstate, *parent_block_id);
 
         for _ in 0..count_blocks {
             let block = produce_test_block(test_block_info);
@@ -147,7 +147,7 @@ impl BlockTestFramework {
         let tx_index = self
             .chainstate
             .chainstate_storage
-            .get_mainchain_tx_index(&OutPointSourceId::from(tx_id.clone()))
+            .get_mainchain_tx_index(&OutPointSourceId::from(*tx_id))
             .unwrap()?;
         tx_index.get_spent_state(output_index).ok()
     }
@@ -174,8 +174,7 @@ impl BlockTestFramework {
                 .chainstate_storage
                 .get_block_id_by_height(&block_height)
                 .unwrap();
-            let expected_block_id: Option<Id<GenBlock>> =
-                expected_block_id.map(|id| id.clone().into());
+            let expected_block_id: Option<Id<GenBlock>> = expected_block_id.map(|id| (*id).into());
             assert_eq!(real_next_block_id, expected_block_id);
         }
     }
@@ -194,7 +193,7 @@ impl BlockTestFramework {
                     let block = self
                         .chainstate
                         .chainstate_storage
-                        .get_block(block_index.block_id().clone())
+                        .get_block(*block_index.block_id())
                         .unwrap()
                         .unwrap();
                     for tx in block.transactions() {

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -183,7 +183,7 @@ impl Block {
 
     pub fn prev_block_id(&self) -> Id<GenBlock> {
         match &self {
-            Block::V1(blk) => blk.prev_block_id().clone(),
+            Block::V1(blk) => *blk.prev_block_id(),
         }
     }
 

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -102,7 +102,7 @@ impl ChainConfig {
     }
 
     pub fn genesis_block_id(&self) -> Id<GenBlock> {
-        self.genesis_block_id.clone()
+        self.genesis_block_id
     }
 
     pub fn genesis_block(&self) -> &Genesis {

--- a/common/src/chain/gen_block.rs
+++ b/common/src/chain/gen_block.rs
@@ -62,6 +62,7 @@ impl Id<GenBlock> {
 
 /// Classified generalized block
 // TODO: Consider if this should be used more often, or even replace Id<GenBlock>
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub enum GenBlockId {
     Genesis(Id<Genesis>),
     Block(Id<Block>),

--- a/common/src/chain/transaction/transaction_index/mod.rs
+++ b/common/src/chain/transaction/transaction_index/mod.rs
@@ -127,8 +127,8 @@ impl From<Id<GenBlock>> for SpendablePosition {
 impl SpendablePosition {
     pub fn block_id_anyway(&self) -> Id<GenBlock> {
         match self {
-            SpendablePosition::Transaction(pos) => pos.block_id().clone().into(),
-            SpendablePosition::BlockReward(id) => id.clone(),
+            SpendablePosition::Transaction(pos) => (*pos.block_id()).into(),
+            SpendablePosition::BlockReward(id) => *id,
         }
     }
 }

--- a/common/src/chain/transaction/transaction_index/tests.rs
+++ b/common/src/chain/transaction/transaction_index/tests.rs
@@ -114,13 +114,13 @@ fn basic_spending() {
     );
 
     // spend one output
-    let spend_0_res = tx_index.spend(0, tx_spending_output_0.clone().into());
+    let spend_0_res = tx_index.spend(0, tx_spending_output_0.into());
     assert!(spend_0_res.is_ok());
 
     // check state
     assert_eq!(
         tx_index.get_spent_state(0).unwrap(),
-        OutputSpentState::SpentBy(tx_spending_output_0.clone().into())
+        OutputSpentState::SpentBy(tx_spending_output_0.into())
     );
     assert_eq!(
         tx_index.get_spent_state(1).unwrap(),
@@ -135,13 +135,13 @@ fn basic_spending() {
 
     // attempt double-spend
     assert_eq!(
-        tx_index.spend(0, tx_spending_output_1.clone().into()).unwrap_err(),
-        SpendError::AlreadySpent(tx_spending_output_0.clone().into())
+        tx_index.spend(0, tx_spending_output_1.into()).unwrap_err(),
+        SpendError::AlreadySpent(tx_spending_output_0.into())
     );
 
     // spend all other outputs
-    assert!(tx_index.spend(1, tx_spending_output_1.clone().into()).is_ok());
-    assert!(tx_index.spend(2, tx_spending_output_2.clone().into()).is_ok());
+    assert!(tx_index.spend(1, tx_spending_output_1.into()).is_ok());
+    assert!(tx_index.spend(2, tx_spending_output_2.into()).is_ok());
 
     // check that all are spent
     assert!(tx_index.all_outputs_spent());
@@ -152,11 +152,11 @@ fn basic_spending() {
     );
     assert_eq!(
         tx_index.get_spent_state(1).unwrap(),
-        OutputSpentState::SpentBy(tx_spending_output_1.clone().into())
+        OutputSpentState::SpentBy(tx_spending_output_1.into())
     );
     assert_eq!(
         tx_index.get_spent_state(2).unwrap(),
-        OutputSpentState::SpentBy(tx_spending_output_2.clone().into())
+        OutputSpentState::SpentBy(tx_spending_output_2.into())
     );
 
     // unspend output 1

--- a/common/src/primitives/encoding/tests.rs
+++ b/common/src/primitives/encoding/tests.rs
@@ -230,7 +230,7 @@ fn check_valid_strings() {
             "split1checkupstagehandshakeupstreamerranterredcaperredlc445v",
             "?1v759aa",
         ).iter().for_each(|s| {
-            match super::bech32m::bech32m_to_base32(*s) {
+            match super::bech32m::bech32m_to_base32(s) {
                Ok(decoded) => {
                    match super::bech32m::base32_to_bech32m(decoded.hrp(), <&[bech32::u5]>::clone(&decoded.data())) {
                        Ok(encoded) => { assert_eq!(s.to_lowercase(), encoded.to_lowercase()) }

--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -80,6 +80,8 @@ impl<T: ?Sized> Clone for Id<T> {
     }
 }
 
+impl<T: ?Sized> Copy for Id<T> {}
+
 impl<T: ?Sized> Display for Id<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.id.fmt(f)

--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -65,7 +65,7 @@ impl<'de> serde::Deserialize<'de> for H256 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Id<T: ?Sized> {
     id: H256,
@@ -73,7 +73,14 @@ pub struct Id<T: ?Sized> {
     _shadow: std::marker::PhantomData<fn() -> T>,
 }
 
-impl<T> Display for Id<T> {
+// Implementing Clone manually to avoid the Clone constraint on T
+impl<T: ?Sized> Clone for Id<T> {
+    fn clone(&self) -> Self {
+        Self::new(self.id)
+    }
+}
+
+impl<T: ?Sized> Display for Id<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.id.fmt(f)
     }
@@ -99,7 +106,7 @@ impl<T: Eq> From<H256> for Id<T> {
     }
 }
 
-impl<T> Id<T> {
+impl<T: ?Sized> Id<T> {
     pub fn get(&self) -> H256 {
         self.id
     }
@@ -112,7 +119,7 @@ impl<T> Id<T> {
     }
 }
 
-impl<T> AsRef<[u8]> for Id<T> {
+impl<T: ?Sized> AsRef<[u8]> for Id<T> {
     fn as_ref(&self) -> &[u8] {
         &self.id[..]
     }

--- a/p2p/src/pubsub.rs
+++ b/p2p/src/pubsub.rs
@@ -240,7 +240,7 @@ where
                 block_id = block_rx.recv().fuse() => {
                     let block_id = block_id.ok_or(P2pError::ChannelClosed)?;
 
-                    match self.chainstate_handle.call(|this| this.get_block(block_id)).await?? {
+                    match self.chainstate_handle.call(move |this| this.get_block(block_id)).await?? {
                         Some(block) => self.announce_block(block).await?,
                         None => log::error!("CRITICAL: best block not available"),
                     }

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -417,7 +417,7 @@ where
                             assert_eq!(block_ids.len(), 1);
                             self.send_block_request(
                                 peer_id,
-                                block_ids.get(0).expect("block id to exist").clone(),
+                                *block_ids.get(0).expect("block id to exist"),
                                 request.retry_count + 1,
                             )
                             .await?;

--- a/p2p/src/sync/request.rs
+++ b/p2p/src/sync/request.rs
@@ -140,7 +140,7 @@ where
         );
 
         // send request to remote peer and start tracking its progress
-        let (wanted_blocks, request_type) = self.make_block_request(vec![block_id.clone()]);
+        let (wanted_blocks, request_type) = self.make_block_request(vec![block_id]);
         self.send_request(peer_id, wanted_blocks, request_type, retry_count).await?;
 
         self.peers

--- a/p2p/test-utils/src/lib.rs
+++ b/p2p/test-utils/src/lib.rs
@@ -86,7 +86,7 @@ impl TestBlockInfo {
 
     pub fn from_genesis(genesis: &Genesis) -> Self {
         let id: Id<GenBlock> = genesis.get_id().into();
-        let outsrc = OutPointSourceId::BlockReward(id.clone());
+        let outsrc = OutPointSourceId::BlockReward(id);
         let txns = vec![(outsrc, genesis.utxos().to_vec())];
         Self { txns, id }
     }
@@ -95,8 +95,8 @@ impl TestBlockInfo {
         match id.classify(config) {
             GenBlockId::Genesis(_) => Self::from_genesis(config.genesis_block()),
             GenBlockId::Block(id) => {
-                let block = ci.call(|this| this.get_block(id)).await.unwrap().unwrap().unwrap();
-                Self::from_block(&block)
+                let block = ci.call(move |this| this.get_block(id)).await.unwrap().unwrap();
+                Self::from_block(&block.unwrap())
             }
         }
     }

--- a/p2p/tests/sync.rs
+++ b/p2p/tests/sync.rs
@@ -333,7 +333,7 @@ async fn remote_ahead_by_7_blocks() {
                 request: Request::BlockRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
-                let id = request.block_ids()[0].clone();
+                let id = request.block_ids()[0];
                 let blocks = vec![mgr2_handle
                     .call(move |this| this.get_block(id))
                     .await
@@ -550,7 +550,7 @@ async fn remote_local_diff_chains_local_higher() {
                 request: Request::BlockRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
-                let id = request.block_ids()[0].clone();
+                let id = request.block_ids()[0];
                 let blocks = vec![mgr2_handle
                     .call(move |this| this.get_block(id))
                     .await
@@ -692,7 +692,7 @@ async fn remote_local_diff_chains_remote_higher() {
                 request: Request::BlockRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
-                let id = request.block_ids()[0].clone();
+                let id = request.block_ids()[0];
                 let blocks = vec![mgr2_handle
                     .call(move |this| this.get_block(id))
                     .await
@@ -839,7 +839,7 @@ async fn two_remote_nodes_different_chains() {
                 request: Request::BlockRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
-                let id = request.block_ids()[0].clone();
+                let id = request.block_ids()[0];
                 let msg = Response::BlockResponse(BlockResponse::new(vec![mgr_handle
                     .call(move |this| this.get_block(id))
                     .await
@@ -961,7 +961,7 @@ async fn two_remote_nodes_same_chains() {
                 request: Request::BlockRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
-                let id = request.block_ids()[0].clone();
+                let id = request.block_ids()[0];
                 let msg = Response::BlockResponse(BlockResponse::new(vec![mgr_handle
                     .call(move |this| this.get_block(id))
                     .await
@@ -1095,7 +1095,7 @@ async fn two_remote_nodes_same_chains_new_blocks() {
                 request: Request::BlockRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
-                let id = request.block_ids()[0].clone();
+                let id = request.block_ids()[0];
                 let msg = Response::BlockResponse(BlockResponse::new(vec![mgr_handle
                     .call(move |this| this.get_block(id))
                     .await
@@ -1208,7 +1208,7 @@ async fn test_connect_disconnect_resyncing() {
                 request: Request::BlockRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
-                let id = request.block_ids()[0].clone();
+                let id = request.block_ids()[0];
                 let blocks = vec![mgr2_handle
                     .call(move |this| this.get_block(id))
                     .await

--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -240,7 +240,7 @@ impl Script {
 
     /// Returns the script data
     pub fn as_bytes(&self) -> &[u8] {
-        &*self.0
+        &self.0
     }
 
     /// Returns a copy of the script data

--- a/utxo/src/utxo_impl/mod.rs
+++ b/utxo/src/utxo_impl/mod.rs
@@ -423,7 +423,7 @@ impl<'a> UtxosView for UtxosCache<'a> {
     }
 
     fn best_block_hash(&self) -> Option<Id<GenBlock>> {
-        self.current_block_hash.clone().or_else(||
+        self.current_block_hash.or_else(||
             // if the block_hash is empty in this view, use parent's `get_best_block_hash`.
             self.parent.and_then(|parent| parent.best_block_hash()))
     }

--- a/utxo/src/utxo_impl/utxo_storage.rs
+++ b/utxo/src/utxo_impl/utxo_storage.rs
@@ -158,12 +158,12 @@ impl UtxosPersistentStorage for UtxoInMemoryDBImpl {
         block_id: &Id<GenBlock>,
     ) -> Result<(), crate::utxo_impl::Error> {
         // TODO: fix; don't store in general block id
-        self.best_block_id = Some(block_id.clone());
+        self.best_block_id = Some(*block_id);
         Ok(())
     }
     fn get_best_block_id(&self) -> Result<Option<Id<GenBlock>>, crate::utxo_impl::Error> {
         // TODO: fix; don't get general block id
-        Ok(self.best_block_id.clone())
+        Ok(self.best_block_id)
     }
 
     fn set_undo_data(&mut self, id: Id<Block>, undo: &BlockUndo) -> Result<(), Error> {
@@ -470,7 +470,7 @@ mod test {
 
             let utxos = ConsumedUtxoCache {
                 container: utxos,
-                best_block: new_best_block_hash.clone(),
+                best_block: new_best_block_hash,
             };
 
             let mut db_interface = UtxoInMemoryDBImpl::new();


### PR DESCRIPTION
* Having to clone IDs manually is really annoying, especially since the underlying `H256` type already is copyable
* This builds on #299 and touches many of the same lines of code, so better swipe it in one go
* All changes of substance are in `common/src/primitives/id.rs`, the rest are fixes to make it work, mostly auto-applied `clippy::clone_on_copy` lint suggestions