### PR TITLE
Added transaction_processing_order test

### DIFF
--- a/chainstate/src/detail/chainstateref.rs
+++ b/chainstate/src/detail/chainstateref.rs
@@ -609,7 +609,6 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateRef<'a, S, O> {
         )?;
         debug_assert!(reward_fees.is_none());
 
-        // TODO: add a test that checks the order in which txs are connected
         let total_fees = block.transactions().iter().enumerate().try_fold(
             Amount::from_atoms(0),
             |total, (tx_num, _)| {


### PR DESCRIPTION
The transaction_processing_order test ensures that transactions in a block appear in the order they are being spent.