### PR TITLE
Ignore RUSTSEC-2022-0040

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -100,4 +100,6 @@ ignore = [
     # time/chrono problems, have not been a problem in practice
     "RUSTSEC-2020-0159",
     "RUSTSEC-2020-0071",
+    # TODO: remove once mintlayer/mintlayer-core#334 is fixed
+    "RUSTSEC-2022-0040",
 ]


### PR DESCRIPTION
Add RUSTSEC-2022-0040 to ignore list.
Created an issue #334 