### PR TITLE
Check block small enhancements

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -134,6 +134,7 @@ impl BanScore for CheckBlockTransactionsError {
             CheckBlockTransactionsError::DuplicateInputInTransaction(_, _) => 100,
             CheckBlockTransactionsError::DuplicateInputInBlock(_) => 100,
             CheckBlockTransactionsError::DuplicatedTransactionInBlock(_, _) => 100,
+            CheckBlockTransactionsError::EmptyInputsOutputsInTransactionInBlock(_, _) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -133,7 +133,6 @@ impl BanScore for CheckBlockTransactionsError {
             CheckBlockTransactionsError::StorageError(_) => 0,
             CheckBlockTransactionsError::DuplicateInputInTransaction(_, _) => 100,
             CheckBlockTransactionsError::DuplicateInputInBlock(_) => 100,
-            CheckBlockTransactionsError::DuplicatedTransactionInBlock(_, _) => 100,
             CheckBlockTransactionsError::EmptyInputsOutputsInTransactionInBlock(_, _) => 100,
         }
     }

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -537,6 +537,8 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     pub fn check_block(&self, block: &WithId<Block>) -> Result<(), CheckBlockError> {
         self.check_block_header(block.header())?;
 
+        self.check_block_size(block).map_err(CheckBlockError::BlockSizeError)?;
+
         self.check_block_reward_maturity_settings(block)?;
 
         // MerkleTree root
@@ -564,8 +566,6 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
                 Ok(())
             },
         )?;
-
-        self.check_block_size(block).map_err(CheckBlockError::BlockSizeError)?;
 
         self.check_transactions(block)
             .map_err(CheckBlockError::CheckTransactionFailed)?;

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -88,8 +88,6 @@ pub enum CheckBlockTransactionsError {
     DuplicateInputInTransaction(Id<Transaction>, Id<Block>),
     #[error("Duplicate input in block")]
     DuplicateInputInBlock(Id<Block>),
-    #[error("Duplicate transaction found in block")]
-    DuplicatedTransactionInBlock(Id<Transaction>, Id<Block>),
     #[error("Empty inputs or outputs in transaction found in block")]
     EmptyInputsOutputsInTransactionInBlock(Id<Transaction>, Id<Block>),
 }

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -90,6 +90,8 @@ pub enum CheckBlockTransactionsError {
     DuplicateInputInBlock(Id<Block>),
     #[error("Duplicate transaction found in block")]
     DuplicatedTransactionInBlock(Id<Transaction>, Id<Block>),
+    #[error("Empty inputs or outputs in transaction found in block")]
+    EmptyInputsOutputsInTransactionInBlock(Id<Transaction>, Id<Block>),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -271,9 +271,15 @@ fn build_test_framework() {
 fn process_block() {
     use crate::TransactionBuilder;
     let mut tf = TestFramework::default();
+    let gen_block_id = tf.genesis().get_id();
     tf.make_block_builder()
         .add_transaction(
             TransactionBuilder::new()
+                .add_input(TxInput::new(
+                    OutPointSourceId::BlockReward(<Id<GenBlock>>::from(gen_block_id)),
+                    0,
+                    InputWitness::NoSignature(None),
+                ))
                 .add_output(TxOutput::new(
                     OutputValue::Coin(Amount::from_atoms(0)),
                     OutputPurpose::Transfer(Destination::AnyoneCanSpend),

--- a/chainstate/test-suite/src/tests/double_spend_tests.rs
+++ b/chainstate/test-suite/src/tests/double_spend_tests.rs
@@ -413,9 +413,7 @@ fn duplicate_tx_in_the_same_block(#[case] seed: Seed) {
 
         let mut rng = make_seedable_rng(seed);
         let first_tx = tx_from_genesis(&tf.genesis(), &mut rng, 1);
-
-        let second_tx = TransactionBuilder::new().build();
-        let second_tx_id = second_tx.get_id();
+        let second_tx = tx_from_tx(&first_tx, rng.gen_range(1000..2000));
 
         let block = tf
             .make_block_builder()
@@ -426,10 +424,7 @@ fn duplicate_tx_in_the_same_block(#[case] seed: Seed) {
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
                 CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::DuplicatedTransactionInBlock(
-                        second_tx_id,
-                        block_id
-                    )
+                    CheckBlockTransactionsError::DuplicateInputInBlock(block_id)
                 )
             ))
         );


### PR DESCRIPTION
Gathered some enhancements that I found while reading the code:

1) Added a check that tx has some inputs or outputs. We previously detected that error while connecting txs, so I moved it to earlier stage.
2) Removed redundant `consensus::validate_consensus` call from `check_block` (it is called in `check_block_header` anyway).
3) Call `check_block_size` before `check_transactions`. Checking size before iterating through all txs is a proper way to handle size constraints.