### PR TITLE
Rerun CI when target branch is updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,17 @@
 name: build
 
 on:
-    push:
-      branches:
-        - master
-        - staging
-    pull_request:
-      branches:
-        - master
-        - staging
+  push:
+    branches:
+      - master
+      - staging
+  pull_request:
+    branches:
+      - master
+      - staging
+  pull_request_target:
+    types: synchronize
+
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
With this change, I'm hoping that merging some PR with master will trigger CI in all other PRs. This is necessary to ensure that all merges yield a working copy of master/staging.

The documentation cannot be any more confusing. I'm not sure this does what I think it does:

https://github.com/orgs/community/discussions/24567

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows