### PR TITLE
Allow calling unwrap in p2p/backend-test-suite

### DIFF
--- a/p2p/backend-test-suite/src/lib.rs
+++ b/p2p/backend-test-suite/src/lib.rs
@@ -15,6 +15,8 @@
 
 //! A test suite for p2p backends.
 
+#![allow(clippy::unwrap_used)]
+
 #[macro_use]
 mod utils;
 mod ban;


### PR DESCRIPTION
Fix warnings for unwrap calls from `./do_checks.sh`.