### PR TITLE
Add utxo simulation test with undo

### DIFF
--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -87,7 +87,7 @@ impl<'a> UtxosCache<'a> {
         self.current_block_hash = block_hash;
     }
 
-    /// Given a block reward adds its outputs to the utxo set
+    /// Given a block reward add its outputs to the utxo set
     pub fn add_utxos_from_block_reward(
         &mut self,
         reward: &BlockReward,
@@ -110,7 +110,7 @@ impl<'a> UtxosCache<'a> {
         Ok(())
     }
 
-    /// Given a transaction adds its outputs to the utxo set
+    /// Given a transaction add its outputs to the utxo set
     pub fn add_utxos_from_tx(
         &mut self,
         tx: &Transaction,

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -96,8 +96,7 @@ impl<'a> UtxosCache<'a> {
         check_for_overwrite: bool,
     ) -> Result<(), Error> {
         for (idx, output) in reward.outputs().iter().enumerate() {
-            let outpoint =
-                OutPoint::new(OutPointSourceId::BlockReward(block_id.clone()), idx as u32);
+            let outpoint = OutPoint::new(OutPointSourceId::BlockReward(*block_id), idx as u32);
             // block reward transactions can always be overwritten
             let overwrite = if check_for_overwrite {
                 self.has_utxo(&outpoint)

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -18,7 +18,7 @@ use crate::{
     {Error, FlushableUtxoView, TxUndo, Utxo, UtxoSource, UtxosView},
 };
 use common::{
-    chain::{GenBlock, OutPoint, OutPointSourceId, Transaction},
+    chain::{block::BlockReward, GenBlock, OutPoint, OutPointSourceId, Transaction},
     primitives::{BlockHeight, Id, Idable},
 };
 use logging::log;
@@ -87,7 +87,32 @@ impl<'a> UtxosCache<'a> {
         self.current_block_hash = block_hash;
     }
 
-    pub fn add_utxos(
+    /// Given a block reward adds its outputs to the utxo set
+    pub fn add_utxos_from_block_reward(
+        &mut self,
+        reward: &BlockReward,
+        source: UtxoSource,
+        block_id: &Id<GenBlock>,
+        check_for_overwrite: bool,
+    ) -> Result<(), Error> {
+        for (idx, output) in reward.outputs().iter().enumerate() {
+            let outpoint =
+                OutPoint::new(OutPointSourceId::BlockReward(block_id.clone()), idx as u32);
+            // block reward transactions can always be overwritten
+            let overwrite = if check_for_overwrite {
+                self.has_utxo(&outpoint)
+            } else {
+                true
+            };
+            let utxo = Utxo::new(output.clone(), true, source.clone());
+
+            self.add_utxo(&outpoint, utxo, overwrite)?;
+        }
+        Ok(())
+    }
+
+    /// Given a transaction adds its outputs to the utxo set
+    pub fn add_utxos_from_tx(
         &mut self,
         tx: &Transaction,
         source: UtxoSource,
@@ -108,11 +133,15 @@ impl<'a> UtxosCache<'a> {
 
     /// Marks the inputs of a transaction as 'spent', adds outputs to the utxo set.
     /// Returns a TxUndo if function is a success or an error if the tx's input cannot be spent.
-    pub fn spend_utxos(&mut self, tx: &Transaction, height: BlockHeight) -> Result<TxUndo, Error> {
+    pub fn spend_utxos_from_tx(
+        &mut self,
+        tx: &Transaction,
+        height: BlockHeight,
+    ) -> Result<TxUndo, Error> {
         let tx_undo: Result<Vec<Utxo>, Error> =
             tx.inputs().iter().map(|tx_in| self.spend_utxo(tx_in.outpoint())).collect();
 
-        self.add_utxos(tx, UtxoSource::Blockchain(height), false)?;
+        self.add_utxos_from_tx(tx, UtxoSource::Blockchain(height), false)?;
 
         tx_undo.map(TxUndo::new)
     }
@@ -341,6 +370,14 @@ mod unit_test {
     use common::primitives::H256;
     use rstest::rstest;
     use test_utils::random::{make_seedable_rng, Seed};
+
+    #[test]
+    fn set_best_block() {
+        let expected_best_block_id: Id<GenBlock> = H256::random().into();
+        let mut cache = UtxosCache::new_for_test(H256::random().into());
+        cache.set_best_block(expected_best_block_id);
+        assert_eq!(expected_best_block_id, cache.best_block_hash());
+    }
 
     #[rstest]
     #[trace]

--- a/utxo/src/storage/in_memory.rs
+++ b/utxo/src/storage/in_memory.rs
@@ -37,11 +37,6 @@ impl UtxosDBInMemoryImpl {
             best_block_id: best_block,
         }
     }
-
-    #[cfg(test)]
-    pub fn internal_store(&mut self) -> &BTreeMap<OutPoint, Utxo> {
-        &self.store
-    }
 }
 
 impl UtxosStorageRead for UtxosDBInMemoryImpl {

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -15,10 +15,11 @@
 
 use super::{in_memory::UtxosDBInMemoryImpl, *};
 use crate::{
-    flush_to_base,
     tests::test_helper::{convert_to_utxo, create_tx_inputs, create_tx_outputs, create_utxo},
     utxo_entry::{IsDirty, IsFresh, UtxoEntry},
-    ConsumedUtxoCache, FlushableUtxoView, UtxosCache, UtxosView,
+    ConsumedUtxoCache,
+    Error::*,
+    FlushableUtxoView, UtxosView,
 };
 use common::{
     chain::{
@@ -118,13 +119,11 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
     let num_of_txs = 1;
 
     // initializing the db with existing utxos.
-    let (db_interface, outpoints) = initialize_db(&mut rng, tx_outputs_size);
+    let (mut db_impl, outpoints) = initialize_db(&mut rng, tx_outputs_size);
     // create the TxInputs for spending.
     let expected_tx_inputs = create_tx_inputs(&mut rng, &outpoints);
-
     // create the UtxosDB.
-    let mut db_interface_clone = db_interface.clone();
-    let mut db = UtxosDBMut::new(&mut db_interface_clone);
+    let mut db = UtxosDBMut::new(&mut db_impl);
 
     // let's check that each tx_input exists in the db. Secure the spent utxos.
     let spent_utxos = expected_tx_inputs
@@ -139,20 +138,13 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
 
     // test the spend
     let (block, block_undo) = {
-        // create a view based on the db.
-
-        let mut parent_view = UtxosCache::new_for_test(H256::random().into());
-        db.0.internal_store().iter().for_each(|(outpoint, utxo)| {
-            parent_view.add_utxo(outpoint, utxo.clone(), false).unwrap();
-        });
-        parent_view.set_best_block(db.best_block_hash());
-
-        let mut view = parent_view.derive_cache();
+        // create a cache based on the db.
+        let mut cache = db.derive_cache();
 
         // create a new block to spend.
         let block = create_block(
             &mut rng,
-            db_interface.best_block_hash(),
+            cache.best_block_hash(),
             expected_tx_inputs.clone(),
             0,
             num_of_txs,
@@ -163,7 +155,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
             let undos = block
                 .transactions()
                 .iter()
-                .map(|tx| view.spend_utxos(tx, block_height).expect("should spend okay."))
+                .map(|tx| cache.spend_utxos_from_tx(tx, block_height).expect("should spend okay."))
                 .collect_vec();
             BlockUndo::new(undos, block_height)
         };
@@ -179,8 +171,9 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
         }
 
         // flush to db
-        view.set_best_block(block.get_id().into());
-        flush_to_base(view, &mut db).unwrap();
+        cache.set_best_block(block.get_id().into());
+        let consumed_cache = cache.consume();
+        db.batch_write(consumed_cache).unwrap();
 
         (block, block_undo)
     };
@@ -193,12 +186,8 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
     // save the undo data to the db.
     {
         db.set_undo_data(block.get_id(), &block_undo).unwrap();
-
         // check that the block_undo retrieved from db is the same as the one being stored.
-        let block_undo_from_db = db
-            .get_undo_data(block.get_id())
-            .expect("getting undo data should not cause any problems");
-
+        let block_undo_from_db = db.get_undo_data(block.get_id()).unwrap();
         assert_eq!(block_undo_from_db.as_ref(), Some(&block_undo));
     }
 
@@ -216,10 +205,8 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
         // get the best_block_id
         let current_best_block_id = db.best_block_hash();
 
-        println!("the current block id: {:?}", current_best_block_id);
-
         // the current best_block_id should be the block id..
-        //  assert_eq!(&current_best_block_id, &block.get_id());
+        assert_eq!(&current_best_block_id, &block.get_id());
 
         // get the block_undo.
         let block_undo = db
@@ -231,29 +218,24 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
         assert_eq!(block_undo.tx_undos().len(), expected_tx_inputs.len());
 
         // let's create a view.
-        let mut view = UtxosCache::new_for_test(H256::random().into());
-        // set the best block to the previous one
-        {
-            view.set_best_block(block.prev_block_id());
-            // the best block id should be the same as the old one.
-            assert_eq!(view.best_block_hash(), block.prev_block_id());
-        }
+        let mut cache = db.derive_cache();
 
         // get the block txinputs, and add them to the view.
         block.transactions().iter().enumerate().for_each(|(idx, tx)| {
             // use the undo to get the utxos
-            let undo = block_undo.tx_undos().get(idx).expect("it should return undo");
+            let undo = block_undo.tx_undos().get(idx).unwrap();
             let undos = undo.inner();
 
             // add the undo utxos back to the view.
             tx.inputs().iter().enumerate().for_each(|(in_idx, input)| {
-                let utxo = undos.get(in_idx).expect("it should have utxo");
-                view.add_utxo(input.outpoint(), utxo.clone(), true).unwrap();
+                let utxo = undos.get(in_idx).unwrap();
+                cache.add_utxo(input.outpoint(), utxo.clone(), true).unwrap();
             });
         });
 
         // flush the view to the db.
-        flush_to_base(view, &mut db).unwrap();
+        let consumed_cache = cache.consume();
+        db.batch_write(consumed_cache).unwrap();
 
         // remove the block undo file
         db.del_undo_data(block.get_id()).unwrap();
@@ -267,116 +249,118 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
         let expected_utxo = spent_utxos.get(idx);
         assert_eq!(res.as_ref(), expected_utxo);
     });
-
-    // For error testing: create dummy tx_inputs for spending.
-    {
-        let num_of_txs = 5;
-        let rnd = rng.gen_range(num_of_txs..20);
-
-        let tx_inputs: Vec<TxInput> = (0..rnd)
-            .into_iter()
-            .map(|i| {
-                let id: Id<GenBlock> = Id::new(H256::random());
-                let id = OutPointSourceId::BlockReward(id);
-
-                TxInput::new(id, i, InputWitness::NoSignature(None))
-            })
-            .collect();
-
-        let id = db.best_block_hash();
-
-        // Create a dummy block.
-        let block = create_block(&mut rng, id, tx_inputs, 0, num_of_txs as usize);
-
-        // Create a view.
-        let mut view = db.derive_cache();
-
-        let tx = block.transactions().get(0).expect("should return a transaction");
-
-        // try to spend that transaction
-        assert!(view.spend_utxos(tx, BlockHeight::new(2)).is_err());
-    }
 }
 
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn test_utxo(#[case] seed: Seed) {
-    common::concurrency::model(move || {
-        let mut rng = make_seedable_rng(seed);
-        let utxos = create_utxo_entries(&mut rng, 10);
-        let new_best_block_hash = Id::new(H256::random());
+fn try_spend_tx_with_no_outputs(#[case] seed: Seed) {
+    let num_of_txs = 1;
+    let tx_outputs_size = 3;
 
-        let utxos = ConsumedUtxoCache {
-            container: utxos,
-            best_block: new_best_block_hash,
-        };
+    let mut rng = make_seedable_rng(seed);
 
-        let mut db_interface = UtxosDBInMemoryImpl::new(new_best_block_hash, Default::default());
-        let mut utxo_db = UtxosDBMut::new(&mut db_interface);
+    let (db_impl, _) = initialize_db(&mut rng, tx_outputs_size);
+    let db = UtxosDB::new(&db_impl);
 
-        // test batch_write
-        let res = utxo_db.batch_write(utxos.clone());
-        res.unwrap();
+    let tx_inputs: Vec<TxInput> = (0..rng.gen_range(num_of_txs..20))
+        .into_iter()
+        .map(|i| {
+            let id: Id<GenBlock> = Id::new(H256::random());
+            let id = OutPointSourceId::BlockReward(id);
 
-        // randomly get a key for checking
-        let keys = utxos.container.keys().collect_vec();
-        let key_index = rng.gen_range(0..keys.len());
-        let outpoint = keys[key_index].clone();
+            TxInput::new(id, i, InputWitness::NoSignature(None))
+        })
+        .collect();
 
-        // test the get_utxo
-        let utxo_opt = utxo_db.utxo(&outpoint);
+    let id = db.best_block_hash();
 
-        let outpoint_key = &outpoint;
-        let utxo_entry = utxos.container.get(outpoint_key).expect("an entry should be found");
-        assert_eq!(utxo_entry.utxo(), utxo_opt.as_ref());
+    // Create a block with 1 tx and 0 outputs in txs
+    let block = create_block(&mut rng, id, tx_inputs, 0, num_of_txs as usize);
+    let mut view = db.derive_cache();
+    let tx = block.transactions().get(0).unwrap();
 
-        // check has_utxo
-        assert!(utxo_db.has_utxo(&outpoint));
+    assert_eq!(
+        view.spend_utxos_from_tx(tx, BlockHeight::new(2)).unwrap_err(),
+        NoUtxoFound
+    );
+}
 
-        //check the best block hash
-        assert_eq!(utxo_db.best_block_hash(), new_best_block_hash);
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn test_batch_write(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let utxos = create_utxo_entries(&mut rng, 10);
+    let new_best_block_hash = Id::new(H256::random());
 
-        // try to write a non-dirty utxo
-        {
-            let (utxo, outpoint) = create_utxo(&mut rng, 1);
-            let mut map = BTreeMap::new();
-            let entry = UtxoEntry::new(Some(utxo), IsFresh::No, IsDirty::No);
-            map.insert(outpoint.clone(), entry);
+    let mut db_interface = UtxosDBInMemoryImpl::new(new_best_block_hash, Default::default());
+    let mut utxo_db = UtxosDBMut::new(&mut db_interface);
 
-            let new_hash = Id::new(H256::random());
-            let another_cache = ConsumedUtxoCache {
-                container: map,
-                best_block: new_hash,
-            };
+    let utxos = ConsumedUtxoCache {
+        container: utxos,
+        best_block: new_best_block_hash,
+    };
 
-            utxo_db.batch_write(another_cache).expect("batch write should work");
+    utxo_db.batch_write(utxos.clone()).unwrap();
 
-            assert!(!utxo_db.has_utxo(&outpoint));
-        }
+    // randomly get a key for checking
+    let keys = utxos.container.keys().collect_vec();
+    let key_index = rng.gen_range(0..keys.len());
+    let outpoint = keys[key_index].clone();
 
-        // write down a spent utxo.
-        {
-            let key_index = rng.gen_range(0..keys.len());
-            let outpoint_key = keys[key_index];
-            let outpoint = outpoint_key;
-            let utxo = utxos
-                .container
-                .get(outpoint_key)
-                .expect("entry should exist")
-                .utxo()
-                .expect("utxo should exist");
+    // test the get_utxo
+    let utxo_opt = utxo_db.utxo(&outpoint);
+    let utxo_entry = utxos.container.get(&outpoint).expect("an entry should be found");
+    assert_eq!(utxo_entry.utxo(), utxo_opt.as_ref());
 
-            let mut parent = UtxosCache::new_for_test(utxo_db.best_block_hash());
-            parent.add_utxo(outpoint, utxo.clone(), false).unwrap();
+    // check has_utxo
+    assert!(utxo_db.has_utxo(&outpoint));
 
-            let mut child = UtxosCache::new(&parent);
-            child.spend_utxo(outpoint).unwrap();
+    //check the best block hash
+    assert_eq!(utxo_db.best_block_hash(), new_best_block_hash);
+}
 
-            let res = flush_to_base(child, &mut utxo_db);
-            res.unwrap();
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn try_flush_non_dirty_utxo(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
 
-            assert!(!utxo_db.has_utxo(outpoint));
-        }
-    });
+    let mut db_interface = UtxosDBInMemoryImpl::new(Id::new(H256::random()), Default::default());
+    let mut utxo_db = UtxosDBMut::new(&mut db_interface);
+
+    let (utxo, outpoint) = create_utxo(&mut rng, 1);
+    let mut map = BTreeMap::new();
+    let entry = UtxoEntry::new(Some(utxo), IsFresh::No, IsDirty::No);
+    map.insert(outpoint.clone(), entry);
+
+    let cache = ConsumedUtxoCache {
+        container: map,
+        best_block: Id::new(H256::random()),
+    };
+
+    utxo_db.batch_write(cache).unwrap();
+
+    assert!(!utxo_db.has_utxo(&outpoint));
+}
+
+#[test]
+fn try_flush_spent_utxo() {
+    let mut db_interface = UtxosDBInMemoryImpl::new(Id::new(H256::random()), Default::default());
+    let mut utxo_db = UtxosDBMut::new(&mut db_interface);
+
+    let outpoint = OutPoint::new(OutPointSourceId::Transaction(Id::new(H256::random())), 0);
+    let mut map = BTreeMap::new();
+    let entry = UtxoEntry::new(None, IsFresh::No, IsDirty::Yes);
+    map.insert(outpoint.clone(), entry);
+
+    let cache = ConsumedUtxoCache {
+        container: map,
+        best_block: Id::new(H256::random()),
+    };
+
+    utxo_db.batch_write(cache).unwrap();
+
+    assert!(!utxo_db.has_utxo(&outpoint));
 }

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -531,7 +531,7 @@ fn check_add_utxos_from_block_reward(#[case] seed: Seed) {
         .is_ok());
 
     block_reward.outputs().iter().enumerate().for_each(|(i, x)| {
-        let outpoint = OutPoint::new(OutPointSourceId::BlockReward(block_id.clone()), i as u32);
+        let outpoint = OutPoint::new(OutPointSourceId::BlockReward(block_id), i as u32);
         let utxo = cache.utxo(&outpoint).expect("utxo should exist");
         assert_eq!(utxo.output(), x);
     });

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -14,18 +14,25 @@
 // limitations under the License.
 
 pub mod simulation;
+pub mod simulation_with_undo;
 pub mod test_helper;
 
 use crate::{
     flush_to_base,
-    tests::test_helper::Presence::{self, *},
+    tests::test_helper::{
+        create_tx_outputs,
+        Presence::{self, *},
+    },
     utxo_entry::{IsDirty, IsFresh, UtxoEntry},
     ConsumedUtxoCache,
     Error::{self, *},
     FlushableUtxoView, Utxo, UtxoSource, UtxosCache, UtxosView,
 };
 use common::{
-    chain::{OutPoint, OutPointSourceId, Transaction, TxInput},
+    chain::{
+        block::BlockReward, signature::inputsig::InputWitness, OutPoint, OutPointSourceId,
+        Transaction, TxInput,
+    },
     primitives::{BlockHeight, Id, Idable, H256},
 };
 use crypto::random::{seq, Rng};
@@ -440,8 +447,6 @@ fn blockchain_or_mempool_utxo_test(#[case] seed: Seed) {
 #[trace]
 #[case(Seed::from_entropy())]
 fn multiple_update_utxos_test(#[case] seed: Seed) {
-    use common::chain::signature::inputsig::InputWitness;
-
     let mut rng = make_seedable_rng(seed);
     let mut cache = UtxosCache::new_for_test(H256::random().into());
 
@@ -453,7 +458,9 @@ fn multiple_update_utxos_test(#[case] seed: Seed) {
         0x01,
     )
     .unwrap();
-    assert!(cache.add_utxos(&tx, UtxoSource::Blockchain(BlockHeight::new(2)), false).is_ok());
+    assert!(cache
+        .add_utxos_from_tx(&tx, UtxoSource::Blockchain(BlockHeight::new(2)), false)
+        .is_ok());
 
     // check that the outputs of tx are added in the cache.
     tx.outputs().iter().enumerate().for_each(|(i, x)| {
@@ -478,8 +485,10 @@ fn multiple_update_utxos_test(#[case] seed: Seed) {
 
     // create a new transaction
     let new_tx = Transaction::new(0x00, to_spend.clone(), vec![], 0).expect("should succeed");
-    // let's test `spend_utxos`
-    let tx_undo = cache.spend_utxos(&new_tx, BlockHeight::new(2)).expect("should return txundo");
+    // let's test `spend_utxos_from_tx`
+    let tx_undo = cache
+        .spend_utxos_from_tx(&new_tx, BlockHeight::new(2))
+        .expect("should return txundo");
 
     // check that these utxos came from the tx's output
     tx_undo.inner().iter().for_each(|x| {
@@ -500,4 +509,65 @@ fn check_best_block_after_flush() {
     let expected_hash = cache2.best_block_hash();
     assert!(flush_to_base(cache2, &mut cache1).is_ok());
     assert_eq!(expected_hash, cache1.best_block_hash());
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn check_add_utxos_from_block_reward(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let mut cache = UtxosCache::new_for_test(H256::random().into());
+
+    let block_reward = BlockReward::new(test_helper::create_tx_outputs(&mut rng, 10));
+
+    let block_id = Id::new(H256::random());
+    assert!(cache
+        .add_utxos_from_block_reward(
+            &block_reward,
+            UtxoSource::Blockchain(BlockHeight::new(2)),
+            &block_id,
+            false
+        )
+        .is_ok());
+
+    block_reward.outputs().iter().enumerate().for_each(|(i, x)| {
+        let outpoint = OutPoint::new(OutPointSourceId::BlockReward(block_id.clone()), i as u32);
+        let utxo = cache.utxo(&outpoint).expect("utxo should exist");
+        assert_eq!(utxo.output(), x);
+    });
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn check_spend_undo_spend(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let mut cache = UtxosCache::new_for_test(H256::random().into());
+
+    // add 1 utxo to the utxo set
+    let (utxo, outpoint) = test_helper::create_utxo(&mut rng, 1);
+    cache.add_utxo(&outpoint, utxo, false).unwrap();
+
+    // spend the utxo in a transaction
+    let input = TxInput::new(
+        outpoint.tx_id(),
+        outpoint.output_index(),
+        InputWitness::NoSignature(None),
+    );
+    let tx = Transaction::new(0x00, vec![input], create_tx_outputs(&mut rng, 1), 0x01).unwrap();
+    let undo = cache.spend_utxos_from_tx(&tx, BlockHeight::new(1)).unwrap();
+
+    //undo spending
+    let tx_outpoint = OutPoint::new(OutPointSourceId::from(tx.get_id()), 0);
+    cache.spend_utxo(&tx_outpoint).unwrap();
+    cache
+        .add_utxo(
+            &outpoint,
+            undo.inner()[0].clone(),
+            cache.has_utxo(&outpoint),
+        )
+        .unwrap();
+
+    //spend the transaction again
+    cache.spend_utxos_from_tx(&tx, BlockHeight::new(1)).unwrap();
 }

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -1,0 +1,207 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::test_helper::create_tx_outputs;
+use crate::{FlushableUtxoView, TxUndo, UtxoSource, UtxosCache, UtxosView};
+use common::{
+    chain::{
+        block::BlockReward, signature::inputsig::InputWitness, OutPoint, OutPointSourceId,
+        Transaction, TxInput,
+    },
+    primitives::{BlockHeight, Id, Idable, H256},
+};
+use crypto::random::Rng;
+use rstest::rstest;
+use std::collections::BTreeMap;
+use test_utils::random::{make_seedable_rng, Seed};
+
+// Structure to store outpoints of current utxo set and info for undo
+#[derive(Default)]
+struct ResultWithUndo {
+    utxo_outpoints: Vec<OutPoint>,
+    outpoints_with_undo: BTreeMap<OutPoint, UndoInfo>,
+}
+
+struct UndoInfo {
+    prev_outpoint: OutPoint,
+    tx_undo: TxUndo,
+}
+
+// This test creates an arbitrary long chain of caches.
+// Every new cache is populated with random block reward, spending transactions and undo of utxo.
+// When the last cache in the chain is created and modified the chain starts to fold by flushing
+// result to a parent. One by one the chain is folded back to a single cache that is checked for consistency.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy(), 8, 1000)]
+fn cache_simulation_with_undo(
+    #[case] seed: Seed,
+    #[case] nested_level: usize,
+    #[case] iterations_per_cache: usize,
+) {
+    let mut rng = make_seedable_rng(seed);
+    let mut result: ResultWithUndo = Default::default();
+    let mut base = UtxosCache::new_for_test(H256::random().into());
+
+    let new_cache = simulation_step(
+        &mut rng,
+        &mut result,
+        &base,
+        iterations_per_cache,
+        nested_level,
+    );
+    let consumed_cache = new_cache.unwrap().consume();
+    base.batch_write(consumed_cache).expect("batch write must succeed");
+
+    for outpoint in &result.utxo_outpoints {
+        let has_utxo = base.has_utxo(outpoint);
+        let utxo = base.utxo(outpoint);
+        assert_eq!(has_utxo, utxo.is_some());
+        if utxo.is_some() {
+            assert!(base.has_utxo_in_cache(outpoint));
+        }
+    }
+}
+
+// Each step a new cache is created based on parent. Then it is randomly modified and passed to the
+// next step as a parent. After recursion stops the resulting cache is returned and flushed to the base.
+fn simulation_step<'a>(
+    rng: &mut impl Rng,
+    result: &mut ResultWithUndo,
+    parent: &'a UtxosCache,
+    iterations_per_cache: usize,
+    nested_level: usize,
+) -> Option<UtxosCache<'a>> {
+    if nested_level == 0 {
+        return None;
+    }
+
+    let mut cache = UtxosCache::new(parent);
+    let mut new_cache_res = populate_cache_with_undo(rng, &mut cache, iterations_per_cache, result);
+    result.utxo_outpoints.append(&mut new_cache_res.utxo_outpoints);
+    result.outpoints_with_undo.append(&mut new_cache_res.outpoints_with_undo);
+
+    let new_cache = simulation_step(rng, result, &cache, iterations_per_cache, nested_level - 1);
+
+    if let Some(new_cache) = new_cache {
+        let consumed_cache = new_cache.consume();
+        cache.batch_write(consumed_cache).expect("batch write must succeed");
+    }
+
+    Some(cache)
+}
+
+fn populate_cache_with_undo(
+    rng: &mut impl Rng,
+    cache: &mut UtxosCache,
+    iterations_count: usize,
+    prev_result: &mut ResultWithUndo,
+) -> ResultWithUndo {
+    // track outpoints of the current utxo set and info for undo
+    let mut result: ResultWithUndo = Default::default();
+
+    for _ in 0..iterations_count {
+        let i = rng.gen_range(0..usize::MAX);
+        // create new utxo
+        if i % 20 < 19 {
+            //create utxo from block reward
+            if i % 20 < 10 {
+                let reward = BlockReward::new(create_tx_outputs(rng, 1));
+                let block_height = BlockHeight::new(rng.gen_range(0..iterations_count as u64));
+                let block_id = Id::new(H256::random());
+                cache
+                    .add_utxos_from_block_reward(
+                        &reward,
+                        UtxoSource::Blockchain(block_height),
+                        &block_id,
+                        false,
+                    )
+                    .unwrap();
+                result.utxo_outpoints.push(OutPoint::new(OutPointSourceId::from(block_id), 0));
+            } else {
+                //spend random utxo in a transaction
+
+                //get random outpoint from existing outpoints
+                let outpoint = if rng.gen::<bool>() && !prev_result.utxo_outpoints.is_empty() {
+                    let outpoint_idx = rng.gen_range(0..prev_result.utxo_outpoints.len());
+                    //this outpoint will be spent so remove strait away
+                    prev_result.utxo_outpoints.remove(outpoint_idx)
+                } else if !result.utxo_outpoints.is_empty() {
+                    let outpoint_idx = rng.gen_range(0..result.utxo_outpoints.len());
+                    //this outpoint will be spent so remove strait away
+                    result.utxo_outpoints.remove(outpoint_idx)
+                } else {
+                    continue; //no outputs to spend yet
+                };
+
+                //use this outpoint as input for transaction
+                let input = TxInput::new(
+                    outpoint.tx_id(),
+                    outpoint.output_index(),
+                    InputWitness::NoSignature(None),
+                );
+                let tx =
+                    Transaction::new(0x00, vec![input], create_tx_outputs(rng, 1), 0x01).unwrap();
+
+                //spent the transaction
+                let block_height = BlockHeight::new(rng.gen_range(0..iterations_count as u64));
+                let undo = cache.spend_utxos_from_tx(&tx, block_height).unwrap();
+
+                //keep result updated
+                let new_outpoint = OutPoint::new(OutPointSourceId::from(tx.get_id()), 0);
+                result.utxo_outpoints.push(new_outpoint.clone());
+                result.outpoints_with_undo.insert(
+                    new_outpoint,
+                    UndoInfo {
+                        prev_outpoint: outpoint,
+                        tx_undo: undo,
+                    },
+                );
+            }
+        } else if !result.outpoints_with_undo.is_empty() {
+            //undo random transaction spending from current utxo set
+
+            let idx = rng.gen_range(0..result.utxo_outpoints.len());
+            let outpoint = result.utxo_outpoints.remove(idx);
+
+            //spend new utxo
+            cache.spend_utxo(&outpoint).unwrap();
+            //restore previous utxo. Only outputs of a tx can be undone
+            if let Some(undo_info) = result.outpoints_with_undo.remove(&outpoint) {
+                cache
+                    .add_utxo(
+                        &undo_info.prev_outpoint,
+                        undo_info.tx_undo.inner()[0].clone(),
+                        cache.has_utxo(&undo_info.prev_outpoint),
+                    )
+                    .unwrap();
+
+                //keep result updated
+                result.utxo_outpoints.push(undo_info.prev_outpoint.clone());
+            }
+        }
+
+        // every 100 iterations check full cache
+        if i % 100 == 0 {
+            for outpoint in &result.utxo_outpoints {
+                let has_utxo = cache.has_utxo(outpoint);
+                let utxo = cache.utxo(outpoint);
+                assert_eq!(has_utxo, utxo.is_some());
+            }
+        }
+    }
+
+    result
+}


### PR DESCRIPTION
- Added another simulation test that focuses on creating utxo from block reward, spending utxo from tx and undoing utxo spending.
- Added function that creates utxo from block reward
- Cleaned up some tests in utxo/storage

P.S. simulation_with_undo.rs is almost copy/paste of simulation.rs, but generalisation of this code is imho an overkill and would affect readability. Besides we don't plan to add more tests like these.