### PR TITLE
Use the 'tap' library as a replacement for the unstable inspect_err function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,6 +2639,7 @@ dependencies = [
  "serialization",
  "sscanf",
  "subsystem",
+ "tap",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -13,6 +13,7 @@ parity-scale-codec = "3.1"
 sscanf = "0.2"
 thiserror = "1.0"
 void = "1.0"
+tap = "1.0"
 
 # local dependencies
 common = { path = "../common/" }

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -101,12 +101,8 @@ impl Libp2pBackend {
                     SwarmEvent::Behaviour(Libp2pBehaviourEvent::Control(
                         ControlEvent::CloseConnection { peer_id })
                     ) => {
-                        // TODO: `inspect_err`
-                        match self.swarm.disconnect_peer_id(peer_id) {
-                            Ok(_) => {}
-                            Err(err) => {
-                                log::error!("Failed to disconnect peer {}: {:?}", peer_id, err);
-                            }
+                        if let Err(e) =  self.swarm.disconnect_peer_id(peer_id) {
+                            log::error!("Failed to disconnect peer {peer_id}: {e:?}");
                         }
                     }
                     _ => {


### PR DESCRIPTION
While implementing some functionality I really missed the `inspect_err` api that is still unstable and as far as I know there are no recent plans to stabilize it. Additionally we have a TODO-comment in our code-base that suggests using `inspect_err`. There is the `tap` crate that provides the missing functionality. Sometimes it leads to a more concise and clear code. On the other hand, it isn't that important and adding one more dependency for such a small thing is controversial. Therefore I would like to hear you opinions.