### PR TITLE
chainstate: Genesis check

### DIFF
--- a/chainstate/launcher/src/lib.rs
+++ b/chainstate/launcher/src/lib.rs
@@ -36,7 +36,7 @@ fn make_chainstate_and_storage_impl<B: 'static + storage::Backend>(
     chainstate_config: ChainstateConfig,
 ) -> Result<Box<dyn ChainstateInterface>, Error> {
     let storage = chainstate_storage::Store::new(storage_backend)
-        .map_err(|e| Error::FailedToInitializeChainstate(e.to_string()))?;
+        .map_err(|e| Error::FailedToInitializeChainstate(e.into()))?;
     let chainstate = chainstate::make_chainstate(
         chain_config,
         chainstate_config,

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -122,6 +122,18 @@ pub enum BlockSizeError {
     SizeOfSmartContracts(usize, usize),
 }
 
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+pub enum InitializationError {
+    #[error("Block storage error: `{0}`")]
+    StorageError(#[from] chainstate_storage::Error),
+    #[error("{0}")]
+    PropertyQuery(#[from] PropertyQueryError),
+    #[error("Not at genesis but block at height 1 not available")]
+    Block1Missing,
+    #[error("Genesis mismatch: {0} according to configuration, {1} inferred from storage")]
+    GenesisMismatch(Id<GenBlock>, Id<GenBlock>),
+}
+
 impl From<OrphanAddError> for Result<(), OrphanCheckError> {
     fn from(err: OrphanAddError) -> Self {
         match err {

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -26,8 +26,9 @@ pub use crate::{
     config::ChainstateConfig,
     detail::{
         ban_score, calculate_median_time_past, is_rfc3986_valid_symbol, BlockError, BlockSource,
-        CheckBlockError, CheckBlockTransactionsError, ConnectTransactionError, Locator,
-        OrphanCheckError, TokensError, TransactionVerifierStorageError, TxIndexError, HEADER_LIMIT,
+        CheckBlockError, CheckBlockTransactionsError, ConnectTransactionError, InitializationError,
+        Locator, OrphanCheckError, TokensError, TransactionVerifierStorageError, TxIndexError,
+        HEADER_LIMIT,
     },
 };
 
@@ -54,8 +55,8 @@ pub enum ChainstateEvent {
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum ChainstateError {
-    #[error("Initialization error")]
-    FailedToInitializeChainstate(String),
+    #[error("Initialization error: {0}")]
+    FailedToInitializeChainstate(#[from] InitializationError),
     #[error("Block processing failed: `{0}`")]
     ProcessBlockError(#[from] BlockError),
     #[error("Property read error: `{0}`")]

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -101,7 +101,7 @@ impl TestFrameworkBuilder {
         self
     }
 
-    pub fn build(self) -> TestFramework {
+    pub fn try_build(self) -> Result<TestFramework, chainstate::ChainstateError> {
         let chainstate = match self.tx_verification_strategy {
             TxVerificationStrategy::Default => chainstate::make_chainstate(
                 Arc::new(self.chain_config),
@@ -127,13 +127,16 @@ impl TestFrameworkBuilder {
                 self.custom_orphan_error_hook,
                 self.time_getter,
             ),
-        }
-        .unwrap();
+        }?;
 
-        TestFramework {
+        Ok(TestFramework {
             chainstate,
             storage: self.chainstate_storage,
             block_indexes: Vec::new(),
-        }
+        })
+    }
+
+    pub fn build(self) -> TestFramework {
+        self.try_build().unwrap()
     }
 }

--- a/chainstate/test-suite/src/tests/initialization.rs
+++ b/chainstate/test-suite/src/tests/initialization.rs
@@ -130,5 +130,5 @@ fn genesis_check_err_height_1() {
 #[trace]
 #[case(Seed::from_entropy())]
 fn genesis_check_err_nonempty_chain(#[case] seed: Seed) {
-    genesis_check_err(make_seedable_rng(seed).gen_range(1..100));
+    genesis_check_err(make_seedable_rng(seed).gen_range(2..100));
 }

--- a/chainstate/test-suite/src/tests/mod.rs
+++ b/chainstate/test-suite/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod double_spend_tests;
 mod events_tests;
 mod fungible_tokens;
 mod homomorphism;
+mod initialization;
 mod nft_burn;
 mod nft_issuance;
 mod nft_reorgs;


### PR DESCRIPTION
Introduce a check that verifies the genesis block the storage builds on matches the one specified in `ChainConfig`. This is to prevent accidentally using storage with a different chain from the one it was started with (e.g. testnet vs mainnet).