### PR TITLE
Remove transaction size from transaction index

### DIFF
--- a/chainstate-storage/src/internal/mod.rs
+++ b/chainstate-storage/src/internal/mod.rs
@@ -261,10 +261,8 @@ impl<Tx: for<'a> traits::GetMapRef<'a, Schema>> BlockchainStorageRead for StoreT
             Ok(None) => Ok(None),
             Ok(Some(block)) => {
                 let begin = tx_index.byte_offset_in_block() as usize;
-                let end = begin + tx_index.serialized_size() as usize;
-                let encoded_tx = block.get(begin..end).expect("Transaction outside of block range");
-                let tx =
-                    Transaction::decode_all(&mut &*encoded_tx).expect("Invalid tx encoding in DB");
+                let encoded_tx = block.get(begin..).expect("Transaction outside of block range");
+                let tx = Transaction::decode(&mut &*encoded_tx).expect("Invalid tx encoding in DB");
                 Ok(Some(tx))
             }
         }

--- a/chainstate-storage/src/internal/test.rs
+++ b/chainstate-storage/src/internal/test.rs
@@ -103,8 +103,7 @@ fn test_storage_manipulation() {
         &enc_block0[offset_tx0..].starts_with(&enc_tx0),
         "Transaction format has changed, adjust the offset in this test",
     );
-    let pos_tx0 =
-        TxMainChainPosition::new(block0.get_id(), offset_tx0 as u32, enc_tx0.len() as u32);
+    let pos_tx0 = TxMainChainPosition::new(block0.get_id(), offset_tx0 as u32);
     assert_eq!(
         &store.get_mainchain_tx_by_position(&pos_tx0).unwrap().unwrap(),
         &tx0

--- a/common/src/chain/transaction/transaction_index/mod.rs
+++ b/common/src/chain/transaction/transaction_index/mod.rs
@@ -64,15 +64,13 @@ pub enum OutputSpentState {
 pub struct TxMainChainPosition {
     block_id: Id<Block>,
     byte_offset_in_block: u32,
-    serialized_size: u32,
 }
 
 impl TxMainChainPosition {
-    pub fn new(block_id: Id<Block>, byte_offset_in_block: u32, serialized_size: u32) -> Self {
+    pub fn new(block_id: Id<Block>, byte_offset_in_block: u32) -> Self {
         TxMainChainPosition {
             block_id,
             byte_offset_in_block,
-            serialized_size,
         }
     }
 
@@ -82,10 +80,6 @@ impl TxMainChainPosition {
 
     pub fn byte_offset_in_block(&self) -> u32 {
         self.byte_offset_in_block
-    }
-
-    pub fn serialized_size(&self) -> u32 {
-        self.serialized_size
     }
 }
 
@@ -175,14 +169,7 @@ pub fn calculate_tx_index_from_block(
         .try_into()
         .expect("Number conversion from usize to u32 should not fail here (1)");
 
-    let tx_position = TxMainChainPosition::new(
-        block.get_id(),
-        offset_tx,
-        enc_tx
-            .len()
-            .try_into()
-            .expect("Number conversion from usize to u32 should not fail here (2)"),
-    );
+    let tx_position = TxMainChainPosition::new(block.get_id(), offset_tx);
 
     TxMainChainIndex::new(
         SpendablePosition::from(tx_position),

--- a/common/src/chain/transaction/transaction_index/tests.rs
+++ b/common/src/chain/transaction/transaction_index/tests.rs
@@ -37,7 +37,7 @@ use std::str::FromStr;
 fn invalid_output_count_for_transaction() {
     let block_id =
         H256::from_str("000000000000000000000000000000000000000000000000000000000000007b").unwrap();
-    let pos = TxMainChainPosition::new(block_id.into(), 1, 2).into();
+    let pos = TxMainChainPosition::new(block_id.into(), 1).into();
     let tx_index = TxMainChainIndex::new(pos, 0);
     assert_eq!(
         tx_index.unwrap_err(),
@@ -60,7 +60,7 @@ fn basic_spending() {
         H256::from_str("000000000000000000000000000000000000000000000000000000000000007b")
             .unwrap()
             .into();
-    let pos = TxMainChainPosition::new(block_id, 1, 2).into();
+    let pos = TxMainChainPosition::new(block_id, 1).into();
     let mut tx_index = TxMainChainIndex::new(pos, 3).unwrap();
 
     // ensure index accesses are correct
@@ -311,10 +311,9 @@ fn test_indices_calculations() {
             SpendablePosition::BlockReward(_) => unreachable!(),
         };
         let tx_start_pos = pos.byte_offset_in_block() as usize;
-        let tx_end_pos = pos.byte_offset_in_block() as usize + pos.serialized_size() as usize;
-        let tx_serialized_in_block = &serialized_block[tx_start_pos..tx_end_pos];
+        let tx_serialized_in_block = &serialized_block[tx_start_pos..];
         let tx_serialized = tx.encode();
-        assert_eq!(tx_serialized_in_block, tx_serialized);
+        assert_eq!(tx_serialized_in_block[..tx_serialized.len()], tx_serialized);
 
         // to ensure Vec comparison is correct since I'm a paranoid C++ dude, let's mess things up
         let tx_messed = tx_serialized.iter().map(|c| c.wrapping_add(1)).collect::<Vec<u8>>();


### PR DESCRIPTION
We don't really need it... it was added as part of being paranoid, but maybe that isn't necessary. Let's see what the fine engineers here think. 