### PR TITLE
Fix the lmdb segfault/SIGSEGV in tests caused by a bug in lmdb

### DIFF
--- a/storage/backend-test-suite/src/concurrent.rs
+++ b/storage/backend-test-suite/src/concurrent.rs
@@ -112,14 +112,17 @@ fn threaded_reads_consistent<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
                 .to_owned()
         }
     });
-    let thr1 = thread::spawn(move || {
-        store
-            .transaction_ro()
-            .unwrap()
-            .get(IDX.0, TEST_KEY)
-            .unwrap()
-            .unwrap()
-            .to_owned()
+    let thr1 = thread::spawn({
+        let store = store.clone();
+        move || {
+            store
+                .transaction_ro()
+                .unwrap()
+                .get(IDX.0, TEST_KEY)
+                .unwrap()
+                .unwrap()
+                .to_owned()
+        }
     });
 
     assert_eq!(thr0.join().unwrap(), val);

--- a/storage/backend-test-suite/src/concurrent.rs
+++ b/storage/backend-test-suite/src/concurrent.rs
@@ -96,6 +96,7 @@ fn commutative_read_modify_write<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>
     assert_eq!(dbtx.get(IDX.0, TEST_KEY), Ok(Some([8].as_ref())));
 }
 
+#[allow(clippy::redundant_clone)] // This is necessary because we want the lmdb env to shutdown in main thread
 fn threaded_reads_consistent<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
     let val = [0x77, 0x88, 0x99].as_ref();
     let store = setup(backend_fn(), val.to_vec());


### PR DESCRIPTION
It seems that there's a rare bug in lmdb that causes the tests to crash in rare occasions. The error can be reproduced by checking out commit before this PR, and running the following command:

```
./untilfail.sh cargo nextest run --all --exclude p2p
```

where `untilfail.sh` is a script that runs forever, it simply consists of the following:

```
#!/bin/bash
 
 while "$@"; do :; done
```

The error happens on my 5950x processors on two machines. On average it takes 12 hours to happen. Some times more, some times as fast as 1 hour.

From our investigation, it seems that due to an unknown bug in lmdb, it's not possible to safely shutdown lmdb (close the environment) from a second thread after starting it in the main thread consistently (that is, tested for a long time repeatedly). This happens in the test `threaded_reads_consistent()`. We're still undecided on how to follow that policy in the node.

The stack trace (read from a core dump file) shows on the SIGSEGV:

```
#0 in mdb_env_reader_dest (ptr=...) at .../mdb.c: 4977
#1 in __nptl_deallocate_tsd () at pthread_create.c:301
...
```

where the line at mdb.c that causes the issue is [this one](https://github.com/mintlayer/lmdb-rs-mintlayer/blob/bb7d0934edf8be64a6953de71f872906b04a1c79/lmdb-sys/lmdb/libraries/liblmdb/mdb.c#L4977).

There's still a hypothesis that the segfault can happen also in any thread that has started a transaction, not ones that didn't. We still have to test that.

Because requiring the main-thread to shutdown lmdb is hard, but requiring an arbitrary new thread to shut it down is easy,  we have to test that to ensure that is/isn't the case.

In this PR, we make the env close happen in the main thread for the aforementioned test, which seems to have solved the problem. 
