### PR TITLE
Fix minor TODO in `outputs_from_block` from tests

### DIFF
--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -113,7 +113,7 @@ impl<'f> BlockBuilder<'f> {
     }
 
     /// Returns regular transaction output(s) if any, otherwise returns block reward outputs
-    fn get_regular_block_outputs(outputs: BlockOutputs) -> BlockOutputs {
+    fn filter_outputs(outputs: BlockOutputs) -> BlockOutputs {
         let has_tx_outputs = outputs
             .iter()
             .any(|(output, _)| matches!(output, OutPointSourceId::Transaction(_)));
@@ -139,7 +139,7 @@ impl<'f> BlockBuilder<'f> {
         rng: &mut impl Rng,
     ) -> Self {
         let (witnesses, inputs, outputs) = self.make_test_inputs_outputs(
-            Self::get_regular_block_outputs(self.framework.outputs_from_genblock(parent)),
+            Self::filter_outputs(self.framework.outputs_from_genblock(parent)),
             rng,
         );
         self.add_transaction(
@@ -150,10 +150,8 @@ impl<'f> BlockBuilder<'f> {
 
     /// Same as `add_test_transaction_with_parent`, but uses reference to a block.
     pub fn add_test_transaction_from_block(self, parent: &Block, rng: &mut impl Rng) -> Self {
-        let (witnesses, inputs, outputs) = self.make_test_inputs_outputs(
-            Self::get_regular_block_outputs(outputs_from_block(parent)),
-            rng,
-        );
+        let (witnesses, inputs, outputs) =
+            self.make_test_inputs_outputs(Self::filter_outputs(outputs_from_block(parent)), rng);
         self.add_transaction(
             SignedTransaction::new(Transaction::new(0, inputs, outputs, 0).unwrap(), witnesses)
                 .expect("invalid witness count"),

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -20,7 +20,7 @@ use crate::utils::{create_multiple_utxo_data, create_new_outputs, outputs_from_b
 use crate::TestFramework;
 use chainstate::{BlockSource, ChainstateError};
 use chainstate_types::BlockIndex;
-use common::chain::OutPoint;
+use common::chain::{OutPoint, OutPointSourceId};
 use common::{
     chain::{
         block::{timestamp::BlockTimestamp, BlockReward, ConsensusData},
@@ -112,6 +112,19 @@ impl<'f> BlockBuilder<'f> {
         self
     }
 
+    /// Returns regular transaction output(s) if any, otherwise returns block reward outputs
+    fn get_regular_block_outputs(outputs: BlockOutputs) -> BlockOutputs {
+        let has_tx_outputs = outputs
+            .iter()
+            .any(|(output, _)| matches!(output, OutPointSourceId::Transaction(_)));
+        outputs
+            .into_iter()
+            .filter(|(output, _)| {
+                matches!(output, OutPointSourceId::Transaction(_)) == has_tx_outputs
+            })
+            .collect()
+    }
+
     /// Adds a transaction that uses the transactions from the best block as inputs and
     /// produces new outputs.
     pub fn add_test_transaction_from_best_block(self, rng: &mut impl Rng) -> Self {
@@ -125,8 +138,10 @@ impl<'f> BlockBuilder<'f> {
         parent: Id<GenBlock>,
         rng: &mut impl Rng,
     ) -> Self {
-        let (witnesses, inputs, outputs) =
-            self.make_test_inputs_outputs(self.framework.outputs_from_genblock(parent), rng);
+        let (witnesses, inputs, outputs) = self.make_test_inputs_outputs(
+            Self::get_regular_block_outputs(self.framework.outputs_from_genblock(parent)),
+            rng,
+        );
         self.add_transaction(
             SignedTransaction::new(Transaction::new(0, inputs, outputs, 0).unwrap(), witnesses)
                 .expect("invalid witness count"),
@@ -135,8 +150,10 @@ impl<'f> BlockBuilder<'f> {
 
     /// Same as `add_test_transaction_with_parent`, but uses reference to a block.
     pub fn add_test_transaction_from_block(self, parent: &Block, rng: &mut impl Rng) -> Self {
-        let (witnesses, inputs, outputs) =
-            self.make_test_inputs_outputs(outputs_from_block(parent), rng);
+        let (witnesses, inputs, outputs) = self.make_test_inputs_outputs(
+            Self::get_regular_block_outputs(outputs_from_block(parent)),
+            rng,
+        );
         self.add_transaction(
             SignedTransaction::new(Transaction::new(0, inputs, outputs, 0).unwrap(), witnesses)
                 .expect("invalid witness count"),

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -16,8 +16,8 @@
 use std::collections::BTreeSet;
 
 use crate::framework::BlockOutputs;
-use crate::utils::{create_multiple_utxo_data, create_new_outputs};
-use crate::{outputs_from_block, TestFramework};
+use crate::utils::{create_multiple_utxo_data, create_new_outputs, outputs_from_block};
+use crate::TestFramework;
 use chainstate::{BlockSource, ChainstateError};
 use chainstate_types::BlockIndex;
 use common::chain::OutPoint;

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -29,9 +29,7 @@ pub type TestStore = chainstate_storage::inmemory::Store;
 pub type TestChainstate = Box<dyn chainstate::chainstate_interface::ChainstateInterface>;
 
 pub use {
-    crate::utils::{
-        anyonecanspend_address, empty_witness, outputs_from_block, outputs_from_genesis,
-    },
+    crate::utils::{anyonecanspend_address, empty_witness},
     block_builder::BlockBuilder,
     framework::TestFramework,
     framework_builder::{OrphanErrorHandler, TestFrameworkBuilder, TxVerificationStrategy},

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -275,14 +275,10 @@ pub fn outputs_from_genesis(genesis: &Genesis) -> BlockOutputs {
 }
 
 pub fn outputs_from_block(blk: &Block) -> BlockOutputs {
-    // This copied from TestBlockInfo which did not copy reward outputs before.
-    // Adding them now breaks tests::processing_tests::consensus_type::case_1.
-    // TODO(Pavel): Revert reward outputs and fix chainstate-test-suite.
     std::iter::once((
         OutPointSourceId::BlockReward(blk.get_id().into()),
         blk.block_reward().outputs().to_vec(),
     ))
-    .skip(1)
     .chain(blk.transactions().iter().map(|tx| {
         (
             OutPointSourceId::Transaction(tx.transaction().get_id()),

--- a/chainstate/test-suite/src/tests/helpers/mod.rs
+++ b/chainstate/test-suite/src/tests/helpers/mod.rs
@@ -17,9 +17,10 @@ use chainstate_test_framework::{anyonecanspend_address, TestFramework, Transacti
 use common::{
     chain::{
         block::timestamp::BlockTimestamp, signature::inputsig::InputWitness,
-        timelock::OutputTimeLock, tokens::OutputValue, OutputPurpose, TxInput, TxOutput,
+        timelock::OutputTimeLock, tokens::OutputValue, OutputPurpose, Transaction, TxInput,
+        TxOutput,
     },
-    primitives::{Amount, BlockDistance},
+    primitives::{Amount, BlockDistance, Id, Idable},
 };
 
 pub mod in_memory_storage_wrapper;
@@ -29,25 +30,25 @@ pub fn add_block_with_locked_output(
     tf: &mut TestFramework,
     output_time_lock: OutputTimeLock,
     timestamp: BlockTimestamp,
-) -> (InputWitness, TxInput) {
+) -> (InputWitness, TxInput, Id<Transaction>) {
     // Find the last block.
     let current_height = tf.best_block_index().block_height();
     let prev_block_outputs = tf.outputs_from_genblock(tf.block_id(current_height.into()));
 
-    tf.make_block_builder()
-        .add_transaction(
-            TransactionBuilder::new()
-                .add_input(
-                    TxInput::new(prev_block_outputs.keys().next().unwrap().clone(), 0),
-                    InputWitness::NoSignature(None),
-                )
-                .add_anyone_can_spend_output(10000)
-                .add_output(TxOutput::new(
-                    OutputValue::Coin(Amount::from_atoms(100000)),
-                    OutputPurpose::LockThenTransfer(anyonecanspend_address(), output_time_lock),
-                ))
-                .build(),
+    let tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::new(prev_block_outputs.keys().next().unwrap().clone(), 0),
+            InputWitness::NoSignature(None),
         )
+        .add_anyone_can_spend_output(10000)
+        .add_output(TxOutput::new(
+            OutputValue::Coin(Amount::from_atoms(100000)),
+            OutputPurpose::LockThenTransfer(anyonecanspend_address(), output_time_lock),
+        ))
+        .build();
+    let tx_id = tx.transaction().get_id();
+    tf.make_block_builder()
+        .add_transaction(tx)
         .with_timestamp(timestamp)
         .build_and_process()
         .unwrap();
@@ -55,9 +56,11 @@ pub fn add_block_with_locked_output(
     let new_height = (current_height + BlockDistance::new(1)).unwrap();
     assert_eq!(tf.best_block_index().block_height(), new_height);
 
-    let block_utxos = tf.outputs_from_genblock(tf.block_id(new_height.into()));
+    let block_outputs = tf.outputs_from_genblock(tf.block_id(new_height.into()));
+    assert!(block_outputs.contains_key(&tx_id.into()));
     (
         InputWitness::NoSignature(None),
-        TxInput::new(block_utxos.keys().next().unwrap().clone(), 1),
+        TxInput::new(tx_id.into(), 1),
+        tx_id,
     )
 }

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -46,31 +46,29 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
         let token_min_issuance_fee = chain_config.token_min_issuance_fee();
 
         // Issuance
+        let tx = TransactionBuilder::new()
+            .add_input(
+                TxInput::new(genesis_outpoint_id, 0),
+                InputWitness::NoSignature(None),
+            )
+            .add_output(TxOutput::new(
+                random_nft_issuance(chain_config, &mut rng).into(),
+                OutputPurpose::Transfer(Destination::AnyoneCanSpend),
+            ))
+            .add_output(TxOutput::new(
+                OutputValue::Coin(token_min_issuance_fee),
+                OutputPurpose::Burn,
+            ))
+            .build();
+        let issuance_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
         let block_index = tf
             .make_block_builder()
-            .add_transaction(
-                TransactionBuilder::new()
-                    .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
-                        InputWitness::NoSignature(None),
-                    )
-                    .add_output(TxOutput::new(
-                        random_nft_issuance(chain_config, &mut rng).into(),
-                        OutputPurpose::Transfer(Destination::AnyoneCanSpend),
-                    ))
-                    .add_output(TxOutput::new(
-                        OutputValue::Coin(token_min_issuance_fee),
-                        OutputPurpose::Burn,
-                    ))
-                    .build(),
-            )
+            .add_transaction(tx)
             .build_and_process()
             .unwrap()
             .unwrap();
 
         let block = tf.block(*block_index.block_id());
-        let issuance_outpoint_id =
-            tf.outputs_from_genblock(block.get_id().into()).keys().next().unwrap().clone();
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
 
         // Burn more NFT than we have
@@ -174,30 +172,31 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
 
         // Burn
+        let tx = TransactionBuilder::new()
+            .add_input(
+                TxInput::new(issuance_outpoint_id, 0),
+                InputWitness::NoSignature(None),
+            )
+            .add_output(TxOutput::new(
+                TokenTransfer {
+                    token_id,
+                    amount: Amount::from_atoms(1),
+                }
+                .into(),
+                OutputPurpose::Burn,
+            ))
+            .build();
+        let first_burn_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
         let block_index = tf
             .make_block_builder()
-            .add_transaction(
-                TransactionBuilder::new()
-                    .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
-                        InputWitness::NoSignature(None),
-                    )
-                    .add_output(TxOutput::new(
-                        TokenTransfer {
-                            token_id,
-                            amount: Amount::from_atoms(1),
-                        }
-                        .into(),
-                        OutputPurpose::Burn,
-                    ))
-                    .build(),
-            )
+            .add_transaction(tx)
             .build_and_process()
             .unwrap()
             .unwrap();
         let block = tf.block(*block_index.block_id());
-        let first_burn_outpoint_id =
-            tf.outputs_from_genblock(block.get_id().into()).keys().next().unwrap().clone();
+        assert!(tf
+            .outputs_from_genblock(block.get_id().into())
+            .contains_key(&first_burn_outpoint_id));
 
         // Try to transfer burned tokens
         let result = tf

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -315,7 +315,7 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
             .add_output(TxOutput::new(
                 NftIssuance {
                     metadata: Metadata {
-                        creator: Some(random_creator()),
+                        creator: Some(random_creator(&mut rng)),
                         name: random_string(&mut rng, 1..max_name_len).into_bytes(),
                         description: random_string(&mut rng, 1..max_desc_len).into_bytes(),
                         ticker: random_string(&mut rng, 1..max_ticker_len).into_bytes(),


### PR DESCRIPTION
Fix remaining TODO after recent TestBlockInfo refactor in `outputs_from_block`.
The fix is a bit ugly but I unable to find a better way.

There also was a fair [comment](https://github.com/mintlayer/mintlayer-core/pull/533#discussion_r1013330998) from @azarovh about collecting all outputs just to get an tx id. I replaced that with getting tx id directly in some places.