### PR TITLE
Use the utxo set to verify signatures instead of the transaction index

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -103,6 +103,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::UtxoError(err) => err.ban_score(),
             ConnectTransactionError::TokensError(err) => err.ban_score(),
             ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoadedFromHeight(_, _) => 100,
+            ConnectTransactionError::BlockIndexCouldNotBeLoaded(_) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -102,6 +102,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::MissingTxUndo(_, _) => 0,
             ConnectTransactionError::UtxoError(err) => err.ban_score(),
             ConnectTransactionError::TokensError(err) => err.ban_score(),
+            ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoadedFromHeight(_, _) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -66,32 +66,24 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::InvariantErrorTxNumWrongInBlock(_, _) => 0,
             ConnectTransactionError::OutputAlreadyPresentInInputsCache => 100,
             ConnectTransactionError::PreviouslyCachedInputNotFound(_) => 0,
-            ConnectTransactionError::PreviouslyCachedInputWasErased => 100,
             ConnectTransactionError::InvariantBrokenAlreadyUnspent => 0,
             // Even though this is an invariant error, it stems from referencing a block for reward that doesn't exist
-            ConnectTransactionError::InvariantBrokenSourceBlockIndexNotFound => 100,
             ConnectTransactionError::MissingOutputOrSpent => 100,
             ConnectTransactionError::MissingOutputOrSpentOutputErasedOnConnect => 100,
             ConnectTransactionError::MissingOutputOrSpentOutputErasedOnDisconnect => 0,
             ConnectTransactionError::AttemptToPrintMoney(_, _) => 100,
             ConnectTransactionError::TxFeeTotalCalcFailed(_, _) => 100,
-            ConnectTransactionError::OutputAdditionError => 100,
             ConnectTransactionError::SignatureVerificationFailed => 100,
             ConnectTransactionError::InvalidOutputCount => 100,
             ConnectTransactionError::BlockHeightArithmeticError => 100,
             ConnectTransactionError::BlockTimestampArithmeticError => 100,
-            ConnectTransactionError::InputAdditionError => 100,
             ConnectTransactionError::DoubleSpendAttempt(_) => 100,
             ConnectTransactionError::OutputIndexOutOfRange {
                 tx_id: _,
                 source_output_index: _,
             } => 100,
-            // Even though this is an invariant error, it stems from a transaction that doesn't exist
-            ConnectTransactionError::InvariantErrorTransactionCouldNotBeLoaded(_) => 100,
             // Even though this is an invariant error, it stems from a block reward that doesn't exist
             ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoaded(_) => 100,
-            ConnectTransactionError::InvariantErrorBlockIndexCouldNotBeLoaded(_) => 100,
-            ConnectTransactionError::InvariantErrorBlockCouldNotBeLoaded(_) => 100,
             ConnectTransactionError::FailedToAddAllFeesOfBlock(_) => 100,
             ConnectTransactionError::RewardAdditionError(_) => 100,
             // Even though this is an invariant, we consider it a violation to be overly cautious

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -881,11 +881,11 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut> ChainstateRef<'a, S, O> 
     }
 }
 
-pub fn block_index_ancestor_getter<'a, S, G>(
+pub fn block_index_ancestor_getter<S, G>(
     gen_block_index_getter: G,
-    db_tx: &'a S,
-    chain_config: &'a ChainConfig,
-    block_index: &'a GenBlockIndex,
+    db_tx: &S,
+    chain_config: &ChainConfig,
+    block_index: &GenBlockIndex,
     target_height: BlockHeight,
 ) -> Result<GenBlockIndex, PropertyQueryError>
 where

--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -889,11 +889,7 @@ pub fn block_index_ancestor_getter<'a, S, G>(
     target_height: BlockHeight,
 ) -> Result<GenBlockIndex, PropertyQueryError>
 where
