### PR TITLE
Use WithId in TxMempoolEntry

### DIFF
--- a/common/src/primitives/id/with_id.rs
+++ b/common/src/primitives/id/with_id.rs
@@ -21,7 +21,7 @@ use super::{Id, Idable};
 ///
 /// This only allows immutable access to the underlying object to prevent it from going out of sync
 /// with the ID, which is calculated for its contents. Getting an ID just returns the stored one.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WithId<T: Idable> {
     id: Id<T::Tag>,
     object: T,

--- a/mempool/src/pool.rs
+++ b/mempool/src/pool.rs
@@ -14,6 +14,7 @@ use common::chain::transaction::Transaction;
 use common::chain::transaction::TxInput;
 use common::chain::OutPoint;
 use common::primitives::amount::Amount;
+use common::primitives::id::WithId;
 use common::primitives::Id;
 use common::primitives::Idable;
 use common::primitives::H256;
@@ -140,7 +141,7 @@ newtype! {
 
 #[derive(Debug, Eq, Clone)]
 struct TxMempoolEntry {
-    tx: Transaction,
+    tx: WithId<Transaction>,
     fee: Amount,
     parents: BTreeSet<Id<Transaction>>,
     children: BTreeSet<Id<Transaction>>,
@@ -157,7 +158,7 @@ impl TxMempoolEntry {
         creation_time: Time,
     ) -> TxMempoolEntry {
         Self {
-            tx,
+            tx: WithId::new(tx),
             fee,
             parents,
             children: BTreeSet::default(),
@@ -172,7 +173,7 @@ impl TxMempoolEntry {
     }
 
     fn tx_id(&self) -> Id<Transaction> {
-        self.tx.get_id()
+        WithId::id(&self.tx)
     }
 
     fn unconfirmed_parents(&self) -> impl Iterator<Item = &Id<Transaction>> {
@@ -1109,7 +1110,7 @@ where
             .txs_by_descendant_score
             .values()
             .flatten()
-            .map(|id| &self.store.get_entry(id).expect("entry").tx)
+            .map(|id| WithId::get(&self.store.get_entry(id).expect("entry").tx))
             .collect()
     }
 

--- a/mempool/src/pool/tests.rs
+++ b/mempool/src/pool/tests.rs
@@ -118,7 +118,7 @@ where
 
     fn process_block(&mut self, tx_id: &Id<Transaction>) -> anyhow::Result<()> {
         let mut chain_state = self.chain_state.clone();
-        chain_state.add_confirmed_tx(
+        chain_state.add_confirmed_tx(WithId::take(
             self.store
                 .txs_by_id
                 .get(&tx_id.get())
@@ -127,7 +127,7 @@ where
                     anyhow::anyhow!("process_block: tx {} not found in mempool", tx_id.get())
                 })?
                 .tx,
-        );
+        ));
         log::debug!("Setting tip to {:?}", chain_state);
         self.new_tip_set(chain_state);
         self.drop_transaction(tx_id);


### PR DESCRIPTION
Small refactoring of the `TxMempoolEntry` struct to make use of the `WithId` caching mechanism.