### PR TITLE
Revert implementation of Idable for TxMempoolEntry

### DIFF
--- a/mempool/src/pool.rs
+++ b/mempool/src/pool.rs
@@ -615,7 +615,7 @@ where
 
     async fn finalize_tx(&mut self, tx: Transaction) -> Result<(), Error> {
         let entry = self.create_entry(tx).await?;
-        let id = entry.get_id();
+        let id = entry.tx_id();
         self.store.add_tx(entry)?;
         self.remove_expired_transactions();
         ensure!(
@@ -668,7 +668,7 @@ where
             .cloned()
             .collect();
 
-        for tx_id in expired.iter().map(|entry| entry.get_id()) {
+        for tx_id in expired.iter().map(|entry| entry.tx_id()) {
             self.store.drop_tx_and_descendants(tx_id)
         }
     }
@@ -697,7 +697,7 @@ where
                 removed.fee(),
                 NonZeroUsize::new(removed.size()).expect("transaction cannot have zero size"),
             )?);
-            self.store.drop_tx_and_descendants(removed.get_id());
+            self.store.drop_tx_and_descendants(removed.tx_id());
         }
         Ok(removed_fees)
     }

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -331,13 +331,6 @@ impl MempoolStore {
     }
 }
 
-impl Idable for TxMempoolEntry {
-    type Tag = Transaction;
-    fn get_id(&self) -> Id<Transaction> {
-        self.tx.get_id()
-    }
-}
-
 #[derive(Debug, Eq, Clone)]
 pub(super) struct TxMempoolEntry {
     tx: WithId<Transaction>,

--- a/mempool/src/pool/tests.rs
+++ b/mempool/src/pool/tests.rs
@@ -1642,7 +1642,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     );
     check_txs_sorted_by_descendant_sore(&mempool);
 
-    mempool.drop_transaction(&entry_c.get_id());
+    mempool.drop_transaction(&entry_c.tx_id());
     assert!(!mempool.store.txs_by_descendant_score.contains_key(&tx_c_fee.into()));
     let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b");
     assert_eq!(entry_b.fees_with_descendants(), entry_b.fee());


### PR DESCRIPTION
In a previous PR I implemented the `Idable` trait for `TxMempoolEntry`. This is incorrect as `TxMempoolEntry` does not represent an entity on the blockchain. This PR reverts the above.