### PR TITLE
Use custom time getter by default for chainstate TestFramework

### DIFF
--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -27,7 +27,7 @@ use common::{
         signed_transaction::SignedTransaction,
         Block, GenBlock, Transaction, TxInput, TxOutput,
     },
-    primitives::{time, Id, H256},
+    primitives::{Id, H256},
 };
 use crypto::random::Rng;
 use itertools::Itertools;
@@ -49,7 +49,7 @@ impl<'f> BlockBuilder<'f> {
     pub fn new(framework: &'f mut TestFramework) -> Self {
         let transactions = Vec::new();
         let prev_block_hash = framework.chainstate.get_best_block_id().unwrap();
-        let timestamp = BlockTimestamp::from_duration_since_epoch(time::get());
+        let timestamp = BlockTimestamp::from_duration_since_epoch(framework.time_getter.get_time());
         let consensus_data = ConsensusData::None;
         let reward = BlockReward::new(Vec::new());
         let block_source = BlockSource::Local;

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -32,8 +32,10 @@ pub struct TestFramework {
     pub chainstate: super::TestChainstate,
     pub storage: TestStore,
     pub block_indexes: Vec<BlockIndex>,
-    pub time_getter: TimeGetter, // A clone of the TimeGetter supplied to the chainstate
-    pub time_value: Option<Arc<AtomicU64>>, // current time since epoch; if None, it means a custom TimeGetter was supplied and this is useless
+    // A clone of the TimeGetter supplied to the chainstate
+    pub time_getter: TimeGetter,
+    // current time since epoch; if None, it means a custom TimeGetter was supplied and this is useless
+    pub time_value: Option<Arc<AtomicU64>>,
 }
 
 impl TestFramework {

--- a/chainstate/test-suite/src/tests/events_tests.rs
+++ b/chainstate/test-suite/src/tests/events_tests.rs
@@ -178,7 +178,8 @@ fn custom_orphan_error_hook(#[case] seed: Seed) {
             tf.make_block_builder().add_test_transaction_from_best_block(&mut rng).build();
         // Produce a block with a bad timestamp.
         let timestamp = tf.genesis().timestamp().as_int_seconds()
-            + tf.chainstate.get_chain_config().max_future_block_time_offset().as_secs();
+            + tf.chainstate.get_chain_config().max_future_block_time_offset().as_secs()
+            + 1;
         let second_block = tf
             .make_block_builder()
             .with_parent(first_block.get_id().into())
@@ -200,11 +201,11 @@ fn custom_orphan_error_hook(#[case] seed: Seed) {
         tf.process_block(first_block, BlockSource::Local).unwrap();
         tf.chainstate.wait_for_all_events();
         assert_eq!(events.lock().unwrap().len(), 1);
-        let guard = errors.lock().unwrap();
-        assert_eq!(guard.len(), 1);
+        let errors_guard = errors.lock().unwrap();
+        assert_eq!(errors_guard.len(), 1);
         assert_eq!(
-            guard[0],
-            BlockError::CheckBlockFailed(CheckBlockError::BlockTimeOrderInvalid)
+            errors_guard[0],
+            BlockError::CheckBlockFailed(CheckBlockError::BlockFromTheFuture)
         );
     });
 }

--- a/chainstate/test-suite/src/tests/output_timelock.rs
+++ b/chainstate/test-suite/src/tests/output_timelock.rs
@@ -30,7 +30,7 @@ use common::{
         tokens::OutputValue,
         OutPointSourceId, OutputPurpose, TxInput, TxOutput,
     },
-    primitives::{time, Amount, BlockDistance, BlockHeight, Id, Idable},
+    primitives::{Amount, BlockDistance, BlockHeight, Id, Idable},
 };
 
 use chainstate::BlockError;
@@ -48,10 +48,11 @@ fn output_lock_until_height() {
         let block_height_that_unlocks = 10;
 
         // create the first block, with a locked output
+        let current_time = tf.current_time();
         let locked_output = add_block_with_locked_output(
             &mut tf,
             OutputTimeLock::UntilHeight(BlockHeight::new(block_height_that_unlocks)),
-            BlockTimestamp::from_duration_since_epoch(time::get()),
+            BlockTimestamp::from_duration_since_epoch(current_time),
         );
 
         // attempt to create the next block, and attempt to spend the locked output
@@ -201,10 +202,11 @@ fn output_lock_for_block_count() {
         let block_height_with_locked_output = 1;
 
         // create the first block, with a locked output
+        let current_time = tf.current_time();
         let locked_output = add_block_with_locked_output(
             &mut tf,
             OutputTimeLock::ForBlockCount(block_count_that_unlocks),
-            BlockTimestamp::from_duration_since_epoch(time::get()),
+            BlockTimestamp::from_duration_since_epoch(current_time),
         );
 
         // attempt to create the next block, and attempt to spend the locked output
@@ -346,10 +348,11 @@ fn output_lock_for_block_count_attempted_overflow() {
         let block_count_that_unlocks = u64::MAX;
 
         // create the first block, with a locked output
+        let current_time = tf.current_time();
         let locked_output = add_block_with_locked_output(
             &mut tf,
             OutputTimeLock::ForBlockCount(block_count_that_unlocks),
-            BlockTimestamp::from_duration_since_epoch(time::get()),
+            BlockTimestamp::from_duration_since_epoch(current_time),
         );
 
         // attempt to create the next block, and attempt to spend the locked output
@@ -666,10 +669,11 @@ fn output_lock_for_seconds_attempted_overflow() {
         let mut tf = TestFramework::default();
 
         // create the first block, with a locked output
+        let current_time = tf.current_time();
         let locked_output = add_block_with_locked_output(
             &mut tf,
             OutputTimeLock::ForSeconds(u64::MAX),
-            BlockTimestamp::from_duration_since_epoch(time::get()),
+            BlockTimestamp::from_duration_since_epoch(current_time),
         );
 
         // attempt to create the next block, and attempt to spend the locked output


### PR DESCRIPTION
With this PR, tests should be 100% deterministic unless the `TimeGetter` decides otherwise. 

The design of the solution I provided is up for discussion. 