### PR TITLE
storage: Make transaction initialization fallible

### DIFF
--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -121,6 +121,7 @@ mod test {
             {
                 let current_height: u64 = chainstate
                     .query()
+                    .unwrap()
                     .get_best_block_index()
                     .unwrap()
                     .unwrap()
@@ -131,7 +132,7 @@ mod test {
 
             {
                 // median time for genesis block
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(
                     &chainstate_ref,
                     &chainstate.chain_config.genesis_block_id(),
@@ -142,7 +143,7 @@ mod test {
             for n in 0..MEDIAN_TIME_SPAN {
                 // median time for block of height n
                 // up to the median span
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median =
                     calculate_median_time_past(&chainstate_ref, &blocks[n].get_id().into());
                 assert_eq!(median, blocks[n / 2].timestamp());
@@ -151,7 +152,7 @@ mod test {
             for n in MEDIAN_TIME_SPAN..block_count {
                 // median time for block of height n
                 // starting from the median span
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median =
                     calculate_median_time_past(&chainstate_ref, &blocks[n].get_id().into());
                 assert_eq!(median, blocks[n - MEDIAN_TIME_SPAN / 2].timestamp());
@@ -201,6 +202,7 @@ mod test {
             {
                 let current_height: u64 = chainstate
                     .query()
+                    .unwrap()
                     .get_best_block_index()
                     .unwrap()
                     .unwrap()
@@ -211,7 +213,7 @@ mod test {
 
             {
                 // median time for genesis block
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(
                     &chainstate_ref,
                     &chainstate.chain_config.genesis_block_id(),
@@ -221,35 +223,35 @@ mod test {
 
             {
                 // median time for block of height 1
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(&chainstate_ref, &block1.get_id().into());
                 assert_eq!(median, BlockTimestamp::from_int_seconds(block1_time));
             }
 
             {
                 // median time for block of height 2
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(&chainstate_ref, &block2.get_id().into());
                 assert_eq!(median, BlockTimestamp::from_int_seconds(block1_time));
             }
 
             {
                 // median time for block of height 3
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(&chainstate_ref, &block3.get_id().into());
                 assert_eq!(median, BlockTimestamp::from_int_seconds(block3_time));
             }
 
             {
                 // median time for block of height 4
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(&chainstate_ref, &block4.get_id().into());
                 assert_eq!(median, BlockTimestamp::from_int_seconds(block3_time));
             }
 
             {
                 // median time for block of height 5
-                let chainstate_ref = chainstate.make_db_tx_ro();
+                let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(&chainstate_ref, &block5.get_id().into());
                 assert_eq!(median, BlockTimestamp::from_int_seconds(block5_time));
             }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -90,7 +90,6 @@ impl<S: BlockchainStorage> Chainstate<S> {
         self.events_controller.wait_for_all_events();
     }
 
-    #[must_use]
     fn make_db_tx(
         &mut self,
     ) -> chainstate_storage::Result<chainstateref::ChainstateRef<TxRw<'_, S>, OrphanBlocksRefMut>>
@@ -105,7 +104,6 @@ impl<S: BlockchainStorage> Chainstate<S> {
         ))
     }
 
-    #[must_use]
     pub(crate) fn make_db_tx_ro(
         &self,
     ) -> chainstate_storage::Result<chainstateref::ChainstateRef<TxRo<'_, S>, OrphanBlocksRef>>
@@ -120,7 +118,6 @@ impl<S: BlockchainStorage> Chainstate<S> {
         ))
     }
 
-    #[must_use]
     pub fn query(
         &self,
     ) -> Result<ChainstateQuery<TxRo<'_, S>, OrphanBlocksRef>, PropertyQueryError> {

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -18,6 +18,7 @@ pub mod ban_score;
 pub use self::error::*;
 pub use self::median_time::calculate_median_time_past;
 pub use chainstate_types::Locator;
+use chainstate_types::PropertyQueryError;
 use common::time_getter::TimeGetter;
 pub use error::BlockError;
 pub use error::CheckBlockError;
@@ -90,34 +91,40 @@ impl<S: BlockchainStorage> Chainstate<S> {
     }
 
     #[must_use]
-    fn make_db_tx(&mut self) -> chainstateref::ChainstateRef<TxRw<'_, S>, OrphanBlocksRefMut> {
-        let db_tx = self.chainstate_storage.transaction_rw();
-        chainstateref::ChainstateRef::new_rw(
+    fn make_db_tx(
+        &mut self,
+    ) -> chainstate_storage::Result<chainstateref::ChainstateRef<TxRw<'_, S>, OrphanBlocksRefMut>>
+    {
+        let db_tx = self.chainstate_storage.transaction_rw()?;
+        Ok(chainstateref::ChainstateRef::new_rw(
             &self.chain_config,
             &self.chainstate_config,
             db_tx,
             self.orphan_blocks.as_rw_ref(),
             self.time_getter.getter(),
-        )
+        ))
     }
 
     #[must_use]
     pub(crate) fn make_db_tx_ro(
         &self,
-    ) -> chainstateref::ChainstateRef<TxRo<'_, S>, OrphanBlocksRef> {
-        let db_tx = self.chainstate_storage.transaction_ro();
-        chainstateref::ChainstateRef::new_ro(
+    ) -> chainstate_storage::Result<chainstateref::ChainstateRef<TxRo<'_, S>, OrphanBlocksRef>>
+    {
+        let db_tx = self.chainstate_storage.transaction_ro()?;
+        Ok(chainstateref::ChainstateRef::new_ro(
             &self.chain_config,
             &self.chainstate_config,
             db_tx,
             self.orphan_blocks.as_ro_ref(),
             self.time_getter.getter(),
-        )
+        ))
     }
 
     #[must_use]
-    pub fn query(&self) -> ChainstateQuery<TxRo<'_, S>, OrphanBlocksRef> {
-        ChainstateQuery::new(self.make_db_tx_ro())
+    pub fn query(
+        &self,
+    ) -> Result<ChainstateQuery<TxRo<'_, S>, OrphanBlocksRef>, PropertyQueryError> {
+        self.make_db_tx_ro().map(ChainstateQuery::new).map_err(PropertyQueryError::from)
     }
 
     pub fn subscribe_to_events(&mut self, handler: ChainstateEventHandler) {
@@ -227,7 +234,7 @@ impl<S: BlockchainStorage> Chainstate<S> {
     ) -> Result<Option<BlockIndex>, BlockError> {
         log::info!("Processing block: {}", block.get_id());
 
-        let mut chainstate_ref = self.make_db_tx();
+        let mut chainstate_ref = self.make_db_tx().map_err(BlockError::from)?;
 
         let block = chainstate_ref.check_legitimate_orphan(block_source, block)?;
 
@@ -286,7 +293,7 @@ impl<S: BlockchainStorage> Chainstate<S> {
             .expect("Genesis not constructed correctly");
 
         // Initialize storage with given info
-        let mut db_tx = self.chainstate_storage.transaction_rw();
+        let mut db_tx = self.chainstate_storage.transaction_rw().map_err(BlockError::from)?;
         db_tx.set_best_block_id(&genesis_id).map_err(BlockError::StorageError)?;
         db_tx
             .set_block_id_at_height(&BlockHeight::zero(), &genesis_id)
@@ -306,13 +313,13 @@ impl<S: BlockchainStorage> Chainstate<S> {
         &self,
         block: WithId<Block>,
     ) -> Result<WithId<Block>, BlockError> {
-        let chainstate_ref = self.make_db_tx_ro();
+        let chainstate_ref = self.make_db_tx_ro().map_err(BlockError::from)?;
         chainstate_ref.check_block(&block)?;
         Ok(block)
     }
 
     pub fn preliminary_header_check(&self, block: BlockHeader) -> Result<(), BlockError> {
-        let chainstate_ref = self.make_db_tx_ro();
+        let chainstate_ref = self.make_db_tx_ro().map_err(BlockError::from)?;
         chainstate_ref.check_block_header(&block)?;
         Ok(())
     }

--- a/chainstate/src/detail/test.rs
+++ b/chainstate/src/detail/test.rs
@@ -49,10 +49,13 @@ fn process_genesis_block() {
         );
 
         chainstate.process_genesis().unwrap();
-        let chainstate_ref = chainstate.make_db_tx_ro();
+        let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
 
         // Check the genesis block is properly set up
-        assert_eq!(chainstate.query().get_best_block_id().unwrap(), genesis_id);
+        assert_eq!(
+            chainstate.query().unwrap().get_best_block_id().unwrap(),
+            genesis_id
+        );
         let genesis_index = chainstate_ref.get_gen_block_index(&genesis_id).unwrap().unwrap();
         assert_eq!(genesis_index.block_height(), BlockHeight::from(0));
         assert_eq!(genesis_index.block_id(), genesis_id);
@@ -88,6 +91,6 @@ fn empty_chainstate_no_genesis() {
             time_getter,
         );
         // This panics
-        let _ = chainstate.query().get_best_block_id();
+        let _ = chainstate.query().unwrap().get_best_block_id();
     })
 }

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -89,7 +89,10 @@ pub trait ChainstateInterface: Send {
         tx_id: &OutPointSourceId,
     ) -> Result<Option<TxMainChainIndex>, ChainstateError>;
     fn subscribers(&self) -> &Vec<EventHandler<ChainstateEvent>>;
-    fn calculate_median_time_past(&self, starting_block: &Id<GenBlock>) -> BlockTimestamp;
+    fn calculate_median_time_past(
+        &self,
+        starting_block: &Id<GenBlock>,
+    ) -> Result<BlockTimestamp, ChainstateError>;
     fn is_already_an_orphan(&self, block_id: &Id<Block>) -> bool;
     fn orphans_count(&self) -> usize;
     fn get_ancestor(

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -153,7 +153,10 @@ impl<
         self.deref().subscribers()
     }
 
-    fn calculate_median_time_past(&self, starting_block: &Id<GenBlock>) -> BlockTimestamp {
+    fn calculate_median_time_past(
+        &self,
+        starting_block: &Id<GenBlock>,
+    ) -> Result<BlockTimestamp, ChainstateError> {
         self.deref().calculate_median_time_past(starting_block)
     }
 

--- a/chainstate/src/interface/mock.rs
+++ b/chainstate/src/interface/mock.rs
@@ -86,7 +86,7 @@ mockall::mock! {
             tx_id: &OutPointSourceId,
         ) -> Result<Option<TxMainChainIndex>, ChainstateError>;
         fn subscribers(&self) -> &Vec<EventHandler<ChainstateEvent>>;
-        fn calculate_median_time_past(&self, starting_block: &Id<GenBlock>) -> BlockTimestamp;
+        fn calculate_median_time_past(&self, starting_block: &Id<GenBlock>) -> Result<BlockTimestamp, ChainstateError>;
         fn is_already_an_orphan(&self, block_id: &Id<Block>) -> bool;
         fn orphans_count(&self) -> usize;
         fn get_ancestor(

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -59,9 +59,9 @@ pub enum ChainstateError {
     #[error("Initialization error")]
     FailedToInitializeChainstate(String),
     #[error("Block processing failed: `{0}`")]
-    ProcessBlockError(BlockError),
+    ProcessBlockError(#[from] BlockError),
     #[error("Property read error: `{0}`")]
-    FailedToReadProperty(PropertyQueryError),
+    FailedToReadProperty(#[from] PropertyQueryError),
     #[error("Block import error {0}")]
     BootstrapError(#[from] BootstrapError),
 }

--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -29,7 +29,7 @@ type TestStore = crate::inmemory::Store;
 fn test_storage_get_default_version_in_tx() {
     utils::concurrency::model(|| {
         let store = TestStore::new_empty().unwrap();
-        let vtx = store.transaction_ro().get_storage_version().unwrap();
+        let vtx = store.transaction_ro().unwrap().get_storage_version().unwrap();
         let vst = store.get_storage_version().unwrap();
         assert_eq!(vtx, 1, "Default storage version wrong");
         assert_eq!(vtx, vst, "Transaction and non-transaction inconsistency");
@@ -156,7 +156,7 @@ fn get_set_transactions() {
         let thr1 = {
             let store = Store::clone(&store);
             utils::thread::spawn(move || {
-                let mut tx = store.transaction_rw();
+                let mut tx = store.transaction_rw().unwrap();
                 let v = tx.get_storage_version().unwrap();
                 tx.set_storage_version(v + 1).unwrap();
                 tx.commit().unwrap();
@@ -165,7 +165,7 @@ fn get_set_transactions() {
         let thr0 = {
             let store = Store::clone(&store);
             utils::thread::spawn(move || {
-                let tx = store.transaction_ro();
+                let tx = store.transaction_ro().unwrap();
                 let v1 = tx.get_storage_version().unwrap();
                 let v2 = tx.get_storage_version().unwrap();
                 assert!([2, 3].contains(&v1));
@@ -190,7 +190,7 @@ fn test_storage_transactions() {
         let thr0 = {
             let store = Store::clone(&store);
             utils::thread::spawn(move || {
-                let mut tx = store.transaction_rw();
+                let mut tx = store.transaction_rw().unwrap();
                 let v = tx.get_storage_version().unwrap();
                 tx.set_storage_version(v + 3).unwrap();
                 tx.commit().unwrap();
@@ -199,7 +199,7 @@ fn test_storage_transactions() {
         let thr1 = {
             let store = Store::clone(&store);
             utils::thread::spawn(move || {
-                let mut tx = store.transaction_rw();
+                let mut tx = store.transaction_rw().unwrap();
                 let v = tx.get_storage_version().unwrap();
                 tx.set_storage_version(v + 5).unwrap();
                 tx.commit().unwrap();
@@ -223,7 +223,7 @@ fn test_storage_transactions_with_result_check() {
         let thr0 = {
             let store = Store::clone(&store);
             utils::thread::spawn(move || {
-                let mut tx = store.transaction_rw();
+                let mut tx = store.transaction_rw().unwrap();
                 let v = tx.get_storage_version().unwrap();
                 assert!(tx.set_storage_version(v + 3).is_ok());
                 assert!(tx.commit().is_ok());
@@ -232,7 +232,7 @@ fn test_storage_transactions_with_result_check() {
         let thr1 = {
             let store = Store::clone(&store);
             utils::thread::spawn(move || {
-                let mut tx = store.transaction_rw();
+                let mut tx = store.transaction_rw().unwrap();
                 let v = tx.get_storage_version().unwrap();
                 assert!(tx.set_storage_version(v + 5).is_ok());
                 assert!(tx.commit().is_ok());

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -165,10 +165,10 @@ pub trait Transactional<'t> {
     type TransactionRw: TransactionRw + 't;
 
     /// Start a read-only transaction.
-    fn transaction_ro<'s: 't>(&'s self) -> Self::TransactionRo;
+    fn transaction_ro<'s: 't>(&'s self) -> crate::Result<Self::TransactionRo>;
 
     /// Start a read-write transaction.
-    fn transaction_rw<'s: 't>(&'s self) -> Self::TransactionRw;
+    fn transaction_rw<'s: 't>(&'s self) -> crate::Result<Self::TransactionRw>;
 }
 
 pub trait BlockchainStorage: BlockchainStorageWrite + for<'tx> Transactional<'tx> + Send {}

--- a/chainstate/test-suite/src/tests/output_timelock.rs
+++ b/chainstate/test-suite/src/tests/output_timelock.rs
@@ -409,8 +409,9 @@ fn output_lock_until_time() {
 
         // Skip the genesis block and the block that contains the locked output.
         for (block_time, height) in block_times.iter().skip(2).zip(expected_height..) {
+            let mtp = tf.chainstate.calculate_median_time_past(&tf.best_block_id()).unwrap();
             assert_eq!(
-                tf.chainstate.calculate_median_time_past(&tf.best_block_id()).as_int_seconds(),
+                mtp.as_int_seconds(),
                 median_block_time(&block_times[..=height])
             );
 
@@ -553,8 +554,9 @@ fn output_lock_for_seconds() {
 
         // Skip the genesis block and the block that contains the locked output.
         for (block_time, height) in block_times.iter().skip(2).zip(expected_height..) {
+            let mtp = tf.chainstate.calculate_median_time_past(&tf.best_block_id()).unwrap();
             assert_eq!(
-                tf.chainstate.calculate_median_time_past(&tf.best_block_id()).as_int_seconds(),
+                mtp.as_int_seconds(),
                 median_block_time(&block_times[..=height])
             );
 

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -1002,7 +1002,7 @@ fn blocks_from_the_future() {
         {
             // constrain the test to protect this test becoming legacy by changing the definition of median time for genesis
             assert_eq!(
-                tf.chainstate.calculate_median_time_past(&tf.genesis().get_id().into()),
+                tf.chainstate.calculate_median_time_past(&tf.genesis().get_id().into()).unwrap(),
                 tf.chainstate.get_chain_config().genesis_block().timestamp()
             );
         }

--- a/storage/backend-test-suite/src/basic.rs
+++ b/storage/backend-test-suite/src/basic.rs
@@ -21,12 +21,12 @@ fn put_and_commit<B: Backend>(backend: B) {
     let store = backend.open(desc(1)).expect("db open to succeed");
 
     // Create a transaction, modify storage and abort transaction
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"hello".to_vec(), b"world".to_vec()).unwrap();
     dbtx.commit().expect("commit to succeed");
 
     // Check the modification did not happen
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"world".as_ref())));
     drop(dbtx);
 }
@@ -35,12 +35,12 @@ fn put_and_abort<B: Backend>(backend: B) {
     let store = backend.open(desc(1)).expect("db open to succeed");
 
     // Create a transaction, modify storage and abort transaction
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"hello".to_vec(), b"world".to_vec()).unwrap();
     drop(dbtx);
 
     // Check the modification did not happen
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(None));
     drop(dbtx);
 }
@@ -49,25 +49,25 @@ fn put_two_under_different_keys<B: Backend>(backend: B) {
     let store = backend.open(desc(1)).expect("db open to succeed");
 
     // Create a transaction, modify storage and commit
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"a".to_vec(), b"0".to_vec()).unwrap();
     dbtx.put(IDX.0, b"b".to_vec(), b"1".to_vec()).unwrap();
     dbtx.commit().expect("commit to succeed");
 
     // Check the values are in place
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     assert_eq!(dbtx.get(IDX.0, b"a"), Ok(Some(b"0".as_ref())));
     assert_eq!(dbtx.get(IDX.0, b"b"), Ok(Some(b"1".as_ref())));
     drop(dbtx);
 
     // Create a transaction, modify storage and abort
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"a".to_vec(), b"00".to_vec()).unwrap();
     dbtx.put(IDX.0, b"b".to_vec(), b"11".to_vec()).unwrap();
     drop(dbtx);
 
     // Check the modification did not happen
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     assert_eq!(dbtx.get(IDX.0, b"a"), Ok(Some(b"0".as_ref())));
     assert_eq!(dbtx.get(IDX.0, b"b"), Ok(Some(b"1".as_ref())));
     drop(dbtx);
@@ -76,28 +76,28 @@ fn put_two_under_different_keys<B: Backend>(backend: B) {
 fn put_twice_then_commit_read_last<B: Backend>(backend: B) {
     let store = backend.open(desc(1)).expect("db open to succeed");
 
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"hello".to_vec(), b"a".to_vec()).unwrap();
     assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"a".as_ref())),);
     dbtx.put(IDX.0, b"hello".to_vec(), b"b".to_vec()).unwrap();
     assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"b".as_ref())),);
     dbtx.commit().expect("commit to succeed");
 
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"b".as_ref())),);
 }
 
 fn put_iterator_count_matches<B: Backend>(backend: B) {
     let store = backend.open(desc(1)).expect("db open to succeed");
 
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, vec![0x00], vec![]).unwrap();
     dbtx.put(IDX.0, vec![0x01], vec![]).unwrap();
     dbtx.put(IDX.0, vec![0x02], vec![]).unwrap();
     dbtx.put(IDX.0, vec![0x03], vec![]).unwrap();
     dbtx.commit().expect("commit to succeed");
 
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     assert_eq!(dbtx.prefix_iter(IDX.0, vec![]).unwrap().count(), 4);
 }
 
@@ -105,7 +105,7 @@ fn put_and_iterate_over_prefixes<B: Backend>(backend: B) {
     let store = backend.open(desc(1)).expect("db open to succeed");
 
     // Populate the database with some values
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"ac".to_vec(), b"2".to_vec()).unwrap();
     dbtx.put(IDX.0, b"bf".to_vec(), b"7".to_vec()).unwrap();
     dbtx.put(IDX.0, b"ab".to_vec(), b"1".to_vec()).unwrap();
@@ -120,13 +120,18 @@ fn put_and_iterate_over_prefixes<B: Backend>(backend: B) {
 
     // Check for a non-existent prefix
     assert_eq!(
-        store.transaction_ro().prefix_iter(IDX.0, b"foo".to_vec()).unwrap().next(),
+        store
+            .transaction_ro()
+            .unwrap()
+            .prefix_iter(IDX.0, b"foo".to_vec())
+            .unwrap()
+            .next(),
         None,
     );
 
     // Check for items that are supposed to be present
     let check = |range: std::ops::RangeInclusive<usize>, prefix: Data| {
-        let dbtx = store.transaction_ro();
+        let dbtx = store.transaction_ro().unwrap();
         let vals = dbtx.prefix_iter(IDX.0, prefix).unwrap().map(|(_key, val)| val);
         let expected_vals = range.map(|x| Data::from(x.to_string()));
         assert!(vals.eq(expected_vals));
@@ -159,7 +164,7 @@ fn put_and_iterate_delete_some<B: Backend>(backend: B) {
     let expected_ac_0 = [("ac", "2"), ("aca", "3"), ("acb", "4")];
 
     // Populate the database with some
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"aa".to_vec(), b"0".to_vec()).unwrap();
     dbtx.put(IDX.0, b"ab".to_vec(), b"1".to_vec()).unwrap();
     dbtx.put(IDX.0, b"ac".to_vec(), b"2".to_vec()).unwrap();
@@ -173,7 +178,7 @@ fn put_and_iterate_delete_some<B: Backend>(backend: B) {
     dbtx.commit().expect("commit to succeed");
 
     // Check db contents after a commit
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     check_prefix(&dbtx, b"".to_vec(), &expected_full_0);
     check_prefix(&dbtx, b"aa".to_vec(), &expected_aa_0);
     check_prefix(&dbtx, b"ac".to_vec(), &expected_ac_0);
@@ -184,7 +189,7 @@ fn put_and_iterate_delete_some<B: Backend>(backend: B) {
     let expected_ac_1 = [("ac", "2"), ("acb", "4")];
 
     // Delete some entries
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.del(IDX.0, b"aca").unwrap();
     dbtx.del(IDX.0, b"ab").unwrap();
     // Check updated contents
@@ -195,14 +200,14 @@ fn put_and_iterate_delete_some<B: Backend>(backend: B) {
     drop(dbtx);
 
     // Check updated contents after a commit
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     check_prefix(&dbtx, b"".to_vec(), &expected_full_0);
     check_prefix(&dbtx, b"aa".to_vec(), &expected_aa_0);
     check_prefix(&dbtx, b"ac".to_vec(), &expected_ac_0);
     drop(dbtx);
 
     // Delete the items, this time for real
-    let mut dbtx = store.transaction_rw();
+    let mut dbtx = store.transaction_rw().unwrap();
     dbtx.del(IDX.0, b"aca").unwrap();
     dbtx.del(IDX.0, b"ab").unwrap();
     // Check updated contents
@@ -213,7 +218,7 @@ fn put_and_iterate_delete_some<B: Backend>(backend: B) {
     dbtx.commit().unwrap();
 
     // Check updated contents after a commit
-    let dbtx = store.transaction_ro();
+    let dbtx = store.transaction_ro().unwrap();
     check_prefix(&dbtx, b"".to_vec(), &expected_full_1);
     check_prefix(&dbtx, b"aa".to_vec(), &expected_aa_1);
     check_prefix(&dbtx, b"ac".to_vec(), &expected_ac_1);

--- a/storage/backend-test-suite/src/model.rs
+++ b/storage/backend-test-suite/src/model.rs
@@ -74,7 +74,7 @@ impl Model {
 
     /// New model obtained by dumping a database
     pub fn from_db<B: backend::BackendImpl>(storage: &B, idx: DbIndex) -> Self {
-        let dbtx = storage.transaction_ro();
+        let dbtx = storage.transaction_ro().unwrap();
         Self::from_tx(&dbtx, idx)
     }
 

--- a/storage/backend-test-suite/src/property.rs
+++ b/storage/backend-test-suite/src/property.rs
@@ -66,37 +66,37 @@ fn overwrite_and_abort<B: Backend + ThreadSafe + Clone>(backend: B) {
             let store = backend.open(desc(1)).expect("db open to succeed");
 
             // Check the store returns None for given key initially
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(None));
             drop(dbtx);
 
             // Create a transaction, put the value in the storage and commit
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.put(IDX.0, key.clone(), val0.clone()).unwrap();
             dbtx.commit().expect("commit to succeed");
 
             // Check the values are in place
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(Some(val0.as_ref())));
             drop(dbtx);
 
             // Create a transaction, modify storage and abort
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.put(IDX.0, key.clone(), val1.clone()).unwrap();
             drop(dbtx);
 
             // Check the store still contains the original value
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(Some(val0.as_ref())));
             drop(dbtx);
 
             // Create a transaction, overwrite the value and commit
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.put(IDX.0, key.clone(), val1.clone()).unwrap();
             dbtx.commit().expect("commit to succeed");
 
             // Check the key now stores the new value
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(Some(val1.as_ref())));
             drop(dbtx);
         },
@@ -113,28 +113,28 @@ fn add_and_delete<B: Backend + ThreadSafe + Clone>(backend: B) {
             let store = backend.open(desc(NUM_DBS)).expect("db open to succeed");
 
             // Add all entries to the database
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             for ((db, key), val) in &entries {
                 dbtx.put(*db, key.clone(), val.clone()).unwrap();
             }
             dbtx.commit().unwrap();
 
             // check all entries have been added
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             for ((db, key), val) in &entries {
                 assert_eq!(dbtx.get(*db, key), Ok(Some(val.as_ref())));
             }
             drop(dbtx);
 
             // remove all entries
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             for (db, key) in entries.keys() {
                 dbtx.del(*db, key).unwrap();
             }
             dbtx.commit().unwrap();
 
             // Check entries no longer present
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             for (db, key) in entries.keys() {
                 assert_eq!(dbtx.get(*db, key), Ok(None));
             }
@@ -156,13 +156,13 @@ fn last_write_wins<B: Backend + ThreadSafe + Clone>(backend: B) {
             let last = vals.last().cloned();
 
             // Add all entries to the database
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             for val in vals.into_iter() {
                 dbtx.put(IDX.0, key.clone(), val).unwrap();
             }
             dbtx.commit().unwrap();
 
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(last.as_deref()));
         },
     )
@@ -182,14 +182,14 @@ fn add_and_delete_some<B: Backend + ThreadSafe + Clone>(backend: B) {
             let store = backend.open(desc(NUM_DBS)).expect("db open to succeed");
 
             // Add all entries to the database
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             for ((db, key), val) in entries1.iter().chain(entries2.iter()) {
                 dbtx.put(*db, key.clone(), val.clone()).unwrap();
             }
             dbtx.commit().unwrap();
 
             // check all entries have been added
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             for ent @ (db, key) in entries1.keys().chain(entries2.keys()).chain(extra_keys.iter()) {
                 let expected = entries2.get(ent).or_else(|| entries1.get(ent)).map(AsRef::as_ref);
                 assert_eq!(dbtx.get(*db, key), Ok(expected));
@@ -197,13 +197,13 @@ fn add_and_delete_some<B: Backend + ThreadSafe + Clone>(backend: B) {
             drop(dbtx);
 
             // remove entries from the second set
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             for (db, key) in entries2.keys() {
                 dbtx.del(*db, key).unwrap();
             }
             dbtx.commit().unwrap();
 
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
 
             // Check entries from the second set are absent
             for (db, key) in entries2.keys() {
@@ -232,7 +232,7 @@ fn add_modify_abort_modify_commit<B: Backend + ThreadSafe + Clone>(backend: B) {
             let store = backend.open(desc(1)).expect("db open to succeed");
 
             // Pre-populate the db with initial data, check the contents agains the model
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, to_prepopulate.into_iter());
             dbtx.commit().unwrap();
             assert_eq!(model, Model::from_db(&store, IDX.0));
@@ -243,7 +243,7 @@ fn add_modify_abort_modify_commit<B: Backend + ThreadSafe + Clone>(backend: B) {
                 tx_model.extend(to_abort.clone().into_iter());
                 tx_model
             };
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, to_abort.into_iter());
             assert_eq!(tx_model, Model::from_tx(&dbtx, IDX.0));
             drop(dbtx);
@@ -255,7 +255,7 @@ fn add_modify_abort_modify_commit<B: Backend + ThreadSafe + Clone>(backend: B) {
                 model.extend(to_commit.clone().into_iter());
                 model
             };
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, to_commit.into_iter());
             dbtx.commit().unwrap();
             assert_eq!(model, Model::from_db(&store, IDX.0));
@@ -272,21 +272,21 @@ fn add_modify_abort_replay_commit<B: Backend + ThreadSafe + Clone>(backend: B) {
             let store = backend.open(desc(1)).expect("db open to succeed");
 
             // Pre-populate the db with initial data, check the contents agains the model
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, initial.into_iter());
             dbtx.commit().unwrap();
 
             let initial_model = Model::from_db(&store, IDX.0);
 
             // Apply another set of changes but abort the transaction, check nothing changed
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, actions.clone().into_iter());
             let modified_model = Model::from_tx(&dbtx, IDX.0);
             drop(dbtx);
             assert_eq!(Model::from_db(&store, IDX.0), initial_model);
 
             // Apply the same changes again, and check that we get to the same state after commit
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, actions.into_iter());
             dbtx.commit().unwrap();
             assert_eq!(modified_model, Model::from_db(&store, IDX.0));
@@ -303,13 +303,13 @@ fn db_writes_do_not_interfere<B: Backend + ThreadSafe + Clone>(backend: B) {
             let store = backend.open(desc(2)).expect("db open to succeed");
 
             // Apply one set of operations to key-value map 0
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, actions0.into_iter());
             dbtx.commit().unwrap();
             let model = Model::from_db(&store, IDX.0);
 
             // Apply another set of operations to key-value map 1
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.1, actions1.into_iter());
             dbtx.commit().unwrap();
 
@@ -332,14 +332,14 @@ fn empty_after_abort<B: Backend + ThreadSafe + Clone>(backend: B) {
 
             // Apply one set of operations to key-value map 0
             let model = Model::from_actions(actions.clone());
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, actions.into_iter());
             for key in &keys {
                 assert_eq!(dbtx.get(IDX.0, key), Ok(model.get(key)));
             }
             drop(dbtx);
 
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             for key in &keys {
                 assert_eq!(dbtx.get(IDX.0, key), Ok(None));
             }
@@ -367,31 +367,31 @@ fn prefix_iteration<B: Backend + ThreadSafe + Clone>(backend: B) {
             let store = backend.open(desc(5)).expect("db open to succeed");
 
             // Populate the database
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, actions_a.iter().chain(actions_b.iter()).cloned());
             dbtx.commit().unwrap();
 
             // Check iteration over keys prefixed "a"
             let model_a = Model::from_actions(actions_a);
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             let iter_a = dbtx.prefix_iter(IDX.0, vec![b'a']).unwrap();
             assert!(model_a.into_iter().eq(iter_a));
             drop(dbtx);
 
             // Check iteration over keys prefixed "b"
             let model_b = Model::from_actions(actions_b);
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             let iter_b = dbtx.prefix_iter(IDX.0, vec![b'b']).unwrap();
             assert!(model_b.into_iter().eq(iter_b));
             drop(dbtx);
 
             // Check there are no entries prefixed "c"
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             assert_eq!(dbtx.prefix_iter(IDX.0, vec![b'c']).unwrap().next(), None);
             drop(dbtx);
 
             // Take all entries prefixed "a" and remove them
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             let keys_a: Vec<_> =
                 dbtx.prefix_iter(IDX.0, vec![b'a']).unwrap().map(|(k, _)| k).collect();
             for key in keys_a {
@@ -400,7 +400,7 @@ fn prefix_iteration<B: Backend + ThreadSafe + Clone>(backend: B) {
             dbtx.commit().unwrap();
 
             // Check there are no entries prefixed "a"
-            let dbtx = store.transaction_ro();
+            let dbtx = store.transaction_ro().unwrap();
             assert_eq!(dbtx.prefix_iter(IDX.0, vec![b'a']).unwrap().next(), None);
             drop(dbtx);
         },
@@ -416,7 +416,7 @@ fn post_commit_consistency<B: Backend + ThreadSafe + Clone>(backend: B) {
             // Open storage
             let store = backend.open(desc(1)).expect("db open to succeed");
 
-            let mut dbtx = store.transaction_rw();
+            let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, actions.into_iter());
             let model = Model::from_tx(&dbtx, IDX.0);
             dbtx.commit().unwrap();

--- a/storage/core/src/adaptor/locking/mod.rs
+++ b/storage/core/src/adaptor/locking/mod.rs
@@ -122,19 +122,19 @@ impl<T> Clone for TransactionLockImpl<T> {
 impl<'tx, T: 'tx + ReadOps> backend::TransactionalRo<'tx> for TransactionLockImpl<T> {
     type TxRo = TxRo<'tx, T>;
 
-    fn transaction_ro<'st: 'tx>(&'st self) -> Self::TxRo {
-        TxRo(self.db.read().expect("lock to be alive"))
+    fn transaction_ro<'st: 'tx>(&'st self) -> crate::Result<Self::TxRo> {
+        Ok(TxRo(self.db.read().expect("lock to be alive")))
     }
 }
 
 impl<'tx, T: 'tx + ReadOps + WriteOps> backend::TransactionalRw<'tx> for TransactionLockImpl<T> {
     type TxRw = TxRw<'tx, T>;
 
-    fn transaction_rw<'st: 'tx>(&'st self) -> Self::TxRw {
-        TxRw {
+    fn transaction_rw<'st: 'tx>(&'st self) -> crate::Result<Self::TxRw> {
+        Ok(TxRw {
             db: self.db.write().expect("lock to be alive"),
             deltas: vec![BTreeMap::new(); self.num_maps],
-        }
+        })
     }
 }
 

--- a/storage/core/src/backend.rs
+++ b/storage/core/src/backend.rs
@@ -63,7 +63,7 @@ pub trait TransactionalRo<'tx> {
     type TxRo: TxRo + 'tx;
 
     /// Start a read-only transaction
-    fn transaction_ro<'st: 'tx>(&'st self) -> Self::TxRo;
+    fn transaction_ro<'st: 'tx>(&'st self) -> crate::Result<Self::TxRo>;
 }
 
 /// Read-write transactional interface to the storage
@@ -72,7 +72,7 @@ pub trait TransactionalRw<'tx> {
     type TxRw: TxRw + 'tx;
 
     /// Start a read-write transaction
-    fn transaction_rw<'st: 'tx>(&'st self) -> Self::TxRw;
+    fn transaction_rw<'st: 'tx>(&'st self) -> crate::Result<Self::TxRw>;
 }
 
 /// Storage backend internal implementation type

--- a/storage/src/database/mod.rs
+++ b/storage/src/database/mod.rs
@@ -51,19 +51,19 @@ impl<B: Backend, Sch: Schema> Storage<B, Sch> {
     }
 
     /// Start a read-only transaction
-    pub fn transaction_ro<'tx, 'st: 'tx>(&'st self) -> TransactionRo<'tx, B, Sch> {
-        TransactionRo {
-            dbtx: backend::TransactionalRo::transaction_ro(&self.backend),
+    pub fn transaction_ro<'tx, 'st: 'tx>(&'st self) -> crate::Result<TransactionRo<'tx, B, Sch>> {
+        Ok(TransactionRo {
+            dbtx: backend::TransactionalRo::transaction_ro(&self.backend)?,
             _schema: Default::default(),
-        }
+        })
     }
 
     /// Start a read-write transaction
-    pub fn transaction_rw<'tx, 'st: 'tx>(&'st self) -> TransactionRw<'tx, B, Sch> {
-        TransactionRw {
-            dbtx: backend::TransactionalRw::transaction_rw(&self.backend),
+    pub fn transaction_rw<'tx, 'st: 'tx>(&'st self) -> crate::Result<TransactionRw<'tx, B, Sch>> {
+        Ok(TransactionRw {
+            dbtx: backend::TransactionalRw::transaction_rw(&self.backend)?,
             _schema: Default::default(),
-        }
+        })
     }
 }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -56,7 +56,7 @@
 //!     let mut store = Storage::<_, Schema>::new(storage::inmemory::InMemory::new())?;
 //!
 //!     // All store operations happen inside of a transaction.
-//!     let mut tx = store.transaction_rw();
+//!     let mut tx = store.transaction_rw()?;
 //!
 //!     // Get the storage map, identified by the index type.
 //!     let mut map = tx.get_mut::<MyMap, _>();
@@ -72,18 +72,18 @@
 //!     tx.commit()?;
 //!
 //!     // Try writing a value but abort the transaction afterwards.
-//!     let mut tx = store.transaction_rw();
+//!     let mut tx = store.transaction_rw()?;
 //!     tx.get_mut::<MyMap, _>().put("baz", &42)?;
 //!     tx.abort();
 //!
 //!     // Transaction can return data. Values taken from the database have to be cloned
 //!     // in order for them to be available after the transaction terminates.
-//!     let tx = store.transaction_ro();
+//!     let tx = store.transaction_ro()?;
 //!     assert_eq!(tx.get::<MyMap, _>().get("baz")?, None);
 //!     tx.close();
 //!
 //!     // Check the value we first inserted is still there.
-//!     let tx = store.transaction_ro();
+//!     let tx = store.transaction_ro()?;
 //!     assert_eq!(tx.get::<MyMap, _>().get("foo")?.map(|x| x.decode()), Some(1337));
 //!     tx.close();
 //!

--- a/storage/src/test.rs
+++ b/storage/src/test.rs
@@ -26,7 +26,7 @@ decl_schema! {
 fn empty_ro() {
     utils::concurrency::model(|| {
         let store = Storage::<_, Schema>::new(inmemory::InMemory::new()).unwrap();
-        let tx = store.transaction_ro();
+        let tx = store.transaction_ro().unwrap();
         assert_eq!(tx.get::<Map1, _>().get(&b"foo".to_vec()), Ok(None));
     });
 }
@@ -35,7 +35,7 @@ fn empty_ro() {
 fn empty_rw() {
     utils::concurrency::model(|| {
         let store = Storage::<_, Schema>::new(inmemory::InMemory::new()).unwrap();
-        let tx = store.transaction_rw();
+        let tx = store.transaction_rw().unwrap();
         assert_eq!(tx.get::<Map1, _>().get(&b"foo".to_vec()), Ok(None));
     });
 }
@@ -62,7 +62,7 @@ fn prefix_iteration() {
         ];
 
         // Populate the database
-        let mut dbtx = store.transaction_rw();
+        let mut dbtx = store.transaction_rw().unwrap();
         let mut map = dbtx.get_mut::<Map2, _>();
         for (key, val) in &test_values {
             map.put(key, val).unwrap();
@@ -70,7 +70,7 @@ fn prefix_iteration() {
         dbtx.commit().unwrap();
 
         // Iterate over the "foo" prefix
-        let dbtx = store.transaction_ro();
+        let dbtx = store.transaction_ro().unwrap();
         let items: Vec<_> = dbtx
             .get::<Map2, _>()
             .prefix_iter(&("foo".into(),))
@@ -87,7 +87,7 @@ fn prefix_iteration() {
             values.sort();
             values
         };
-        let dbtx = store.transaction_ro();
+        let dbtx = store.transaction_ro().unwrap();
         let items: Vec<_> = dbtx
             .get::<Map2, _>()
             .prefix_iter(&())


### PR DESCRIPTION
This is an earlier oversight exposed by the attempt to implement the LMDB storage backend where starting a new transaction can fail.