-    G: Fn(
-        &'a S,
-        &'a ChainConfig,
-        &Id<GenBlock>,
-    ) -> Result<Option<GenBlockIndex>, PropertyQueryError>,
+    G: Fn(&S, &ChainConfig, &Id<GenBlock>) -> Result<Option<GenBlockIndex>, PropertyQueryError>,
 {
     if target_height > block_index.block_height() {
         return Err(PropertyQueryError::InvalidAncestorHeight {

--- a/chainstate/src/detail/transaction_verifier/cached_operation.rs
+++ b/chainstate/src/detail/transaction_verifier/cached_operation.rs
@@ -67,14 +67,6 @@ impl CachedInputsOperation {
         };
         replace_with::replace_with_or_abort(self, replacer_func);
     }
-
-    pub fn get_tx_index(&self) -> Option<&TxMainChainIndex> {
-        match self {
-            CachedInputsOperation::Write(idx) => Some(idx),
-            CachedInputsOperation::Read(idx) => Some(idx),
-            CachedInputsOperation::Erase => None,
-        }
-    }
 }
 
 // TODO: tests

--- a/chainstate/src/detail/transaction_verifier/error.rs
+++ b/chainstate/src/detail/transaction_verifier/error.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chainstate_types::PropertyQueryError;
 use common::{
     chain::{
         block::{Block, GenBlock},
@@ -20,7 +21,7 @@ use common::{
         OutPointSourceId, SpendError, Spender, Transaction, TxMainChainIndexError,
         TxMainChainPosition,
     },
-    primitives::{Amount, Id},
+    primitives::{Amount, BlockHeight, Id},
 };
 use thiserror::Error;
 
@@ -84,7 +85,9 @@ pub enum ConnectTransactionError {
     #[error("Transaction index found but transaction not found")]
     InvariantErrorTransactionCouldNotBeLoaded(TxMainChainPosition),
     #[error("Transaction index for header found but header not found")]
-    InvariantErrorHeaderCouldNotBeLoaded(Id<Block>),
+    InvariantErrorHeaderCouldNotBeLoaded(Id<GenBlock>),
+    #[error("Transaction index for header found but header not found")]
+    InvariantErrorHeaderCouldNotBeLoadedFromHeight(PropertyQueryError, BlockHeight),
     #[error("Unable to find block index")]
     InvariantErrorBlockIndexCouldNotBeLoaded(Id<Block>),
     #[error("Unable to find block")]

--- a/chainstate/src/detail/transaction_verifier/error.rs
+++ b/chainstate/src/detail/transaction_verifier/error.rs
@@ -90,6 +90,8 @@ pub enum ConnectTransactionError {
     InvariantErrorHeaderCouldNotBeLoadedFromHeight(PropertyQueryError, BlockHeight),
     #[error("Unable to find block index")]
     InvariantErrorBlockIndexCouldNotBeLoaded(Id<Block>),
+    #[error("Unable to find block index")]
+    BlockIndexCouldNotBeLoaded(Id<GenBlock>),
     #[error("Unable to find block")]
     InvariantErrorBlockCouldNotBeLoaded(Id<Block>),
     #[error("Addition of all fees in block `{0}` failed")]

--- a/chainstate/src/detail/transaction_verifier/error.rs
+++ b/chainstate/src/detail/transaction_verifier/error.rs
@@ -19,7 +19,6 @@ use common::{
         block::{Block, GenBlock},
         tokens::TokenId,
         OutPointSourceId, SpendError, Spender, Transaction, TxMainChainIndexError,
-        TxMainChainPosition,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -39,12 +38,8 @@ pub enum ConnectTransactionError {
     OutputAlreadyPresentInInputsCache,
     #[error("Input was cached, but could not be found")]
     PreviouslyCachedInputNotFound(OutPointSourceId),
-    #[error("Input was cached, but it is erased")]
-    PreviouslyCachedInputWasErased,
     #[error("Block disconnect already-unspent (invariant broken)")]
     InvariantBrokenAlreadyUnspent,
-    #[error("Source block index for block reward output not found")]
-    InvariantBrokenSourceBlockIndexNotFound,
     #[error("Output is not found in the cache or database")]
     MissingOutputOrSpent,
     #[error("While connecting a block, output was erased in a previous step (possible in reorgs with no cache flushing)")]
@@ -63,8 +58,6 @@ pub enum ConnectTransactionError {
     AttemptToPrintMoney(Amount, Amount),
     #[error("Fee calculation failed (total inputs: `{0:?}` vs total outputs `{1:?}`")]
     TxFeeTotalCalcFailed(Amount, Amount),
-    #[error("Output addition error")]
-    OutputAdditionError,
     #[error("Signature verification failed in transaction")]
     SignatureVerificationFailed,
     #[error("Invalid output count")]
@@ -73,8 +66,6 @@ pub enum ConnectTransactionError {
     BlockHeightArithmeticError,
     #[error("Error while calculating timestamps; possibly an overflow")]
     BlockTimestampArithmeticError,
-    #[error("Input addition error")]
-    InputAdditionError,
     #[error("Double-spend attempt in `{0:?}`")]
     DoubleSpendAttempt(Spender),
     #[error("Input of tx {tx_id:?} has an out-of-range output index {source_output_index}")]
@@ -82,18 +73,12 @@ pub enum ConnectTransactionError {
         tx_id: Option<Spender>,
         source_output_index: usize,
     },
-    #[error("Transaction index found but transaction not found")]
-    InvariantErrorTransactionCouldNotBeLoaded(TxMainChainPosition),
     #[error("Transaction index for header found but header not found")]
     InvariantErrorHeaderCouldNotBeLoaded(Id<GenBlock>),
     #[error("Transaction index for header found but header not found")]
     InvariantErrorHeaderCouldNotBeLoadedFromHeight(PropertyQueryError, BlockHeight),
     #[error("Unable to find block index")]
-    InvariantErrorBlockIndexCouldNotBeLoaded(Id<Block>),
-    #[error("Unable to find block index")]
     BlockIndexCouldNotBeLoaded(Id<GenBlock>),
-    #[error("Unable to find block")]
-    InvariantErrorBlockCouldNotBeLoaded(Id<Block>),
     #[error("Addition of all fees in block `{0}` failed")]
     FailedToAddAllFeesOfBlock(Id<Block>),
     #[error("Block reward addition error for block {0}")]

--- a/chainstate/src/detail/transaction_verifier/mod.rs
+++ b/chainstate/src/detail/transaction_verifier/mod.rs
@@ -60,7 +60,7 @@ use super::chainstateref::block_index_ancestor_getter;
 
 // TODO: We can move it to mod common, because in chain config we have `token_min_issuance_fee`
 //       that essentially belongs to this type, but return Amount
-#[derive(PartialEq, Eq, PartialOrd)]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct Fee(pub Amount);
 
 pub struct Subsidy(pub Amount);

--- a/chainstate/src/detail/transaction_verifier/mod.rs
+++ b/chainstate/src/detail/transaction_verifier/mod.rs
@@ -109,14 +109,6 @@ impl<'a, S> TransactionVerifier<'a, S> {
 }
 
 impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
-    pub fn get_gen_block_index(
-        &self,
-        block_id: &Id<GenBlock>,
-    ) -> Result<Option<GenBlockIndex>, ConnectTransactionError> {
-        gen_block_index_getter(self.db_tx, self.chain_config, *block_id)
-            .map_err(|_| ConnectTransactionError::BlockIndexCouldNotBeLoaded(*block_id))
-    }
-
     fn calculate_total_outputs(
         outputs: &[TxOutput],
         include_issuance: Option<&Transaction>,
@@ -343,8 +335,8 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
                     }
                 };
 
-                let block_index_getter = |_db_tx, _chain_config, id| {
-                    self.get_gen_block_index(&id)
+                let block_index_getter = |_db_tx, _chain_config, id: Id<GenBlock>| {
+                    gen_block_index_getter(self.db_tx, self.chain_config, id)
                         .map_err(|_| PropertyQueryError::BlockIndexAtHeightNotFound(*height))
                 };
 

--- a/chainstate/src/detail/transaction_verifier/mod.rs
+++ b/chainstate/src/detail/transaction_verifier/mod.rs
@@ -335,8 +335,8 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
                     }
                 };
 
-                let block_index_getter = |_db_tx, _chain_config, id: Id<GenBlock>| {
-                    gen_block_index_getter(self.db_tx, self.chain_config, id)
+                let block_index_getter = |db_tx, chain_config, id: Id<GenBlock>| {
+                    gen_block_index_getter(db_tx, chain_config, id)
                         .map_err(|_| PropertyQueryError::BlockIndexAtHeightNotFound(*height))
                 };
 

--- a/chainstate/src/detail/transaction_verifier/mod.rs
+++ b/chainstate/src/detail/transaction_verifier/mod.rs
@@ -335,10 +335,11 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
                     }
                 };
 
-                let block_index_getter = |db_tx, chain_config, id: &Id<GenBlock>| {
-                    gen_block_index_getter(db_tx, chain_config, id)
-                        .map_err(|_| PropertyQueryError::BlockIndexAtHeightNotFound(*height))
-                };
+                let block_index_getter =
+                    |db_tx: &S, chain_config: &ChainConfig, id: &Id<GenBlock>| {
+                        gen_block_index_getter(db_tx, chain_config, id)
+                            .map_err(|_| PropertyQueryError::BlockIndexAtHeightNotFound(*height))
+                    };
 
                 let block_index = block_index_ancestor_getter(
                     block_index_getter,

--- a/chainstate/src/detail/transaction_verifier/mod.rs
+++ b/chainstate/src/detail/transaction_verifier/mod.rs
@@ -34,15 +34,14 @@ use std::{
 };
 
 use chainstate_storage::{BlockchainStorageRead, BlockchainStorageWrite};
-use chainstate_types::GenBlockIndex;
+use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
 use common::{
     amount_sum,
     chain::{
         block::timestamp::BlockTimestamp,
         signature::{verify_signature, Transactable},
         tokens::{get_tokens_issuance_count, OutputValue, TokenId},
-        Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId, SpendablePosition, Transaction,
-        TxInput, TxOutput,
+        Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId, Transaction, TxInput, TxOutput,
     },
     primitives::{id::WithId, Amount, BlockDistance, BlockHeight, Id, Idable},
 };
@@ -56,6 +55,8 @@ use self::token_issuance_cache::TokenIssuanceCache;
 
 mod utils;
 use self::utils::{check_transferred_amount, get_input_token_id_and_amount};
+
+use super::chainstateref::block_index_ancestor_getter;
 
 // TODO: We can move it to mod common, because in chain config we have `token_min_issuance_fee`
 //       that essentially belongs to this type, but return Amount
@@ -115,6 +116,7 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
         &self,
         block_id: &Id<GenBlock>,
     ) -> Result<Option<GenBlockIndex>, ConnectTransactionError> {
+        // TODO: this seems to be repeated in the query interface. Seek to unify them to avoid redundancy
         match block_id.classify(self.chain_config) {
             GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(Arc::clone(
                 self.chain_config.genesis_block(),
@@ -324,6 +326,7 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
 
     fn verify_signatures<T: Transactable>(
         &self,
+        block_index: &BlockIndex,
         tx: &T,
         spend_height: &BlockHeight,
         spending_time: &BlockTimestamp,
@@ -335,77 +338,43 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
 
         for (input_idx, input) in inputs.iter().enumerate() {
             let outpoint = input.outpoint();
-            let tx_index =
-                self.tx_index_cache.get_from_cached(&outpoint.tx_id())?.ok_or_else(|| {
-                    ConnectTransactionError::PreviouslyCachedInputNotFound(outpoint.tx_id())
+            let utxo = self
+                .utxo_cache
+                .utxo(outpoint)
+                .ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
+
+            // TODO: see if a different treatment should be done for different output purposes
+            verify_signature(utxo.output().purpose().destination(), tx, input_idx)
+                .map_err(|_| ConnectTransactionError::SignatureVerificationFailed)?;
+
+            {
+                let height = match utxo.source() {
+                    utxo::UtxoSource::Blockchain(h) => h,
+                    utxo::UtxoSource::Mempool => {
+                        unreachable!("Mempool utxos can never be reached from storage")
+                    }
+                };
+
+                let block_index_getter = |_db_tx, _chain_config, id| {
+                    self.get_gen_block_index(&id)
+                        .map_err(|_| PropertyQueryError::BlockIndexAtHeightNotFound(*height))
+                };
+
+                let block_index = block_index_ancestor_getter(
+                    block_index_getter,
+                    self.db_tx,
+                    self.chain_config,
+                    &block_index.clone().into(),
+                    *height,
+                )
+                .map_err(|e| {
+                    ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoadedFromHeight(
+                        e, *height,
+                    )
                 })?;
 
-            match tx_index.position() {
-                SpendablePosition::Transaction(tx_pos) => {
-                    let prev_tx = self
-                        .db_tx
-                        .get_mainchain_tx_by_position(tx_pos)
-                        .map_err(ConnectTransactionError::from)?
-                        .ok_or_else(|| {
-                            ConnectTransactionError::InvariantErrorTransactionCouldNotBeLoaded(
-                                tx_pos.clone(),
-                            )
-                        })?;
-
-                    let output = prev_tx
-                        .outputs()
-                        .get(input.outpoint().output_index() as usize)
-                        .ok_or(ConnectTransactionError::OutputIndexOutOfRange {
-                            tx_id: None,
-                            source_output_index: outpoint.output_index() as usize,
-                        })?;
-
-                    // TODO: see if a different treatment should be done for different output purposes
-
-                    {
-                        let block_index = self
-                            .db_tx
-                            .get_block_index(tx_pos.block_id())
-                            .map_err(ConnectTransactionError::from)?
-                            .ok_or_else(|| {
-                                ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoaded(
-                                    *tx_pos.block_id(),
-                                )
-                            })?;
-                        self.check_timelock(
-                            &GenBlockIndex::Block(block_index),
-                            output,
-                            spend_height,
-                            spending_time,
-                        )?;
-                    }
-
-                    verify_signature(output.purpose().destination(), tx, input_idx)
-                        .map_err(|_| ConnectTransactionError::SignatureVerificationFailed)?;
-                }
-                SpendablePosition::BlockReward(block_id) => {
-                    let block_index = self.get_gen_block_index(block_id)?.ok_or_else(|| {
-                        // TODO get rid of the coercion
-                        let block_id = Id::new(block_id.get());
-                        ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoaded(block_id)
-                    })?;
-
-                    let outputs = self.block_reward_outputs(block_id)?;
-                    let output = outputs.get(input.outpoint().output_index() as usize).ok_or(
-                        ConnectTransactionError::OutputIndexOutOfRange {
-                            tx_id: None,
-                            source_output_index: outpoint.output_index() as usize,
-                        },
-                    )?;
-
-                    // TODO: see if a different treatment should be done for different output purposes
-
-                    self.check_timelock(&block_index, output, spend_height, spending_time)?;
-
-                    verify_signature(output.purpose().destination(), tx, input_idx)
-                        .map_err(|_| ConnectTransactionError::SignatureVerificationFailed)?;
-                }
-            };
+                self.check_timelock(&block_index, utxo.output(), spend_height, spending_time)?;
+            }
         }
 
         Ok(())
@@ -468,6 +437,7 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
 
     pub fn connect_transactable(
         &mut self,
+        block_index: &BlockIndex,
         spend_ref: BlockTransactableRef,
         spend_height: &BlockHeight,
         median_time_past: &BlockTimestamp,
@@ -499,7 +469,7 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
                 self.token_issuance_cache.register(block.get_id(), tx)?;
 
                 // verify input signatures
-                self.verify_signatures(tx, spend_height, median_time_past)?;
+                self.verify_signatures(block_index, tx, spend_height, median_time_past)?;
 
                 // spend utxos
                 let tx_undo = self
@@ -524,7 +494,12 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
                     self.tx_index_cache.precache_inputs(inputs, tx_index_fetcher)?;
 
                     // verify input signatures
-                    self.verify_signatures(&reward_transactable, spend_height, median_time_past)?;
+                    self.verify_signatures(
+                        block_index,
+                        &reward_transactable,
+                        spend_height,
+                        median_time_past,
+                    )?;
                 }
 
                 let fee = None;
@@ -617,36 +592,6 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
         }
 
         Ok(())
-    }
-
-    fn block_reward_outputs(
-        &self,
-        block_id: &Id<GenBlock>,
-    ) -> Result<Vec<TxOutput>, ConnectTransactionError> {
-        match block_id.classify(self.chain_config) {
-            GenBlockId::Genesis(_) => Ok(self
-                .chain_config
-                .genesis_block()
-                .block_reward_transactable()
-                .outputs()
-                .unwrap_or(&[])
-                .to_vec()),
-            // TODO: Getting the whole block just for reward outputs isn't optimal. See the
-            // https://github.com/mintlayer/mintlayer-core/issues/344 issue for details.
-            GenBlockId::Block(id) => {
-                let block_index = self
-                    .db_tx
-                    .get_block_index(&id)?
-                    .ok_or(ConnectTransactionError::InvariantErrorBlockIndexCouldNotBeLoaded(id))?;
-                let reward = self
-                    .db_tx
-                    .get_block_reward(&block_index)?
-                    .ok_or(ConnectTransactionError::InvariantErrorBlockCouldNotBeLoaded(id))?
-                    .outputs()
-                    .to_vec();
-                Ok(reward)
-            }
-        }
     }
 
     pub fn consume(self) -> Result<TransactionVerifierDelta, ConnectTransactionError> {

--- a/chainstate/src/detail/transaction_verifier/mod.rs
+++ b/chainstate/src/detail/transaction_verifier/mod.rs
@@ -335,7 +335,7 @@ impl<'a, S: BlockchainStorageRead> TransactionVerifier<'a, S> {
                     }
                 };
 
-                let block_index_getter = |db_tx, chain_config, id: Id<GenBlock>| {
+                let block_index_getter = |db_tx, chain_config, id: &Id<GenBlock>| {
                     gen_block_index_getter(db_tx, chain_config, id)
                         .map_err(|_| PropertyQueryError::BlockIndexAtHeightNotFound(*height))
                 };

--- a/chainstate/src/detail/transaction_verifier/tx_index_cache.rs
+++ b/chainstate/src/detail/transaction_verifier/tx_index_cache.rs
@@ -133,21 +133,6 @@ impl TxIndexCache {
         Ok(result)
     }
 
-    pub fn get_from_cached(
-        &self,
-        outpoint: &OutPointSourceId,
-    ) -> Result<Option<&TxMainChainIndex>, ConnectTransactionError> {
-        let result = match self.data.get(outpoint) {
-            Some(tx_index) => tx_index.get_tx_index(),
-            None => {
-                return Err(ConnectTransactionError::PreviouslyCachedInputNotFound(
-                    outpoint.clone(),
-                ))
-            }
-        };
-        Ok(result)
-    }
-
     pub fn spend_tx_index_inputs(
         &mut self,
         inputs: &[TxInput],

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -32,7 +32,7 @@ pub enum PropertyQueryError {
     BlockNotFound(Id<Block>),
     #[error("Previous block index not found {0}")]
     PrevBlockIndexNotFound(Id<GenBlock>),
-    #[error("Block index at height not found {0}")]
+    #[error("Block index at height {0} not found")]
     BlockIndexAtHeightNotFound(BlockHeight),
     #[error("Block for height {0} not found")]
     BlockForHeightNotFound(BlockHeight),

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -32,7 +32,7 @@ pub enum PropertyQueryError {
     BlockNotFound(Id<Block>),
     #[error("Previous block index not found {0}")]
     PrevBlockIndexNotFound(Id<GenBlock>),
-    #[error("Previous block index not found {0}")]
+    #[error("Block index at height not found {0}")]
     BlockIndexAtHeightNotFound(BlockHeight),
     #[error("Block for height {0} not found")]
     BlockForHeightNotFound(BlockHeight),

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -32,6 +32,8 @@ pub enum PropertyQueryError {
     BlockNotFound(Id<Block>),
     #[error("Previous block index not found {0}")]
     PrevBlockIndexNotFound(Id<GenBlock>),
+    #[error("Previous block index not found {0}")]
+    BlockIndexAtHeightNotFound(BlockHeight),
     #[error("Block for height {0} not found")]
     BlockForHeightNotFound(BlockHeight),
     #[error("Provided an empty list")]

--- a/chainstate/types/src/gen_block_index.rs
+++ b/chainstate/types/src/gen_block_index.rs
@@ -74,3 +74,9 @@ impl GenBlockIndex {
         }
     }
 }
+
+impl From<BlockIndex> for GenBlockIndex {
+    fn from(bi: BlockIndex) -> Self {
+        GenBlockIndex::Block(bi)
+    }
+}


### PR DESCRIPTION
This seems to have been missed before when we moved to use the utxo set. Now it's complete.

Please review this carefully. I hope I did't miss anything. It's Friday night though :-)