### PR TITLE
chainstate: Rename the `tests` crate to `test-suite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "chainstate-tests"
+name = "chainstate-test-suite"
 version = "0.1.0"
 dependencies = [
  "chainstate",

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::unwrap_used)]
+
 mod block_builder;
 mod framework;
 mod framework_builder;

--- a/chainstate/test-suite/Cargo.toml
+++ b/chainstate/test-suite/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "chainstate-tests"
+name = "chainstate-test-suite"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
In #412 that moved chainstate-related crates to a subfolder, `chainstate-tests` was moved to `chainstate/test-suite` because calling it `chainstate/tests` would clash with Rust's standard location for integration tests. This adjusts the crate name to reflect that.