### PR TITLE
Appease clippy 1.65

### DIFF
--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -940,7 +940,7 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut, V: TransactionVerificati
     fn new_orphan_block(&mut self, block: WithId<Block>) -> Result<(), OrphanCheckError> {
         match self.orphan_blocks.add_block(block) {
             Ok(_) => Ok(()),
-            Err(err) => err.into(),
+            Err(err) => (*err).into(),
         }
     }
 }

--- a/chainstate/src/detail/orphan_blocks/orphans_refs.rs
+++ b/chainstate/src/detail/orphan_blocks/orphans_refs.rs
@@ -26,7 +26,7 @@ pub trait OrphanBlocks {
 
 pub trait OrphanBlocksMut: OrphanBlocks {
     fn clear(&mut self);
-    fn add_block(&mut self, block: WithId<Block>) -> Result<(), OrphanAddError>;
+    fn add_block(&mut self, block: WithId<Block>) -> Result<(), Box<OrphanAddError>>;
     fn take_all_children_of(&mut self, block_id: &Id<GenBlock>) -> Vec<WithId<Block>>;
 }
 
@@ -75,7 +75,7 @@ impl<'a> OrphanBlocksMut for OrphanBlocksRefMut<'a> {
         self.inner.clear()
     }
 
-    fn add_block(&mut self, block: WithId<Block>) -> Result<(), OrphanAddError> {
+    fn add_block(&mut self, block: WithId<Block>) -> Result<(), Box<OrphanAddError>> {
         self.inner.add_block(block)
     }
 

--- a/chainstate/src/detail/orphan_blocks/pool.rs
+++ b/chainstate/src/detail/orphan_blocks/pool.rs
@@ -95,12 +95,12 @@ impl OrphanBlocksPool {
         self.del_one_deepest_child(&id);
     }
 
-    pub fn add_block(&mut self, block: WithId<Block>) -> Result<(), OrphanAddError> {
+    pub fn add_block(&mut self, block: WithId<Block>) -> Result<(), Box<OrphanAddError>> {
         self.prune();
         let block_id = block.get_id();
         if self.orphan_by_id.contains_key(&block_id) {
-            return Err(OrphanAddError::BlockAlreadyInOrphanList(WithId::take(
-                block,
+            return Err(Box::new(OrphanAddError::BlockAlreadyInOrphanList(
+                WithId::take(block),
             )));
         }
 
@@ -384,7 +384,7 @@ mod tests {
         let rand_block = blocks.choose(&mut rng).expect("this should return any block");
 
         assert_eq!(
-            orphans_pool.add_block(rand_block.clone().into()).unwrap_err(),
+            *orphans_pool.add_block(rand_block.clone().into()).unwrap_err(),
             OrphanAddError::BlockAlreadyInOrphanList(rand_block.clone())
         );
     }

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -311,8 +311,8 @@ mod tests {
             )
             .unwrap();
 
-            test_interface_ref(&boxed_chainstate, &*chain_config);
-            test_interface(boxed_chainstate, &*chain_config);
+            test_interface_ref(&boxed_chainstate, &chain_config);
+            test_interface(boxed_chainstate, &chain_config);
         });
     }
 }

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -223,7 +223,7 @@ mod tests {
 
         assert_eq!(h1, h2.into());
 
-        let h3 = crypto::hash::hash::<DefaultHashAlgo, _>(&random_bytes);
+        let h3 = crypto::hash::hash::<DefaultHashAlgo, _>(random_bytes);
 
         assert_eq!(h1, h3.into());
     }
@@ -295,7 +295,7 @@ mod tests {
             // ID should serialize into its hex string
             serde_test::assert_tokens(&id, &[serde_test::Token::Str(hex)]);
             assert_eq!(
-                serde_json::to_value(&id).ok(),
+                serde_json::to_value(id).ok(),
                 Some(Value::String(format!("{:x}", id.id)))
             );
         }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -37,7 +37,7 @@ pub fn gen_text_with_non_ascii(c: u8, rng: &mut impl Rng, max_len: usize) -> Vec
         .into_iter()
         .map(|idx| {
             if idx != random_index_to_replace {
-                rng.sample(&crypto::random::distributions::Alphanumeric)
+                rng.sample(crypto::random::distributions::Alphanumeric)
             } else {
                 c
             }


### PR DESCRIPTION
Clippy fails now after releasing the new Rust 1.65. This fixes that.