### PR TITLE
Fix rust analyzer errors in p2p

### DIFF
--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -24,9 +24,10 @@ use p2p::{
     net::{
         self, types::SyncingEvent, ConnectivityService, NetworkingService, SyncingMessagingService,
     },
+    peer_manager::helpers::connect_services,
     sync::BlockSyncManager,
 };
-use p2p_test_utils::{connect_services, MakeTestAddress, TestBlockInfo};
+use p2p_test_utils::{MakeTestAddress, TestBlockInfo};
 
 tests![invalid_pubsub_block, invalid_sync_block,];
 

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -34,8 +34,9 @@ use p2p::{
         types::{PubSubTopic, SyncingEvent},
         ConnectivityService, NetworkingService, SyncingMessagingService,
     },
+    peer_manager::helpers::connect_services,
 };
-use p2p_test_utils::{connect_services, MakeTestAddress};
+use p2p_test_utils::MakeTestAddress;
 
 tests![
     block_announcement,

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -34,10 +34,11 @@ use p2p::{
         types::{ConnectivityEvent, SyncingEvent},
         ConnectivityService, NetworkingService, SyncingMessagingService,
     },
+    peer_manager::helpers::connect_services,
     sync::BlockSyncManager,
     sync::SyncState,
 };
-use p2p_test_utils::{connect_services, MakeTestAddress, TestBlockInfo};
+use p2p_test_utils::{MakeTestAddress, TestBlockInfo};
 
 tests![
     local_and_remote_in_sync,

--- a/p2p/src/peer_manager/helpers.rs
+++ b/p2p/src/peer_manager/helpers.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::unwrap_used)]
+
 use std::time::Duration;
 
 use tokio::time::timeout;

--- a/p2p/src/peer_manager/helpers.rs
+++ b/p2p/src/peer_manager/helpers.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use tokio::time::timeout;
+
+use crate::net::{
+    types::{ConnectivityEvent, PeerInfo},
+    ConnectivityService, NetworkingService,
+};
+
+/// Can be used in tests only, will panic in case of errors
+pub async fn connect_services<T>(
+    conn1: &mut T::ConnectivityHandle,
+    conn2: &mut T::ConnectivityHandle,
+) -> (T::Address, PeerInfo<T>)
+where
+    T: NetworkingService + std::fmt::Debug,
+    T::ConnectivityHandle: ConnectivityService<T>,
+{
+    let addr = timeout(Duration::from_secs(5), conn2.local_addr())
+        .await
+        .expect("local address fetch not to timeout")
+        .unwrap()
+        .unwrap();
+    conn1.connect(addr).await.expect("dial to succeed");
+
+    let (address, peer_info) = match timeout(Duration::from_secs(5), conn2.poll_next()).await {
+        Ok(event) => match event.unwrap() {
+            ConnectivityEvent::InboundAccepted { address, peer_info } => (address, peer_info),
+            event => panic!("expected `InboundAccepted`, got {event:?}"),
+        },
+        Err(_err) => panic!("did not receive `InboundAccepted` in time"),
+    };
+
+    match timeout(Duration::from_secs(5), conn1.poll_next()).await {
+        Ok(event) => match event.unwrap() {
+            ConnectivityEvent::OutboundAccepted { .. } => {}
+            event => panic!("expected `OutboundAccepted`, got {event:?}"),
+        },
+        Err(_err) => panic!("did not receive `OutboundAccepted` in time"),
+    }
+
+    (address, peer_info)
+}

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -21,6 +21,7 @@
 
 #![allow(rustdoc::private_intra_doc_links)]
 
+pub mod helpers;
 pub mod peerdb;
 
 use std::{

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -31,7 +31,8 @@ use crate::{
         types::{Protocol, ProtocolType},
         AsBannableAddress, ConnectivityService, NetworkingService,
     },
-    peer_manager::tests::{connect_services, default_protocols, make_peer_manager},
+    peer_manager::helpers::connect_services,
+    peer_manager::tests::{default_protocols, make_peer_manager},
 };
 
 // ban peer whose connected to us

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -37,7 +37,8 @@ use crate::{
     },
     peer_manager::{
         self,
-        tests::{connect_services, default_protocols, make_peer_manager},
+        helpers::connect_services,
+        tests::{default_protocols, make_peer_manager},
     },
 };
 

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -17,15 +17,13 @@ mod ban;
 mod connections;
 mod peerdb;
 
