### PR TITLE
Fix utxo indexes for txs with burned outputs

### DIFF
--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -1043,7 +1043,7 @@ fn burn_tokens(#[case] seed: Seed) {
         assert_eq!(
             result.unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::AttemptToSpendBurnedAmount
+                ConnectTransactionError::MissingOutputOrSpent
             ))
         );
     })

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -217,7 +217,7 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
         assert_eq!(
             result.unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::AttemptToSpendBurnedAmount
+                ConnectTransactionError::MissingOutputOrSpent
             ))
         );
     })

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -179,9 +179,9 @@ impl<'a> UtxosCache<'a> {
 
         tx.outputs()
             .iter()
-            // burned outputs should not be included into utxo set
-            .filter(|output| !output.purpose().is_burn())
             .enumerate()
+            // burned outputs should not be included into utxo set
+            .filter(|(_, output)| !output.purpose().is_burn())
             .try_for_each(|(idx, output)| {
                 let outpoint = OutPoint::new(id.clone(), idx as u32);
                 // by default no overwrite allowed.


### PR DESCRIPTION
The problem was that `filter` should be applied after `enumerate` to take skipped outputs into account.

Also few errors changed to `MissingOutputOrSpent` because we are now skipping burned outputs.