### PR TITLE
storage: Marker trait for transaction types

### DIFF
--- a/chainstate-storage/src/internal/mod.rs
+++ b/chainstate-storage/src/internal/mod.rs
@@ -437,5 +437,8 @@ impl<'st, B: storage::Backend> crate::TransactionRw for StoreTxRw<'st, B> {
     }
 }
 
+impl<'st, B: storage::Backend> crate::IsTransaction for StoreTxRo<'st, B> {}
+impl<'st, B: storage::Backend> crate::IsTransaction for StoreTxRw<'st, B> {}
+
 #[cfg(test)]
 mod test;

--- a/chainstate-storage/src/is_transaction_seal.rs
+++ b/chainstate-storage/src/is_transaction_seal.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Prevent more types from implementing the [crate::IsTransaction] trait
+pub trait Seal {}
+
+impl<'st, B: storage::Backend> Seal for crate::internal::StoreTxRo<'st, B> {}
+impl<'st, B: storage::Backend> Seal for crate::internal::StoreTxRw<'st, B> {}
+
+#[cfg(any(test, feature = "mock"))]
+impl Seal for crate::mock::MockStoreTxRo {}
+#[cfg(any(test, feature = "mock"))]
+impl Seal for crate::mock::MockStoreTxRw {}

--- a/chainstate-storage/src/lib.rs
+++ b/chainstate-storage/src/lib.rs
@@ -16,6 +16,7 @@
 //! Application-level interface for the persistent blockchain storage.
 
 mod internal;
+mod is_transaction_seal;
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
 
@@ -24,8 +25,7 @@ pub use internal::{utxo_db, Store};
 use chainstate_types::BlockIndex;
 use common::chain::block::BlockReward;
 use common::chain::transaction::{Transaction, TxMainChainIndex, TxMainChainPosition};
-use common::chain::OutPointSourceId;
-use common::chain::{Block, GenBlock};
+use common::chain::{Block, GenBlock, OutPointSourceId};
 use common::primitives::{BlockHeight, Id};
 use utxo::{UtxosStorageRead, UtxosStorageWrite};
 
@@ -106,14 +106,17 @@ pub trait BlockchainStorageWrite: BlockchainStorageRead + UtxosStorageWrite {
     fn del_block_id_at_height(&mut self, height: &BlockHeight) -> crate::Result<()>;
 }
 
+/// Marker trait for types where read/write operations are run in a transaction
+pub trait IsTransaction: is_transaction_seal::Seal {}
+
 /// Operations on read-only transactions
-pub trait TransactionRo: BlockchainStorageRead {
+pub trait TransactionRo: BlockchainStorageRead + IsTransaction {
     /// Close the transaction
     fn close(self);
 }
 
 /// Operations on read-write transactions
-pub trait TransactionRw: BlockchainStorageWrite {
+pub trait TransactionRw: BlockchainStorageWrite + IsTransaction {
     /// Abort the transaction
     fn abort(self);
 

--- a/chainstate-storage/src/mock.rs
+++ b/chainstate-storage/src/mock.rs
@@ -139,6 +139,8 @@ mockall::mock! {
     impl crate::TransactionRo for StoreTxRo {
         fn close(self);
     }
+
+    impl crate::IsTransaction for StoreTxRo {}
 }
 
 mockall::mock! {
@@ -212,6 +214,8 @@ mockall::mock! {
         fn abort(self);
         fn commit(self) -> crate::Result<()>;
     }
+
+    impl crate::IsTransaction for StoreTxRw {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Useful for marking types where read/write operations provide transactional guarantees. Operations may require this trait to be implemented to enforce the code to be run inside a DB transaction.

This will only really become useful once operations in `chainstate-storage` start requiring the trait to be implemented. @sinitcin @TheQuantumPhysicist 