### PR TITLE
Integration of utxo crate in chainstate

### DIFF
--- a/chainstate-storage/src/internal/test.rs
+++ b/chainstate-storage/src/internal/test.rs
@@ -302,7 +302,7 @@ pub fn create_rand_block_undo(
         tx_undo.push(TxUndo::new(tx_utxos));
     }
 
-    BlockUndo::new(reward_undo, tx_undo)
+    BlockUndo::new(Some(reward_undo), tx_undo)
 }
 
 #[cfg(not(loom))]

--- a/chainstate-storage/src/internal/test.rs
+++ b/chainstate-storage/src/internal/test.rs
@@ -21,7 +21,7 @@ use crypto::key::{KeyKind, PrivateKey};
 use crypto::random::Rng;
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
-use utxo::{BlockUndo, TxUndo};
+use utxo::{BlockRewardUndo, BlockUndo, TxUndo};
 
 type TestStore = crate::inmemory::Store;
 
@@ -277,27 +277,32 @@ pub fn create_rand_block_undo(
     rng: &mut impl Rng,
     max_lim_of_utxos: u8,
     max_lim_of_tx_undos: u8,
-    block_height: BlockHeight,
 ) -> BlockUndo {
     let mut counter: u64 = 0;
 
-    let mut block_undo: Vec<TxUndo> = vec![];
+    let mut reward_utxos: Vec<Utxo> = vec![];
+    let utxo_rng = rng.gen_range(1..max_lim_of_utxos);
+    for i in 0..utxo_rng {
+        counter += u64::from(i);
+        reward_utxos.push(create_rand_utxo(rng, counter));
+    }
+    let reward_undo = BlockRewardUndo::new(reward_utxos);
 
+    let mut tx_undo = vec![];
     let undo_rng = rng.gen_range(1..max_lim_of_tx_undos);
     for _ in 0..undo_rng {
-        let mut tx_undo = vec![];
-
+        let mut tx_utxos = vec![];
         let utxo_rng = rng.gen_range(1..max_lim_of_utxos);
         for i in 0..utxo_rng {
             counter += u64::from(i);
 
-            tx_undo.push(create_rand_utxo(rng, counter));
+            tx_utxos.push(create_rand_utxo(rng, counter));
         }
 
-        block_undo.push(TxUndo::new(tx_undo));
+        tx_undo.push(TxUndo::new(tx_utxos));
     }
 
-    BlockUndo::new(block_undo, block_height)
+    BlockUndo::new(reward_undo, tx_undo)
 }
 
 #[cfg(not(loom))]
