### PR TITLE
Make private keys deterministic in tests

### DIFF
--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -19,7 +19,7 @@ use common::chain::transaction::signed_transaction::SignedTransaction;
 use common::chain::{Destination, OutputPurpose, TxOutput};
 use common::primitives::{Amount, H256};
 use crypto::key::{KeyKind, PrivateKey};
-use crypto::random::Rng;
+use crypto::random::{CryptoRng, Rng};
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
 use utxo::{BlockRewardUndo, BlockUndo, TxUndoWithSources};
@@ -247,10 +247,10 @@ fn test_storage_transactions_with_result_check() {
 }
 
 /// returns a tuple of utxo and outpoint, for testing.
-fn create_rand_utxo(rng: &mut impl Rng, block_height: u64) -> Utxo {
+fn create_rand_utxo(rng: &mut (impl Rng + CryptoRng), block_height: u64) -> Utxo {
     // just a random value generated, and also a random `is_block_reward` value.
     let random_value = rng.gen_range(0..(u128::MAX - 1));
-    let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (_, pub_key) = PrivateKey::new_from_rng(rng, KeyKind::RistrettoSchnorr);
     let output = TxOutput::new(
         OutputValue::Coin(Amount::from_atoms(random_value)),
         OutputPurpose::Transfer(Destination::PublicKey(pub_key)),
@@ -267,7 +267,7 @@ fn create_rand_utxo(rng: &mut impl Rng, block_height: u64) -> Utxo {
 /// `max_lim_of_utxos` - sets the maximum limit of utxos of a random TxUndo.
 /// `max_lim_of_tx_undos` - the maximum limit of TxUndos in the BlockUndo.
 pub fn create_rand_block_undo(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     max_lim_of_utxos: u8,
     max_lim_of_tx_undos: u8,
 ) -> BlockUndo {

--- a/chainstate/storage/src/internal/utxo_db.rs
+++ b/chainstate/storage/src/internal/utxo_db.rs
@@ -22,14 +22,18 @@ mod test {
     };
     use common::primitives::{Amount, BlockHeight, Id, H256};
     use crypto::key::{KeyKind, PrivateKey};
-    use crypto::random::Rng;
+    use crypto::random::{CryptoRng, Rng};
     use rstest::rstest;
     use test_utils::random::{make_seedable_rng, Seed};
     use utxo::{Utxo, UtxosDBMut, UtxosStorageRead, UtxosStorageWrite};
 
-    fn create_utxo(rng: &mut impl Rng, block_height: u64, output_value: u128) -> (Utxo, OutPoint) {
+    fn create_utxo(
+        rng: &mut (impl Rng + CryptoRng),
+        block_height: u64,
+        output_value: u128,
+    ) -> (Utxo, OutPoint) {
         // just a random value generated, and also a random `is_block_reward` value.
-        let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (_, pub_key) = PrivateKey::new_from_rng(rng, KeyKind::RistrettoSchnorr);
         let output = TxOutput::new(
             OutputValue::Coin(Amount::from_atoms(output_value)),
             OutputPurpose::Transfer(Destination::PublicKey(pub_key)),

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -30,7 +30,7 @@ use common::{
     },
     primitives::{Id, H256},
 };
-use crypto::random::Rng;
+use crypto::random::{CryptoRng, Rng};
 use itertools::Itertools;
 
 /// The block builder that allows construction and processing of a block.
@@ -81,7 +81,7 @@ impl<'f> BlockBuilder<'f> {
     }
 
     /// Adds a transaction that uses random utxos
-    pub fn add_test_transaction(mut self, rng: &mut impl Rng) -> Self {
+    pub fn add_test_transaction(mut self, rng: &mut (impl Rng + CryptoRng)) -> Self {
         let utxo_set = self.framework.storage.read_utxo_set().unwrap();
 
         if !utxo_set.is_empty() {

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -23,7 +23,7 @@ use common::{
     },
     primitives::{Amount, Idable},
 };
-use crypto::random::Rng;
+use crypto::random::{CryptoRng, Rng};
 use test_utils::nft_utils::*;
 
 pub fn empty_witness(rng: &mut impl Rng) -> InputWitness {
@@ -95,7 +95,7 @@ pub fn create_multiple_utxo_data(
     outsrc: OutPointSourceId,
     index: usize,
     output: &TxOutput,
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
 ) -> Option<(InputWitness, TxInput, Vec<TxOutput>)> {
     let num_outputs = rng.gen_range(1..10);
     let new_outputs = match output.value() {

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -1812,7 +1812,8 @@ fn token_issuance_in_block_reward(#[case] seed: Seed) {
         let mut tf = TestFramework::default();
         let mut rng = make_seedable_rng(seed);
         let total_funds = Amount::from_atoms(rng.gen_range(1..u128::MAX));
-        let (_, pub_key) = crypto::key::PrivateKey::new(crypto::key::KeyKind::RistrettoSchnorr);
+        let (_, pub_key) =
+            crypto::key::PrivateKey::new_from_rng(&mut rng, crypto::key::KeyKind::RistrettoSchnorr);
 
         // Check if it issuance
         let reward_output = TxOutput::new(

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -28,7 +28,7 @@ use common::chain::{
     Destination, OutputPurpose, TxInput, TxOutput,
 };
 use common::primitives::Idable;
-use crypto::random::Rng;
+use crypto::random::{CryptoRng, Rng};
 use rstest::rstest;
 use serialization::extras::non_empty_vec::DataOrNoVec;
 use test_utils::{
@@ -61,7 +61,7 @@ fn nft_name_too_long(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(
                                     &mut rng,
                                     max_name_len + 1..max_name_len + 1000,
@@ -117,7 +117,7 @@ fn nft_empty_name(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: vec![],
                                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -180,7 +180,7 @@ fn nft_invalid_name(#[case] seed: Seed) {
                         .add_output(TxOutput::new(
                             NftIssuance {
                                 metadata: Metadata {
-                                    creator: Some(random_creator()),
+                                    creator: Some(random_creator(&mut rng)),
                                     name,
                                     description: random_string(&mut rng, 1..max_desc_len)
                                         .into_bytes(),
@@ -236,7 +236,7 @@ fn nft_ticker_too_long(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                                 ticker: random_string(
@@ -293,7 +293,7 @@ fn nft_empty_ticker(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                                 ticker: vec![],
@@ -356,7 +356,7 @@ fn nft_invalid_ticker(#[case] seed: Seed) {
                         .add_output(TxOutput::new(
                             NftIssuance {
                                 metadata: Metadata {
-                                    creator: Some(random_creator()),
+                                    creator: Some(random_creator(&mut rng)),
                                     name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                     description: random_string(&mut rng, 1..max_desc_len)
                                         .into_bytes(),
@@ -412,7 +412,7 @@ fn nft_description_too_long(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                 description: random_string(
                                     &mut rng,
@@ -469,7 +469,7 @@ fn nft_empty_description(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                 description: vec![],
                                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -532,7 +532,7 @@ fn nft_invalid_description(#[case] seed: Seed) {
                         .add_output(TxOutput::new(
                             NftIssuance {
                                 metadata: Metadata {
-                                    creator: Some(random_creator()),
+                                    creator: Some(random_creator(&mut rng)),
                                     name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                     description,
                                     ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -587,7 +587,7 @@ fn nft_icon_uri_too_long(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -637,7 +637,7 @@ fn nft_icon_uri_empty(#[case] seed: Seed) {
 
         let output_value: OutputValue = TokenData::from(NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -719,7 +719,7 @@ fn nft_icon_uri_invalid(#[case] seed: Seed) {
                         .add_output(TxOutput::new(
                             NftIssuance {
                                 metadata: Metadata {
-                                    creator: Some(random_creator()),
+                                    creator: Some(random_creator(&mut rng)),
                                     name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                     description: random_string(&mut rng, 1..max_desc_len)
                                         .into_bytes(),
@@ -776,7 +776,7 @@ fn nft_metadata_uri_too_long(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -825,7 +825,7 @@ fn nft_metadata_uri_empty(#[case] seed: Seed) {
         let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let output_value: OutputValue = TokenData::from(NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -907,7 +907,7 @@ fn nft_metadata_uri_invalid(#[case] seed: Seed) {
                         .add_output(TxOutput::new(
                             NftIssuance {
                                 metadata: Metadata {
-                                    creator: Some(random_creator()),
+                                    creator: Some(random_creator(&mut rng)),
                                     name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                     description: random_string(&mut rng, 1..max_desc_len)
                                         .into_bytes(),
@@ -964,7 +964,7 @@ fn nft_media_uri_too_long(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -1014,7 +1014,7 @@ fn nft_media_uri_empty(#[case] seed: Seed) {
         let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let output_value: OutputValue = TokenData::from(NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -1097,7 +1097,7 @@ fn nft_media_uri_invalid(#[case] seed: Seed) {
                         .add_output(TxOutput::new(
                             NftIssuance {
                                 metadata: Metadata {
-                                    creator: Some(random_creator()),
+                                    creator: Some(random_creator(&mut rng)),
                                     name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                     description: random_string(&mut rng, 1..max_desc_len)
                                         .into_bytes(),
@@ -1130,7 +1130,7 @@ fn nft_media_uri_invalid(#[case] seed: Seed) {
 }
 
 fn new_block_with_media_hash(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     tf: &mut TestFramework,
     input_source_id: &OutPointSourceId,
     media_hash: Vec<u8>,
@@ -1155,7 +1155,7 @@ fn new_block_with_media_hash(
                 .add_output(TxOutput::new(
                     NftIssuance {
                         metadata: Metadata {
-                            creator: Some(random_creator()),
+                            creator: Some(random_creator(rng)),
                             name,
                             description,
                             ticker,
@@ -1303,7 +1303,7 @@ fn nft_valid_case(#[case] seed: Seed) {
 
         let output_value = NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -59,7 +59,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
         let genesis_outpoint_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
         let issuance_data = NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -389,7 +389,7 @@ fn nft_reorgs_and_cleanup_data(#[case] seed: Seed) {
         // Issue a new NFT
         let issuance_value = NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -53,7 +53,7 @@ fn nft_transfer_wrong_id(#[case] seed: Seed) {
         // Issue a new NFT
         let output_value = NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -140,7 +140,7 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
         // Issue a new NFT
         let output_value = NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -256,7 +256,7 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
         let genesis_outpoint_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
         let output_value = NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -323,7 +323,7 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
                     .add_output(TxOutput::new(
                         NftIssuance {
                             metadata: Metadata {
-                                creator: Some(random_creator()),
+                                creator: Some(random_creator(&mut rng)),
                                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),
@@ -416,7 +416,7 @@ fn nft_valid_transfer(#[case] seed: Seed) {
         // Issue a new NFT
         let output_value = NftIssuance {
             metadata: Metadata {
-                creator: Some(random_creator()),
+                creator: Some(random_creator(&mut rng)),
                 name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                 description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                 ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -63,7 +63,8 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
         let mut tf = TestFramework::builder().with_chain_config(chain_config).build();
 
         let coins = OutputValue::Coin(Amount::from_atoms(10));
-        let destination = Destination::PublicKey(PrivateKey::new(KeyKind::RistrettoSchnorr).1);
+        let destination =
+            Destination::PublicKey(PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr).1);
 
         // Case 1: reward is a simple transfer
         let block = tf
@@ -749,7 +750,7 @@ fn consensus_type(#[case] seed: Seed) {
 
     // Mine blocks 5-9 with minimal difficulty, as expected by net upgrades
     for i in 5..10 {
-        let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (_, pub_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let prev_block = tf.block(*tf.index_at(i - 1).block_id());
         let mut mined_block = tf
             .make_block_builder()
@@ -818,7 +819,7 @@ fn consensus_type(#[case] seed: Seed) {
 
     // Mining should work
     for i in 15..20 {
-        let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (_, pub_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let prev_block = tf.block(*tf.index_at(i - 1).block_id());
         let mut mined_block = tf
             .make_block_builder()
@@ -879,7 +880,7 @@ fn pow(#[case] seed: Seed) {
 
     // Let's create a block with random (invalid) PoW data and see that it fails the consensus
     // checks
-    let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (_, pub_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let mut random_invalid_block = tf
         .make_block_builder()
         .with_reward(vec![TxOutput::new(
@@ -952,7 +953,7 @@ fn read_block_reward_from_storage(#[case] seed: Seed) {
     let expected_block_reward = (0..block_reward_output_count)
         .map(|_| {
             let amount = Amount::from_atoms(rng.gen::<u128>() % 50);
-            let pub_key = PrivateKey::new(KeyKind::RistrettoSchnorr).1;
+            let pub_key = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr).1;
             TxOutput::new(
                 OutputValue::Coin(amount),
                 OutputPurpose::LockThenTransfer(

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -30,13 +30,19 @@ use crypto::key::{KeyKind, PrivateKey};
 
 use chainstate_test_framework::TestFramework;
 use chainstate_test_framework::TransactionBuilder;
+use rstest::rstest;
+use test_utils::random::Seed;
 
-#[test]
-fn signed_tx() {
-    utils::concurrency::model(|| {
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn signed_tx(#[case] seed: Seed) {
+    utils::concurrency::model(move || {
         let mut tf = TestFramework::default();
+        let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
 
         // The first transaction uses the `AnyoneCanSpend` output of the transaction from the
         // genesis block.

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
@@ -24,15 +24,15 @@ use common::{
 };
 use crypto::{
     key::{KeyKind, PrivateKey},
-    random::Rng,
+    random::{CryptoRng, Rng},
 };
 
-fn create_utxo(rng: &mut impl Rng, value: UnsignedIntType) -> (OutPoint, Utxo) {
+fn create_utxo(rng: &mut (impl Rng + CryptoRng), value: UnsignedIntType) -> (OutPoint, Utxo) {
     let outpoint = OutPoint::new(
         OutPointSourceId::Transaction(Id::new(H256::random_using(rng))),
         0,
     );
-    let (_, pub_key1) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (_, pub_key1) = PrivateKey::new_from_rng(rng, KeyKind::RistrettoSchnorr);
     let output1 = TxOutput::new(
         OutputValue::Coin(Amount::from_atoms(value)),
         OutputPurpose::Transfer(Destination::PublicKey(pub_key1)),

--- a/common/src/address/mod.rs
+++ b/common/src/address/mod.rs
@@ -106,11 +106,16 @@ mod tests {
     use super::*;
     use crate::chain::config::create_mainnet;
     use crypto::key::{KeyKind, PrivateKey};
+    use rstest::rstest;
+    use test_utils::random::Seed;
 
-    #[test]
-    fn basic() {
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn basic(#[case] seed: Seed) {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
         let cfg = create_mainnet();
-        let (_priv_key, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (_priv_key, pub_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let public_key_hash = PublicKeyHash::from(&pub_key);
         let address = Address::from_public_key_hash(&cfg, &public_key_hash)
             .expect("Address from pubkeyhash failed");
@@ -121,10 +126,13 @@ mod tests {
         assert_eq!(public_key_hash_restored, public_key_hash);
     }
 
-    #[test]
-    fn ensure_cfg_and_with_hrp_compatiblity() {
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn ensure_cfg_and_with_hrp_compatiblity(#[case] seed: Seed) {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
         let cfg = create_mainnet();
-        let (_priv_key, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (_priv_key, pub_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let public_key_hash = PublicKeyHash::from(&pub_key);
         let hrp = cfg.address_prefix();
         let address1 = Address::new(&cfg, public_key_hash.encode());

--- a/common/src/chain/transaction/signature/inputsig.rs
+++ b/common/src/chain/transaction/signature/inputsig.rs
@@ -188,8 +188,8 @@ mod test {
     fn produce_signature_address_missmatch(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, _) = PrivateKey::new(KeyKind::RistrettoSchnorr);
-        let (_, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, _) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
+        let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::Address(PublicKeyHash::from(&public_key));
         let tx = generate_unsigned_tx(&mut rng, &destination, 1, 2).unwrap();
 
@@ -214,8 +214,8 @@ mod test {
     fn produce_signature_key_missmatch(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, _) = PrivateKey::new(KeyKind::RistrettoSchnorr);
-        let (_, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, _) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
+        let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::PublicKey(public_key);
         let tx = generate_unsigned_tx(&mut rng, &destination, 1, 2).unwrap();
 
@@ -240,7 +240,8 @@ mod test {
     fn produce_and_verify(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let outpoints = [
             Destination::Address(PublicKeyHash::from(&public_key)),
             Destination::PublicKey(public_key),

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
@@ -90,7 +90,8 @@ mod test {
     fn invalid_input_index(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::PublicKey(public_key);
         let tx = generate_unsigned_tx(&mut rng, &destination, 1, 2).unwrap();
 
@@ -113,7 +114,8 @@ mod test {
     fn wrong_destination_type(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::Address(PublicKeyHash::from(&public_key));
         let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
 
@@ -141,7 +143,8 @@ mod test {
     fn invalid_signature_type(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::PublicKey(public_key);
         let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
 
@@ -175,7 +178,8 @@ mod test {
     fn test_verify_public_key_spending(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::PublicKey(public_key.clone());
         let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
 
@@ -203,7 +207,8 @@ mod test {
     fn test_sign_pubkey_spending(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::PublicKey(public_key.clone());
         let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
 

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
@@ -98,7 +98,8 @@ mod test {
     fn invalid_input_index(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let pubkey_hash = PublicKeyHash::from(&public_key);
         let destination = Destination::Address(pubkey_hash);
         let tx = generate_unsigned_tx(&mut rng, &destination, 1, 2).unwrap();
@@ -122,7 +123,8 @@ mod test {
     fn wrong_destination_type(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::PublicKey(public_key);
         let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
 
@@ -151,7 +153,8 @@ mod test {
     fn invalid_signature_type(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let pubkey_hash = PublicKeyHash::from(&public_key);
         let destination = Destination::Address(pubkey_hash);
         let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
@@ -188,7 +191,8 @@ mod test {
     fn test_verify_address_spending(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let pubkey_hash = PublicKeyHash::from(&public_key);
         let destination = Destination::Address(pubkey_hash);
         let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
@@ -218,7 +222,8 @@ mod test {
     fn test_sign_address_spending(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
-        let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let destination = Destination::PublicKey(public_key.clone());
         let pubkey_hash = PublicKeyHash::from(&public_key);
         let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();

--- a/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
+++ b/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
@@ -31,7 +31,7 @@ use crate::chain::{signature::inputsig::InputWitness, Destination};
 fn mixed_sighash_types(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
 
     // Test all combinations of signature hash types in every position.

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -48,7 +48,7 @@ pub mod utils;
 fn sign_and_verify_different_sighash_types(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
 
     for sighash_type in sig_hash_types() {
@@ -69,7 +69,7 @@ fn sign_and_verify_different_sighash_types(#[case] seed: Seed) {
 fn verify_no_signature(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (_, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
 
     for destination in
         destinations(&mut rng, public_key).filter(|d| d != &Destination::AnyoneCanSpend)
@@ -95,7 +95,7 @@ fn verify_no_signature(#[case] seed: Seed) {
 fn verify_invalid_signature(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (_, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
     let empty_signature = vec![];
     let invalid_signature = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -131,7 +131,7 @@ fn verify_signature_invalid_signature_index(#[case] seed: Seed) {
 
     const INVALID_SIGNATURE_INDEX: usize = 1234567890;
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
 
     for sighash_type in sig_hash_types() {
@@ -154,10 +154,10 @@ fn verify_signature_invalid_signature_index(#[case] seed: Seed) {
 fn verify_signature_wrong_destination(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let outpoint = Destination::PublicKey(public_key);
 
-    let (_, public_key_2) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (_, public_key_2) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let different_outpoint = Destination::PublicKey(public_key_2);
 
     for sighash_type in sig_hash_types() {
@@ -178,7 +178,7 @@ fn verify_signature_wrong_destination(#[case] seed: Seed) {
 fn mutate_all(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
     let original_tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &outpoint_dest);
@@ -196,7 +196,7 @@ fn mutate_all(#[case] seed: Seed) {
 fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL | SigHashType::ANYONECANPAY).unwrap();
     let original_tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &outpoint_dest);
@@ -214,7 +214,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
 fn mutate_none(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::NONE).unwrap();
     let original_tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &outpoint_dest);
@@ -232,7 +232,7 @@ fn mutate_none(#[case] seed: Seed) {
 fn mutate_none_anyonecanpay(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type =
         SigHashType::try_from(SigHashType::NONE | SigHashType::ANYONECANPAY).unwrap();
@@ -251,7 +251,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
 fn mutate_single(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::SINGLE).unwrap();
     let original_tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &outpoint_dest);
@@ -269,7 +269,7 @@ fn mutate_single(#[case] seed: Seed) {
 fn mutate_single_anyonecanpay(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type =
         SigHashType::try_from(SigHashType::SINGLE | SigHashType::ANYONECANPAY).unwrap();

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -110,7 +110,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &destination);
         check_insert_input(&mut rng, &tx, &destination, true);
         check_mutate_input(&mut rng, &tx, &destination, true);
-        check_insert_output(&tx, &destination, true);
+        check_insert_output(&mut rng, &tx, &destination, true);
         check_mutate_output(&tx, &destination, true);
     }
 
@@ -120,7 +120,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &destination);
         check_insert_input(&mut rng, &tx, &destination, false);
         check_mutate_input(&mut rng, &tx, &destination, true);
-        check_insert_output(&tx, &destination, true);
+        check_insert_output(&mut rng, &tx, &destination, true);
         check_mutate_output(&tx, &destination, true);
     }
 
@@ -129,7 +129,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &destination);
         check_insert_input(&mut rng, &tx, &destination, true);
         check_mutate_input(&mut rng, &tx, &destination, true);
-        check_insert_output(&tx, &destination, false);
+        check_insert_output(&mut rng, &tx, &destination, false);
         check_mutate_output(&tx, &destination, false);
     }
 
@@ -139,7 +139,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &destination);
         check_insert_input(&mut rng, &tx, &destination, false);
         check_mutate_input(&mut rng, &tx, &destination, true);
-        check_insert_output(&tx, &destination, false);
+        check_insert_output(&mut rng, &tx, &destination, false);
         check_mutate_output(&tx, &destination, false);
     }
 
@@ -148,7 +148,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &destination);
         check_insert_input(&mut rng, &tx, &destination, true);
         check_mutate_input(&mut rng, &tx, &destination, true);
-        check_insert_output(&tx, &destination, false);
+        check_insert_output(&mut rng, &tx, &destination, false);
         check_mutate_output(&tx, &destination, true);
     }
 
@@ -158,7 +158,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(&mut rng, &private_key, sighash_type, &destination);
         check_insert_input(&mut rng, &tx, &destination, false);
         check_mutate_input(&mut rng, &tx, &destination, true);
-        check_insert_output(&tx, &destination, false);
+        check_insert_output(&mut rng, &tx, &destination, false);
         check_mutate_output(&tx, &destination, true);
     }
 }

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -49,7 +49,7 @@ const INVALID_INPUT: usize = 1235466;
 fn test_mutate_tx_internal_data(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
 
     let test_data = [
         (0, 31, Ok(())),
@@ -102,7 +102,7 @@ fn test_mutate_tx_internal_data(#[case] seed: Seed) {
 fn modify_and_verify(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
 
     {
@@ -171,7 +171,7 @@ fn modify_and_verify(#[case] seed: Seed) {
 fn mutate_all(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
     let tx = generate_and_sign_tx(
@@ -212,7 +212,7 @@ fn mutate_all(#[case] seed: Seed) {
 fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL | SigHashType::ANYONECANPAY).unwrap();
     let tx = generate_and_sign_tx(
@@ -258,7 +258,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
 fn mutate_none(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::NONE).unwrap();
     let tx = generate_and_sign_tx(
@@ -302,7 +302,7 @@ fn mutate_none(#[case] seed: Seed) {
 fn mutate_none_anyonecanpay(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
     let sighash_type =
         SigHashType::try_from(SigHashType::NONE | SigHashType::ANYONECANPAY).unwrap();
@@ -349,7 +349,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
 fn mutate_single(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::SINGLE).unwrap();
     let tx = generate_and_sign_tx(
@@ -429,7 +429,7 @@ fn mutate_single(#[case] seed: Seed) {
 fn mutate_single_anyonecanpay(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let destination = Destination::PublicKey(public_key);
     let sighash_type =
         SigHashType::try_from(SigHashType::SINGLE | SigHashType::ANYONECANPAY).unwrap();

--- a/common/src/chain/transaction/signature/tests/sign_and_verify.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_verify.rs
@@ -43,7 +43,7 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let test_data = [(0, 31), (31, 0), (20, 3), (3, 20)];
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
 
     for ((destination, sighash_type), (inputs, outputs)) in destinations(&mut rng, public_key)
         .cartesian_product(sig_hash_types().filter(|t| t.outputs_mode() != OutputsMode::Single))
@@ -75,7 +75,7 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
 fn sign_and_verify_single(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
-    let (private_key, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
     let test_data = [
         // SigHashType::SINGLE. Destination = PubKey.
         (

--- a/crypto/src/key/mod.rs
+++ b/crypto/src/key/mod.rs
@@ -23,6 +23,7 @@ use serialization::{Decode, Encode};
 use crate::key::rschnorr::{MLRistrettoPrivateKey, MLRistrettoPublicKey, RistrettoSignatureError};
 use crate::key::Signature::RistrettoSchnorr;
 use crate::random::make_true_rng;
+use crate::random::{CryptoRng, Rng};
 pub use signature::Signature;
 
 use self::hdkd::child_number::ChildNumber;
@@ -64,10 +65,16 @@ impl From<RistrettoSignatureError> for SignatureError {
 
 impl PrivateKey {
     pub fn new(key_kind: KeyKind) -> (PrivateKey, PublicKey) {
-        let mut rng = make_true_rng();
+        Self::new_from_rng(&mut make_true_rng(), key_kind)
+    }
+
+    pub fn new_from_rng(
+        rng: &mut (impl Rng + CryptoRng),
+        key_kind: KeyKind,
+    ) -> (PrivateKey, PublicKey) {
         match key_kind {
             KeyKind::RistrettoSchnorr => {
-                let k = MLRistrettoPrivateKey::new(&mut rng);
+                let k = MLRistrettoPrivateKey::new(rng);
                 (
                     PrivateKey {
                         key: PrivateKeyHolder::RistrettoSchnorr(k.0),

--- a/crypto/src/key/signature/mod.rs
+++ b/crypto/src/key/signature/mod.rs
@@ -90,10 +90,16 @@ mod test {
     use super::*;
     use crate::key::{KeyKind, PrivateKey, PublicKey};
     use hex::FromHex;
+    use rstest::rstest;
+    use test_utils::random::make_seedable_rng;
+    use test_utils::random::Seed;
 
-    #[test]
-    fn serialize() {
-        let (sk, pk) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn serialize(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let (sk, pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let msg = b"abc";
         let sig = sk.sign_message(msg).unwrap();
         assert!(pk.verify_message(&sig, msg));

--- a/test-utils/src/nft_utils.rs
+++ b/test-utils/src/nft_utils.rs
@@ -23,14 +23,12 @@ use common::{
     },
     primitives::Amount,
 };
-use crypto::{
-    key::{KeyKind, PrivateKey},
-    random::Rng,
-};
+use crypto::key::{KeyKind, PrivateKey};
+use crypto::random::{CryptoRng, Rng};
 use serialization::extras::non_empty_vec::DataOrNoVec;
 
-pub fn random_creator() -> TokenCreator {
-    let (_, public_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+pub fn random_creator(rng: &mut (impl Rng + CryptoRng)) -> TokenCreator {
+    let (_, public_key) = PrivateKey::new_from_rng(rng, KeyKind::RistrettoSchnorr);
     TokenCreator::from(public_key)
 }
 
@@ -47,14 +45,17 @@ pub fn random_token_issuance(chain_config: Arc<ChainConfig>, rng: &mut impl Rng)
     }
 }
 
-pub fn random_nft_issuance(chain_config: Arc<ChainConfig>, rng: &mut impl Rng) -> NftIssuance {
+pub fn random_nft_issuance(
+    chain_config: Arc<ChainConfig>,
+    rng: &mut (impl Rng + CryptoRng),
+) -> NftIssuance {
     let max_desc_len = chain_config.token_max_description_len();
     let max_name_len = chain_config.token_max_name_len();
     let max_ticker_len = chain_config.token_max_ticker_len();
 
     NftIssuance {
         metadata: Metadata {
-            creator: Some(random_creator()),
+            creator: Some(random_creator(rng)),
             name: random_string(rng, 1..max_name_len).into_bytes(),
             description: random_string(rng, 1..max_desc_len).into_bytes(),
             ticker: random_string(rng, 1..max_ticker_len).into_bytes(),

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -28,14 +28,14 @@ use common::{
     },
     primitives::{BlockHeight, Id, Idable, H256},
 };
-use crypto::random::Rng;
+use crypto::random::{CryptoRng, Rng};
 use itertools::Itertools;
 use rstest::rstest;
 use std::collections::BTreeMap;
 use test_utils::random::{make_seedable_rng, Seed};
 
 fn create_transactions(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     inputs: Vec<TxInput>,
     max_num_of_outputs: usize,
     num_of_txs: usize,
@@ -69,7 +69,7 @@ fn create_transactions(
 }
 
 fn create_block(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     prev_block_id: Id<GenBlock>,
     inputs: Vec<TxInput>,
     max_num_of_outputs: usize,
@@ -82,7 +82,10 @@ fn create_block(
 
 /// populate the db with random values, for testing.
 /// returns a tuple of the best block id and the outpoints (for spending)
-fn initialize_db(rng: &mut impl Rng, tx_outputs_size: u32) -> (UtxosDBInMemoryImpl, Vec<OutPoint>) {
+fn initialize_db(
+    rng: &mut (impl Rng + CryptoRng),
+    tx_outputs_size: u32,
+) -> (UtxosDBInMemoryImpl, Vec<OutPoint>) {
     let best_block_id: Id<GenBlock> = Id::new(H256::random_using(rng));
     let mut db_interface = UtxosDBInMemoryImpl::new(best_block_id, Default::default());
 
@@ -105,7 +108,10 @@ fn initialize_db(rng: &mut impl Rng, tx_outputs_size: u32) -> (UtxosDBInMemoryIm
     (db_interface, outpoints)
 }
 
-fn create_utxo_entries(rng: &mut impl Rng, num_of_utxos: u8) -> BTreeMap<OutPoint, UtxoEntry> {
+fn create_utxo_entries(
+    rng: &mut (impl Rng + CryptoRng),
+    num_of_utxos: u8,
+) -> BTreeMap<OutPoint, UtxoEntry> {
     let mut map = BTreeMap::new();
     for _ in 0..num_of_utxos {
         let (utxo, outpoint) = create_utxo(rng, 0);

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -69,7 +69,7 @@ use common::{
     },
     primitives::{Amount, BlockHeight, Compact, Id, Idable, H256},
 };
-use crypto::random::{seq, Rng};
+use crypto::random::{seq, CryptoRng, Rng};
 use itertools::Itertools;
 use rstest::rstest;
 use std::collections::BTreeMap;
@@ -83,7 +83,7 @@ use test_utils::random::{make_seedable_rng, Seed};
 /// `result_flags` - the result ( dirty/not, fresh/not ) after calling the `add_utxo` method.
 /// `op_result` - the result of calling `add_utxo` method, whether it succeeded or not.
 fn check_add_utxo(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     cache_presence: Presence,
     cache_flags: Option<(IsFresh, IsDirty)>,
     possible_overwrite: bool,
@@ -116,7 +116,7 @@ fn check_add_utxo(
 /// `cache_flags` - The flags of a utxo entry in a cache.
 /// `result_flags` - the result ( dirty/not, fresh/not ) after performing `spend_utxo`.
 fn check_spend_utxo(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     parent_presence: Presence,
     cache_presence: Presence,
     cache_flags: Option<(IsFresh, IsDirty)>,
@@ -176,7 +176,7 @@ fn check_spend_utxo(
 /// `result` - The result of the parent after performing the `batch_write`.
 /// `result_flags` - the pair of `result`, indicating whether it is dirty/not, fresh/not or nothing at all.
 fn check_write_utxo(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     parent_presence: Presence,
     child_presence: Presence,
     result: Result<Presence, Error>,
@@ -238,7 +238,7 @@ fn check_write_utxo(
 
 /// Checks the `get_mut_utxo` method behavior.
 fn check_get_mut_utxo(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     parent_presence: Presence,
     cache_presence: Presence,
     result_presence: Presence,

--- a/utxo/src/tests/simulation.rs
+++ b/utxo/src/tests/simulation.rs
@@ -16,7 +16,7 @@
 use super::{empty_test_utxos_view, test_helper::create_utxo};
 use crate::{FlushableUtxoView, UtxosCache, UtxosView};
 use common::{chain::OutPoint, primitives::H256};
-use crypto::random::Rng;
+use crypto::random::{CryptoRng, Rng};
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
 
@@ -60,7 +60,7 @@ fn cache_simulation_test(
 // Each step a new cache is created based on parent. Then it is randomly modified and passed to the
 // next step as a parent. After recursion stops the resulting cache is returned and flushed to the base.
 fn simulation_step<'a>(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     result: &mut Vec<OutPoint>,
     parent: &'a UtxosCache,
     iterations_per_cache: usize,
@@ -87,7 +87,7 @@ fn simulation_step<'a>(
 
 // Perform random modification on a cache (add new, spend existing, uncache), tracking the coverage
 fn populate_cache(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     cache: &mut UtxosCache,
     iterations_count: usize,
     prev_result: &[OutPoint],

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -19,7 +19,7 @@ use common::{
     chain::{block::BlockReward, OutPoint, OutPointSourceId, Transaction, TxInput},
     primitives::{BlockHeight, Id, Idable, H256},
 };
-use crypto::random::Rng;
+use crypto::random::{CryptoRng, Rng};
 use rstest::rstest;
 use std::collections::BTreeMap;
 use test_utils::random::{make_seedable_rng, Seed};
@@ -76,7 +76,7 @@ fn cache_simulation_with_undo(
 // Each step a new cache is created based on parent. Then it is randomly modified and passed to the
 // next step as a parent. After recursion stops the resulting cache is returned and flushed to the base.
 fn simulation_step<'a>(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     result: &mut ResultWithUndo,
     parent: &'a UtxosCache,
     iterations_per_cache: usize,
@@ -103,7 +103,7 @@ fn simulation_step<'a>(
 }
 
 fn populate_cache_with_undo(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     cache: &mut UtxosCache,
     iterations_count: usize,
     prev_result: &mut ResultWithUndo,

--- a/utxo/src/tests/test_helper.rs
+++ b/utxo/src/tests/test_helper.rs
@@ -26,7 +26,7 @@ use common::{
 };
 use crypto::{
     key::{KeyKind, PrivateKey},
-    random::{seq, Rng},
+    random::{seq, CryptoRng, Rng},
 };
 use itertools::Itertools;
 
@@ -37,11 +37,11 @@ pub enum Presence {
     Spent,
 }
 
-pub fn create_tx_outputs(rng: &mut impl Rng, size: u32) -> Vec<TxOutput> {
+pub fn create_tx_outputs(rng: &mut (impl Rng + CryptoRng), size: u32) -> Vec<TxOutput> {
     let mut tx_outputs = vec![];
     for _ in 0..size {
         let random_amt = rng.gen_range(1..u128::MAX);
-        let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+        let (_, pub_key) = PrivateKey::new_from_rng(rng, KeyKind::RistrettoSchnorr);
         tx_outputs.push(TxOutput::new(
             OutputValue::Coin(Amount::from_atoms(random_amt)),
             OutputPurpose::Transfer(Destination::PublicKey(pub_key)),
@@ -78,31 +78,34 @@ pub fn convert_to_utxo(
     (outpoint, utxo)
 }
 
-pub fn create_utxo(rng: &mut impl Rng, block_height: u64) -> (Utxo, OutPoint) {
+pub fn create_utxo(rng: &mut (impl Rng + CryptoRng), block_height: u64) -> (Utxo, OutPoint) {
     let random_value = rng.gen_range(0..u128::MAX);
     let is_block_reward = random_value % 3 == 0;
     inner_create_utxo(rng, is_block_reward, Some(block_height))
 }
 
-pub fn create_utxo_for_mempool(rng: &mut impl Rng) -> (Utxo, OutPoint) {
+pub fn create_utxo_for_mempool(rng: &mut (impl Rng + CryptoRng)) -> (Utxo, OutPoint) {
     let random_value = rng.gen_range(0..u128::MAX);
     let is_block_reward = random_value % 3 == 0;
     inner_create_utxo(rng, is_block_reward, None)
 }
 
-pub fn create_utxo_from_reward(rng: &mut impl Rng, block_height: u64) -> (Utxo, OutPoint) {
+pub fn create_utxo_from_reward(
+    rng: &mut (impl Rng + CryptoRng),
+    block_height: u64,
+) -> (Utxo, OutPoint) {
     inner_create_utxo(rng, true, Some(block_height))
 }
 
 /// returns a tuple of utxo and outpoint, for testing.
 fn inner_create_utxo(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     is_block_reward: bool,
     block_height: Option<u64>,
 ) -> (Utxo, OutPoint) {
     // just a random value generated, and also a random `is_block_reward` value.
     let output_value = rng.gen_range(0..u128::MAX);
-    let (_, pub_key) = PrivateKey::new(KeyKind::RistrettoSchnorr);
+    let (_, pub_key) = PrivateKey::new_from_rng(rng, KeyKind::RistrettoSchnorr);
     let output = TxOutput::new(
         OutputValue::Coin(Amount::from_atoms(output_value)),
         OutputPurpose::Transfer(Destination::PublicKey(pub_key)),
@@ -138,7 +141,7 @@ fn inner_create_utxo(
 /// `cache_flags` - sets the entry of the utxo (fresh/not, dirty/not)
 /// `outpoint` - optional key to be used, rather than a randomly generated one.
 pub fn insert_single_entry(
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     cache: &mut UtxosCache,
     cache_presence: Presence,
     cache_flags: Option<(IsFresh, IsDirty)>,


### PR DESCRIPTION
Make private keys generation deterministic in tests (from the @TheQuantumPhysicist request).
I switched to using seeded RNG where it was available.
There are some places (not many) where it's not available.
I did not change keys generations in that parts.