### PR TITLE
net: Clean up `ConnectivityEvent` enum

### DIFF
--- a/p2p/src/net/libp2p/behaviour.rs
+++ b/p2p/src/net/libp2p/behaviour.rs
@@ -401,14 +401,14 @@ impl NetworkBehaviourEventProcess<ConnectionManagerEvent> for Libp2pBehaviour {
     fn inject_event(&mut self, event: ConnectionManagerEvent) {
         match event {
             ConnectionManagerEvent::Behaviour(event) => match event {
-                BehaviourEvent::InboundAccepted { addr, peer_info } => {
+                BehaviourEvent::InboundAccepted { address, peer_info } => {
                     self.add_event(Libp2pBehaviourEvent::Connectivity(
-                        ConnectivityEvent::IncomingConnection { addr, peer_info },
+                        ConnectivityEvent::InboundAccepted { address, peer_info },
                     ))
                 }
-                BehaviourEvent::OutboundAccepted { addr, peer_info } => {
+                BehaviourEvent::OutboundAccepted { address, peer_info } => {
                     self.add_event(Libp2pBehaviourEvent::Connectivity(
-                        ConnectivityEvent::ConnectionAccepted { addr, peer_info },
+                        ConnectivityEvent::OutboundAccepted { address, peer_info },
                     ))
                 }
                 BehaviourEvent::ConnectionClosed { peer_id } => {
@@ -416,9 +416,9 @@ impl NetworkBehaviourEventProcess<ConnectionManagerEvent> for Libp2pBehaviour {
                         ConnectivityEvent::ConnectionClosed { peer_id },
                     ))
                 }
-                BehaviourEvent::ConnectionError { addr, error } => {
+                BehaviourEvent::ConnectionError { address, error } => {
                     self.add_event(Libp2pBehaviourEvent::Connectivity(
-                        ConnectivityEvent::ConnectionError { addr, error },
+                        ConnectivityEvent::ConnectionError { address, error },
                     ))
                 }
             },

--- a/p2p/src/net/libp2p/connectivity/mod.rs
+++ b/p2p/src/net/libp2p/connectivity/mod.rs
@@ -145,7 +145,7 @@ impl ConnectionManager {
             if connection.is_outbound_pending() {
                 self.add_event(ConnectionManagerEvent::Behaviour(
                     BehaviourEvent::ConnectionError {
-                        addr: connection.addr().clone(),
+                        address: connection.addr().clone(),
                         error: P2pError::DialError(DialError::IoError(
                             std::io::ErrorKind::ConnectionRefused,
                         )),
@@ -185,7 +185,7 @@ impl ConnectionManager {
         if let Some(connection) = self.connections.remove(&peer_id) {
             self.add_event(ConnectionManagerEvent::Behaviour(
                 BehaviourEvent::ConnectionError {
-                    addr: connection.addr().clone(),
+                    address: connection.addr().clone(),
                     error: P2pError::PeerError(PeerError::BannedPeer(peer_id.to_string())),
                 },
             ));
@@ -225,7 +225,7 @@ impl ConnectionManager {
 
                 Some(ConnectionManagerEvent::Behaviour(
                     BehaviourEvent::InboundAccepted {
-                        addr: connection.addr().clone(),
+                        address: connection.addr().clone(),
                         peer_info: IdentifyInfoWrapper::new(received_info),
                     },
                 ))
@@ -236,7 +236,7 @@ impl ConnectionManager {
 
                 Some(ConnectionManagerEvent::Behaviour(
                     BehaviourEvent::OutboundAccepted {
-                        addr: connection.addr().clone(),
+                        address: connection.addr().clone(),
                         peer_info: IdentifyInfoWrapper::new(received_info),
                     },
                 ))

--- a/p2p/src/net/libp2p/connectivity/tests.rs
+++ b/p2p/src/net/libp2p/connectivity/tests.rs
@@ -227,7 +227,7 @@ async fn register_identify_info() {
         connmgr.events.front(),
         Some(&types::ConnectionManagerEvent::Behaviour(
             types::BehaviourEvent::InboundAccepted {
-                addr: Multiaddr::empty(),
+                address: Multiaddr::empty(),
                 peer_info: IdentifyInfoWrapper::new(info),
             },
         )),
@@ -254,7 +254,7 @@ async fn register_identify_info() {
         connmgr.events.front(),
         Some(&types::ConnectionManagerEvent::Behaviour(
             types::BehaviourEvent::OutboundAccepted {
-                addr: Multiaddr::empty(),
+                address: Multiaddr::empty(),
                 peer_info: IdentifyInfoWrapper::new(info),
             },
         )),
@@ -360,7 +360,7 @@ async fn handle_connection_refused() {
         connmgr.events.front(),
         Some(&types::ConnectionManagerEvent::Behaviour(
             types::BehaviourEvent::ConnectionError {
-                addr: Multiaddr::empty(),
+                address: Multiaddr::empty(),
                 error: P2pError::DialError(DialError::IoError(
                     std::io::ErrorKind::ConnectionRefused,
                 )),
@@ -447,7 +447,7 @@ async fn banned_peer() {
         connmgr.events.front(),
         Some(&types::ConnectionManagerEvent::Behaviour(
             types::BehaviourEvent::ConnectionError {
-                addr: Multiaddr::empty(),
+                address: Multiaddr::empty(),
                 error: P2pError::PeerError(PeerError::BannedPeer(peer_id.to_string())),
             },
         )),

--- a/p2p/src/net/libp2p/connectivity/types.rs
+++ b/p2p/src/net/libp2p/connectivity/types.rs
@@ -32,13 +32,13 @@ pub enum ControlEvent {
 pub enum BehaviourEvent {
     /// Inbound connection accepted
     InboundAccepted {
-        addr: Multiaddr,
+        address: Multiaddr,
         peer_info: IdentifyInfoWrapper,
     },
 
     /// Outbound connection accepted
     OutboundAccepted {
-        addr: Multiaddr,
+        address: Multiaddr,
         peer_info: IdentifyInfoWrapper,
     },
 
@@ -46,7 +46,7 @@ pub enum BehaviourEvent {
     ConnectionClosed { peer_id: PeerId },
 
     /// Connection error
-    ConnectionError { addr: Multiaddr, error: P2pError },
+    ConnectionError { address: Multiaddr, error: P2pError },
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -375,18 +375,18 @@ where
 
     async fn poll_next(&mut self) -> crate::Result<ConnectivityEvent<T>> {
         match self.conn_rx.recv().await.ok_or(P2pError::ChannelClosed)? {
-            types::ConnectivityEvent::ConnectionAccepted { addr, peer_info } => {
-                Ok(ConnectivityEvent::ConnectionAccepted {
-                    addr,
+            types::ConnectivityEvent::OutboundAccepted { address, peer_info } => {
+                Ok(ConnectivityEvent::OutboundAccepted {
+                    address,
                     peer_info: peer_info.try_into()?,
                 })
             }
-            types::ConnectivityEvent::ConnectionError { addr, error } => {
-                Ok(ConnectivityEvent::ConnectionError { addr, error })
+            types::ConnectivityEvent::ConnectionError { address, error } => {
+                Ok(ConnectivityEvent::ConnectionError { address, error })
             }
-            types::ConnectivityEvent::IncomingConnection { addr, peer_info } => {
-                Ok(ConnectivityEvent::IncomingConnection {
-                    addr,
+            types::ConnectivityEvent::InboundAccepted { address, peer_info } => {
+                Ok(ConnectivityEvent::InboundAccepted {
+                    address,
                     peer_info: peer_info.try_into()?,
                 })
             }
@@ -399,9 +399,6 @@ where
             types::ConnectivityEvent::Expired { peers } => Ok(ConnectivityEvent::Expired {
                 peers: parse_peers(peers),
             }),
-            types::ConnectivityEvent::Disconnected { peer_id } => {
-                Ok(ConnectivityEvent::Disconnected { peer_id })
-            }
             types::ConnectivityEvent::Error { peer_id, error } => {
                 Ok(ConnectivityEvent::Error { peer_id, error })
             }

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -322,7 +322,7 @@ async fn test_connect_with_timeout() {
     assert!(std::matches!(
         service.poll_next().await,
         Ok(net::types::ConnectivityEvent::ConnectionError {
-            addr: _,
+            address: _,
             error: P2pError::DialError(DialError::IoError(std::io::ErrorKind::ConnectionRefused))
         })
     ));
@@ -346,7 +346,7 @@ async fn test_connect_with_timeout() {
     assert!(std::matches!(
         service.poll_next().await,
         Ok(net::types::ConnectivityEvent::ConnectionError {
-            addr: _,
+            address: _,
             error: P2pError::DialError(DialError::IoError(std::io::ErrorKind::ConnectionRefused))
         })
     ));

--- a/p2p/src/net/libp2p/types.rs
+++ b/p2p/src/net/libp2p/types.rs
@@ -133,20 +133,20 @@ pub enum Command {
 #[derive(Debug)]
 pub enum ConnectivityEvent {
     /// Outbound connection accepted by remote
-    ConnectionAccepted {
-        addr: Multiaddr,
+    OutboundAccepted {
+        address: Multiaddr,
         peer_info: IdentifyInfoWrapper,
     },
 
     /// Inbound connection incoming
-    IncomingConnection {
-        addr: Multiaddr,
+    InboundAccepted {
+        address: Multiaddr,
         peer_info: IdentifyInfoWrapper,
     },
 
     /// Outbound connection failed
     ConnectionError {
-        addr: Multiaddr,
+        address: Multiaddr,
         error: error::P2pError,
     },
 
@@ -158,9 +158,6 @@ pub enum ConnectivityEvent {
 
     /// One or more peers that were previously discovered have expired
     Expired { peers: Vec<(PeerId, Multiaddr)> },
-
-    /// Peer disconnected from the swarm
-    Disconnected { peer_id: PeerId },
 
     /// An error occurred with a connected peer
     Error {

--- a/p2p/src/net/types.rs
+++ b/p2p/src/net/types.rs
@@ -83,18 +83,18 @@ impl<T: NetworkingService> Display for PeerInfo<T> {
 #[derive(Debug)]
 pub enum ConnectivityEvent<T: NetworkingService> {
     /// Outbound connection accepted
-    ConnectionAccepted {
+    OutboundAccepted {
         /// Peer address
-        addr: T::Address,
+        address: T::Address,
 
         /// Peer information
         peer_info: PeerInfo<T>,
     },
 
     /// Inbound connection received
-    IncomingConnection {
+    InboundAccepted {
         /// Peer address
-        addr: T::Address,
+        address: T::Address,
 
         /// Peer information
         peer_info: PeerInfo<T>,
@@ -103,7 +103,7 @@ pub enum ConnectivityEvent<T: NetworkingService> {
     /// Outbound connection failed
     ConnectionError {
         /// Address that was dialed
-        addr: T::Address,
+        address: T::Address,
 
         /// Error that occurred
         error: error::P2pError,
@@ -125,12 +125,6 @@ pub enum ConnectivityEvent<T: NetworkingService> {
     Expired {
         /// Address information
         peers: Vec<AddrInfo<T>>,
-    },
-
-    /// Peer disconnected
-    Disconnected {
-        /// Unique ID of the peer
-        peer_id: T::PeerId,
     },
 
     /// Error occurred with peer

--- a/p2p/src/swarm/tests/ban.rs
+++ b/p2p/src/swarm/tests/ban.rs
@@ -37,8 +37,8 @@ async fn ban_connected_peer() {
     let (_conn1_res, conn2_res) =
         tokio::join!(swarm1.handle.connect(addr), swarm2.handle.poll_next(),);
 
-    if let Ok(net::types::ConnectivityEvent::IncomingConnection { peer_info, addr }) = conn2_res {
-        swarm2.accept_inbound_connection(addr, peer_info).await.unwrap();
+    if let Ok(net::types::ConnectivityEvent::InboundAccepted { peer_info, address }) = conn2_res {
+        swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
     }
 
     let peer_id = *swarm1.handle_mut().peer_id();
@@ -61,8 +61,8 @@ async fn banned_peer_attempts_to_connect() {
     let (_conn1_res, conn2_res) =
         tokio::join!(swarm1.handle.connect(addr), swarm2.handle.poll_next(),);
 
-    if let Ok(net::types::ConnectivityEvent::IncomingConnection { peer_info, addr }) = conn2_res {
-        swarm2.accept_inbound_connection(addr, peer_info).await.unwrap();
+    if let Ok(net::types::ConnectivityEvent::InboundAccepted { peer_info, address }) = conn2_res {
+        swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
     }
 
     let peer_id = *swarm1.handle_mut().peer_id();
@@ -97,8 +97,8 @@ async fn connect_to_banned_peer() {
     let (_conn1_res, conn2_res) =
         tokio::join!(swarm1.handle.connect(addr), swarm2.handle.poll_next(),);
 
-    if let Ok(net::types::ConnectivityEvent::IncomingConnection { peer_info, addr }) = conn2_res {
-        swarm2.accept_inbound_connection(addr, peer_info).await.unwrap();
+    if let Ok(net::types::ConnectivityEvent::InboundAccepted { peer_info, address }) = conn2_res {
+        swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
     }
 
     let peer_id = *swarm1.handle_mut().peer_id();
@@ -119,10 +119,10 @@ async fn connect_to_banned_peer() {
     });
 
     swarm2.handle.connect(remote_addr.clone()).await.unwrap();
-    if let Ok(net::types::ConnectivityEvent::ConnectionError { addr, error }) =
+    if let Ok(net::types::ConnectivityEvent::ConnectionError { address, error }) =
         swarm2.handle.poll_next().await
     {
-        assert_eq!(remote_addr, addr);
+        assert_eq!(remote_addr, address);
         assert_eq!(
             error,
             P2pError::PeerError(PeerError::BannedPeer(remote_id.to_string()))

--- a/p2p/src/swarm/tests/tmp.rs
+++ b/p2p/src/swarm/tests/tmp.rs
@@ -52,7 +52,7 @@ async fn test_swarm_connect_libp2p() {
     assert!(std::matches!(
         swarm.handle.poll_next().await,
         Ok(net::types::ConnectivityEvent::ConnectionError {
-            addr: _,
+            address: _,
             error: P2pError::DialError(DialError::IoError(std::io::ErrorKind::ConnectionRefused))
         })
     ));
@@ -90,7 +90,7 @@ async fn test_auto_connect_libp2p() {
     assert_eq!(swarm.pending.len(), 1);
     assert!(std::matches!(
         swarm.handle.poll_next().await,
-        Ok(net::types::ConnectivityEvent::ConnectionAccepted { .. })
+        Ok(net::types::ConnectivityEvent::OutboundAccepted { .. })
     ));
 }
 
@@ -107,7 +107,7 @@ async fn connect_outbound_same_network() {
 
     assert!(std::matches!(
         swarm1.handle.poll_next().await,
-        Ok(net::types::ConnectivityEvent::ConnectionAccepted { .. })
+        Ok(net::types::ConnectivityEvent::OutboundAccepted { .. })
     ));
 }
 
@@ -173,8 +173,10 @@ async fn connect_outbound_different_network() {
     tokio::spawn(async move { swarm2.handle.poll_next().await.unwrap() });
     swarm1.handle.connect(addr).await.unwrap();
 
-    if let Ok(net::types::ConnectivityEvent::ConnectionAccepted { peer_info, addr: _ }) =
-        swarm1.handle.poll_next().await
+    if let Ok(net::types::ConnectivityEvent::OutboundAccepted {
+        peer_info,
+        address: _,
+    }) = swarm1.handle.poll_next().await
     {
         assert_ne!(peer_info.magic_bytes, *config.magic_bytes());
     }
@@ -191,9 +193,9 @@ async fn connect_inbound_same_network() {
         swarm2.handle.poll_next()
     );
     let conn2_res: net::types::ConnectivityEvent<Libp2pService> = conn2_res.unwrap();
-    if let net::types::ConnectivityEvent::IncomingConnection { peer_info, addr } = conn2_res {
+    if let net::types::ConnectivityEvent::InboundAccepted { peer_info, address } = conn2_res {
         assert_eq!(
-            swarm2.accept_inbound_connection(addr, peer_info).await,
+            swarm2.accept_inbound_connection(address, peer_info).await,
             Ok(())
         );
     } else {
@@ -218,9 +220,9 @@ async fn connect_inbound_different_network() {
     );
     let conn2_res: net::types::ConnectivityEvent<Libp2pService> = conn2_res.unwrap();
 
-    if let net::types::ConnectivityEvent::IncomingConnection { peer_info, addr } = conn2_res {
+    if let net::types::ConnectivityEvent::InboundAccepted { peer_info, address } = conn2_res {
         assert_eq!(
-            swarm2.accept_inbound_connection(addr, peer_info).await,
+            swarm2.accept_inbound_connection(address, peer_info).await,
             Err(P2pError::ProtocolError(ProtocolError::DifferentNetwork(
                 [1, 2, 3, 4],
                 *config::create_mainnet().magic_bytes(),
@@ -248,11 +250,11 @@ async fn remote_closes_connection() {
 
     assert!(std::matches!(
         conn2_res,
-        net::types::ConnectivityEvent::IncomingConnection { .. }
+        net::types::ConnectivityEvent::InboundAccepted { .. }
     ));
     assert!(std::matches!(
         swarm1.handle.poll_next().await,
-        Ok(net::types::ConnectivityEvent::ConnectionAccepted { .. })
+        Ok(net::types::ConnectivityEvent::OutboundAccepted { .. })
     ));
 
     assert_eq!(

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -106,7 +106,7 @@ where
     let (_conn1_res, conn2_res) = tokio::join!(conn1.connect(addr), conn2.poll_next());
     let conn2_res: ConnectivityEvent<T> = conn2_res.unwrap();
     let _conn1_id = match conn2_res {
-        ConnectivityEvent::IncomingConnection { peer_info, .. } => peer_info.peer_id,
+        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
         _ => panic!("invalid event received, expected incoming connection"),
     };
 }

--- a/p2p/tests/ban.rs
+++ b/p2p/tests/ban.rs
@@ -40,7 +40,7 @@ where
     let (_conn1_res, conn2_res) = tokio::join!(conn1.connect(addr), conn2.poll_next());
     let conn2_res: ConnectivityEvent<T> = conn2_res.unwrap();
     let _conn1_id = match conn2_res {
-        ConnectivityEvent::IncomingConnection { peer_info, .. } => peer_info.peer_id,
+        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
         _ => panic!("invalid event received, expected incoming connection"),
     };
 }

--- a/p2p/tests/libp2p-gossipsub.rs
+++ b/p2p/tests/libp2p-gossipsub.rs
@@ -53,7 +53,7 @@ async fn test_libp2p_gossipsub() {
     );
     let conn2_res: ConnectivityEvent<Libp2pService> = conn2_res.unwrap();
     let _conn1_id = match conn2_res {
-        ConnectivityEvent::IncomingConnection { peer_info, .. } => peer_info.peer_id,
+        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
         _ => panic!("invalid event received, expected incoming connection"),
     };
 
@@ -123,7 +123,7 @@ async fn connect_peers(
 
     let peer2_res: ConnectivityEvent<Libp2pService> = peer2_res.unwrap();
     let _peer1_id = match peer2_res {
-        ConnectivityEvent::IncomingConnection { peer_info, .. } => peer_info.peer_id,
+        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
         _ => panic!("invalid event received, expected incoming connection"),
     };
 }
@@ -282,7 +282,7 @@ async fn test_libp2p_gossipsub_too_big_message() {
     );
     let conn2_res: ConnectivityEvent<Libp2pService> = conn2_res.unwrap();
     let _conn1_id = match conn2_res {
-        ConnectivityEvent::IncomingConnection { peer_info, .. } => peer_info.peer_id,
+        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
         _ => panic!("invalid event received, expected incoming connection"),
     };
 

--- a/p2p/tests/sync.rs
+++ b/p2p/tests/sync.rs
@@ -96,7 +96,7 @@ where
     let (_conn1_res, conn2_res) = tokio::join!(conn1.connect(addr), conn2.poll_next());
     let conn2_res: ConnectivityEvent<T> = conn2_res.unwrap();
     let _conn1_id = match conn2_res {
-        ConnectivityEvent::IncomingConnection { peer_info, .. } => peer_info.peer_id,
+        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
         _ => panic!("invalid event received, expected incoming connection"),
     };
 }


### PR DESCRIPTION
Rename some events to be more logical, use consistent name for address,
and remove an old event that was not used for anything.