### PR TITLE
chainstate: Make generic w.r.t. the storage backend

### DIFF
--- a/chainstate-storage/src/internal/mod.rs
+++ b/chainstate-storage/src/internal/mod.rs
@@ -102,7 +102,7 @@ impl<'tx, B: traits::Transactional<'tx, Schema>> crate::Transactional<'tx> for S
     }
 }
 
-impl<B: for<'tx> traits::Transactional<'tx, Schema>> BlockchainStorage for Store<B> {}
+impl<B: for<'tx> traits::Transactional<'tx, Schema> + Send> BlockchainStorage for Store<B> {}
 
 macro_rules! delegate_to_transaction {
     ($(fn $f:ident $args:tt -> $ret:ty;)*) => {

--- a/chainstate-storage/src/internal/test.rs
+++ b/chainstate-storage/src/internal/test.rs
@@ -23,7 +23,7 @@ use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
 use utxo::{BlockUndo, TxUndo};
 
-type TestStore = Store<storage::inmemory::Store<Schema>>;
+type TestStore = crate::inmemory::Store;
 
 #[test]
 fn test_storage_get_default_version_in_tx() {

--- a/chainstate-storage/src/internal/utxo_db.rs
+++ b/chainstate-storage/src/internal/utxo_db.rs
@@ -50,7 +50,7 @@ mod test {
     #[case(Seed::from_entropy())]
     fn db_impl_test(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
-        let mut store = crate::Store::new_empty().expect("should create a store");
+        let mut store = crate::inmemory::Store::new_empty().expect("should create a store");
         store
             .set_best_block_for_utxos(&H256::random().into())
             .expect("Setting best block cannot fail");

--- a/chainstate-storage/src/lib.rs
+++ b/chainstate-storage/src/lib.rs
@@ -20,22 +20,24 @@ use common::chain::transaction::{Transaction, TxMainChainIndex, TxMainChainPosit
 use common::chain::OutPointSourceId;
 use common::chain::{Block, GenBlock};
 use common::primitives::{BlockHeight, Id};
-use storage::{inmemory, traits};
+use storage::traits;
 use utxo::utxo_storage::{UtxosStorageRead, UtxosStorageWrite};
 
 mod internal;
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
 
-pub use internal::utxo_db;
+pub use internal::{utxo_db, Store};
 pub use storage::transaction::{TransactionRo, TransactionRw};
-
-// Alias the in-memory store as the store used by other crates for now
-pub type Store = internal::Store<inmemory::Store<internal::Schema>>;
 
 /// Possibly failing result of blockchain storage query
 pub type Result<T> = chainstate_types::storage_result::Result<T>;
 pub type Error = chainstate_types::storage_result::Error;
+
+pub mod inmemory {
+    use crate::internal;
+    pub type Store = internal::Store<storage::inmemory::Store<internal::Schema>>;
+}
 
 /// Queries on persistent blockchain data
 pub trait BlockchainStorageRead: UtxosStorageRead {
@@ -119,4 +121,4 @@ pub trait Transactional<'t> {
     fn transaction_rw<'s: 't>(&'s self) -> Self::TransactionRw;
 }
 
-pub trait BlockchainStorage: BlockchainStorageWrite + for<'tx> Transactional<'tx> {}
+pub trait BlockchainStorage: BlockchainStorageWrite + for<'tx> Transactional<'tx> + Send {}

--- a/chainstate-storage/src/mock.rs
+++ b/chainstate-storage/src/mock.rs
@@ -221,6 +221,8 @@ mod tests {
     };
     use storage::traits::{TransactionRo, TransactionRw};
 
+    type TestStore = crate::inmemory::Store;
+
     const TXFAIL: crate::Error =
         crate::Error::Storage(storage::error::Recoverable::TransactionFailed);
     const HASH1: H256 = H256([0x01; 32]);
@@ -296,7 +298,7 @@ mod tests {
     #[test]
     fn use_generic_test() {
         common::concurrency::model(|| {
-            let store = crate::Store::new_empty().unwrap();
+            let store = TestStore::new_empty().unwrap();
             generic_test(&store);
         });
     }
@@ -362,7 +364,7 @@ mod tests {
     #[test]
     fn attach_to_top_real_storage() {
         common::concurrency::model(|| {
-            let mut store = crate::Store::new_empty().unwrap();
+            let mut store = TestStore::new_empty().unwrap();
             let (_block0, block1) = sample_data();
             let _result = attach_block_to_top(&mut store, &block1);
         });

--- a/chainstate/src/chainstate_interface_impl.rs
+++ b/chainstate/src/chainstate_interface_impl.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chainstate_storage::BlockchainStorage;
 use common::{
     chain::block::{Block, BlockHeader, GenBlock},
     primitives::{BlockHeight, Id},
@@ -24,17 +25,17 @@ use crate::{
     ChainstateError, ChainstateEvent, ChainstateInterface, Locator,
 };
 
-pub struct ChainstateInterfaceImpl {
-    chainstate: detail::Chainstate,
+pub struct ChainstateInterfaceImpl<S> {
+    chainstate: detail::Chainstate<S>,
 }
 
-impl ChainstateInterfaceImpl {
-    pub fn new(chainstate: detail::Chainstate) -> Self {
+impl<S> ChainstateInterfaceImpl<S> {
+    pub fn new(chainstate: detail::Chainstate<S>) -> Self {
         Self { chainstate }
     }
 }
 
-impl ChainstateInterface for ChainstateInterfaceImpl {
+impl<S: BlockchainStorage> ChainstateInterface for ChainstateInterfaceImpl<S> {
     fn subscribe_to_events(&mut self, handler: EventHandler<ChainstateEvent>) {
         self.chainstate.subscribe_to_events(handler)
     }

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -45,7 +45,7 @@ mod test {
     use crate::{detail::time_getter::TimeGetter, BlockSource, Chainstate, ChainstateConfig};
 
     use super::*;
-    use chainstate_storage::Store;
+    use chainstate_storage::inmemory::Store;
     use common::{
         chain::{
             block::{

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{detail::orphan_blocks::OrphanBlocksPool, ChainstateConfig, ChainstateEvent};
-use chainstate_storage::Transactional;
+use chainstate_storage::{BlockchainStorage, Transactional};
 use chainstate_types::block_index::BlockIndex;
 use common::chain::config::ChainConfig;
 use common::chain::{block::BlockHeader, Block, GenBlock};
@@ -45,8 +45,8 @@ mod gen_block_index;
 
 use gen_block_index::GenBlockIndex;
 
-type TxRw<'a> = <chainstate_storage::Store as Transactional<'a>>::TransactionRw;
-type TxRo<'a> = <chainstate_storage::Store as Transactional<'a>>::TransactionRo;
+type TxRw<'a, S> = <S as Transactional<'a>>::TransactionRw;
+type TxRo<'a, S> = <S as Transactional<'a>>::TransactionRo;
 type ChainstateEventHandler = EventHandler<ChainstateEvent>;
 
 const HEADER_LIMIT: BlockDistance = BlockDistance::new(2000);
@@ -59,10 +59,10 @@ pub mod time_getter;
 use time_getter::TimeGetter;
 
 #[must_use]
-pub struct Chainstate {
+pub struct Chainstate<S> {
     chain_config: Arc<ChainConfig>,
     chainstate_config: ChainstateConfig,
-    chainstate_storage: chainstate_storage::Store,
+    chainstate_storage: S,
     orphan_blocks: OrphanBlocksPool,
     custom_orphan_error_hook: Option<Arc<OrphanErrorHandler>>,
     events_controller: EventsController<ChainstateEvent>,
@@ -75,14 +75,14 @@ pub enum BlockSource {
     Local,
 }
 
-impl Chainstate {
+impl<S: BlockchainStorage> Chainstate<S> {
     #[allow(dead_code)]
     pub fn wait_for_all_events(&self) {
         self.events_controller.wait_for_all_events();
     }
 
     #[must_use]
-    fn make_db_tx(&mut self) -> chainstateref::ChainstateRef<TxRw, OrphanBlocksRefMut> {
+    fn make_db_tx(&mut self) -> chainstateref::ChainstateRef<TxRw<'_, S>, OrphanBlocksRefMut> {
         let db_tx = self.chainstate_storage.transaction_rw();
         chainstateref::ChainstateRef::new_rw(
             &self.chain_config,
@@ -94,7 +94,7 @@ impl Chainstate {
     }
 
     #[must_use]
-    fn make_db_tx_ro(&self) -> chainstateref::ChainstateRef<TxRo, OrphanBlocksRef> {
+    fn make_db_tx_ro(&self) -> chainstateref::ChainstateRef<TxRo<'_, S>, OrphanBlocksRef> {
         let db_tx = self.chainstate_storage.transaction_ro();
         chainstateref::ChainstateRef::new_ro(
             &self.chain_config,
@@ -112,12 +112,11 @@ impl Chainstate {
     pub fn new(
         chain_config: Arc<ChainConfig>,
         chainstate_config: ChainstateConfig,
-        chainstate_storage: chainstate_storage::Store,
+        chainstate_storage: S,
         custom_orphan_error_hook: Option<Arc<OrphanErrorHandler>>,
         time_getter: TimeGetter,
     ) -> Result<Self, crate::ChainstateError> {
         use crate::ChainstateError;
-        use chainstate_storage::BlockchainStorageRead;
 
         let best_block_id = chainstate_storage.get_best_block_id().map_err(|e| {
             ChainstateError::FailedToInitializeChainstate(format!("Database read error: {:?}", e))
@@ -142,7 +141,7 @@ impl Chainstate {
     fn new_no_genesis(
         chain_config: Arc<ChainConfig>,
         chainstate_config: ChainstateConfig,
-        chainstate_storage: chainstate_storage::Store,
+        chainstate_storage: S,
         custom_orphan_error_hook: Option<Arc<OrphanErrorHandler>>,
         time_getter: TimeGetter,
     ) -> Self {

--- a/chainstate/src/detail/tests/events_tests.rs
+++ b/chainstate/src/detail/tests/events_tests.rs
@@ -15,7 +15,10 @@
 
 use std::sync::Arc;
 
-use crate::detail::tests::{test_framework::TestFramework, *};
+use crate::detail::tests::{
+    test_framework::{TestChainstate, TestFramework},
+    *,
+};
 
 type ErrorList = Arc<Mutex<Vec<BlockError>>>;
 
@@ -181,7 +184,7 @@ fn custom_orphan_error_hook(#[case] seed: Seed) {
 }
 
 // Subscribes to events N times emulating different subscribers.
-fn subscribe(chainstate: &mut Chainstate, n: usize) -> EventList {
+fn subscribe(chainstate: &mut TestChainstate, n: usize) -> EventList {
     let events = Arc::new(Mutex::new(Vec::new()));
 
     for _ in 0..n {

--- a/chainstate/src/detail/tests/mod.rs
+++ b/chainstate/src/detail/tests/mod.rs
@@ -109,7 +109,7 @@ impl TestBlockInfo {
         Self { txns, id }
     }
 
-    fn from_id(cs: &Chainstate, id: Id<GenBlock>) -> Self {
+    fn from_id(cs: &test_framework::TestChainstate, id: Id<GenBlock>) -> Self {
         use chainstate_storage::BlockchainStorageRead;
         match id.classify(&cs.chain_config) {
             GenBlockId::Genesis(_) => Self::from_genesis(cs.chain_config.genesis_block()),

--- a/chainstate/src/detail/tests/processing_tests.rs
+++ b/chainstate/src/detail/tests/processing_tests.rs
@@ -15,7 +15,7 @@
 
 use std::{sync::atomic::Ordering, time::Duration};
 
-use chainstate_storage::{BlockchainStorageRead, Store};
+use chainstate_storage::BlockchainStorageRead;
 use common::{
     chain::{
         block::consensus_data::PoWData,
@@ -32,7 +32,10 @@ use crate::{
     detail::{
         median_time::calculate_median_time_past,
         pow::error::ConsensusPoWError,
-        tests::{test_framework::TestFramework, *},
+        tests::{
+            test_framework::{TestFramework, TestStore},
+            *,
+        },
     },
     make_chainstate, ChainstateConfig,
 };
@@ -728,7 +731,7 @@ fn blocks_from_the_future() {
 fn mainnet_initialization() {
     let chain_config = Arc::new(common::chain::config::create_mainnet());
     let chainstate_config = ChainstateConfig::new();
-    let storage = Store::new_empty().unwrap();
+    let storage = TestStore::new_empty().unwrap();
     make_chainstate(
         chain_config,
         chainstate_config,

--- a/chainstate/src/detail/tests/syncing_tests.rs
+++ b/chainstate/src/detail/tests/syncing_tests.rs
@@ -15,11 +15,15 @@
 
 use std::iter;
 
-use crate::detail::tests::{test_framework::TestFramework, *};
+use crate::detail::tests::{
+    test_framework::{TestChainstate, TestFramework},
+    *,
+};
 
 #[test]
 fn locator_distances() {
-    let distances: Vec<i64> = Chainstate::locator_tip_distances().take(7).map(From::from).collect();
+    let distances: Vec<i64> =
+        TestChainstate::locator_tip_distances().take(7).map(From::from).collect();
     assert_eq!(distances, vec![0, 1, 2, 4, 8, 16, 32]);
 }
 

--- a/chainstate/src/detail/tests/test_framework/framework.rs
+++ b/chainstate/src/detail/tests/test_framework/framework.rs
@@ -32,12 +32,12 @@ use crate::{
         },
         BlockIndex, GenBlockIndex, TimeGetter,
     },
-    BlockError, BlockHeight, BlockSource, Chainstate, ChainstateConfig,
+    BlockError, BlockHeight, BlockSource, ChainstateConfig,
 };
 
 /// The `Chainstate` wrapper that simplifies operations and checks in the tests.
 pub struct TestFramework {
-    pub chainstate: Chainstate,
+    pub chainstate: super::TestChainstate,
     pub block_indexes: Vec<BlockIndex>,
 }
 

--- a/chainstate/src/detail/tests/test_framework/framework_builder.rs
+++ b/chainstate/src/detail/tests/test_framework/framework_builder.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use chainstate_storage::Store;
+use chainstate_storage::inmemory::Store;
 use common::chain::{
     config::{Builder as ChainConfigBuilder, ChainType},
     ChainConfig, Destination, NetUpgrades,

--- a/chainstate/src/detail/tests/test_framework/mod.rs
+++ b/chainstate/src/detail/tests/test_framework/mod.rs
@@ -18,6 +18,12 @@ mod framework;
 mod framework_builder;
 mod transaction_builder;
 
+/// Storage backend used for testing (the in-memory backend)
+pub type TestStore = chainstate_storage::inmemory::Store;
+
+/// Chainstate instantiation for testing, using the in-memory storage backend
+pub type TestChainstate = crate::Chainstate<TestStore>;
+
 pub use self::{
     block_builder::BlockBuilder, framework::TestFramework, framework_builder::TestFrameworkBuilder,
     transaction_builder::TransactionBuilder,

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -54,10 +54,10 @@ impl subsystem::Subsystem for Box<dyn ChainstateInterface> {}
 
 type ChainstateHandle = subsystem::Handle<Box<dyn ChainstateInterface>>;
 
-pub fn make_chainstate(
+pub fn make_chainstate<S: chainstate_storage::BlockchainStorage + 'static>(
     chain_config: Arc<ChainConfig>,
     chainstate_config: ChainstateConfig,
-    chainstate_storage: chainstate_storage::Store,
+    chainstate_storage: S,
     custom_orphan_error_hook: Option<Arc<detail::OrphanErrorHandler>>,
     time_getter: TimeGetter,
 ) -> Result<Box<dyn ChainstateInterface>, ChainstateError> {

--- a/chainstate/src/rpc.rs
+++ b/chainstate/src/rpc.rs
@@ -90,7 +90,7 @@ mod test {
     async fn with_chainstate<F: 'static + Send + Future<Output = ()>>(
         proc: impl 'static + Send + FnOnce(crate::ChainstateHandle) -> F,
     ) {
-        let storage = chainstate_storage::Store::new_empty().unwrap();
+        let storage = chainstate_storage::inmemory::Store::new_empty().unwrap();
         let chain_config = Arc::new(common::chain::config::create_unit_test_config());
         let chainstate_config = ChainstateConfig::new();
         let mut man = subsystem::Manager::new("rpctest");

--- a/chainstate/src/test.rs
+++ b/chainstate/src/test.rs
@@ -16,6 +16,6 @@
 use super::*;
 use static_assertions::*;
 
-assert_impl_all!(ChainstateInterfaceImpl: Send);
+assert_impl_all!(ChainstateInterfaceImpl<chainstate_storage::inmemory::Store>: Send);
 
 // TODO: write tests for consensus crate

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -44,7 +44,8 @@ pub async fn initialize(
     let chain_config = Arc::new(chain_config);
 
     // Initialize storage.
-    let storage = chainstate_storage::Store::new_empty()?;
+    // TODO: Uses in-memory for now, will be configurable once multiple backends are implemented.
+    let storage = chainstate_storage::inmemory::Store::new_empty()?;
 
     // INITIALIZE SUBSYSTEMS
 

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -185,7 +185,7 @@ fn anyonecanspend_address() -> Destination {
 pub async fn start_chainstate(
     chain_config: Arc<ChainConfig>,
 ) -> subsystem::Handle<Box<dyn ChainstateInterface>> {
-    let storage = chainstate_storage::Store::new_empty().unwrap();
+    let storage = chainstate_storage::inmemory::Store::new_empty().unwrap();
     let mut man = subsystem::Manager::new("TODO");
     let handle = man.add_subsystem(
         "chainstate",

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -47,7 +47,7 @@ where
     let (tx_p2p_sync, rx_p2p_sync) = mpsc::channel(16);
     let (tx_pubsub, rx_pubsub) = mpsc::channel(16);
     let (tx_swarm, rx_swarm) = mpsc::channel(16);
-    let storage = chainstate_storage::Store::new_empty().unwrap();
+    let storage = chainstate_storage::inmemory::Store::new_empty().unwrap();
     let chain_config = Arc::new(common::chain::config::create_unit_test_config());
     let chainstate_config = ChainstateConfig::new();
     let mut man = subsystem::Manager::new("TODO");


### PR DESCRIPTION
Not that many changes were required in the end.

* Tests use type aliases that refer to the in-memory backend.
* The node initialisation code specifies the in-memory backend since it's the only one currently available