### PR TITLE
Include magic bytes in minimum buffer size in block bootstrap import

### DIFF
--- a/chainstate/src/detail/bootstrap.rs
+++ b/chainstate/src/detail/bootstrap.rs
@@ -71,7 +71,7 @@ where
     let mut buffer_queue = Vec::<u8>::new();
 
     loop {
-        if buffer_queue.len() < min_buffer_size {
+        if buffer_queue.len() < min_buffer_size + expected_magic_bytes.len() {
             fill_buffer(&mut buffer_queue, file_reader, max_buffer_size)?;
         }
 


### PR DESCRIPTION
Fix the calculation of the minimum buffer size to include magic bytes