### PR TITLE
storage: Strongly typed schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,6 +4038,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "storage"
 version = "0.1.0"
 dependencies = [
+ "serialization",
  "storage-core",
  "storage-inmemory",
  "utils",

--- a/chainstate-storage/src/internal/mod.rs
+++ b/chainstate-storage/src/internal/mod.rs
@@ -24,7 +24,8 @@ use common::{
     },
     primitives::{BlockHeight, Id, Idable},
 };
-use serialization::{Codec, Decode, DecodeAll, Encode};
+use serialization::{Codec, Decode, DecodeAll, Encode, EncodeLike};
+use storage::schema;
 use utxo::{BlockUndo, Utxo, UtxosStorageRead, UtxosStorageWrite};
 
 use crate::{
@@ -58,22 +59,22 @@ mod well_known {
 }
 
 storage::decl_schema! {
-    // Database schema for blockchain storage
+    /// Database schema for blockchain storage
     Schema {
-        // Storage for individual values.
-        pub DBValue: Single,
-        // Storage for blocks.
-        pub DBBlock: Single,
-        // Store tag for blocks indexes.
-        pub DBBlockIndex: Single,
-        // Storage for transaction indices.
-        pub DBTxIndex: Single,
-        // Storage for block IDs indexed by block height.
-        pub DBBlockByHeight: Single,
-        // Store for Utxo Entries
-        pub DBUtxo: Single,
-        // Store for BlockUndo
-        pub DBBlockUndo: Single,
+        /// Storage for individual values.
+        pub DBValue: Map<Vec<u8>, Vec<u8>>,
+        /// Storage for blocks.
+        pub DBBlock: Map<Id<Block>, Block>,
+        /// Store tag for blocks indexes.
+        pub DBBlockIndex: Map<Id<Block>, BlockIndex>,
+        /// Storage for transaction indices.
+        pub DBTxIndex: Map<OutPointSourceId, TxMainChainIndex>,
+        /// Storage for block IDs indexed by block height.
+        pub DBBlockByHeight: Map<BlockHeight, Id<GenBlock>>,
+        /// Store for Utxo Entries
+        pub DBUtxo: Map<OutPoint, Utxo>,
+        /// Store for BlockUndo
+        pub DBBlockUndo: Map<Id<Block>, BlockUndo>,
     }
 }
 
@@ -231,7 +232,7 @@ macro_rules! impl_read_ops {
             }
 
             fn get_block_index(&self, id: &Id<Block>) -> crate::Result<Option<BlockIndex>> {
-                self.read::<DBBlockIndex, _, _>(id.as_ref())
+                self.read::<DBBlockIndex, _, _>(id)
             }
 
             /// Get the hash of the best block
@@ -240,19 +241,19 @@ macro_rules! impl_read_ops {
             }
 
             fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>> {
-                self.read::<DBBlock, _, _>(id.as_ref())
+                self.read::<DBBlock, _, _>(id)
             }
 
             fn get_block_reward(
                 &self,
                 block_index: &BlockIndex,
             ) -> crate::Result<Option<BlockReward>> {
-                match self.0.get::<DBBlock, _>().get(block_index.block_id().as_ref()) {
+                match self.0.get::<DBBlock, _>().get(block_index.block_id()) {
                     Err(e) => Err(e.into()),
                     Ok(None) => Ok(None),
                     Ok(Some(block)) => {
-                        let header_size = block_index.block_header().encoded_size();
-                        let begin = header_size;
+                        let block = block.bytes();
+                        let begin = block_index.block_header().encoded_size();
                         let encoded_block_reward_begin =
                             block.get(begin..).expect("Block reward outside of block range");
                         let block_reward = BlockReward::decode(&mut &*encoded_block_reward_begin)
@@ -266,7 +267,7 @@ macro_rules! impl_read_ops {
                 &self,
                 tx_id: &OutPointSourceId,
             ) -> crate::Result<Option<TxMainChainIndex>> {
-                self.read::<DBTxIndex, _, _>(&tx_id.encode())
+                self.read::<DBTxIndex, _, _>(tx_id)
             }
 
             fn get_mainchain_tx_by_position(
@@ -274,10 +275,11 @@ macro_rules! impl_read_ops {
                 tx_index: &TxMainChainPosition,
             ) -> crate::Result<Option<Transaction>> {
                 let block_id = tx_index.block_id();
-                match self.0.get::<DBBlock, _>().get(block_id.as_ref()) {
+                match self.0.get::<DBBlock, _>().get(block_id) {
                     Err(e) => Err(e.into()),
                     Ok(None) => Ok(None),
                     Ok(Some(block)) => {
+                        let block = block.bytes();
                         let begin = tx_index.byte_offset_in_block() as usize;
                         let encoded_tx =
                             block.get(begin..).expect("Transaction outside of block range");
@@ -292,13 +294,13 @@ macro_rules! impl_read_ops {
                 &self,
                 height: &BlockHeight,
             ) -> crate::Result<Option<Id<GenBlock>>> {
-                self.read::<DBBlockByHeight, _, _>(&height.encode())
+                self.read::<DBBlockByHeight, _, _>(height)
             }
         }
 
         impl<'st, B: storage::Backend> UtxosStorageRead for $TxType<'st, B> {
             fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>> {
-                self.read::<DBUtxo, _, _>(&outpoint.encode())
+                self.read::<DBUtxo, _, _>(outpoint)
             }
 
             fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>> {
@@ -306,26 +308,30 @@ macro_rules! impl_read_ops {
             }
 
             fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<BlockUndo>> {
-                self.read::<DBBlockUndo, _, _>(id.as_ref())
+                self.read::<DBBlockUndo, _, _>(id)
             }
         }
 
         impl<'st, B: storage::Backend> $TxType<'st, B> {
             // Read a value from the database and decode it
-            fn read<DBIdx, I, T>(&self, key: &[u8]) -> crate::Result<Option<T>>
+            fn read<DbMap, I, K>(&self, key: K) -> crate::Result<Option<DbMap::Value>>
             where
-                DBIdx: storage::schema::DbMap,
-                Schema: storage::schema::HasDbMap<DBIdx, I>,
-                T: Decode,
+                DbMap: schema::DbMap,
+                Schema: schema::HasDbMap<DbMap, I>,
+                K: EncodeLike<DbMap::Key>,
             {
-                let col = self.0.get::<DBIdx, I>();
-                let data = col.get(key).map_err(crate::Error::from)?;
-                Ok(data.map(|d| T::decode_all(&mut &*d).expect("Cannot decode a database value")))
+                let map = self.0.get::<DbMap, I>();
+                map.get(key).map_err(crate::Error::from).map(|x| x.map(|x| x.decode()))
             }
 
             // Read a value for a well-known entry
             fn read_value<E: well_known::Entry>(&self) -> crate::Result<Option<E::Value>> {
-                self.read::<DBValue, _, _>(E::KEY)
+                self.read::<DBValue, _, _>(E::KEY).map(|x| {
+                    x.map(|x| {
+                        E::Value::decode_all(&mut x.as_ref())
+                            .expect("db values to be encoded correctly")
+                    })
+                })
             }
         }
     };
@@ -344,15 +350,15 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn add_block(&mut self, block: &Block) -> crate::Result<()> {
-        self.write::<DBBlock, _, _>(block.get_id().encode(), block)
+        self.write::<DBBlock, _, _, _>(block.get_id(), block)
     }
 
     fn del_block(&mut self, id: Id<Block>) -> crate::Result<()> {
-        self.0.get_mut::<DBBlock, _>().del(id.as_ref()).map_err(Into::into)
+        self.0.get_mut::<DBBlock, _>().del(id).map_err(Into::into)
     }
 
     fn set_block_index(&mut self, block_index: &BlockIndex) -> crate::Result<()> {
-        self.write::<DBBlockIndex, _, _>(block_index.block_id().encode(), block_index)
+        self.write::<DBBlockIndex, _, _, _>(block_index.block_id(), block_index)
     }
 
     fn set_mainchain_tx_index(
@@ -360,11 +366,11 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
         tx_id: &OutPointSourceId,
         tx_index: &TxMainChainIndex,
     ) -> crate::Result<()> {
-        self.write::<DBTxIndex, _, _>(tx_id.encode(), tx_index)
+        self.write::<DBTxIndex, _, _, _>(tx_id, tx_index)
     }
 
     fn del_mainchain_tx_index(&mut self, tx_id: &OutPointSourceId) -> crate::Result<()> {
-        self.0.get_mut::<DBTxIndex, _>().del(&tx_id.encode()).map_err(Into::into)
+        self.0.get_mut::<DBTxIndex, _>().del(tx_id).map_err(Into::into)
     }
 
     fn set_block_id_at_height(
@@ -372,23 +378,21 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
         height: &BlockHeight,
         block_id: &Id<GenBlock>,
     ) -> crate::Result<()> {
-        self.write::<DBBlockByHeight, _, _>(height.encode(), block_id)
+        self.write::<DBBlockByHeight, _, _, _>(height, block_id)
     }
 
     fn del_block_id_at_height(&mut self, height: &BlockHeight) -> crate::Result<()> {
-        self.0.get_mut::<DBBlockByHeight, _>().del(&height.encode()).map_err(Into::into)
+        self.0.get_mut::<DBBlockByHeight, _>().del(height).map_err(Into::into)
     }
 }
 
 impl<'st, B: storage::Backend> UtxosStorageWrite for StoreTxRw<'st, B> {
     fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> crate::Result<()> {
-        let key = outpoint.encode();
-        self.write::<DBUtxo, _, _>(key, &entry)
+        self.write::<DBUtxo, _, _, _>(outpoint, entry)
     }
 
     fn del_utxo(&mut self, outpoint: &OutPoint) -> crate::Result<()> {
-        let key = outpoint.encode();
-        self.0.get_mut::<DBUtxo, _>().del(&key).map_err(Into::into)
+        self.0.get_mut::<DBUtxo, _>().del(outpoint).map_err(Into::into)
     }
 
     fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> crate::Result<()> {
@@ -396,28 +400,29 @@ impl<'st, B: storage::Backend> UtxosStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn set_undo_data(&mut self, id: Id<Block>, undo: &BlockUndo) -> crate::Result<()> {
-        self.write::<DBBlockUndo, _, _>(id.encode(), undo)
+        self.write::<DBBlockUndo, _, _, _>(id, undo)
     }
 
     fn del_undo_data(&mut self, id: Id<Block>) -> crate::Result<()> {
-        self.0.get_mut::<DBBlockUndo, _>().del(id.as_ref()).map_err(Into::into)
+        self.0.get_mut::<DBBlockUndo, _>().del(id).map_err(Into::into)
     }
 }
 
 impl<'st, B: storage::Backend> StoreTxRw<'st, B> {
     // Encode a value and write it to the database
-    fn write<DbMap, I, T>(&mut self, key: Vec<u8>, value: &T) -> crate::Result<()>
+    fn write<DbMap, I, K, V>(&mut self, key: K, value: V) -> crate::Result<()>
     where
-        DbMap: storage::schema::DbMap,
-        Schema: storage::schema::HasDbMap<DbMap, I>,
-        T: Encode,
+        DbMap: schema::DbMap,
+        Schema: schema::HasDbMap<DbMap, I>,
+        K: EncodeLike<<DbMap as schema::DbMap>::Key>,
+        V: EncodeLike<<DbMap as schema::DbMap>::Value>,
     {
-        self.0.get_mut::<DbMap, I>().put(key, value.encode()).map_err(Into::into)
+        self.0.get_mut::<DbMap, I>().put(key, value).map_err(Into::into)
     }
 
     // Write a value for a well-known entry
     fn write_value<E: well_known::Entry>(&mut self, val: &E::Value) -> crate::Result<()> {
-        self.write::<DBValue, _, _>(E::KEY.to_vec(), val)
+        self.write::<DBValue, _, _, _>(E::KEY, val.encode())
     }
 }
 

--- a/serialization/core/src/lib.rs
+++ b/serialization/core/src/lib.rs
@@ -16,7 +16,7 @@
 //! Blockchain data encoding and decoding tools
 
 // Re-export SCALE traits
-pub use parity_scale_codec::{Codec, Decode, DecodeAll, Encode, Input, Output};
+pub use parity_scale_codec::{Codec, Decode, DecodeAll, Encode, EncodeLike, Input, Output};
 
 // Re-export SCALE types
 pub use parity_scale_codec::{Compact, Error};

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,6 +10,7 @@ default = [ 'inmemory' ]
 inmemory = [ 'storage-inmemory' ]
 
 [dependencies]
+serialization = { path = "../serialization" }
 storage-core = { path = "core" }
 storage-inmemory = { path = "inmemory", optional = true }
 

--- a/storage/src/schema.rs
+++ b/storage/src/schema.rs
@@ -24,6 +24,12 @@ pub trait DbMap: 'static {
 
     /// Expected size of values in the map. May be used for storage optimization.
     const SIZE_HINT: core::ops::Range<usize> = 0..usize::MAX;
+
+    /// Type of keys in the map
+    type Key: serialization::Codec;
+
+    /// Type of values stored in the map
+    type Value: serialization::Codec;
 }
 
 /// What constitutes a valid database schema
@@ -74,21 +80,32 @@ mod internal {
 #[macro_export]
 macro_rules! decl_schema {
     (
-        $svis:vis $schema:ident {
-            $($vis:vis $name:ident: $mul:ident),* $(,)?
+        $(#[$sch_attrs:meta])* $sch_vis:vis $schema:ident {
+            $($(#[$map_attrs:meta])* $map_vis:vis $name:ident: Map<$key:ty, $val:ty>),* $(,)?
         }
     ) => {
         $(
-            #[doc = concat!("Database map: `", stringify!($name), "`")]
-            $vis struct $name;
+            $(#[$map_attrs])*
+            #[doc = concat!("\n\nDatabase map ", $crate::decl_schema!(@DOC $name: $key, $val))]
+            $map_vis struct $name;
             impl $crate::schema::DbMap for $name {
                 const NAME: &'static str = stringify!($name);
+                type Key = $key;
+                type Value = $val;
             }
         )*
-        $svis type $schema = $crate::decl_schema!(@LIST $($name)*);
+
+        $(#[$sch_attrs])*
+        #[doc = concat!("\n\nDatabase schema `", stringify!($schema), "`\n\n")]
+        #[doc = "## Key-value mappings"]
+        #[doc = concat!($("* ", $crate::decl_schema!(@DOC $name: $key, $val), "\n"),*)]
+        $sch_vis type $schema = $crate::decl_schema!(@LIST $($name)*);
     };
     (@LIST) => { () };
     (@LIST $head:ident $($tail:ident)*) => { ($head, $crate::decl_schema!(@LIST $($tail)*)) };
+    (@DOC $name:ident: $key:ty, $val:ty) => {
+        concat!("[`", stringify!($name), "`]`: ", stringify!($key), " -> ", stringify!($val), "`")
+    }
 }
 
 #[cfg(test)]
@@ -97,9 +114,9 @@ mod test {
 
     decl_schema! {
         MySchema {
-            DBIdx0: Single,
-            DBIdx1: Single,
-            DBIdx2: Single,
+            DBIdx0: Map<u8, u16>,
+            DBIdx1: Map<u8, u32>,
+            DBIdx2: Map<u8, u64>,
         }
     }
 


### PR DESCRIPTION
Add key and value types to schema to make sure reads and writes are decoded and encoded in a consistent way.

Also a small improvement to the auto-generated schema docs.