### PR TITLE
Rename all swam occurrences

### DIFF
--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -254,8 +254,8 @@ impl From<libp2p::swarm::DialError> for P2pError {
     }
 }
 
-impl<T> From<libp2p::swarm::handler::ConnectionHandlerUpgrErr<T>> for P2pError {
-    fn from(err: libp2p::swarm::handler::ConnectionHandlerUpgrErr<T>) -> P2pError {
+impl<T> From<ConnectionHandlerUpgrErr<T>> for P2pError {
+    fn from(err: ConnectionHandlerUpgrErr<T>) -> P2pError {
         match err {
             ConnectionHandlerUpgrErr::Timeout => {
                 P2pError::ConnectionError(ConnectionError::Timeout)

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -13,12 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::net::NetworkingService;
-use common::chain::block::Block;
 use tokio::sync::oneshot;
 
+use common::chain::block::Block;
+
+use crate::net::NetworkingService;
+
 #[derive(Debug)]
-pub enum SwarmEvent<T: NetworkingService> {
+pub enum PeerManagerEvent<T: NetworkingService> {
     /// Try to establish connection with a remote peer
     Connect(T::Address, oneshot::Sender<crate::Result<()>>),
 

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -42,8 +42,8 @@ pub struct AddrInfo<T: NetworkingService> {
 /// When an inbound/outbound connection succeeds, the networking service handshakes with the remote
 /// peer, exchanges node information with them and verifies that the bare minimum requirements are met
 /// (both are Mintlayer nodes and that both support mandatory protocols). If those checks pass,
-/// the information is passed on to [crate::swarm::PeerManager] which decides whether it wants to keep
-/// the connection open or close it and possibly ban the peer from.
+/// the information is passed on to [crate::peer_manager::PeerManager] which decides whether it
+/// wants to keep the connection open or close it and possibly ban the peer from.
 #[derive(Debug)]
 pub struct PeerInfo<T: NetworkingService> {
     /// Unique ID of the peer

--- a/p2p/src/peer_manager/peerdb.rs
+++ b/p2p/src/peer_manager/peerdb.rs
@@ -20,11 +20,11 @@
 //! - idle peers
 //! - reserved peers (not implemented)
 //!
-//! Active peers are those peers that the [`crate::swarm::PeerManager`] has an active connection with
-//! whereas idle peers are the peers that are known to `PeerDb` but are not part of our swarm.
-//! Idle peers are discovered through various peer discovery mechanisms and they are used by
-//! [`crate::swarm::PeerManager::heartbeat()`] to establish new outbound connections if the actual
-//! number of active connection is less than the desired number of connections.
+//! Active peers are those peers that the [`crate::peer_manager::PeerManager`] has an active
+//! connection with whereas idle peers are the peers that are known to `PeerDb` but are not
+//! connected. Idle peers are discovered through various peer discovery mechanisms and they are
+//! used by [`crate::peer_manager::PeerManager::heartbeat()`] to establish new outbound connections
+//! if the actual number of active connection is less than the desired number of connections.
 //!
 //! TODO: reserved peers
 
@@ -193,7 +193,7 @@ impl<T: NetworkingService> PeerDb<T> {
         false
     }
 
-    /// Check if the peers is part of our active swarm
+    /// Checks if the peer is active.
     pub fn is_active_peer(&self, peer_id: &T::PeerId) -> bool {
         std::matches!(self.peers.get(peer_id), Some(Peer::Active(_)))
     }
@@ -257,7 +257,7 @@ impl<T: NetworkingService> PeerDb<T> {
 
     /// Report outbound connection failure
     ///
-    /// When [`crate::swarm::PeerManager::heartbeat()`] has initiated an outbound connection
+    /// When [`crate::peer_manager::PeerManager::heartbeat()`] has initiated an outbound connection
     /// and the connection is refused, it's reported back to the `PeerDb` so it knows to update
     /// the peer information accordingly by forgetting the address and adjusting the peer score
     /// appropriately.

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -38,7 +38,7 @@ where
     let addr = A::make_address();
     let peer_id = P::random();
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
 
     assert_eq!(
         mgr.validate_header_response(&peer_id, vec![]).await,
@@ -74,7 +74,7 @@ where
     let peer_id = P::random();
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let blocks = p2p_test_utils::create_n_blocks(
@@ -123,7 +123,7 @@ where
     let peer_id = P::random();
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let blocks = p2p_test_utils::create_n_blocks(
@@ -169,7 +169,7 @@ where
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let blocks = p2p_test_utils::create_n_blocks(
@@ -229,7 +229,7 @@ where
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let mut blocks = p2p_test_utils::create_n_blocks(

--- a/p2p/src/sync/tests/connection.rs
+++ b/p2p/src/sync/tests/connection.rs
@@ -33,7 +33,7 @@ where
     let addr = A::make_address();
     let peer_id = P::random();
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     assert_eq!(mgr.peers.len(), 1);
@@ -72,7 +72,7 @@ where
     let peer_id1 = P::random();
     let peer_id2 = P::random();
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
 
     // send Connected event to SyncManager
     register_peer(&mut mgr, peer_id1).await;

--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -37,7 +37,7 @@ where
     let peer_id = P::random();
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
@@ -82,7 +82,7 @@ where
     let addr = A::make_address();
     let peer_id = P::random();
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     assert_eq!(
@@ -121,7 +121,7 @@ where
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
@@ -170,7 +170,7 @@ where
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let headers = p2p_test_utils::create_n_blocks(
@@ -225,7 +225,7 @@ where
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     let mut headers = p2p_test_utils::create_n_blocks(
@@ -275,7 +275,7 @@ where
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
     register_peer(&mut mgr, peer_id).await;
 
     mgr.peers.get_mut(&peer_id).unwrap().set_state(peer::PeerSyncState::Unknown);
@@ -322,7 +322,7 @@ where
     let addr = A::make_address();
     let peer_id = P::random();
 
-    let (mut mgr, _conn, _sync, _swarm) = make_sync_manager::<T>(addr).await;
+    let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(addr).await;
 
     assert_eq!(
         mgr.validate_header_response(&peer_id, vec![]).await,

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -38,8 +38,8 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let (mut mgr1, mut conn1, _sync1, _swarm1) = make_sync_manager::<T>(addr1).await;
-    let (mut mgr2, mut conn2, _sync2, _swarm2) = make_sync_manager::<T>(addr2).await;
+    let (mut mgr1, mut conn1, _sync1, _pm1) = make_sync_manager::<T>(addr1).await;
+    let (mut mgr2, mut conn2, _sync2, _pm2) = make_sync_manager::<T>(addr2).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<T>(&mut conn1, &mut conn2).await;
@@ -100,8 +100,8 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let (mut mgr1, mut conn1, _sync1, _swarm1) = make_sync_manager::<T>(addr1).await;
-    let (mut mgr2, mut conn2, _sync2, _swarm2) = make_sync_manager::<T>(addr2).await;
+    let (mut mgr1, mut conn1, _sync1, _pm1) = make_sync_manager::<T>(addr1).await;
+    let (mut mgr2, mut conn2, _sync2, _pm2) = make_sync_manager::<T>(addr2).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<T>(&mut conn1, &mut conn2).await;
@@ -178,8 +178,8 @@ async fn test_multiple_requests_and_responses_mock_channels() {
         .await;
 }
 
-// receive getheaders before receiving `Connected` event from swarm manager
-// which makes the request to be rejected and to time out in the sender end
+// Receive getheaders before receiving the `Connected` event from the peer manager which makes the
+// request be rejected and time out in the sender's end.
 async fn test_request_timeout_error<A, T>()
 where
     A: MakeTestAddress<Address = T::Address>,
@@ -190,8 +190,8 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let (mut mgr1, mut conn1, _sync1, _swarm1) = make_sync_manager::<T>(addr1).await;
-    let (mut mgr2, mut conn2, _sync2, _swarm2) = make_sync_manager::<T>(addr2).await;
+    let (mut mgr1, mut conn1, _sync1, _pm1) = make_sync_manager::<T>(addr1).await;
+    let (mut mgr2, mut conn2, _sync2, _pm2) = make_sync_manager::<T>(addr2).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<T>(&mut conn1, &mut conn2).await;
@@ -269,8 +269,8 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let (mut mgr1, mut conn1, _sync1, mut swarm_rx) = make_sync_manager::<T>(addr1).await;
-    let (mut mgr2, mut conn2, _sync2, _swarm2) = make_sync_manager::<T>(addr2).await;
+    let (mut mgr1, mut conn1, _sync1, mut pm_rx) = make_sync_manager::<T>(addr1).await;
+    let (mut mgr2, mut conn2, _sync2, _pm2) = make_sync_manager::<T>(addr2).await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<T>(&mut conn1, &mut conn2).await;
@@ -295,8 +295,8 @@ where
 
         let (_tx, rx) = oneshot::channel();
         assert!(std::matches!(
-            swarm_rx.try_recv(),
-            Ok(SwarmEvent::Disconnect(_peer2_id, _tx))
+            pm_rx.try_recv(),
+            Ok(PeerManagerEvent::Disconnect(_peer2_id, _tx))
         ));
         assert_eq!(rx.await, Ok(()));
     });


### PR DESCRIPTION
The "swarm" is the `libp2p` specific term and we have our own "peer manager" abstraction.

There are no changes in logic in this pull request, only renaming.