### PR TITLE
Fix WithId equality issue

### DIFF
--- a/common/src/chain/transaction.rs
+++ b/common/src/chain/transaction.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::primitives::{Id, Idable};
+use crate::primitives::{id::WithId, Id, Idable};
 use serialization::{DirectDecode, DirectEncode, Encode};
 use thiserror::Error;
 
@@ -52,6 +52,14 @@ impl Idable for Transaction {
         }
     }
 }
+
+impl PartialEq for WithId<Transaction> {
+    fn eq(&self, other: &Self) -> bool {
+        WithId::get(self) == WithId::get(other)
+    }
+}
+
+impl Eq for WithId<Transaction> {}
 
 #[derive(Error, Debug, Clone)]
 pub enum TransactionCreationError {

--- a/common/src/primitives/id/with_id.rs
+++ b/common/src/primitives/id/with_id.rs
@@ -21,7 +21,7 @@ use super::{Id, Idable};
 ///
 /// This only allows immutable access to the underlying object to prevent it from going out of sync
 /// with the ID, which is calculated for its contents. Getting an ID just returns the stored one.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub struct WithId<T: Idable> {
     id: Id<T::Tag>,
     object: T,


### PR DESCRIPTION
As per our earlier discussion, a generic WithId should not have equality derived, but the developer should decide whether they want to compare the id or the object by getting its reference. Since the equality of WithId of transactions is used in mempool entries, I implemented equality for WithId of transactions.

All done from my smart phone on a hotel bed 😅... I feel the urgency for this change because I don't want anyone to build upon it. 