### PR TITLE
Introduce `WithId` wrapper and use it in ChainConfig for Genesis

### DIFF
--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -153,7 +153,9 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
         block_id: &Id<GenBlock>,
     ) -> Result<Option<GenBlockIndex<'a>>, PropertyQueryError> {
         match block_id.classify(self.chain_config) {
-            GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(self.chain_config))),
+            GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(
+                self.chain_config.genesis_block(),
+            ))),
             GenBlockId::Block(id) => self.get_block_index(&id).map(|b| b.map(GenBlockIndex::Block)),
         }
     }

--- a/chainstate/src/detail/gen_block_index.rs
+++ b/chainstate/src/detail/gen_block_index.rs
@@ -15,8 +15,8 @@
 
 use chainstate_types::block_index::BlockIndex;
 use common::chain::block::{consensus_data::BlockRewardTransactable, timestamp::BlockTimestamp};
-use common::chain::{ChainConfig, GenBlock};
-use common::primitives::{BlockHeight, Id};
+use common::chain::{GenBlock, Genesis};
+use common::primitives::{id::WithId, BlockHeight, Id};
 use common::Uint256;
 
 /// Generalized block index
@@ -24,50 +24,49 @@ use common::Uint256;
 #[allow(clippy::large_enum_variant)]
 pub enum GenBlockIndex<'a> {
     Block(BlockIndex),
-    // TODO: This could contain just Genesis + pre-calculated ID
-    Genesis(&'a ChainConfig),
+    Genesis(&'a WithId<Genesis>),
 }
 
 impl<'a> GenBlockIndex<'a> {
     pub fn block_id(&self) -> Id<GenBlock> {
         match self {
             GenBlockIndex::Block(b) => (*b.block_id()).into(),
-            GenBlockIndex::Genesis(c) => c.genesis_block_id(),
+            GenBlockIndex::Genesis(g) => g.id().into(),
         }
     }
 
     pub fn block_timestamp(&self) -> BlockTimestamp {
         match self {
             GenBlockIndex::Block(b) => b.block_timestamp(),
-            GenBlockIndex::Genesis(c) => c.genesis_block().timestamp(),
+            GenBlockIndex::Genesis(g) => g.timestamp(),
         }
     }
 
     pub fn chain_timestamps_max(&self) -> BlockTimestamp {
         match self {
             GenBlockIndex::Block(b) => b.chain_timestamps_max(),
-            GenBlockIndex::Genesis(c) => c.genesis_block().timestamp(),
+            GenBlockIndex::Genesis(g) => g.timestamp(),
         }
     }
 
     pub fn block_height(&self) -> BlockHeight {
         match self {
             GenBlockIndex::Block(b) => b.block_height(),
-            GenBlockIndex::Genesis(_c) => BlockHeight::zero(),
+            GenBlockIndex::Genesis(_g) => BlockHeight::zero(),
         }
     }
 
     pub fn chain_trust(&self) -> &Uint256 {
         match self {
             GenBlockIndex::Block(b) => b.chain_trust(),
-            GenBlockIndex::Genesis(_c) => &Uint256::ZERO,
+            GenBlockIndex::Genesis(_g) => &Uint256::ZERO,
         }
     }
 
     pub fn block_reward_transactable(&self) -> BlockRewardTransactable {
         match self {
             GenBlockIndex::Block(b) => b.block_header().block_reward_transactable(),
-            GenBlockIndex::Genesis(c) => c.genesis_block().block_reward_transactable(),
+            GenBlockIndex::Genesis(g) => g.block_reward_transactable(),
         }
     }
 }

--- a/chainstate/src/detail/gen_block_index.rs
+++ b/chainstate/src/detail/gen_block_index.rs
@@ -16,7 +16,7 @@
 use chainstate_types::block_index::BlockIndex;
 use common::chain::block::{consensus_data::BlockRewardTransactable, timestamp::BlockTimestamp};
 use common::chain::{GenBlock, Genesis};
-use common::primitives::{id::WithId, BlockHeight, Id};
+use common::primitives::{id::WithId, BlockHeight, Id, Idable};
 use common::Uint256;
 
 /// Generalized block index
@@ -31,7 +31,7 @@ impl<'a> GenBlockIndex<'a> {
     pub fn block_id(&self) -> Id<GenBlock> {
         match self {
             GenBlockIndex::Block(b) => (*b.block_id()).into(),
-            GenBlockIndex::Genesis(g) => g.id().into(),
+            GenBlockIndex::Genesis(g) => g.get_id().into(),
         }
     }
 

--- a/chainstate/src/detail/spend_cache/mod.rs
+++ b/chainstate/src/detail/spend_cache/mod.rs
@@ -116,7 +116,9 @@ impl<'a, S: BlockchainStorageRead> CachedInputs<'a, S> {
         block_id: &Id<GenBlock>,
     ) -> Result<Option<GenBlockIndex<'a>>, StateUpdateError> {
         match block_id.classify(self.chain_config) {
-            GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(self.chain_config))),
+            GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(
+                self.chain_config.genesis_block(),
+            ))),
             GenBlockId::Block(id) => self
                 .db_tx
                 .get_block_index(&id)

