### PR TITLE
p2p: Change item order in `PeerManager::validate_supported_protocols`

### DIFF
--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -151,15 +151,15 @@ where
             Protocol::new(ProtocolType::PubSub, SemVer::new(1, 1, 0)),
         ];
 
-        if !ONE_OF.iter().any(|p| protocols.contains(p)) {
-            return false;
-        }
-
         // All of these protocols are required.
         const REQUIRED: &[Protocol] = &[
             Protocol::new(ProtocolType::Ping, SemVer::new(1, 0, 0)),
             Protocol::new(ProtocolType::Sync, SemVer::new(0, 1, 0)),
         ];
+
+        if !ONE_OF.iter().any(|p| protocols.contains(p)) {
+            return false;
+        }
 
         REQUIRED.iter().all(|p| protocols.contains(p))
     }


### PR DESCRIPTION
Clippy on GitHub keeps complaining about this:

```
warning: adding items after statements is confusing, since items exist from the start of the scope
   --> p2p/src/peer_manager/mod.rs:159:9
    |
159 | /         const REQUIRED: &[Protocol] = &[
160 | |             Protocol::new(ProtocolType::Ping, SemVer::new(1, 0, 0)),
161 | |             Protocol::new(ProtocolType::Sync, SemVer::new(0, 1, 0)),
162 | |         ];
    | |__________^
    |
    = note: requested on the command line with `-W clippy::items-after-statements`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#items_after_statements
```