### PR TITLE
Ignore burned outputs in utxo set

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -261,6 +261,7 @@ impl BanScore for utxo::Error {
             utxo::Error::NoUtxoFound => 100,
             utxo::Error::NoBlockchainHeightFound => 0,
             utxo::Error::MissingBlockRewardUndo(_) => 0,
+            utxo::Error::InvalidBlockRewardOutputType(_) => 100,
             utxo::Error::DBError(_) => 0,
         }
     }

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -85,11 +85,6 @@ impl<B: storage::Backend> Store<B> {
         let res = map
             .prefix_iter(&())?
             .map(|(k, v)| crate::Result::<(OutPoint, Utxo)>::Ok((k, v.decode())))
-            .filter(|r| match r {
-                // remove OutputPurpose::Burn outputs to avoid attempting to spend them
-                Ok((_k, v)) => !v.output().purpose().is_burn(),
-                Err(_) => true,
-            })
             .collect::<Result<BTreeMap<OutPoint, Utxo>, _>>()?;
 
         Ok(res)

--- a/chainstate/test-suite/src/tests/double_spend_tests.rs
+++ b/chainstate/test-suite/src/tests/double_spend_tests.rs
@@ -490,7 +490,7 @@ fn try_spend_burned_output_same_block(#[case] seed: Seed) {
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::AttemptToSpendBurnedAmount
+                ConnectTransactionError::MissingOutputOrSpent
             ))
         );
         assert_eq!(tf.best_block_id(), tf.genesis().get_id());
@@ -526,7 +526,7 @@ fn try_spend_burned_output_different_blocks(#[case] seed: Seed) {
         assert_eq!(
             tf.process_block(block_2, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::AttemptToSpendBurnedAmount
+                ConnectTransactionError::MissingOutputOrSpent
             ))
         );
     });

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -1655,6 +1655,10 @@ fn spend_different_token_than_one_in_input(#[case] seed: Seed) {
                     ))
                     .add_output(TxOutput::new(
                         OutputValue::Coin(token_min_issuance_fee),
+                        OutputPurpose::Transfer(Destination::AnyoneCanSpend),
+                    ))
+                    .add_output(TxOutput::new(
+                        OutputValue::Coin(token_min_issuance_fee),
                         OutputPurpose::Burn,
                     ))
                     .build(),

--- a/utxo/src/error.rs
+++ b/utxo/src/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     NoBlockchainHeightFound,
     #[error("Block reward undo info is missing while unspending the utxo for block `{0}`")]
     MissingBlockRewardUndo(Id<GenBlock>),
+    #[error("Block reward type is invalid `{0}`")]
+    InvalidBlockRewardOutputType(Id<GenBlock>),
     #[error("Database error: `{0}`")]
     DBError(#[from] storage_result::Error),
 }

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -64,9 +64,10 @@ use common::{
             Block, BlockReward, ConsensusData,
         },
         signature::inputsig::InputWitness,
-        OutPoint, OutPointSourceId, Transaction, TxInput,
+        tokens::OutputValue,
+        OutPoint, OutPointSourceId, OutputPurpose, Transaction, TxInput, TxOutput,
     },
-    primitives::{BlockHeight, Compact, Id, Idable, H256},
+    primitives::{Amount, BlockHeight, Compact, Id, Idable, H256},
 };
 use crypto::random::{seq, Rng};
 use itertools::Itertools;
@@ -626,6 +627,41 @@ fn check_tx_spend_undo_spend(#[case] seed: Seed) {
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
+fn check_burn_spend_undo_spend(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let test_view = empty_test_utxos_view();
+    let mut cache = UtxosCache::new_for_test(H256::random_using(&mut rng).into(), &*test_view);
+
+    // add 1 utxo to the utxo set
+    let (u, outpoint) = test_helper::create_utxo(&mut rng, 1);
+    cache.add_utxo(&outpoint, u, false).unwrap();
+
+    // burn output in a tx
+    let output = TxOutput::new(
+        OutputValue::Coin(Amount::from_atoms(10)),
+        OutputPurpose::Burn,
+    );
+    let input = TxInput::new(outpoint.tx_id(), outpoint.output_index());
+    let tx = Transaction::new(0x00, vec![input], vec![output], 0x01).unwrap();
+    let undo1 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    assert!(!cache.has_utxo_in_cache(&outpoint));
+    assert!(undo1.utxos().len() == 1);
+
+    //undo spending
+    cache
+        .disconnect_transaction(&tx, TxUndo::new(undo1.utxos().to_owned()))
+        .unwrap();
+    assert!(cache.has_utxo_in_cache(&outpoint));
+
+    //spend the transaction again
+    let undo2 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    assert!(!cache.has_utxo_in_cache(&outpoint));
+    assert_eq!(undo1, undo2);
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
 fn check_pos_reward_spend_undo_spend(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let test_view = empty_test_utxos_view();
@@ -757,5 +793,47 @@ fn check_missing_reward_undo(#[case] seed: Seed) {
     assert_eq!(
         res,
         Err(Error::MissingBlockRewardUndo(block.get_id().into()))
+    );
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn check_burn_output_in_block_reward(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let test_view = empty_test_utxos_view();
+    let mut cache = UtxosCache::new_for_test(H256::random_using(&mut rng).into(), &*test_view);
+
+    // add 1 utxo to the utxo set
+    let (utxo, outpoint) = test_helper::create_utxo_from_reward(&mut rng, 1);
+    cache.add_utxo(&outpoint, utxo, false).unwrap();
+
+    let inputs = vec![TxInput::new(outpoint.tx_id(), outpoint.output_index())];
+    let outputs = vec![TxOutput::new(
+        OutputValue::Coin(Amount::from_atoms(10)),
+        OutputPurpose::Burn,
+    )];
+
+    let block = Block::new(
+        vec![],
+        Id::new(H256::random_using(&mut rng)),
+        BlockTimestamp::from_int_seconds(1),
+        ConsensusData::PoS(PoSData::new(
+            inputs,
+            vec![InputWitness::NoSignature(None)],
+            Compact(1),
+        )),
+        BlockReward::new(outputs),
+    )
+    .unwrap();
+    let reward = block.block_reward_transactable();
+
+    // spend the utxo in a block reward
+    let block_id = block.get_id().into();
+    assert_eq!(
+        cache
+            .connect_block_transactable(&reward, &block_id, BlockHeight::new(1))
+            .unwrap_err(),
+        Error::InvalidBlockRewardOutputType(block_id)
     );
 }


### PR DESCRIPTION
There is no point in storing burned outputs in the utxo set, so just ignore them 