### PR TITLE
Add syncing support for mock interface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # RUST_LOG: debug
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # RUST_LOG: debug
+  RUST_LOG: debug
 
 jobs:
 

--- a/p2p/src/net/libp2p/tests/mod.rs
+++ b/p2p/src/net/libp2p/tests/mod.rs
@@ -54,6 +54,8 @@ mod mdns;
 #[cfg(test)]
 mod ping;
 #[cfg(test)]
+mod request_response;
+#[cfg(test)]
 mod swarm;
 
 #[allow(dead_code)]

--- a/p2p/src/net/libp2p/tests/request_response.rs
+++ b/p2p/src/net/libp2p/tests/request_response.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use crate::{
+    error::{P2pError, PeerError},
+    net::libp2p::tests::message_types::SyncRequest,
+    net::libp2p::types,
+};
+use futures::StreamExt;
+use libp2p::swarm::SwarmEvent;
+use p2p_test_utils::make_libp2p_addr;
+use tokio::sync::oneshot;
+
+// try to send request to an uknown peer and verify that the request is not rejected
+#[tokio::test]
+async fn request_sent_directly_but_peer_not_part_of_swarm() {
+    let (mut backend, _cmd, _conn_rx, _gossip_rx, _sync_rx) = make_libp2p(
+        common::chain::config::create_mainnet(),
+        Arc::new(Default::default()),
+        make_libp2p_addr(),
+        &[],
+    )
+    .await;
+
+    backend
+        .swarm
+        .behaviour_mut()
+        .sync
+        .send_request(&PeerId::random(), SyncRequest::new(vec![0u8; 128]));
+    assert!(std::matches!(
+        backend.swarm.select_next_some().await,
+        SwarmEvent::NewListenAddr { .. }
+    ));
+}
+
+// try to send request to peer that is not part of our swarm and verify
+// that the request is rejected by the backend
+#[tokio::test]
+async fn request_sent_but_peer_not_part_of_swarm() {
+    let (mut backend, _cmd, _conn_rx, _gossip_rx, _sync_rx) = make_libp2p(
+        common::chain::config::create_mainnet(),
+        Arc::new(Default::default()),
+        make_libp2p_addr(),
+        &[],
+    )
+    .await;
+
+    tokio::spawn(async move { backend.run().await });
+
+    let (tx, rx) = oneshot::channel();
+    _cmd.send(types::Command::SendRequest {
+        peer_id: PeerId::random(),
+        request: Box::new(SyncRequest::new(vec![0u8; 128])),
+        response: tx,
+    })
+    .unwrap();
+
+    assert_eq!(
+        rx.await.unwrap(),
+        Err(P2pError::PeerError(PeerError::PeerDoesntExist))
+    );
+}

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -73,7 +73,7 @@ where
     _marker: std::marker::PhantomData<fn() -> T>,
 }
 
