### PR TITLE
Transport initialization updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,6 @@ dependencies = [
  "crypto",
  "libp2p",
  "mempool",
- "p2p",
  "portpicker",
  "subsystem",
  "tokio",

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -71,11 +71,14 @@ pub async fn initialize(
     });
 
     // P2P subsystem
+    let p2p_config = node_config.p2p.into();
+    let p2p_transport = p2p::net::libp2p::make_transport(&p2p_config);
     let p2p = manager.add_subsystem(
         "p2p",
         p2p::make_p2p::<p2p::net::libp2p::Libp2pService>(
+            p2p_transport,
             Arc::clone(&chain_config),
-            Arc::new(node_config.p2p.into()),
+            Arc::new(p2p_config),
             chainstate.clone(),
             mempool.clone(),
         )

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -71,14 +71,11 @@ pub async fn initialize(
     });
 
     // P2P subsystem
-    let p2p_config = node_config.p2p.into();
-    let p2p_transport = p2p::net::libp2p::make_transport(&p2p_config);
     let p2p = manager.add_subsystem(
         "p2p",
-        p2p::make_p2p::<p2p::net::libp2p::Libp2pService>(
-            p2p_transport,
+        p2p::make_p2p(
             Arc::clone(&chain_config),
-            Arc::new(p2p_config),
+            Arc::new(node_config.p2p.into()),
             chainstate.clone(),
             mempool.clone(),
         )

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 
+[features]
+default = []
+testing_utils = []
+
 [dependencies]
 common = { path = "../common/" }
 crypto = { path = "../crypto/" }

--- a/p2p/backend-test-suite/Cargo.toml
+++ b/p2p/backend-test-suite/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 
 [dependencies]
 common = { path = "../../common" }
-p2p = { path = "../../p2p" }
+p2p = { path = "../../p2p", features = ["testing_utils"] }
 p2p-test-utils = { path = "../p2p-test-utils" }
 logging = { path = "../../logging" }
 serialization = { path = "../../serialization" }

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -17,7 +17,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use tokio::sync::mpsc;
 
-use p2p::testing_utils::TestTransport;
+use p2p::testing_utils::TestTransportMaker;
 use p2p::{
     config::P2pConfig,
     error::{P2pError, PublishError},
@@ -38,7 +38,7 @@ tests![invalid_pubsub_block, invalid_sync_block,];
 // receives a `AdjustPeerScore` event which bans the peer of the second service.
 async fn invalid_pubsub_block<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -134,7 +134,7 @@ where
 // Start two networking services and give an invalid block, verify that `PeerManager` is informed.
 async fn invalid_sync_block<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -17,6 +17,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use tokio::sync::mpsc;
 
+use p2p::testing_utils::MakeTestAddress;
 use p2p::{
     config::P2pConfig,
     error::{P2pError, PublishError},
@@ -28,7 +29,7 @@ use p2p::{
     peer_manager::helpers::connect_services,
     sync::BlockSyncManager,
 };
-use p2p_test_utils::{MakeTestAddress, TestBlockInfo};
+use p2p_test_utils::TestBlockInfo;
 
 tests![invalid_pubsub_block, invalid_sync_block,];
 
@@ -37,7 +38,7 @@ tests![invalid_pubsub_block, invalid_sync_block,];
 // receives a `AdjustPeerScore` event which bans the peer of the second service.
 async fn invalid_pubsub_block<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -49,6 +50,7 @@ where
     let handle = p2p_test_utils::start_chainstate(Arc::clone(&chain_config)).await;
 
     let (mut conn1, sync1) = S::start(
+        A::make_transport(),
         A::make_address(),
         Arc::clone(&chain_config),
         Default::default(),
@@ -66,6 +68,7 @@ where
     );
 
     let (mut conn2, mut sync2) = S::start(
+        A::make_transport(),
         A::make_address(),
         Arc::clone(&chain_config),
         Arc::clone(&p2p_config),
@@ -131,7 +134,7 @@ where
 // Start two networking services and give an invalid block, verify that `PeerManager` is informed.
 async fn invalid_sync_block<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -142,6 +145,7 @@ where
     let handle = p2p_test_utils::start_chainstate(Arc::clone(&chain_config)).await;
 
     let (mut conn1, sync1) = S::start(
+        A::make_transport(),
         A::make_address(),
         Arc::clone(&chain_config),
         Default::default(),
@@ -150,6 +154,7 @@ where
     .unwrap();
 
     let (mut conn2, _sync2) = S::start(
+        A::make_transport(),
         A::make_address(),
         Arc::clone(&chain_config),
         Default::default(),

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -17,7 +17,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use tokio::sync::mpsc;
 
-use p2p::testing_utils::MakeTestAddress;
+use p2p::testing_utils::TestTransport;
 use p2p::{
     config::P2pConfig,
     error::{P2pError, PublishError},
@@ -38,7 +38,7 @@ tests![invalid_pubsub_block, invalid_sync_block,];
 // receives a `AdjustPeerScore` event which bans the peer of the second service.
 async fn invalid_pubsub_block<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -134,7 +134,7 @@ where
 // Start two networking services and give an invalid block, verify that `PeerManager` is informed.
 async fn invalid_sync_block<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -32,6 +32,7 @@ use common::{
 };
 use serialization::Encode;
 
+use p2p::testing_utils::MakeTestAddress;
 use p2p::{
     error::{P2pError, PublishError},
     message::Announcement,
@@ -42,7 +43,6 @@ use p2p::{
     },
     peer_manager::helpers::connect_services,
 };
-use p2p_test_utils::MakeTestAddress;
 
 tests![
     block_announcement,
@@ -52,20 +52,28 @@ tests![
 
 async fn block_announcement<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
 {
     let config = Arc::new(common::chain::config::create_mainnet());
-    let (mut conn1, mut sync1) =
-        S::start(A::make_address(), Arc::clone(&config), Default::default())
-            .await
-            .unwrap();
-    let (mut conn2, mut sync2) =
-        S::start(A::make_address(), Arc::clone(&config), Default::default())
-            .await
-            .unwrap();
+    let (mut conn1, mut sync1) = S::start(
+        A::make_transport(),
+        A::make_address(),
+        Arc::clone(&config),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    let (mut conn2, mut sync2) = S::start(
+        A::make_transport(),
+        A::make_address(),
+        Arc::clone(&config),
+        Default::default(),
+    )
+    .await
+    .unwrap();
 
     connect_services::<S>(&mut conn1, &mut conn2).await;
 
@@ -130,19 +138,28 @@ where
 
 async fn block_announcement_no_subscription<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
 {
     let config = Arc::new(common::chain::config::create_mainnet());
-    let (mut conn1, mut sync1) =
-        S::start(A::make_address(), Arc::clone(&config), Default::default())
-            .await
-            .unwrap();
-    let (mut conn2, _sync2) = S::start(A::make_address(), Arc::clone(&config), Default::default())
-        .await
-        .unwrap();
+    let (mut conn1, mut sync1) = S::start(
+        A::make_transport(),
+        A::make_address(),
+        Arc::clone(&config),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    let (mut conn2, _sync2) = S::start(
+        A::make_transport(),
+        A::make_address(),
+        Arc::clone(&config),
+        Default::default(),
+    )
+    .await
+    .unwrap();
 
     connect_services::<S>(&mut conn1, &mut conn2).await;
 
@@ -169,21 +186,29 @@ where
 
 async fn block_announcement_too_big_message<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
 {
     let config = Arc::new(common::chain::config::create_mainnet());
-    let (mut conn1, mut sync1) =
-        S::start(A::make_address(), Arc::clone(&config), Default::default())
-            .await
-            .unwrap();
+    let (mut conn1, mut sync1) = S::start(
+        A::make_transport(),
+        A::make_address(),
+        Arc::clone(&config),
+        Default::default(),
+    )
+    .await
+    .unwrap();
 
-    let (mut conn2, mut sync2) =
-        S::start(A::make_address(), Arc::clone(&config), Default::default())
-            .await
-            .unwrap();
+    let (mut conn2, mut sync2) = S::start(
+        A::make_transport(),
+        A::make_address(),
+        Arc::clone(&config),
+        Default::default(),
+    )
+    .await
+    .unwrap();
 
     connect_services::<S>(&mut conn1, &mut conn2).await;
 

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -32,7 +32,7 @@ use common::{
 };
 use serialization::Encode;
 
-use p2p::testing_utils::TestTransport;
+use p2p::testing_utils::TestTransportMaker;
 use p2p::{
     error::{P2pError, PublishError},
     message::Announcement,
@@ -52,7 +52,7 @@ tests![
 
 async fn block_announcement<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
@@ -138,7 +138,7 @@ where
 
 async fn block_announcement_no_subscription<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
@@ -186,7 +186,7 @@ where
 
 async fn block_announcement_too_big_message<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -32,7 +32,7 @@ use common::{
 };
 use serialization::Encode;
 
-use p2p::testing_utils::MakeTestAddress;
+use p2p::testing_utils::TestTransport;
 use p2p::{
     error::{P2pError, PublishError},
     message::Announcement,
@@ -52,7 +52,7 @@ tests![
 
 async fn block_announcement<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
@@ -138,7 +138,7 @@ where
 
 async fn block_announcement_no_subscription<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
@@ -186,7 +186,7 @@ where
 
 async fn block_announcement_too_big_message<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,

--- a/p2p/backend-test-suite/src/connect.rs
+++ b/p2p/backend-test-suite/src/connect.rs
@@ -17,7 +17,7 @@
 
 use std::{fmt::Debug, sync::Arc};
 
-use p2p::testing_utils::TestTransport;
+use p2p::testing_utils::TestTransportMaker;
 use p2p::{
     error::{DialError, P2pError},
     net::{ConnectivityService, NetworkingService, SyncingMessagingService},
@@ -32,7 +32,7 @@ tests![
 
 async fn connect<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -53,7 +53,7 @@ where
 #[cfg(not(target_os = "windows"))]
 async fn connect_address_in_use<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S> + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S> + Debug,
@@ -82,7 +82,7 @@ where
 // trying to connect to `service1`.
 async fn connect_accept<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + std::fmt::Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,

--- a/p2p/backend-test-suite/src/connect.rs
+++ b/p2p/backend-test-suite/src/connect.rs
@@ -17,7 +17,7 @@
 
 use std::{fmt::Debug, sync::Arc};
 
-use p2p::testing_utils::MakeTestAddress;
+use p2p::testing_utils::TestTransport;
 use p2p::{
     error::{DialError, P2pError},
     net::{ConnectivityService, NetworkingService, SyncingMessagingService},
@@ -32,7 +32,7 @@ tests![
 
 async fn connect<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -53,7 +53,7 @@ where
 #[cfg(not(target_os = "windows"))]
 async fn connect_address_in_use<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S> + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S> + Debug,
@@ -82,7 +82,7 @@ where
 // trying to connect to `service1`.
 async fn connect_accept<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + std::fmt::Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,

--- a/p2p/backend-test-suite/src/lib.rs
+++ b/p2p/backend-test-suite/src/lib.rs
@@ -29,12 +29,12 @@ use std::fmt::Debug;
 use libtest_mimic::{Arguments, Trial};
 
 use p2p::net::{ConnectivityService, NetworkingService, SyncingMessagingService};
-use p2p_test_utils::MakeTestAddress;
+use p2p::testing_utils::MakeTestAddress;
 
 /// Runs all tests.
 pub fn run<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S> + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S> + Debug,
@@ -47,7 +47,7 @@ where
 /// Collects all backend agnostic tests.
 fn tests<A, S>() -> Vec<Trial>
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S> + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S> + Debug,

--- a/p2p/backend-test-suite/src/lib.rs
+++ b/p2p/backend-test-suite/src/lib.rs
@@ -29,12 +29,12 @@ use std::fmt::Debug;
 use libtest_mimic::{Arguments, Trial};
 
 use p2p::net::{ConnectivityService, NetworkingService, SyncingMessagingService};
-use p2p::testing_utils::MakeTestAddress;
+use p2p::testing_utils::TestTransport;
 
 /// Runs all tests.
 pub fn run<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S> + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S> + Debug,
@@ -47,7 +47,7 @@ where
 /// Collects all backend agnostic tests.
 fn tests<A, S>() -> Vec<Trial>
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S> + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S> + Debug,

--- a/p2p/backend-test-suite/src/lib.rs
+++ b/p2p/backend-test-suite/src/lib.rs
@@ -29,12 +29,12 @@ use std::fmt::Debug;
 use libtest_mimic::{Arguments, Trial};
 
 use p2p::net::{ConnectivityService, NetworkingService, SyncingMessagingService};
-use p2p::testing_utils::TestTransport;
+use p2p::testing_utils::TestTransportMaker;
 
 /// Runs all tests.
 pub fn run<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S> + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S> + Debug,
@@ -47,7 +47,7 @@ where
 /// Collects all backend agnostic tests.
 fn tests<A, S>() -> Vec<Trial>
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S> + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S> + Debug,

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -27,7 +27,7 @@ use common::{
     chain::{config::ChainConfig, GenBlock},
     primitives::{Id, Idable},
 };
-use p2p::testing_utils::TestTransport;
+use p2p::testing_utils::TestTransportMaker;
 use p2p::{
     config::{MdnsConfig, P2pConfig},
     error::P2pError,
@@ -58,7 +58,7 @@ tests![
 
 async fn local_and_remote_in_sync<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -107,7 +107,7 @@ where
 // no blocks are downloaded whereas local node downloads the 7 new blocks from remote
 async fn remote_ahead_by_7_blocks<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -209,7 +209,7 @@ where
 // local and remote nodes are in the same chain but local is ahead of remote by 12 blocks
 async fn local_ahead_by_12_blocks<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -330,7 +330,7 @@ where
 // verify that remote nodes does a reorg
 async fn remote_local_diff_chains_local_higher<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -476,7 +476,7 @@ where
 // verify that local node does a reorg
 async fn remote_local_diff_chains_remote_higher<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -620,7 +620,7 @@ where
 
 async fn two_remote_nodes_different_chains<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -742,7 +742,7 @@ where
 
 async fn two_remote_nodes_same_chains<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -880,7 +880,7 @@ where
 
 async fn two_remote_nodes_same_chains_new_blocks<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -1032,7 +1032,7 @@ where
 // // verify that local node downloads the blocks and after that they are in sync
 async fn connect_disconnect_resyncing<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -1159,7 +1159,7 @@ where
 // Check that the peer that ignores requests is disconnected.
 async fn disconnect_unresponsive_peer<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -27,6 +27,7 @@ use common::{
     chain::{config::ChainConfig, GenBlock},
     primitives::{Id, Idable},
 };
+use p2p::testing_utils::MakeTestAddress;
 use p2p::{
     config::{MdnsConfig, P2pConfig},
     error::P2pError,
@@ -40,7 +41,7 @@ use p2p::{
     sync::BlockSyncManager,
     sync::SyncState,
 };
-use p2p_test_utils::{MakeTestAddress, TestBlockInfo};
+use p2p_test_utils::TestBlockInfo;
 
 tests![
     local_and_remote_in_sync,
@@ -57,7 +58,7 @@ tests![
 
 async fn local_and_remote_in_sync<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -67,10 +68,20 @@ where
     let mgr1_handle = handle1.clone();
     let mgr2_handle = handle2.clone();
 
-    let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle1, P2pConfig::default()).await;
-    let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle2, P2pConfig::default()).await;
+    let (mut mgr1, mut conn1, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle1,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr2, mut conn2, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle2,
+        P2pConfig::default(),
+    )
+    .await;
 
     // connect the two managers together so that they can exchange messages
     connect_services::<S>(&mut conn1, &mut conn2).await;
@@ -96,7 +107,7 @@ where
 // no blocks are downloaded whereas local node downloads the 7 new blocks from remote
 async fn remote_ahead_by_7_blocks<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -106,10 +117,20 @@ where
     let mgr1_handle = handle1.clone();
     let mgr2_handle = handle2.clone();
 
-    let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle1, P2pConfig::default()).await;
-    let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle2, P2pConfig::default()).await;
+    let (mut mgr1, mut conn1, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle1,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr2, mut conn2, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle2,
+        P2pConfig::default(),
+    )
+    .await;
 
     // add 7 more blocks on top of the best block (which is also known by mgr1)
     assert!(same_tip(&mgr1_handle, &mgr2_handle).await);
@@ -188,7 +209,7 @@ where
 // local and remote nodes are in the same chain but local is ahead of remote by 12 blocks
 async fn local_ahead_by_12_blocks<A, T>()
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -202,9 +223,9 @@ where
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<T>(addr1, handle1, P2pConfig::default()).await;
+        make_sync_manager::<T>(A::make_transport(), addr1, handle1, P2pConfig::default()).await;
     let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<T>(addr2, handle2, P2pConfig::default()).await;
+        make_sync_manager::<T>(A::make_transport(), addr2, handle2, P2pConfig::default()).await;
 
     // add 12 more blocks on top of the best block (which is also known by mgr2)
     assert!(same_tip(&mgr1_handle, &mgr2_handle).await);
@@ -309,7 +330,7 @@ where
 // verify that remote nodes does a reorg
 async fn remote_local_diff_chains_local_higher<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -323,9 +344,9 @@ where
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<S>(addr1, handle1, P2pConfig::default()).await;
+        make_sync_manager::<S>(A::make_transport(), addr1, handle1, P2pConfig::default()).await;
     let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<S>(addr2, handle2, P2pConfig::default()).await;
+        make_sync_manager::<S>(A::make_transport(), addr2, handle2, P2pConfig::default()).await;
 
     // add 14 more blocks to local chain and 7 more blocks to remote chain
     assert!(same_tip(&mgr1_handle, &mgr2_handle).await);
@@ -455,7 +476,7 @@ where
 // verify that local node does a reorg
 async fn remote_local_diff_chains_remote_higher<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -469,9 +490,9 @@ where
     let mgr2_handle = handle2.clone();
 
     let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<S>(addr1, handle1, P2pConfig::default()).await;
+        make_sync_manager::<S>(A::make_transport(), addr1, handle1, P2pConfig::default()).await;
     let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<S>(addr2, handle2, P2pConfig::default()).await;
+        make_sync_manager::<S>(A::make_transport(), addr2, handle2, P2pConfig::default()).await;
 
     // add 5 more blocks to local chain and 12 more blocks to remote chain
     assert!(same_tip(&mgr1_handle, &mgr2_handle).await);
@@ -599,7 +620,7 @@ where
 
 async fn two_remote_nodes_different_chains<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -610,12 +631,27 @@ where
     let mgr2_handle = handle2.clone();
     let mgr3_handle = handle3.clone();
 
-    let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle1, P2pConfig::default()).await;
-    let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle2, P2pConfig::default()).await;
-    let (mut mgr3, mut conn3, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle3, P2pConfig::default()).await;
+    let (mut mgr1, mut conn1, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle1,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr2, mut conn2, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle2,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr3, mut conn3, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle3,
+        P2pConfig::default(),
+    )
+    .await;
 
     // add 5 more blocks for first remote and 7 blocks to second remote
     p2p_test_utils::add_more_blocks(Arc::clone(&config), &mgr2_handle, 5).await;
@@ -706,7 +742,7 @@ where
 
 async fn two_remote_nodes_same_chains<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -717,12 +753,27 @@ where
     let mgr2_handle = handle2.clone();
     let mgr3_handle = handle3.clone();
 
-    let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle1, P2pConfig::default()).await;
-    let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle2, P2pConfig::default()).await;
-    let (mut mgr3, mut conn3, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle3, P2pConfig::default()).await;
+    let (mut mgr1, mut conn1, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle1,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr2, mut conn2, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle2,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr3, mut conn3, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle3,
+        P2pConfig::default(),
+    )
+    .await;
 
     // add the same 32 new blocks for both mgr2 and mgr3
     let blocks = p2p_test_utils::create_n_blocks(
@@ -829,7 +880,7 @@ where
 
 async fn two_remote_nodes_same_chains_new_blocks<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -840,12 +891,27 @@ where
     let mgr2_handle = handle2.clone();
     let mgr3_handle = handle3.clone();
 
-    let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle1, P2pConfig::default()).await;
-    let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle2, P2pConfig::default()).await;
-    let (mut mgr3, mut conn3, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle3, P2pConfig::default()).await;
+    let (mut mgr1, mut conn1, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle1,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr2, mut conn2, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle2,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr3, mut conn3, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle3,
+        P2pConfig::default(),
+    )
+    .await;
 
     // add the same 32 new blocks for both mgr2 and mgr3
     let blocks = p2p_test_utils::create_n_blocks(
@@ -966,7 +1032,7 @@ where
 // // verify that local node downloads the blocks and after that they are in sync
 async fn connect_disconnect_resyncing<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -976,10 +1042,20 @@ where
     let mgr1_handle = handle1.clone();
     let mgr2_handle = handle2.clone();
 
-    let (mut mgr1, mut conn1, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle1, P2pConfig::default()).await;
-    let (mut mgr2, mut conn2, _, _) =
-        make_sync_manager::<S>(A::make_address(), handle2, P2pConfig::default()).await;
+    let (mut mgr1, mut conn1, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle1,
+        P2pConfig::default(),
+    )
+    .await;
+    let (mut mgr2, mut conn2, _, _) = make_sync_manager::<S>(
+        A::make_transport(),
+        A::make_address(),
+        handle2,
+        P2pConfig::default(),
+    )
+    .await;
 
     connect_services::<S>(&mut conn1, &mut conn2).await;
     assert_eq!(mgr1.register_peer(*conn2.peer_id()).await, Ok(()));
@@ -1083,7 +1159,7 @@ where
 // Check that the peer that ignores requests is disconnected.
 async fn disconnect_unresponsive_peer<A, T>()
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -1097,10 +1173,20 @@ where
         mdns_config: MdnsConfig::Disabled.into(),
         request_timeout: Duration::from_secs(1).into(),
     };
-    let (mut mgr1, mut conn1, _sync1, mut pm1) =
-        make_sync_manager::<T>(A::make_address(), chainstate1, p2p_config).await;
-    let (_mgr2, mut conn2, _sync2, _pm2) =
-        make_sync_manager::<T>(A::make_address(), chainstate2, P2pConfig::default()).await;
+    let (mut mgr1, mut conn1, _sync1, mut pm1) = make_sync_manager::<T>(
+        A::make_transport(),
+        A::make_address(),
+        chainstate1,
+        p2p_config,
+    )
+    .await;
+    let (_mgr2, mut conn2, _sync2, _pm2) = make_sync_manager::<T>(
+        A::make_transport(),
+        A::make_address(),
+        chainstate2,
+        P2pConfig::default(),
+    )
+    .await;
 
     connect_services::<T>(&mut conn1, &mut conn2).await;
     let peer2_id = *conn2.peer_id();
@@ -1117,6 +1203,7 @@ where
 }
 
 async fn make_sync_manager<T>(
+    transport: T::Transport,
     addr: T::Address,
     chainstate: subsystem::Handle<Box<dyn ChainstateInterface>>,
     p2p_config: P2pConfig,
@@ -1138,9 +1225,14 @@ where
 
     let chain_config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(p2p_config);
-    let (conn, sync) = T::start(addr, Arc::clone(&chain_config), Arc::clone(&p2p_config))
-        .await
-        .unwrap();
+    let (conn, sync) = T::start(
+        transport,
+        addr,
+        Arc::clone(&chain_config),
+        Arc::clone(&p2p_config),
+    )
+    .await
+    .unwrap();
 
     (
         BlockSyncManager::<T>::new(

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -27,7 +27,7 @@ use common::{
     chain::{config::ChainConfig, GenBlock},
     primitives::{Id, Idable},
 };
-use p2p::testing_utils::MakeTestAddress;
+use p2p::testing_utils::TestTransport;
 use p2p::{
     config::{MdnsConfig, P2pConfig},
     error::P2pError,
@@ -58,7 +58,7 @@ tests![
 
 async fn local_and_remote_in_sync<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -107,7 +107,7 @@ where
 // no blocks are downloaded whereas local node downloads the 7 new blocks from remote
 async fn remote_ahead_by_7_blocks<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -209,7 +209,7 @@ where
 // local and remote nodes are in the same chain but local is ahead of remote by 12 blocks
 async fn local_ahead_by_12_blocks<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -330,7 +330,7 @@ where
 // verify that remote nodes does a reorg
 async fn remote_local_diff_chains_local_higher<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug + 'static,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -476,7 +476,7 @@ where
 // verify that local node does a reorg
 async fn remote_local_diff_chains_remote_higher<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -620,7 +620,7 @@ where
 
 async fn two_remote_nodes_different_chains<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -742,7 +742,7 @@ where
 
 async fn two_remote_nodes_same_chains<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -880,7 +880,7 @@ where
 
 async fn two_remote_nodes_same_chains_new_blocks<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -1032,7 +1032,7 @@ where
 // // verify that local node downloads the blocks and after that they are in sync
 async fn connect_disconnect_resyncing<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
@@ -1159,7 +1159,7 @@ where
 // Check that the peer that ignores requests is disconnected.
 async fn disconnect_unresponsive_peer<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,

--- a/p2p/backend-test-suite/src/utils.rs
+++ b/p2p/backend-test-suite/src/utils.rs
@@ -17,7 +17,7 @@ macro_rules! tests {
     ($($(#[$meta:meta])* $name:ident,)+) => {
         pub fn tests<A, S>() -> impl Iterator<Item = libtest_mimic::Trial>
         where
-            A: p2p::testing_utils::MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+            A: p2p::testing_utils::TestTransport<Transport = S::Transport, Address = S::Address>,
             S: p2p::net::NetworkingService + std::fmt::Debug + 'static,
             S::ConnectivityHandle: p2p::net::ConnectivityService<S> + std::fmt::Debug,
             S::SyncingMessagingHandle: p2p::net::SyncingMessagingService<S> + std::fmt::Debug,

--- a/p2p/backend-test-suite/src/utils.rs
+++ b/p2p/backend-test-suite/src/utils.rs
@@ -17,7 +17,7 @@ macro_rules! tests {
     ($($(#[$meta:meta])* $name:ident,)+) => {
         pub fn tests<A, S>() -> impl Iterator<Item = libtest_mimic::Trial>
         where
-            A: p2p_test_utils::MakeTestAddress<Address = S::Address>,
+            A: p2p::testing_utils::MakeTestAddress<Transport = S::Transport, Address = S::Address>,
             S: p2p::net::NetworkingService + std::fmt::Debug + 'static,
             S::ConnectivityHandle: p2p::net::ConnectivityService<S> + std::fmt::Debug,
             S::SyncingMessagingHandle: p2p::net::SyncingMessagingService<S> + std::fmt::Debug,

--- a/p2p/backend-test-suite/src/utils.rs
+++ b/p2p/backend-test-suite/src/utils.rs
@@ -17,7 +17,7 @@ macro_rules! tests {
     ($($(#[$meta:meta])* $name:ident,)+) => {
         pub fn tests<A, S>() -> impl Iterator<Item = libtest_mimic::Trial>
         where
-            A: p2p::testing_utils::TestTransport<Transport = S::Transport, Address = S::Address>,
+            A: p2p::testing_utils::TestTransportMaker<Transport = S::Transport, Address = S::Address>,
             S: p2p::net::NetworkingService + std::fmt::Debug + 'static,
             S::ConnectivityHandle: p2p::net::ConnectivityService<S> + std::fmt::Debug,
             S::SyncingMessagingHandle: p2p::net::SyncingMessagingService<S> + std::fmt::Debug,

--- a/p2p/p2p-test-utils/Cargo.toml
+++ b/p2p/p2p-test-utils/Cargo.toml
@@ -10,7 +10,6 @@ chainstate = { path = "../../chainstate/" }
 common = { path = "../../common/" }
 crypto = { path = "../../crypto/" }
 mempool = { path = "../../mempool/" }
-p2p = { path = "../" }
 subsystem = { path = "../../subsystem/" }
 
 portpicker = "0.1"

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -15,9 +15,7 @@
 
 #![allow(clippy::unwrap_used)]
 
-use std::{fmt::Debug, net::SocketAddr, sync::Arc};
-
-use libp2p::Multiaddr;
+use std::{fmt::Debug, sync::Arc};
 
 use chainstate::{
     chainstate_interface::ChainstateInterface, make_chainstate, BlockSource, ChainstateConfig,
@@ -234,48 +232,4 @@ pub async fn add_more_blocks(
 
     let blocks = create_n_blocks(config, base_block, nblocks);
     import_blocks(handle, blocks).await;
-}
-
-/// An interface for creating the address.
-///
-/// This abstraction layer is needed to uniformly create an address in the tests for different
-/// mocks transport implementations.
-pub trait MakeTestAddress {
-    /// An address type.
-    type Address: Clone + Debug + Eq + std::hash::Hash + Send + Sync + ToString;
-
-    /// Creates a new unused address.
-    ///
-    /// This should work similar to requesting a port of number 0 when opening a TCP connection.
-    fn make_address() -> Self::Address;
-}
-
-pub struct MakeP2pAddress {}
-
-impl MakeTestAddress for MakeP2pAddress {
-    type Address = Multiaddr;
-
-    fn make_address() -> Self::Address {
-        "/ip6/::1/tcp/0".parse().unwrap()
-    }
-}
-
-pub struct MakeTcpAddress {}
-
-impl MakeTestAddress for MakeTcpAddress {
-    type Address = SocketAddr;
-
-    fn make_address() -> Self::Address {
-        "[::1]:0".parse().unwrap()
-    }
-}
-
-pub struct MakeChannelAddress {}
-
-impl MakeTestAddress for MakeChannelAddress {
-    type Address = u64;
-
-    fn make_address() -> Self::Address {
-        0
-    }
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -146,23 +146,15 @@ impl subsystem::Subsystem for Box<dyn P2pInterface> {}
 
 pub type P2pHandle = subsystem::Handle<Box<dyn P2pInterface>>;
 
-pub async fn make_p2p<T>(
-    transport: T::Transport,
+pub async fn make_p2p(
     chain_config: Arc<ChainConfig>,
     p2p_config: Arc<P2pConfig>,
     chainstate_handle: subsystem::Handle<Box<dyn chainstate_interface::ChainstateInterface>>,
     mempool_handle: mempool::MempoolHandle,
-) -> crate::Result<Box<dyn P2pInterface>>
-where
-    T: NetworkingService + 'static,
-    T::ConnectivityHandle: ConnectivityService<T>,
-    T::SyncingMessagingHandle: SyncingMessagingService<T>,
-    <T as NetworkingService>::Address: FromStr,
-    <<T as NetworkingService>::Address as FromStr>::Err: Debug,
-    <T as NetworkingService>::PeerId: FromStr,
-    <<T as NetworkingService>::PeerId as FromStr>::Err: Debug,
-{
-    let p2p = P2p::<T>::new(
+) -> crate::Result<Box<dyn P2pInterface>> {
+    let transport = net::libp2p::make_transport(&p2p_config);
+
+    let p2p = P2p::<net::libp2p::Libp2pService>::new(
         transport,
         chain_config,
         p2p_config,
@@ -170,5 +162,6 @@ where
         mempool_handle,
     )
     .await?;
+
     Ok(Box::new(p2p))
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -23,6 +23,7 @@ pub mod net;
 pub mod peer_manager;
 pub mod rpc;
 pub mod sync;
+#[cfg(feature = "testing_utils")]
 pub mod testing_utils;
 
 use std::{fmt::Debug, str::FromStr, sync::Arc};

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -341,7 +341,7 @@ mod tests {
         self, connection_manager, discovery,
         sync_codec::{SyncMessagingCodec, SyncingProtocol},
     };
-    use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
+    use crate::testing_utils::{TestTransport, TestTransportLibp2p};
     use libp2p::{
         core::upgrade,
         gossipsub::{Gossipsub, GossipsubConfigBuilder, MessageAuthenticity},
@@ -422,7 +422,7 @@ mod tests {
 
         let (tx, rx) = oneshot::channel();
         let res = cmd_tx.send(types::Command::Listen {
-            addr: MakeP2pAddress::make_address(),
+            addr: TestTransportLibp2p::make_address(),
             response: tx,
         });
         assert!(res.is_ok());
@@ -446,7 +446,7 @@ mod tests {
 
         let (tx, rx) = oneshot::channel();
         let res = cmd_tx.send(types::Command::Listen {
-            addr: MakeP2pAddress::make_address(),
+            addr: TestTransportLibp2p::make_address(),
             response: tx,
         });
         assert!(res.is_ok());
@@ -458,7 +458,7 @@ mod tests {
         // try to bind to the same interface again
         let (tx, rx) = oneshot::channel();
         let res = cmd_tx.send(types::Command::Listen {
-            addr: MakeP2pAddress::make_address(),
+            addr: TestTransportLibp2p::make_address(),
             response: tx,
         });
         assert!(res.is_ok());

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -341,7 +341,7 @@ mod tests {
         self, connection_manager, discovery,
         sync_codec::{SyncMessagingCodec, SyncingProtocol},
     };
-    use crate::testing_utils::{TestTransport, TestTransportLibp2p};
+    use crate::testing_utils::{TestTransportLibp2p, TestTransportMaker};
     use libp2p::{
         core::upgrade,
         gossipsub::{Gossipsub, GossipsubConfigBuilder, MessageAuthenticity},

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -341,6 +341,7 @@ mod tests {
         self, connection_manager, discovery,
         sync_codec::{SyncMessagingCodec, SyncingProtocol},
     };
+    use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
     use libp2p::{
         core::upgrade,
         gossipsub::{Gossipsub, GossipsubConfigBuilder, MessageAuthenticity},
@@ -351,7 +352,6 @@ mod tests {
         tcp::{GenTcpConfig, TcpTransport},
         Transport,
     };
-    use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
     use std::{
         collections::{HashMap, VecDeque},
         iter,

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::Duration};
 use libp2p::{core::PeerId, multiaddr::Protocol, Multiaddr};
 use tokio::net::TcpListener;
 
-use crate::testing_utils::{TestTransport, TestTransportLibp2p};
+use crate::testing_utils::{TestTransportLibp2p, TestTransportMaker};
 use serialization::{Decode, Encode};
 
 use crate::{

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::Duration};
 use libp2p::{core::PeerId, multiaddr::Protocol, Multiaddr};
 use tokio::net::TcpListener;
 
-use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{TestTransport, TestTransportLibp2p};
 use serialization::{Decode, Encode};
 
 use crate::{
@@ -47,8 +47,8 @@ async fn test_connect_peer_id_missing() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let addr: Multiaddr = "/ip6/::1/tcp/8904".parse().unwrap();
     let (mut service, _) = Libp2pService::start(
-        MakeP2pAddress::make_transport(),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_transport(),
+        TestTransportLibp2p::make_address(),
         config,
         Default::default(),
     )
@@ -233,8 +233,8 @@ fn test_parse_peers_valid_3_peers_1_valid() {
 async fn test_connect_with_timeout() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let (mut service, _) = Libp2pService::start(
-        MakeP2pAddress::make_transport(),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_transport(),
+        TestTransportLibp2p::make_address(),
         config,
         Arc::new(P2pConfig {
             bind_address: "/ip6/::1/tcp/3031".to_owned().into(),

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::Duration};
 use libp2p::{core::PeerId, multiaddr::Protocol, Multiaddr};
 use tokio::net::TcpListener;
 
-use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
 use serialization::{Decode, Encode};
 
 use crate::{
@@ -46,10 +46,14 @@ struct Transaction {
 async fn test_connect_peer_id_missing() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let addr: Multiaddr = "/ip6/::1/tcp/8904".parse().unwrap();
-    let (mut service, _) =
-        Libp2pService::start(MakeP2pAddress::make_address(), config, Default::default())
-            .await
-            .unwrap();
+    let (mut service, _) = Libp2pService::start(
+        MakeP2pAddress::make_transport(),
+        MakeP2pAddress::make_address(),
+        config,
+        Default::default(),
+    )
+    .await
+    .unwrap();
 
     match service.connect(addr.clone()).await {
         Ok(_) => panic!("connect succeeded without peer id"),
@@ -229,6 +233,7 @@ fn test_parse_peers_valid_3_peers_1_valid() {
 async fn test_connect_with_timeout() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let (mut service, _) = Libp2pService::start(
+        MakeP2pAddress::make_transport(),
         MakeP2pAddress::make_address(),
         config,
         Arc::new(P2pConfig {

--- a/p2p/src/net/libp2p/tests/gossipsub.rs
+++ b/p2p/src/net/libp2p/tests/gossipsub.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use crate::net::libp2p::{behaviour, types::*};
-use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{TestTransport, TestTransportLibp2p};
 use futures::StreamExt;
 use libp2p::gossipsub::IdentTopic as Topic;
 use serialization::Encode;
@@ -26,7 +26,7 @@ async fn test_invalid_message() {
     let (mut backend1, _cmd1, _conn1, _sync1) = make_libp2p(
         common::chain::config::create_mainnet(),
         Default::default(),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[net::types::PubSubTopic::Blocks],
     )
     .await;
@@ -34,7 +34,7 @@ async fn test_invalid_message() {
     let (mut backend2, _cmd2, _conn2, _sync2) = make_libp2p(
         common::chain::config::create_mainnet(),
         Default::default(),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[net::types::PubSubTopic::Blocks],
     )
     .await;
@@ -87,7 +87,7 @@ async fn test_gossipsub_not_supported() {
     let (mut backend1, _cmd, _conn_rx, _sync_rx) = make_libp2p(
         config.clone(),
         Default::default(),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[net::types::PubSubTopic::Blocks],
     )
     .await;

--- a/p2p/src/net/libp2p/tests/gossipsub.rs
+++ b/p2p/src/net/libp2p/tests/gossipsub.rs
@@ -16,9 +16,9 @@
 
 use super::*;
 use crate::net::libp2p::{behaviour, types::*};
+use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
 use futures::StreamExt;
 use libp2p::gossipsub::IdentTopic as Topic;
-use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
 use serialization::Encode;
 
 #[tokio::test]

--- a/p2p/src/net/libp2p/tests/gossipsub.rs
+++ b/p2p/src/net/libp2p/tests/gossipsub.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 use crate::net::libp2p::{behaviour, types::*};
-use crate::testing_utils::{TestTransport, TestTransportLibp2p};
+use crate::testing_utils::{TestTransportLibp2p, TestTransportMaker};
 use futures::StreamExt;
 use libp2p::gossipsub::IdentTopic as Topic;
 use serialization::Encode;

--- a/p2p/src/net/libp2p/tests/identify.rs
+++ b/p2p/src/net/libp2p/tests/identify.rs
@@ -15,8 +15,8 @@
 
 use super::*;
 use crate::net::libp2p::behaviour;
+use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
 use libp2p::ping;
-use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
 use std::time::Duration;
 
 #[tokio::test]

--- a/p2p/src/net/libp2p/tests/identify.rs
+++ b/p2p/src/net/libp2p/tests/identify.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 use crate::net::libp2p::behaviour;
-use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{TestTransport, TestTransportLibp2p};
 use libp2p::ping;
 use std::time::Duration;
 
@@ -25,7 +25,7 @@ async fn test_identify_not_supported() {
     let (mut backend1, _cmd1, _conn1, _sync1) = make_libp2p(
         config.clone(),
         Default::default(),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[],
     )
     .await;

--- a/p2p/src/net/libp2p/tests/identify.rs
+++ b/p2p/src/net/libp2p/tests/identify.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 use crate::net::libp2p::behaviour;
-use crate::testing_utils::{TestTransport, TestTransportLibp2p};
+use crate::testing_utils::{TestTransportLibp2p, TestTransportMaker};
 use libp2p::ping;
 use std::time::Duration;
 

--- a/p2p/src/net/libp2p/tests/mdns.rs
+++ b/p2p/src/net/libp2p/tests/mdns.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::Duration};
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
 
-use crate::testing_utils::{TestTransport, TestTransportLibp2p};
+use crate::testing_utils::{TestTransportLibp2p, TestTransportMaker};
 
 use crate::{
     config::{MdnsConfig, P2pConfig},

--- a/p2p/src/net/libp2p/tests/mdns.rs
+++ b/p2p/src/net/libp2p/tests/mdns.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::Duration};
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
 
-use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
 
 use crate::{
     config::{MdnsConfig, P2pConfig},

--- a/p2p/src/net/libp2p/tests/mdns.rs
+++ b/p2p/src/net/libp2p/tests/mdns.rs
@@ -18,7 +18,7 @@ use std::{sync::Arc, time::Duration};
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
 
-use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{TestTransport, TestTransportLibp2p};
 
 use crate::{
     config::{MdnsConfig, P2pConfig},
@@ -44,7 +44,7 @@ async fn test_discovered_and_expired() {
             .into(),
             request_timeout: Duration::from_secs(10).into(),
         }),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[],
     )
     .await;
@@ -62,7 +62,7 @@ async fn test_discovered_and_expired() {
             .into(),
             request_timeout: Duration::from_secs(10).into(),
         }),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[],
     )
     .await;

--- a/p2p/src/net/libp2p/tests/ping.rs
+++ b/p2p/src/net/libp2p/tests/ping.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 use crate::net::libp2p::behaviour;
-use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{TestTransport, TestTransportLibp2p};
 use futures::StreamExt;
 use libp2p::{
     ping,
@@ -28,7 +28,7 @@ async fn test_remote_doesnt_respond() {
     let (mut backend1, _cmd, _conn_rx, _sync_rx) = make_libp2p_with_ping(
         common::chain::config::create_mainnet(),
         Arc::new(Default::default()),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[],
         make_ping(
             Some(Duration::from_secs(2)),
@@ -72,7 +72,7 @@ async fn test_ping_not_supported() {
     let (mut backend1, _cmd, _conn_rx, _) = make_libp2p_with_ping(
         config.clone(),
         Arc::new(Default::default()),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[],
         make_ping(
             Some(Duration::from_secs(2)),

--- a/p2p/src/net/libp2p/tests/ping.rs
+++ b/p2p/src/net/libp2p/tests/ping.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 use crate::net::libp2p::behaviour;
-use crate::testing_utils::{TestTransport, TestTransportLibp2p};
+use crate::testing_utils::{TestTransportLibp2p, TestTransportMaker};
 use futures::StreamExt;
 use libp2p::{
     ping,

--- a/p2p/src/net/libp2p/tests/ping.rs
+++ b/p2p/src/net/libp2p/tests/ping.rs
@@ -15,12 +15,12 @@
 
 use super::*;
 use crate::net::libp2p::behaviour;
+use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
 use futures::StreamExt;
 use libp2p::{
     ping,
     swarm::{SwarmBuilder, SwarmEvent},
 };
-use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
 use std::time::Duration;
 
 #[tokio::test]

--- a/p2p/src/net/libp2p/tests/request_response.rs
+++ b/p2p/src/net/libp2p/tests/request_response.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::testing_utils::{TestTransport, TestTransportLibp2p};
+use crate::testing_utils::{TestTransportLibp2p, TestTransportMaker};
 use crate::{
     error::{P2pError, PeerError},
     net::libp2p::{behaviour::sync_codec::message_types::SyncRequest, types},

--- a/p2p/src/net/libp2p/tests/request_response.rs
+++ b/p2p/src/net/libp2p/tests/request_response.rs
@@ -14,13 +14,13 @@
 // limitations under the License.
 
 use super::*;
+use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
 use crate::{
     error::{P2pError, PeerError},
     net::libp2p::{behaviour::sync_codec::message_types::SyncRequest, types},
 };
 use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
-use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
 use tokio::sync::oneshot;
 
 // try to send request to an unknown peer and verify that the request is not rejected

--- a/p2p/src/net/libp2p/tests/request_response.rs
+++ b/p2p/src/net/libp2p/tests/request_response.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{TestTransport, TestTransportLibp2p};
 use crate::{
     error::{P2pError, PeerError},
     net::libp2p::{behaviour::sync_codec::message_types::SyncRequest, types},
@@ -29,7 +29,7 @@ async fn request_sent_directly_but_peer_not_part_of_swarm() {
     let (mut backend, _cmd, _conn_rx, _sync_rx) = make_libp2p(
         common::chain::config::create_mainnet(),
         Arc::new(Default::default()),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[],
     )
     .await;
@@ -52,7 +52,7 @@ async fn request_sent_but_peer_not_part_of_swarm() {
     let (mut backend, _cmd, _conn_rx, _sync_rx) = make_libp2p(
         common::chain::config::create_mainnet(),
         Arc::new(Default::default()),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_address(),
         &[],
     )
     .await;

--- a/p2p/src/net/libp2p/tests/swarm.rs
+++ b/p2p/src/net/libp2p/tests/swarm.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 use crate::error::P2pError;
-use crate::testing_utils::{TestTransport, TestTransportLibp2p};
+use crate::testing_utils::{TestTransportLibp2p, TestTransportMaker};
 use futures::StreamExt;
 use libp2p::{
     core::upgrade,

--- a/p2p/src/net/libp2p/tests/swarm.rs
+++ b/p2p/src/net/libp2p/tests/swarm.rs
@@ -15,6 +15,7 @@
 
 use super::*;
 use crate::error::P2pError;
+use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
 use futures::StreamExt;
 use libp2p::{
     core::upgrade,
@@ -22,7 +23,6 @@ use libp2p::{
     swarm::{DialError, SwarmBuilder, SwarmEvent},
     PeerId, Swarm,
 };
-use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
 
 // TODO: add more tests at some point
 

--- a/p2p/src/net/libp2p/tests/swarm.rs
+++ b/p2p/src/net/libp2p/tests/swarm.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 use crate::error::P2pError;
-use crate::testing_utils::{MakeP2pAddress, MakeTestAddress};
+use crate::testing_utils::{TestTransport, TestTransportLibp2p};
 use futures::StreamExt;
 use libp2p::{
     core::upgrade,
@@ -62,7 +62,7 @@ async fn dial_then_disconnect() {
     let (_peer_id1, mut swarm1) = make_dummy_swarm();
     let (peer_id2, mut swarm2) = make_dummy_swarm();
 
-    swarm2.listen_on(MakeP2pAddress::make_address()).unwrap();
+    swarm2.listen_on(TestTransportLibp2p::make_address()).unwrap();
     let addr = get_address::<identify::Identify>(&mut swarm2).await;
 
     tokio::spawn(async move {
@@ -89,7 +89,7 @@ async fn disconnect_closing_connection() {
     let (_peer_id1, mut swarm1) = make_dummy_swarm();
     let (peer_id2, mut swarm2) = make_dummy_swarm();
 
-    swarm2.listen_on(MakeP2pAddress::make_address()).unwrap();
+    swarm2.listen_on(TestTransportLibp2p::make_address()).unwrap();
     let addr = get_address(&mut swarm2).await;
 
     tokio::spawn(async move {

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -386,21 +386,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::{transport::NoiseTcpTransport, *};
-    use crate::testing_utils::{MakeChannelAddress, MakeTcpAddress, MakeTestAddress};
+    use crate::testing_utils::{TestTransport, TestTransportChannel, TestTransportTcp};
     use crate::{
         net::{
             self,
             mock::transport::{MockChannelTransport, TcpTransportSocket},
             types::{Protocol, ProtocolType},
         },
-        testing_utils::MakeNoiseAddress,
+        testing_utils::TestTransportNoise,
     };
     use common::primitives::semver::SemVer;
     use std::fmt::Debug;
 
     async fn connect_to_remote<A, T>()
     where
-        A: MakeTestAddress<Transport = T, Address = T::Address>,
+        A: TestTransport<Transport = T, Address = T::Address>,
         T: TransportSocket + Debug,
     {
         let config = Arc::new(common::chain::config::create_mainnet());
@@ -454,22 +454,22 @@ mod tests {
 
     #[tokio::test]
     async fn connect_to_remote_tcp() {
-        connect_to_remote::<MakeTcpAddress, TcpTransportSocket>().await;
+        connect_to_remote::<TestTransportTcp, TcpTransportSocket>().await;
     }
 
     #[tokio::test]
     async fn connect_to_remote_channels() {
-        connect_to_remote::<MakeChannelAddress, MockChannelTransport>().await;
+        connect_to_remote::<TestTransportChannel, MockChannelTransport>().await;
     }
 
     #[tokio::test]
     async fn connect_to_remote_noise() {
-        connect_to_remote::<MakeNoiseAddress, NoiseTcpTransport>().await;
+        connect_to_remote::<TestTransportNoise, NoiseTcpTransport>().await;
     }
 
     async fn accept_incoming<A, T>()
     where
-        A: MakeTestAddress<Transport = T, Address = T::Address>,
+        A: TestTransport<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let config = Arc::new(common::chain::config::create_mainnet());
@@ -523,22 +523,22 @@ mod tests {
 
     #[tokio::test]
     async fn accept_incoming_tcp() {
-        accept_incoming::<MakeTcpAddress, TcpTransportSocket>().await;
+        accept_incoming::<TestTransportTcp, TcpTransportSocket>().await;
     }
 
     #[tokio::test]
     async fn accept_incoming_channels() {
-        accept_incoming::<MakeChannelAddress, MockChannelTransport>().await;
+        accept_incoming::<TestTransportChannel, MockChannelTransport>().await;
     }
 
     #[tokio::test]
     async fn accept_incoming_noise() {
-        accept_incoming::<MakeNoiseAddress, NoiseTcpTransport>().await;
+        accept_incoming::<TestTransportNoise, NoiseTcpTransport>().await;
     }
 
     async fn disconnect<A, T>()
     where
-        A: MakeTestAddress<Transport = T, Address = T::Address>,
+        A: TestTransport<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let config = Arc::new(common::chain::config::create_mainnet());
@@ -575,16 +575,16 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_tcp() {
-        disconnect::<MakeTcpAddress, TcpTransportSocket>().await;
+        disconnect::<TestTransportTcp, TcpTransportSocket>().await;
     }
 
     #[tokio::test]
     async fn disconnect_channels() {
-        disconnect::<MakeChannelAddress, MockChannelTransport>().await;
+        disconnect::<TestTransportChannel, MockChannelTransport>().await;
     }
 
     #[tokio::test]
     async fn disconnect_noise() {
-        disconnect::<MakeNoiseAddress, NoiseTcpTransport>().await;
+        disconnect::<TestTransportNoise, NoiseTcpTransport>().await;
     }
 }

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -386,7 +386,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{transport::NoiseTcpTransport, *};
-    use crate::testing_utils::{TestTransport, TestTransportChannel, TestTransportTcp};
+    use crate::testing_utils::{TestTransportChannel, TestTransportMaker, TestTransportTcp};
     use crate::{
         net::{
             self,
@@ -400,7 +400,7 @@ mod tests {
 
     async fn connect_to_remote<A, T>()
     where
-        A: TestTransport<Transport = T, Address = T::Address>,
+        A: TestTransportMaker<Transport = T, Address = T::Address>,
         T: TransportSocket + Debug,
     {
         let config = Arc::new(common::chain::config::create_mainnet());
@@ -469,7 +469,7 @@ mod tests {
 
     async fn accept_incoming<A, T>()
     where
-        A: TestTransport<Transport = T, Address = T::Address>,
+        A: TestTransportMaker<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let config = Arc::new(common::chain::config::create_mainnet());
@@ -538,7 +538,7 @@ mod tests {
 
     async fn disconnect<A, T>()
     where
-        A: TestTransport<Transport = T, Address = T::Address>,
+        A: TestTransportMaker<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let config = Arc::new(common::chain::config::create_mainnet());

--- a/p2p/src/net/mock/peer.rs
+++ b/p2p/src/net/mock/peer.rs
@@ -233,7 +233,7 @@ where
 mod tests {
     use super::*;
     use crate::testing_utils::{
-        MakeChannelAddress, MakeNoiseAddress, MakeTcpAddress, MakeTestAddress,
+        TestTransport, TestTransportChannel, TestTransportNoise, TestTransportTcp,
     };
     use crate::{
         message,
@@ -250,7 +250,7 @@ mod tests {
 
     async fn handshake_inbound<A, T>()
     where
-        A: MakeTestAddress<Transport = T, Address = T::Address>,
+        A: TestTransport<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -317,22 +317,22 @@ mod tests {
 
     #[tokio::test]
     async fn handshake_inbound_tcp() {
-        handshake_inbound::<MakeTcpAddress, TcpTransportSocket>().await;
+        handshake_inbound::<TestTransportTcp, TcpTransportSocket>().await;
     }
 
     #[tokio::test]
     async fn handshake_inbound_channels() {
-        handshake_inbound::<MakeChannelAddress, MockChannelTransport>().await;
+        handshake_inbound::<TestTransportChannel, MockChannelTransport>().await;
     }
 
     #[tokio::test]
     async fn handshake_inbound_noise() {
-        handshake_inbound::<MakeNoiseAddress, NoiseTcpTransport>().await;
+        handshake_inbound::<TestTransportNoise, NoiseTcpTransport>().await;
     }
 
     async fn handshake_outbound<A, T>()
     where
-        A: MakeTestAddress<Transport = T, Address = T::Address>,
+        A: TestTransport<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -402,22 +402,22 @@ mod tests {
 
     #[tokio::test]
     async fn handshake_outbound_tcp() {
-        handshake_outbound::<MakeTcpAddress, TcpTransportSocket>().await;
+        handshake_outbound::<TestTransportTcp, TcpTransportSocket>().await;
     }
 
     #[tokio::test]
     async fn handshake_outbound_channels() {
-        handshake_outbound::<MakeChannelAddress, MockChannelTransport>().await;
+        handshake_outbound::<TestTransportChannel, MockChannelTransport>().await;
     }
 
     #[tokio::test]
     async fn handshake_outbound_noise() {
-        handshake_outbound::<MakeNoiseAddress, NoiseTcpTransport>().await;
+        handshake_outbound::<TestTransportNoise, NoiseTcpTransport>().await;
     }
 
     async fn handshake_different_network<A, T>()
     where
-        A: MakeTestAddress<Transport = T, Address = T::Address>,
+        A: TestTransport<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -463,22 +463,22 @@ mod tests {
 
     #[tokio::test]
     async fn handshake_different_network_tcp() {
-        handshake_different_network::<MakeTcpAddress, TcpTransportSocket>().await;
+        handshake_different_network::<TestTransportTcp, TcpTransportSocket>().await;
     }
 
     #[tokio::test]
     async fn handshake_different_network_channels() {
-        handshake_different_network::<MakeChannelAddress, MockChannelTransport>().await;
+        handshake_different_network::<TestTransportChannel, MockChannelTransport>().await;
     }
 
     #[tokio::test]
     async fn handshake_different_network_noise() {
-        handshake_different_network::<MakeNoiseAddress, NoiseTcpTransport>().await;
+        handshake_different_network::<TestTransportNoise, NoiseTcpTransport>().await;
     }
 
     async fn invalid_handshake_message<A, T>()
     where
-        A: MakeTestAddress<Transport = T, Address = T::Address>,
+        A: TestTransport<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -520,22 +520,22 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_handshake_message_tcp() {
-        invalid_handshake_message::<MakeTcpAddress, TcpTransportSocket>().await;
+        invalid_handshake_message::<TestTransportTcp, TcpTransportSocket>().await;
     }
 
     #[tokio::test]
     async fn invalid_handshake_message_channels() {
-        invalid_handshake_message::<MakeChannelAddress, MockChannelTransport>().await;
+        invalid_handshake_message::<TestTransportChannel, MockChannelTransport>().await;
     }
 
     #[tokio::test]
     async fn invalid_handshake_message_noise() {
-        invalid_handshake_message::<MakeNoiseAddress, NoiseTcpTransport>().await;
+        invalid_handshake_message::<TestTransportNoise, NoiseTcpTransport>().await;
     }
 
     pub async fn get_two_connected_sockets<A, T>() -> (T::Stream, T::Stream)
     where
-        A: MakeTestAddress<Transport = T, Address = T::Address>,
+        A: TestTransport<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let transport = A::make_transport();

--- a/p2p/src/net/mock/peer.rs
+++ b/p2p/src/net/mock/peer.rs
@@ -233,7 +233,7 @@ where
 mod tests {
     use super::*;
     use crate::testing_utils::{
-        TestTransport, TestTransportChannel, TestTransportNoise, TestTransportTcp,
+        TestTransportChannel, TestTransportMaker, TestTransportNoise, TestTransportTcp,
     };
     use crate::{
         message,
@@ -250,7 +250,7 @@ mod tests {
 
     async fn handshake_inbound<A, T>()
     where
-        A: TestTransport<Transport = T, Address = T::Address>,
+        A: TestTransportMaker<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -332,7 +332,7 @@ mod tests {
 
     async fn handshake_outbound<A, T>()
     where
-        A: TestTransport<Transport = T, Address = T::Address>,
+        A: TestTransportMaker<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -417,7 +417,7 @@ mod tests {
 
     async fn handshake_different_network<A, T>()
     where
-        A: TestTransport<Transport = T, Address = T::Address>,
+        A: TestTransportMaker<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -478,7 +478,7 @@ mod tests {
 
     async fn invalid_handshake_message<A, T>()
     where
-        A: TestTransport<Transport = T, Address = T::Address>,
+        A: TestTransportMaker<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -535,7 +535,7 @@ mod tests {
 
     pub async fn get_two_connected_sockets<A, T>() -> (T::Stream, T::Stream)
     where
-        A: TestTransport<Transport = T, Address = T::Address>,
+        A: TestTransportMaker<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let transport = A::make_transport();

--- a/p2p/src/net/mock/peer.rs
+++ b/p2p/src/net/mock/peer.rs
@@ -232,6 +232,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testing_utils::{
+        MakeChannelAddress, MakeNoiseAddress, MakeTcpAddress, MakeTestAddress,
+    };
     use crate::{
         message,
         net::mock::{
@@ -244,11 +247,10 @@ mod tests {
     use chainstate::Locator;
     use common::primitives::semver::SemVer;
     use futures::FutureExt;
-    use p2p_test_utils::{MakeChannelAddress, MakeTcpAddress, MakeTestAddress};
 
     async fn handshake_inbound<A, T>()
     where
-        A: MakeTestAddress<Address = T::Address>,
+        A: MakeTestAddress<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -325,12 +327,12 @@ mod tests {
 
     #[tokio::test]
     async fn handshake_inbound_noise() {
-        handshake_inbound::<MakeTcpAddress, NoiseTcpTransport>().await;
+        handshake_inbound::<MakeNoiseAddress, NoiseTcpTransport>().await;
     }
 
     async fn handshake_outbound<A, T>()
     where
-        A: MakeTestAddress<Address = T::Address>,
+        A: MakeTestAddress<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -410,12 +412,12 @@ mod tests {
 
     #[tokio::test]
     async fn handshake_outbound_noise() {
-        handshake_outbound::<MakeTcpAddress, NoiseTcpTransport>().await;
+        handshake_outbound::<MakeNoiseAddress, NoiseTcpTransport>().await;
     }
 
     async fn handshake_different_network<A, T>()
     where
-        A: MakeTestAddress<Address = T::Address>,
+        A: MakeTestAddress<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -471,12 +473,12 @@ mod tests {
 
     #[tokio::test]
     async fn handshake_different_network_noise() {
-        handshake_different_network::<MakeTcpAddress, NoiseTcpTransport>().await;
+        handshake_different_network::<MakeNoiseAddress, NoiseTcpTransport>().await;
     }
 
     async fn invalid_handshake_message<A, T>()
     where
-        A: MakeTestAddress<Address = T::Address>,
+        A: MakeTestAddress<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
@@ -528,15 +530,15 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_handshake_message_noise() {
-        invalid_handshake_message::<MakeTcpAddress, NoiseTcpTransport>().await;
+        invalid_handshake_message::<MakeNoiseAddress, NoiseTcpTransport>().await;
     }
 
     pub async fn get_two_connected_sockets<A, T>() -> (T::Stream, T::Stream)
     where
-        A: MakeTestAddress<Address = T::Address>,
+        A: MakeTestAddress<Transport = T, Address = T::Address>,
         T: TransportSocket,
     {
-        let transport = T::new();
+        let transport = A::make_transport();
         let addr = A::make_address();
         let mut server = transport.bind(addr).await.unwrap();
         let peer_fut = transport.connect(server.local_address().unwrap());

--- a/p2p/src/net/mock/transport/impls/channel.rs
+++ b/p2p/src/net/mock/transport/impls/channel.rs
@@ -48,16 +48,18 @@ static CONNECTIONS: Lazy<Mutex<BTreeMap<Address, UnboundedSender<Sender<DuplexSt
 #[derive(Debug)]
 pub struct MockChannelTransport;
 
+impl MockChannelTransport {
+    pub fn new() -> Self {
+        MockChannelTransport
+    }
+}
+
 #[async_trait]
 impl TransportSocket for MockChannelTransport {
     type Address = Address;
     type BannableAddress = Address;
     type Listener = MockChannelListener;
     type Stream = ChannelMockStream;
-
-    fn new() -> Self {
-        Self
-    }
 
     async fn bind(&self, address: Self::Address) -> Result<Self::Listener> {
         let mut connections = CONNECTIONS.lock().expect("Connections mutex is poisoned");

--- a/p2p/src/net/mock/transport/impls/stream_adapter/identity.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/identity.rs
@@ -22,13 +22,15 @@ use super::StreamAdapter;
 #[derive(Debug, Clone)]
 pub struct IdentityStreamAdapter;
 
+impl IdentityStreamAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
 /// A StreamAdapter that does nothing with no handshake (Identity operation on data that goes through it)
 impl<T: PeerStream + 'static> StreamAdapter<T> for IdentityStreamAdapter {
     type Stream = T;
-
-    fn new() -> Self {
-        Self
-    }
 
     fn handshake(&self, base: T, _role: Role) -> BoxFuture<'static, crate::Result<Self::Stream>> {
         Box::pin(ready(Ok(base)))

--- a/p2p/src/net/mock/transport/impls/stream_adapter/identity.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/identity.rs
@@ -19,7 +19,7 @@ use crate::net::mock::{peer::Role, transport::PeerStream};
 
 use super::StreamAdapter;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IdentityStreamAdapter;
 
 /// A StreamAdapter that does nothing with no handshake (Identity operation on data that goes through it)

--- a/p2p/src/net/mock/transport/impls/stream_adapter/noise.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/noise.rs
@@ -38,6 +38,15 @@ pub struct NoiseEncryptionAdapter {
     local_key: snowstorm::Keypair,
 }
 
+impl NoiseEncryptionAdapter {
+    pub fn gen_new() -> Self {
+        let local_key = snowstorm::Builder::new(NOISE_HANDSHAKE_PARAMS.clone())
+            .generate_keypair()
+            .expect("key generation must succeed");
+        Self { local_key }
+    }
+}
+
 impl std::fmt::Debug for NoiseEncryptionAdapter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NoiseEncryptionAdapter").finish()
@@ -58,13 +67,6 @@ impl Clone for NoiseEncryptionAdapter {
 /// StreamAdapter that encrypts the data going through it with noise protocol
 impl<T: PeerStream + 'static> StreamAdapter<T> for NoiseEncryptionAdapter {
     type Stream = snowstorm::NoiseStream<T>;
-
-    fn new() -> Self {
-        let local_key = snowstorm::Builder::new(NOISE_HANDSHAKE_PARAMS.clone())
-            .generate_keypair()
-            .expect("key generation must succeed");
-        Self { local_key }
-    }
 
     fn handshake(&self, base: T, role: Role) -> BoxFuture<'static, crate::Result<Self::Stream>> {
         let local_key = self.clone().local_key;

--- a/p2p/src/net/mock/transport/impls/stream_adapter/traits.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/traits.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// Represents a stream that requires a handshake to function (such as encrypted streams)
-pub trait StreamAdapter<T>: Send + Sync + 'static {
+pub trait StreamAdapter<T>: Clone + Send + Sync + 'static {
     type Stream: PeerStream;
 
     fn new() -> Self;

--- a/p2p/src/net/mock/transport/impls/stream_adapter/traits.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/traits.rs
@@ -24,8 +24,6 @@ use crate::{
 pub trait StreamAdapter<T>: Clone + Send + Sync + 'static {
     type Stream: PeerStream;
 
-    fn new() -> Self;
-
     /// Wraps base async stream into AsyncRead/AsyncWrite stream that may implement encryption.
     fn handshake(&self, base: T, role: Role) -> BoxFuture<'static, Result<Self::Stream>>;
 }

--- a/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/tests.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/tests.rs
@@ -18,9 +18,9 @@ use std::{
     time::Duration,
 };
 
+use crate::testing_utils::{MakeChannelAddress, MakeTcpAddress, MakeTestAddress};
 use async_trait::async_trait;
 use futures::StreamExt;
-use p2p_test_utils::{MakeChannelAddress, MakeTcpAddress, MakeTestAddress};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     time::timeout,

--- a/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/tests.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/tests.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use crate::testing_utils::{TestTransport, TestTransportChannel, TestTransportTcp};
+use crate::testing_utils::{TestTransportChannel, TestTransportMaker, TestTransportTcp};
 use async_trait::async_trait;
 use futures::StreamExt;
 use tokio::{
@@ -51,7 +51,7 @@ async fn send_recv<T: PeerStream>(sender: &mut T, receiver: &mut T, len: usize) 
     assert_eq!(send_data, recv_data);
 }
 
-async fn test<A: TestTransport<Address = T::Address>, T: TransportSocket>(transport: T) {
+async fn test<A: TestTransportMaker<Address = T::Address>, T: TransportSocket>(transport: T) {
     let mut server = transport.bind(A::make_address()).await.unwrap();
     let peer_fut = transport.connect(server.local_address().unwrap());
 

--- a/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/wrapped_listener.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/wrapped_listener.rs
@@ -36,10 +36,20 @@ pub const MAX_CONCURRENT_HANDSHAKES: usize = 100;
 
 /// A listener (acceptor) object that handles new incoming connections, and does any required handshakes
 pub struct AdaptedListener<S: StreamAdapter<T::Stream>, T: TransportSocket> {
-    pub stream_adapter: S,
-    pub listener: T::Listener,
+    stream_adapter: S,
+    listener: T::Listener,
     #[allow(clippy::type_complexity)]
-    pub handshakes: Vec<(BoxFuture<'static, Result<S::Stream>>, T::Address)>,
+    handshakes: Vec<(BoxFuture<'static, Result<S::Stream>>, T::Address)>,
+}
+
+impl<S: StreamAdapter<T::Stream>, T: TransportSocket> AdaptedListener<S, T> {
+    pub fn new(stream_adapter: S, listener: T::Listener) -> Self {
+        Self {
+            stream_adapter,
+            listener,
+            handshakes: Vec::new(),
+        }
+    }
 }
 
 #[async_trait]

--- a/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/wrapped_socket.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/wrapped_socket.rs
@@ -53,7 +53,7 @@ impl<S: StreamAdapter<T::Stream>, T: TransportSocket> TransportSocket
     }
 
     async fn bind(&self, address: Self::Address) -> Result<Self::Listener> {
-        let stream_adapter = S::new();
+        let stream_adapter = self.stream_adapter.clone();
         let listener = self.base_transport.bind(address).await?;
         Ok(AdaptedListener {
             listener,

--- a/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/wrapped_socket.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/wrapped_socket.rs
@@ -34,6 +34,15 @@ pub struct WrappedTransportSocket<S, T> {
     pub base_transport: T,
 }
 
+impl<S, T> WrappedTransportSocket<S, T> {
+    pub fn new(stream_adapter: S, base_transport: T) -> Self {
+        Self {
+            stream_adapter,
+            base_transport,
+        }
+    }
+}
+
 #[async_trait]
 impl<S: StreamAdapter<T::Stream>, T: TransportSocket> TransportSocket
     for WrappedTransportSocket<S, T>
@@ -42,15 +51,6 @@ impl<S: StreamAdapter<T::Stream>, T: TransportSocket> TransportSocket
     type BannableAddress = T::BannableAddress;
     type Listener = AdaptedListener<S, T>;
     type Stream = S::Stream;
-
-    fn new() -> Self {
-        let base_transport = T::new();
-        let stream_adapter = S::new();
-        Self {
-            stream_adapter,
-            base_transport,
-        }
-    }
 
     async fn bind(&self, address: Self::Address) -> Result<Self::Listener> {
         let stream_adapter = self.stream_adapter.clone();

--- a/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/wrapped_socket.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/wrapped_socket.rs
@@ -55,11 +55,7 @@ impl<S: StreamAdapter<T::Stream>, T: TransportSocket> TransportSocket
     async fn bind(&self, address: Self::Address) -> Result<Self::Listener> {
         let stream_adapter = self.stream_adapter.clone();
         let listener = self.base_transport.bind(address).await?;
-        Ok(AdaptedListener {
-            listener,
-            stream_adapter,
-            handshakes: Vec::new(),
-        })
+        Ok(AdaptedListener::new(stream_adapter, listener))
     }
 
     async fn connect(&self, address: Self::Address) -> Result<Self::Stream> {

--- a/p2p/src/net/mock/transport/impls/tcp.rs
+++ b/p2p/src/net/mock/transport/impls/tcp.rs
@@ -42,10 +42,6 @@ impl TransportSocket for TcpTransportSocket {
     type Listener = TcpTransportListener;
     type Stream = TcpTransportStream;
 
-    fn new() -> Self {
-        Self
-    }
-
     async fn bind(&self, address: Self::Address) -> Result<Self::Listener> {
         TcpTransportListener::new(address).await
     }

--- a/p2p/src/net/mock/transport/impls/tcp.rs
+++ b/p2p/src/net/mock/transport/impls/tcp.rs
@@ -98,7 +98,7 @@ impl PeerStream for TcpTransportStream {}
 
 #[cfg(test)]
 mod tests {
-    use crate::testing_utils::{TestTransport, TestTransportTcp};
+    use crate::testing_utils::{TestTransportMaker, TestTransportTcp};
 
     use super::*;
     use crate::net::{

--- a/p2p/src/net/mock/transport/impls/tcp.rs
+++ b/p2p/src/net/mock/transport/impls/tcp.rs
@@ -98,7 +98,7 @@ impl PeerStream for TcpTransportStream {}
 
 #[cfg(test)]
 mod tests {
-    use crate::testing_utils::{MakeTcpAddress, MakeTestAddress};
+    use crate::testing_utils::{TestTransport, TestTransportTcp};
 
     use super::*;
     use crate::net::{
@@ -112,7 +112,7 @@ mod tests {
     #[tokio::test]
     async fn send_recv() {
         let transport = TcpTransportSocket::new();
-        let mut server = transport.bind(MakeTcpAddress::make_address()).await.unwrap();
+        let mut server = transport.bind(TestTransportTcp::make_address()).await.unwrap();
         let peer_fut = transport.connect(server.local_address().unwrap());
 
         let (server_res, peer_res) = tokio::join!(server.accept(), peer_fut);
@@ -143,7 +143,7 @@ mod tests {
     #[tokio::test]
     async fn send_2_reqs() {
         let transport = TcpTransportSocket::new();
-        let mut server = transport.bind(MakeTcpAddress::make_address()).await.unwrap();
+        let mut server = transport.bind(TestTransportTcp::make_address()).await.unwrap();
         let peer_fut = transport.connect(server.local_address().unwrap());
 
         let (server_res, peer_res) = tokio::join!(server.accept(), peer_fut);

--- a/p2p/src/net/mock/transport/impls/tcp.rs
+++ b/p2p/src/net/mock/transport/impls/tcp.rs
@@ -102,7 +102,7 @@ impl PeerStream for TcpTransportStream {}
 
 #[cfg(test)]
 mod tests {
-    use p2p_test_utils::{MakeTcpAddress, MakeTestAddress};
+    use crate::testing_utils::{MakeTcpAddress, MakeTestAddress};
 
     use super::*;
     use crate::net::{

--- a/p2p/src/net/mock/transport/traits/socket.rs
+++ b/p2p/src/net/mock/transport/traits/socket.rs
@@ -51,9 +51,6 @@ pub trait TransportSocket: Send + Sync + 'static {
     /// A messages stream.
     type Stream: PeerStream;
 
-    /// Creates a new transport.
-    fn new() -> Self;
-
     /// Creates a new listener bound to the specified address.
     async fn bind(&self, address: Self::Address) -> Result<Self::Listener>;
 

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -34,7 +34,7 @@ use crate::{config, message, message::Announcement};
 pub trait NetworkingService {
     /// A generic networking transport.
     ///
-    /// Can be used to initialize networking transport with authentification keys for example.
+    /// Can be used to initialize networking transport with authentication keys for example.
     type Transport;
 
     /// A generic network address.

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -32,6 +32,11 @@ use crate::{config, message, message::Announcement};
 /// that each network service provider must implement
 #[async_trait]
 pub trait NetworkingService {
+    /// A generic networking transport.
+    ///
+    /// Can be used to initialize networking transport with authentification keys for example.
+    type Transport;
+
     /// A generic network address.
     ///
     /// Although the `Address` allows a fallible conversion to `BannableAddress`, a valid address
@@ -81,6 +86,7 @@ pub trait NetworkingService {
     /// `bind_addr` - socket address for incoming P2P traffic
     /// `chain_config` - chain config of the node
     async fn start(
+        transport: Self::Transport,
         bind_addr: Self::Address,
         chain_config: Arc<common::chain::ChainConfig>,
         p2p_config: Arc<config::P2pConfig>,

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -16,7 +16,8 @@
 use std::sync::Arc;
 
 use crate::testing_utils::{
-    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
+    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+    TestTransportTcp,
 };
 use common::{chain::config, primitives::semver::SemVer};
 
@@ -40,7 +41,7 @@ use crate::{
 // ban peer whose connected to us
 async fn ban_connected_peer<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -95,7 +96,7 @@ async fn ban_connected_peer_mock_noise() {
 
 async fn banned_peer_attempts_to_connect<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + std::fmt::Debug + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -166,7 +167,7 @@ async fn banned_peer_attempts_to_connect_mock_noise() {
 // attempt to connect to banned peer
 async fn connect_to_banned_peer<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -241,7 +242,7 @@ async fn connect_to_banned_peer_mock_noise() {
 
 async fn validate_invalid_outbound_connection<A, S>(peer_address: S::Address, peer_id: S::PeerId)
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + std::fmt::Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     <S as net::NetworkingService>::Address: std::str::FromStr,
@@ -353,7 +354,7 @@ async fn validate_invalid_outbound_connection_mock_noise() {
 
 async fn validate_invalid_inbound_connection<A, S>(peer_address: S::Address, peer_id: S::PeerId)
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + std::fmt::Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     <S as net::NetworkingService>::Address: std::str::FromStr,
@@ -464,7 +465,7 @@ async fn validate_invalid_inbound_connection_mock_noise() {
 
 async fn inbound_connection_invalid_magic<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -16,7 +16,7 @@
 use std::sync::Arc;
 
 use crate::testing_utils::{
-    MakeChannelAddress, MakeNoiseAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
+    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
 };
 use common::{chain::config, primitives::semver::SemVer};
 
@@ -40,7 +40,7 @@ use crate::{
 // ban peer whose connected to us
 async fn ban_connected_peer<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -72,12 +72,12 @@ where
 
 #[tokio::test]
 async fn ban_connected_peer_libp2p() {
-    ban_connected_peer::<MakeP2pAddress, Libp2pService>().await;
+    ban_connected_peer::<TestTransportLibp2p, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn ban_connected_peer_mock_tcp() {
-    ban_connected_peer::<MakeTcpAddress, MockService<TcpTransportSocket>>().await;
+    ban_connected_peer::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 #[ignore]
@@ -85,17 +85,17 @@ async fn ban_connected_peer_mock_tcp() {
 async fn ban_connected_peer_mock_channels() {
     // TODO: Currently in the channels backend peer receives a new address every time it connects.
     // For the banning to work properly the addresses must be persistent.
-    ban_connected_peer::<MakeChannelAddress, MockService<MockChannelTransport>>().await;
+    ban_connected_peer::<TestTransportChannel, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn ban_connected_peer_mock_noise() {
-    ban_connected_peer::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
+    ban_connected_peer::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }
 
 async fn banned_peer_attempts_to_connect<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + std::fmt::Debug + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -138,21 +138,21 @@ where
 
 #[tokio::test]
 async fn banned_peer_attempts_to_connect_libp2p() {
-    banned_peer_attempts_to_connect::<MakeP2pAddress, Libp2pService>().await;
+    banned_peer_attempts_to_connect::<TestTransportLibp2p, Libp2pService>().await;
 }
 
 #[ignore]
 #[tokio::test]
 async fn banned_peer_attempts_to_connect_mock_tcp() {
     // TODO: implement proper peer banning
-    banned_peer_attempts_to_connect::<MakeTcpAddress, MockService<TcpTransportSocket>>().await;
+    banned_peer_attempts_to_connect::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 #[ignore]
 #[tokio::test]
 async fn banned_peer_attempts_to_connect_mock_channel() {
     // TODO: implement proper peer banning
-    banned_peer_attempts_to_connect::<MakeChannelAddress, MockService<MockChannelTransport>>()
+    banned_peer_attempts_to_connect::<TestTransportChannel, MockService<MockChannelTransport>>()
         .await;
 }
 
@@ -160,13 +160,13 @@ async fn banned_peer_attempts_to_connect_mock_channel() {
 #[tokio::test]
 async fn banned_peer_attempts_to_connect_mock_noise() {
     // TODO: implement proper peer banning
-    banned_peer_attempts_to_connect::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
+    banned_peer_attempts_to_connect::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }
 
 // attempt to connect to banned peer
 async fn connect_to_banned_peer<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -218,12 +218,12 @@ where
 
 #[tokio::test]
 async fn connect_to_banned_peer_libp2p() {
-    connect_to_banned_peer::<MakeP2pAddress, Libp2pService>().await;
+    connect_to_banned_peer::<TestTransportLibp2p, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn connect_to_banned_peer_mock_tcp() {
-    connect_to_banned_peer::<MakeTcpAddress, MockService<TcpTransportSocket>>().await;
+    connect_to_banned_peer::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 #[ignore]
@@ -231,17 +231,17 @@ async fn connect_to_banned_peer_mock_tcp() {
 async fn connect_to_banned_peer_mock_channels() {
     // TODO: Currently in the channels backend peer receives a new address every time it connects.
     // For the banning to work properly the addresses must be persistent.
-    connect_to_banned_peer::<MakeChannelAddress, MockService<MockChannelTransport>>().await;
+    connect_to_banned_peer::<TestTransportChannel, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn connect_to_banned_peer_mock_noise() {
-    connect_to_banned_peer::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
+    connect_to_banned_peer::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }
 
 async fn validate_invalid_outbound_connection<A, S>(peer_address: S::Address, peer_id: S::PeerId)
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + std::fmt::Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     <S as net::NetworkingService>::Address: std::str::FromStr,
@@ -317,7 +317,7 @@ where
 
 #[tokio::test]
 async fn validate_invalid_outbound_connection_libp2p() {
-    validate_invalid_outbound_connection::<MakeP2pAddress, Libp2pService>(
+    validate_invalid_outbound_connection::<TestTransportLibp2p, Libp2pService>(
         "/ip4/175.69.140.46".parse().unwrap(),
         libp2p::PeerId::random(),
     )
@@ -326,7 +326,7 @@ async fn validate_invalid_outbound_connection_libp2p() {
 
 #[tokio::test]
 async fn validate_invalid_outbound_connection_mock_tcp() {
-    validate_invalid_outbound_connection::<MakeTcpAddress, MockService<TcpTransportSocket>>(
+    validate_invalid_outbound_connection::<TestTransportTcp, MockService<TcpTransportSocket>>(
         "210.113.67.107:2525".parse().unwrap(),
         MockPeerId::random(),
     )
@@ -335,7 +335,7 @@ async fn validate_invalid_outbound_connection_mock_tcp() {
 
 #[tokio::test]
 async fn validate_invalid_outbound_connection_mock_channels() {
-    validate_invalid_outbound_connection::<MakeChannelAddress, MockService<MockChannelTransport>>(
+    validate_invalid_outbound_connection::<TestTransportChannel, MockService<MockChannelTransport>>(
         1,
         MockPeerId::random(),
     )
@@ -344,7 +344,7 @@ async fn validate_invalid_outbound_connection_mock_channels() {
 
 #[tokio::test]
 async fn validate_invalid_outbound_connection_mock_noise() {
-    validate_invalid_outbound_connection::<MakeNoiseAddress, MockService<NoiseTcpTransport>>(
+    validate_invalid_outbound_connection::<TestTransportNoise, MockService<NoiseTcpTransport>>(
         "210.113.67.107:2525".parse().unwrap(),
         MockPeerId::random(),
     )
@@ -353,7 +353,7 @@ async fn validate_invalid_outbound_connection_mock_noise() {
 
 async fn validate_invalid_inbound_connection<A, S>(peer_address: S::Address, peer_id: S::PeerId)
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + 'static + std::fmt::Debug,
     S::ConnectivityHandle: ConnectivityService<S>,
     <S as net::NetworkingService>::Address: std::str::FromStr,
@@ -428,7 +428,7 @@ where
 
 #[tokio::test]
 async fn validate_invalid_inbound_connection_libp2p() {
-    validate_invalid_inbound_connection::<MakeP2pAddress, Libp2pService>(
+    validate_invalid_inbound_connection::<TestTransportLibp2p, Libp2pService>(
         "/ip4/175.69.140.46".parse().unwrap(),
         libp2p::PeerId::random(),
     )
@@ -437,7 +437,7 @@ async fn validate_invalid_inbound_connection_libp2p() {
 
 #[tokio::test]
 async fn validate_invalid_inbound_connection_mock_tcp() {
-    validate_invalid_inbound_connection::<MakeTcpAddress, MockService<TcpTransportSocket>>(
+    validate_invalid_inbound_connection::<TestTransportTcp, MockService<TcpTransportSocket>>(
         "210.113.67.107:2525".parse().unwrap(),
         MockPeerId::random(),
     )
@@ -446,7 +446,7 @@ async fn validate_invalid_inbound_connection_mock_tcp() {
 
 #[tokio::test]
 async fn validate_invalid_inbound_connection_mock_channels() {
-    validate_invalid_inbound_connection::<MakeChannelAddress, MockService<MockChannelTransport>>(
+    validate_invalid_inbound_connection::<TestTransportChannel, MockService<MockChannelTransport>>(
         1,
         MockPeerId::random(),
     )
@@ -455,7 +455,7 @@ async fn validate_invalid_inbound_connection_mock_channels() {
 
 #[tokio::test]
 async fn validate_invalid_inbound_connection_mock_noise() {
-    validate_invalid_inbound_connection::<MakeNoiseAddress, MockService<NoiseTcpTransport>>(
+    validate_invalid_inbound_connection::<TestTransportNoise, MockService<NoiseTcpTransport>>(
         "210.113.67.107:2525".parse().unwrap(),
         MockPeerId::random(),
     )
@@ -464,7 +464,7 @@ async fn validate_invalid_inbound_connection_mock_noise() {
 
 async fn inbound_connection_invalid_magic<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -508,21 +508,21 @@ where
 
 #[tokio::test]
 async fn inbound_connection_invalid_magic_libp2p() {
-    inbound_connection_invalid_magic::<MakeP2pAddress, Libp2pService>().await;
+    inbound_connection_invalid_magic::<TestTransportLibp2p, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn inbound_connection_invalid_magic_mock_tcp() {
-    inbound_connection_invalid_magic::<MakeTcpAddress, MockService<TcpTransportSocket>>().await;
+    inbound_connection_invalid_magic::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn inbound_connection_invalid_magic_mock_channels() {
-    inbound_connection_invalid_magic::<MakeChannelAddress, MockService<MockChannelTransport>>()
+    inbound_connection_invalid_magic::<TestTransportChannel, MockService<MockChannelTransport>>()
         .await;
 }
 
 #[tokio::test]
 async fn inbound_connection_invalid_magic_mock_noise() {
-    inbound_connection_invalid_magic::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
+    inbound_connection_invalid_magic::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -19,7 +19,8 @@ use libp2p::{Multiaddr, PeerId};
 use tokio::{sync::oneshot, time::timeout};
 
 use crate::testing_utils::{
-    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
+    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+    TestTransportTcp,
 };
 use common::{chain::config, primitives::semver::SemVer};
 
@@ -95,7 +96,7 @@ async fn test_peer_manager_connect_libp2p() {
 // is below the desired threshold and there are idle peers in the peerdb
 async fn test_auto_connect<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -154,7 +155,7 @@ async fn test_auto_connect_mock_noise() {
 
 async fn connect_outbound_same_network<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -248,7 +249,7 @@ async fn test_validate_supported_protocols() {
 
 async fn connect_outbound_different_network<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -298,7 +299,7 @@ async fn connect_outbound_different_network_mock_noise() {
 
 async fn connect_inbound_same_network<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -341,7 +342,7 @@ async fn connect_inbound_same_network_mock_noise() {
 
 async fn connect_inbound_different_network<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -401,7 +402,7 @@ async fn connect_inbound_different_network_mock_noise() {
 
 async fn remote_closes_connection<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -463,7 +464,7 @@ async fn remote_closes_connection_mock_noise() {
 
 async fn inbound_connection_too_many_peers<A, T>(peers: Vec<net::types::PeerInfo<T>>)
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -18,8 +18,10 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use libp2p::{Multiaddr, PeerId};
 use tokio::{sync::oneshot, time::timeout};
 
+use crate::testing_utils::{
+    MakeChannelAddress, MakeNoiseAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
+};
 use common::{chain::config, primitives::semver::SemVer};
-use p2p_test_utils::{MakeChannelAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress};
 
 use crate::{
     error::{DialError, P2pError, ProtocolError},
@@ -44,6 +46,7 @@ use crate::{
 
 // try to connect to an address that no one listening on and verify it fails
 async fn test_peer_manager_connect<T: NetworkingService>(
+    transport: T::Transport,
     bind_addr: T::Address,
     remote_addr: T::Address,
 ) where
@@ -53,7 +56,7 @@ async fn test_peer_manager_connect<T: NetworkingService>(
     <<T as net::NetworkingService>::Address as std::str::FromStr>::Err: std::fmt::Debug,
 {
     let config = Arc::new(config::create_mainnet());
-    let mut peer_manager = make_peer_manager::<T>(bind_addr, config).await;
+    let mut peer_manager = make_peer_manager::<T>(transport, bind_addr, config).await;
 
     peer_manager.connect(remote_addr).await.unwrap();
 
@@ -68,28 +71,31 @@ async fn test_peer_manager_connect<T: NetworkingService>(
 
 #[tokio::test]
 async fn test_peer_manager_connect_mock() {
+    let transport = MakeTcpAddress::make_transport();
     let bind_addr = MakeTcpAddress::make_address();
     let remote_addr: SocketAddr = "[::1]:1".parse().unwrap();
 
-    test_peer_manager_connect::<MockService<TcpTransportSocket>>(bind_addr, remote_addr).await;
+    test_peer_manager_connect::<MockService<TcpTransportSocket>>(transport, bind_addr, remote_addr)
+        .await;
 }
 
 #[tokio::test]
 async fn test_peer_manager_connect_libp2p() {
+    let transport = MakeP2pAddress::make_transport();
     let bind_addr = MakeP2pAddress::make_address();
     let remote_addr: Multiaddr =
         "/ip6/::1/tcp/6666/p2p/12D3KooWRn14SemPVxwzdQNg8e8Trythiww1FWrNfPbukYBmZEbJ"
             .parse()
             .unwrap();
 
-    test_peer_manager_connect::<Libp2pService>(bind_addr, remote_addr).await;
+    test_peer_manager_connect::<Libp2pService>(transport, bind_addr, remote_addr).await;
 }
 
 // verify that the auto-connect functionality works if the number of active connections
 // is below the desired threshold and there are idle peers in the peerdb
 async fn test_auto_connect<A, T>()
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -99,8 +105,8 @@ where
     let addr2 = A::make_address();
 
     let config = Arc::new(config::create_mainnet());
-    let mut pm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
-    let mut pm2 = make_peer_manager::<T>(addr2, config).await;
+    let mut pm1 = make_peer_manager::<T>(A::make_transport(), addr1, Arc::clone(&config)).await;
+    let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
     let addr = pm2.peer_connectivity_handle.local_addr().await.unwrap().unwrap();
     let peer_id = *pm2.peer_connectivity_handle.peer_id();
@@ -143,12 +149,12 @@ async fn test_auto_connect_mock_channels() {
 
 #[tokio::test]
 async fn test_auto_connect_mock_noise() {
-    test_auto_connect::<MakeTcpAddress, MockService<NoiseTcpTransport>>().await;
+    test_auto_connect::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
 }
 
 async fn connect_outbound_same_network<A, T>()
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -158,8 +164,8 @@ where
     let addr2 = A::make_address();
 
     let config = Arc::new(config::create_mainnet());
-    let mut pm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
-    let mut pm2 = make_peer_manager::<T>(addr2, config).await;
+    let mut pm1 = make_peer_manager::<T>(A::make_transport(), addr1, Arc::clone(&config)).await;
+    let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
     connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
@@ -185,14 +191,18 @@ async fn connect_outbound_same_network_mock_channels() {
 
 #[tokio::test]
 async fn connect_outbound_same_network_mock_noise() {
-    connect_outbound_same_network::<MakeTcpAddress, MockService<NoiseTcpTransport>>().await;
+    connect_outbound_same_network::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
 }
 
 #[tokio::test]
 async fn test_validate_supported_protocols() {
     let config = Arc::new(config::create_mainnet());
-    let peer_manager =
-        make_peer_manager::<Libp2pService>(MakeP2pAddress::make_address(), config).await;
+    let peer_manager = make_peer_manager::<Libp2pService>(
+        MakeP2pAddress::make_transport(),
+        MakeP2pAddress::make_address(),
+        config,
+    )
+    .await;
 
     // all needed protocols
     assert!(peer_manager.validate_supported_protocols(&default_protocols()));
@@ -237,7 +247,7 @@ async fn test_validate_supported_protocols() {
 
 async fn connect_outbound_different_network<A, T>()
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -247,8 +257,9 @@ where
     let addr2 = A::make_address();
 
     let config = Arc::new(config::create_mainnet());
-    let mut pm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
+    let mut pm1 = make_peer_manager::<T>(A::make_transport(), addr1, Arc::clone(&config)).await;
     let mut pm2 = make_peer_manager::<T>(
+        A::make_transport(),
         addr2,
         Arc::new(common::chain::config::Builder::test_chain().magic_bytes([1, 2, 3, 4]).build()),
     )
@@ -280,12 +291,12 @@ async fn connect_outbound_different_network_mock_channels() {
 
 #[tokio::test]
 async fn connect_outbound_different_network_mock_noise() {
-    connect_outbound_different_network::<MakeTcpAddress, MockService<NoiseTcpTransport>>().await;
+    connect_outbound_different_network::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
 }
 
 async fn connect_inbound_same_network<A, T>()
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -295,8 +306,8 @@ where
     let addr2 = A::make_address();
 
     let config = Arc::new(config::create_mainnet());
-    let mut pm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
-    let mut pm2 = make_peer_manager::<T>(addr2, config).await;
+    let mut pm1 = make_peer_manager::<T>(A::make_transport(), addr1, Arc::clone(&config)).await;
+    let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
     let (address, peer_info) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
@@ -323,12 +334,12 @@ async fn connect_inbound_same_network_mock_channel() {
 
 #[tokio::test]
 async fn connect_inbound_same_network_mock_noise() {
-    connect_inbound_same_network::<MakeTcpAddress, MockService<NoiseTcpTransport>>().await;
+    connect_inbound_same_network::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
 }
 
 async fn connect_inbound_different_network<A, T>()
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -337,8 +348,14 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let mut pm1 = make_peer_manager::<T>(addr1, Arc::new(config::create_mainnet())).await;
+    let mut pm1 = make_peer_manager::<T>(
+        A::make_transport(),
+        addr1,
+        Arc::new(config::create_mainnet()),
+    )
+    .await;
     let mut pm2 = make_peer_manager::<T>(
+        A::make_transport(),
         addr2,
         Arc::new(common::chain::config::Builder::test_chain().magic_bytes([1, 2, 3, 4]).build()),
     )
@@ -377,12 +394,12 @@ async fn connect_inbound_different_network_mock_channels() {
 
 #[tokio::test]
 async fn connect_inbound_different_network_mock_noise() {
-    connect_inbound_different_network::<MakeTcpAddress, MockService<NoiseTcpTransport>>().await;
+    connect_inbound_different_network::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
 }
 
 async fn remote_closes_connection<A, T>()
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -391,8 +408,18 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let mut pm1 = make_peer_manager::<T>(addr1, Arc::new(config::create_mainnet())).await;
-    let mut pm2 = make_peer_manager::<T>(addr2, Arc::new(config::create_mainnet())).await;
+    let mut pm1 = make_peer_manager::<T>(
+        A::make_transport(),
+        addr1,
+        Arc::new(config::create_mainnet()),
+    )
+    .await;
+    let mut pm2 = make_peer_manager::<T>(
+        A::make_transport(),
+        addr2,
+        Arc::new(config::create_mainnet()),
+    )
+    .await;
 
     let (_address, _peer_info) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
@@ -429,12 +456,12 @@ async fn remote_closes_connection_mock_channels() {
 
 #[tokio::test]
 async fn remote_closes_connection_mock_noise() {
-    remote_closes_connection::<MakeTcpAddress, MockService<NoiseTcpTransport>>().await;
+    remote_closes_connection::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
 }
 
 async fn inbound_connection_too_many_peers<A, T>(peers: Vec<net::types::PeerInfo<T>>)
 where
-    A: MakeTestAddress<Address = T::Address>,
+    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -445,8 +472,8 @@ where
     let default_addr = A::make_address();
 
     let config = Arc::new(config::create_mainnet());
-    let mut pm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
-    let mut pm2 = make_peer_manager::<T>(addr2, Arc::clone(&config)).await;
+    let mut pm1 = make_peer_manager::<T>(A::make_transport(), addr1, Arc::clone(&config)).await;
+    let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, Arc::clone(&config)).await;
 
     peers.into_iter().for_each(|info| {
         pm1.peerdb.peer_connected(default_addr.clone(), info);
@@ -560,11 +587,11 @@ async fn inbound_connection_too_many_peers_mock_noise() {
         })
         .collect::<Vec<_>>();
 
-    inbound_connection_too_many_peers::<MakeTcpAddress, MockService<NoiseTcpTransport>>(peers)
+    inbound_connection_too_many_peers::<MakeNoiseAddress, MockService<NoiseTcpTransport>>(peers)
         .await;
 }
 
-async fn connection_timeout<T>(addr1: T::Address, addr2: T::Address)
+async fn connection_timeout<T>(transport: T::Transport, addr1: T::Address, addr2: T::Address)
 where
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -572,7 +599,7 @@ where
     <<T as net::NetworkingService>::Address as std::str::FromStr>::Err: std::fmt::Debug,
 {
     let config = Arc::new(config::create_mainnet());
-    let mut pm1 = make_peer_manager::<T>(addr1, Arc::clone(&config)).await;
+    let mut pm1 = make_peer_manager::<T>(transport, addr1, Arc::clone(&config)).await;
 
     pm1.peer_connectivity_handle.connect(addr2).await.expect("dial to succeed");
 
@@ -596,6 +623,7 @@ where
 #[tokio::test]
 async fn connection_timeout_libp2p() {
     connection_timeout::<Libp2pService>(
+        MakeP2pAddress::make_transport(),
         MakeP2pAddress::make_address(),
         format!("/ip4/255.255.255.255/tcp/8888/p2p/{}", PeerId::random())
             .parse()
@@ -607,6 +635,7 @@ async fn connection_timeout_libp2p() {
 #[tokio::test]
 async fn connection_timeout_mock_tcp() {
     connection_timeout::<MockService<TcpTransportSocket>>(
+        MakeTcpAddress::make_transport(),
         MakeTcpAddress::make_address(),
         MakeTcpAddress::make_address(),
     )
@@ -616,6 +645,7 @@ async fn connection_timeout_mock_tcp() {
 #[tokio::test]
 async fn connection_timeout_mock_channels() {
     connection_timeout::<MockService<MockChannelTransport>>(
+        MakeChannelAddress::make_transport(),
         MakeChannelAddress::make_address(),
         65_535,
     )
@@ -625,15 +655,19 @@ async fn connection_timeout_mock_channels() {
 #[tokio::test]
 async fn connection_timeout_mock_noise() {
     connection_timeout::<MockService<NoiseTcpTransport>>(
-        MakeTcpAddress::make_address(),
-        MakeTcpAddress::make_address(),
+        MakeNoiseAddress::make_transport(),
+        MakeNoiseAddress::make_address(),
+        MakeNoiseAddress::make_address(),
     )
     .await;
 }
 
 // try to establish a new connection through RPC and verify that it is notified of the timeout
-async fn connection_timeout_rpc_notified<T>(addr1: T::Address, addr2: T::Address)
-where
+async fn connection_timeout_rpc_notified<T>(
+    transport: T::Transport,
+    addr1: T::Address,
+    addr2: T::Address,
+) where
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     <T as net::NetworkingService>::Address: std::str::FromStr,
@@ -641,7 +675,14 @@ where
 {
     let config = Arc::new(config::create_mainnet());
     let p2p_config = Arc::new(Default::default());
-    let (conn, _) = T::start(addr1, Arc::clone(&config), Arc::clone(&p2p_config)).await.unwrap();
+    let (conn, _) = T::start(
+        transport,
+        addr1,
+        Arc::clone(&config),
+        Arc::clone(&p2p_config),
+    )
+    .await
+    .unwrap();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let (tx_sync, mut rx_sync) = tokio::sync::mpsc::unbounded_channel();
 
@@ -682,6 +723,7 @@ where
 #[tokio::test]
 async fn connection_timeout_rpc_notified_libp2p() {
     connection_timeout_rpc_notified::<Libp2pService>(
+        MakeP2pAddress::make_transport(),
         MakeP2pAddress::make_address(),
         format!("/ip4/255.255.255.255/tcp/8888/p2p/{}", PeerId::random())
             .parse()
@@ -693,6 +735,7 @@ async fn connection_timeout_rpc_notified_libp2p() {
 #[tokio::test]
 async fn connection_timeout_rpc_notified_mock_tcp() {
     connection_timeout_rpc_notified::<MockService<TcpTransportSocket>>(
+        MakeTcpAddress::make_transport(),
         MakeTcpAddress::make_address(),
         MakeTcpAddress::make_address(),
     )
@@ -702,6 +745,7 @@ async fn connection_timeout_rpc_notified_mock_tcp() {
 #[tokio::test]
 async fn connection_timeout_rpc_notified_mock_channels() {
     connection_timeout_rpc_notified::<MockService<MockChannelTransport>>(
+        MakeChannelAddress::make_transport(),
         MakeChannelAddress::make_address(),
         9999,
     )
@@ -711,8 +755,9 @@ async fn connection_timeout_rpc_notified_mock_channels() {
 #[tokio::test]
 async fn connection_timeout_rpc_notified_mock_noise() {
     connection_timeout_rpc_notified::<MockService<NoiseTcpTransport>>(
-        MakeTcpAddress::make_address(),
-        MakeTcpAddress::make_address(),
+        MakeNoiseAddress::make_transport(),
+        MakeNoiseAddress::make_address(),
+        MakeNoiseAddress::make_address(),
     )
     .await;
 }
@@ -722,7 +767,9 @@ async fn connection_timeout_rpc_notified_mock_noise() {
 async fn connect_no_ip_in_address_libp2p() {
     let config = Arc::new(config::create_mainnet());
     let bind_address = MakeP2pAddress::make_address();
-    let mut peer_manager = make_peer_manager::<Libp2pService>(bind_address, config).await;
+    let mut peer_manager =
+        make_peer_manager::<Libp2pService>(MakeP2pAddress::make_transport(), bind_address, config)
+            .await;
 
     let no_ip_addresses = [
         Multiaddr::empty(),

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -31,6 +31,7 @@ use crate::{
 };
 
 async fn make_peer_manager<T>(
+    transport: T::Transport,
     addr: T::Address,
     chain_config: Arc<common::chain::ChainConfig>,
 ) -> PeerManager<T>
@@ -40,7 +41,14 @@ where
     <T as NetworkingService>::Address: FromStr,
     <<T as NetworkingService>::Address as FromStr>::Err: Debug,
 {
-    let (conn, _) = T::start(addr, Arc::clone(&chain_config), Default::default()).await.unwrap();
+    let (conn, _) = T::start(
+        transport,
+        addr,
+        Arc::clone(&chain_config),
+        Default::default(),
+    )
+    .await
+    .unwrap();
     let (_, rx) = tokio::sync::mpsc::unbounded_channel();
     let (tx_sync, mut rx_sync) = tokio::sync::mpsc::unbounded_channel();
 

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -19,7 +19,8 @@ use libp2p::PeerId;
 use p2p_test_utils::TestBlockInfo;
 
 use crate::testing_utils::{
-    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
+    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+    TestTransportTcp,
 };
 use chainstate::ChainstateError;
 use common::{chain::block::consensus_data::PoWData, primitives::Idable};
@@ -44,7 +45,7 @@ use crate::{
 // peer doesn't exist
 async fn peer_doesnt_exist<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -85,7 +86,7 @@ async fn peer_doesnt_exist_mock_noise() {
 // submit valid block but the peer is in invalid state
 async fn valid_block<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -139,7 +140,7 @@ async fn valid_block_mock_noise() {
 // submit valid block
 async fn valid_block_invalid_state<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -191,7 +192,7 @@ async fn valid_block_invalid_state_mock_noise() {
 // submit the same block twice
 async fn valid_block_resubmitted_chainstate<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -264,7 +265,7 @@ async fn valid_block_resubmitted_chainstate_mock_noise() {
 // block validation fails
 async fn invalid_block<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -19,7 +19,7 @@ use libp2p::PeerId;
 use p2p_test_utils::TestBlockInfo;
 
 use crate::testing_utils::{
-    MakeChannelAddress, MakeNoiseAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
+    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
 };
 use chainstate::ChainstateError;
 use common::{chain::block::consensus_data::PoWData, primitives::Idable};
@@ -44,7 +44,7 @@ use crate::{
 // peer doesn't exist
 async fn peer_doesnt_exist<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -63,28 +63,29 @@ where
 
 #[tokio::test]
 async fn peer_doesnt_exist_libp2p() {
-    peer_doesnt_exist::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    peer_doesnt_exist::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn peer_doesnt_exist_mock_tcp() {
-    peer_doesnt_exist::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    peer_doesnt_exist::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn peer_doesnt_exist_mock_channels() {
-    peer_doesnt_exist::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>().await;
+    peer_doesnt_exist::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>()
+        .await;
 }
 
 #[tokio::test]
 async fn peer_doesnt_exist_mock_noise() {
-    peer_doesnt_exist::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    peer_doesnt_exist::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }
 
 // submit valid block but the peer is in invalid state
 async fn valid_block<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -117,28 +118,28 @@ where
 
 #[tokio::test]
 async fn valid_block_libp2p() {
-    valid_block::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    valid_block::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn valid_block_mock_tcp() {
-    valid_block::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    valid_block::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn valid_block_mock_channels() {
-    valid_block::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>().await;
+    valid_block::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn valid_block_mock_noise() {
-    valid_block::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    valid_block::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }
 
 // submit valid block
 async fn valid_block_invalid_state<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -165,32 +166,32 @@ where
 
 #[tokio::test]
 async fn valid_block_invalid_state_libp2p() {
-    valid_block_invalid_state::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    valid_block_invalid_state::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn valid_block_invalid_state_mock_tcp() {
-    valid_block_invalid_state::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>()
+    valid_block_invalid_state::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>()
         .await;
 }
 
 #[tokio::test]
 async fn valid_block_invalid_state_mock_channels() {
-    valid_block_invalid_state::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>(
+    valid_block_invalid_state::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>(
     )
     .await;
 }
 
 #[tokio::test]
 async fn valid_block_invalid_state_mock_noise() {
-    valid_block_invalid_state::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>()
+    valid_block_invalid_state::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>()
         .await;
 }
 
 // submit the same block twice
 async fn valid_block_resubmitted_chainstate<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -227,19 +228,23 @@ where
 
 #[tokio::test]
 async fn valid_block_resubmitted_chainstate_libp2p() {
-    valid_block_resubmitted_chainstate::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    valid_block_resubmitted_chainstate::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn valid_block_resubmitted_chainstate_mock_tcp() {
-    valid_block_resubmitted_chainstate::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>()
-        .await;
+    valid_block_resubmitted_chainstate::<
+        TestTransportTcp,
+        MockPeerId,
+        MockService<TcpTransportSocket>,
+    >()
+    .await;
 }
 
 #[tokio::test]
 async fn valid_block_resubmitted_chainstate_mock_channels() {
     valid_block_resubmitted_chainstate::<
-        MakeChannelAddress,
+        TestTransportChannel,
         MockPeerId,
         MockService<MockChannelTransport>,
     >()
@@ -249,7 +254,7 @@ async fn valid_block_resubmitted_chainstate_mock_channels() {
 #[tokio::test]
 async fn valid_block_resubmitted_chainstate_mock_noise() {
     valid_block_resubmitted_chainstate::<
-        MakeNoiseAddress,
+        TestTransportNoise,
         MockPeerId,
         MockService<NoiseTcpTransport>,
     >()
@@ -259,7 +264,7 @@ async fn valid_block_resubmitted_chainstate_mock_noise() {
 // block validation fails
 async fn invalid_block<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -298,20 +303,20 @@ where
 
 #[tokio::test]
 async fn invalid_block_libp2p() {
-    invalid_block::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    invalid_block::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn invalid_block_mock_tcp() {
-    invalid_block::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    invalid_block::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn invalid_block_mock_channels() {
-    invalid_block::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>().await;
+    invalid_block::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn invalid_block_mock_noise() {
-    invalid_block::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    invalid_block::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }

--- a/p2p/src/sync/tests/connection.rs
+++ b/p2p/src/sync/tests/connection.rs
@@ -16,7 +16,7 @@
 use libp2p::PeerId;
 
 use crate::testing_utils::{
-    MakeChannelAddress, MakeNoiseAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
+    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
 };
 
 use crate::{
@@ -36,7 +36,7 @@ use crate::{
 // handle peer reconnection
 async fn test_peer_reconnected<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -57,29 +57,29 @@ where
 
 #[tokio::test]
 async fn test_peer_reconnected_libp2p() {
-    test_peer_reconnected::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    test_peer_reconnected::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn test_peer_reconnected_mock_tcp() {
-    test_peer_reconnected::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    test_peer_reconnected::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn test_peer_reconnected_mock_channels() {
-    test_peer_reconnected::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>()
+    test_peer_reconnected::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>()
         .await;
 }
 
 #[tokio::test]
 async fn test_peer_reconnected_mock_noise() {
-    test_peer_reconnected::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    test_peer_reconnected::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }
 
 // handle peer disconnection event
 async fn test_peer_disconnected<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -105,21 +105,22 @@ where
 
 #[tokio::test]
 async fn test_peer_disconnected_libp2p() {
-    test_peer_disconnected::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    test_peer_disconnected::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn test_peer_disconnected_mock_tcp() {
-    test_peer_disconnected::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    test_peer_disconnected::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn test_peer_disconnected_mock_channels() {
-    test_peer_disconnected::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>()
+    test_peer_disconnected::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>()
         .await;
 }
 
 #[tokio::test]
 async fn test_peer_disconnected_mock_noise() {
-    test_peer_disconnected::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    test_peer_disconnected::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>()
+        .await;
 }

--- a/p2p/src/sync/tests/connection.rs
+++ b/p2p/src/sync/tests/connection.rs
@@ -16,7 +16,8 @@
 use libp2p::PeerId;
 
 use crate::testing_utils::{
-    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
+    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+    TestTransportTcp,
 };
 
 use crate::{
@@ -36,7 +37,7 @@ use crate::{
 // handle peer reconnection
 async fn test_peer_reconnected<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -79,7 +80,7 @@ async fn test_peer_reconnected_mock_noise() {
 // handle peer disconnection event
 async fn test_peer_disconnected<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,

--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -19,7 +19,8 @@ use crypto::random::{Rng, SliceRandom};
 use libp2p::PeerId;
 
 use crate::testing_utils::{
-    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
+    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+    TestTransportTcp,
 };
 use p2p_test_utils::TestBlockInfo;
 
@@ -43,7 +44,7 @@ use crate::{
 // response contains more than 2000 headers
 async fn too_many_headers<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -94,7 +95,7 @@ async fn too_many_headers_mock_noise() {
 // header response is empty
 async fn empty_response<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -135,7 +136,7 @@ async fn empty_response_mock_noise() {
 // valid response with headers in order and the first header attaching to local chain
 async fn valid_response<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -189,7 +190,7 @@ async fn valid_response_mock_noise() {
 // the first header doesn't attach to local chain
 async fn header_doesnt_attach_to_local_chain<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -257,7 +258,7 @@ async fn header_doesnt_attach_to_local_chain_mock_noise() {
 // valid headers but they are not in order
 async fn headers_not_in_order<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -312,7 +313,7 @@ async fn headers_not_in_order_mock_noise() {
 // peer state is incorrect to be sending header responses
 async fn invalid_state<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -367,7 +368,7 @@ async fn invalid_state_mock_noise() {
 // peer doesn't exist
 async fn peer_doesnt_exist<A, P, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,

--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -19,7 +19,7 @@ use crypto::random::{Rng, SliceRandom};
 use libp2p::PeerId;
 
 use crate::testing_utils::{
-    MakeChannelAddress, MakeNoiseAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
+    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
 };
 use p2p_test_utils::TestBlockInfo;
 
@@ -43,7 +43,7 @@ use crate::{
 // response contains more than 2000 headers
 async fn too_many_headers<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -73,28 +73,28 @@ where
 
 #[tokio::test]
 async fn too_many_headers_libp2p() {
-    too_many_headers::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    too_many_headers::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn too_many_headers_mock_tcp() {
-    too_many_headers::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    too_many_headers::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn too_many_headers_mock_channels() {
-    too_many_headers::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>().await;
+    too_many_headers::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn too_many_headers_mock_noise() {
-    too_many_headers::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    too_many_headers::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }
 
 // header response is empty
 async fn empty_response<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -114,28 +114,28 @@ where
 
 #[tokio::test]
 async fn empty_response_libp2p() {
-    empty_response::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    empty_response::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn empty_response_mock_tcp() {
-    empty_response::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    empty_response::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn empty_response_mock_channels() {
-    empty_response::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>().await;
+    empty_response::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn empty_response_mock_noise() {
-    empty_response::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    empty_response::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }
 
 // valid response with headers in order and the first header attaching to local chain
 async fn valid_response<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -168,28 +168,28 @@ where
 
 #[tokio::test]
 async fn valid_response_libp2p() {
-    valid_response::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    valid_response::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn valid_response_mock_tcp() {
-    valid_response::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    valid_response::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn valid_response_mock_channles() {
-    valid_response::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>().await;
+    valid_response::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn valid_response_mock_noise() {
-    valid_response::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    valid_response::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }
 
 // the first header doesn't attach to local chain
 async fn header_doesnt_attach_to_local_chain<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -221,13 +221,13 @@ where
 
 #[tokio::test]
 async fn header_doesnt_attach_to_local_chain_libp2p() {
-    header_doesnt_attach_to_local_chain::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    header_doesnt_attach_to_local_chain::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn header_doesnt_attach_to_local_chain_mock_tcp() {
     header_doesnt_attach_to_local_chain::<
-        MakeTcpAddress,
+        TestTransportTcp,
         MockPeerId,
         MockService<TcpTransportSocket>,
     >()
@@ -237,7 +237,7 @@ async fn header_doesnt_attach_to_local_chain_mock_tcp() {
 #[tokio::test]
 async fn header_doesnt_attach_to_local_chain_mock_channel() {
     header_doesnt_attach_to_local_chain::<
-        MakeChannelAddress,
+        TestTransportChannel,
         MockPeerId,
         MockService<MockChannelTransport>,
     >()
@@ -247,7 +247,7 @@ async fn header_doesnt_attach_to_local_chain_mock_channel() {
 #[tokio::test]
 async fn header_doesnt_attach_to_local_chain_mock_noise() {
     header_doesnt_attach_to_local_chain::<
-        MakeNoiseAddress,
+        TestTransportNoise,
         MockPeerId,
         MockService<NoiseTcpTransport>,
     >()
@@ -257,7 +257,7 @@ async fn header_doesnt_attach_to_local_chain_mock_noise() {
 // valid headers but they are not in order
 async fn headers_not_in_order<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -290,29 +290,29 @@ where
 
 #[tokio::test]
 async fn headers_not_in_order_libp2p() {
-    headers_not_in_order::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    headers_not_in_order::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn headers_not_in_order_mock_tcp() {
-    headers_not_in_order::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    headers_not_in_order::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn headers_not_in_order_mock_channels() {
-    headers_not_in_order::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>()
+    headers_not_in_order::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>()
         .await;
 }
 
 #[tokio::test]
 async fn headers_not_in_order_mock_noise() {
-    headers_not_in_order::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    headers_not_in_order::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }
 
 // peer state is incorrect to be sending header responses
 async fn invalid_state<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -346,28 +346,28 @@ where
 
 #[tokio::test]
 async fn invalid_state_libp2p() {
-    invalid_state::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    invalid_state::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn invalid_state_mock_tcp() {
-    invalid_state::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    invalid_state::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn invalid_state_mock_channels() {
-    invalid_state::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>().await;
+    invalid_state::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn invalid_state_mock_noise() {
-    invalid_state::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    invalid_state::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }
 
 // peer doesn't exist
 async fn peer_doesnt_exist<A, P, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     P: MakeTestPeerId<PeerId = T::PeerId>,
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -386,20 +386,21 @@ where
 
 #[tokio::test]
 async fn peer_doesnt_exist_libp2p() {
-    peer_doesnt_exist::<MakeP2pAddress, PeerId, Libp2pService>().await;
+    peer_doesnt_exist::<TestTransportLibp2p, PeerId, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn peer_doesnt_exist_mock_tcp() {
-    peer_doesnt_exist::<MakeTcpAddress, MockPeerId, MockService<TcpTransportSocket>>().await;
+    peer_doesnt_exist::<TestTransportTcp, MockPeerId, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn peer_doesnt_exist_mock_channels() {
-    peer_doesnt_exist::<MakeChannelAddress, MockPeerId, MockService<MockChannelTransport>>().await;
+    peer_doesnt_exist::<TestTransportChannel, MockPeerId, MockService<MockChannelTransport>>()
+        .await;
 }
 
 #[tokio::test]
 async fn peer_doesnt_exist_mock_noise() {
-    peer_doesnt_exist::<MakeNoiseAddress, MockPeerId, MockService<NoiseTcpTransport>>().await;
+    peer_doesnt_exist::<TestTransportNoise, MockPeerId, MockService<NoiseTcpTransport>>().await;
 }

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 
 async fn make_sync_manager<T>(
+    transport: T::Transport,
     addr: T::Address,
 ) -> (
     BlockSyncManager<T>,
@@ -76,9 +77,14 @@ where
         mdns_config: MdnsConfig::Disabled.into(),
         request_timeout: Duration::from_secs(1).into(),
     });
-    let (conn, sync) = T::start(addr, Arc::clone(&chain_config), Arc::clone(&p2p_config))
-        .await
-        .unwrap();
+    let (conn, sync) = T::start(
+        transport,
+        addr,
+        Arc::clone(&chain_config),
+        Arc::clone(&p2p_config),
+    )
+    .await
+    .unwrap();
 
     (
         BlockSyncManager::<T>::new(chain_config, p2p_config, sync, handle, rx_p2p_sync, tx_pm),

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -20,7 +20,7 @@ use tokio::time::timeout;
 use chainstate::Locator;
 
 use crate::testing_utils::{
-    MakeChannelAddress, MakeNoiseAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
+    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
 };
 use crate::{
     event::PeerManagerEvent,
@@ -40,7 +40,7 @@ use crate::{
 
 async fn request_response<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + Debug + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -86,27 +86,27 @@ where
 
 #[tokio::test]
 async fn request_response_libp2p() {
-    request_response::<MakeP2pAddress, Libp2pService>().await;
+    request_response::<TestTransportLibp2p, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn request_response_mock_tcp() {
-    request_response::<MakeTcpAddress, MockService<TcpTransportSocket>>().await;
+    request_response::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn request_response_mock_channels() {
-    request_response::<MakeChannelAddress, MockService<MockChannelTransport>>().await;
+    request_response::<TestTransportChannel, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn test_request_response_mock_noise() {
-    request_response::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
+    request_response::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }
 
 async fn multiple_requests_and_responses<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -180,30 +180,30 @@ where
 
 #[tokio::test]
 async fn multiple_requests_and_responses_libp2p() {
-    multiple_requests_and_responses::<MakeP2pAddress, Libp2pService>().await;
+    multiple_requests_and_responses::<TestTransportLibp2p, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn multiple_requests_and_responses_mock_tcp() {
-    multiple_requests_and_responses::<MakeTcpAddress, MockService<TcpTransportSocket>>().await;
+    multiple_requests_and_responses::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn multiple_requests_and_responses_mock_channels() {
-    multiple_requests_and_responses::<MakeChannelAddress, MockService<MockChannelTransport>>()
+    multiple_requests_and_responses::<TestTransportChannel, MockService<MockChannelTransport>>()
         .await;
 }
 
 #[tokio::test]
 async fn multiple_requests_and_responses_mock_noise() {
-    multiple_requests_and_responses::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
+    multiple_requests_and_responses::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }
 
 // Receive getheaders before receiving the `Connected` event from the peer manager which makes the
 // request be rejected and time out in the sender's end.
 async fn request_timeout<A, T>()
 where
-    A: MakeTestAddress<Transport = T::Transport, Address = T::Address>,
+    A: TestTransport<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -248,20 +248,20 @@ where
 
 #[tokio::test]
 async fn request_timeout_libp2p() {
-    request_timeout::<MakeP2pAddress, Libp2pService>().await;
+    request_timeout::<TestTransportLibp2p, Libp2pService>().await;
 }
 
 #[tokio::test]
 async fn request_timeout_mock_tcp() {
-    request_timeout::<MakeTcpAddress, MockService<TcpTransportSocket>>().await;
+    request_timeout::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 #[tokio::test]
 async fn request_timeout_mock_channels() {
-    request_timeout::<MakeChannelAddress, MockService<MockChannelTransport>>().await;
+    request_timeout::<TestTransportChannel, MockService<MockChannelTransport>>().await;
 }
 
 #[tokio::test]
 async fn request_timeout_mock_noise() {
-    request_timeout::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
+    request_timeout::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -20,7 +20,8 @@ use tokio::time::timeout;
 use chainstate::Locator;
 
 use crate::testing_utils::{
-    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
+    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+    TestTransportTcp,
 };
 use crate::{
     event::PeerManagerEvent,
@@ -40,7 +41,7 @@ use crate::{
 
 async fn request_response<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + Debug + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -106,7 +107,7 @@ async fn test_request_response_mock_noise() {
 
 async fn multiple_requests_and_responses<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
@@ -203,7 +204,7 @@ async fn multiple_requests_and_responses_mock_noise() {
 // request be rejected and time out in the sender's end.
 async fn request_timeout<A, T>()
 where
-    A: TestTransport<Transport = T::Transport, Address = T::Address>,
+    A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -16,11 +16,11 @@
 use libp2p::Multiaddr;
 use std::net::SocketAddr;
 
-/// An interface for creating test transports and addresses.
+/// An interface for creating transports and addresses used in tests.
 ///
 /// This abstraction layer is needed to uniformly create transports and addresses
 /// in the tests for different mocks transport implementations.
-pub trait TestTransport {
+pub trait TestTransportMaker {
     /// A transport type.
     type Transport;
 
@@ -38,7 +38,7 @@ pub trait TestTransport {
 
 pub struct TestTransportLibp2p {}
 
-impl TestTransport for TestTransportLibp2p {
+impl TestTransportMaker for TestTransportLibp2p {
     type Transport = crate::net::libp2p::Libp2pTransport;
 
     type Address = Multiaddr;
@@ -55,7 +55,7 @@ impl TestTransport for TestTransportLibp2p {
 
 pub struct TestTransportTcp {}
 
-impl TestTransport for TestTransportTcp {
+impl TestTransportMaker for TestTransportTcp {
     type Transport = crate::net::mock::transport::TcpTransportSocket;
 
     type Address = SocketAddr;
@@ -71,7 +71,7 @@ impl TestTransport for TestTransportTcp {
 
 pub struct TestTransportChannel {}
 
-impl TestTransport for TestTransportChannel {
+impl TestTransportMaker for TestTransportChannel {
     type Transport = crate::net::mock::transport::MockChannelTransport;
 
     type Address = u64;
@@ -87,7 +87,7 @@ impl TestTransport for TestTransportChannel {
 
 pub struct TestTransportNoise {}
 
-impl TestTransport for TestTransportNoise {
+impl TestTransportMaker for TestTransportNoise {
     type Transport = crate::net::mock::transport::NoiseTcpTransport;
 
     type Address = SocketAddr;

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -16,11 +16,11 @@
 use libp2p::Multiaddr;
 use std::net::SocketAddr;
 
-/// An interface for creating the address.
+/// An interface for creating test transports and addresses.
 ///
-/// This abstraction layer is needed to uniformly create an address in the tests for different
-/// mocks transport implementations.
-pub trait MakeTestAddress {
+/// This abstraction layer is needed to uniformly create transports and addresses
+/// in the tests for different mocks transport implementations.
+pub trait TestTransport {
     /// A transport type.
     type Transport;
 
@@ -36,9 +36,9 @@ pub trait MakeTestAddress {
     fn make_address() -> Self::Address;
 }
 
-pub struct MakeP2pAddress {}
+pub struct TestTransportLibp2p {}
 
-impl MakeTestAddress for MakeP2pAddress {
+impl TestTransport for TestTransportLibp2p {
     type Transport = crate::net::libp2p::Libp2pTransport;
 
     type Address = Multiaddr;
@@ -53,9 +53,9 @@ impl MakeTestAddress for MakeP2pAddress {
     }
 }
 
-pub struct MakeTcpAddress {}
+pub struct TestTransportTcp {}
 
-impl MakeTestAddress for MakeTcpAddress {
+impl TestTransport for TestTransportTcp {
     type Transport = crate::net::mock::transport::TcpTransportSocket;
 
     type Address = SocketAddr;
@@ -69,9 +69,9 @@ impl MakeTestAddress for MakeTcpAddress {
     }
 }
 
-pub struct MakeChannelAddress {}
+pub struct TestTransportChannel {}
 
-impl MakeTestAddress for MakeChannelAddress {
+impl TestTransport for TestTransportChannel {
     type Transport = crate::net::mock::transport::MockChannelTransport;
 
     type Address = u64;
@@ -85,9 +85,9 @@ impl MakeTestAddress for MakeChannelAddress {
     }
 }
 
-pub struct MakeNoiseAddress {}
+pub struct TestTransportNoise {}
 
-impl MakeTestAddress for MakeNoiseAddress {
+impl TestTransport for TestTransportNoise {
     type Transport = crate::net::mock::transport::NoiseTcpTransport;
 
     type Address = SocketAddr;
@@ -99,6 +99,6 @@ impl MakeTestAddress for MakeNoiseAddress {
     }
 
     fn make_address() -> Self::Address {
-        MakeTcpAddress::make_address()
+        TestTransportTcp::make_address()
     }
 }

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -1,4 +1,17 @@
-use crate::net::mock::transport::TransportSocket;
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use libp2p::Multiaddr;
 use std::net::SocketAddr;
@@ -36,7 +49,7 @@ impl MakeTestAddress for MakeP2pAddress {
     }
 
     fn make_address() -> Self::Address {
-        "/ip6/::1/tcp/0".parse().unwrap()
+        "/ip6/::1/tcp/0".parse().expect("valid address")
     }
 }
 
@@ -52,7 +65,7 @@ impl MakeTestAddress for MakeTcpAddress {
     }
 
     fn make_address() -> Self::Address {
-        "[::1]:0".parse().unwrap()
+        "[::1]:0".parse().expect("valid address")
     }
 }
 
@@ -80,10 +93,12 @@ impl MakeTestAddress for MakeNoiseAddress {
     type Address = SocketAddr;
 
     fn make_transport() -> Self::Transport {
-        crate::net::mock::transport::NoiseTcpTransport::new()
+        let stream_adapter = crate::net::mock::transport::NoiseEncryptionAdapter::gen_new();
+        let base_transport = crate::net::mock::transport::TcpTransportSocket::new();
+        crate::net::mock::transport::NoiseTcpTransport::new(stream_adapter, base_transport)
     }
 
     fn make_address() -> Self::Address {
-        "[::1]:0".parse().unwrap()
+        MakeTcpAddress::make_address()
     }
 }

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -1,0 +1,89 @@
+use crate::net::mock::transport::TransportSocket;
+
+use libp2p::Multiaddr;
+use std::net::SocketAddr;
+
+/// An interface for creating the address.
+///
+/// This abstraction layer is needed to uniformly create an address in the tests for different
+/// mocks transport implementations.
+pub trait MakeTestAddress {
+    /// A transport type.
+    type Transport;
+
+    /// An address type.
+    type Address: Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + ToString;
+
+    /// Creates new transport instance, generating new keys if needed.
+    fn make_transport() -> Self::Transport;
+
+    /// Creates a new unused address.
+    ///
+    /// This should work similar to requesting a port of number 0 when opening a TCP connection.
+    fn make_address() -> Self::Address;
+}
+
+pub struct MakeP2pAddress {}
+
+impl MakeTestAddress for MakeP2pAddress {
+    type Transport = crate::net::libp2p::Libp2pTransport;
+
+    type Address = Multiaddr;
+
+    fn make_transport() -> Self::Transport {
+        let p2p_config = Default::default();
+        crate::net::libp2p::make_transport(&p2p_config)
+    }
+
+    fn make_address() -> Self::Address {
+        "/ip6/::1/tcp/0".parse().unwrap()
+    }
+}
+
+pub struct MakeTcpAddress {}
+
+impl MakeTestAddress for MakeTcpAddress {
+    type Transport = crate::net::mock::transport::TcpTransportSocket;
+
+    type Address = SocketAddr;
+
+    fn make_transport() -> Self::Transport {
+        crate::net::mock::transport::TcpTransportSocket::new()
+    }
+
+    fn make_address() -> Self::Address {
+        "[::1]:0".parse().unwrap()
+    }
+}
+
+pub struct MakeChannelAddress {}
+
+impl MakeTestAddress for MakeChannelAddress {
+    type Transport = crate::net::mock::transport::MockChannelTransport;
+
+    type Address = u64;
+
+    fn make_transport() -> Self::Transport {
+        crate::net::mock::transport::MockChannelTransport::new()
+    }
+
+    fn make_address() -> Self::Address {
+        0
+    }
+}
+
+pub struct MakeNoiseAddress {}
+
+impl MakeTestAddress for MakeNoiseAddress {
+    type Transport = crate::net::mock::transport::NoiseTcpTransport;
+
+    type Address = SocketAddr;
+
+    fn make_transport() -> Self::Transport {
+        crate::net::mock::transport::NoiseTcpTransport::new()
+    }
+
+    fn make_address() -> Self::Address {
+        "[::1]:0".parse().unwrap()
+    }
+}

--- a/p2p/tests/backend_libp2p.rs
+++ b/p2p/tests/backend_libp2p.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 use p2p::net::libp2p::Libp2pService;
-use p2p::testing_utils::MakeP2pAddress;
+use p2p::testing_utils::TestTransportLibp2p;
 
 fn main() {
-    p2p_backend_test_suite::run::<MakeP2pAddress, Libp2pService>();
+    p2p_backend_test_suite::run::<TestTransportLibp2p, Libp2pService>();
 }

--- a/p2p/tests/backend_libp2p.rs
+++ b/p2p/tests/backend_libp2p.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use p2p::net::libp2p::Libp2pService;
-use p2p_test_utils::MakeP2pAddress;
+use p2p::testing_utils::MakeP2pAddress;
 
 fn main() {
     p2p_backend_test_suite::run::<MakeP2pAddress, Libp2pService>();

--- a/p2p/tests/backend_mock_channels.rs
+++ b/p2p/tests/backend_mock_channels.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use p2p::net::mock::{transport::MockChannelTransport, MockService};
-use p2p_test_utils::MakeChannelAddress;
+use p2p::testing_utils::MakeChannelAddress;
 
 fn main() {
     p2p_backend_test_suite::run::<MakeChannelAddress, MockService<MockChannelTransport>>();

--- a/p2p/tests/backend_mock_channels.rs
+++ b/p2p/tests/backend_mock_channels.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 use p2p::net::mock::{transport::MockChannelTransport, MockService};
-use p2p::testing_utils::MakeChannelAddress;
+use p2p::testing_utils::TestTransportChannel;
 
 fn main() {
-    p2p_backend_test_suite::run::<MakeChannelAddress, MockService<MockChannelTransport>>();
+    p2p_backend_test_suite::run::<TestTransportChannel, MockService<MockChannelTransport>>();
 }

--- a/p2p/tests/backend_mock_noise.rs
+++ b/p2p/tests/backend_mock_noise.rs
@@ -17,11 +17,11 @@ use p2p::net::mock::{
     transport::{NoiseEncryptionAdapter, TcpTransportSocket, WrappedTransportSocket},
     MockService,
 };
-use p2p::testing_utils::MakeNoiseAddress;
+use p2p::testing_utils::TestTransportNoise;
 
 fn main() {
     p2p_backend_test_suite::run::<
-        MakeNoiseAddress,
+        TestTransportNoise,
         MockService<WrappedTransportSocket<NoiseEncryptionAdapter, TcpTransportSocket>>,
     >();
 }

--- a/p2p/tests/backend_mock_noise.rs
+++ b/p2p/tests/backend_mock_noise.rs
@@ -17,11 +17,11 @@ use p2p::net::mock::{
     transport::{NoiseEncryptionAdapter, TcpTransportSocket, WrappedTransportSocket},
     MockService,
 };
-use p2p_test_utils::MakeTcpAddress;
+use p2p::testing_utils::MakeNoiseAddress;
 
 fn main() {
     p2p_backend_test_suite::run::<
-        MakeTcpAddress,
+        MakeNoiseAddress,
         MockService<WrappedTransportSocket<NoiseEncryptionAdapter, TcpTransportSocket>>,
     >();
 }

--- a/p2p/tests/backend_mock_tcp.rs
+++ b/p2p/tests/backend_mock_tcp.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 use p2p::net::mock::{transport::TcpTransportSocket, MockService};
-use p2p::testing_utils::MakeTcpAddress;
+use p2p::testing_utils::TestTransportTcp;
 
 fn main() {
-    p2p_backend_test_suite::run::<MakeTcpAddress, MockService<TcpTransportSocket>>();
+    p2p_backend_test_suite::run::<TestTransportTcp, MockService<TcpTransportSocket>>();
 }

--- a/p2p/tests/backend_mock_tcp.rs
+++ b/p2p/tests/backend_mock_tcp.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use p2p::net::mock::{transport::TcpTransportSocket, MockService};
-use p2p_test_utils::MakeTcpAddress;
+use p2p::testing_utils::MakeTcpAddress;
 
 fn main() {
     p2p_backend_test_suite::run::<MakeTcpAddress, MockService<TcpTransportSocket>>();

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -21,7 +21,7 @@ use common::{
 };
 
 use p2p::testing_utils::{
-    MakeChannelAddress, MakeNoiseAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
+    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
 };
 use p2p::{
     error::{P2pError, PublishError},
@@ -42,7 +42,7 @@ use p2p::{
 // don't automatically forward the messages.
 async fn block_announcement_3_peers<A, S>()
 where
-    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
+    A: TestTransport<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
@@ -189,26 +189,26 @@ where
 
 #[tokio::test]
 async fn block_announcement_3_peers_libp2p() {
-    block_announcement_3_peers::<MakeP2pAddress, Libp2pService>().await;
+    block_announcement_3_peers::<TestTransportLibp2p, Libp2pService>().await;
 }
 
 // TODO: Implement announcements resending in partially connected networks.
 #[ignore]
 #[tokio::test]
 async fn block_announcement_3_peers_tcp() {
-    block_announcement_3_peers::<MakeTcpAddress, MockService<TcpTransportSocket>>().await;
+    block_announcement_3_peers::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 // TODO: Implement announcements resending in partially connected networks.
 #[tokio::test]
 #[ignore]
 async fn block_announcement_3_peers_channels() {
-    block_announcement_3_peers::<MakeChannelAddress, MockService<MockChannelTransport>>().await;
+    block_announcement_3_peers::<TestTransportChannel, MockService<MockChannelTransport>>().await;
 }
 
 // TODO: Implement announcements resending in partially connected networks.
 #[ignore]
 #[tokio::test]
 async fn block_announcement_3_peers_noise() {
-    block_announcement_3_peers::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
+    block_announcement_3_peers::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -21,7 +21,8 @@ use common::{
 };
 
 use p2p::testing_utils::{
-    TestTransport, TestTransportChannel, TestTransportLibp2p, TestTransportNoise, TestTransportTcp,
+    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+    TestTransportTcp,
 };
 use p2p::{
     error::{P2pError, PublishError},
@@ -42,7 +43,7 @@ use p2p::{
 // don't automatically forward the messages.
 async fn block_announcement_3_peers<A, S>()
 where
-    A: TestTransport<Transport = S::Transport, Address = S::Address>,
+    A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -20,6 +20,9 @@ use common::{
     primitives::{Id, H256},
 };
 
+use p2p::testing_utils::{
+    MakeChannelAddress, MakeNoiseAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress,
+};
 use p2p::{
     error::{P2pError, PublishError},
     message::Announcement,
@@ -34,28 +37,36 @@ use p2p::{
     },
     peer_manager::helpers::connect_services,
 };
-use p2p_test_utils::{MakeChannelAddress, MakeP2pAddress, MakeTcpAddress, MakeTestAddress};
 
 // Test announcements with multiple peers and verify that the message validation is done and peers
 // don't automatically forward the messages.
 async fn block_announcement_3_peers<A, S>()
 where
-    A: MakeTestAddress<Address = S::Address>,
+    A: MakeTestAddress<Transport = S::Transport, Address = S::Address>,
     S: NetworkingService + Debug,
     S::SyncingMessagingHandle: SyncingMessagingService<S>,
     S::ConnectivityHandle: ConnectivityService<S>,
 {
     let config = Arc::new(common::chain::config::create_mainnet());
-    let (mut conn1, mut sync1) =
-        S::start(A::make_address(), Arc::clone(&config), Default::default())
-            .await
-            .unwrap();
+    let (mut conn1, mut sync1) = S::start(
+        A::make_transport(),
+        A::make_address(),
+        Arc::clone(&config),
+        Default::default(),
+    )
+    .await
+    .unwrap();
 
     let (mut peer1, mut peer2, mut peer3) = {
         let mut peers = futures::future::join_all((0..3).map(|_| async {
-            let res = S::start(A::make_address(), Arc::clone(&config), Default::default())
-                .await
-                .unwrap();
+            let res = S::start(
+                A::make_transport(),
+                A::make_address(),
+                Arc::clone(&config),
+                Default::default(),
+            )
+            .await
+            .unwrap();
             (res.0, res.1)
         }))
         .await;
@@ -199,5 +210,5 @@ async fn block_announcement_3_peers_channels() {
 #[ignore]
 #[tokio::test]
 async fn block_announcement_3_peers_noise() {
-    block_announcement_3_peers::<MakeTcpAddress, MockService<NoiseTcpTransport>>().await;
+    block_announcement_3_peers::<MakeNoiseAddress, MockService<NoiseTcpTransport>>().await;
 }

--- a/p2p/tests/libp2p-mdns.rs
+++ b/p2p/tests/libp2p-mdns.rs
@@ -17,7 +17,7 @@ use std::{sync::Arc, time::Duration};
 
 use libp2p::multiaddr::Protocol;
 
-use p2p::testing_utils::{MakeP2pAddress, MakeTestAddress};
+use p2p::testing_utils::{TestTransport, TestTransportLibp2p};
 use p2p::{
     config::{MdnsConfig, P2pConfig},
     net::{
@@ -30,8 +30,8 @@ use p2p::{
 async fn test_libp2p_peer_discovery() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let (mut serv, _) = Libp2pService::start(
-        MakeP2pAddress::make_transport(),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_transport(),
+        TestTransportLibp2p::make_address(),
         Arc::clone(&config),
         Arc::new(P2pConfig {
             bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
@@ -49,8 +49,8 @@ async fn test_libp2p_peer_discovery() {
     .unwrap();
 
     let (mut serv2, _) = Libp2pService::start(
-        MakeP2pAddress::make_transport(),
-        MakeP2pAddress::make_address(),
+        TestTransportLibp2p::make_transport(),
+        TestTransportLibp2p::make_address(),
         Arc::clone(&config),
         Arc::new(P2pConfig {
             bind_address: "/ip6/::1/tcp/3031".to_owned().into(),

--- a/p2p/tests/libp2p-mdns.rs
+++ b/p2p/tests/libp2p-mdns.rs
@@ -17,7 +17,7 @@ use std::{sync::Arc, time::Duration};
 
 use libp2p::multiaddr::Protocol;
 
-use p2p::testing_utils::{TestTransport, TestTransportLibp2p};
+use p2p::testing_utils::{TestTransportLibp2p, TestTransportMaker};
 use p2p::{
     config::{MdnsConfig, P2pConfig},
     net::{

--- a/p2p/tests/libp2p-mdns.rs
+++ b/p2p/tests/libp2p-mdns.rs
@@ -17,19 +17,20 @@ use std::{sync::Arc, time::Duration};
 
 use libp2p::multiaddr::Protocol;
 
+use p2p::testing_utils::{MakeP2pAddress, MakeTestAddress};
 use p2p::{
     config::{MdnsConfig, P2pConfig},
     net::{
         libp2p::Libp2pService, types::ConnectivityEvent, ConnectivityService, NetworkingService,
     },
 };
-use p2p_test_utils::{MakeP2pAddress, MakeTestAddress};
 
 // verify that libp2p mdns peer discovery works
 #[tokio::test]
 async fn test_libp2p_peer_discovery() {
     let config = Arc::new(common::chain::config::create_mainnet());
     let (mut serv, _) = Libp2pService::start(
+        MakeP2pAddress::make_transport(),
         MakeP2pAddress::make_address(),
         Arc::clone(&config),
         Arc::new(P2pConfig {
@@ -48,6 +49,7 @@ async fn test_libp2p_peer_discovery() {
     .unwrap();
 
     let (mut serv2, _) = Libp2pService::start(
+        MakeP2pAddress::make_transport(),
         MakeP2pAddress::make_address(),
         Arc::clone(&config),
         Arc::new(P2pConfig {


### PR DESCRIPTION
This is continuation of this discussion:
https://github.com/mintlayer/mintlayer-core/pull/571#discussion_r1034797452

New associated type (`Transport`) is added to `NetworkingService` trait.
Now when a P2P subsystem is created a transport object is required.
For `Libp2pService` it's `transport::Boxed<(PeerId, StreamMuxerBox)>` from libp2p (with some auxiliary key details).
For `MockService` it's actual `TransportSocket` trait implementation.

I added new `make_transport` function to the `MakeTestAddress` trait to be able to create new transport in tests.

There was a problem with circular dev dependency when I tried to use updated `MakeTestAddress` from unit tests.
It because `p2p` unit tests are refering `p2p-test-utils`, while `p2p-test-utils` is referring `p2p` itself.
Rust does not allow build cycles so `p2p` is compiled twice, once with the test flag enabled and once without, making two unrelated artifacts.
And because `MakeTestAddress` was returning two different types (from "p2p as lib" and "p2p as test lib") compilation failed.
Here is an example of such an error: https://github.com/rust-lang/cargo/issues/6765
As a workaround I moved `MakeTestAddress` to `p2p` sources.
Perhaps the proper fix would be to move unit tests from p2p to `backend-test-suite` instead.