### PR TITLE
Minor bans fixes

### DIFF
--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -135,6 +135,7 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
     let P2pConfigFile {
         bind_address,
         ban_threshold,
+        ban_duration,
         outbound_connection_timeout,
         mdns_config: _,
         request_timeout,
@@ -157,6 +158,7 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
     P2pConfigFile {
         bind_address,
         ban_threshold,
+        ban_duration,
         outbound_connection_timeout,
         mdns_config,
         request_timeout,

--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -125,6 +125,8 @@ pub struct P2pConfigFile {
     pub bind_address: Option<String>,
     /// The score threshold after which a peer is banned.
     pub ban_threshold: Option<u32>,
+    /// Duration of bans in seconds.
+    pub ban_duration: Option<u64>,
     /// The outbound connection timeout value in seconds.
     pub outbound_connection_timeout: Option<u64>,
     /// Multicast DNS configuration.
@@ -141,6 +143,7 @@ impl From<P2pConfigFile> for P2pConfig {
         P2pConfig {
             bind_address: c.bind_address.into(),
             ban_threshold: c.ban_threshold.into(),
+            ban_duration: c.ban_duration.map(Duration::from_secs).into(),
             outbound_connection_timeout: c.outbound_connection_timeout.into(),
             mdns_config: mdns_config.into(),
             request_timeout: c.request_timeout.map(Duration::from_secs).into(),

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -144,6 +144,7 @@ where
     let p2p_config = Arc::new(P2pConfig {
         bind_address: Default::default(),
         ban_threshold: Default::default(),
+        ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         mdns_config: Default::default(),
         request_timeout: Default::default(),

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -1170,6 +1170,7 @@ where
     let p2p_config = P2pConfig {
         bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
         ban_threshold: 100.into(),
+        ban_duration: Default::default(),
         outbound_connection_timeout: 10.into(),
         mdns_config: MdnsConfig::Disabled.into(),
         request_timeout: Duration::from_secs(1).into(),

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -25,6 +25,7 @@ pub const MDNS_DEFAULT_IPV6_STATE: bool = false;
 
 make_config_setting!(P2pBindAddress, String, "/ip6/::1/tcp/3031".into());
 make_config_setting!(BanThreshold, u32, 100);
+make_config_setting!(BanDuration, Duration, Duration::from_secs(60 * 60 * 24));
 make_config_setting!(OutboundConnectionTimeout, u64, 10);
 make_config_setting!(MdnsConfigSetting, MdnsConfig, MdnsConfig::Disabled);
 make_config_setting!(MdnsQueryInterval, u64, MDNS_DEFAULT_QUERY_INTERVAL);
@@ -92,6 +93,8 @@ pub struct P2pConfig {
     pub bind_address: P2pBindAddress,
     /// The score threshold after which a peer is banned.
     pub ban_threshold: BanThreshold,
+    /// Duration of bans in seconds.
+    pub ban_duration: BanDuration,
     /// The outbound connection timeout value in seconds.
     pub outbound_connection_timeout: OutboundConnectionTimeout,
     /// Multicast DNS configuration.

--- a/p2p/src/net/libp2p/backend.rs
+++ b/p2p/src/net/libp2p/backend.rs
@@ -262,18 +262,6 @@ impl Libp2pBackend {
         }
     }
 
-    /// Ban peer
-    fn ban_peer(
-        &mut self,
-        peer_id: PeerId,
-        response: oneshot::Sender<crate::Result<()>>,
-    ) -> crate::Result<()> {
-        log::trace!("ban peer {peer_id}");
-
-        self.swarm.ban_peer_id(peer_id);
-        response.send(Ok(())).map_err(|_| P2pError::ChannelClosed)
-    }
-
     // TODO: design p2p global command system
     /// Handle command received from the libp2p front-end
     fn on_command(&mut self, cmd: types::Command) -> crate::Result<()> {
@@ -308,7 +296,6 @@ impl Libp2pBackend {
                 response,
                 channel,
             } => self.send_response(request_id, *response, channel),
-            types::Command::BanPeer { peer_id, response } => self.ban_peer(peer_id, response),
             types::Command::ListenAddress { response } => {
                 response.send(self.listen_addr.clone()).map_err(|_| P2pError::ChannelClosed)
             }

--- a/p2p/src/net/libp2p/service/connectivity.rs
+++ b/p2p/src/net/libp2p/service/connectivity.rs
@@ -218,17 +218,6 @@ where
         &self.peer_id
     }
 
-    async fn ban_peer(&mut self, peer_id: T::PeerId) -> crate::Result<()> {
-        log::debug!("ban peer {}", peer_id);
-
-        let (tx, rx) = oneshot::channel();
-        self.cmd_tx.send(types::Command::BanPeer {
-            peer_id,
-            response: tx,
-        })?;
-        rx.await.map_err(P2pError::from)?.map_err(P2pError::from)
-    }
-
     async fn poll_next(&mut self) -> crate::Result<ConnectivityEvent<T>> {
         match self.conn_rx.recv().await.ok_or(P2pError::ChannelClosed)? {
             types::ConnectivityEvent::OutboundAccepted { address, peer_info } => {

--- a/p2p/src/net/libp2p/tests/frontend.rs
+++ b/p2p/src/net/libp2p/tests/frontend.rs
@@ -239,6 +239,7 @@ async fn test_connect_with_timeout() {
         Arc::new(P2pConfig {
             bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
             ban_threshold: 100.into(),
+            ban_duration: Default::default(),
             outbound_connection_timeout: 2.into(),
             mdns_config: MdnsConfig::Disabled.into(),
             request_timeout: Duration::from_secs(10).into(),

--- a/p2p/src/net/libp2p/tests/mdns.rs
+++ b/p2p/src/net/libp2p/tests/mdns.rs
@@ -36,6 +36,7 @@ async fn test_discovered_and_expired() {
         Arc::new(P2pConfig {
             bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
             ban_threshold: 100.into(),
+            ban_duration: Default::default(),
             outbound_connection_timeout: 10.into(),
             mdns_config: MdnsConfig::Enabled {
                 query_interval: 200.into(),
@@ -55,6 +56,7 @@ async fn test_discovered_and_expired() {
         Arc::new(P2pConfig {
             bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
             ban_threshold: 100.into(),
+            ban_duration: Default::default(),
             outbound_connection_timeout: 10.into(),
             mdns_config: MdnsConfig::Enabled {
                 query_interval: 200.into(),

--- a/p2p/src/net/libp2p/types.rs
+++ b/p2p/src/net/libp2p/types.rs
@@ -114,12 +114,6 @@ pub enum Command {
     ListenAddress {
         response: oneshot::Sender<Option<Multiaddr>>,
     },
-
-    /// Ban remote peer
-    BanPeer {
-        peer_id: PeerId,
-        response: oneshot::Sender<crate::Result<()>>,
-    },
 }
 
 #[derive(Debug)]

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -216,20 +216,6 @@ where
         &self.peer_id
     }
 
-    async fn ban_peer(&mut self, peer_id: S::PeerId) -> crate::Result<()> {
-        log::debug!("ban remote peer, peer id {peer_id}");
-
-        let (tx, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(types::Command::BanPeer {
-                peer_id,
-                response: tx,
-            })
-            .await?;
-
-        rx.await?
-    }
-
     async fn poll_next(&mut self) -> crate::Result<ConnectivityEvent<S>> {
         match self.conn_rx.recv().await.ok_or(P2pError::ChannelClosed)? {
             types::ConnectivityEvent::OutboundAccepted { address, peer_info } => {

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -124,9 +124,6 @@ where
     /// Return peer id of the local node
     fn peer_id(&self) -> &T::PeerId;
 
-    /// Ban peer
-    async fn ban_peer(&mut self, peer_id: T::PeerId) -> crate::Result<()>;
-
     /// Poll events from the network service provider
     ///
     /// There are three types of events that can be received:

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -269,7 +269,7 @@ where
         log::debug!("adjusting score for peer {peer_id}, adjustment {score}");
 
         if self.peerdb.adjust_peer_score(&peer_id, score) {
-            return self.peer_connectivity_handle.ban_peer(peer_id).await;
+            let _ = self.peer_connectivity_handle.disconnect(peer_id).await;
         }
 
         Ok(())

--- a/p2p/src/peer_manager/peerdb.rs
+++ b/p2p/src/peer_manager/peerdb.rs
@@ -42,8 +42,6 @@ use crate::{
     net::{types, AsBannableAddress, NetworkingService},
 };
 
-const BAN_DURATION: Duration = Duration::from_secs(60 * 60 * 24);
-
 #[derive(Debug)]
 pub struct PeerContext<T: NetworkingService> {
     /// Peer information
@@ -403,7 +401,7 @@ impl<T: NetworkingService> PeerDb<T> {
                 .duration_since(UNIX_EPOCH)
                 // This can fail only if `SystemTime::now()` returns the time before `UNIX_EPOCH`.
                 .expect("Invalid system time")
-                + BAN_DURATION;
+                + *self.p2p_config.ban_duration;
             self.banned.insert(address, ban_till);
         } else {
             log::error!("Failed to get address for peer {}", peer_id);

--- a/p2p/src/peer_manager/peerdb.rs
+++ b/p2p/src/peer_manager/peerdb.rs
@@ -417,8 +417,6 @@ impl<T: NetworkingService> PeerDb<T> {
     /// If peer is banned, it is still kept in the peer storage but it is removed
     /// from the `available` storage so it won't be picked up again and its peer ID
     /// is recorded into the `banned` storage which keeps track of all banned peers.
-    ///
-    /// TODO: implement unbanning
     pub fn adjust_peer_score(&mut self, peer_id: &T::PeerId, score: u32) -> bool {
         let final_score = match self.peers.entry(*peer_id) {
             Entry::Vacant(entry) => {

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -121,17 +121,6 @@ where
         pm2.peer_connectivity_handle.poll_next().await,
         Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })
     ));
-
-    // try to reestablish connection, it timeouts because it's rejected in the backend
-    let addr = pm2.peer_connectivity_handle.local_addr().await.unwrap().unwrap();
-    tokio::spawn(async move { pm1.peer_connectivity_handle.connect(addr).await });
-
-    tokio::select! {
-        _event = pm2.peer_connectivity_handle.poll_next() => {
-            panic!("did not expect event, received {:?}", _event)
-        },
-        _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
-    }
 }
 
 #[tokio::test]
@@ -139,25 +128,22 @@ async fn banned_peer_attempts_to_connect_libp2p() {
     banned_peer_attempts_to_connect::<TestTransportLibp2p, Libp2pService>().await;
 }
 
-#[ignore]
 #[tokio::test]
 async fn banned_peer_attempts_to_connect_mock_tcp() {
-    // TODO: implement proper peer banning
     banned_peer_attempts_to_connect::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
 #[ignore]
 #[tokio::test]
 async fn banned_peer_attempts_to_connect_mock_channel() {
-    // TODO: implement proper peer banning
+    // TODO: Currently in the channels backend peer receives a new address every time it connects.
+    // For the banning to work properly the addresses must be persistent.
     banned_peer_attempts_to_connect::<TestTransportChannel, MockService<MockChannelTransport>>()
         .await;
 }
 
-#[ignore]
 #[tokio::test]
 async fn banned_peer_attempts_to_connect_mock_noise() {
-    // TODO: implement proper peer banning
     banned_peer_attempts_to_connect::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
 }
 

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -133,11 +133,8 @@ async fn banned_peer_attempts_to_connect_mock_tcp() {
     banned_peer_attempts_to_connect::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
 }
 
-#[ignore]
 #[tokio::test]
 async fn banned_peer_attempts_to_connect_mock_channel() {
-    // TODO: Currently in the channels backend peer receives a new address every time it connects.
-    // For the banning to work properly the addresses must be persistent.
     banned_peer_attempts_to_connect::<TestTransportChannel, MockService<MockChannelTransport>>()
         .await;
 }

--- a/p2p/src/peer_manager/tests/peerdb.rs
+++ b/p2p/src/peer_manager/tests/peerdb.rs
@@ -605,3 +605,25 @@ fn peer_discovered_libp2p() {
         vec!["/ip6/::1/tcp/9097".parse().unwrap()],
     );
 }
+
+#[tokio::test]
+async fn unban_peer() {
+    let mut peerdb = PeerDb::<Libp2pService>::new(Arc::new(P2pConfig {
+        bind_address: Default::default(),
+        ban_threshold: Default::default(),
+        ban_duration: Duration::from_secs(2).into(),
+        outbound_connection_timeout: Default::default(),
+        mdns_config: Default::default(),
+        request_timeout: Default::default(),
+        node_type: Default::default(),
+    }));
+
+    let id = add_banned_peer(&mut peerdb);
+    let address = peerdb.peers().get(&id).unwrap().address().unwrap().as_bannable();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert!(peerdb.is_address_banned(&address));
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert!(!peerdb.is_address_banned(&address));
+}

--- a/p2p/src/peer_manager/tests/peerdb.rs
+++ b/p2p/src/peer_manager/tests/peerdb.rs
@@ -164,6 +164,7 @@ fn adjust_peer_score_higher_threshold() {
     let config = P2pConfig {
         bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
         ban_threshold: 200.into(),
+        ban_duration: Default::default(),
         outbound_connection_timeout: 10.into(),
         mdns_config: MdnsConfig::Disabled.into(),
         request_timeout: Duration::from_secs(10).into(),
@@ -183,6 +184,7 @@ fn adjust_peer_score_lower_threshold() {
     let config = P2pConfig {
         bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
         ban_threshold: 20.into(),
+        ban_duration: Default::default(),
         outbound_connection_timeout: 10.into(),
         mdns_config: MdnsConfig::Disabled.into(),
         request_timeout: Duration::from_secs(10).into(),

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -73,6 +73,7 @@ where
     let p2p_config = Arc::new(P2pConfig {
         bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
         ban_threshold: 100.into(),
+        ban_duration: Default::default(),
         outbound_connection_timeout: 10.into(),
         mdns_config: MdnsConfig::Disabled.into(),
         request_timeout: Duration::from_secs(1).into(),

--- a/p2p/tests/libp2p-mdns.rs
+++ b/p2p/tests/libp2p-mdns.rs
@@ -36,6 +36,7 @@ async fn test_libp2p_peer_discovery() {
         Arc::new(P2pConfig {
             bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
             ban_threshold: 100.into(),
+            ban_duration: Default::default(),
             outbound_connection_timeout: 10.into(),
             mdns_config: MdnsConfig::Enabled {
                 query_interval: 200.into(),
@@ -56,6 +57,7 @@ async fn test_libp2p_peer_discovery() {
         Arc::new(P2pConfig {
             bind_address: "/ip6/::1/tcp/3031".to_owned().into(),
             ban_threshold: 100.into(),
+            ban_duration: Default::default(),
             outbound_connection_timeout: 10.into(),
             mdns_config: MdnsConfig::Enabled {
                 query_interval: 200.into(),


### PR DESCRIPTION
Some disabled unit tests were failing because peer manager was expecting that the network backend will block incoming connections from banned addresses. At first I tried to re-implement same logic in mock backend. That worked but I think the better way is to keep bans logic in one place (peer manager). Overall I think what we already have is enough for bans to work.

For reference how bans work in bitcoin:
Bitcoin has two mechanisms: Banning and Discouraging.
1. Banning is done via RPC only. IP addresses or subnets are banned (for 24 hours by default). DB is persistent.
2. Discouraging is done automatically for misbehaved or incompatible peers. DB is not persistent but IP addresses are stored in rolling bloom filter (revoking in not possible but older entries replaced as new entries are added).
Incoming connections from discoraged peers are allowed but are first candidates for eviction if incoming slots are full.
Outgoing connections and gossips are not allowed. 

Our implementation is different because we don't separate "banning" and "discouraging".

I also noticed that `bitcoind` never bans local and manual connections:

```
    if (pnode.HasPermission(NetPermissionFlags::NoBan)) {
        // We never disconnect or discourage peers for bad behavior if they have NetPermissionFlags::NoBan permission
        LogPrintf("Warning: not punishing noban peer %d!\n", peer.m_id);
        return false;
    }

    if (pnode.IsManualConn()) {
        // We never disconnect or discourage manual peers for bad behavior
        LogPrintf("Warning: not punishing manually connected peer %d!\n", peer.m_id);
        return false;
    }

    if (pnode.addr.IsLocal()) {
        // We disconnect local peers for bad behavior but don't discourage (since that would discourage
        // all peers on the same local address)
        LogPrint(BCLog::NET, "Warning: disconnecting but not discouraging %s peer %d!\n",
                 pnode.m_inbound_onion ? "inbound onion" : "local", peer.m_id);
        pnode.fDisconnect = true;
        return true;
    }
```