### PR TITLE
In Mempool, follow Bitcoin Core and use `fees_with_descendants/size_with_desdendants` as descendant_score

### DIFF
--- a/mempool/src/pool.rs
+++ b/mempool/src/pool.rs
@@ -764,7 +764,14 @@ where
             .txs_by_descendant_score
             .values()
             .flatten()
-            .map(|id| WithId::get(self.store.get_entry(id).expect("entry").tx()))
+            .map(|id| {
+                WithId::get(
+                    self.store
+                        .get_entry(id)
+                        .unwrap_or_else(|| panic!("did not find entry with id {}", id))
+                        .tx(),
+                )
+            })
             .collect()
     }
 

--- a/mempool/src/pool.rs
+++ b/mempool/src/pool.rs
@@ -690,7 +690,7 @@ where
             log::debug!(
                 "Mempool trim: Evicting tx {} which has a descendant score of {:?} and has size {}",
                 removed.tx_id(),
-                removed.fees_with_descendants,
+                removed.fees_with_descendants(),
                 removed.size()
             );
             removed_fees.push(FeeRate::from_total_tx_fee(

--- a/mempool/src/pool.rs
+++ b/mempool/src/pool.rs
@@ -652,12 +652,12 @@ where
             .map(|entry_id| self.store.txs_by_id.get(entry_id).expect("entry should exist"))
             .filter(|entry| {
                 let now = self.clock.get_time();
-                let expired = now.saturating_sub(entry.creation_time) > self.max_tx_age;
+                let expired = now.saturating_sub(entry.creation_time()) > self.max_tx_age;
                 if expired {
                     log::trace!(
                         "Evicting tx {} which was created at {:?}. It is now {:?}",
                         entry.tx_id(),
-                        entry.creation_time,
+                        entry.creation_time(),
                         now
                     );
                     true

--- a/mempool/src/pool.rs
+++ b/mempool/src/pool.rs
@@ -539,7 +539,7 @@ where
         });
 
         let total_conflict_fees = conflicts_with_descendants
-            .map(|conflict| conflict.fee)
+            .map(|conflict| conflict.fee())
             .sum::<Option<Amount>>()
             .ok_or(TxValidationError::ConflictsFeeOverflow)?;
 
@@ -580,13 +580,13 @@ where
         conflicts: &[&TxMempoolEntry],
     ) -> Result<(), TxValidationError> {
         let replacement_fee = self.try_get_fee(tx).await?;
-        conflicts.iter().find(|conflict| conflict.fee >= replacement_fee).map_or_else(
+        conflicts.iter().find(|conflict| conflict.fee() >= replacement_fee).map_or_else(
             || Ok(()),
             |conflict| {
                 Err(TxValidationError::ReplacementFeeLowerThanOriginal {
                     replacement_tx: tx.get_id().get(),
                     replacement_fee,
-                    original_fee: conflict.fee,
+                    original_fee: conflict.fee(),
                     original_tx: conflict.tx_id().get(),
                 })
             },
@@ -694,7 +694,7 @@ where
                 removed.size()
             );
             removed_fees.push(FeeRate::from_total_tx_fee(
-                removed.fee,
+                removed.fee(),
                 NonZeroUsize::new(removed.size()).expect("transaction cannot have zero size"),
             )?);
             self.store.drop_tx_and_descendants(removed.get_id());

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -330,7 +330,6 @@ impl Idable for TxMempoolEntry {
 
 #[derive(Debug, Eq, Clone)]
 pub(super) struct TxMempoolEntry {
-    // TODO(Roy) make members private and add getters
     tx: WithId<Transaction>,
     fee: Amount,
     parents: BTreeSet<Id<Transaction>>,
@@ -338,7 +337,7 @@ pub(super) struct TxMempoolEntry {
     count_with_descendants: usize,
     fees_with_descendants: Amount,
     size_with_descendants: usize,
-    pub(super) creation_time: Time,
+    creation_time: Time,
 }
 
 impl TxMempoolEntry {
@@ -388,6 +387,10 @@ impl TxMempoolEntry {
     pub(super) fn size(&self) -> usize {
         // TODO(Roy) this should follow Bitcoin's GetTxSize, which weighs in sigops, etc.
         self.tx.encoded_size()
+    }
+
+    pub(super) fn creation_time(&self) -> Time {
+        self.creation_time
     }
 
     fn unconfirmed_parents(&self) -> impl Iterator<Item = &Id<Transaction>> {

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -332,7 +332,7 @@ impl Idable for TxMempoolEntry {
 pub(super) struct TxMempoolEntry {
     // TODO(Roy) make members private and add getters
     tx: WithId<Transaction>,
-    pub(super) fee: Amount,
+    fee: Amount,
     parents: BTreeSet<Id<Transaction>>,
     children: BTreeSet<Id<Transaction>>,
     pub(super) count_with_descendants: usize,
@@ -362,6 +362,10 @@ impl TxMempoolEntry {
 
     pub(super) fn tx(&self) -> &WithId<Transaction> {
         &self.tx
+    }
+
+    pub(super) fn fee(&self) -> Amount {
+        self.fee
     }
 
     pub(super) fn count_with_descendants(&self) -> usize {

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -336,7 +336,7 @@ pub(super) struct TxMempoolEntry {
     parents: BTreeSet<Id<Transaction>>,
     children: BTreeSet<Id<Transaction>>,
     count_with_descendants: usize,
-    pub(super) fees_with_descendants: Amount,
+    fees_with_descendants: Amount,
     size_with_descendants: usize,
     pub(super) creation_time: Time,
 }
@@ -370,6 +370,10 @@ impl TxMempoolEntry {
 
     pub(super) fn count_with_descendants(&self) -> usize {
         self.count_with_descendants
+    }
+
+    pub(super) fn fees_with_descendants(&self) -> Amount {
+        self.fees_with_descendants
     }
 
     #[allow(unused)]

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -321,6 +321,13 @@ impl MempoolStore {
     }
 }
 
+impl Idable for TxMempoolEntry {
+    type Tag = Transaction;
+    fn get_id(&self) -> Id<Transaction> {
+        self.tx.get_id()
+    }
+}
+
 #[derive(Debug, Eq, Clone)]
 pub(super) struct TxMempoolEntry {
     // TODO(Roy) make members private and add getters

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -331,7 +331,7 @@ impl Idable for TxMempoolEntry {
 #[derive(Debug, Eq, Clone)]
 pub(super) struct TxMempoolEntry {
     // TODO(Roy) make members private and add getters
-    pub(super) tx: WithId<Transaction>,
+    tx: WithId<Transaction>,
     pub(super) fee: Amount,
     parents: BTreeSet<Id<Transaction>>,
     children: BTreeSet<Id<Transaction>>,
@@ -358,6 +358,10 @@ impl TxMempoolEntry {
             size_with_descendants: tx.encoded_size(),
             tx: WithId::new(tx),
         }
+    }
+
+    pub(super) fn tx(&self) -> &WithId<Transaction> {
+        &self.tx
     }
 
     pub(super) fn count_with_descendants(&self) -> usize {

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -190,6 +190,7 @@ impl MempoolStore {
             let ancestor = self.txs_by_id.get_mut(&ancestor).expect("ancestor");
             ancestor.fees_with_descendants =
                 (ancestor.fees_with_descendants - entry.fee).expect("fee with descendants");
+            ancestor.size_with_descendants -= entry.size();
             ancestor.count_with_descendants -= 1;
         }
     }
@@ -329,7 +330,7 @@ pub(super) struct TxMempoolEntry {
     children: BTreeSet<Id<Transaction>>,
     pub(super) count_with_descendants: usize,
     pub(super) fees_with_descendants: Amount,
-    pub(super) size_with_descendants: usize,
+    size_with_descendants: usize,
     pub(super) creation_time: Time,
 }
 
@@ -354,6 +355,11 @@ impl TxMempoolEntry {
 
     pub(super) fn count_with_descendants(&self) -> usize {
         self.count_with_descendants
+    }
+
+    #[allow(unused)]
+    pub(super) fn size_with_descendants(&self) -> usize {
+        self.size_with_descendants
     }
 
     pub(super) fn tx_id(&self) -> Id<Transaction> {

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -335,7 +335,7 @@ pub(super) struct TxMempoolEntry {
     fee: Amount,
     parents: BTreeSet<Id<Transaction>>,
     children: BTreeSet<Id<Transaction>>,
-    pub(super) count_with_descendants: usize,
+    count_with_descendants: usize,
     pub(super) fees_with_descendants: Amount,
     size_with_descendants: usize,
     pub(super) creation_time: Time,

--- a/mempool/src/pool/tests.rs
+++ b/mempool/src/pool/tests.rs
@@ -1625,14 +1625,14 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     mempool.add_transaction(tx_c).await?;
 
     let entry_a = mempool.store.txs_by_id.get(&tx_a_id).expect("tx_a");
-    log::debug!("entry a has score {:?}", entry_a.fees_with_descendants);
+    log::debug!("entry a has score {:?}", entry_a.fees_with_descendants());
     let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b");
-    log::debug!("entry b has score {:?}", entry_b.fees_with_descendants);
+    log::debug!("entry b has score {:?}", entry_b.fees_with_descendants());
     let entry_c = mempool.store.txs_by_id.get(&tx_c_id).expect("tx_c").clone();
-    log::debug!("entry c has score {:?}", entry_c.fees_with_descendants);
-    assert_eq!(entry_a.fee(), entry_a.fees_with_descendants);
+    log::debug!("entry c has score {:?}", entry_c.fees_with_descendants());
+    assert_eq!(entry_a.fee(), entry_a.fees_with_descendants());
     assert_eq!(
-        entry_b.fees_with_descendants,
+        entry_b.fees_with_descendants(),
         (entry_b.fee() + entry_c.fee()).unwrap()
     );
     assert!(!mempool.store.txs_by_descendant_score.contains_key(&tx_b_fee.into()));
@@ -1645,7 +1645,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     mempool.drop_transaction(&entry_c.get_id());
     assert!(!mempool.store.txs_by_descendant_score.contains_key(&tx_c_fee.into()));
     let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b");
-    assert_eq!(entry_b.fees_with_descendants, entry_b.fee());
+    assert_eq!(entry_b.fees_with_descendants(), entry_b.fee());
 
     check_txs_sorted_by_descendant_sore(&mempool);
     mempool.store.assert_valid();
@@ -1660,9 +1660,9 @@ fn check_txs_sorted_by_descendant_sore(mempool: &Mempool<SystemUsageEstimator>) 
         log::debug!("i =  {}", i);
         let tx_id = txs_by_descendant_score.get(i).unwrap();
         let next_tx_id = txs_by_descendant_score.get(i + 1).unwrap();
-        let entry_score = mempool.store.txs_by_id.get(tx_id).unwrap().fees_with_descendants;
+        let entry_score = mempool.store.txs_by_id.get(tx_id).unwrap().fees_with_descendants();
         let next_entry_score =
-            mempool.store.txs_by_id.get(next_tx_id).unwrap().fees_with_descendants;
+            mempool.store.txs_by_id.get(next_tx_id).unwrap().fees_with_descendants();
         log::debug!("entry_score: {:?}", entry_score);
         log::debug!("next_entry_score: {:?}", next_entry_score);
         assert!(entry_score <= next_entry_score)

--- a/mempool/src/pool/tests.rs
+++ b/mempool/src/pool/tests.rs
@@ -1630,10 +1630,10 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     log::debug!("entry b has score {:?}", entry_b.fees_with_descendants);
     let entry_c = mempool.store.txs_by_id.get(&tx_c_id).expect("tx_c").clone();
     log::debug!("entry c has score {:?}", entry_c.fees_with_descendants);
-    assert_eq!(entry_a.fee, entry_a.fees_with_descendants);
+    assert_eq!(entry_a.fee(), entry_a.fees_with_descendants);
     assert_eq!(
         entry_b.fees_with_descendants,
-        (entry_b.fee + entry_c.fee).unwrap()
+        (entry_b.fee() + entry_c.fee()).unwrap()
     );
     assert!(!mempool.store.txs_by_descendant_score.contains_key(&tx_b_fee.into()));
     log::debug!(
@@ -1645,7 +1645,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     mempool.drop_transaction(&entry_c.get_id());
     assert!(!mempool.store.txs_by_descendant_score.contains_key(&tx_c_fee.into()));
     let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b");
-    assert_eq!(entry_b.fees_with_descendants, entry_b.fee);
+    assert_eq!(entry_b.fees_with_descendants, entry_b.fee());
 
     check_txs_sorted_by_descendant_sore(&mempool);
     mempool.store.assert_valid();

--- a/mempool/src/pool/tests.rs
+++ b/mempool/src/pool/tests.rs
@@ -1660,9 +1660,8 @@ fn check_txs_sorted_by_descendant_sore(mempool: &Mempool<SystemUsageEstimator>) 
         log::debug!("i =  {}", i);
         let tx_id = txs_by_descendant_score.get(i).unwrap();
         let next_tx_id = txs_by_descendant_score.get(i + 1).unwrap();
-        let entry_score = mempool.store.txs_by_id.get(tx_id).unwrap().fees_with_descendants();
-        let next_entry_score =
-            mempool.store.txs_by_id.get(next_tx_id).unwrap().fees_with_descendants();
+        let entry_score = mempool.store.txs_by_id.get(tx_id).unwrap().descendant_score();
+        let next_entry_score = mempool.store.txs_by_id.get(next_tx_id).unwrap().descendant_score();
         log::debug!("entry_score: {:?}", entry_score);
         log::debug!("next_entry_score: {:?}", next_entry_score);
         assert!(entry_score <= next_entry_score)

--- a/mempool/src/pool/tests.rs
+++ b/mempool/src/pool/tests.rs
@@ -1642,7 +1642,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     );
     check_txs_sorted_by_descendant_sore(&mempool);
 
-    mempool.drop_transaction(&entry_c.tx.get_id());
+    mempool.drop_transaction(&entry_c.get_id());
     assert!(!mempool.store.txs_by_descendant_score.contains_key(&tx_c_fee.into()));
     let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b");
     assert_eq!(entry_b.fees_with_descendants, entry_b.fee);


### PR DESCRIPTION
Up until now, we've used the total fees of a transaction and all its in-mempool descendants as the "descendant score" by which we decide which transactions to keep when the mempool is full. This deviated from Bitcoin core, which uses `fees_with_descendants/size_with_descendants`. In this PR we modify the mempool to follow Bitcoin core in this regard.

Closes #93.