### PR TITLE
Introduce LogError trait for easy logging and use it in chainstate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,7 @@ dependencies = [
  "serialization",
  "static_assertions",
  "subsystem",
+ "tap",
  "test-utils",
  "thiserror",
  "tokio",
@@ -4723,6 +4724,7 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "atomic-traits",
+ "logging",
  "loom",
  "num-traits",
  "slave-pool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,6 @@ dependencies = [
  "serialization",
  "static_assertions",
  "subsystem",
- "tap",
  "test-utils",
  "thiserror",
  "tokio",

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -27,6 +27,7 @@ replace_with = "0.1"
 thiserror = "1.0"
 serde = { version = "1", features = ["derive"] }
 fallible-iterator = "0.2.0"
+tap = "1.0"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -27,7 +27,6 @@ replace_with = "0.1"
 thiserror = "1.0"
 serde = { version = "1", features = ["derive"] }
 fallible-iterator = "0.2.0"
-tap = "1.0"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 atomic-traits = "0.3"
 num-traits = "0.2"
 slave-pool = "0.2"
+logging = {path = '../logging'}
 
 [target.'cfg(loom)'.dependencies]
 loom = "0.5"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -18,6 +18,7 @@ pub mod counttracker;
 pub mod ensure;
 pub mod eventhandler;
 pub mod newtype;
+pub mod tap_error_log;
 
 mod concurrency_impl;
 pub use concurrency_impl::*;

--- a/utils/src/tap_error_log.rs
+++ b/utils/src/tap_error_log.rs
@@ -6,6 +6,8 @@ where
 {
     fn log_err(self) -> Self;
     fn log_err_pfx(self, prefix: &str) -> Self;
+    fn log_warn(self) -> Self;
+    fn log_warn_pfx(self, prefix: &str) -> Self;
 }
 
 impl<T, E: Display> LogError for Result<T, E> {
@@ -18,18 +20,26 @@ impl<T, E: Display> LogError for Result<T, E> {
     }
 
     #[inline(always)]
+    fn log_warn(self) -> Self {
+        if let Err(ref err) = self {
+            logging::log::warn!("{}", err);
+        }
+        self
+    }
+
+    #[inline(always)]
     fn log_err_pfx(self, prefix: &str) -> Self {
         if let Err(ref err) = self {
             logging::log::error!("{}{}", prefix, err);
         }
         self
     }
-}
 
-pub fn log_err<T: Display>(err: &T) {
-    logging::log::error!("{}", err);
-}
-
-pub fn log_warn<T: Display>(err: &T) {
-    logging::log::error!("{}", err);
+    #[inline(always)]
+    fn log_warn_pfx(self, prefix: &str) -> Self {
+        if let Err(ref err) = self {
+            logging::log::warn!("{}{}", prefix, err);
+        }
+        self
+    }
 }

--- a/utils/src/tap_error_log.rs
+++ b/utils/src/tap_error_log.rs
@@ -1,0 +1,35 @@
+use std::fmt::Display;
+
+pub trait LogError
+where
+    Self: Sized,
+{
+    fn log_err(self) -> Self;
+    fn log_err_pfx(self, prefix: &str) -> Self;
+}
+
+impl<T, E: Display> LogError for Result<T, E> {
+    #[inline(always)]
+    fn log_err(self) -> Self {
+        if let Err(ref err) = self {
+            logging::log::error!("{}", err);
+        }
+        self
+    }
+
+    #[inline(always)]
+    fn log_err_pfx(self, prefix: &str) -> Self {
+        if let Err(ref err) = self {
+            logging::log::error!("{}{}", prefix, err);
+        }
+        self
+    }
+}
+
+pub fn log_err<T: Display>(err: &T) {
+    logging::log::error!("{}", err);
+}
+
+pub fn log_warn<T: Display>(err: &T) {
+    logging::log::error!("{}", err);
+}

--- a/utils/src/tap_error_log.rs
+++ b/utils/src/tap_error_log.rs
@@ -1,3 +1,18 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt::Display;
 
 pub trait LogError


### PR DESCRIPTION
While the Try operator in rust makes it easy to return control to the caller, it introduces the problem that it's not easy to log errors without beefy text or calls. In this PR, I attempt to provide a solution as a compromise that'll simply log errors before returning control to the caller with a simple function call.