### PR TITLE
mempool: Remove some occurrences `pub(..)`

### DIFF
--- a/mempool/src/config.rs
+++ b/mempool/src/config.rs
@@ -15,19 +15,19 @@
 
 use std::time::Duration;
 
-pub(crate) type Time = Duration;
+pub type Time = Duration;
 
-pub(crate) const ROLLING_FEE_BASE_HALFLIFE: Time = Duration::new(60 * 60 * 12, 1);
+pub const ROLLING_FEE_BASE_HALFLIFE: Time = Duration::new(60 * 60 * 12, 1);
 // TODO this will be defined elsewhere (some of limits.rs file)
-pub(crate) const MAX_BLOCK_SIZE_BYTES: usize = 1_000_000;
+pub const MAX_BLOCK_SIZE_BYTES: usize = 1_000_000;
 
-pub(crate) const MAX_BIP125_REPLACEMENT_CANDIDATES: usize = 100;
+pub const MAX_BIP125_REPLACEMENT_CANDIDATES: usize = 100;
 
 // TODO this should really be taken from some global node settings
-pub(crate) const RELAY_FEE_PER_BYTE: usize = 1;
+pub const RELAY_FEE_PER_BYTE: usize = 1;
 
-pub(crate) const MAX_MEMPOOL_SIZE_BYTES: usize = 300_000_000;
+pub const MAX_MEMPOOL_SIZE_BYTES: usize = 300_000_000;
 
-pub(crate) const DEFAULT_MEMPOOL_EXPIRY: Duration = Duration::new(336 * 60 * 60, 0);
+pub const DEFAULT_MEMPOOL_EXPIRY: Duration = Duration::new(336 * 60 * 60, 0);
 
-pub(crate) const ROLLING_FEE_DECAY_INTERVAL: Time = Duration::new(10, 0);
+pub const ROLLING_FEE_DECAY_INTERVAL: Time = Duration::new(10, 0);

--- a/mempool/src/interface/mempool_interface_impl/pool/feerate.rs
+++ b/mempool/src/interface/mempool_interface_impl/pool/feerate.rs
@@ -19,8 +19,8 @@ use common::primitives::amount::Amount;
 
 use crate::error::TxValidationError;
 
-pub(crate) const INCREMENTAL_RELAY_FEE_RATE: FeeRate = FeeRate::new(Amount::from_atoms(1000));
-pub(crate) const INCREMENTAL_RELAY_THRESHOLD: FeeRate = FeeRate::new(Amount::from_atoms(500));
+pub const INCREMENTAL_RELAY_FEE_RATE: FeeRate = FeeRate::new(Amount::from_atoms(1000));
+pub const INCREMENTAL_RELAY_THRESHOLD: FeeRate = FeeRate::new(Amount::from_atoms(500));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FeeRate {

--- a/mempool/src/interface/mempool_interface_impl/pool/tests/mod.rs
+++ b/mempool/src/interface/mempool_interface_impl/pool/tests/mod.rs
@@ -728,12 +728,12 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
     let entry4 = mempool.store.get_entry(ids.get(3).expect("index")).expect("entry");
     let entry5 = mempool.store.get_entry(ids.get(4).expect("index")).expect("entry");
     let entry6 = mempool.store.get_entry(ids.get(5).expect("index")).expect("entry");
-    assert_eq!(entry1.unconfirmed_ancestors(&mempool.store).0.len(), 0);
-    assert_eq!(entry2.unconfirmed_ancestors(&mempool.store).0.len(), 0);
-    assert_eq!(entry3.unconfirmed_ancestors(&mempool.store).0.len(), 2);
-    assert_eq!(entry4.unconfirmed_ancestors(&mempool.store).0.len(), 3);
-    assert_eq!(entry5.unconfirmed_ancestors(&mempool.store).0.len(), 3);
-    assert_eq!(entry6.unconfirmed_ancestors(&mempool.store).0.len(), 5);
+    assert_eq!(entry1.unconfirmed_ancestors(&mempool.store).len(), 0);
+    assert_eq!(entry2.unconfirmed_ancestors(&mempool.store).len(), 0);
+    assert_eq!(entry3.unconfirmed_ancestors(&mempool.store).len(), 2);
+    assert_eq!(entry4.unconfirmed_ancestors(&mempool.store).len(), 3);
+    assert_eq!(entry5.unconfirmed_ancestors(&mempool.store).len(), 3);
+    assert_eq!(entry6.unconfirmed_ancestors(&mempool.store).len(), 5);
 
     assert_eq!(entry1.count_with_descendants(), 5);
     assert_eq!(entry2.count_with_descendants(), 5);

--- a/mempool/src/interface/mempool_interface_impl/pool/tests/utils.rs
+++ b/mempool/src/interface/mempool_interface_impl/pool/tests/utils.rs
@@ -20,9 +20,9 @@ use common::primitives::H256;
 use super::*;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(in crate::interface::mempool_interface_impl::pool::tests) struct ValuedOutPoint {
-    pub(in crate::interface::mempool_interface_impl::pool::tests) outpoint: OutPoint,
-    pub(in crate::interface::mempool_interface_impl::pool::tests) value: Amount,
+pub struct ValuedOutPoint {
+    pub outpoint: OutPoint,
+    pub value: Amount,
 }
 
 impl std::cmp::PartialOrd for ValuedOutPoint {
@@ -54,10 +54,7 @@ fn dummy_output() -> TxOutput {
     TxOutput::new(OutputValue::Coin(value), purpose)
 }
 
-pub(in crate::interface::mempool_interface_impl::pool::tests) fn estimate_tx_size(
-    num_inputs: usize,
-    num_outputs: usize,
-) -> usize {
+pub fn estimate_tx_size(num_inputs: usize, num_outputs: usize) -> usize {
     let witnesses: Vec<InputWitness> =
         (0..num_inputs).into_iter().map(|_| dummy_witness()).collect();
     let inputs = (0..num_inputs).into_iter().map(|_| dummy_input()).collect();


### PR DESCRIPTION
Changing them to `pub` does not increase visibility since the module itself is private and all the `use` items in the parent are private too.

Had to move some struct definitions around a bit to make it work but nothing too big.