### PR TITLE
Add timeout for connection establishment in P2P tests

### DIFF
--- a/p2p/src/net/libp2p/behaviour.rs
+++ b/p2p/src/net/libp2p/behaviour.rs
@@ -61,12 +61,12 @@ use std::{
     poll_method = "poll"
 )]
 pub struct Libp2pBehaviour {
+    pub connmgr: connectivity::ConnectionManager,
+    pub identify: identify::Identify,
+    pub discovery: discovery::DiscoveryManager,
     pub gossipsub: Gossipsub,
     pub ping: ping::Behaviour,
-    pub identify: identify::Identify,
     pub sync: RequestResponse<SyncingCodec>,
-    pub connmgr: connectivity::ConnectionManager,
-    pub discovery: discovery::DiscoveryManager,
 
     #[behaviour(ignore)]
     pub events: VecDeque<Libp2pBehaviourEvent>,

--- a/p2p/src/net/libp2p/tests/mod.rs
+++ b/p2p/src/net/libp2p/tests/mod.rs
@@ -38,7 +38,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time::timeout};
 
 #[cfg(test)]
 mod frontend;
@@ -247,7 +247,11 @@ pub async fn make_libp2p_with_ping(
 
 async fn get_address<T: NetworkBehaviour>(swarm: &mut Swarm<T>) -> Multiaddr {
     loop {
-        if let SwarmEvent::NewListenAddr { address, .. } = swarm.select_next_some().await {
+        if let SwarmEvent::NewListenAddr { address, .. } =
+            timeout(Duration::from_secs(5), swarm.select_next_some())
+                .await
+                .expect("event to be received")
+        {
             return address;
         }
     }
@@ -262,7 +266,7 @@ where
     let addr = get_address::<A>(swarm1).await;
 
     for _ in 0..3 {
-        swarm2.dial(addr.clone()).expect("swarm dial failed");
+        swarm2.dial(addr.clone()).expect("dial to succeed");
 
         loop {
             tokio::select! {

--- a/p2p/src/swarm/tests/ban.rs
+++ b/p2p/src/swarm/tests/ban.rs
@@ -16,7 +16,7 @@
 use crate::{
     error::{P2pError, PeerError},
     net::{self, libp2p::Libp2pService, mock::MockService, ConnectivityService, NetworkingService},
-    swarm::tests::make_peer_manager,
+    swarm::tests::{connect_services, make_peer_manager},
 };
 use common::chain::config;
 use libp2p::Multiaddr;
@@ -26,7 +26,7 @@ use std::sync::Arc;
 // ban peer whose connected to us
 async fn ban_connected_peer<T>(addr1: T::Address, addr2: T::Address)
 where
-    T: NetworkingService + 'static,
+    T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
     <<T as net::NetworkingService>::Address as std::str::FromStr>::Err: std::fmt::Debug,
@@ -35,13 +35,8 @@ where
     let mut swarm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
     let mut swarm2 = make_peer_manager::<T>(addr2, config).await;
 
-    let addr = swarm2.handle.local_addr().await.unwrap().unwrap();
-    let (_conn1_res, conn2_res) =
-        tokio::join!(swarm1.handle.connect(addr), swarm2.handle.poll_next(),);
-
-    if let Ok(net::types::ConnectivityEvent::InboundAccepted { peer_info, address }) = conn2_res {
-        swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
-    }
+    let (address, peer_info) = connect_services::<T>(&mut swarm1.handle, &mut swarm2.handle).await;
+    swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
 
     let peer_id = *swarm1.handle_mut().peer_id();
     assert_eq!(swarm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
@@ -74,13 +69,8 @@ where
     let mut swarm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
     let mut swarm2 = make_peer_manager::<T>(addr2, config).await;
 
-    let addr = swarm2.handle.local_addr().await.unwrap().unwrap();
-    let (_conn1_res, conn2_res) =
-        tokio::join!(swarm1.handle.connect(addr), swarm2.handle.poll_next(),);
-
-    if let Ok(net::types::ConnectivityEvent::InboundAccepted { peer_info, address }) = conn2_res {
-        swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
-    }
+    let (address, peer_info) = connect_services::<T>(&mut swarm1.handle, &mut swarm2.handle).await;
+    swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
 
     let peer_id = *swarm1.handle_mut().peer_id();
     assert_eq!(swarm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
@@ -116,7 +106,7 @@ async fn banned_peer_attempts_to_connect_mock() {
 // attempt to connect to banned peer
 async fn connect_to_banned_peer<T>(addr1: T::Address, addr2: T::Address)
 where
-    T: NetworkingService + 'static,
+    T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
     <<T as net::NetworkingService>::Address as std::str::FromStr>::Err: std::fmt::Debug,
@@ -125,13 +115,8 @@ where
     let mut swarm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
     let mut swarm2 = make_peer_manager::<T>(addr2, config).await;
 
-    let addr = swarm2.handle.local_addr().await.unwrap().unwrap();
-    let (_conn1_res, conn2_res) =
-        tokio::join!(swarm1.handle.connect(addr), swarm2.handle.poll_next(),);
-
-    if let Ok(net::types::ConnectivityEvent::InboundAccepted { peer_info, address }) = conn2_res {
-        swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
-    }
+    let (address, peer_info) = connect_services::<T>(&mut swarm1.handle, &mut swarm2.handle).await;
+    swarm2.accept_inbound_connection(address, peer_info).await.unwrap();
 
     let peer_id = *swarm1.handle_mut().peer_id();
     assert_eq!(swarm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
@@ -391,10 +376,7 @@ where
     )
     .await;
 
-    let addr = swarm2.handle.local_addr().await.unwrap().unwrap();
-    let (_conn1_res, conn2_res) =
-        tokio::join!(swarm1.handle.connect(addr), swarm2.handle.poll_next());
-    let _conn2_res: net::types::ConnectivityEvent<T> = conn2_res.unwrap();
+    connect_services::<T>(&mut swarm1.handle, &mut swarm2.handle).await;
     let swarm1_id = *swarm1.handle.peer_id();
 
     // run the first peer manager in the background and poll events from the peer manager

--- a/p2p/src/swarm/tests/mod.rs
+++ b/p2p/src/swarm/tests/mod.rs
@@ -18,11 +18,15 @@ mod connections;
 mod peerdb;
 
 use crate::{
-    net::{ConnectivityService, NetworkingService},
+    net::{
+        types::{ConnectivityEvent, PeerInfo},
+        ConnectivityService, NetworkingService,
+    },
     swarm::PeerManager,
     P2pConfig,
 };
-use std::{fmt::Debug, str::FromStr, sync::Arc};
+use std::{fmt::Debug, str::FromStr, sync::Arc, time::Duration};
+use tokio::time::timeout;
 
 async fn make_peer_manager<T>(
     addr: T::Address,
@@ -46,4 +50,38 @@ where
 
     let p2p_config = Arc::new(P2pConfig::new());
     PeerManager::<T>::new(Arc::clone(&config), p2p_config, conn, rx, tx_sync)
+}
+
+async fn connect_services<T>(
+    conn1: &mut T::ConnectivityHandle,
+    conn2: &mut T::ConnectivityHandle,
+) -> (T::Address, PeerInfo<T>)
+where
+    T: NetworkingService + std::fmt::Debug,
+    T::ConnectivityHandle: ConnectivityService<T>,
+{
+    let addr = timeout(Duration::from_secs(5), conn2.local_addr())
+        .await
+        .expect("local address fetch not to timeout")
+        .unwrap()
+        .unwrap();
+    conn1.connect(addr).await.expect("dial to succeed");
+
+    let (address, peer_info) = match timeout(Duration::from_secs(5), conn2.poll_next()).await {
+        Ok(event) => match event.unwrap() {
+            ConnectivityEvent::InboundAccepted { address, peer_info } => (address, peer_info),
+            event => panic!("expected `InboundAccepted`, got {event:?}"),
+        },
+        Err(_err) => panic!("did not receive `InboundAccepted` in time"),
+    };
+
+    match timeout(Duration::from_secs(5), conn1.poll_next()).await {
+        Ok(event) => match event.unwrap() {
+            ConnectivityEvent::OutboundAccepted { .. } => {}
+            event => panic!("expected `OutboundAccepted`, got {event:?}"),
+        },
+        Err(_err) => panic!("did not receive `OutboundAccepted` in time"),
+    }
+
+    (address, peer_info)
 }

--- a/p2p/tests/libp2p-gossipsub.rs
+++ b/p2p/tests/libp2p-gossipsub.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use p2p_test_utils::make_libp2p_addr;
-
 use common::chain::{
     block::{consensus_data::ConsensusData, timestamp::BlockTimestamp, Block},
     transaction::Transaction,
@@ -25,11 +23,12 @@ use p2p::{
     message::Announcement,
     net::{
         self,
-        libp2p::{Libp2pConnectivityHandle, Libp2pService},
-        types::{ConnectivityEvent, PubSubEvent, PubSubTopic},
-        ConnectivityService, NetworkingService, PubSubService,
+        libp2p::Libp2pService,
+        types::{PubSubEvent, PubSubTopic},
+        NetworkingService, PubSubService,
     },
 };
+use p2p_test_utils::{connect_services, make_libp2p_addr};
 use serialization::Encode;
 use std::sync::Arc;
 
@@ -46,15 +45,7 @@ async fn test_libp2p_gossipsub() {
             .await
             .unwrap();
 
-    let (_conn1_res, conn2_res) = tokio::join!(
-        conn1.connect(conn2.local_addr().await.unwrap().unwrap()),
-        conn2.poll_next()
-    );
-    let conn2_res: ConnectivityEvent<Libp2pService> = conn2_res.unwrap();
-    let _conn1_id = match conn2_res {
-        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
-        _ => panic!("invalid event received, expected incoming connection"),
-    };
+    connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
 
     pubsub1.subscribe(&[net::types::PubSubTopic::Blocks]).await.unwrap();
     pubsub2.subscribe(&[net::types::PubSubTopic::Blocks]).await.unwrap();
@@ -113,20 +104,6 @@ async fn test_libp2p_gossipsub() {
     assert_eq!(block.timestamp(), BlockTimestamp::from_int_seconds(1338u64));
 }
 
-async fn connect_peers(
-    peer1: &mut Libp2pConnectivityHandle<Libp2pService>,
-    peer2: &mut Libp2pConnectivityHandle<Libp2pService>,
-) {
-    let addr = peer2.local_addr().await.unwrap().unwrap();
-    let (_peer1_res, peer2_res) = tokio::join!(peer1.connect(addr), peer2.poll_next());
-
-    let peer2_res: ConnectivityEvent<Libp2pService> = peer2_res.unwrap();
-    let _peer1_id = match peer2_res {
-        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
-        _ => panic!("invalid event received, expected incoming connection"),
-    };
-}
-
 // test libp2p gossipsub with multiple peers and verify that as our libp2p requires message
 // validation, peers don't automatically forward the messages
 #[tokio::test]
@@ -155,9 +132,9 @@ async fn test_libp2p_gossipsub_3_peers() {
     };
 
     // connect peers into a partial mesh
-    connect_peers(&mut conn1, &mut peer1.0).await;
-    connect_peers(&mut peer1.0, &mut peer2.0).await;
-    connect_peers(&mut peer2.0, &mut peer3.0).await;
+    connect_services::<Libp2pService>(&mut conn1, &mut peer1.0).await;
+    connect_services::<Libp2pService>(&mut peer1.0, &mut peer2.0).await;
+    connect_services::<Libp2pService>(&mut peer2.0, &mut peer3.0).await;
 
     pubsub1.subscribe(&[PubSubTopic::Blocks]).await.unwrap();
     peer1.1.subscribe(&[PubSubTopic::Blocks]).await.unwrap();
@@ -275,15 +252,7 @@ async fn test_libp2p_gossipsub_too_big_message() {
             .await
             .unwrap();
 
-    let (_conn1_res, conn2_res) = tokio::join!(
-        conn1.connect(conn2.local_addr().await.unwrap().unwrap()),
-        conn2.poll_next()
-    );
-    let conn2_res: ConnectivityEvent<Libp2pService> = conn2_res.unwrap();
-    let _conn1_id = match conn2_res {
-        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
-        _ => panic!("invalid event received, expected incoming connection"),
-    };
+    connect_services::<Libp2pService>(&mut conn1, &mut conn2).await;
 
     pubsub1.subscribe(&[PubSubTopic::Blocks]).await.unwrap();
     pubsub2.subscribe(&[PubSubTopic::Blocks]).await.unwrap();

--- a/p2p/tests/sync.rs
+++ b/p2p/tests/sync.rs
@@ -29,7 +29,7 @@ use p2p::{
     sync::SyncManager,
     sync::SyncState,
 };
-use p2p_test_utils::{make_libp2p_addr, TestBlockInfo};
+use p2p_test_utils::{connect_services, make_libp2p_addr, TestBlockInfo};
 use std::{
     collections::{HashSet, VecDeque},
     sync::Arc,
@@ -72,32 +72,6 @@ where
         rx_pubsub,
         rx_swarm,
     )
-}
-
-async fn get_address<T>(handle: &mut T::ConnectivityHandle) -> T::Address
-where
-    T: NetworkingService,
-    T::ConnectivityHandle: ConnectivityService<T>,
-{
-    loop {
-        if let Some(addr) = handle.local_addr().await.unwrap() {
-            return addr;
-        }
-    }
-}
-
-async fn connect_services<T>(conn1: &mut T::ConnectivityHandle, conn2: &mut T::ConnectivityHandle)
-where
-    T: NetworkingService,
-    T::ConnectivityHandle: ConnectivityService<T>,
-{
-    let addr = get_address::<T>(conn2).await;
-    let (_conn1_res, conn2_res) = tokio::join!(conn1.connect(addr), conn2.poll_next());
-    let conn2_res: ConnectivityEvent<T> = conn2_res.unwrap();
-    let _conn1_id = match conn2_res {
-        ConnectivityEvent::InboundAccepted { peer_info, .. } => peer_info.peer_id,
-        _ => panic!("invalid event received, expected incoming connection"),
-    };
 }
 
 // initialize two blockchains which have the same longest chain
@@ -1156,6 +1130,10 @@ async fn test_connect_disconnect_resyncing() {
     assert_eq!(conn1.disconnect(*conn2.peer_id()).await, Ok(()));
     assert!(std::matches!(
         conn2.poll_next().await,
+        Ok(ConnectivityEvent::ConnectionClosed { .. })
+    ));
+    assert!(std::matches!(
+        conn1.poll_next().await,
         Ok(ConnectivityEvent::ConnectionClosed { .. })
     ));
 


### PR DESCRIPTION
Couple all `poll_next()` calls with `tokio::time::timeout` so tests in CI don't hang in case the connection establishment fails