### PR TITLE
Use utxo set to calculate block total fees

### DIFF
--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -572,7 +572,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
             TransactionVerifier::new(&self.db_tx, utxo_view.derive_cache(), self.chain_config);
 
         // TODO: add a test that checks the order in which txs are disconnected
-        block.transactions().iter().rev().enumerate().try_for_each(|(tx_num, _)| {
+        block.transactions().iter().enumerate().rev().try_for_each(|(tx_num, _)| {
             tx_verifier.disconnect_transactable(BlockTransactableRef::Transaction(block, tx_num))
         })?;
         tx_verifier.disconnect_transactable(BlockTransactableRef::BlockReward(block))?;

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -24,7 +24,7 @@ use common::{
         },
         Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId,
     },
-    primitives::{BlockDistance, BlockHeight, Id, Idable},
+    primitives::{Amount, BlockDistance, BlockHeight, Id, Idable},
     Uint256,
 };
 use consensus::{BlockIndexHandle, TransactionIndexHandle};
@@ -37,7 +37,9 @@ use crate::{BlockError, BlockSource, ChainstateConfig};
 
 use super::{
     orphan_blocks::{OrphanBlocks, OrphanBlocksMut},
-    transaction_verifier::{BlockTransactableRef, TransactionVerifier},
+    transaction_verifier::{
+        error::ConnectTransactionError, BlockTransactableRef, Fee, Subsidy, TransactionVerifier,
+    },
     BlockSizeError, CheckBlockError, CheckBlockTransactionsError, OrphanCheckError,
 };
 
@@ -528,25 +530,35 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
         let mut tx_verifier =
             TransactionVerifier::new(&self.db_tx, utxo_view.derive_cache(), self.chain_config);
 
-        tx_verifier.connect_transaction(
+        let reward_fees = tx_verifier.connect_transactable(
             BlockTransactableRef::BlockReward(block),
             spend_height,
             &median_time_past,
             blockreward_maturity,
         )?;
+        debug_assert!(reward_fees.is_none());
 
         // TODO: add a test that checks the order in which txs are connected
-        for (tx_num, _tx) in block.transactions().iter().enumerate() {
-            tx_verifier.connect_transaction(
-                BlockTransactableRef::Transaction(block, tx_num),
-                spend_height,
-                &median_time_past,
-                blockreward_maturity,
-            )?;
-        }
+        let total_fees = block
+            .transactions()
+            .iter()
+            .enumerate()
+            .map(|(tx_num, _)| {
+                tx_verifier.connect_transactable(
+                    BlockTransactableRef::Transaction(block, tx_num),
+                    spend_height,
+                    &median_time_past,
+                    blockreward_maturity,
+                )
+            })
+            .try_fold(Amount::from_atoms(0), |total, fee| {
+                (total + fee?.expect("connect tx should return fees").0).ok_or_else(|| {
+                    ConnectTransactionError::FailedToAddAllFeesOfBlock(block.get_id())
+                })
+            })?;
 
         let block_subsidy = self.chain_config.block_subsidy_at_height(spend_height);
-        tx_verifier.check_block_reward(block, block_subsidy)?;
+        tx_verifier.check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy))?;
 
         Ok(tx_verifier)
     }
