### PR TITLE
p2p: Add tests for connection timeout

### DIFF
--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -107,6 +107,8 @@ pub enum DialError {
     InvalidPeerId,
     #[error("PeerId doesn't match the PeerId of endpoint")]
     WrongPeerId,
+    #[error("Connection refused or timed out")]
+    ConnectionRefusedOrTimedOut,
     #[error("I/O error: `{0:?}`")]
     IoError(std::io::ErrorKind),
     #[error("Failed to negotiate transport protocol")]

--- a/p2p/src/net/libp2p/behaviour/connection_manager/mod.rs
+++ b/p2p/src/net/libp2p/behaviour/connection_manager/mod.rs
@@ -143,9 +143,7 @@ impl ConnectionManager {
                 self.add_event(ConnectionManagerEvent::Behaviour(
                     BehaviourEvent::ConnectionError {
                         address: connection.addr().clone(),
-                        error: P2pError::DialError(DialError::IoError(
-                            std::io::ErrorKind::ConnectionRefused,
-                        )),
+                        error: P2pError::DialError(DialError::ConnectionRefusedOrTimedOut),
                     },
                 ));
             }
@@ -378,6 +376,8 @@ impl NetworkBehaviour for ConnectionManager {
         error: &Libp2pDialError,
     ) {
         if let Some(peer_id) = peer_id {
+            log::error!("Failed to dial peer: {error:?}");
+
             if let Err(err) = self.handle_dial_failure(&peer_id) {
                 if !std::matches!(error, Libp2pDialError::NoAddresses)
                     || err != P2pError::PeerError(PeerError::PeerDoesntExist)

--- a/p2p/src/net/libp2p/behaviour/connection_manager/tests.rs
+++ b/p2p/src/net/libp2p/behaviour/connection_manager/tests.rs
@@ -285,7 +285,7 @@ async fn handle_dial_failure() {
         Err(P2pError::PeerError(PeerError::PeerDoesntExist))
     );
 
-    // pending connections emit `ConnectionRefused` error
+    // pending connections emit `ConnectionRefusedOrTimedOut` error
     assert!(
         types::Connection::new(Multiaddr::empty(), types::ConnectionState::Dialing, None)
             .is_pending()
@@ -354,9 +354,7 @@ async fn handle_connection_refused() {
         Some(&types::ConnectionManagerEvent::Behaviour(
             types::BehaviourEvent::ConnectionError {
                 address: Multiaddr::empty(),
-                error: P2pError::DialError(DialError::IoError(
-                    std::io::ErrorKind::ConnectionRefused,
-                )),
+                error: P2pError::DialError(DialError::ConnectionRefusedOrTimedOut),
             },
         )),
     );

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -325,7 +325,7 @@ async fn test_connect_with_timeout() {
         service.poll_next().await,
         Ok(net::types::ConnectivityEvent::ConnectionError {
             address: _,
-            error: P2pError::DialError(DialError::IoError(std::io::ErrorKind::ConnectionRefused))
+            error: P2pError::DialError(DialError::ConnectionRefusedOrTimedOut)
         })
     ));
 
@@ -340,7 +340,7 @@ async fn test_connect_with_timeout() {
     );
 
     // then create a socket that listens to the address and verify that it takes
-    // 2 seconds to get the `ConnectionRefused` error, as expected
+    // 2 seconds to get the `ConnectionRefusedOrTimedOut` error, as expected
     let _service = TcpListener::bind(format!("[::1]:{}", port)).await.unwrap();
     let start = std::time::SystemTime::now();
 
@@ -349,7 +349,7 @@ async fn test_connect_with_timeout() {
         service.poll_next().await,
         Ok(net::types::ConnectivityEvent::ConnectionError {
             address: _,
-            error: P2pError::DialError(DialError::IoError(std::io::ErrorKind::ConnectionRefused))
+            error: P2pError::DialError(DialError::ConnectionRefusedOrTimedOut)
         })
     ));
     assert!(std::time::SystemTime::now().duration_since(start).unwrap().as_secs() >= 2);

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -174,22 +174,23 @@ impl Backend {
                     )
                     .await
                 }
-                Err(err) => self
-                    .conn_tx
-                    .send(types::ConnectivityEvent::ConnectionError {
-                        address,
-                        error: err.into(),
-                    })
-                    .await
-                    .map_err(P2pError::from),
+                Err(err) => {
+                    log::error!("Failed to establish connection: {err}");
+
+                    self.conn_tx
+                        .send(types::ConnectivityEvent::ConnectionError {
+                            address,
+                            error: P2pError::DialError(DialError::ConnectionRefusedOrTimedOut),
+                        })
+                        .await
+                        .map_err(P2pError::from)
+                }
             },
             Err(_err) => self
                 .conn_tx
                 .send(types::ConnectivityEvent::ConnectionError {
                     address,
-                    error: P2pError::DialError(DialError::IoError(
-                        std::io::ErrorKind::ConnectionRefused,
-                    )),
+                    error: P2pError::DialError(DialError::ConnectionRefusedOrTimedOut),
                 })
                 .await
                 .map_err(P2pError::from),

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -54,7 +54,7 @@ where
         swarm.peer_connectivity_handle.poll_next().await,
         Ok(net::types::ConnectivityEvent::ConnectionError {
             address: _,
-            error: P2pError::DialError(DialError::IoError(std::io::ErrorKind::ConnectionRefused))
+            error: P2pError::DialError(DialError::ConnectionRefusedOrTimedOut)
         })
     ));
 }
