### PR TITLE
Fix remaining clippy warning from p2p tests

### DIFF
--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -31,6 +31,7 @@ use p2p::{
     error::{P2pError, PublishError},
     message::Announcement,
     net::{
+        mock::constants::ANNOUNCEMENT_MAX_SIZE,
         types::{PubSubTopic, SyncingEvent},
         ConnectivityService, NetworkingService, SyncingMessagingService,
     },
@@ -200,14 +201,12 @@ where
         .unwrap(),
     );
     let encoded_size = message.encode().len();
-    // TODO: move this to a spec.rs so it's accessible everywhere
-    const MAXIMUM_SIZE: usize = 2 * 1024 * 1024;
 
     assert_eq!(
         sync1.make_announcement(message).await,
         Err(P2pError::PublishError(PublishError::MessageTooLarge(
             Some(encoded_size),
-            Some(MAXIMUM_SIZE)
+            Some(ANNOUNCEMENT_MAX_SIZE)
         )))
     );
 }

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -14,12 +14,11 @@
 // limitations under the License.
 
 pub mod backend;
+pub mod constants;
 pub mod peer;
 pub mod request_manager;
 pub mod transport;
 pub mod types;
-
-mod constants;
 
 use std::{marker::PhantomData, sync::Arc};
 


### PR DESCRIPTION
@TheQuantumPhysicist  asked to fix it here: https://github.com/mintlayer/mintlayer-core/pull/564#pullrequestreview-1183883673

I made `p2p/src/net/mock/constants.rs` public. I think that should be OK because we plan to transform mock implementation into production p2p implementation.