@@ -306,7 +311,7 @@ pub fn create_rand_block_undo(
 #[case(Seed::from_entropy())]
 fn undo_test(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
-    let block_undo0 = create_rand_block_undo(&mut rng, 10, 5, BlockHeight::new(1));
+    let block_undo0 = create_rand_block_undo(&mut rng, 10, 5);
     // create id:
     let id0: Id<Block> = Id::new(H256::random());
 
@@ -325,7 +330,7 @@ fn undo_test(#[case] seed: Seed) {
 
     // insert, remove, and reinsert the next block_undo
 
-    let block_undo1 = create_rand_block_undo(&mut rng, 5, 10, BlockHeight::new(2));
+    let block_undo1 = create_rand_block_undo(&mut rng, 5, 10);
     // create id:
     let id1: Id<Block> = Id::new(H256::random());
 

--- a/chainstate-storage/src/internal/test.rs
+++ b/chainstate-storage/src/internal/test.rs
@@ -278,26 +278,23 @@ pub fn create_rand_block_undo(
     max_lim_of_utxos: u8,
     max_lim_of_tx_undos: u8,
 ) -> BlockUndo {
-    let mut counter: u64 = 0;
-
-    let mut reward_utxos: Vec<Utxo> = vec![];
     let utxo_rng = rng.gen_range(1..max_lim_of_utxos);
-    for i in 0..utxo_rng {
-        counter += u64::from(i);
-        reward_utxos.push(create_rand_utxo(rng, counter));
-    }
+    let reward_utxos = (0..utxo_rng)
+        .into_iter()
+        .enumerate()
+        .map(|(i, _)| create_rand_utxo(rng, i as u64))
+        .collect();
     let reward_undo = BlockRewardUndo::new(reward_utxos);
 
     let mut tx_undo = vec![];
     let undo_rng = rng.gen_range(1..max_lim_of_tx_undos);
     for _ in 0..undo_rng {
-        let mut tx_utxos = vec![];
         let utxo_rng = rng.gen_range(1..max_lim_of_utxos);
-        for i in 0..utxo_rng {
-            counter += u64::from(i);
-
-            tx_utxos.push(create_rand_utxo(rng, counter));
-        }
+        let tx_utxos = (0..utxo_rng)
+            .into_iter()
+            .enumerate()
+            .map(|(i, _)| create_rand_utxo(rng, i as u64))
+            .collect();
 
         tx_undo.push(TxUndo::new(tx_utxos));
     }

--- a/chainstate-storage/src/internal/utxo_db.rs
+++ b/chainstate-storage/src/internal/utxo_db.rs
@@ -74,7 +74,7 @@ mod test {
         );
 
         // undo checking
-        let undo = create_rand_block_undo(&mut rng, 10, 10, BlockHeight::new(10));
+        let undo = create_rand_block_undo(&mut rng, 10, 10);
 
         assert!(db_interface.set_undo_data(block_id, &undo).is_ok());
         assert_eq!(db_interface.get_undo_data(block_id), Ok(Some(undo)));

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -102,7 +102,7 @@ impl BanScore for ConnectTransactionError {
             &ConnectTransactionError::MissingBlockUndo(_) => 0,
             &ConnectTransactionError::MissingBlockRewardUndo(_) => 0,
             &ConnectTransactionError::MissingTxUndo(_, _) => 0,
-            &ConnectTransactionError::UtxoInvariantBroken(_) => 0,
+            &ConnectTransactionError::UtxoInvariantBroken => 0,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -100,6 +100,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::SerializationInvariantError(_) => 100,
             ConnectTransactionError::TimeLockViolation => 100,
             &ConnectTransactionError::MissingBlockUndo(_) => 0,
+            &ConnectTransactionError::MissingBlockRewardUndo(_) => 0,
             &ConnectTransactionError::MissingTxUndo(_, _) => 0,
             &ConnectTransactionError::UtxoInvariantBroken(_) => 0,
         }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -101,8 +101,8 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::TimeLockViolation => 100,
             &ConnectTransactionError::MissingBlockUndo(_) => 0,
             &ConnectTransactionError::MissingBlockRewardUndo(_) => 0,
-            &ConnectTransactionError::MissingTxUndo(_, _) => 0,
-            &ConnectTransactionError::UtxoInvariantBroken => 0,
+            ConnectTransactionError::MissingTxUndo(_, _) => 0,
+            ConnectTransactionError::UtxoError(err) => err.ban_score(),
         }
     }
 }
@@ -168,6 +168,20 @@ impl BanScore for BlockSizeError {
             BlockSizeError::Header(_, _) => 100,
             BlockSizeError::SizeOfTxs(_, _) => 100,
             BlockSizeError::SizeOfSmartContracts(_, _) => 100,
+        }
+    }
+}
+
+impl BanScore for utxo::Error {
+    fn ban_score(&self) -> u32 {
+        match self {
+            utxo::Error::OverwritingUtxo => 0,
+            utxo::Error::FreshUtxoAlreadyExists => 0,
+            utxo::Error::UtxoAlreadySpent(_) => 100,
+            utxo::Error::NoUtxoFound => 0,
+            utxo::Error::NoBlockchainHeightFound => 0,
+            utxo::Error::MissingBlockRewardUndo(_) => 0,
+            utxo::Error::DBError(_) => 0,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -99,6 +99,9 @@ impl BanScore for ConnectTransactionError {
             // Even though this is an invariant, we consider it a violation to be overly cautious
             ConnectTransactionError::SerializationInvariantError(_) => 100,
             ConnectTransactionError::TimeLockViolation => 100,
+            &ConnectTransactionError::MissingBlockUndo(_) => 0, //???
+            &ConnectTransactionError::MissingTxUndo(_, _) => 0, //???
+            &ConnectTransactionError::UtxoInvariantBroken(_) => 0, //???
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -99,9 +99,9 @@ impl BanScore for ConnectTransactionError {
             // Even though this is an invariant, we consider it a violation to be overly cautious
             ConnectTransactionError::SerializationInvariantError(_) => 100,
             ConnectTransactionError::TimeLockViolation => 100,
-            &ConnectTransactionError::MissingBlockUndo(_) => 0, //???
-            &ConnectTransactionError::MissingTxUndo(_, _) => 0, //???
-            &ConnectTransactionError::UtxoInvariantBroken(_) => 0, //???
+            &ConnectTransactionError::MissingBlockUndo(_) => 0,
+            &ConnectTransactionError::MissingTxUndo(_, _) => 0,
+            &ConnectTransactionError::UtxoInvariantBroken(_) => 0,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -99,8 +99,8 @@ impl BanScore for ConnectTransactionError {
             // Even though this is an invariant, we consider it a violation to be overly cautious
             ConnectTransactionError::SerializationInvariantError(_) => 100,
             ConnectTransactionError::TimeLockViolation => 100,
-            &ConnectTransactionError::MissingBlockUndo(_) => 0,
-            &ConnectTransactionError::MissingBlockRewardUndo(_) => 0,
+            ConnectTransactionError::MissingBlockUndo(_) => 0,
+            ConnectTransactionError::MissingBlockRewardUndo(_) => 0,
             ConnectTransactionError::MissingTxUndo(_, _) => 0,
             ConnectTransactionError::UtxoError(err) => err.ban_score(),
         }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -178,7 +178,7 @@ impl BanScore for utxo::Error {
             utxo::Error::OverwritingUtxo => 0,
             utxo::Error::FreshUtxoAlreadyExists => 0,
             utxo::Error::UtxoAlreadySpent(_) => 100,
-            utxo::Error::NoUtxoFound => 0,
+            utxo::Error::NoUtxoFound => 100,
             utxo::Error::NoBlockchainHeightFound => 0,
             utxo::Error::MissingBlockRewardUndo(_) => 0,
             utxo::Error::DBError(_) => 0,

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -557,7 +557,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     ) -> Result<TransactionVerifier<S>, BlockError> {
         let mut tx_verifier =
             TransactionVerifier::new(&self.db_tx, utxo_view.derive_cache(), self.chain_config);
-        block.transactions().iter().enumerate().try_for_each(|(tx_num, _tx)| {
+        block.transactions().iter().rev().enumerate().try_for_each(|(tx_num, _tx)| {
             tx_verifier.disconnect_transaction(BlockTransactableRef::Transaction(block, tx_num))
         })?;
         tx_verifier.disconnect_transaction(BlockTransactableRef::BlockReward(block))?;

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -528,9 +528,6 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
         let mut tx_verifier =
             TransactionVerifier::new(&self.db_tx, utxo_view.derive_cache(), self.chain_config);
 
-        let block_subsidy = self.chain_config.block_subsidy_at_height(spend_height);
-        tx_verifier.check_block_reward(block, block_subsidy)?;
-
         tx_verifier.connect_transaction(
             BlockTransactableRef::BlockReward(block),
             spend_height,
@@ -546,6 +543,9 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
                 blockreward_maturity,
             )?;
         }
+
+        let block_subsidy = self.chain_config.block_subsidy_at_height(spend_height);
+        tx_verifier.check_block_reward(block, block_subsidy)?;
 
         Ok(tx_verifier)
     }

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -535,6 +535,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
             blockreward_maturity,
         )?;
 
+        // TODO: add a test that checks the order in which txs are connected
         for (tx_num, _tx) in block.transactions().iter().enumerate() {
             tx_verifier.connect_transaction(
                 BlockTransactableRef::Transaction(block, tx_num),
@@ -557,6 +558,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     ) -> Result<TransactionVerifier<S>, BlockError> {
         let mut tx_verifier =
             TransactionVerifier::new(&self.db_tx, utxo_view.derive_cache(), self.chain_config);
+        // TODO: add a test that checks the order in which txs are disconnected
         block.transactions().iter().rev().enumerate().try_for_each(|(tx_num, _tx)| {
             tx_verifier.disconnect_transaction(BlockTransactableRef::Transaction(block, tx_num))
         })?;

--- a/chainstate/src/detail/transaction_verifier/error.rs
+++ b/chainstate/src/detail/transaction_verifier/error.rs
@@ -97,8 +97,8 @@ pub enum ConnectTransactionError {
     SerializationInvariantError(Id<Block>),
     #[error("Timelock rules violated")]
     TimeLockViolation,
-    #[error("Utxo invariant broken: `{0}`")]
-    UtxoInvariantBroken(String),
+    #[error("Utxo invariant broken")]
+    UtxoInvariantBroken,
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {
@@ -136,12 +136,8 @@ impl From<utxo::Error> for ConnectTransactionError {
                 })
             }
             utxo::Error::DBError(error) => ConnectTransactionError::StorageError(error),
-            utxo::Error::FreshUtxoAlreadyExists => {
-                ConnectTransactionError::UtxoInvariantBroken(err.to_string())
-            }
-            utxo::Error::OverwritingUtxo => {
-                ConnectTransactionError::UtxoInvariantBroken(err.to_string())
-            }
+            utxo::Error::FreshUtxoAlreadyExists => ConnectTransactionError::UtxoInvariantBroken,
+            utxo::Error::OverwritingUtxo => ConnectTransactionError::UtxoInvariantBroken,
             utxo::Error::NoBlockchainHeightFound => {
                 ConnectTransactionError::BlockHeightArithmeticError
             }

--- a/chainstate/src/detail/transaction_verifier/error.rs
+++ b/chainstate/src/detail/transaction_verifier/error.rs
@@ -51,10 +51,10 @@ pub enum ConnectTransactionError {
     #[error("While disconnecting a block, output was erased in a previous step (possible in reorgs with no cache flushing)")]
     MissingOutputOrSpentOutputErasedOnDisconnect,
     #[error(
-        "While disconnecting a block, undo transaction number `{0}` does not exist in block `{1}`"
+        "While disconnecting a block, undo transaction number `{0}` doesn't exist for block `{1}`"
     )]
     MissingTxUndo(usize, Id<Block>),
-    #[error("While disconnecting a block, block undo info does not exist in block `{0}`")]
+    #[error("While disconnecting a block, block undo info doesn't exist for block `{0}`")]
     MissingBlockUndo(Id<Block>),
     #[error("Attempt to print money (total inputs: `{0:?}` vs total outputs `{1:?}`")]
     AttemptToPrintMoney(Amount, Amount),

--- a/chainstate/src/detail/transaction_verifier/error.rs
+++ b/chainstate/src/detail/transaction_verifier/error.rs
@@ -15,8 +15,8 @@
 
 use common::{
     chain::{
-        block::Block, OutPointSourceId, SpendError, Spender, TxMainChainIndexError,
-        TxMainChainPosition,
+        block::{Block, GenBlock},
+        OutPointSourceId, SpendError, Spender, TxMainChainIndexError, TxMainChainPosition,
     },
     primitives::{Amount, Id},
 };
@@ -56,6 +56,8 @@ pub enum ConnectTransactionError {
     MissingTxUndo(usize, Id<Block>),
     #[error("While disconnecting a block, block undo info doesn't exist for block `{0}`")]
     MissingBlockUndo(Id<Block>),
+    #[error("While disconnecting a block, block reward undo info doesn't exist for block `{0}`")]
+    MissingBlockRewardUndo(Id<GenBlock>),
     #[error("Attempt to print money (total inputs: `{0:?}` vs total outputs `{1:?}`")]
     AttemptToPrintMoney(Amount, Amount),
     #[error("Fee calculation failed (total inputs: `{0:?}` vs total outputs `{1:?}`")]
@@ -144,6 +146,9 @@ impl From<utxo::Error> for ConnectTransactionError {
                 ConnectTransactionError::BlockHeightArithmeticError
             }
             utxo::Error::NoUtxoFound => ConnectTransactionError::MissingOutputOrSpent,
+            utxo::Error::MissingBlockRewardUndo(id) => {
+                ConnectTransactionError::MissingBlockRewardUndo(id)
+            }
         }
     }
 }

--- a/chainstate/src/detail/transaction_verifier/mod.rs
+++ b/chainstate/src/detail/transaction_verifier/mod.rs
@@ -540,11 +540,18 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
         tx_num: usize,
     ) -> Result<TxUndo, ConnectTransactionError> {
         self.fetch_block_undo(block_id)?;
-        self.utxo_block_undo
+        let block_undo = &mut self
+            .utxo_block_undo
             .get_mut(block_id)
             .expect("block undo should be available")
-            .undo
-            .take_tx_undo(tx_num)
+            .undo;
+        debug_assert_eq!(
+            block_undo.tx_undos().len(),
+            tx_num + 1,
+            "only the last tx undo can be taken"
+        );
+        block_undo
+            .pop_tx_undo()
             .ok_or(ConnectTransactionError::MissingTxUndo(tx_num, *block_id))
     }
 

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -69,8 +69,8 @@ impl<'a> UtxosCache<'a> {
         // since the utxo does not exist in this view, try to check from parent.
         self.parent.and_then(|parent| {
             // if the utxo exists in parent:
-            // dirty is FALSE because this view does not have the utxo, therefore is different from parent
-            // fresh is FALSE because this view does not have the utxo but the parent has.
+            // dirty is 'No' because this view does not have the utxo, therefore is different from parent
+            // fresh is 'No' because this view does not have the utxo but the parent has.
             let entry = parent
                 .utxo(outpoint)
                 .map(|utxo| UtxoEntry::new(Some(utxo), IsFresh::No, IsDirty::No));
@@ -163,6 +163,7 @@ impl<'a> UtxosCache<'a> {
             self.spend_utxo(&tx_outpoint)?;
         }
 
+        assert_eq!(tx.inputs().len(), tx_undo.inner().len());
         for (tx_in, utxo) in tx.inputs().iter().zip(tx_undo.into_inner().into_iter()) {
             self.add_utxo(tx_in.outpoint(), utxo, false)?;
         }

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -287,7 +287,7 @@ impl<'a> UtxosCache<'a> {
             self.utxos.insert(outpoint.clone(), new_entry);
         }
 
-        entry.take_utxo().ok_or(Error::UtxoAlreadySpent(outpoint.tx_id()))
+        entry.take_utxo().ok_or_else(|| Error::UtxoAlreadySpent(outpoint.tx_id()))
     }
 
     /// Checks whether utxo exists in the cache

--- a/utxo/src/error.rs
+++ b/utxo/src/error.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use chainstate_types::storage_result;
+use common::chain::OutPointSourceId;
 use thiserror::Error;
 
 #[derive(Error, Debug, Eq, PartialEq)]
@@ -25,7 +26,7 @@ pub enum Error {
     )]
     FreshUtxoAlreadyExists,
     #[error("Attempted to spend a UTXO that's already spent")]
-    UtxoAlreadySpent,
+    UtxoAlreadySpent(OutPointSourceId),
     #[error("Attempted to spend a non-existing UTXO")]
     NoUtxoFound,
     #[error("Attempted to get the block height of a UTXO source that is based on the mempool")]

--- a/utxo/src/error.rs
+++ b/utxo/src/error.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chainstate_types::storage_result;
 use thiserror::Error;
 
 #[derive(Error, Debug, Eq, PartialEq)]
@@ -30,11 +31,11 @@ pub enum Error {
     #[error("Attempted to get the block height of a UTXO source that is based on the mempool")]
     NoBlockchainHeightFound,
     #[error("Database error: `{0}`")]
-    DBError(String),
+    DBError(storage_result::Error),
 }
 
-impl From<chainstate_types::storage_result::Error> for Error {
-    fn from(e: chainstate_types::storage_result::Error) -> Self {
-        Error::DBError(format!("{:?}", e))
+impl From<storage_result::Error> for Error {
+    fn from(e: storage_result::Error) -> Self {
+        Error::DBError(e)
     }
 }

--- a/utxo/src/error.rs
+++ b/utxo/src/error.rs
@@ -20,7 +20,7 @@ use common::{
 };
 use thiserror::Error;
 
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Error, Debug, Eq, PartialEq, Clone)]
 pub enum Error {
     #[error("Attempted to overwrite an existing utxo")]
     OverwritingUtxo,
@@ -37,11 +37,5 @@ pub enum Error {
     #[error("Block reward undo info is missing while unspending the utxo for block `{0}`")]
     MissingBlockRewardUndo(Id<GenBlock>),
     #[error("Database error: `{0}`")]
-    DBError(storage_result::Error),
-}
-
-impl From<storage_result::Error> for Error {
-    fn from(e: storage_result::Error) -> Self {
-        Error::DBError(e)
-    }
+    DBError(#[from] storage_result::Error),
 }

--- a/utxo/src/error.rs
+++ b/utxo/src/error.rs
@@ -14,7 +14,10 @@
 // limitations under the License.
 
 use chainstate_types::storage_result;
-use common::chain::OutPointSourceId;
+use common::{
+    chain::{block::GenBlock, OutPointSourceId},
+    primitives::Id,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug, Eq, PartialEq)]
@@ -31,6 +34,8 @@ pub enum Error {
     NoUtxoFound,
     #[error("Attempted to get the block height of a UTXO source that is based on the mempool")]
     NoBlockchainHeightFound,
+    #[error("Block reward undo info is missing while unspending the utxo for block `{0}`")]
+    MissingBlockRewardUndo(Id<GenBlock>),
     #[error("Database error: `{0}`")]
     DBError(storage_result::Error),
 }

--- a/utxo/src/lib.rs
+++ b/utxo/src/lib.rs
@@ -25,7 +25,7 @@ pub use crate::{
     cache::{ConsumedUtxoCache, UtxosCache},
     error::Error,
     storage::{UtxosDB, UtxosDBMut, UtxosStorageRead, UtxosStorageWrite},
-    undo::{BlockUndo, TxUndo},
+    undo::{BlockRewardUndo, BlockUndo, TxUndo},
     utxo::{Utxo, UtxoSource},
     view::{flush_to_base, FlushableUtxoView, UtxosView},
 };

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -155,7 +155,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
             let undos = block
                 .transactions()
                 .iter()
-                .map(|tx| cache.spend_utxos_from_tx(tx, block_height).expect("should spend okay."))
+                .map(|tx| cache.connect_transaction(tx, block_height).expect("should spend okay."))
                 .collect_vec();
             BlockUndo::new(Default::default(), undos)
         };
@@ -281,7 +281,7 @@ fn try_spend_tx_with_no_outputs(#[case] seed: Seed) {
     let tx = block.transactions().get(0).unwrap();
 
     assert_eq!(
-        view.spend_utxos_from_tx(tx, BlockHeight::new(2)).unwrap_err(),
+        view.connect_transaction(tx, BlockHeight::new(2)).unwrap_err(),
         NoUtxoFound
     );
 }

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -157,7 +157,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
                 .iter()
                 .map(|tx| cache.spend_utxos_from_tx(tx, block_height).expect("should spend okay."))
                 .collect_vec();
-            BlockUndo::new(undos, block_height)
+            BlockUndo::new(Default::default(), undos)
         };
 
         // check that the block_undo contains the same utxos recorded as "spent",

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -36,9 +36,9 @@ mod utxosdb_utxosview_impls {
         utxo(db, outpoint).is_some()
     }
 
-    pub fn best_block_hash<S: UtxosStorageRead>(db: &S) -> Option<Id<GenBlock>> {
+    pub fn best_block_hash<S: UtxosStorageRead>(db: &S) -> Id<GenBlock> {
         db.get_best_block_for_utxos().unwrap_or_else(|e| panic!("Database error while attempting to retrieve utxo set best block hash from the database: {}",
-        e))
+        e)).expect("Failed to get best block hash")
     }
 
     pub fn estimated_size<S: UtxosStorageRead>(_db: &S) -> Option<usize> {
@@ -62,7 +62,7 @@ impl<'a, S: UtxosStorageRead> UtxosView for UtxosDB<'a, S> {
     }
 
     fn best_block_hash(&self) -> Id<GenBlock> {
-        utxosdb_utxosview_impls::best_block_hash(self).expect("Failed to get best block hash")
+        utxosdb_utxosview_impls::best_block_hash(self)
     }
 
     fn estimated_size(&self) -> Option<usize> {
@@ -84,7 +84,7 @@ impl<'a, S: UtxosStorageWrite> UtxosView for UtxosDBMut<'a, S> {
     }
 
     fn best_block_hash(&self) -> Id<GenBlock> {
-        utxosdb_utxosview_impls::best_block_hash(self).expect("Failed to get best block hash")
+        utxosdb_utxosview_impls::best_block_hash(self)
     }
 
     fn estimated_size(&self) -> Option<usize> {

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -574,7 +574,7 @@ fn check_tx_spend_undo_spend(#[case] seed: Seed) {
     assert!(undo1.inner().len() == 1);
 
     //undo spending
-    cache.disconnect_transaction(&tx, &undo1).unwrap();
+    cache.disconnect_transaction(&tx, undo1.clone()).unwrap();
     assert!(cache.has_utxo_in_cache(&outpoint));
 
     //spend the transaction again
@@ -621,7 +621,7 @@ fn check_pos_reward_spend_undo_spend(#[case] seed: Seed) {
 
     //undo spending
     cache
-        .disconnect_block_transactable(&reward, &block.get_id().into(), Some(&undo1))
+        .disconnect_block_transactable(&reward, &block.get_id().into(), Some(undo1.clone()))
         .unwrap();
     assert!(cache.has_utxo_in_cache(&outpoint));
 

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -556,18 +556,13 @@ fn check_spend_undo_spend(#[case] seed: Seed) {
     );
     let tx = Transaction::new(0x00, vec![input], create_tx_outputs(&mut rng, 1), 0x01).unwrap();
     let undo = cache.spend_utxos_from_tx(&tx, BlockHeight::new(1)).unwrap();
+    assert!(!cache.has_utxo_in_cache(&outpoint));
 
     //undo spending
-    let tx_outpoint = OutPoint::new(OutPointSourceId::from(tx.get_id()), 0);
-    cache.spend_utxo(&tx_outpoint).unwrap();
-    cache
-        .add_utxo(
-            &outpoint,
-            undo.inner()[0].clone(),
-            cache.has_utxo(&outpoint),
-        )
-        .unwrap();
+    cache.unspend_utxos_from_tx(&tx, &undo).unwrap();
+    assert!(cache.has_utxo_in_cache(&outpoint));
 
     //spend the transaction again
     cache.spend_utxos_from_tx(&tx, BlockHeight::new(1)).unwrap();
+    assert!(!cache.has_utxo_in_cache(&outpoint));
 }

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -157,7 +157,7 @@ fn populate_cache_with_undo(
 
                 //spent the transaction
                 let block_height = BlockHeight::new(rng.gen_range(0..iterations_count as u64));
-                let undo = cache.spend_utxos_from_tx(&tx, block_height).unwrap();
+                let undo = cache.connect_transaction(&tx, block_height).unwrap();
 
                 //keep result updated
                 let new_outpoint = OutPoint::new(OutPointSourceId::from(tx.get_id()), 0);

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -129,7 +129,6 @@ pub mod test {
     #[case(Seed::from_entropy())]
     fn block_undo_test(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
-        let expected_height = BlockHeight::new(5);
         let (utxo0, _) = create_utxo(&mut rng, 0);
         let (utxo1, _) = create_utxo(&mut rng, 1);
         let tx_undo0 = TxUndo::new(vec![utxo0, utxo1]);
@@ -139,17 +138,20 @@ pub mod test {
         let (utxo4, _) = create_utxo(&mut rng, 4);
         let tx_undo1 = TxUndo::new(vec![utxo2, utxo3, utxo4]);
 
-        let blockundo = BlockUndo::new(vec![tx_undo0.clone(), tx_undo1.clone()], expected_height);
+        let (utxo5, _) = create_utxo(&mut rng, 5);
+        let reward_undo = BlockRewardUndo::new(vec![utxo5]);
+
+        let blockundo = BlockUndo::new(
+            reward_undo.clone(),
+            vec![tx_undo0.clone(), tx_undo1.clone()],
+        );
 
         // check `inner()`
-        {
-            let inner = blockundo.tx_undos();
+        let inner = blockundo.tx_undos();
 
-            assert_eq!(&tx_undo0, &inner[0]);
-            assert_eq!(&tx_undo1, &inner[1]);
-        }
+        assert_eq!(&tx_undo0, &inner[0]);
+        assert_eq!(&tx_undo1, &inner[1]);
 
-        // check the height
-        assert_eq!(blockundo.height, expected_height);
+        assert_eq!(&reward_undo, blockundo.block_reward_undo());
     }
 }

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -60,12 +60,12 @@ impl TxUndo {
 
 #[derive(Default, Debug, Clone, Eq, PartialEq, Encode, Decode)]
 pub struct BlockUndo {
-    reward_undo: BlockRewardUndo,
+    reward_undo: Option<BlockRewardUndo>,
     tx_undos: Vec<TxUndo>,
 }
 
 impl BlockUndo {
-    pub fn new(reward_undo: BlockRewardUndo, tx_undos: Vec<TxUndo>) -> Self {
+    pub fn new(reward_undo: Option<BlockRewardUndo>, tx_undos: Vec<TxUndo>) -> Self {
         Self {
             tx_undos,
             reward_undo,
@@ -80,12 +80,12 @@ impl BlockUndo {
         self.tx_undos.push(tx_undo);
     }
 
-    pub fn block_reward_undo(&self) -> &BlockRewardUndo {
-        &self.reward_undo
+    pub fn block_reward_undo(&self) -> Option<&BlockRewardUndo> {
+        self.reward_undo.as_ref()
     }
 
     pub fn set_block_reward_undo(&mut self, reward_undo: BlockRewardUndo) {
-        self.reward_undo = reward_undo;
+        self.reward_undo = Some(reward_undo);
     }
 }
 
@@ -142,7 +142,7 @@ pub mod test {
         let reward_undo = BlockRewardUndo::new(vec![utxo5]);
 
         let blockundo = BlockUndo::new(
-            reward_undo.clone(),
+            Some(reward_undo.clone()),
             vec![tx_undo0.clone(), tx_undo1.clone()],
         );
 
@@ -152,6 +152,6 @@ pub mod test {
         assert_eq!(&tx_undo0, &inner[0]);
         assert_eq!(&tx_undo1, &inner[1]);
 
-        assert_eq!(&reward_undo, blockundo.block_reward_undo());
+        assert_eq!(&reward_undo, blockundo.block_reward_undo().unwrap());
     }
 }

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -85,6 +85,7 @@ impl BlockUndo {
     }
 
     pub fn set_block_reward_undo(&mut self, reward_undo: BlockRewardUndo) {
+        debug_assert!(self.reward_undo.is_none());
         self.reward_undo = Some(reward_undo);
     }
 }

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -84,12 +84,8 @@ impl BlockUndo {
         self.tx_undos.push(tx_undo);
     }
 
-    pub fn take_tx_undo(&mut self, tx_num: usize) -> Option<TxUndo> {
-        if tx_num < self.tx_undos.len() {
-            Some(self.tx_undos.remove(tx_num))
-        } else {
-            None
-        }
+    pub fn pop_tx_undo(&mut self) -> Option<TxUndo> {
+        self.tx_undos.pop()
     }
 
     pub fn block_reward_undo(&self) -> Option<&BlockRewardUndo> {

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -67,8 +67,8 @@ pub struct BlockUndo {
 impl BlockUndo {
     pub fn new(reward_undo: BlockRewardUndo, tx_undos: Vec<TxUndo>) -> Self {
         Self {
-            tx_undos: tx_undos,
-            reward_undo: reward_undo,
+            tx_undos,
+            reward_undo,
         }
     }
 

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -27,6 +27,10 @@ impl BlockRewardUndo {
     pub fn inner(&self) -> &[Utxo] {
         &self.0
     }
+
+    pub fn into_inner(self) -> Vec<Utxo> {
+        self.0
+    }
 }
 
 #[derive(Default, Debug, Clone, Eq, PartialEq, Encode, Decode)]
@@ -80,6 +84,14 @@ impl BlockUndo {
         self.tx_undos.push(tx_undo);
     }
 
+    pub fn take_tx_undo(&mut self, tx_num: usize) -> Option<TxUndo> {
+        if tx_num < self.tx_undos.len() {
+            Some(self.tx_undos.remove(tx_num))
+        } else {
+            None
+        }
+    }
+
     pub fn block_reward_undo(&self) -> Option<&BlockRewardUndo> {
         self.reward_undo.as_ref()
     }
@@ -87,6 +99,10 @@ impl BlockUndo {
     pub fn set_block_reward_undo(&mut self, reward_undo: BlockRewardUndo) {
         debug_assert!(self.reward_undo.is_none());
         self.reward_undo = Some(reward_undo);
+    }
+
+    pub fn take_block_reward_undo(&mut self) -> Option<BlockRewardUndo> {
+        self.reward_undo.take()
     }
 }
 

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -14,10 +14,22 @@
 // limitations under the License.
 
 use crate::Utxo;
-use common::primitives::BlockHeight;
 use serialization::{Decode, Encode};
 
-#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Encode, Decode)]
+pub struct BlockRewardUndo(Vec<Utxo>);
+
+impl BlockRewardUndo {
+    pub fn new(utxos: Vec<Utxo>) -> Self {
+        Self(utxos)
+    }
+
+    pub fn inner(&self) -> &[Utxo] {
+        &self.0
+    }
+}
+
+#[derive(Default, Debug, Clone, Eq, PartialEq, Encode, Decode)]
 pub struct TxUndo(Vec<Utxo>);
 
 impl TxUndo {
@@ -46,26 +58,34 @@ impl TxUndo {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Encode, Decode)]
+#[derive(Default, Debug, Clone, Eq, PartialEq, Encode, Decode)]
 pub struct BlockUndo {
-    // determines at what height this undo file belongs to.
-    height: BlockHeight,
-    undos: Vec<TxUndo>,
+    reward_undo: BlockRewardUndo,
+    tx_undos: Vec<TxUndo>,
 }
 
 impl BlockUndo {
-    pub fn new(tx_undos: Vec<TxUndo>, height: BlockHeight) -> Self {
+    pub fn new(reward_undo: BlockRewardUndo, tx_undos: Vec<TxUndo>) -> Self {
         Self {
-            height,
-            undos: tx_undos,
+            tx_undos: tx_undos,
+            reward_undo: reward_undo,
         }
     }
+
     pub fn tx_undos(&self) -> &[TxUndo] {
-        &self.undos
+        &self.tx_undos
     }
 
-    pub fn height(&self) -> BlockHeight {
-        self.height
+    pub fn push_tx_undo(&mut self, tx_undo: TxUndo) {
+        self.tx_undos.push(tx_undo);
+    }
+
+    pub fn block_reward_undo(&self) -> &BlockRewardUndo {
+        &self.reward_undo
+    }
+
+    pub fn set_block_reward_undo(&mut self, reward_undo: BlockRewardUndo) {
+        self.reward_undo = reward_undo;
     }
 }
 


### PR DESCRIPTION
~~This is initial draft integration just to check that I'm on the right track. 
The code still doesn't fully compile and I didn't touch tests at all.~~

The main idea is that I added `utxo` into `transactino_verifier` side by side with `tx_index_cache`. Transaction index that was responsible for the logic of tracking spent outputs is left almost without changes. It should be modified in the next separate PR to clean up the code and avoid duplicated logic.