### PR TITLE
storage: Pass backend constructor into test functions

### DIFF
--- a/storage/backend-test-suite/src/basic.rs
+++ b/storage/backend-test-suite/src/basic.rs
@@ -17,8 +17,8 @@
 
 use crate::prelude::*;
 
-fn put_and_commit<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn put_and_commit<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     // Create a transaction, modify storage and abort transaction
     let mut dbtx = store.transaction_rw().unwrap();
@@ -31,8 +31,8 @@ fn put_and_commit<B: Backend>(backend: B) {
     drop(dbtx);
 }
 
-fn put_and_abort<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn put_and_abort<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     // Create a transaction, modify storage and abort transaction
     let mut dbtx = store.transaction_rw().unwrap();
@@ -45,8 +45,8 @@ fn put_and_abort<B: Backend>(backend: B) {
     drop(dbtx);
 }
 
-fn put_two_under_different_keys<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn put_two_under_different_keys<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     // Create a transaction, modify storage and commit
     let mut dbtx = store.transaction_rw().unwrap();
@@ -73,8 +73,8 @@ fn put_two_under_different_keys<B: Backend>(backend: B) {
     drop(dbtx);
 }
 
-fn put_twice_then_commit_read_last<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn put_twice_then_commit_read_last<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"hello".to_vec(), b"a".to_vec()).unwrap();
@@ -87,8 +87,8 @@ fn put_twice_then_commit_read_last<B: Backend>(backend: B) {
     assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"b".as_ref())),);
 }
 
-fn put_iterator_count_matches<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn put_iterator_count_matches<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, vec![0x00], vec![]).unwrap();
@@ -101,8 +101,8 @@ fn put_iterator_count_matches<B: Backend>(backend: B) {
     assert_eq!(dbtx.prefix_iter(IDX.0, vec![]).unwrap().count(), 4);
 }
 
-fn put_and_iterate_over_prefixes<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn put_and_iterate_over_prefixes<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     // Populate the database with some values
     let mut dbtx = store.transaction_rw().unwrap();
@@ -155,8 +155,8 @@ fn check_prefix<Tx: ReadOps>(dbtx: &Tx, prefix: Data, expected: &[(&str, &str)])
     assert!(entries.eq(expected));
 }
 
-fn put_and_iterate_delete_some<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn put_and_iterate_delete_some<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     let expected_full_0 =
         [("aa", "0"), ("ab", "1"), ("ac", "2"), ("aca", "3"), ("acb", "4"), ("b", "5")];

--- a/storage/backend-test-suite/src/concurrent.rs
+++ b/storage/backend-test-suite/src/concurrent.rs
@@ -27,8 +27,8 @@ fn setup<B: Backend>(backend: B, init: Vec<u8>) -> B::Impl {
     store
 }
 
