### PR TITLE
Change genesis block index to Arc to solve ownership issue when isolating chainstate interfaces

### DIFF
--- a/chainstate/src/detail/block_index_history_iter.rs
+++ b/chainstate/src/detail/block_index_history_iter.rs
@@ -35,7 +35,7 @@ impl<'a, H: BlockIndexHandle> BlockIndexHistoryIterator<'a, H> {
 }
 
 impl<'a, H: BlockIndexHandle> Iterator for BlockIndexHistoryIterator<'a, H> {
-    type Item = GenBlockIndex<'a>;
+    type Item = GenBlockIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
         let next_id = self.next_id.as_ref()?;

--- a/chainstate/src/detail/gen_block_index.rs
+++ b/chainstate/src/detail/gen_block_index.rs
@@ -18,16 +18,17 @@ use common::chain::block::{consensus_data::BlockRewardTransactable, timestamp::B
 use common::chain::{GenBlock, Genesis};
 use common::primitives::{id::WithId, BlockHeight, Id, Idable};
 use common::Uint256;
+use std::sync::Arc;
 
 /// Generalized block index
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum GenBlockIndex<'a> {
+pub enum GenBlockIndex {
     Block(BlockIndex),
-    Genesis(&'a WithId<Genesis>),
+    Genesis(Arc<WithId<Genesis>>),
 }
 
-impl<'a> GenBlockIndex<'a> {
+impl GenBlockIndex {
     pub fn block_id(&self) -> Id<GenBlock> {
         match self {
             GenBlockIndex::Block(b) => (*b.block_id()).into(),

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -323,7 +323,7 @@ impl Chainstate {
         self.make_db_tx_ro().get_block_index(id)
     }
 
-    pub fn get_best_block_index(&self) -> Result<Option<GenBlockIndex<'_>>, PropertyQueryError> {
+    pub fn get_best_block_index(&self) -> Result<Option<GenBlockIndex>, PropertyQueryError> {
         self.make_db_tx_ro().get_best_block_index()
     }
 

--- a/chainstate/src/detail/spend_cache/mod.rs
+++ b/chainstate/src/detail/spend_cache/mod.rs
@@ -15,7 +15,10 @@
 //
 // Author(s): S. Afach
 
-use std::collections::{btree_map::Entry, BTreeMap};
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    sync::Arc,
+};
 
 use super::gen_block_index::GenBlockIndex;
 use chainstate_storage::{BlockchainStorageRead, BlockchainStorageWrite};
@@ -114,11 +117,11 @@ impl<'a, S: BlockchainStorageRead> CachedInputs<'a, S> {
     pub fn get_gen_block_index(
         &self,
         block_id: &Id<GenBlock>,
-    ) -> Result<Option<GenBlockIndex<'a>>, StateUpdateError> {
+    ) -> Result<Option<GenBlockIndex>, StateUpdateError> {
         match block_id.classify(self.chain_config) {
-            GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(
+            GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(Arc::clone(
                 self.chain_config.genesis_block(),
-            ))),
+            )))),
             GenBlockId::Block(id) => self
                 .db_tx
                 .get_block_index(&id)

--- a/chainstate/src/detail/tests/processing_tests.rs
+++ b/chainstate/src/detail/tests/processing_tests.rs
@@ -231,7 +231,8 @@ fn straight_chain(#[case] seed: Seed) {
         assert_eq!(genesis_index.block_height(), BlockHeight::new(0));
 
         let chain_config_clone = chainstate.chain_config.clone();
-        let mut block_index = GenBlockIndex::Genesis(chain_config_clone.genesis_block());
+        let mut block_index =
+            GenBlockIndex::Genesis(Arc::clone(chain_config_clone.genesis_block()));
         let mut prev_block = TestBlockInfo::from_genesis(chainstate.chain_config.genesis_block());
 
         for _ in 0..rng.gen_range(100..200) {
@@ -420,7 +421,7 @@ fn last_common_ancestor(#[case] seed: Seed) {
     btf.create_chain(&btf.genesis().get_id().into(), SPLIT_HEIGHT, &mut rng)
         .expect("Chain creation to succeed");
     let config_clone = btf.chainstate.chain_config.clone();
-    let genesis = GenBlockIndex::Genesis(config_clone.genesis_block());
+    let genesis = GenBlockIndex::Genesis(Arc::clone(config_clone.genesis_block()));
     let split = GenBlockIndex::Block(btf.index_at(SPLIT_HEIGHT).clone());
 
     // First branch of fork

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -22,6 +22,7 @@ use crate::chain::{
 use crate::primitives::{id::WithId, semver::SemVer, BlockDistance, BlockHeight};
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 impl ChainType {
@@ -161,7 +162,7 @@ impl Builder {
                 premine_destination,
             } => create_unit_test_genesis(premine_destination),
         };
-        let genesis_block = WithId::new(genesis_block);
+        let genesis_block = Arc::new(WithId::new(genesis_block));
 
         ChainConfig {
             chain_type,

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -31,6 +31,7 @@ use crate::primitives::id::{Id, Idable, WithId};
 use crate::primitives::semver::SemVer;
 use crate::primitives::{Amount, BlockDistance, BlockHeight};
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 const DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET: Duration = Duration::from_secs(60 * 60);
@@ -71,7 +72,7 @@ pub struct ChainConfig {
     height_checkpoint_data: BTreeMap<BlockHeight, Id<Block>>,
     net_upgrades: NetUpgrades<UpgradeVersion>,
     magic_bytes: [u8; 4],
-    genesis_block: WithId<Genesis>,
+    genesis_block: Arc<WithId<Genesis>>,
     blockreward_maturity: BlockDistance,
     max_future_block_time_offset: Duration,
     version: SemVer,
@@ -92,7 +93,7 @@ impl ChainConfig {
         self.genesis_block.get_id().into()
     }
 
-    pub fn genesis_block(&self) -> &WithId<Genesis> {
+    pub fn genesis_block(&self) -> &Arc<WithId<Genesis>> {
         &self.genesis_block
     }
 


### PR DESCRIPTION
Using a reference for genesis creates an issue with traits that are supposed to isolate chainstate interface from block index accesses. Using an Arc seems to be a reasonable solution.