@@ -463,9 +463,7 @@ where
             res,
             Ok(net::types::ConnectivityEvent::ConnectionError {
                 address: _,
-                error: P2pError::DialError(DialError::IoError(
-                    std::io::ErrorKind::ConnectionRefused
-                )),
+                error: P2pError::DialError(DialError::ConnectionRefusedOrTimedOut),
             })
         )),
         Err(_err) => panic!("did not receive `ConnectionError` in time"),
@@ -531,9 +529,7 @@ where
     {
         Ok(res) => assert!(std::matches!(
             res.unwrap(),
-            Err(P2pError::DialError(DialError::IoError(
-                std::io::ErrorKind::ConnectionRefused
-            )))
+            Err(P2pError::DialError(DialError::ConnectionRefusedOrTimedOut))
         )),
         Err(_err) => panic!("did not receive `ConnectionError` in time"),
     }

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -13,15 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use libp2p::{Multiaddr, PeerId};
+use tokio::{sync::oneshot, time::timeout};
 
 use common::{chain::config, primitives::semver::SemVer};
 use p2p_test_utils::{make_libp2p_addr, make_mock_addr};
 
 use crate::{
     error::{DialError, P2pError, ProtocolError},
+    event::SwarmEvent,
     net::{
         self,
         libp2p::Libp2pService,
@@ -433,4 +435,123 @@ async fn inbound_connection_too_many_peers_mock() {
         peers,
     )
     .await;
+}
+
+async fn connection_timeout<T>(addr1: T::Address, addr2: T::Address)
+where
+    T: NetworkingService + 'static + std::fmt::Debug,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    <T as net::NetworkingService>::Address: std::str::FromStr,
+    <<T as net::NetworkingService>::Address as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    let config = Arc::new(config::create_mainnet());
+    let mut swarm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
+
+    swarm1
+        .peer_connectivity_handle
+        .connect(addr2.clone())
+        .await
+        .expect("dial to succeed");
+
+    match timeout(
+        Duration::from_secs(swarm1._p2p_config.outbound_connection_timeout),
+        swarm1.peer_connectivity_handle.poll_next(),
+    )
+    .await
+    {
+        Ok(res) => assert!(std::matches!(
+            res,
+            Ok(net::types::ConnectivityEvent::ConnectionError {
+                address: _,
+                error: P2pError::DialError(DialError::IoError(
+                    std::io::ErrorKind::ConnectionRefused
+                )),
+            })
+        )),
+        Err(_err) => panic!("did not receive `ConnectionError` in time"),
+    }
+}
+
+#[tokio::test]
+async fn connection_timeout_libp2p() {
+    connection_timeout::<Libp2pService>(
+        make_libp2p_addr(),
+        format!("/ip4/255.255.255.255/tcp/8888/p2p/{}", PeerId::random())
+            .parse()
+            .unwrap(),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn connection_timeout_mock() {
+    // TODO: implement timeouts for mock backend
+}
+
+// try to establish a new connection through RPC and verify that it is notified of the timeout
+async fn connection_timeout_rpc_notified<T>(addr1: T::Address, addr2: T::Address)
+where
+    T: NetworkingService + 'static + std::fmt::Debug,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    <T as net::NetworkingService>::Address: std::str::FromStr,
+    <<T as net::NetworkingService>::Address as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    let config = Arc::new(config::create_mainnet());
+    let p2p_config = Arc::new(Default::default());
+    let (conn, _, _) = T::start(addr1, Arc::clone(&config), Arc::clone(&p2p_config)).await.unwrap();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let (tx_sync, mut rx_sync) = tokio::sync::mpsc::unbounded_channel();
+
+    let mut swarm = peer_manager::PeerManager::<T>::new(
+        Arc::clone(&config),
+        Arc::clone(&p2p_config),
+        conn,
+        rx,
+        tx_sync,
+    );
+
+    tokio::spawn(async move {
+        loop {
+            let _ = rx_sync.recv().await;
+        }
+    });
+    tokio::spawn(async move {
+        swarm.run().await.unwrap();
+    });
+
+    let (rtx, rrx) = oneshot::channel();
+    tx.send(SwarmEvent::Connect(addr2, rtx)).unwrap();
+
+    match timeout(
+        Duration::from_secs(p2p_config.outbound_connection_timeout),
+        rrx,
+    )
+    .await
+    {
+        Ok(res) => assert!(std::matches!(
+            res.unwrap(),
+            Err(P2pError::DialError(DialError::IoError(
+                std::io::ErrorKind::ConnectionRefused
+            )))
+        )),
+        Err(_err) => panic!("did not receive `ConnectionError` in time"),
+    }
+}
+
+#[tokio::test]
+async fn connection_timeout_rpc_notified_libp2p() {
+    connection_timeout_rpc_notified::<Libp2pService>(
+        make_libp2p_addr(),
+        format!("/ip4/255.255.255.255/tcp/8888/p2p/{}", PeerId::random())
+            .parse()
+            .unwrap(),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn connection_timeout_rpc_notified_mock() {
+    // TODO: implement timeouts for mock backend
 }


### PR DESCRIPTION
Add tests to ensure that connection timeout is reported to the `PeerManager` and all the way to RPC if a new outbound connection was initiated by the user.