-fn read_initialize_race<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn read_initialize_race<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     let thr0 = thread::spawn({
         let store = store.clone();
@@ -47,8 +47,8 @@ fn read_initialize_race<B: Backend>(backend: B) {
     thr0.join().unwrap();
 }
 
-fn read_write_race<B: Backend>(backend: B) {
-    let store = setup(backend, vec![0]);
+fn read_write_race<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = setup(backend_fn(), vec![0]);
 
     let thr0 = thread::spawn({
         let store = store.clone();
@@ -67,8 +67,8 @@ fn read_write_race<B: Backend>(backend: B) {
     thr0.join().unwrap();
 }
 
-fn commutative_read_modify_write<B: Backend>(backend: B) {
-    let store = setup(backend, vec![0]);
+fn commutative_read_modify_write<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = setup(backend_fn(), vec![0]);
 
     let thr0 = thread::spawn({
         let store = store.clone();
@@ -96,9 +96,9 @@ fn commutative_read_modify_write<B: Backend>(backend: B) {
     assert_eq!(dbtx.get(IDX.0, TEST_KEY), Ok(Some([8].as_ref())));
 }
 
-fn threaded_reads_consistent<B: Backend>(backend: B) {
+fn threaded_reads_consistent<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     let val = [0x77, 0x88, 0x99].as_ref();
-    let store = setup(backend, val.to_vec());
+    let store = setup(backend_fn(), val.to_vec());
 
     let thr0 = thread::spawn({
         let store = store.clone();
@@ -126,8 +126,8 @@ fn threaded_reads_consistent<B: Backend>(backend: B) {
     assert_eq!(thr1.join().unwrap(), val);
 }
 
-fn write_different_keys_and_iterate<B: Backend>(backend: B) {
-    let store = backend.open(desc(1)).expect("db open to succeed");
+fn write_different_keys_and_iterate<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
+    let store = backend_fn().open(desc(1)).expect("db open to succeed");
 
     let thr0 = thread::spawn({
         let store = store.clone();

--- a/storage/backend-test-suite/src/lib.rs
+++ b/storage/backend-test-suite/src/lib.rs
@@ -31,16 +31,17 @@ mod property;
 use prelude::*;
 
 /// Get all tests
-fn tests<B: Backend + ThreadSafe + Clone>(backend: B) -> Vec<libtest_mimic::Trial> {
+fn tests<B: 'static + Backend, F: BackendFn<B>>(backend_fn: F) -> Vec<libtest_mimic::Trial> {
+    let backend_fn = Arc::new(backend_fn);
     std::iter::empty()
-        .chain(basic::tests(backend.clone()))
-        .chain(concurrent::tests(backend.clone()))
-        .chain(property::tests(backend))
+        .chain(basic::tests(Arc::clone(&backend_fn)))
+        .chain(concurrent::tests(Arc::clone(&backend_fn)))
+        .chain(property::tests(backend_fn))
         .collect()
 }
 
 /// Main test suite entry point
-pub fn main<B: Backend + ThreadSafe + Clone>(backend: B) {
+pub fn main<B: 'static + Backend, F: BackendFn<B>>(backend_fn: F) {
     let args = libtest_mimic::Arguments::from_args();
-    libtest_mimic::run(&args, tests(backend)).exit();
+    libtest_mimic::run(&args, tests(backend_fn)).exit();
 }

--- a/storage/backend-test-suite/src/prelude.rs
+++ b/storage/backend-test-suite/src/prelude.rs
@@ -25,10 +25,11 @@ pub use utils::{sync, thread};
 
 pub use std::{mem::drop, sync::Arc};
 
-/// Alias for `Send + Sync + 'static`
-pub trait ThreadSafe: std::panic::UnwindSafe + Send + Sync + 'static {}
-impl<T: std::panic::UnwindSafe + Send + Sync + 'static> ThreadSafe for T {}
+/// A function to construct a backend
+pub trait BackendFn<B: Backend>: 'static + Fn() -> B + Send + Sync {}
+impl<B: Backend, F: 'static + Fn() -> B + Send + Sync> BackendFn<B> for F {}
 
+/// A couple of DB index constants
 pub const IDX: (DbIndex, DbIndex) = (DbIndex::new(0), DbIndex::new(1));
 
 /// Sample datbase decription with `n` maps
@@ -37,16 +38,16 @@ pub fn desc(n: usize) -> DbDesc {
 }
 
 /// Run tests with backend using proptest
-pub fn using_proptest<B: Backend + ThreadSafe + Clone, S: proptest::prelude::Strategy>(
+pub fn using_proptest<B: Backend, F: BackendFn<B>, S: proptest::prelude::Strategy>(
     source_file: &'static str,
-    backend: B,
+    backend_fn: impl std::ops::Deref<Target = F>,
     strategy: S,
     test: impl Fn(B, S::Value),
 ) {
     let config = proptest::prelude::ProptestConfig::with_source_file(source_file);
     let mut runner = proptest::test_runner::TestRunner::new(config);
     let result = runner.run(&strategy, |val| {
-        test(backend.clone(), val);
+        test(backend_fn(), val);
         Ok(())
     });
     result.unwrap_or_else(|e| panic!("{}{}", &e, &runner))
@@ -58,14 +59,14 @@ pub mod support {
     use libtest_mimic::Trial;
 
     /// Create the test list
-    pub fn create_tests<B: Backend + ThreadSafe + Clone>(
-        backend: B,
-        tests: impl IntoIterator<Item = (&'static str, fn(B))>,
+    pub fn create_tests<B: 'static + Backend, F: BackendFn<B>>(
+        backend_fn: Arc<F>,
+        tests: impl IntoIterator<Item = (&'static str, fn(Arc<F>))>,
     ) -> impl Iterator<Item = Trial> {
         tests.into_iter().map(move |(name, test)| {
-            let backend = backend.clone();
+            let backend_fn = Arc::clone(&backend_fn);
             let test_fn = move || {
-                utils::concurrency::model(move || test(backend.clone()));
+                utils::concurrency::model(move || test(backend_fn.clone()));
                 Ok(())
             };
             Trial::test(name, test_fn)
@@ -75,11 +76,11 @@ pub mod support {
 
 macro_rules! tests {
     ($($name:ident),* $(,)?) => {
-        pub fn tests<B: crate::prelude::Backend + crate::prelude::ThreadSafe + Clone>(
-            backend: B,
+        pub fn tests<B: 'static + $crate::prelude::Backend, F: $crate::prelude::BackendFn<B>>(
+            backend_fn: Arc<F>,
         ) -> impl std::iter::Iterator<Item = libtest_mimic::Trial> {
-            crate::prelude::support::create_tests(backend, [
-                $((concat!(module_path!(), "::", stringify!($name)), $name as fn(B)),)*
+            $crate::prelude::support::create_tests(backend_fn, [
+                $((concat!(module_path!(), "::", stringify!($name)), $name as fn(Arc<F>)),)*
             ])
         }
     }

--- a/storage/backend-test-suite/src/property.rs
+++ b/storage/backend-test-suite/src/property.rs
@@ -56,10 +56,10 @@ mod gen {
     }
 }
 
-fn overwrite_and_abort<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn overwrite_and_abort<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         (gen::key(100), gen::any::<Data>(), gen::any::<Data>())
             .prop_filter("not equal", |(_, a, b)| a != b),
         |backend, (key, val0, val1)| {
@@ -103,11 +103,11 @@ fn overwrite_and_abort<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn add_and_delete<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn add_and_delete<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     const NUM_DBS: usize = 5;
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         gen::entries(NUM_DBS, 0usize..20),
         |backend, entries| {
             let store = backend.open(desc(NUM_DBS)).expect("db open to succeed");
@@ -143,10 +143,10 @@ fn add_and_delete<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn last_write_wins<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn last_write_wins<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         (
             gen::key(1000),
             gen::prop::collection::vec(gen::any::<Data>(), 0..100),
@@ -168,11 +168,11 @@ fn last_write_wins<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn add_and_delete_some<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn add_and_delete_some<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     const NUM_DBS: usize = 5;
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         (
             gen::entries(NUM_DBS, 0usize..20),
             gen::entries(NUM_DBS, 0usize..20),
@@ -218,10 +218,10 @@ fn add_and_delete_some<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn add_modify_abort_modify_commit<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn add_modify_abort_modify_commit<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         (
             gen::actions(100, 0..20),
             gen::actions(100, 0..20),
@@ -263,10 +263,10 @@ fn add_modify_abort_modify_commit<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn add_modify_abort_replay_commit<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn add_modify_abort_replay_commit<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         (gen::actions(100, 0..20), gen::actions(100, 0..20)),
         |backend, (initial, actions)| {
             let store = backend.open(desc(1)).expect("db open to succeed");
@@ -294,10 +294,10 @@ fn add_modify_abort_replay_commit<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn db_writes_do_not_interfere<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn db_writes_do_not_interfere<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         (gen::actions(100, 0..20), gen::actions(100, 0..20)),
         |backend, (actions0, actions1)| {
             let store = backend.open(desc(2)).expect("db open to succeed");
@@ -319,10 +319,10 @@ fn db_writes_do_not_interfere<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn empty_after_abort<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn empty_after_abort<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         (
             gen::actions(100, 0..20),
             gen::prop::collection::vec(gen::key(100), 0..20),
@@ -347,10 +347,10 @@ fn empty_after_abort<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn prefix_iteration<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn prefix_iteration<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         (gen::actions(100, 0..20), gen::actions(100, 0..20)),
         |backend, (actions_a, actions_b)| {
             // Add prefixes to action keys
@@ -407,10 +407,10 @@ fn prefix_iteration<B: Backend + ThreadSafe + Clone>(backend: B) {
     )
 }
 
-fn post_commit_consistency<B: Backend + ThreadSafe + Clone>(backend: B) {
+fn post_commit_consistency<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     using_proptest(
         file!(),
-        backend,
+        backend_fn,
         gen::actions(100, 0..50),
         |backend, actions| {
             // Open storage

--- a/storage/inmemory/tests/backend.rs
+++ b/storage/inmemory/tests/backend.rs
@@ -14,5 +14,5 @@
 // limitations under the License.
 
 fn main() {
-    storage_backend_test_suite::main(storage_inmemory::InMemory::new())
+    storage_backend_test_suite::main(storage_inmemory::InMemory::new)
 }


### PR DESCRIPTION
Pass a backend constructor function into the tests instead of an instantiated backend. This gives more flexibility in how backend is initialized in tests. Will be useful in LMDB where each test run needs a separate database file.