### PR TITLE
Added a new ChainConfig property and block reward outputs maturity tests

### DIFF
--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -422,7 +422,6 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
     }
 
     fn check_block_reward_maturity_settings(&self, block: &Block) -> Result<(), CheckBlockError> {
-        // TODO: test every individual case
         let required = block.consensus_data().reward_maturity_distance(self.chain_config);
         for output in block.block_reward().outputs() {
             match output.purpose() {

--- a/common/src/chain/block/consensus_data.rs
+++ b/common/src/chain/block/consensus_data.rs
@@ -41,7 +41,7 @@ impl ConsensusData {
 
     pub fn reward_maturity_distance(&self, chain_config: &ChainConfig) -> BlockDistance {
         match self {
-            ConsensusData::None => BlockDistance::new(0),
+            ConsensusData::None => chain_config.empty_consensus_reward_maturity_distance(),
             ConsensusData::PoW(_) => {
                 chain_config.get_proof_of_work_config().reward_maturity_distance()
             }

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -19,8 +19,8 @@ use super::{create_mainnet_genesis, create_unit_test_genesis, ChainConfig, Chain
 use crate::chain::{
     ConsensusUpgrade, Destination, Genesis, NetUpgrades, PoWChainConfig, UpgradeVersion,
 };
-use crate::primitives::Amount;
 use crate::primitives::{id::WithId, semver::SemVer, BlockHeight};
+use crate::primitives::{Amount, BlockDistance};
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -102,6 +102,7 @@ pub struct Builder {
     token_max_uri_len: usize,
     token_max_dec_count: u8,
     token_max_ticker_len: usize,
+    empty_consensus_reward_maturity_distance: BlockDistance,
 }
 
 impl Builder {
@@ -125,6 +126,7 @@ impl Builder {
             token_max_uri_len: super::TOKEN_MAX_URI_LEN,
             token_max_dec_count: super::TOKEN_MAX_DEC_COUNT,
             token_max_ticker_len: super::TOKEN_MAX_TICKER_LEN,
+            empty_consensus_reward_maturity_distance: BlockDistance::new(0),
         }
     }
 
@@ -155,6 +157,7 @@ impl Builder {
             token_max_uri_len,
             token_max_dec_count,
             token_max_ticker_len,
+            empty_consensus_reward_maturity_distance,
         } = self;
 
         let emission_schedule = match emission_schedule {
@@ -193,6 +196,7 @@ impl Builder {
             token_max_uri_len,
             token_max_dec_count,
             token_max_ticker_len,
+            empty_consensus_reward_maturity_distance,
         }
     }
 }
@@ -220,6 +224,7 @@ impl Builder {
     builder_method!(max_block_size_with_standard_txs: usize);
     builder_method!(max_block_size_with_smart_contracts: usize);
     builder_method!(net_upgrades: NetUpgrades<UpgradeVersion>);
+    builder_method!(empty_consensus_reward_maturity_distance: BlockDistance);
 
     /// Set the genesis block to be the unit test version
     pub fn genesis_unittest(mut self, premine_destination: Destination) -> Self {

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -29,7 +29,7 @@ use crate::chain::{Block, GenBlock, Genesis};
 use crate::chain::{PoWChainConfig, UpgradeVersion};
 use crate::primitives::id::{Id, Idable, WithId};
 use crate::primitives::semver::SemVer;
-use crate::primitives::{Amount, BlockHeight};
+use crate::primitives::{Amount, BlockDistance, BlockHeight};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -85,6 +85,7 @@ pub struct ChainConfig {
     token_max_uri_len: usize,
     token_max_dec_count: u8,
     token_max_ticker_len: usize,
+    empty_consensus_reward_maturity_distance: BlockDistance,
 }
 
 impl ChainConfig {
@@ -170,6 +171,10 @@ impl ChainConfig {
 
     pub fn token_max_ticker_len(&self) -> usize {
         self.token_max_ticker_len
+    }
+
+    pub fn empty_consensus_reward_maturity_distance(&self) -> BlockDistance {
+        self.empty_consensus_reward_maturity_distance
     }
 
     // TODO: this should be part of net-upgrades. There should be no canonical definition of PoW for any chain config


### PR DESCRIPTION
A new property `empty_consensus_reward_maturity_distance` has been added to the ChainConfig so that it is possible to specify a non-zero block reward maturity even when the consensus is set to `None`. This is used for testing.

Added tests for 100% coverage of the
`ChainstateRef::check_block_reward_maturity_settings` failure cases.