### PR TITLE
storage: LMDB memory map resizing

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -26,4 +26,4 @@ jobs:
       with:
         submodules: recursive
     - name: Run permutation tests
-      run: cargo test --tests --release -p storage -p chainstate-storage
+      run: cargo test --tests --release -p storage -p chainstate-storage -p storage-lmdb -p storage-inmemory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4265,6 +4265,7 @@ name = "storage-lmdb"
 version = "0.1.0"
 dependencies = [
  "lmdb-mintlayer",
+ "logging",
  "storage-backend-test-suite",
  "storage-core",
  "test-utils",

--- a/storage/backend-test-suite/src/lib.rs
+++ b/storage/backend-test-suite/src/lib.rs
@@ -25,8 +25,16 @@ pub mod model;
 // Test modules
 mod basic;
 mod concurrent;
+
 #[cfg(not(loom))]
 mod property;
+#[cfg(loom)]
+mod property {
+    // No property tests with loom for now
+    pub fn tests<F>(_backend_fn: F) -> impl Iterator<Item = libtest_mimic::Trial> {
+        std::iter::empty()
+    }
+}
 
 use prelude::*;
 

--- a/storage/core/src/error.rs
+++ b/storage/core/src/error.rs
@@ -44,8 +44,8 @@ pub enum Fatal {
     OutOfSpace,
     #[error("Database has been corrupted")]
     DatabaseCorrupted,
-    #[error("Database internal error")]
-    InternalError,
+    #[error("Database internal error: {0}")]
+    InternalError(String),
     #[error("Database schema does not match database settings or contents")]
     SchemaMismatch,
     #[error("Fatal I/O error: {1}")]

--- a/storage/lmdb/Cargo.toml
+++ b/storage/lmdb/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
+logging = { path = '../../logging' }
 storage-core = { path = '../core' }
 utils = { path = '../../utils' }
 

--- a/storage/lmdb/src/lib.rs
+++ b/storage/lmdb/src/lib.rs
@@ -14,6 +14,9 @@
 // limitations under the License.
 
 mod error;
+mod remap;
+
+pub use remap::MemSize;
 
 use std::path::PathBuf;
 
@@ -23,7 +26,7 @@ use storage_core::{
     info::{DbDesc, MapDesc},
     Data, DbIndex,
 };
-use utils::sync::Arc;
+use utils::sync::{Arc, RwLock, RwLockReadGuard};
 
 /// Identifiers of the list of databases (key-value maps)
 #[derive(Eq, PartialEq, Debug, Clone)]
@@ -65,6 +68,7 @@ impl<'tx, C: lmdb::Cursor<'tx>> Iterator for PrefixIter<'tx, C> {
 pub struct DbTx<'m, Tx> {
     tx: Tx,
     dbs: &'m DbList,
+    _map_token: RwLockReadGuard<'m, remap::MemMapToken>,
 }
 
 type DbTxRo<'a> = DbTx<'a, lmdb::RoTransaction<'a>>;
@@ -118,17 +122,43 @@ impl backend::TxRw for DbTxRw<'_> {
 
 #[derive(Clone)]
 pub struct LmdbImpl {
+    /// Handle to the environment
     env: Arc<lmdb::Environment>,
+
+    /// List of open databases
     dbs: DbList,
+
+    /// Guards access to memory map.
+    ///
+    /// * Shared (read) lock is required for running transactions, both read-only and read-write.
+    /// * Exclusive (write) lock is required to reallocate the memory map
+    map_token: Arc<RwLock<remap::MemMapToken>>,
+
+    /// Size required to write a transaction
+    tx_size: MemSize,
+}
+
+impl LmdbImpl {
+    /// Start a transaction using the low-level method provided
+    fn start_transaction<'a, Tx: 'a>(
+        &'a self,
+        start_tx: impl FnOnce(&'a lmdb::Environment) -> Result<Tx, lmdb::Error>,
+    ) -> storage_core::Result<DbTx<'a, Tx>> {
+        // Make sure map token is acquired before starting the transaction below
+        let _map_token = self.map_token.read().expect("mutex to be alive");
+        Ok(DbTx {
+            tx: start_tx(&self.env).or_else(error::process_with_err)?,
+            dbs: &self.dbs,
+            _map_token,
+        })
+    }
 }
 
 impl<'tx> TransactionalRo<'tx> for LmdbImpl {
     type TxRo = DbTxRo<'tx>;
 
     fn transaction_ro<'st: 'tx>(&'st self) -> storage_core::Result<Self::TxRo> {
-        let tx = self.env.begin_ro_txn().or_else(error::process_with_err)?;
-        let dbs = &self.dbs;
-        Ok(DbTx { tx, dbs })
+        self.start_transaction(lmdb::Environment::begin_ro_txn)
     }
 }
 
@@ -136,24 +166,54 @@ impl<'tx> TransactionalRw<'tx> for LmdbImpl {
     type TxRw = DbTxRw<'tx>;
 
     fn transaction_rw<'st: 'tx>(&'st self) -> storage_core::Result<Self::TxRw> {
-        let tx = self.env.begin_rw_txn().or_else(error::process_with_err)?;
-        let dbs = &self.dbs;
-        Ok(DbTx { tx, dbs })
+        remap::remap(
+            &self.env,
+            // Acquire exclusive memory map token to make sure no transactions are active for
+            // the duration of memory remapping.
+            self.map_token.write().expect("mmap lock to be alive"),
+            self.tx_size,
+        )?;
+        self.start_transaction(lmdb::Environment::begin_rw_txn)
     }
 }
 
 impl backend::BackendImpl for LmdbImpl {}
 
+#[derive(Eq, PartialEq, Clone, Debug)]
 pub struct Lmdb {
     path: PathBuf,
     flags: lmdb::EnvironmentFlags,
+    map_size: MemSize,
+    tx_size: MemSize,
 }
 
 impl Lmdb {
+    /// Amount of space the memory map is initialized with
+    pub const DEFAULT_MAP_SIZE: MemSize = MemSize::from_megabytes(16);
+
+    /// Amount of space needed for a transaction by default
+    pub const DEFAULT_TX_SIZE: MemSize = MemSize::from_megabytes(8);
+
     /// New LMDB database backend
     pub fn new(path: PathBuf) -> Self {
-        let flags = lmdb::EnvironmentFlags::default();
-        Self { path, flags }
+        Self {
+            path,
+            flags: lmdb::EnvironmentFlags::default(),
+            map_size: Self::DEFAULT_MAP_SIZE,
+            tx_size: Self::DEFAULT_TX_SIZE,
+        }
+    }
+
+    /// Set the initial memory map size
+    pub fn with_map_size(mut self, map_size: MemSize) -> Self {
+        self.map_size = map_size;
+        self
+    }
+
+    /// Set maximum transaction size
+    pub fn with_tx_size(mut self, tx_size: MemSize) -> Self {
+        self.tx_size = tx_size;
+        self
     }
 
     /// Use a writable memory map.
@@ -180,21 +240,26 @@ impl backend::Backend for Lmdb {
         std::fs::create_dir_all(&self.path).map_err(error::process_io_error)?;
 
         // Set up LMDB environment
-        let mut env = lmdb::Environment::new();
-        env.set_max_dbs(desc.len() as u32);
-        env.set_flags(self.flags);
-        //env.set_map_size(todo!());
-        //env.set_max_readers(todo!());
-        let env = env.open(&self.path).or_else(error::process_with_err)?;
+        let environment = {
+            let mut env_builder = lmdb::Environment::new();
+            env_builder.set_max_dbs(desc.len() as u32);
+            env_builder.set_flags(self.flags);
+            env_builder.set_map_size(self.map_size.as_bytes());
+            env_builder.open(&self.path).or_else(error::process_with_err)?
+        };
 
         // Set up all the databases
         let dbs = desc
             .iter()
-            .map(|desc| Self::open_db(&env, desc))
+            .map(|desc| Self::open_db(&environment, desc))
             .collect::<storage_core::Result<Vec<_>>>()
             .map(DbList)?;
 
-        let env = Arc::new(env);
-        Ok(LmdbImpl { env, dbs })
+        Ok(LmdbImpl {
+            env: Arc::new(environment),
+            dbs,
+            map_token: Arc::new(RwLock::new(remap::MemMapToken::new())),
+            tx_size: self.tx_size,
+        })
     }
 }

--- a/storage/lmdb/src/remap.rs
+++ b/storage/lmdb/src/remap.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Support for memory map reallocation
+
+use logging::log;
+use utils::tap_error_log::LogError;
+
+/// Represents LMDB memory map size
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Debug)]
+pub struct MemSize(usize);
+
+impl MemSize {
+    /// Specify in the number of bytes
+    pub const fn from_bytes(bytes: usize) -> Self {
+        Self(bytes)
+    }
+
+    /// Specify in the number of kilobytes
+    pub const fn from_kilobytes(kilobytes: usize) -> Self {
+        Self::from_bytes(1024 * kilobytes)
+    }
+
+    /// Specify in the number of megabytes
+    pub const fn from_megabytes(megabytes: usize) -> Self {
+        Self::from_kilobytes(1024 * megabytes)
+    }
+
+    /// Convert to raw byte count
+    pub const fn as_bytes(self) -> usize {
+        self.0
+    }
+
+    pub fn div_ceil(self, rhs: Self) -> usize {
+        self.0 / rhs.0 + (self.0 % rhs.0 > 0) as usize
+    }
+}
+
+impl std::fmt::Display for MemSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}B", self.0)
+    }
+}
+
+impl std::ops::Add for MemSize {
+    type Output = MemSize;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl std::ops::Mul<MemSize> for usize {
+    type Output = MemSize;
+
+    fn mul(self, rhs: MemSize) -> Self::Output {
+        MemSize(self * rhs.0)
+    }
+}
+
+/// Token representing acquisition of the memory map resource
+#[derive(Debug)]
+pub struct MemMapToken();
+
+impl MemMapToken {
+    pub fn new() -> Self {
+        Self()
+    }
+}
+
+/// A proof of having acquired the memory map resource exclusively
+pub type ExclusiveMemMapToken<'a> = std::sync::RwLockWriteGuard<'a, MemMapToken>;
+
+/// Memory remapping procedure. Ensure at least `headroom` free space is available
+pub fn remap(
+    env: &lmdb::Environment,
+    _map_token: ExclusiveMemMapToken<'_>,
+    headroom: MemSize,
+) -> storage_core::Result<()> {
+    // Get page size
+    let page_size = {
+        let stat = env.stat().or_else(crate::error::process_with_err)?;
+        MemSize::from_bytes(stat.page_size() as usize)
+    };
+
+    // Get current occupancy info
+    let info = env.info().or_else(crate::error::process_with_err)?;
+    let current_size = MemSize::from_bytes(info.map_size());
+    let current_pages = current_size.div_ceil(page_size);
+    let used_pages = info.last_pgno() + 1;
+    let freelist_pages = env.freelist().or_else(crate::error::process_with_err)?;
+    let free_pages = (current_pages - used_pages) + freelist_pages;
+
+    // Get map size requirements
+    let required_free_pages = headroom.div_ceil(page_size);
+    let required_pages = used_pages + required_free_pages;
+    let required_size = required_pages * page_size;
+
+    log::trace!(
+        "LMDB memory: occupied = {} - {}, reserved = {}, free = {}, required = {}",
+        used_pages * page_size,
+        freelist_pages * page_size,
+        current_size,
+        free_pages * page_size,
+        required_size,
+    );
+
+    // Ensure there is enough space
+    if required_size > current_size {
+        // Remap with double the size but or the required size, whichever is larger
+        let new_size = std::cmp::max(2 * current_size, required_size);
+        log::info!(
+            "Resizing LMDB memory map from {} to {}",
+            current_size,
+            new_size,
+        );
+        env.set_map_size(new_size.as_bytes())
+            .or_else(crate::error::process_with_err)
+            .log_err()?;
+    }
+
+    Ok(())
+}

--- a/storage/lmdb/tests/remap.rs
+++ b/storage/lmdb/tests/remap.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use storage_core::{backend, info::MapDesc, Backend, DbDesc, DbIndex};
+use storage_lmdb::{Lmdb, MemSize};
+
+const IDX0: DbIndex = DbIndex::new(0);
+
+fn perform_writes(name: &str, initial_size: MemSize, tx_size: MemSize, write_sizes: &[MemSize]) {
+    logging::init_logging::<&std::path::Path>(None);
+    let test_root = test_utils::test_root!("remap-tests").unwrap();
+
+    // Open a new datbase with given map size
+    let dir = test_root.fresh_test_dir(name).as_ref().to_owned();
+    let lmdb = Lmdb::new(dir)
+        .with_map_size(initial_size)
+        .with_tx_size(tx_size)
+        .open(DbDesc::from_iter(std::iter::once(MapDesc::new("map"))))
+        .unwrap();
+
+    // Try inserting values with sizes given by the `write_sizes` param
+    for (i, size) in write_sizes.iter().enumerate() {
+        let mut txrw = backend::TransactionalRw::transaction_rw(&lmdb).unwrap();
+        let val = vec![42u8; size.as_bytes()];
+        backend::WriteOps::put(&mut txrw, IDX0, i.to_le_bytes().to_vec(), val).unwrap();
+        backend::TxRw::commit(txrw).unwrap();
+    }
+
+    test_root.delete();
+}
+
+#[test]
+fn map_too_small_initially() {
+    perform_writes(
+        "map_too_small_initially",
+        MemSize::from_kilobytes(100),
+        MemSize::from_kilobytes(300),
+        [MemSize::from_kilobytes(111)].as_ref(),
+    );
+}
+
+#[test]
+fn map_too_small_by_a_lot() {
+    perform_writes(
+        "map_too_small_by_a_lot",
+        MemSize::from_kilobytes(200),
+        MemSize::from_megabytes(55),
+        [MemSize::from_megabytes(50)].as_ref(),
+    );
+}
+
+#[test]
+fn map_too_small_after_a_number_of_writes() {
+    let write_sizes = [MemSize::from_kilobytes(100); 100];
+    perform_writes(
+        "map_too_small_after_a_number_of_writes",
+        MemSize::from_kilobytes(400),
+        MemSize::from_kilobytes(200),
+        write_sizes.as_ref(),
+    );
+}
+
+#[test]
+#[should_panic]
+fn tx_size_too_small() {
+    perform_writes(
+        "tx_size_too_small",
+        MemSize::from_kilobytes(200),
+        MemSize::from_megabytes(30),
+        [MemSize::from_megabytes(50)].as_ref(),
+    );
+}

--- a/storage/lmdb/tests/remap.rs
+++ b/storage/lmdb/tests/remap.rs
@@ -19,7 +19,12 @@ use utils::{concurrency, thread};
 
 const IDX0: DbIndex = DbIndex::new(0);
 
-fn perform_writes(name: &'static str, initial_size: MemSize, tx_size: MemSize, write_sizes: &[MemSize]) {
+fn perform_writes(
+    name: &'static str,
+    initial_size: MemSize,
+    tx_size: MemSize,
+    write_sizes: &[MemSize],
+) {
     #[cfg(not(loom))]
     logging::init_logging::<&std::path::Path>(None);
     let test_root = std::sync::Arc::new(test_utils::test_root!("remap-tests").unwrap());

--- a/storage/lmdb/tests/remap.rs
+++ b/storage/lmdb/tests/remap.rs
@@ -15,30 +15,38 @@
 
 use storage_core::{backend, info::MapDesc, Backend, DbDesc, DbIndex};
 use storage_lmdb::{Lmdb, MemSize};
+use utils::{concurrency, thread};
 
 const IDX0: DbIndex = DbIndex::new(0);
 
-fn perform_writes(name: &str, initial_size: MemSize, tx_size: MemSize, write_sizes: &[MemSize]) {
+fn perform_writes(name: &'static str, initial_size: MemSize, tx_size: MemSize, write_sizes: &[MemSize]) {
+    #[cfg(not(loom))]
     logging::init_logging::<&std::path::Path>(None);
-    let test_root = test_utils::test_root!("remap-tests").unwrap();
+    let test_root = std::sync::Arc::new(test_utils::test_root!("remap-tests").unwrap());
 
-    // Open a new datbase with given map size
-    let dir = test_root.fresh_test_dir(name).as_ref().to_owned();
-    let lmdb = Lmdb::new(dir)
-        .with_map_size(initial_size)
-        .with_tx_size(tx_size)
-        .open(DbDesc::from_iter(std::iter::once(MapDesc::new("map"))))
-        .unwrap();
+    concurrency::model({
+        let test_root = std::sync::Arc::clone(&test_root);
+        let write_sizes = write_sizes.to_vec();
+        move || {
+            // Open a new datbase with given map size
+            let dir = test_root.fresh_test_dir(name).as_ref().to_owned();
+            let lmdb = Lmdb::new(dir)
+                .with_map_size(initial_size)
+                .with_tx_size(tx_size)
+                .open(DbDesc::from_iter(std::iter::once(MapDesc::new("map"))))
+                .unwrap();
 
-    // Try inserting values with sizes given by the `write_sizes` param
-    for (i, size) in write_sizes.iter().enumerate() {
-        let mut txrw = backend::TransactionalRw::transaction_rw(&lmdb).unwrap();
-        let val = vec![42u8; size.as_bytes()];
-        backend::WriteOps::put(&mut txrw, IDX0, i.to_le_bytes().to_vec(), val).unwrap();
-        backend::TxRw::commit(txrw).unwrap();
-    }
+            // Try inserting values with sizes given by the `write_sizes` param
+            for (i, size) in write_sizes.iter().enumerate() {
+                let mut txrw = backend::TransactionalRw::transaction_rw(&lmdb).unwrap();
+                let val = vec![42u8; size.as_bytes()];
+                backend::WriteOps::put(&mut txrw, IDX0, i.to_le_bytes().to_vec(), val).unwrap();
+                backend::TxRw::commit(txrw).unwrap();
+            }
+        }
+    });
 
-    test_root.delete();
+    std::sync::Arc::try_unwrap(test_root).unwrap().delete();
 }
 
 #[test]
@@ -81,4 +89,42 @@ fn tx_size_too_small() {
         MemSize::from_megabytes(30),
         [MemSize::from_megabytes(50)].as_ref(),
     );
+}
+
+#[test]
+fn two_concurrent_writers() {
+    #[cfg(not(loom))]
+    logging::init_logging::<&std::path::Path>(None);
+    let test_root = std::sync::Arc::new(test_utils::test_root!("remap-tests").unwrap());
+
+    concurrency::model({
+        let test_root = std::sync::Arc::clone(&test_root);
+        move || {
+            // Open a new datbase with initial map size 500kB, with 500kB transactions
+            let dir = test_root.fresh_test_dir("two_concurrent_writes").as_ref().to_owned();
+            let storage = Lmdb::new(dir)
+                .with_map_size(MemSize::from_kilobytes(500))
+                .with_tx_size(MemSize::from_kilobytes(500))
+                .open(DbDesc::from_iter(std::iter::once(MapDesc::new("map"))))
+                .unwrap();
+
+            let spawn_writer = |key: Vec<u8>| {
+                let storage = storage.clone();
+                thread::spawn(move || {
+                    let mut txrw = backend::TransactionalRw::transaction_rw(&storage).unwrap();
+                    let val = vec![0x33u8; MemSize::from_kilobytes(300).as_bytes()];
+                    backend::WriteOps::put(&mut txrw, IDX0, key, val).unwrap();
+                    backend::TxRw::commit(txrw).unwrap();
+                })
+            };
+
+            let wr0 = spawn_writer(b"wr0".to_vec());
+            let wr1 = spawn_writer(b"wr1".to_vec());
+
+            wr0.join().unwrap();
+            wr1.join().unwrap();
+        }
+    });
+
+    std::sync::Arc::try_unwrap(test_root).unwrap().delete();
 }

--- a/storage/lmdb/tests/remap.rs
+++ b/storage/lmdb/tests/remap.rs
@@ -91,7 +91,7 @@ fn tx_size_too_small() {
     perform_writes(
         "tx_size_too_small",
         MemSize::from_kilobytes(200),
-        MemSize::from_megabytes(30),
+        MemSize::from_megabytes(20),
         [MemSize::from_megabytes(50)].as_ref(),
     );
 }


### PR DESCRIPTION
At the moment this is just a dead simple approach that uses locks to make sure transactions and memory map resize do not happen concurrently. There certainly is a room for optimization that can be discussed as a follow-up.