### PR TITLE
Replace the unmaintained tempdir dependency with tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,7 +2448,7 @@ dependencies = [
  "rpc",
  "serde",
  "subsystem",
- "tempdir",
+ "tempfile",
  "tokio",
  "toml",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -28,4 +28,4 @@ paste = "1.0"
 
 [dev-dependencies]
 assert_cmd = "2"
-tempdir = "0.3.7"
+tempfile = "3.3"

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -17,7 +17,7 @@ use std::{net::SocketAddr, path::Path, str::FromStr};
 
 use assert_cmd::Command;
 use directories::UserDirs;
-use tempfile::tempdir;
+use tempfile::TempDir;
 
 use node::{NodeConfig, RunOptions};
 
@@ -38,7 +38,7 @@ fn no_args() {
 
 #[test]
 fn create_default_config() {
-    let data_dir = tempdir().unwrap();
+    let data_dir = TempDir::new().unwrap();
 
     Command::new(BIN_NAME)
         .arg("--datadir")
@@ -70,7 +70,7 @@ fn create_default_config() {
 // Check that the config fields are overwritten by the run options.
 #[test]
 fn read_config_override_values() {
-    let data_dir = tempdir().unwrap();
+    let data_dir = TempDir::new().unwrap();
 
     Command::new(BIN_NAME)
         .arg("--datadir")
@@ -120,7 +120,7 @@ fn read_config_override_values() {
 // Check that the `--conf` option has the precedence over the default data directory value.
 #[test]
 fn custom_config_path() {
-    let temp_dir = tempdir().unwrap();
+    let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join(CONFIG_NAME);
 
     Command::new(BIN_NAME)
@@ -142,8 +142,8 @@ fn custom_config_path() {
 // Check that the `--conf` option has the precedence over the `--datadir` option.
 #[test]
 fn custom_config_path_and_data_dir() {
-    let data_dir = tempdir().unwrap();
-    let temp_dir = tempdir().unwrap();
+    let data_dir = TempDir::new().unwrap();
+    let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join(CONFIG_NAME);
 
     Command::new(BIN_NAME)

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -17,7 +17,7 @@ use std::{net::SocketAddr, path::Path, str::FromStr};
 
 use assert_cmd::Command;
 use directories::UserDirs;
-use tempdir::TempDir;
+use tempfile::tempdir;
 
 use node::{NodeConfig, RunOptions};
 
@@ -38,7 +38,7 @@ fn no_args() {
 
 #[test]
 fn create_default_config() {
-    let data_dir = TempDir::new("").unwrap();
+    let data_dir = tempdir().unwrap();
 
     Command::new(BIN_NAME)
         .arg("--datadir")
@@ -70,7 +70,7 @@ fn create_default_config() {
 // Check that the config fields are overwritten by the run options.
 #[test]
 fn read_config_override_values() {
-    let data_dir = TempDir::new("").unwrap();
+    let data_dir = tempdir().unwrap();
 
     Command::new(BIN_NAME)
         .arg("--datadir")
@@ -120,7 +120,7 @@ fn read_config_override_values() {
 // Check that the `--conf` option has the precedence over the default data directory value.
 #[test]
 fn custom_config_path() {
-    let temp_dir = TempDir::new("").unwrap();
+    let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join(CONFIG_NAME);
 
     Command::new(BIN_NAME)
@@ -142,8 +142,8 @@ fn custom_config_path() {
 // Check that the `--conf` option has the precedence over the `--datadir` option.
 #[test]
 fn custom_config_path_and_data_dir() {
-    let data_dir = TempDir::new("").unwrap();
-    let temp_dir = TempDir::new("").unwrap();
+    let data_dir = tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let config_path = temp_dir.path().join(CONFIG_NAME);
 
     Command::new(BIN_NAME)


### PR DESCRIPTION
During the discussion of the https://github.com/mintlayer/mintlayer-core/issues/334 issue I noticed that there is a warning in the cargo-deny output about using the unmaintained `tempdir` library.

Unfortunately, it is also used by our `merkletree` dependency (https://github.com/filecoin-project/merkletree/issues/108), but at least we can get rid of it locally.