### PR TITLE
Enforce TODO(PR) policy

### DIFF
--- a/.github/scripts/codecheck.py
+++ b/.github/scripts/codecheck.py
@@ -83,11 +83,34 @@ def check_licenses():
     print()
     return ok
 
+# check TODO(PR) and FIXME instances
+def check_todos():
+    print("==== Checking TODO(PR) and FIXME instances:")
+    
+    # list of files exempted from checks
+    exempted_files = [
+        ]
+    
+    ok = True
+    for path in rs_sources():
+        if any(os.path.samefile(path, exempted) for exempted in exempted_files):
+            continue
+        
+        with open(path) as file:
+            file_data = file.read()
+            if 'TODO(PR)' in file_data or 'FIXME' in file_data:
+                ok = False
+                print("{}: Found TODO(PR) or FIXME instances".format(path))
+
+    print()
+    return ok
+
 def run_checks():
     return all([
             disallow(SCALECODEC_RE, exclude = ['serialization/core']),
             disallow(JSONRPSEE_RE, exclude = ['rpc']),
-            check_licenses()
+            check_licenses(),
+            check_todos()
         ])
 
 if __name__ == '__main__':

--- a/chainstate/src/detail/orphan_blocks/pool.rs
+++ b/chainstate/src/detail/orphan_blocks/pool.rs
@@ -21,7 +21,7 @@ use common::primitives::id::WithId;
 use common::primitives::{Id, Idable};
 use crypto::random::SliceRandom;
 
-// FIXME: The Arc here is unnecessary: https://github.com/mintlayer/mintlayer-core/issues/164
+// TODO: The Arc here is unnecessary: https://github.com/mintlayer/mintlayer-core/issues/164
 pub struct OrphanBlocksPool {
     orphan_ids: Vec<Id<Block>>,
     orphan_by_id: BTreeMap<Id<Block>, Arc<WithId<Block>>>,

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -57,7 +57,7 @@ pub struct MempoolStore {
     // would no longer be valid to mine). Entries with a lower descendant score will be evicted
     // first.
     //
-    // FIXME currently, the descendant score is the sum fee of the transaction to gether with all
+    // TODO: currently, the descendant score is the sum fee of the transaction to gether with all
     // of its descendants. If we wish to follow Bitcoin Core, we should use:
     // max(feerate(tx, tx_with_descendants)),
     // Where feerate is computed as fee(tx)/size(tx)


### PR DESCRIPTION
Basically CI checks will fail if the rust source files contain a TODO(PR) or FIXME