### PR TITLE
Update MockChannelTransport

### DIFF
--- a/p2p/backend-test-suite/src/connect.rs
+++ b/p2p/backend-test-suite/src/connect.rs
@@ -72,10 +72,12 @@ where
     let res = S::start(A::make_transport(), address, config, Default::default())
         .await
         .expect_err("address is not in use");
-    assert_eq!(
+    assert!(matches!(
         res,
-        P2pError::DialError(DialError::IoError(std::io::ErrorKind::AddrInUse))
-    );
+        P2pError::DialError(DialError::IoError(
+            std::io::ErrorKind::AddrInUse | std::io::ErrorKind::AddrNotAvailable
+        ))
+    ));
 }
 
 // Try to connect two nodes by having `service1` listen for network events and having `service2`

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -81,11 +81,8 @@ async fn ban_connected_peer_mock_tcp() {
     ban_connected_peer::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
-#[ignore]
 #[tokio::test]
 async fn ban_connected_peer_mock_channels() {
-    // TODO: Currently in the channels backend peer receives a new address every time it connects.
-    // For the banning to work properly the addresses must be persistent.
     ban_connected_peer::<TestTransportChannel, MockService<MockChannelTransport>>().await;
 }
 
@@ -227,11 +224,8 @@ async fn connect_to_banned_peer_mock_tcp() {
     connect_to_banned_peer::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
-#[ignore]
 #[tokio::test]
 async fn connect_to_banned_peer_mock_channels() {
-    // TODO: Currently in the channels backend peer receives a new address every time it connects.
-    // For the banning to work properly the addresses must be persistent.
     connect_to_banned_peer::<TestTransportChannel, MockService<MockChannelTransport>>().await;
 }
 


### PR DESCRIPTION
Update `MockChannelTransport` semantics to align with `MockTcpTransport`.
This fixes some failed unit tests.
Now creating new mock channel transport is like attaching new "host" to the network.
New unique address is registered for the new "host".
Unlike TCP only one active bind is allowed at any moment to keep things simple (so there is only one port per host).