### PR TITLE
Clean up mempool's `txs_by_creation_time` index after entries have been removed.

### DIFF
--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -275,8 +275,9 @@ impl MempoolStore {
         self.refresh_ancestors(entry);
         self.txs_by_descendant_score
             .entry(entry.descendant_score())
-            .or_default()
-            .remove(&entry.tx_id());
+            .and_modify(|entries| {
+                entries.remove(&entry.tx_id());
+            });
         if self
             .txs_by_descendant_score
             .get(&entry.descendant_score())

--- a/mempool/src/pool/tests.rs
+++ b/mempool/src/pool/tests.rs
@@ -1789,7 +1789,7 @@ async fn mempool_full(#[case] seed: Seed) -> anyhow::Result<()> {
 #[trace]
 #[case(Seed::from_entropy())]
 #[tokio::test]
-async fn no_empty_bags_in_descendant_score_index(#[case] seed: Seed) -> anyhow::Result<()> {
+async fn no_empty_bags_in_indices(#[case] seed: Seed) -> anyhow::Result<()> {
     let tf = TestFramework::default();
     let mut rng = make_seedable_rng(seed);
     let genesis = tf.genesis();
@@ -1845,6 +1845,7 @@ async fn no_empty_bags_in_descendant_score_index(#[case] seed: Seed) -> anyhow::
         mempool.drop_transaction(&id)
     }
     assert!(mempool.store.txs_by_descendant_score.is_empty());
+    assert!(mempool.store.txs_by_creation_time.is_empty());
     mempool.store.assert_valid();
     Ok(())
 }


### PR DESCRIPTION
Fix a bug in which we forgot to clean up empty `BTreeSet`s in mempool store's `txs_by_creation_time: BTreeMap<Time, BTreeSet<Id<Transaction>>>` once all entries created at a particular time have been removed.