-pub struct MockSyncingCodecHandle<T: NetworkingService> {
+pub struct MockSyncingMessagingHandle<T: NetworkingService> {
     /// TX channel for sending commands to mock backend
     cmd_tx: mpsc::Sender<types::Command>,
 
@@ -107,7 +107,7 @@ impl NetworkingService for MockService {
     type PubSubMessageId = MockMessageId;
     type ConnectivityHandle = MockConnectivityHandle<Self>;
     type PubSubHandle = MockPubSubHandle<Self>;
-    type SyncingMessagingHandle = MockSyncingCodecHandle<Self>;
+    type SyncingMessagingHandle = MockSyncingMessagingHandle<Self>;
 
     async fn start(
         addr: Self::Address,
@@ -275,7 +275,7 @@ where
 }
 
 #[async_trait]
-impl<T> SyncingMessagingService<T> for MockSyncingCodecHandle<T>
+impl<T> SyncingMessagingService<T> for MockSyncingMessagingHandle<T>
 where
     T: NetworkingService<PeerId = types::MockPeerId, SyncingPeerRequestId = types::MockRequestId>
         + Send,

--- a/p2p/src/net/mock/request_manager.rs
+++ b/p2p/src/net/mock/request_manager.rs
@@ -1,0 +1,227 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Request-response manager
+//!
+//! The request-response manager is responsible for handling all activity related to inbound/outbound
+//! requests/responses. When a new peer joins, it allocates a 16-bit wide request ID zone for it which
+//! it uses for the requests it sends to that particular peer.
+//!
+//! For inbound requests, the original request ID is stored inside the manager's storage and an ephemeral
+//! request ID is allocated for the request which is then forwarded to the frontend. This is to allow the
+//! remote peers to use whatever request IDs they want for book keeping while still being able to associate
+//! outbound responses with correct inbound requests.
+
+use crate::{
+    error::{P2pError, PeerError},
+    message,
+    net::mock::types,
+};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+
+#[derive(Debug, Default)]
+struct PeerContext {
+    ephemerals: HashSet<types::MockRequestId>,
+    request_id: u16,
+    base: u64,
+}
+
+impl PeerContext {
+    pub fn new(base: u64) -> Self {
+        Self {
+            base,
+            request_id: 0u16,
+            ephemerals: Default::default(),
+        }
+    }
+
+    pub fn allocate_request_id(&mut self) -> types::MockRequestId {
+        let id = self.base + self.request_id as u64;
+        self.request_id = self.request_id.overflowing_add(1).0;
+        types::MockRequestId::new(id)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct RequestManager {
+    /// Registered peers
+    peers: HashMap<types::MockPeerId, PeerContext>,
+
+    /// Pending outbound requests (TODO: timeouts)
+    _pending: HashMap<types::MockRequestId, types::MockRequestId>,
+
+    /// Request ID zone for allocating unique IDs for peers
+    req_id_zone: u64,
+
+    /// Next ephemeral request ID
+    next_ephemeral: types::MockRequestId,
+
+    /// Ephemeral requests IDs which are mapped to remote peer ID/request ID pair
+    ephemeral: HashMap<types::MockRequestId, (types::MockPeerId, types::MockRequestId)>,
+}
+
+impl RequestManager {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Register peer to the request manager
+    ///
+    /// Initialize peer context and allocate request ID slice for the peer
+    pub fn register_peer(&mut self, peer_id: types::MockPeerId) -> crate::Result<()> {
+        match self.peers.entry(peer_id) {
+            Entry::Occupied(_) => Err(P2pError::PeerError(PeerError::PeerAlreadyExists)),
+            Entry::Vacant(entry) => {
+                entry.insert(PeerContext::new(self.req_id_zone));
+                self.req_id_zone =
+                    self.req_id_zone.checked_add(0x10000).expect("number of peers to be lower");
+                Ok(())
+            }
+        }
+    }
+
+    /// Unregister peer from the request manager
+    pub fn unregister_peer(&mut self, peer_id: &types::MockPeerId) {
+        if let Some(context) = self.peers.remove(peer_id) {
+            context.ephemerals.iter().for_each(|id| {
+                self.ephemeral.remove(id);
+            });
+        }
+    }
+
+    /// Create new outgoing request
+    ///
+    /// Allocate peer-specific request ID, create new request and return
+    /// both of them to the caller.
+    pub fn make_request(
+        &mut self,
+        peer_id: &types::MockPeerId,
+        request: message::Request,
+    ) -> crate::Result<(types::MockRequestId, Box<types::Message>)> {
+        let peer = self
+            .peers
+            .get_mut(peer_id)
+            .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
+
+        let request_id = peer.allocate_request_id();
+
+        Ok((
+            request_id,
+            Box::new(types::Message::Request {
+                request_id,
+                request,
+            }),
+        ))
+    }
+
+    /// Create new outgoing response
+    ///
+    /// Use the assigned ephemeral ID to fetch the peer ID and the actual request ID
+    /// of the remote node and return all information to the caller.
+    pub fn make_response(
+        &mut self,
+        request_id: &types::MockRequestId,
+        response: message::Response,
+    ) -> Option<(types::MockPeerId, Box<types::Message>)> {
+        if let Some((peer_id, request_id)) = self.ephemeral.remove(request_id) {
+            return Some((
+                peer_id,
+                Box::new(types::Message::Response {
+                    request_id,
+                    response,
+                }),
+            ));
+        }
+
+        None
+    }
+
+    /// Register inbound request
+    ///
+    /// The request ID is stored into a temporary storage holding all pending
+    /// inbound requests.
+    pub fn register_request(
+        &mut self,
+        peer_id: &types::MockPeerId,
+        request_id: &types::MockRequestId,
+        _request: &message::Request,
+    ) -> crate::Result<types::MockRequestId> {
+        let peer = self
+            .peers
+            .get_mut(peer_id)
+            .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
+
+        let ephemeral_id = self.next_ephemeral;
+        self.next_ephemeral = types::MockRequestId::new(*ephemeral_id + 1);
+
+        peer.ephemerals.insert(ephemeral_id);
+        self.ephemeral.insert(ephemeral_id, (*peer_id, *request_id));
+        Ok(ephemeral_id)
+    }
+
+    /// Register inbound response
+    pub fn register_response(
+        &mut self,
+        _peer_id: &types::MockPeerId,
+        _request_id: &types::MockRequestId,
+        _response: &message::Response,
+    ) -> crate::Result<()> {
+        // TODO: implement request timeouts
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // verify that there are no request id collisions in adjacent zones
+    #[test]
+    fn request_id_collision() {
+        let mut mgr = RequestManager::new();
+
+        let peer1 = types::MockPeerId::random();
+        let peer2 = types::MockPeerId::random();
+
+        mgr.register_peer(peer1).unwrap();
+        mgr.register_peer(peer2).unwrap();
+
+        // peers have different zones
+        assert_eq!(mgr.peers.get(&peer1).unwrap().base, 0);
+        assert_eq!(mgr.peers.get(&peer1).unwrap().request_id, 0);
+
+        assert_eq!(mgr.peers.get(&peer2).unwrap().base, 0x10000);
+        assert_eq!(mgr.peers.get(&peer2).unwrap().request_id, 0);
+
+        // allocate request ids from the full range
+        let peer1 = mgr.peers.get_mut(&peer1).unwrap();
+
+        for i in 0..0xffff {
+            assert_eq!(
+                types::MockRequestId::new(i as u64),
+                peer1.allocate_request_id()
+            );
+        }
+
+        // allocate the last request id and verify it's `0xffff`
+        assert_eq!(
+            types::MockRequestId::new(0xffff),
+            peer1.allocate_request_id()
+        );
+
+        // overflow the counter and verify that the request id has rolled to zero
+        assert_eq!(types::MockRequestId::new(0), peer1.allocate_request_id());
+    }
+}

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -107,13 +107,12 @@ impl MockRequestId {
     pub fn new(request_id: u64) -> Self {
         Self(request_id)
     }
-}
 
-impl std::ops::Deref for MockRequestId {
-    type Target = u64;
+    pub fn fetch_and_inc(&mut self) -> Self {
+        let id = self.0;
+        self.0 += 1;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        Self(id)
     }
 }
 

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -166,7 +166,7 @@ where
     async fn poll_next(&mut self) -> crate::Result<types::PubSubEvent<T>>;
 }
 
-/// [SyncingCodecService] provides an interface for sending and receiving block
+/// [SyncingMessagingService] provides an interface for sending and receiving block
 /// and header requests with a remote peer.
 #[async_trait]
 pub trait SyncingMessagingService<T>

--- a/p2p/src/pubsub.rs
+++ b/p2p/src/pubsub.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 use chainstate::{
     ban_score::BanScore,
-    chainstate_interface, BlockError,
+    chainstate_interface,
     ChainstateError::{FailedToInitializeChainstate, FailedToReadProperty, ProcessBlockError},
 };
 use common::{
@@ -115,7 +115,6 @@ where
         Ok(rx)
     }
 
-    /// Process block announcement from the network
     async fn process_block_announcement(
         &mut self,
         peer_id: T::PeerId,
@@ -135,41 +134,13 @@ where
             Err(err) => Err(err),
         };
 
-        let (validation_result, score) = match result {
-            Ok(_) => (ValidationResult::Accept, 0),
-            Err(ProcessBlockError(ref block_error)) => match block_error {
-                err @ BlockError::BlockAlreadyExists(_id) => {
-                    (ValidationResult::Accept, err.ban_score())
-                }
-                err @ BlockError::StorageError(_) => (ValidationResult::Ignore, err.ban_score()),
-                err @ BlockError::BestBlockLoadError(_) => {
-                    (ValidationResult::Ignore, err.ban_score())
-                }
-                err @ BlockError::InvariantErrorFailedToFindNewChainPath(_, _, _) => {
-                    (ValidationResult::Ignore, err.ban_score())
-                }
-                err @ BlockError::InvariantErrorInvalidTip => {
-                    (ValidationResult::Ignore, err.ban_score())
-                }
-                err @ BlockError::DatabaseCommitError(_, _, _) => {
-                    (ValidationResult::Ignore, err.ban_score())
-                }
-                err @ BlockError::OrphanCheckFailed(_err) => {
-                    (ValidationResult::Ignore, err.ban_score())
-                }
-                err @ BlockError::CheckBlockFailed(_err) => {
-                    (ValidationResult::Reject, err.ban_score())
-                }
-                err @ BlockError::StateUpdateFailed(_err) => {
-                    (ValidationResult::Ignore, err.ban_score())
-                }
-                err @ BlockError::PrevBlockNotFound => (ValidationResult::Reject, err.ban_score()),
-                err @ BlockError::BlockProofCalculationError(_) => {
-                    (ValidationResult::Reject, err.ban_score())
-                }
+        let score = match result {
+            Ok(_) => 0,
+            Err(e) => match e {
+                FailedToInitializeChainstate(_) => 0,
+                ProcessBlockError(err) => err.ban_score(),
+                FailedToReadProperty(_) => 0,
             },
-            Err(FailedToInitializeChainstate(_)) => (ValidationResult::Ignore, 0),
-            Err(FailedToReadProperty(_)) => (ValidationResult::Ignore, 0),
         };
 
         if score > 0 {
@@ -182,7 +153,7 @@ where
         }
 
         self.pubsub_handle
-            .report_validation_result(peer_id, message_id, validation_result)
+            .report_validation_result(peer_id, message_id, ValidationResult::Ignore)
             .await
     }
 

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -31,10 +31,7 @@ use common::{
 };
 use futures::FutureExt;
 use logging::log;
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{mpsc, oneshot};
 use utils::ensure;
 
@@ -142,17 +139,26 @@ where
 
     /// Register peer to the `SyncManager`
     pub async fn register_peer(&mut self, peer_id: T::PeerId) -> crate::Result<()> {
-        match self.peers.entry(peer_id) {
-            Entry::Occupied(_) => Err(P2pError::PeerError(PeerError::PeerAlreadyExists)),
-            Entry::Vacant(entry) => {
-                let locator = self.chainstate_handle.call(|this| this.get_locator()).await??;
-                entry.insert(peer::PeerContext::new_with_locator(
-                    peer_id,
-                    locator.clone(),
-                ));
-                self.send_header_request(peer_id, locator, 0).await
-            }
-        }
+        ensure!(
+            !self.peers.contains_key(&peer_id),
+            P2pError::PeerError(PeerError::PeerAlreadyExists),
+        );
+
+        let locator = self.chainstate_handle.call(|this| this.get_locator()).await??;
+
+        self.send_request(
+            peer_id,
+            message::Request::HeaderListRequest(message::HeaderListRequest::new(locator.clone())),
+            request::RequestType::GetHeaders,
+            0,
+        )
+        .await
+        .map(|_| {
+            self.peers.insert(
+                peer_id,
+                peer::PeerContext::new_with_locator(peer_id, locator),
+            );
+        })
     }
 
     /// Unregister peer from the `SyncManager`
@@ -429,6 +435,7 @@ where
         Ok(())
     }
 
+    // TODO: refactor this
     pub async fn handle_error(
         &mut self,
         peer_id: T::PeerId,

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -169,10 +169,12 @@ where
     /// Process header request
     pub async fn process_header_request(
         &mut self,
-        _peer_id: T::PeerId,
+        peer_id: T::PeerId,
         request_id: T::SyncingPeerRequestId,
         locator: Locator,
     ) -> crate::Result<()> {
+        log::debug!("send header response to peer {peer_id}, request_id: {request_id:?}");
+
         // TODO: check if remote has already asked for these headers?
         let headers = self.chainstate_handle.call(move |this| this.get_headers(locator)).await??;
         self.send_header_response(request_id, headers).await

--- a/p2p/src/sync/request.rs
+++ b/p2p/src/sync/request.rs
@@ -137,6 +137,10 @@ where
             P2pError::PeerError(PeerError::PeerDoesntExist),
         );
 
+        log::trace!(
+            "send block request to {peer_id}, retry count {retry_count}, block id {block_id}"
+        );
+
         // send request to remote peer and start tracking its progress
         let (wanted_blocks, request_type) = self.make_block_request(vec![block_id]);
         self.send_request(peer_id, wanted_blocks, request_type, retry_count).await?;
@@ -168,6 +172,8 @@ where
             P2pError::PeerError(PeerError::PeerDoesntExist),
         );
 
+        log::trace!("send header request to {peer_id}, retry count {retry_count}");
+
         // send header request and start tracking its progress
         let (wanted_headers, request_type) = self.make_header_request(locator.clone());
         self.send_request(peer_id, wanted_headers, request_type, retry_count).await?;
@@ -192,6 +198,8 @@ where
         request_id: T::SyncingPeerRequestId,
         headers: Vec<BlockHeader>,
     ) -> crate::Result<()> {
+        log::trace!("send header response, request id {request_id:?}");
+
         // TODO: save sent header IDs somewhere and validate future requests against those?
         let message = self.make_header_response(headers);
         self.peer_sync_handle.send_response(request_id, message).await
@@ -210,6 +218,8 @@ where
         request_id: T::SyncingPeerRequestId,
         blocks: Vec<Block>,
     ) -> crate::Result<()> {
+        log::trace!("send block response, request id {request_id:?}");
+
         // TODO: save sent block IDs somewhere and validate future requests against those?
         let message = self.make_block_response(blocks);
         self.peer_sync_handle.send_response(request_id, message).await

--- a/p2p/src/sync/request.rs
+++ b/p2p/src/sync/request.rs
@@ -98,7 +98,7 @@ where
     /// * `request` - [`crate::message::Request`] containing the request
     /// * `request_type` - [`RequestType`] indicating the type, used for tracking progress
     /// * `retry_count` - how many times the request has been resent
-    async fn send_request(
+    pub async fn send_request(
         &mut self,
         peer_id: T::PeerId,
         request: message::Request,

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -37,14 +37,16 @@ async fn valid_block() {
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     let blocks = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),
         TestBlockInfo::from_genesis(config.genesis_block()),
         1,
     );
+
     let first = blocks[0].header().clone();
     mgr.peers
         .get_mut(&peer_id)
@@ -64,8 +66,9 @@ async fn valid_block_invalid_state() {
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     let blocks = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),
@@ -86,8 +89,9 @@ async fn valid_block_resubmitted_chainstate() {
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     let blocks = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),
@@ -117,8 +121,9 @@ async fn invalid_block() {
 
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     let mut blocks = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -39,7 +39,9 @@ async fn peer_doesnt_exist_libp2p() {
     peer_doesnt_exist::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn peer_doesnt_exist_mock() {
     peer_doesnt_exist::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -78,7 +80,9 @@ async fn valid_block_libp2p() {
     valid_block::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn valid_block_mock() {
     valid_block::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -111,7 +115,9 @@ async fn valid_block_invalid_state_libp2p() {
     valid_block_invalid_state::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn valid_block_invalid_state_mock() {
     valid_block_invalid_state::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -154,7 +160,9 @@ async fn valid_block_resubmitted_chainstate_libp2p() {
     valid_block_resubmitted_chainstate::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn valid_block_resubmitted_chainstate_mock() {
     valid_block_resubmitted_chainstate::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -199,7 +207,9 @@ async fn invalid_block_libp2p() {
     invalid_block::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn invalid_block_mock() {
     invalid_block::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }

--- a/p2p/src/sync/tests/connection.rs
+++ b/p2p/src/sync/tests/connection.rs
@@ -16,16 +16,6 @@
 use super::*;
 use p2p_test_utils::make_libp2p_addr;
 
-// handle peer connection event
-#[tokio::test]
-async fn test_peer_connected() {
-    let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-
-    assert_eq!(mgr.register_peer(PeerId::random()).await, Ok(()));
-    assert_eq!(mgr.peers.len(), 1);
-}
-
 // handle peer reconnection
 #[tokio::test]
 async fn test_peer_reconnected() {
@@ -33,7 +23,8 @@ async fn test_peer_reconnected() {
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
 
     let peer_id = PeerId::random();
-    assert_eq!(mgr.register_peer(peer_id).await, Ok(()));
+    register_peer(&mut mgr, peer_id).await;
+
     assert_eq!(mgr.peers.len(), 1);
     assert_eq!(
         mgr.register_peer(peer_id).await,
@@ -49,8 +40,7 @@ async fn test_peer_disconnected() {
 
     // send Connected event to SyncManager
     let peer_id = PeerId::random();
-
-    assert_eq!(mgr.register_peer(peer_id).await, Ok(()));
+    register_peer(&mut mgr, peer_id).await;
     assert_eq!(mgr.peers.len(), 1);
 
     // no peer with this id exist, nothing happens

--- a/p2p/src/sync/tests/connection.rs
+++ b/p2p/src/sync/tests/connection.rs
@@ -39,7 +39,9 @@ async fn test_peer_reconnected_libp2p() {
     test_peer_reconnected::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn test_peer_reconnected_mock() {
     test_peer_reconnected::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -71,7 +73,9 @@ async fn test_peer_disconnected_libp2p() {
         .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn test_peer_disconnected_mock() {
     test_peer_disconnected::<MockService>(
         make_mock_addr(),

--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -24,7 +24,7 @@ async fn too_many_headers() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),
@@ -47,7 +47,7 @@ async fn empty_response() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     assert_eq!(
         mgr.validate_header_response(&peer_id, vec![]).await,
@@ -64,7 +64,7 @@ async fn valid_response() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),
@@ -91,7 +91,7 @@ async fn header_doesnt_attach_to_local_chain() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),
@@ -117,7 +117,7 @@ async fn headers_not_in_order() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     let mut headers = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),
@@ -144,7 +144,7 @@ async fn invalid_state() {
     let (mut mgr, _conn, _sync, _pubsub, _swarm) =
         make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
     let peer_id = PeerId::random();
-    mgr.register_peer(peer_id).await.unwrap();
+    register_peer(&mut mgr, peer_id).await;
 
     mgr.peers.get_mut(&peer_id).unwrap().set_state(peer::PeerSyncState::Unknown);
 

--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -14,16 +14,19 @@
 // limitations under the License.
 
 use super::*;
+use crate::net::mock::{types::MockPeerId, MockService};
 use crypto::random::{Rng, SliceRandom};
-use p2p_test_utils::{make_libp2p_addr, TestBlockInfo};
+use p2p_test_utils::{make_libp2p_addr, make_mock_addr, TestBlockInfo};
 
 // response contains more than 2000 headers
-#[tokio::test]
-async fn too_many_headers() {
+async fn too_many_headers<T>(addr: T::Address, peer_id: T::PeerId)
+where
+    T: NetworkingService + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
     let config = Arc::new(common::chain::config::create_unit_test_config());
-    let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let peer_id = PeerId::random();
+    let (mut mgr, _conn, _sync, _pubsub, _swarm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
@@ -41,12 +44,24 @@ async fn too_many_headers() {
     );
 }
 
-// header response is empty
 #[tokio::test]
-async fn empty_response() {
-    let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let peer_id = PeerId::random();
+async fn too_many_headers_libp2p() {
+    too_many_headers::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
+}
+
+#[tokio::test]
+async fn too_many_headers_mock() {
+    too_many_headers::<MockService>(make_mock_addr(), MockPeerId::random()).await;
+}
+
+// header response is empty
+async fn empty_response<T>(addr: T::Address, peer_id: T::PeerId)
+where
+    T: NetworkingService + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
+    let (mut mgr, _conn, _sync, _pubsub, _swarm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     assert_eq!(
@@ -55,15 +70,27 @@ async fn empty_response() {
     );
 }
 
-// valid response with headers in order and the first header attaching to local chain
 #[tokio::test]
-async fn valid_response() {
+async fn empty_response_libp2p() {
+    empty_response::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
+}
+
+#[tokio::test]
+async fn empty_response_mock() {
+    empty_response::<MockService>(make_mock_addr(), MockPeerId::random()).await;
+}
+
+// valid response with headers in order and the first header attaching to local chain
+async fn valid_response<T>(addr: T::Address, peer_id: T::PeerId)
+where
+    T: NetworkingService + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let peer_id = PeerId::random();
+    let (mut mgr, _conn, _sync, _pubsub, _swarm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
@@ -82,15 +109,27 @@ async fn valid_response() {
     );
 }
 
-// the first header doesn't attach to local chain
 #[tokio::test]
-async fn header_doesnt_attach_to_local_chain() {
+async fn valid_response_libp2p() {
+    valid_response::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
+}
+
+#[tokio::test]
+async fn valid_response_mock() {
+    valid_response::<MockService>(make_mock_addr(), MockPeerId::random()).await;
+}
+
+// the first header doesn't attach to local chain
+async fn header_doesnt_attach_to_local_chain<T>(addr: T::Address, peer_id: T::PeerId)
+where
+    T: NetworkingService + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let peer_id = PeerId::random();
+    let (mut mgr, _conn, _sync, _pubsub, _swarm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
@@ -108,15 +147,29 @@ async fn header_doesnt_attach_to_local_chain() {
     );
 }
 
-// valid headers but they are not in order
 #[tokio::test]
-async fn headers_not_in_order() {
+async fn header_doesnt_attach_to_local_chain_libp2p() {
+    header_doesnt_attach_to_local_chain::<Libp2pService>(make_libp2p_addr(), PeerId::random())
+        .await;
+}
+
+#[tokio::test]
+async fn header_doesnt_attach_to_local_chain_mock() {
+    header_doesnt_attach_to_local_chain::<MockService>(make_mock_addr(), MockPeerId::random())
+        .await;
+}
+
+// valid headers but they are not in order
+async fn headers_not_in_order<T>(addr: T::Address, peer_id: T::PeerId)
+where
+    T: NetworkingService + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let peer_id = PeerId::random();
+    let (mut mgr, _conn, _sync, _pubsub, _swarm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let mut headers = p2p_test_utils::create_n_blocks(
@@ -135,15 +188,27 @@ async fn headers_not_in_order() {
     );
 }
 
-// peer state is incorrect to be sending header responses
 #[tokio::test]
-async fn invalid_state() {
+async fn headers_not_in_order_libp2p() {
+    headers_not_in_order::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
+}
+
+#[tokio::test]
+async fn headers_not_in_order_mock() {
+    headers_not_in_order::<MockService>(make_mock_addr(), MockPeerId::random()).await;
+}
+
+// peer state is incorrect to be sending header responses
+async fn invalid_state<T>(addr: T::Address, peer_id: T::PeerId)
+where
+    T: NetworkingService + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let peer_id = PeerId::random();
+    let (mut mgr, _conn, _sync, _pubsub, _swarm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     mgr.peers.get_mut(&peer_id).unwrap().set_state(peer::PeerSyncState::Unknown);
@@ -163,14 +228,37 @@ async fn invalid_state() {
     );
 }
 
-// peer doesn't exist
 #[tokio::test]
-async fn peer_doesnt_exist() {
-    let (mut mgr, _conn, _sync, _pubsub, _swarm) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+async fn invalid_state_libp2p() {
+    invalid_state::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
+}
+
+#[tokio::test]
+async fn invalid_state_mock() {
+    invalid_state::<MockService>(make_mock_addr(), MockPeerId::random()).await;
+}
+
+// peer doesn't exist
+async fn peer_doesnt_exist<T>(addr: T::Address, peer_id: T::PeerId)
+where
+    T: NetworkingService + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
+    let (mut mgr, _conn, _sync, _pubsub, _swarm) = make_sync_manager::<T>(addr).await;
 
     assert_eq!(
-        mgr.validate_header_response(&PeerId::random(), vec![]).await,
+        mgr.validate_header_response(&peer_id, vec![]).await,
         Err(P2pError::PeerError(PeerError::PeerDoesntExist)),
     );
+}
+
+#[tokio::test]
+async fn peer_doesnt_exist_libp2p() {
+    peer_doesnt_exist::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
+}
+
+#[tokio::test]
+async fn peer_doesnt_exist_mock() {
+    peer_doesnt_exist::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }

--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -49,7 +49,9 @@ async fn too_many_headers_libp2p() {
     too_many_headers::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn too_many_headers_mock() {
     too_many_headers::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -75,7 +77,9 @@ async fn empty_response_libp2p() {
     empty_response::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn empty_response_mock() {
     empty_response::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -114,7 +118,9 @@ async fn valid_response_libp2p() {
     valid_response::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn valid_response_mock() {
     valid_response::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -153,7 +159,9 @@ async fn header_doesnt_attach_to_local_chain_libp2p() {
         .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn header_doesnt_attach_to_local_chain_mock() {
     header_doesnt_attach_to_local_chain::<MockService>(make_mock_addr(), MockPeerId::random())
         .await;
@@ -193,7 +201,9 @@ async fn headers_not_in_order_libp2p() {
     headers_not_in_order::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn headers_not_in_order_mock() {
     headers_not_in_order::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -233,7 +243,9 @@ async fn invalid_state_libp2p() {
     invalid_state::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn invalid_state_mock() {
     invalid_state::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }
@@ -258,7 +270,9 @@ async fn peer_doesnt_exist_libp2p() {
     peer_doesnt_exist::<Libp2pService>(make_libp2p_addr(), PeerId::random()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn peer_doesnt_exist_mock() {
     peer_doesnt_exist::<MockService>(make_mock_addr(), MockPeerId::random()).await;
 }

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -115,3 +115,16 @@ pub async fn connect_services<T>(
         Err(_err) => panic!("did not receive `OutboundAccepted` in time"),
     }
 }
+
+async fn register_peer<T>(mgr: &mut BlockSyncManager<T>, peer_id: T::PeerId)
+where
+    T: NetworkingService,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
+    let locator = mgr.chainstate_handle.call(|this| this.get_locator()).await.unwrap().unwrap();
+
+    mgr.peers.insert(
+        peer_id,
+        peer::PeerContext::new_with_locator(peer_id, locator),
+    );
+}

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -89,7 +89,7 @@ pub async fn connect_services<T>(
     conn1: &mut T::ConnectivityHandle,
     conn2: &mut T::ConnectivityHandle,
 ) where
-    T: NetworkingService + std::fmt::Debug,
+    T: NetworkingService + std::fmt::Debug + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
 {
     let addr = timeout(Duration::from_secs(5), conn2.local_addr())

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -14,20 +14,22 @@
 // limitations under the License.
 
 use super::*;
-use crate::message::*;
-use p2p_test_utils::make_libp2p_addr;
+use crate::{message::*, net::mock::MockService};
+use p2p_test_utils::{make_libp2p_addr, make_mock_addr};
 use std::{collections::HashSet, time::Duration};
 use tokio::time::timeout;
 
-#[tokio::test]
-async fn test_request_response() {
-    let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+async fn test_request_response<T>(addr1: T::Address, addr2: T::Address)
+where
+    T: NetworkingService + std::fmt::Debug + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
+    let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) = make_sync_manager::<T>(addr1).await;
+    let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) = make_sync_manager::<T>(addr2).await;
 
     // connect the two managers together so that they can exchange messages
-    connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
+    connect_services::<T>(&mut conn1, &mut conn2).await;
 
     mgr1.peer_sync_handle
         .send_request(
@@ -61,14 +63,26 @@ async fn test_request_response() {
 }
 
 #[tokio::test]
-async fn test_multiple_requests_and_responses() {
-    let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+async fn test_request_response_libp2p() {
+    test_request_response::<Libp2pService>(make_libp2p_addr(), make_libp2p_addr()).await;
+}
+
+#[tokio::test]
+async fn test_request_response_mock() {
+    test_request_response::<MockService>(make_mock_addr(), make_mock_addr()).await;
+}
+
+async fn test_multiple_requests_and_responses<T>(addr1: T::Address, addr2: T::Address)
+where
+    T: NetworkingService + 'static + std::fmt::Debug,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
+    let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) = make_sync_manager::<T>(addr1).await;
+    let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) = make_sync_manager::<T>(addr2).await;
 
     // connect the two managers together so that they can exchange messages
-    connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
+    connect_services::<T>(&mut conn1, &mut conn2).await;
     let mut request_ids = HashSet::new();
 
     let id = mgr1
@@ -126,17 +140,30 @@ async fn test_multiple_requests_and_responses() {
     assert!(request_ids.is_empty());
 }
 
+#[tokio::test]
+async fn test_multiple_requests_and_responses_libp2p() {
+    test_multiple_requests_and_responses::<Libp2pService>(make_libp2p_addr(), make_libp2p_addr())
+        .await;
+}
+
+#[tokio::test]
+async fn test_multiple_requests_and_responses_mock() {
+    test_multiple_requests_and_responses::<MockService>(make_mock_addr(), make_mock_addr()).await;
+}
+
 // receive getheaders before receiving `Connected` event from swarm manager
 // which makes the request to be rejected and to time out in the sender end
-#[tokio::test]
-async fn test_request_timeout_error() {
-    let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+async fn test_request_timeout_error<T>(addr1: T::Address, addr2: T::Address)
+where
+    T: NetworkingService + 'static + std::fmt::Debug,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
+    let (mut mgr1, mut conn1, _sync1, _pubsub1, _swarm1) = make_sync_manager::<T>(addr1).await;
+    let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) = make_sync_manager::<T>(addr2).await;
 
     // connect the two managers together so that they can exchange messages
-    connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
+    connect_services::<T>(&mut conn1, &mut conn2).await;
     let peer2_id = *conn2.peer_id();
 
     tokio::spawn(async move {
@@ -180,20 +207,32 @@ async fn test_request_timeout_error() {
     }
 }
 
+#[tokio::test]
+async fn test_request_timeout_error_libp2p() {
+    test_request_timeout_error::<Libp2pService>(make_libp2p_addr(), make_libp2p_addr()).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_request_timeout_error_mock() {
+    test_request_timeout_error::<MockService>(make_mock_addr(), make_mock_addr()).await;
+}
+
 // verify that if after three retries the remote peer still
 // hasn't responded to our request, the connection is closed
 //
 // marked as ignored as it takes quite a long time to complete
-#[ignore]
-#[tokio::test]
-async fn request_timeout() {
-    let (mut mgr1, mut conn1, _sync1, _pubsub1, mut swarm_rx) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
-    let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) =
-        make_sync_manager::<Libp2pService>(make_libp2p_addr()).await;
+async fn request_timeout<T>(addr1: T::Address, addr2: T::Address)
+where
+    T: NetworkingService + 'static + std::fmt::Debug,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    T::SyncingMessagingHandle: SyncingMessagingService<T>,
+{
+    let (mut mgr1, mut conn1, _sync1, _pubsub1, mut swarm_rx) = make_sync_manager::<T>(addr1).await;
+    let (mut mgr2, mut conn2, _sync2, _pubsub2, _swarm2) = make_sync_manager::<T>(addr2).await;
 
     // connect the two managers together so that they can exchange messages
-    connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
+    connect_services::<T>(&mut conn1, &mut conn2).await;
     let _peer2_id = *conn2.peer_id();
 
     tokio::spawn(async move {
@@ -227,4 +266,16 @@ async fn request_timeout() {
             Ok(net::types::SyncingEvent::Request { .. } | net::types::SyncingEvent::Error { .. })
         ));
     }
+}
+
+#[tokio::test]
+#[ignore]
+async fn request_timeout_libp2p() {
+    request_timeout::<Libp2pService>(make_libp2p_addr(), make_libp2p_addr()).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn request_timeout_mock() {
+    request_timeout::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -67,7 +67,9 @@ async fn test_request_response_libp2p() {
     test_request_response::<Libp2pService>(make_libp2p_addr(), make_libp2p_addr()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn test_request_response_mock() {
     test_request_response::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }
@@ -146,7 +148,9 @@ async fn test_multiple_requests_and_responses_libp2p() {
         .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn test_multiple_requests_and_responses_mock() {
     test_multiple_requests_and_responses::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }

--- a/p2p/tests/sync.rs
+++ b/p2p/tests/sync.rs
@@ -246,7 +246,9 @@ async fn local_and_remote_in_sync_libp2p() {
     local_and_remote_in_sync::<Libp2pService>(make_libp2p_addr(), make_libp2p_addr()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn local_and_remote_in_sync_mock() {
     local_and_remote_in_sync::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }
@@ -352,7 +354,9 @@ async fn remote_ahead_by_7_blocks_libp2p() {
     remote_ahead_by_7_blocks::<Libp2pService>(make_libp2p_addr(), make_libp2p_addr()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn remote_ahead_by_7_blocks_mock() {
     remote_ahead_by_7_blocks::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }
@@ -480,7 +484,9 @@ async fn local_ahead_by_12_blocks_libp2p() {
     local_ahead_by_12_blocks::<Libp2pService>(make_libp2p_addr(), make_libp2p_addr()).await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn local_ahead_by_12_blocks_mock() {
     local_ahead_by_12_blocks::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }
@@ -635,7 +641,9 @@ async fn remote_local_diff_chains_local_higher_libp2p() {
         .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn remote_local_diff_chains_local_higher_mock() {
     remote_local_diff_chains_local_higher::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }
@@ -790,7 +798,9 @@ async fn remote_local_diff_chains_remote_higher_libp2p() {
         .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn remote_local_diff_chains_remote_higher_mock() {
     remote_local_diff_chains_remote_higher::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }
@@ -915,7 +925,9 @@ async fn two_remote_nodes_different_chains_libp2p() {
     .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn two_remote_nodes_different_chains_mock() {
     two_remote_nodes_different_chains::<MockService>(
         make_mock_addr(),
@@ -1058,7 +1070,9 @@ async fn two_remote_nodes_same_chains_libp2p() {
     .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn two_remote_nodes_same_chains_mock() {
     two_remote_nodes_same_chains::<MockService>(
         make_mock_addr(),
@@ -1215,7 +1229,9 @@ async fn two_remote_nodes_same_chains_new_blocks_libp2p() {
     .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn two_remote_nodes_same_chains_new_blocks_mock() {
     two_remote_nodes_same_chains_new_blocks::<MockService>(
         make_mock_addr(),
@@ -1347,7 +1363,9 @@ async fn test_connect_disconnect_resyncing_libp2p() {
         .await;
 }
 
+// TODO: fix https://github.com/mintlayer/mintlayer-core/issues/375
 #[tokio::test]
+#[cfg(not(target_os = "macos"))]
 async fn test_connect_disconnect_resyncing_mock() {
     test_connect_disconnect_resyncing::<MockService>(make_mock_addr(), make_mock_addr()).await;
 }


### PR DESCRIPTION
Add request-response support for the mock interface and rewrite all syncing-related tests to be executed both with mock interface and libp2p.