### PR TITLE
common: Mark `Amount` and `SignedAmount` as `must_use`

### DIFF
--- a/chainstate/src/detail/transaction_verifier/mod.rs
+++ b/chainstate/src/detail/transaction_verifier/mod.rs
@@ -533,7 +533,7 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
                 self.precache_inputs(tx.inputs())?;
 
                 // check for attempted money printing
-                self.check_transferred_amounts_and_get_fee(tx)?;
+                let _ = self.check_transferred_amounts_and_get_fee(tx)?;
 
                 // verify input signatures
                 self.verify_signatures(tx, spend_height, median_time_past)?;

--- a/common/src/primitives/amount.rs
+++ b/common/src/primitives/amount.rs
@@ -42,6 +42,7 @@ pub type UnsignedIntType = u128;
 /// An unsigned fixed-point type for amounts
 /// The smallest unit of count is called an atom
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+#[must_use]
 pub struct Amount {
     #[codec(compact)]
     val: UnsignedIntType,

--- a/common/src/primitives/signed_amount.rs
+++ b/common/src/primitives/signed_amount.rs
@@ -24,6 +24,7 @@ pub type SignedIntType = i128;
 /// A signed fixed-point type for amounts used in accounting, specifically
 /// The smallest unit of count is called an atom
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[must_use]
 pub struct SignedAmount {
     val: SignedIntType,
 }


### PR DESCRIPTION
to prevent the results from being ignored accidentally