--- a/chainstate/src/detail/tests/processing_tests.rs
+++ b/chainstate/src/detail/tests/processing_tests.rs
@@ -221,7 +221,7 @@ fn straight_chain() {
         assert_eq!(genesis_index.block_height(), BlockHeight::new(0));
 
         let chain_config_clone = chainstate.chain_config.clone();
-        let mut block_index = GenBlockIndex::Genesis(&chain_config_clone);
+        let mut block_index = GenBlockIndex::Genesis(chain_config_clone.genesis_block());
         let mut prev_block = TestBlockInfo::from_genesis(chainstate.chain_config.genesis_block());
 
         for _ in 0..random::make_pseudo_rng().gen_range(100..200) {
@@ -393,7 +393,7 @@ fn last_common_ancestor() {
     btf.create_chain(&btf.genesis().get_id().into(), SPLIT_HEIGHT)
         .expect("Chain creation to succeed");
     let config_clone = btf.chainstate.chain_config.clone();
-    let genesis = GenBlockIndex::Genesis(&config_clone);
+    let genesis = GenBlockIndex::Genesis(config_clone.genesis_block());
     let split = GenBlockIndex::Block(btf.index_at(SPLIT_HEIGHT).clone());
 
     // First branch of fork

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -19,7 +19,7 @@ use super::{create_mainnet_genesis, create_unit_test_genesis, ChainConfig, Chain
 use crate::chain::{
     ConsensusUpgrade, Destination, Genesis, NetUpgrades, PoWChainConfig, UpgradeVersion,
 };
-use crate::primitives::{semver::SemVer, BlockDistance, BlockHeight, Idable};
+use crate::primitives::{id::WithId, semver::SemVer, BlockDistance, BlockHeight};
 
 use std::collections::BTreeMap;
 use std::time::Duration;
@@ -161,6 +161,7 @@ impl Builder {
                 premine_destination,
             } => create_unit_test_genesis(premine_destination),
         };
+        let genesis_block = WithId::new(genesis_block);
 
         ChainConfig {
             chain_type,
@@ -174,7 +175,6 @@ impl Builder {
             max_block_size_with_smart_contracts,
             max_future_block_time_offset,
             target_block_spacing,
-            genesis_block_id: genesis_block.get_id().into(),
             genesis_block,
             height_checkpoint_data: BTreeMap::new(),
             emission_schedule,

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -27,7 +27,7 @@ use crate::chain::upgrades::NetUpgrades;
 use crate::chain::OutputPurpose;
 use crate::chain::{Block, GenBlock, Genesis};
 use crate::chain::{PoWChainConfig, UpgradeVersion};
-use crate::primitives::id::Id;
+use crate::primitives::id::{Id, Idable, WithId};
 use crate::primitives::semver::SemVer;
 use crate::primitives::{Amount, BlockDistance, BlockHeight};
 use std::collections::BTreeMap;
@@ -71,8 +71,7 @@ pub struct ChainConfig {
     height_checkpoint_data: BTreeMap<BlockHeight, Id<Block>>,
     net_upgrades: NetUpgrades<UpgradeVersion>,
     magic_bytes: [u8; 4],
-    genesis_block: Genesis,
-    genesis_block_id: Id<GenBlock>,
+    genesis_block: WithId<Genesis>,
     blockreward_maturity: BlockDistance,
     max_future_block_time_offset: Duration,
     version: SemVer,
@@ -90,10 +89,10 @@ impl ChainConfig {
     }
 
     pub fn genesis_block_id(&self) -> Id<GenBlock> {
-        self.genesis_block_id
+        self.genesis_block.get_id().into()
     }
 
-    pub fn genesis_block(&self) -> &Genesis {
+    pub fn genesis_block(&self) -> &WithId<Genesis> {
         &self.genesis_block
     }
 

--- a/common/src/primitives/id.rs
+++ b/common/src/primitives/id.rs
@@ -143,8 +143,8 @@ impl<T: Idable> Idable for &T {
 /// An object together with its pre-calculated ID.
 ///
 /// This only allows immutable access to the underlying object to prevent it from going out of sync
-/// with the ID, which is calculated for its contents. Getting an ID is nearly cost-free.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+/// with the ID, which is calculated for its contents. Getting an ID just returns the stored one.
+#[derive(Clone, Debug)]
 pub struct WithId<T: Idable> {
     id: Id<T::Tag>,
     object: T,
@@ -152,13 +152,18 @@ pub struct WithId<T: Idable> {
 
 impl<T: Idable> WithId<T> {
     /// Get a reference to the underlying object
-    pub fn get(&self) -> &T {
-        &self.object
+    pub fn get(this: &Self) -> &T {
+        &this.object
     }
 
     /// Get the pre-calucated object ID
-    pub fn id(&self) -> Id<T::Tag> {
-        self.id
+    pub fn id(this: &Self) -> Id<T::Tag> {
+        this.id
+    }
+
+    /// Take ownership of the underlying object
+    pub fn take(this: Self) -> T {
+        this.object
     }
 }
 
@@ -172,7 +177,7 @@ impl<T: Idable> WithId<T> {
 impl<T: Idable> Idable for WithId<T> {
     type Tag = T::Tag;
     fn get_id(&self) -> Id<Self::Tag> {
-        self.id()
+        Self::id(self)
     }
 }
 
@@ -180,7 +185,7 @@ impl<T: Idable> Idable for WithId<T> {
 impl<T: Idable> std::ops::Deref for WithId<T> {
     type Target = T;
     fn deref(&self) -> &T {
-        self.get()
+        Self::get(self)
     }
 }
 

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -15,6 +15,9 @@
 //
 // Author(s): S. Afach
 
+mod with_id;
+pub use with_id::WithId;
+
 use crate::{construct_fixed_hash, Uint256};
 use generic_array::{typenum, GenericArray};
 use serialization::{Decode, Encode};
@@ -137,55 +140,6 @@ impl<T: Idable> Idable for &T {
     type Tag = T::Tag;
     fn get_id(&self) -> Id<Self::Tag> {
         (*self).get_id()
-    }
-}
-
-/// An object together with its pre-calculated ID.
-///
-/// This only allows immutable access to the underlying object to prevent it from going out of sync
-/// with the ID, which is calculated for its contents. Getting an ID just returns the stored one.
-#[derive(Clone, Debug)]
-pub struct WithId<T: Idable> {
-    id: Id<T::Tag>,
-    object: T,
-}
-
-impl<T: Idable> WithId<T> {
-    /// Get a reference to the underlying object
-    pub fn get(this: &Self) -> &T {
-        &this.object
-    }
-
-    /// Get the pre-calucated object ID
-    pub fn id(this: &Self) -> Id<T::Tag> {
-        this.id
-    }
-
-    /// Take ownership of the underlying object
-    pub fn take(this: Self) -> T {
-        this.object
-    }
-}
-
-impl<T: Idable> WithId<T> {
-    pub fn new(object: T) -> Self {
-        let id = object.get_id();
-        Self { id, object }
-    }
-}
-
-impl<T: Idable> Idable for WithId<T> {
-    type Tag = T::Tag;
-    fn get_id(&self) -> Id<Self::Tag> {
-        Self::id(self)
-    }
-}
-
-// Implement Deref to the wrapped type but not DerefMut to prevent it from being modified.
-impl<T: Idable> std::ops::Deref for WithId<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        Self::get(self)
     }
 }
 

--- a/common/src/primitives/id/with_id.rs
+++ b/common/src/primitives/id/with_id.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+//! ID caching mechanism
+
+use super::{Id, Idable};
+
+/// An object together with its pre-calculated ID.
+///
+/// This only allows immutable access to the underlying object to prevent it from going out of sync
+/// with the ID, which is calculated for its contents. Getting an ID just returns the stored one.
+#[derive(Clone, Debug)]
+pub struct WithId<T: Idable> {
+    id: Id<T::Tag>,
+    object: T,
+}
+
+impl<T: Idable> WithId<T> {
+    /// Get a reference to the underlying object
+    pub fn get(this: &Self) -> &T {
+        &this.object
+    }
+
+    /// Get the pre-calucated object ID
+    pub fn id(this: &Self) -> Id<T::Tag> {
+        this.id
+    }
+
+    /// Take ownership of the underlying object
+    pub fn take(this: Self) -> T {
+        this.object
+    }
+}
+
+impl<T: Idable> WithId<T> {
+    pub fn new(object: T) -> Self {
+        let id = object.get_id();
+        Self { id, object }
+    }
+}
+
+impl<T: Idable> Idable for WithId<T> {
+    type Tag = T::Tag;
+    fn get_id(&self) -> Id<Self::Tag> {
+        Self::id(self)
+    }
+}
+
+impl<T: Idable> AsRef<T> for WithId<T> {
+    fn as_ref(&self) -> &T {
+        Self::get(self)
+    }
+}
+
+// Implement Deref to the wrapped type but not DerefMut to prevent it from being modified.
+impl<T: Idable> std::ops::Deref for WithId<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.as_ref()
+    }
+}


### PR DESCRIPTION
* Introduce `WithId<T>` which behaves largely like `T` but also stores the pre-calculated ID. Calling `Idable::get_id` just returns the stored result instead of serializing and hashing the object.
* Use it in `ChainConfig` for Genesis (to store genesis itself and its pre-calculated ID)
* Also adjust `GenBlockIndex` to use it
* Can be used with any `Idable` type, e.g. the likes of `WithId<Transaction>` and `WithId<Block>` should also work, but that's not taken advantage of at the moment.