### PR TITLE
Separate timelock checking from signature verification

### DIFF
--- a/chainstate/src/detail/bootstrap.rs
+++ b/chainstate/src/detail/bootstrap.rs
@@ -22,7 +22,10 @@ use serialization::{Decode, Encode};
 
 use crate::{BlockError, ChainstateConfig};
 
-use super::{orphan_blocks::OrphanBlocks, query::ChainstateQuery};
+use super::{
+    orphan_blocks::OrphanBlocks, query::ChainstateQuery,
+    tx_verification_strategy::TransactionVerificationStrategy,
+};
 
 const DEFAULT_MIN_IMPORT_BUFFER_SIZE: usize = 1 << 22; // 4 MB
 const DEFAULT_MAX_IMPORT_BUFFER_SIZE: usize = 1 << 26; // 64 MB
@@ -112,11 +115,16 @@ fn fill_buffer<S: std::io::Read>(
     Ok(())
 }
 
-pub fn export_bootstrap_stream<'a, S: BlockchainStorageRead, O: OrphanBlocks>(
+pub fn export_bootstrap_stream<
+    'a,
+    S: BlockchainStorageRead,
+    O: OrphanBlocks,
+    V: TransactionVerificationStrategy,
+>(
     magic_bytes: &[u8],
     writer: &mut std::io::BufWriter<Box<dyn std::io::Write + 'a + Send>>,
     include_orphans: bool,
-    query_interface: &ChainstateQuery<'a, S, O>,
+    query_interface: &ChainstateQuery<'a, S, O, V>,
 ) -> Result<(), BootstrapError>
 where
 {

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -35,6 +35,7 @@ use common::{
 };
 use consensus::TransactionIndexHandle;
 use logging::log;
+use tx_verifier::transaction_verifier::TransactionVerifier;
 use utils::{ensure, tap_error_log::LogError};
 use utxo::{UtxosDB, UtxosView};
 
@@ -772,6 +773,7 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut, V: TransactionVerificati
         let connected_txs = self
             .tx_verification_strategy
             .connect_block(
+                TransactionVerifier::new,
                 self,
                 self,
                 self.chain_config,
@@ -793,6 +795,7 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut, V: TransactionVerificati
         prev_block_id: Id<GenBlock>,
     ) -> Result<(), BlockError> {
         let cached_inputs = self.tx_verification_strategy.disconnect_block(
+            TransactionVerifier::new,
             self,
             self.chain_config,
             block,

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -42,7 +42,10 @@ pub fn calculate_median_time_past<H: BlockIndexHandle>(
 
 #[cfg(test)]
 mod test {
-    use crate::{BlockSource, Chainstate, ChainstateConfig};
+    use crate::{
+        detail::tx_verification_strategy::DefaultTransactionVerificationStrategy, BlockSource,
+        Chainstate, ChainstateConfig,
+    };
     use common::time_getter::TimeGetter;
 
     use super::*;
@@ -101,6 +104,7 @@ mod test {
                 chain_config,
                 chainstate_config,
                 storage,
+                DefaultTransactionVerificationStrategy::new(),
                 None,
                 Default::default(),
             )
@@ -176,9 +180,15 @@ mod test {
 
             let storage = Store::new_empty().unwrap();
             let chainstate_config = ChainstateConfig::new();
-            let mut chainstate =
-                Chainstate::new(chain_config, chainstate_config, storage, None, time_getter)
-                    .unwrap();
+            let mut chainstate = Chainstate::new(
+                chain_config,
+                chainstate_config,
+                storage,
+                DefaultTransactionVerificationStrategy::new(),
+                None,
+                time_getter,
+            )
+            .unwrap();
 
             // we use unordered block times, and ensure that the median will be in the right spot
             let block1_time = current_time.load(Ordering::SeqCst) + 1;

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -23,6 +23,7 @@ mod chainstateref;
 mod error;
 mod median_time;
 mod orphan_blocks;
+pub mod tx_verification_strategy;
 
 pub use self::error::*;
 pub use self::median_time::calculate_median_time_past;

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -57,6 +57,7 @@ use utxo::UtxosDBMut;
 use self::{
     orphan_blocks::{OrphanBlocksRef, OrphanBlocksRefMut},
     query::ChainstateQuery,
+    tx_verification_strategy::TransactionVerificationStrategy,
 };
 use crate::{detail::orphan_blocks::OrphanBlocksPool, ChainstateConfig, ChainstateEvent};
 
@@ -70,10 +71,11 @@ pub const HEADER_LIMIT: BlockDistance = BlockDistance::new(2000);
 pub type OrphanErrorHandler = dyn Fn(&BlockError) + Send + Sync;
 
 #[must_use]
-pub struct Chainstate<S> {
+pub struct Chainstate<S, V> {
     chain_config: Arc<ChainConfig>,
     chainstate_config: ChainstateConfig,
     chainstate_storage: S,
+    tx_verification_strategy: V,
     orphan_blocks: OrphanBlocksPool,
     custom_orphan_error_hook: Option<Arc<OrphanErrorHandler>>,
     events_controller: EventsController<ChainstateEvent>,
@@ -86,7 +88,7 @@ pub enum BlockSource {
     Local,
 }
 
-impl<S: BlockchainStorage> Chainstate<S> {
+impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> {
     #[allow(dead_code)]
     pub fn wait_for_all_events(&self) {
         self.events_controller.wait_for_all_events();
@@ -94,12 +96,13 @@ impl<S: BlockchainStorage> Chainstate<S> {
 
     fn make_db_tx(
         &mut self,
-    ) -> chainstate_storage::Result<chainstateref::ChainstateRef<TxRw<'_, S>, OrphanBlocksRefMut>>
+    ) -> chainstate_storage::Result<chainstateref::ChainstateRef<TxRw<'_, S>, OrphanBlocksRefMut, V>>
     {
         let db_tx = self.chainstate_storage.transaction_rw()?;
         Ok(chainstateref::ChainstateRef::new_rw(
             &self.chain_config,
             &self.chainstate_config,
+            &self.tx_verification_strategy,
             db_tx,
             self.orphan_blocks.as_rw_ref(),
             self.time_getter.getter(),
@@ -108,12 +111,13 @@ impl<S: BlockchainStorage> Chainstate<S> {
 
     pub(crate) fn make_db_tx_ro(
         &self,
-    ) -> chainstate_storage::Result<chainstateref::ChainstateRef<TxRo<'_, S>, OrphanBlocksRef>>
+    ) -> chainstate_storage::Result<chainstateref::ChainstateRef<TxRo<'_, S>, OrphanBlocksRef, V>>
     {
         let db_tx = self.chainstate_storage.transaction_ro()?;
         Ok(chainstateref::ChainstateRef::new_ro(
             &self.chain_config,
             &self.chainstate_config,
+            &self.tx_verification_strategy,
             db_tx,
             self.orphan_blocks.as_ro_ref(),
             self.time_getter.getter(),
@@ -122,7 +126,7 @@ impl<S: BlockchainStorage> Chainstate<S> {
 
     pub fn query(
         &self,
-    ) -> Result<ChainstateQuery<TxRo<'_, S>, OrphanBlocksRef>, PropertyQueryError> {
+    ) -> Result<ChainstateQuery<TxRo<'_, S>, OrphanBlocksRef, V>, PropertyQueryError> {
         self.make_db_tx_ro().map(ChainstateQuery::new).map_err(PropertyQueryError::from)
     }
 
@@ -134,6 +138,7 @@ impl<S: BlockchainStorage> Chainstate<S> {
         chain_config: Arc<ChainConfig>,
         chainstate_config: ChainstateConfig,
         chainstate_storage: S,
+        tx_verification_strategy: V,
         custom_orphan_error_hook: Option<Arc<OrphanErrorHandler>>,
         time_getter: TimeGetter,
     ) -> Result<Self, crate::ChainstateError> {
@@ -153,6 +158,7 @@ impl<S: BlockchainStorage> Chainstate<S> {
             chain_config,
             chainstate_config,
             chainstate_storage,
+            tx_verification_strategy,
             custom_orphan_error_hook,
             time_getter,
         );
@@ -170,6 +176,7 @@ impl<S: BlockchainStorage> Chainstate<S> {
         chain_config: Arc<ChainConfig>,
         chainstate_config: ChainstateConfig,
         chainstate_storage: S,
+        tx_verification_strategy: V,
         custom_orphan_error_hook: Option<Arc<OrphanErrorHandler>>,
         time_getter: TimeGetter,
     ) -> Self {
@@ -178,6 +185,7 @@ impl<S: BlockchainStorage> Chainstate<S> {
             chain_config,
             chainstate_config,
             chainstate_storage,
+            tx_verification_strategy,
             orphan_blocks,
             custom_orphan_error_hook,
             events_controller: EventsController::new(),

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -24,18 +24,23 @@ use common::{
     primitives::{BlockDistance, BlockHeight, Id, Idable},
 };
 
-use super::{chainstateref, orphan_blocks::OrphanBlocks, HEADER_LIMIT};
+use super::{
+    chainstateref, orphan_blocks::OrphanBlocks,
+    tx_verification_strategy::TransactionVerificationStrategy, HEADER_LIMIT,
+};
 
 pub fn locator_tip_distances() -> impl Iterator<Item = BlockDistance> {
     itertools::iterate(0, |&i| std::cmp::max(1, i * 2)).map(BlockDistance::new)
 }
 
-pub struct ChainstateQuery<'a, S, O> {
-    chainstate_ref: chainstateref::ChainstateRef<'a, S, O>,
+pub struct ChainstateQuery<'a, S, O, V> {
+    chainstate_ref: chainstateref::ChainstateRef<'a, S, O, V>,
 }
 
-impl<'a, S: BlockchainStorageRead, O: OrphanBlocks> ChainstateQuery<'a, S, O> {
-    pub(crate) fn new(chainstate_ref: chainstateref::ChainstateRef<'a, S, O>) -> Self {
+impl<'a, S: BlockchainStorageRead, O: OrphanBlocks, V: TransactionVerificationStrategy>
+    ChainstateQuery<'a, S, O, V>
+{
+    pub(crate) fn new(chainstate_ref: chainstateref::ChainstateRef<'a, S, O, V>) -> Self {
         Self { chainstate_ref }
     }
 

--- a/chainstate/src/detail/test.rs
+++ b/chainstate/src/detail/test.rs
@@ -15,6 +15,7 @@
 
 use crate::detail::query::locator_tip_distances;
 use crate::interface::chainstate_interface_impl::ChainstateInterfaceImpl;
+use crate::DefaultTransactionVerificationStrategy;
 
 use super::*;
 use chainstate_storage::inmemory::Store;
@@ -25,7 +26,7 @@ use common::chain::NetUpgrades;
 use common::Uint256;
 use static_assertions::*;
 
-assert_impl_all!(ChainstateInterfaceImpl<chainstate_storage::inmemory::Store>: Send);
+assert_impl_all!(ChainstateInterfaceImpl<chainstate_storage::inmemory::Store, DefaultTransactionVerificationStrategy>: Send);
 
 // TODO: write tests for consensus crate
 #[test]
@@ -44,6 +45,7 @@ fn process_genesis_block() {
             Arc::new(chain_config),
             chainstate_config,
             chainstate_storage,
+            DefaultTransactionVerificationStrategy::new(),
             None,
             time_getter,
         );
@@ -87,6 +89,7 @@ fn empty_chainstate_no_genesis() {
             Arc::new(chain_config),
             chainstate_config,
             chainstate_storage,
+            DefaultTransactionVerificationStrategy::new(),
             None,
             time_getter,
         );

--- a/chainstate/src/detail/tx_verification_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy.rs
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_types::{BlockIndex, BlockIndexHandle};
+use common::{
+    chain::{Block, ChainConfig, GenBlock},
+    primitives::{id::WithId, Amount, BlockHeight, Id, Idable},
+};
+use tx_verifier::transaction_verifier::{
+    error::ConnectTransactionError, storage::TransactionVerifierStorageRef, BlockTransactableRef,
+    Fee, Subsidy, TransactionVerifier,
+};
+use utils::tap_error_log::LogError;
+
+use crate::{calculate_median_time_past, BlockError};
+
+pub struct TransactionVerificationStrategy<'a, H, S> {
+    block_index_handle: &'a H,
+    storage_backend: &'a S,
+    chain_config: &'a ChainConfig,
+}
+
+impl<'a, H: BlockIndexHandle, S: TransactionVerifierStorageRef>
+    TransactionVerificationStrategy<'a, H, S>
+{
+    pub fn new(
+        block_index_handle: &'a H,
+        storage_backend: &'a S,
+        chain_config: &'a ChainConfig,
+    ) -> Self {
+        Self {
+            block_index_handle,
+            storage_backend,
+            chain_config,
+        }
+    }
+
+    pub fn connect_block(
+        &'a self,
+        block_index: &'a BlockIndex,
+        block: &WithId<Block>,
+        spend_height: &BlockHeight,
+    ) -> Result<TransactionVerifier<S>, BlockError> {
+        // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
+        let median_time_past =
+            calculate_median_time_past(self.block_index_handle, &block.prev_block_id());
+
+        let mut tx_verifier = TransactionVerifier::new(self.storage_backend, self.chain_config);
+
+        let reward_fees = tx_verifier
+            .connect_transactable(
+                block_index,
+                BlockTransactableRef::BlockReward(block),
+                spend_height,
+                &median_time_past,
+            )
+            .log_err()?;
+        debug_assert!(reward_fees.is_none());
+
+        let total_fees = block
+            .transactions()
+            .iter()
+            .enumerate()
+            .try_fold(Amount::from_atoms(0), |total, (tx_num, _)| {
+                let fee = tx_verifier
+                    .connect_transactable(
+                        block_index,
+                        BlockTransactableRef::Transaction(block, tx_num),
+                        spend_height,
+                        &median_time_past,
+                    )
+                    .log_err()?;
+                (total + fee.expect("connect tx should return fees").0).ok_or_else(|| {
+                    ConnectTransactionError::FailedToAddAllFeesOfBlock(block.get_id())
+                })
+            })
+            .log_err()?;
+
+        let block_subsidy = self.chain_config.block_subsidy_at_height(spend_height);
+        tx_verifier
+            .check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy))
+            .log_err()?;
+
+        tx_verifier.set_best_block(block.get_id().into());
+
+        Ok(tx_verifier)
+    }
+
+    pub fn disconnect_block(
+        &'a self,
+        block: &WithId<Block>,
+        prev_block_id: Id<GenBlock>,
+    ) -> Result<TransactionVerifier<S>, BlockError> {
+        let mut tx_verifier = TransactionVerifier::new(self.storage_backend, self.chain_config);
+
+        // TODO: add a test that checks the order in which txs are disconnected
+        block
+            .transactions()
+            .iter()
+            .enumerate()
+            .rev()
+            .try_for_each(|(tx_num, _)| {
+                tx_verifier
+                    .disconnect_transactable(BlockTransactableRef::Transaction(block, tx_num))
+            })
+            .log_err()?;
+        tx_verifier
+            .disconnect_transactable(BlockTransactableRef::BlockReward(block))
+            .log_err()?;
+
+        tx_verifier.set_best_block(prev_block_id);
+
+        Ok(tx_verifier)
+    }
+}

--- a/chainstate/src/detail/tx_verification_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy.rs
@@ -28,6 +28,12 @@ use crate::{calculate_median_time_past, BlockError};
 
 /// A trait that specifies how a block will be verified
 pub trait TransactionVerificationStrategy: Sized + Send {
+    /// Connect the transactions given by block and block_index,
+    /// and return a TransactionVerifier with an internal state
+    /// that represents them being connected.
+    /// Notice that this doesn't modify the internal database/storage
+    /// state. It just returns a TransactionVerifier that can be
+    /// used to update the database/storage state.
     fn connect_block<'a, H, S, M>(
         &self,
         tx_verifier_maker: M,
@@ -43,6 +49,12 @@ pub trait TransactionVerificationStrategy: Sized + Send {
         S: TransactionVerifierStorageRef,
         M: Fn(&'a S, &'a ChainConfig) -> TransactionVerifier<'a, S>;
 
+    /// Disconnect the transactions given by block and block_index,
+    /// and return a TransactionVerifier with an internal state
+    /// that represents them being disconnected.
+    /// Notice that this doesn't modify the internal database/storage
+    /// state. It just returns a TransactionVerifier that can be
+    /// used to update the database/storage state.
     fn disconnect_block<'a, S, M>(
         &self,
         tx_verifier_maker: M,

--- a/chainstate/src/detail/tx_verification_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy.rs
@@ -27,7 +27,7 @@ use utils::tap_error_log::LogError;
 use crate::{calculate_median_time_past, BlockError};
 
 /// A trait that specifies how a block will be verified
-pub trait TransactionVerificationStrategy: Sized {
+pub trait TransactionVerificationStrategy: Sized + Send {
     fn connect_block<'a, H: BlockIndexHandle, S: TransactionVerifierStorageRef>(
         &self,
         block_index_handle: &'a H,

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use crate::detail::bootstrap::export_bootstrap_stream;
 use crate::detail::bootstrap::import_bootstrap_stream;
 use crate::detail::calculate_median_time_past;
+use crate::detail::tx_verification_strategy::TransactionVerificationStrategy;
 use chainstate_storage::BlockchainStorage;
 use chainstate_types::{BlockIndex, GenBlockIndex};
 use common::chain::block::BlockReward;
@@ -45,17 +46,19 @@ use crate::{
     ChainstateError, ChainstateEvent, ChainstateInterface, Locator,
 };
 
-pub struct ChainstateInterfaceImpl<S> {
-    chainstate: detail::Chainstate<S>,
+pub struct ChainstateInterfaceImpl<S, V> {
+    chainstate: detail::Chainstate<S, V>,
 }
 
-impl<S> ChainstateInterfaceImpl<S> {
-    pub fn new(chainstate: detail::Chainstate<S>) -> Self {
+impl<S, V> ChainstateInterfaceImpl<S, V> {
+    pub fn new(chainstate: detail::Chainstate<S, V>) -> Self {
         Self { chainstate }
     }
 }
 
-impl<S: BlockchainStorage> ChainstateInterface for ChainstateInterfaceImpl<S> {
+impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterface
+    for ChainstateInterfaceImpl<S, V>
+{
     fn subscribe_to_events(&mut self, handler: EventHandler<ChainstateEvent>) {
         self.chainstate.subscribe_to_events(handler)
     }

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -262,7 +262,10 @@ mod tests {
         primitives::BlockHeight,
     };
 
-    use crate::{chainstate_interface::ChainstateInterface, make_chainstate, ChainstateConfig};
+    use crate::{
+        chainstate_interface::ChainstateInterface, make_chainstate, ChainstateConfig,
+        DefaultTransactionVerificationStrategy,
+    };
     use common::time_getter::TimeGetter;
 
     fn test_interface_ref<C: ChainstateInterface>(chainstate: &C, chain_config: &ChainConfig) {
@@ -302,6 +305,7 @@ mod tests {
                 chain_config.clone(),
                 chainstate_config,
                 chainstate_storage,
+                DefaultTransactionVerificationStrategy::new(),
                 None,
                 TimeGetter::default(),
             )

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -15,6 +15,7 @@
 
 mod interface;
 use detail::bootstrap::BootstrapError;
+pub use detail::tx_verification_strategy::*;
 pub use interface::chainstate_interface;
 use interface::chainstate_interface_impl;
 pub use interface::chainstate_interface_impl_delegation;
@@ -67,10 +68,14 @@ impl subsystem::Subsystem for Box<dyn ChainstateInterface> {}
 
 type ChainstateHandle = subsystem::Handle<Box<dyn ChainstateInterface>>;
 
-pub fn make_chainstate<S: chainstate_storage::BlockchainStorage + 'static>(
+pub fn make_chainstate<
+    S: chainstate_storage::BlockchainStorage + 'static,
+    V: TransactionVerificationStrategy + 'static,
+>(
     chain_config: Arc<ChainConfig>,
     chainstate_config: ChainstateConfig,
     chainstate_storage: S,
+    tx_verification_strategy: V,
     custom_orphan_error_hook: Option<Arc<detail::OrphanErrorHandler>>,
     time_getter: TimeGetter,
 ) -> Result<Box<dyn ChainstateInterface>, ChainstateError> {
@@ -78,6 +83,7 @@ pub fn make_chainstate<S: chainstate_storage::BlockchainStorage + 'static>(
         chain_config,
         chainstate_config,
         chainstate_storage,
+        tx_verification_strategy,
         custom_orphan_error_hook,
         time_getter,
     )?;

--- a/chainstate/src/rpc.rs
+++ b/chainstate/src/rpc.rs
@@ -148,7 +148,7 @@ fn handle_error<T>(e: Result<Result<T, ChainstateError>, CallError>) -> rpc::Res
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::ChainstateConfig;
+    use crate::{ChainstateConfig, DefaultTransactionVerificationStrategy};
     use serde_json::Value;
     use std::{future::Future, sync::Arc};
 
@@ -165,6 +165,7 @@ mod test {
                 chain_config,
                 chainstate_config,
                 storage,
+                DefaultTransactionVerificationStrategy::new(),
                 None,
                 Default::default(),
             )

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -23,8 +23,8 @@ use common::chain::{
 
 use crate::TestFramework;
 
-use chainstate::BlockError;
 use chainstate::ChainstateConfig;
+use chainstate::{BlockError, DefaultTransactionVerificationStrategy};
 use common::time_getter::TimeGetter;
 
 pub type OrphanErrorHandler = dyn Fn(&BlockError) + Send + Sync;
@@ -87,6 +87,7 @@ impl TestFrameworkBuilder {
             Arc::new(self.chain_config),
             self.chainstate_config,
             self.chainstate_storage,
+            DefaultTransactionVerificationStrategy::new(),
             self.custom_orphan_error_hook,
             self.time_getter,
         )

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -19,7 +19,8 @@ use std::{sync::atomic::Ordering, time::Duration};
 use chainstate::chainstate_interface::ChainstateInterface;
 use chainstate::{
     make_chainstate, BlockError, BlockSource, ChainstateConfig, ChainstateError, CheckBlockError,
-    CheckBlockTransactionsError, ConnectTransactionError, OrphanCheckError, TxIndexError,
+    CheckBlockTransactionsError, ConnectTransactionError, DefaultTransactionVerificationStrategy,
+    OrphanCheckError, TxIndexError,
 };
 use chainstate_test_framework::{
     anyonecanspend_address, empty_witness, TestBlockInfo, TestFramework, TestStore,
@@ -1091,6 +1092,7 @@ fn mainnet_initialization() {
         chain_config,
         chainstate_config,
         storage,
+        DefaultTransactionVerificationStrategy::new(),
         None,
         Default::default(),
     )

--- a/mempool/src/pool/tests.rs
+++ b/mempool/src/pool/tests.rs
@@ -18,6 +18,7 @@ use chainstate::chainstate_interface;
 use chainstate::make_chainstate;
 use chainstate::BlockSource;
 use chainstate::ChainstateConfig;
+use chainstate::DefaultTransactionVerificationStrategy;
 use chainstate_test_framework::anyonecanspend_address;
 use chainstate_test_framework::empty_witness;
 use chainstate_test_framework::TestFramework;
@@ -199,6 +200,7 @@ pub async fn start_chainstate_with_config(
         chain_config,
         ChainstateConfig::new(),
         storage,
+        DefaultTransactionVerificationStrategy::new(),
         None,
         Default::default(),
     )

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -20,7 +20,7 @@ use std::{fs, path::Path, str::FromStr, sync::Arc, time::Duration};
 use anyhow::{anyhow, Context, Result};
 use paste::paste;
 
-use chainstate::rpc::ChainstateRpcServer;
+use chainstate::{rpc::ChainstateRpcServer, DefaultTransactionVerificationStrategy};
 use common::{
     chain::config::{
         Builder as ChainConfigBuilder, ChainConfig, ChainType, EmissionScheduleTabular,
@@ -62,6 +62,7 @@ pub async fn initialize(
             Arc::clone(&chain_config),
             node_config.chainstate,
             storage.clone(),
+            DefaultTransactionVerificationStrategy::new(),
             None,
             Default::default(),
         )?,

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -25,6 +25,7 @@ use tokio::{
 
 use chainstate::{
     chainstate_interface::ChainstateInterface, make_chainstate, BlockSource, ChainstateConfig,
+    DefaultTransactionVerificationStrategy,
 };
 use common::{
     chain::{
@@ -225,6 +226,7 @@ pub async fn start_chainstate(
             chain_config,
             ChainstateConfig::new(),
             storage,
+            DefaultTransactionVerificationStrategy::new(),
             None,
             Default::default(),
         )

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use libp2p::PeerId;
 use tokio::time::timeout;
 
-use chainstate::{make_chainstate, ChainstateConfig};
+use chainstate::{make_chainstate, ChainstateConfig, DefaultTransactionVerificationStrategy};
 
 use super::*;
 use crate::{
@@ -61,6 +61,7 @@ where
             chain_config,
             chainstate_config,
             storage,
+            DefaultTransactionVerificationStrategy::new(),
             None,
             Default::default(),
         )


### PR DESCRIPTION
In preparation to make it possible to verify transactions without blocks