-use std::{collections::BTreeSet, fmt::Debug, str::FromStr, sync::Arc, time::Duration};
-
-use tokio::time::timeout;
+use std::{collections::BTreeSet, fmt::Debug, str::FromStr, sync::Arc};
 
 use common::primitives::semver::SemVer;
 
 use crate::{
     net::{
-        types::{ConnectivityEvent, PeerInfo, Protocol, ProtocolType},
+        types::{Protocol, ProtocolType},
         ConnectivityService, NetworkingService,
     },
     peer_manager::PeerManager,
@@ -54,40 +52,6 @@ where
 
     let p2p_config = Arc::new(P2pConfig::default());
     PeerManager::<T>::new(Arc::clone(&config), p2p_config, conn, rx, tx_sync)
-}
-
-async fn connect_services<T>(
-    conn1: &mut T::ConnectivityHandle,
-    conn2: &mut T::ConnectivityHandle,
-) -> (T::Address, PeerInfo<T>)
-where
-    T: NetworkingService + std::fmt::Debug,
-    T::ConnectivityHandle: ConnectivityService<T>,
-{
-    let addr = timeout(Duration::from_secs(5), conn2.local_addr())
-        .await
-        .expect("local address fetch not to timeout")
-        .unwrap()
-        .unwrap();
-    conn1.connect(addr).await.expect("dial to succeed");
-
-    let (address, peer_info) = match timeout(Duration::from_secs(5), conn2.poll_next()).await {
-        Ok(event) => match event.unwrap() {
-            ConnectivityEvent::InboundAccepted { address, peer_info } => (address, peer_info),
-            event => panic!("expected `InboundAccepted`, got {event:?}"),
-        },
-        Err(_err) => panic!("did not receive `InboundAccepted` in time"),
-    };
-
-    match timeout(Duration::from_secs(5), conn1.poll_next()).await {
-        Ok(event) => match event.unwrap() {
-            ConnectivityEvent::OutboundAccepted { .. } => {}
-            event => panic!("expected `OutboundAccepted`, got {event:?}"),
-        },
-        Err(_err) => panic!("did not receive `OutboundAccepted` in time"),
-    }
-
-    (address, peer_info)
 }
 
 /// Returns a set of minimal required protocols.

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -24,6 +24,7 @@ use crate::{
         transport::{ChannelMockTransport, TcpMockTransport},
         MockService,
     },
+    peer_manager::helpers::connect_services,
 };
 use p2p_test_utils::{MakeChannelAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress};
 

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -32,10 +32,9 @@ use p2p::{
         types::{PubSubTopic, SyncingEvent, ValidationResult},
         ConnectivityService, NetworkingService, SyncingMessagingService,
     },
+    peer_manager::helpers::connect_services,
 };
-use p2p_test_utils::{
-    connect_services, MakeChannelAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
-};
+use p2p_test_utils::{MakeChannelAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress};
 
 // Test announcements with multiple peers and verify that the message validation is done and peers
 // don't automatically forward the messages.


### PR DESCRIPTION
Rust analyzer shows some false positive errors in p2p integration tests:
![2022-11-15_16-54-55_938908271](https://user-images.githubusercontent.com/10401053/201950849-155b2940-7317-4972-acce-599ff6286fe2.png)

From the rust analyzer logs:
```
[ERROR project_model::workspace] cyclic deps: p2p_test_utils(CrateId(263)) -> p2p(CrateId(257)), alternative path: p2p(CrateId(257)) -> p2p_test_utils(CrateId(263))
```
I moved some code from `p2p/p2p-test-utils` crate to `p2p/tests/p2p_tests_common/mod.rs` file. This fixes the problem for me.