### PR TITLE
ci: Duplicate crate check in `codecheck.py`

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -47,4 +47,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - run: pip install toml
       - run: ./.github/scripts/codecheck.py


### PR DESCRIPTION
Code to detect duplicate crates (i.e. crates pulled in as deps in multiple versions).
Applied to `partity-scale-codec(-derive)?`.

<s>Draft to see how if it works in Github CI.</s>