@@ -558,11 +570,13 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     ) -> Result<TransactionVerifier<S>, BlockError> {
         let mut tx_verifier =
             TransactionVerifier::new(&self.db_tx, utxo_view.derive_cache(), self.chain_config);
+
         // TODO: add a test that checks the order in which txs are disconnected
-        block.transactions().iter().rev().enumerate().try_for_each(|(tx_num, _tx)| {
-            tx_verifier.disconnect_transaction(BlockTransactableRef::Transaction(block, tx_num))
+        block.transactions().iter().rev().enumerate().try_for_each(|(tx_num, _)| {
+            tx_verifier.disconnect_transactable(BlockTransactableRef::Transaction(block, tx_num))
         })?;
-        tx_verifier.disconnect_transaction(BlockTransactableRef::BlockReward(block))?;
+        tx_verifier.disconnect_transactable(BlockTransactableRef::BlockReward(block))?;
+
         Ok(tx_verifier)
     }
 }

--- a/chainstate/src/detail/tests/double_spend_tests.rs
+++ b/chainstate/src/detail/tests/double_spend_tests.rs
@@ -161,7 +161,7 @@ fn double_spend_tx_in_another_block(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let tx1_output_value = rng.gen_range(100_000..200_000);
         let first_tx = tx_from_genesis(tf.genesis(), &mut rng, tx1_output_value);
-        let first_block = tf.make_block_builder().add_transaction(first_tx.clone()).build();
+        let first_block = tf.make_block_builder().add_transaction(first_tx).build();
         let first_block_id = first_block.get_id();
         tf.process_block(first_block, BlockSource::Local).unwrap();
         assert_eq!(tf.best_block_id(), first_block_id);

--- a/chainstate/src/detail/tests/double_spend_tests.rs
+++ b/chainstate/src/detail/tests/double_spend_tests.rs
@@ -168,11 +168,11 @@ fn double_spend_tx_in_another_block(#[case] seed: Seed) {
 
         let tx2_output_value = rng.gen_range(100_000..200_000);
         let second_tx = tx_from_genesis(tf.genesis(), &mut rng, tx2_output_value);
-        let second_block = tf.make_block_builder().add_transaction(second_tx).build();
+        let second_block = tf.make_block_builder().add_transaction(second_tx.clone()).build();
         assert_eq!(
             tf.process_block(second_block, BlockSource::Local).unwrap_err(),
             BlockError::StateUpdateFailed(ConnectTransactionError::DoubleSpendAttempt(
-                Spender::RegularInput(first_tx.get_id())
+                Spender::RegularInput(second_tx.get_id())
             ))
         );
         assert_eq!(tf.best_block_id(), first_block_id);

--- a/chainstate/src/detail/tests/double_spend_tests.rs
+++ b/chainstate/src/detail/tests/double_spend_tests.rs
@@ -18,7 +18,7 @@ use crate::detail::{
     transaction_verifier::error::ConnectTransactionError,
 };
 use common::{
-    chain::{tokens::OutputValue, OutPointSourceId, Spender, Transaction, TxInput, TxOutput},
+    chain::{tokens::OutputValue, OutPointSourceId, Transaction, TxInput, TxOutput},
     primitives::{Amount, Id},
 };
 
@@ -168,12 +168,10 @@ fn double_spend_tx_in_another_block(#[case] seed: Seed) {
 
         let tx2_output_value = rng.gen_range(100_000..200_000);
         let second_tx = tx_from_genesis(tf.genesis(), &mut rng, tx2_output_value);
-        let second_block = tf.make_block_builder().add_transaction(second_tx.clone()).build();
+        let second_block = tf.make_block_builder().add_transaction(second_tx).build();
         assert_eq!(
             tf.process_block(second_block, BlockSource::Local).unwrap_err(),
-            BlockError::StateUpdateFailed(ConnectTransactionError::DoubleSpendAttempt(
-                Spender::RegularInput(second_tx.get_id())
-            ))
+            BlockError::StateUpdateFailed(ConnectTransactionError::MissingOutputOrSpent)
         );
         assert_eq!(tf.best_block_id(), first_block_id);
     });

--- a/chainstate/src/detail/transaction_verifier/error.rs
+++ b/chainstate/src/detail/transaction_verifier/error.rs
@@ -74,7 +74,7 @@ pub enum ConnectTransactionError {
     BlockTimestampArithmeticError,
     #[error("Input addition error")]
     InputAdditionError,
-    #[error("Double-spend attempt")]
+    #[error("Double-spend attempt in `{0}`")]
     DoubleSpendAttempt(Spender),
     #[error("Input of tx {tx_id:?} has an out-of-range output index {source_output_index}")]
     OutputIndexOutOfRange {

--- a/chainstate/src/detail/transaction_verifier/error.rs
+++ b/chainstate/src/detail/transaction_verifier/error.rs
@@ -74,7 +74,7 @@ pub enum ConnectTransactionError {
     BlockTimestampArithmeticError,
     #[error("Input addition error")]
     InputAdditionError,
-    #[error("Double-spend attempt in `{0}`")]
+    #[error("Double-spend attempt in `{0:?}`")]
     DoubleSpendAttempt(Spender),
     #[error("Input of tx {tx_id:?} has an out-of-range output index {source_output_index}")]
     OutputIndexOutOfRange {

--- a/common/src/chain/transaction/transaction_index/mod.rs
+++ b/common/src/chain/transaction/transaction_index/mod.rs
@@ -48,6 +48,15 @@ impl From<Id<GenBlock>> for Spender {
     }
 }
 
+impl std::fmt::Display for Spender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Spender::RegularInput(id) => id.fmt(f),
+            Spender::BlockInput(id) => id.fmt(f),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub enum OutputSpentState {
     Unspent,

--- a/common/src/chain/transaction/transaction_index/mod.rs
+++ b/common/src/chain/transaction/transaction_index/mod.rs
@@ -48,15 +48,6 @@ impl From<Id<GenBlock>> for Spender {
     }
 }
 
-impl std::fmt::Display for Spender {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Spender::RegularInput(id) => id.fmt(f),
-            Spender::BlockInput(id) => id.fmt(f),
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub enum OutputSpentState {
     Unspent,


### PR DESCRIPTION
Use utxo set to calculate block total fees.

Pay attention that I had to change the meaning of spender in `DoubleSpendAttempt(Spender)` error. Previously Spender was a tx where the original output was spent. But since utxo set doesn't store spent outputs I redefine Spender as a tx where double spend occurred. Can be clearly seen in the test.