### PR TITLE
mempool: Mempool constructor does not need to be async

### DIFF
--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -40,7 +40,7 @@ pub struct MempoolInterfaceImpl {
 }
 
 impl MempoolInterfaceImpl {
-    pub async fn new<M: GetMemoryUsage + Sync + Send + 'static>(
+    pub fn new<M: GetMemoryUsage + Sync + Send + 'static>(
         chain_config: Arc<ChainConfig>,
         chainstate_handle: subsystem::Handle<Box<dyn ChainstateInterface>>,
         time_getter: TimeGetter,
@@ -55,8 +55,7 @@ impl MempoolInterfaceImpl {
             memory_usage_estimator,
             receiver,
         )
-        .run()
-        .await?;
+        .run()?;
 
         Ok(Self { sender })
     }

--- a/mempool/src/interface/mempool_interface_impl/pool/mod.rs
+++ b/mempool/src/interface/mempool_interface_impl/pool/mod.rs
@@ -148,7 +148,7 @@ where
         }
     }
 
-    pub async fn run(mut self) -> Result<(), Error> {
+    pub fn run(mut self) -> Result<(), Error> {
         tokio::spawn(async move {
             let event_receiver =
                 self.subscribe_to_chainstate_events().await.log_err().expect("chainstate dead");

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -47,7 +47,7 @@ pub type MempoolHandle = subsystem::Handle<Box<dyn MempoolInterface>>;
 
 pub type Result<T> = core::result::Result<T, MempoolError>;
 
-pub async fn make_mempool<M>(
+pub fn make_mempool<M>(
     chain_config: Arc<ChainConfig>,
     chainstate_handle: subsystem::Handle<Box<dyn ChainstateInterface>>,
     time_getter: TimeGetter,
@@ -56,13 +56,10 @@ pub async fn make_mempool<M>(
 where
     M: GetMemoryUsage + 'static + Send + Sync,
 {
-    Ok(Box::new(
-        MempoolInterfaceImpl::new(
-            chain_config,
-            chainstate_handle,
-            time_getter,
-            memory_usage_estimator,
-        )
-        .await?,
-    ))
+    Ok(Box::new(MempoolInterfaceImpl::new(
+        chain_config,
+        chainstate_handle,
+        time_getter,
+        memory_usage_estimator,
+    )?))
 }

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -67,8 +67,7 @@ pub async fn initialize(
             chainstate.clone(),
             Default::default(),
             mempool::SystemUsageEstimator {},
-        )
-        .await?,
+        )?,
     );
 
     // P2P subsystem


### PR DESCRIPTION
The mempool object is initialized in a separate task, meaning the constructor itself does not need to be `async`.