### PR TITLE
chainstate-storage: Make Storage generic

### DIFF
--- a/chainstate-storage/Cargo.toml
+++ b/chainstate-storage/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT"
 [dependencies]
 common = { path = '../common' }
 utxo = { path = '../utxo' }
-storage = { path = '../storage'}
+storage = { path = '../storage', features = ['inmemory'] }
 serialization = { path = "../serialization" }
-chainstate-types = {path = '../chainstate-types'}
+chainstate-types = { path = '../chainstate-types' }
 
 mockall = { version = "0.11", optional = true }
 thiserror = "1.0"

--- a/chainstate-storage/src/lib.rs
+++ b/chainstate-storage/src/lib.rs
@@ -21,16 +21,18 @@ use common::chain::OutPoint;
 use common::chain::OutPointSourceId;
 use common::chain::{Block, GenBlock};
 use common::primitives::{BlockHeight, Id};
-use storage::traits;
+use storage::{inmemory, traits};
 use utxo::{BlockUndo, Utxo};
 
+mod internal;
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
-mod store;
 mod utxo_db;
 
 pub use storage::transaction::{TransactionRo, TransactionRw};
-pub use store::Store;
+
+// Alias the in-memory store as the store used by other crates for now
+pub type Store = internal::Store<inmemory::Store<internal::Schema>>;
 
 /// Blockchain storage error
 #[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, thiserror::Error)]

--- a/chainstate-storage/src/mock.rs
+++ b/chainstate-storage/src/mock.rs
@@ -255,7 +255,7 @@ mod tests {
     #[test]
     fn use_generic_test() {
         common::concurrency::model(|| {
-            let store: crate::Store = crate::Store::new_empty().unwrap();
+            let store = crate::Store::new_empty().unwrap();
             generic_test(&store);
         });
     }

--- a/chainstate-storage/src/utxo_db.rs
+++ b/chainstate-storage/src/utxo_db.rs
@@ -15,23 +15,26 @@
 
 #![allow(dead_code)]
 
-use crate::{Error, Store, UndoRead, UndoWrite, UtxoRead, UtxoWrite};
+use crate::{internal::Store, Error, UndoRead, UndoWrite, UtxoRead, UtxoWrite};
 use common::chain::{Block, GenBlock, OutPoint};
 use common::primitives::Id;
 use utxo::{utxo_storage::UtxosPersistentStorage, BlockUndo, Utxo};
 
 #[derive(Clone)]
-pub struct UtxoDBImpl {
-    store: Store,
+pub struct UtxoDBImpl<B> {
+    store: Store<B>,
 }
 
-impl UtxoDBImpl {
-    pub fn new(store: Store) -> Self {
+impl<B> UtxoDBImpl<B> {
+    pub fn new(store: Store<B>) -> Self {
         Self { store }
     }
 }
 
-impl UtxosPersistentStorage for UtxoDBImpl {
+impl<B> UtxosPersistentStorage for UtxoDBImpl<B>
+where
+    B: for<'tx> storage::traits::Transactional<'tx, crate::internal::Schema>,
+{
     fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), utxo::Error> {
         self.store.add_utxo(outpoint, entry).map_err(|e| e.into())
     }
@@ -70,7 +73,7 @@ impl From<Error> for utxo::Error {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::store::test::create_rand_block_undo;
+    use crate::internal::test::create_rand_block_undo;
     use common::chain::{Destination, OutPoint, OutPointSourceId, OutputPurpose, TxOutput};
     use common::primitives::{Amount, BlockHeight, H256};
     use crypto::key::{KeyKind, PrivateKey};
@@ -101,7 +104,7 @@ mod test {
     #[case(Seed::from_entropy())]
     fn db_impl_test(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
-        let store = Store::new_empty().expect("should create a store");
+        let store = crate::Store::new_empty().expect("should create a store");
         let mut db_interface = UtxoDBImpl::new(store);
 
         // utxo checking

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -37,7 +37,7 @@
 //! }
 //!
 //! // Our store type is parametrized by the schema.
-//! type MyStore = storage::Store<Schema>;
+//! type MyStore = storage::inmemory::Store<Schema>;
 //!
 //! // Initialize an empty store.
 //! let mut store = MyStore::default();
@@ -84,8 +84,3 @@ pub use storage_core::*;
 // Re-export the in-memory storage
 #[cfg(feature = "inmemory")]
 pub use storage_inmemory as inmemory;
-
-// TODO Just a temporary re-export for backwards compatibility. When multiple backend functionality
-//      is implemented, users will be required to pick and initialize the backend themselves.
-#[cfg(feature = "inmemory")]
-pub use inmemory::Store;


### PR DESCRIPTION
Just another couple of tiny wee baby steps towards the support of multiple storage backends.

* Makes the implementation more agnostic to storage backend by making it generic
* The type that other crates use to interface storage is still just an alias to the in-memory storage engine. Abstracting that will be a follow-up PR.
* Also shuffles some module names around