### PR TITLE
Add support for derivable extended keys for Secp256k1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e89470017230c38e52b82b3ee3f530db1856ba1d434e3a67a3456a8a8dec5f"
+dependencies = [
+ "bitcoin_hashes",
+ "rand_core 0.4.2",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +332,12 @@ checksum = "754eb4c7f35c031f33c95cc257b4c4192a5c9d3de637d3ee78ab052a3f35da57"
 dependencies = [
  "bech32 0.8.1",
 ]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
 
 [[package]]
 name = "bitflags"
@@ -860,10 +876,12 @@ name = "crypto"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "bip39",
  "blake2",
  "chacha20poly1305 0.10.1",
  "generic-array",
  "hex",
+ "hmac",
  "merlin",
  "num",
  "num-derive",
@@ -1483,6 +1501,15 @@ name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.6",
+]
 
 [[package]]
 name = "http"
@@ -3316,6 +3343,12 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -10,6 +10,8 @@ authors = ["Samer Afach <samer.afach@mintlayer.org>", "Ben Marsh <benjamin.marsh
 [dependencies]
 serialization = { path = "../serialization" }
 secp256k1 = { version = "0.24.2", default-features = false, features = ["global-context", "rand-std"] }
+hmac = "0.12.1"
+bip39 = { version = "1.0.1", default-features = false }
 sha-1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"

--- a/crypto/src/key/extended.rs
+++ b/crypto/src/key/extended.rs
@@ -1,0 +1,201 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serialization::{Decode, Encode};
+
+use crate::key::hdkd::child_number::ChildNumber;
+use crate::key::hdkd::derivable::{Derivable, DerivationError};
+use crate::key::key_holder::{ExtendedPrivateKeyHolder, ExtendedPublicKeyHolder};
+use crate::key::secp256k1::extended_keys::{
+    Secp256k1ExtendedPrivateKey, Secp256k1ExtendedPublicKey,
+};
+use crate::key::{PrivateKey, PublicKey};
+use crate::random::make_true_rng;
+use crate::random::{CryptoRng, Rng};
+
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum ExtendedKeyKind {
+    #[codec(index = 0)]
+    Secp256k1Schnorr,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct ExtendedPrivateKey {
+    key: ExtendedPrivateKeyHolder,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct ExtendedPublicKey {
+    pub_key: ExtendedPublicKeyHolder,
+}
+
+impl ExtendedPrivateKey {
+    pub fn new_master(
+        seed: &[u8],
+        key_kind: ExtendedKeyKind,
+    ) -> Result<ExtendedPrivateKey, DerivationError> {
+        match key_kind {
+            ExtendedKeyKind::Secp256k1Schnorr => {
+                let secp_key = Secp256k1ExtendedPrivateKey::new_master(seed)?;
+                Ok(ExtendedPrivateKey {
+                    key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(secp_key),
+                })
+            }
+        }
+    }
+
+    pub fn new_from_entropy(key_kind: ExtendedKeyKind) -> (ExtendedPrivateKey, ExtendedPublicKey) {
+        Self::new_from_rng(&mut make_true_rng(), key_kind)
+    }
+
+    pub fn new_from_rng(
+        rng: &mut (impl Rng + CryptoRng),
+        key_kind: ExtendedKeyKind,
+    ) -> (ExtendedPrivateKey, ExtendedPublicKey) {
+        match key_kind {
+            ExtendedKeyKind::Secp256k1Schnorr => {
+                let k = Secp256k1ExtendedPrivateKey::new(rng);
+                (
+                    ExtendedPrivateKey {
+                        key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(k.0),
+                    },
+                    ExtendedPublicKey {
+                        pub_key: ExtendedPublicKeyHolder::Secp256k1Schnorr(k.1),
+                    },
+                )
+            }
+        }
+    }
+
+    pub fn kind(&self) -> ExtendedKeyKind {
+        match self.key {
+            ExtendedPrivateKeyHolder::Secp256k1Schnorr(_) => ExtendedKeyKind::Secp256k1Schnorr,
+        }
+    }
+
+    pub(crate) fn get_internal_key(&self) -> &ExtendedPrivateKeyHolder {
+        &self.key
+    }
+
+    pub fn private_key(self) -> PrivateKey {
+        match self.key {
+            ExtendedPrivateKeyHolder::Secp256k1Schnorr(k) => k.private_key.into(),
+        }
+    }
+}
+
+impl ExtendedPublicKey {
+    pub fn kind(&self) -> ExtendedKeyKind {
+        match self.pub_key {
+            ExtendedPublicKeyHolder::Secp256k1Schnorr(_) => ExtendedKeyKind::Secp256k1Schnorr,
+        }
+    }
+
+    pub fn get_internal_key(&self) -> &ExtendedPublicKeyHolder {
+        &self.pub_key
+    }
+
+    pub fn from_private_key(private_key: &ExtendedPrivateKey) -> ExtendedPublicKey {
+        match private_key.get_internal_key() {
+            ExtendedPrivateKeyHolder::Secp256k1Schnorr(ref k) => {
+                let secp_key = Secp256k1ExtendedPublicKey::from_private_key(k);
+                ExtendedPublicKey {
+                    pub_key: ExtendedPublicKeyHolder::Secp256k1Schnorr(secp_key),
+                }
+            }
+        }
+    }
+
+    pub fn public_key(self) -> PublicKey {
+        match self.pub_key {
+            ExtendedPublicKeyHolder::Secp256k1Schnorr(k) => k.public_key.into(),
+        }
+    }
+}
+
+impl Derivable for ExtendedPrivateKey {
+    fn derive_child(self, num: ChildNumber) -> Result<Self, DerivationError> {
+        match self.key {
+            ExtendedPrivateKeyHolder::Secp256k1Schnorr(key) => {
+                let secp_key = key.derive_child(num)?;
+                Ok(ExtendedPrivateKey {
+                    key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(secp_key),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::key::hdkd::derivation_path::DerivationPath;
+    use bip39::Mnemonic;
+    use hex::ToHex;
+    use rstest::rstest;
+    use std::str::FromStr;
+    use test_utils::random::make_seedable_rng;
+    use test_utils::random::Seed;
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn sign_and_verify_extended_secp256k1schnorr(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let (sk, pk) =
+            ExtendedPrivateKey::new_from_rng(&mut rng, ExtendedKeyKind::Secp256k1Schnorr);
+        assert_eq!(sk.kind(), ExtendedKeyKind::Secp256k1Schnorr);
+        let msg_size = 1 + rand::random::<usize>() % 10000;
+        let msg: Vec<u8> = (0..msg_size).map(|_| rand::random::<u8>()).collect();
+        let sig = sk.private_key().sign_message(&msg).unwrap();
+        assert!(pk.public_key().verify_message(&sig, &msg));
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn derive_secp256k1schnorr(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let (sk, _) = ExtendedPrivateKey::new_from_rng(&mut rng, ExtendedKeyKind::Secp256k1Schnorr);
+        let sk1 = sk
+            .clone()
+            .derive_child(ChildNumber::from_hardened(123.try_into().unwrap()))
+            .unwrap();
+        let sk2 = sk1.derive_child(ChildNumber::from_hardened(456.try_into().unwrap())).unwrap();
+        let sk3 = sk2.derive_child(ChildNumber::from_hardened(789.try_into().unwrap())).unwrap();
+        let sk4 = sk.derive_path(&DerivationPath::from_str("m/123h/456h/789h").unwrap()).unwrap();
+        assert_eq!(sk3, sk4);
+    }
+
+    #[test]
+    fn master_key_from_mnemonic_secp256k1schnorr() {
+        let mnemonic_str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let mnemonic = Mnemonic::parse_normalized(mnemonic_str).unwrap();
+        let master_key = ExtendedPrivateKey::new_master(
+            &mnemonic.to_seed_normalized(""),
+            ExtendedKeyKind::Secp256k1Schnorr,
+        )
+        .unwrap();
+        let master_pub_key = ExtendedPublicKey::from_private_key(&master_key);
+        assert_eq!(
+            master_key.encode().encode_hex::<String>(),
+            "007923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70e1837c1be8e2995ec11cda2b066151be2cfb48adf9e47b151d46adab3a21cdf67"
+        );
+        assert_eq!(
+            master_pub_key.encode().encode_hex::<String>(),
+            "007923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70ed902f35f560e0470c63313c7369168d9d7df2d49bf295fd9fb7cb109ccee0494"
+        );
+    }
+}

--- a/crypto/src/key/hdkd/chain_code.rs
+++ b/crypto/src/key/hdkd/chain_code.rs
@@ -42,7 +42,7 @@ impl From<ChainCode> for [u8; CHAINCODE_LENGTH] {
 impl From<ChildNumber> for ChainCode {
     fn from(num: ChildNumber) -> Self {
         let mut chaincode = ChainCode([0u8; CHAINCODE_LENGTH]);
-        chaincode.0[0..4].copy_from_slice(&num.to_encoded_index().to_be_bytes());
+        chaincode.0[0..4].copy_from_slice(&num.into_encoded_index().to_be_bytes());
         chaincode
     }
 }

--- a/crypto/src/key/hdkd/chain_code.rs
+++ b/crypto/src/key/hdkd/chain_code.rs
@@ -14,10 +14,11 @@
 // limitations under the License.
 
 use super::child_number::ChildNumber;
+use serialization::{Decode, Encode};
 
 pub const CHAINCODE_LENGTH: usize = 32;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub struct ChainCode([u8; CHAINCODE_LENGTH]);
 
 impl ChainCode {

--- a/crypto/src/key/hdkd/child_number.rs
+++ b/crypto/src/key/hdkd/child_number.rs
@@ -34,42 +34,29 @@ enum DerivationType {
 
 impl ChildNumber {
     /// Return a hardened child number
-    pub fn from_hardened(index: U31) -> Result<Self, DerivationError> {
-        Ok(ChildNumber(DerivationType::Hardened(index)))
-    }
-
-    /// Return a normal child number
-    fn from_normal(_index: U31) -> Result<Self, DerivationError> {
-        // For the time being we don't support non-hardened derivations
-        Err(DerivationError::UnsupportedDerivationType)
+    pub fn from_hardened(index: U31) -> Self {
+        ChildNumber(DerivationType::Hardened(index))
     }
 
     /// Return a child based on the hardened bit (MSB bit)
     pub fn from_index_with_hardened_bit(index: u32) -> Result<Self, DerivationError> {
         let (index_u31, msb) = U31::from_u32_with_msb(index);
         if msb {
-            Self::from_hardened(index_u31)
+            Ok(Self::from_hardened(index_u31))
         } else {
-            Self::from_normal(index_u31)
+            Err(DerivationError::UnsupportedDerivationType)
         }
     }
 
     /// Return a BIP32-like child number index that has the hardened bit set if needed
-    pub fn to_encoded_index(self) -> u32 {
+    pub fn into_encoded_index(self) -> u32 {
         match self.0 {
             DerivationType::Hardened(i) => i.into_encoded_with_msb(true),
         }
     }
 
-    pub fn to_encoded_be_bytes(self) -> [u8; 4] {
-        self.to_encoded_index().to_be_bytes()
-    }
-
-    /// Returns true if this child number is hardened
-    pub fn is_hardened(&self) -> bool {
-        match self.0 {
-            DerivationType::Hardened(_) => true,
-        }
+    pub fn into_encoded_be_bytes(self) -> [u8; 4] {
+        self.into_encoded_index().to_be_bytes()
     }
 }
 
@@ -96,9 +83,9 @@ impl FromStr for ChildNumber {
         let index = U31::from_str(index_str)?;
 
         if is_hardened {
-            ChildNumber::from_hardened(index)
+            Ok(ChildNumber::from_hardened(index))
         } else {
-            ChildNumber::from_normal(index)
+            Err(DerivationError::UnsupportedDerivationType)
         }
     }
 }

--- a/crypto/src/key/hdkd/child_number.rs
+++ b/crypto/src/key/hdkd/child_number.rs
@@ -61,6 +61,10 @@ impl ChildNumber {
         }
     }
 
+    pub fn to_encoded_be_bytes(self) -> [u8; 4] {
+        self.to_encoded_index().to_be_bytes()
+    }
+
     /// Returns true if this child number is hardened
     pub fn is_hardened(&self) -> bool {
         match self.0 {

--- a/crypto/src/key/hdkd/derivable.rs
+++ b/crypto/src/key/hdkd/derivable.rs
@@ -29,6 +29,8 @@ pub enum DerivationError {
     UnsupportedDerivationType,
     #[error("Unsupported derivation for key type")]
     UnsupportedKeyType,
+    #[error("Key derivation error")]
+    KeyDerivationError,
 }
 
 pub trait Derivable: Sized {

--- a/crypto/src/key/hdkd/derivable.rs
+++ b/crypto/src/key/hdkd/derivable.rs
@@ -59,20 +59,19 @@ mod tests {
     }
 
     #[test]
-    fn test_derivation_trait() {
+    fn derivation_trait() {
         let dummy = DummyDerivable::default();
         let path = DerivationPath::from_str("m/1'/2'/3'").unwrap();
         let derived = dummy.derive_path(&path).unwrap();
         let mut expected = DummyDerivable(vec![
-            ChildNumber::from_hardened(1.try_into().unwrap()).unwrap(),
-            ChildNumber::from_hardened(2.try_into().unwrap()).unwrap(),
-            ChildNumber::from_hardened(3.try_into().unwrap()).unwrap(),
+            ChildNumber::from_hardened(1.try_into().unwrap()),
+            ChildNumber::from_hardened(2.try_into().unwrap()),
+            ChildNumber::from_hardened(3.try_into().unwrap()),
         ]);
         assert_eq!(derived, expected);
-        let derived = derived
-            .derive_child(ChildNumber::from_hardened(4.try_into().unwrap()).unwrap())
-            .unwrap();
-        expected.0.push(ChildNumber::from_hardened(4.try_into().unwrap()).unwrap());
+        let derived =
+            derived.derive_child(ChildNumber::from_hardened(4.try_into().unwrap())).unwrap();
+        expected.0.push(ChildNumber::from_hardened(4.try_into().unwrap()));
         assert_eq!(derived, expected);
     }
 }

--- a/crypto/src/key/hdkd/derivation_path.rs
+++ b/crypto/src/key/hdkd/derivation_path.rs
@@ -26,6 +26,14 @@ const SEPARATOR: &str = "/";
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct DerivationPath(Vec<ChildNumber>);
 
+impl DerivationPath {
+    pub fn extend(&self, num: ChildNumber) -> Self {
+        let mut new_path = self.0.clone();
+        new_path.push(num);
+        new_path.into()
+    }
+}
+
 impl From<Vec<ChildNumber>> for DerivationPath {
     fn from(path: Vec<ChildNumber>) -> Self {
         DerivationPath(path)
@@ -62,8 +70,8 @@ impl fmt::Display for DerivationPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(PREFIX, f)?;
         for child in self.0.iter() {
-            fmt::Display::fmt(child, f)?;
             fmt::Display::fmt(SEPARATOR, f)?;
+            fmt::Display::fmt(child, f)?;
         }
         Ok(())
     }

--- a/crypto/src/key/key_holder.rs
+++ b/crypto/src/key/key_holder.rs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::key::secp256k1::extended_keys::{
+    Secp256k1ExtendedPrivateKey, Secp256k1ExtendedPublicKey,
+};
 use crate::key::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use serialization::{Decode, Encode};
 
@@ -32,4 +35,16 @@ pub enum PublicKeyHolder {
     Secp256k1Schnorr(Secp256k1PublicKey),
     #[codec(index = 2)]
     RistrettoSchnorr(MLRistrettoPublicKey),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum ExtendedPrivateKeyHolder {
+    #[codec(index = 1)]
+    Secp256k1Schnorr(Secp256k1ExtendedPrivateKey),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Decode, Encode)]
+pub enum ExtendedPublicKeyHolder {
+    #[codec(index = 1)]
+    Secp256k1Schnorr(Secp256k1ExtendedPublicKey),
 }

--- a/crypto/src/key/key_holder.rs
+++ b/crypto/src/key/key_holder.rs
@@ -25,7 +25,7 @@ use super::rschnorr::{MLRistrettoPrivateKey, MLRistrettoPublicKey};
 pub enum PrivateKeyHolder {
     #[codec(index = 0)]
     Secp256k1Schnorr(Secp256k1PrivateKey),
-    #[codec(index = 2)]
+    #[codec(index = 1)]
     RistrettoSchnorr(MLRistrettoPrivateKey),
 }
 
@@ -33,18 +33,18 @@ pub enum PrivateKeyHolder {
 pub enum PublicKeyHolder {
     #[codec(index = 0)]
     Secp256k1Schnorr(Secp256k1PublicKey),
-    #[codec(index = 2)]
+    #[codec(index = 1)]
     RistrettoSchnorr(MLRistrettoPublicKey),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
 pub enum ExtendedPrivateKeyHolder {
-    #[codec(index = 1)]
+    #[codec(index = 0)]
     Secp256k1Schnorr(Secp256k1ExtendedPrivateKey),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Decode, Encode)]
 pub enum ExtendedPublicKeyHolder {
-    #[codec(index = 1)]
+    #[codec(index = 0)]
     Secp256k1Schnorr(Secp256k1ExtendedPublicKey),
 }

--- a/crypto/src/key/mod.rs
+++ b/crypto/src/key/mod.rs
@@ -22,6 +22,9 @@ pub mod signature;
 use serialization::{Decode, Encode};
 
 use crate::key::rschnorr::{MLRistrettoPrivateKey, MLRistrettoPublicKey, RistrettoSignatureError};
+use crate::key::secp256k1::extended_keys::{
+    Secp256k1ExtendedPrivateKey, Secp256k1ExtendedPublicKey,
+};
 use crate::key::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use crate::key::Signature::{RistrettoSchnorr, Secp256k1Schnorr};
 use crate::random::make_true_rng;
@@ -30,7 +33,9 @@ pub use signature::Signature;
 
 use self::hdkd::child_number::ChildNumber;
 use self::hdkd::derivable::{Derivable, DerivationError};
-use self::key_holder::{PrivateKeyHolder, PublicKeyHolder};
+use self::key_holder::{
+    ExtendedPrivateKeyHolder, ExtendedPublicKeyHolder, PrivateKeyHolder, PublicKeyHolder,
+};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum SignatureError {
@@ -43,8 +48,16 @@ pub enum SignatureError {
 pub enum KeyKind {
     #[codec(index = 0)]
     Secp256k1Schnorr,
+    // Index 1 is used for extended Secp256k1Schnorr
     #[codec(index = 2)]
     RistrettoSchnorr,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub enum ExtendedKeyKind {
+    // Index 0 is used for Secp256k1Schnorr
+    #[codec(index = 1)]
+    Secp256k1Schnorr,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
@@ -55,6 +68,16 @@ pub struct PrivateKey {
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Decode, Encode)]
 pub struct PublicKey {
     pub_key: PublicKeyHolder,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct ExtendedPrivateKey {
+    key: ExtendedPrivateKeyHolder,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
+pub struct ExtendedPublicKey {
+    pub_key: ExtendedPublicKeyHolder,
 }
 
 impl From<RistrettoSignatureError> for SignatureError {
@@ -140,6 +163,81 @@ impl From<MLRistrettoPrivateKey> for PrivateKey {
     }
 }
 
+impl ExtendedPrivateKey {
+    pub fn new_master(
+        seed: &[u8],
+        key_kind: ExtendedKeyKind,
+    ) -> Result<ExtendedPrivateKey, DerivationError> {
+        match key_kind {
+            ExtendedKeyKind::Secp256k1Schnorr => {
+                Ok(Secp256k1ExtendedPrivateKey::new_master(seed)?.into())
+            }
+        }
+    }
+
+    pub fn new_from_entropy(key_kind: ExtendedKeyKind) -> (ExtendedPrivateKey, ExtendedPublicKey) {
+        Self::new_from_rng(&mut make_true_rng(), key_kind)
+    }
+
+    pub fn new_from_rng(
+        rng: &mut (impl Rng + CryptoRng),
+        key_kind: ExtendedKeyKind,
+    ) -> (ExtendedPrivateKey, ExtendedPublicKey) {
+        match key_kind {
+            ExtendedKeyKind::Secp256k1Schnorr => {
+                let k = Secp256k1ExtendedPrivateKey::new(rng);
+                (k.0.into(), k.1.into())
+            }
+        }
+    }
+
+    pub fn kind(&self) -> ExtendedKeyKind {
+        match self.key {
+            ExtendedPrivateKeyHolder::Secp256k1Schnorr(_) => ExtendedKeyKind::Secp256k1Schnorr,
+        }
+    }
+
+    pub(crate) fn get_internal_key(&self) -> &ExtendedPrivateKeyHolder {
+        &self.key
+    }
+}
+
+impl ExtendedPublicKey {
+    pub fn kind(&self) -> ExtendedKeyKind {
+        match self.pub_key {
+            ExtendedPublicKeyHolder::Secp256k1Schnorr(_) => ExtendedKeyKind::Secp256k1Schnorr,
+        }
+    }
+
+    pub fn get_internal_key(&self) -> &ExtendedPublicKeyHolder {
+        &self.pub_key
+    }
+
+    pub fn from_private_key(private_key: &ExtendedPrivateKey) -> ExtendedPublicKey {
+        match private_key.get_internal_key() {
+            ExtendedPrivateKeyHolder::Secp256k1Schnorr(ref k) => {
+                Secp256k1ExtendedPublicKey::from_private_key(k).into()
+            }
+        }
+    }
+}
+
+impl From<Secp256k1ExtendedPrivateKey> for ExtendedPrivateKey {
+    fn from(sk: Secp256k1ExtendedPrivateKey) -> Self {
+        Self {
+            key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(sk),
+        }
+    }
+}
+
+impl Derivable for ExtendedPrivateKey {
+    fn derive_child(self, num: ChildNumber) -> Result<Self, DerivationError> {
+        match self.key {
+            ExtendedPrivateKeyHolder::Secp256k1Schnorr(key) => Ok(key.derive_child(num)?.into()),
+        }
+    }
+}
+
 impl PublicKey {
     pub fn from_private_key(private_key: &PrivateKey) -> Self {
         match private_key.get_internal_key() {
@@ -190,10 +288,20 @@ impl From<Secp256k1PublicKey> for PublicKey {
     }
 }
 
+impl From<Secp256k1ExtendedPublicKey> for ExtendedPublicKey {
+    fn from(pk: Secp256k1ExtendedPublicKey) -> Self {
+        Self {
+            pub_key: ExtendedPublicKeyHolder::Secp256k1Schnorr(pk),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::key::hdkd::derivation_path::DerivationPath;
+    use bip39::Mnemonic;
+    use hex::ToHex;
     use rstest::rstest;
     use std::str::FromStr;
     use test_utils::random::make_seedable_rng;
@@ -230,6 +338,26 @@ mod test {
     #[case(Seed::from_entropy())]
     fn derive(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
+        let (sk, _) = ExtendedPrivateKey::new_from_rng(&mut rng, ExtendedKeyKind::Secp256k1Schnorr);
+        let sk1 = sk
+            .clone()
+            .derive_child(ChildNumber::from_hardened(123.try_into().unwrap()).unwrap())
+            .unwrap();
+        let sk2 = sk1
+            .derive_child(ChildNumber::from_hardened(456.try_into().unwrap()).unwrap())
+            .unwrap();
+        let sk3 = sk2
+            .derive_child(ChildNumber::from_hardened(789.try_into().unwrap()).unwrap())
+            .unwrap();
+        let sk4 = sk.derive_path(&DerivationPath::from_str("m/123h/456h/789h").unwrap()).unwrap();
+        assert_eq!(sk3, sk4);
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn derive_ristretto(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
         let (sk, _) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let sk1 = sk
             .clone()
@@ -243,5 +371,25 @@ mod test {
             .unwrap();
         let sk4 = sk.derive_path(&DerivationPath::from_str("m/123h/456h/789h").unwrap()).unwrap();
         assert_eq!(sk3, sk4);
+    }
+
+    #[test]
+    fn master_key_from_mnemonic() {
+        let mnemonic_str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let mnemonic = Mnemonic::parse_normalized(mnemonic_str).unwrap();
+        let master_key = ExtendedPrivateKey::new_master(
+            &mnemonic.to_seed_normalized(""),
+            ExtendedKeyKind::Secp256k1Schnorr,
+        )
+        .unwrap();
+        let master_pub_key = ExtendedPublicKey::from_private_key(&master_key);
+        assert_eq!(
+            master_key.encode().encode_hex::<String>(),
+            "017923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70e1837c1be8e2995ec11cda2b066151be2cfb48adf9e47b151d46adab3a21cdf67"
+        );
+        assert_eq!(
+            master_pub_key.encode().encode_hex::<String>(),
+            "017923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70ed902f35f560e0470c63313c7369168d9d7df2d49bf295fd9fb7cb109ccee0494"
+        );
     }
 }

--- a/crypto/src/key/mod.rs
+++ b/crypto/src/key/mod.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod extended;
 pub mod hdkd;
 mod key_holder;
 pub mod rschnorr;
@@ -22,9 +23,6 @@ pub mod signature;
 use serialization::{Decode, Encode};
 
 use crate::key::rschnorr::{MLRistrettoPrivateKey, MLRistrettoPublicKey, RistrettoSignatureError};
-use crate::key::secp256k1::extended_keys::{
-    Secp256k1ExtendedPrivateKey, Secp256k1ExtendedPublicKey,
-};
 use crate::key::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use crate::key::Signature::{RistrettoSchnorr, Secp256k1Schnorr};
 use crate::random::make_true_rng;
@@ -33,9 +31,7 @@ pub use signature::Signature;
 
 use self::hdkd::child_number::ChildNumber;
 use self::hdkd::derivable::{Derivable, DerivationError};
-use self::key_holder::{
-    ExtendedPrivateKeyHolder, ExtendedPublicKeyHolder, PrivateKeyHolder, PublicKeyHolder,
-};
+use self::key_holder::{PrivateKeyHolder, PublicKeyHolder};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum SignatureError {
@@ -48,16 +44,8 @@ pub enum SignatureError {
 pub enum KeyKind {
     #[codec(index = 0)]
     Secp256k1Schnorr,
-    // Index 1 is used for extended Secp256k1Schnorr
-    #[codec(index = 2)]
-    RistrettoSchnorr,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
-pub enum ExtendedKeyKind {
-    // Index 0 is used for Secp256k1Schnorr
     #[codec(index = 1)]
-    Secp256k1Schnorr,
+    RistrettoSchnorr,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
@@ -68,16 +56,6 @@ pub struct PrivateKey {
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Decode, Encode)]
 pub struct PublicKey {
     pub_key: PublicKeyHolder,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
-pub struct ExtendedPrivateKey {
-    key: ExtendedPrivateKeyHolder,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
-pub struct ExtendedPublicKey {
-    pub_key: ExtendedPublicKeyHolder,
 }
 
 impl From<RistrettoSignatureError> for SignatureError {
@@ -163,81 +141,6 @@ impl From<MLRistrettoPrivateKey> for PrivateKey {
     }
 }
 
-impl ExtendedPrivateKey {
-    pub fn new_master(
-        seed: &[u8],
-        key_kind: ExtendedKeyKind,
-    ) -> Result<ExtendedPrivateKey, DerivationError> {
-        match key_kind {
-            ExtendedKeyKind::Secp256k1Schnorr => {
-                Ok(Secp256k1ExtendedPrivateKey::new_master(seed)?.into())
-            }
-        }
-    }
-
-    pub fn new_from_entropy(key_kind: ExtendedKeyKind) -> (ExtendedPrivateKey, ExtendedPublicKey) {
-        Self::new_from_rng(&mut make_true_rng(), key_kind)
-    }
-
-    pub fn new_from_rng(
-        rng: &mut (impl Rng + CryptoRng),
-        key_kind: ExtendedKeyKind,
-    ) -> (ExtendedPrivateKey, ExtendedPublicKey) {
-        match key_kind {
-            ExtendedKeyKind::Secp256k1Schnorr => {
-                let k = Secp256k1ExtendedPrivateKey::new(rng);
-                (k.0.into(), k.1.into())
-            }
-        }
-    }
-
-    pub fn kind(&self) -> ExtendedKeyKind {
-        match self.key {
-            ExtendedPrivateKeyHolder::Secp256k1Schnorr(_) => ExtendedKeyKind::Secp256k1Schnorr,
-        }
-    }
-
-    pub(crate) fn get_internal_key(&self) -> &ExtendedPrivateKeyHolder {
-        &self.key
-    }
-}
-
-impl ExtendedPublicKey {
-    pub fn kind(&self) -> ExtendedKeyKind {
-        match self.pub_key {
-            ExtendedPublicKeyHolder::Secp256k1Schnorr(_) => ExtendedKeyKind::Secp256k1Schnorr,
-        }
-    }
-
-    pub fn get_internal_key(&self) -> &ExtendedPublicKeyHolder {
-        &self.pub_key
-    }
-
-    pub fn from_private_key(private_key: &ExtendedPrivateKey) -> ExtendedPublicKey {
-        match private_key.get_internal_key() {
-            ExtendedPrivateKeyHolder::Secp256k1Schnorr(ref k) => {
-                Secp256k1ExtendedPublicKey::from_private_key(k).into()
-            }
-        }
-    }
-}
-
-impl From<Secp256k1ExtendedPrivateKey> for ExtendedPrivateKey {
-    fn from(sk: Secp256k1ExtendedPrivateKey) -> Self {
-        Self {
-            key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(sk),
-        }
-    }
-}
-
-impl Derivable for ExtendedPrivateKey {
-    fn derive_child(self, num: ChildNumber) -> Result<Self, DerivationError> {
-        match self.key {
-            ExtendedPrivateKeyHolder::Secp256k1Schnorr(key) => Ok(key.derive_child(num)?.into()),
-        }
-    }
-}
-
 impl PublicKey {
     pub fn from_private_key(private_key: &PrivateKey) -> Self {
         match private_key.get_internal_key() {
@@ -288,20 +191,10 @@ impl From<Secp256k1PublicKey> for PublicKey {
     }
 }
 
-impl From<Secp256k1ExtendedPublicKey> for ExtendedPublicKey {
-    fn from(pk: Secp256k1ExtendedPublicKey) -> Self {
-        Self {
-            pub_key: ExtendedPublicKeyHolder::Secp256k1Schnorr(pk),
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::key::hdkd::derivation_path::DerivationPath;
-    use bip39::Mnemonic;
-    use hex::ToHex;
     use rstest::rstest;
     use std::str::FromStr;
     use test_utils::random::make_seedable_rng;
@@ -310,7 +203,7 @@ mod test {
     #[rstest]
     #[trace]
     #[case(Seed::from_entropy())]
-    fn sign_and_verify(#[case] seed: Seed) {
+    fn sign_and_verify_secp256k1schnorr(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let (sk, pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         assert_eq!(sk.kind(), KeyKind::Secp256k1Schnorr);
@@ -336,60 +229,16 @@ mod test {
     #[rstest]
     #[trace]
     #[case(Seed::from_entropy())]
-    fn derive(#[case] seed: Seed) {
-        let mut rng = make_seedable_rng(seed);
-        let (sk, _) = ExtendedPrivateKey::new_from_rng(&mut rng, ExtendedKeyKind::Secp256k1Schnorr);
-        let sk1 = sk
-            .clone()
-            .derive_child(ChildNumber::from_hardened(123.try_into().unwrap()).unwrap())
-            .unwrap();
-        let sk2 = sk1
-            .derive_child(ChildNumber::from_hardened(456.try_into().unwrap()).unwrap())
-            .unwrap();
-        let sk3 = sk2
-            .derive_child(ChildNumber::from_hardened(789.try_into().unwrap()).unwrap())
-            .unwrap();
-        let sk4 = sk.derive_path(&DerivationPath::from_str("m/123h/456h/789h").unwrap()).unwrap();
-        assert_eq!(sk3, sk4);
-    }
-
-    #[rstest]
-    #[trace]
-    #[case(Seed::from_entropy())]
     fn derive_ristretto(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let (sk, _) = PrivateKey::new_from_rng(&mut rng, KeyKind::RistrettoSchnorr);
         let sk1 = sk
             .clone()
-            .derive_child(ChildNumber::from_hardened(123.try_into().unwrap()).unwrap())
+            .derive_child(ChildNumber::from_hardened(123.try_into().unwrap()))
             .unwrap();
-        let sk2 = sk1
-            .derive_child(ChildNumber::from_hardened(456.try_into().unwrap()).unwrap())
-            .unwrap();
-        let sk3 = sk2
-            .derive_child(ChildNumber::from_hardened(789.try_into().unwrap()).unwrap())
-            .unwrap();
+        let sk2 = sk1.derive_child(ChildNumber::from_hardened(456.try_into().unwrap())).unwrap();
+        let sk3 = sk2.derive_child(ChildNumber::from_hardened(789.try_into().unwrap())).unwrap();
         let sk4 = sk.derive_path(&DerivationPath::from_str("m/123h/456h/789h").unwrap()).unwrap();
         assert_eq!(sk3, sk4);
-    }
-
-    #[test]
-    fn master_key_from_mnemonic() {
-        let mnemonic_str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        let mnemonic = Mnemonic::parse_normalized(mnemonic_str).unwrap();
-        let master_key = ExtendedPrivateKey::new_master(
-            &mnemonic.to_seed_normalized(""),
-            ExtendedKeyKind::Secp256k1Schnorr,
-        )
-        .unwrap();
-        let master_pub_key = ExtendedPublicKey::from_private_key(&master_key);
-        assert_eq!(
-            master_key.encode().encode_hex::<String>(),
-            "017923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70e1837c1be8e2995ec11cda2b066151be2cfb48adf9e47b151d46adab3a21cdf67"
-        );
-        assert_eq!(
-            master_pub_key.encode().encode_hex::<String>(),
-            "017923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70ed902f35f560e0470c63313c7369168d9d7df2d49bf295fd9fb7cb109ccee0494"
-        );
     }
 }

--- a/crypto/src/key/rschnorr/mod.rs
+++ b/crypto/src/key/rschnorr/mod.rs
@@ -144,10 +144,6 @@ impl From<super::hdkd::chain_code::ChainCode> for schnorrkel::derive::ChainCode 
 
 impl Derivable for MLRistrettoPrivateKey {
     fn derive_child(self, num: ChildNumber) -> Result<Self, DerivationError> {
-        // We can perform only hard derivations
-        if !num.is_hardened() {
-            return Err(DerivationError::UnsupportedDerivationType);
-        }
         let chaincode: super::hdkd::chain_code::ChainCode = num.into();
         let mini_key = self.as_native().hard_derive_mini_secret_key(Some(chaincode.into()), b"").0;
         let key = MLRistrettoPrivateKey::from_native(mini_key.expand(Ed25519));
@@ -363,7 +359,7 @@ mod test {
         assert_eq!(hex::encode(child_sk.encode()), "010118959f5bfcde4299d177763c94c30b56cd8a7df22d6fc4861d45067c4dccd0470957e0852e2b4af0d8d44a29ad8fdf17db6cf0f5f7feef9d268790b326bda500");
 
         let child_sk_final = child_sk
-            .derive_child(ChildNumber::from_hardened(1.try_into().unwrap()).unwrap())
+            .derive_child(ChildNumber::from_hardened(1.try_into().unwrap()))
             .unwrap();
 
         let path = DerivationPath::from_str("m/0'/1'").unwrap();

--- a/crypto/src/key/secp256k1/extended_keys.rs
+++ b/crypto/src/key/secp256k1/extended_keys.rs
@@ -1,0 +1,256 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::key::hdkd::chain_code::CHAINCODE_LENGTH;
+use crate::key::hdkd::{
+    chain_code::ChainCode,
+    child_number::ChildNumber,
+    derivable::{Derivable, DerivationError},
+};
+use crate::key::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
+use crate::random::{CryptoRng, Rng};
+use hmac::{Hmac, Mac};
+use secp256k1;
+use secp256k1::SECP256K1;
+use serialization::{Decode, Encode};
+use sha2::Sha512;
+use zeroize::Zeroize;
+
+// Create alias for HMAC-SHA512
+type HmacSha512 = Hmac<Sha512>;
+
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
+pub struct Secp256k1ExtendedPrivateKey {
+    /// Chain code
+    pub chain_code: ChainCode,
+    /// Private key
+    pub private_key: Secp256k1PrivateKey,
+}
+
+impl Secp256k1ExtendedPrivateKey {
+    pub fn new_master(seed: &[u8]) -> Result<Secp256k1ExtendedPrivateKey, DerivationError> {
+        let mut mac =
+            HmacSha512::new_from_slice(b"Bitcoin seed").expect("HMAC can take key of any size");
+        mac.update(seed);
+        let mut result = mac.finalize().into_bytes();
+
+        let private_key = secp256k1::SecretKey::from_slice(&result[..32])
+            .map_err(|_| DerivationError::KeyDerivationError)?
+            .into();
+
+        let chain_code: [u8; CHAINCODE_LENGTH] =
+            result[32..].try_into().expect("Chaincode size is 32 bytes");
+        let chain_code = ChainCode::from(chain_code);
+
+        result.zeroize();
+
+        Ok(Secp256k1ExtendedPrivateKey {
+            private_key,
+            chain_code,
+        })
+    }
+
+    pub fn new<R: Rng + CryptoRng>(
+        rng: &mut R,
+    ) -> (Secp256k1ExtendedPrivateKey, Secp256k1ExtendedPublicKey) {
+        // Create a new chain code
+        let mut chain_code = [0u8; 32];
+        rng.fill_bytes(&mut chain_code);
+        let chain_code = chain_code.into();
+        let private_key = secp256k1::SecretKey::new(rng).into();
+        // Generate a new private key
+        let ext_priv = Secp256k1ExtendedPrivateKey {
+            private_key,
+            chain_code,
+        };
+        // Generate the public key
+        let ext_pub = Secp256k1ExtendedPublicKey::from_private_key(&ext_priv);
+        // Return the pair
+        (ext_priv, ext_pub)
+    }
+
+    pub fn as_private_key(&self) -> &Secp256k1PrivateKey {
+        &self.private_key
+    }
+}
+
+impl Derivable for Secp256k1ExtendedPrivateKey {
+    fn derive_child(self, num: ChildNumber) -> Result<Self, DerivationError> {
+        let mut mac = HmacSha512::new_from_slice(&self.chain_code.into_array())
+            .expect("HMAC can take key of any size");
+
+        let secp_key = self.private_key.data;
+
+        // We only support hard derivations
+        if num.is_hardened() {
+            mac.update(&[0u8]);
+            mac.update(&secp_key[..]);
+        } else {
+            return Err(DerivationError::UnsupportedDerivationType);
+        }
+
+        // Add the child number
+        mac.update(&num.to_encoded_be_bytes());
+
+        let mut result = mac.finalize().into_bytes();
+        let private_key = secp256k1::SecretKey::from_slice(&result[..32])
+            .map_err(|_| DerivationError::KeyDerivationError)?
+            // TODO [SECURITY] a Scalar is created here but not erased
+            .add_tweak(&secp_key.into())
+            .map_err(|_| DerivationError::KeyDerivationError)?
+            .into();
+
+        let chain_code: [u8; CHAINCODE_LENGTH] =
+            result[32..].try_into().expect("Chaincode size is 32 bytes");
+        let chain_code = ChainCode::from(chain_code);
+
+        result.zeroize();
+
+        Ok(Secp256k1ExtendedPrivateKey {
+            private_key,
+            chain_code,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode)]
+pub struct Secp256k1ExtendedPublicKey {
+    /// Chain code
+    pub chain_code: ChainCode,
+    /// Public key
+    pub public_key: Secp256k1PublicKey,
+}
+
+impl Secp256k1ExtendedPublicKey {
+    pub fn as_public_key(&self) -> &Secp256k1PublicKey {
+        &self.public_key
+    }
+
+    pub fn from_private_key(private_key: &Secp256k1ExtendedPrivateKey) -> Self {
+        Secp256k1ExtendedPublicKey {
+            public_key: private_key.private_key.data.x_only_public_key(SECP256K1).0.into(),
+            chain_code: private_key.chain_code,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::key::hdkd::derivation_path::DerivationPath;
+    use bip39::Mnemonic;
+    use hex::ToHex;
+    use serialization::DecodeAll;
+    use serialization::Encode;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_serialization() {
+        let sk_hex = "7923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70e1837c1be8e2995ec11cda2b066151be2cfb48adf9e47b151d46adab3a21cdf67";
+        let sk =
+            Secp256k1ExtendedPrivateKey::decode_all(&mut hex::decode(sk_hex).unwrap().as_slice())
+                .unwrap();
+        assert_eq!(sk.encode().encode_hex::<String>(), sk_hex);
+        let pk_hex = "7923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70ed902f35f560e0470c63313c7369168d9d7df2d49bf295fd9fb7cb109ccee0494";
+        let pk =
+            Secp256k1ExtendedPublicKey::decode_all(&mut hex::decode(pk_hex).unwrap().as_slice())
+                .unwrap();
+        assert_eq!(pk.encode().encode_hex::<String>(), pk_hex);
+    }
+
+    #[test]
+    fn test_derivation_private_key() {
+        let mnemonic_str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let mnemonic = Mnemonic::parse_normalized(mnemonic_str).unwrap();
+        let master_key =
+            Secp256k1ExtendedPrivateKey::new_master(&mnemonic.to_seed_normalized("")).unwrap();
+        let master_pub_key = Secp256k1ExtendedPublicKey::from_private_key(&master_key);
+        assert_eq!(master_key.chain_code, master_pub_key.chain_code);
+        assert_eq!(
+            master_key.encode().encode_hex::<String>(),
+            "7923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70e1837c1be8e2995ec11cda2b066151be2cfb48adf9e47b151d46adab3a21cdf67"
+        );
+        assert_eq!(
+            master_pub_key.encode().encode_hex::<String>(),
+            "7923408dadd3c7b56eed15567707ae5e5dca089de972e07f3b860450e2a3b70ed902f35f560e0470c63313c7369168d9d7df2d49bf295fd9fb7cb109ccee0494"
+        );
+
+        let test_vec = vec![
+            (
+                "m/86'/0'/0'",
+                "9043214d33a3c162a9a825d26b2a1c381455a72306ed17857f55ea65b7dd20da",
+                "418278a2885c8bb98148158d1474634097a179c642f23cf1cc04da629ac6f0fb",
+                "c61a8f27e98182314d2444da3e600eb5836ec8ad183c86c311f95df8082b18aa",
+            ),
+            (
+                "m/44'/0'/0'",
+                "fe64af825b5b78554c33a28b23085fc082f691b3c712cc1d4e66e133297da87a",
+                "774c910fcf07fa96886ea794f0d5caed9afe30b44b83f7e213bb92930e7df4bd",
+                "3da4bc190a2680111d31fadfdc905f2a7f6ce77c6f109919116f253d43445219",
+            ),
+            (
+                "m/44'/0'/1'",
+                "8855dfda37fe663bffc0136618504e3cbd7d992134609cef6191c729339d5c65",
+                "5d0261853d4c3a379160fb51d2f262ac64e65219139982c4e2180bcef1a233d9",
+                "2971fa2db0ff5d69e166a406813aa3d9ed09c4adac2e0ce33523da8c5609f4f4",
+            ),
+            (
+                "m/44'/2'/0'",
+                "983cd10d8d14160b10b9a4bb63207e9585054a3133619d57b78ea9d5aa3046d2",
+                "40fe3b8e89165258bac0cb711613c618d1af63dc321a90b751d0697301441bcc",
+                "869c5045e5fc789646babcd1961b101bc31e75fe50df8a585c79b05dca0ac758",
+            ),
+            (
+                "m/49'/0'/0'",
+                "880d51752bda4190607e079588d3f644d96bfa03446bce93cddfda3c4a99c7e6",
+                "f1f347891b20f7568eae3ec9869fbfb67bcab6f358326f10ecc42356bd55939d",
+                "6eaae365ae0e0a0aab84325cfe7cd76c3b909035f889e7d3f1b847a9a0797ecb",
+            ),
+            (
+                "m/49'/2'/0'",
+                "cf222cc2e097049fe2ca76626c19c7e7a3ef971b1f64195758ab3c832463fcf4",
+                "b07388bd2edaba3c0a2c0856716fd7c9965d212fb2736f7b925f57d922b10ace",
+                "67b7e1dc5c70a93504218ccf40c47ad46d4a9c858196376ce0e853aca7be0498",
+            ),
+            (
+                "m/84'/0'/0'",
+                "e14f274d16ca0d91031b98b162618061d03930fa381af6d4caf44b01819ab6d4",
+                "707a62fdacc26ea9b63b1c197906f56ee0180d0bcf1966e1a2da34f5f3a09a9b",
+                "4a53a0ab21b9dc95869c4e92a161194e03c0ef3ff5014ac692f433c4765490fc",
+            ),
+            (
+                "m/0'/1'/2'/3'/4'/5'/6'/7'/8'/9'",
+                "1754f94b8f5bfbacfbbc6b71bc6b2a2aefa3bb31a5579b2da7a0543451041c6a",
+                "f030912b83528995b199908bf45caad86262ede2016aa748dcf0d556b1ec120b",
+                "0c61a6e40d45b7b04ac86ed5a75ebd32fca2d06ff3c1eaaef43f985920ef873f",
+            ),
+        ];
+
+        for (path, secret, public, chaincode) in test_vec {
+            let path = DerivationPath::from_str(path).unwrap();
+            let sk = master_key.clone().derive_path(&path).unwrap();
+            let pk = Secp256k1ExtendedPublicKey::from_private_key(&sk);
+            assert_eq!(sk.chain_code, pk.chain_code);
+            assert_eq!(
+                sk.encode().encode_hex::<String>(),
+                format!("{}{}", chaincode, secret)
+            );
+            assert_eq!(
+                pk.encode().encode_hex::<String>(),
+                format!("{}{}", chaincode, public)
+            );
+        }
+    }
+}

--- a/crypto/src/key/secp256k1/mod.rs
+++ b/crypto/src/key/secp256k1/mod.rs
@@ -27,7 +27,7 @@ pub enum Secp256k1KeyError {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-// TODO [SECURITY] erase secret on drop
+// TODO(SECURITY) erase secret on drop
 pub struct Secp256k1PrivateKey {
     data: secp256k1::SecretKey,
 }
@@ -89,9 +89,9 @@ impl Secp256k1PrivateKey {
         let e = Blake2b32Stream::new().write(msg).finalize();
         let msg_hash = secp256k1::Message::from_slice(e.as_slice()).expect("Blake2b32 is 32 bytes");
         // Sign the hash
-        // TODO [SECURITY] erase keypair after signing
+        // TODO(SECURITY) erase keypair after signing
         let keypair = self.data.keypair(&secp);
-        // TODO [SECURITY] examine the usage of sign_schnorr_with_rng or a RFC6979 scheme
+        // TODO(SECURITY) examine the usage of sign_schnorr_with_rng or a RFC6979 scheme
         secp.sign_schnorr(&msg_hash, &keypair)
     }
 }

--- a/crypto/src/key/secp256k1/mod.rs
+++ b/crypto/src/key/secp256k1/mod.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod extended_keys;
+
 use crate::hash::{Blake2b32Stream, StreamHasher};
 use crate::random::{CryptoRng, Rng};
 use secp256k1;
@@ -27,12 +29,12 @@ pub enum Secp256k1KeyError {
 #[derive(Debug, PartialEq, Eq, Clone)]
 // TODO [SECURITY] erase secret on drop
 pub struct Secp256k1PrivateKey {
-    key_data: secp256k1::SecretKey,
+    data: secp256k1::SecretKey,
 }
 
 impl Encode for Secp256k1PrivateKey {
     fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-        self.key_data.as_ref().using_encoded(f)
+        self.data.as_ref().using_encoded(f)
     }
 }
 
@@ -40,10 +42,16 @@ impl Decode for Secp256k1PrivateKey {
     fn decode<I: serialization::Input>(input: &mut I) -> Result<Self, serialization::Error> {
         let mut v = <[u8; secp256k1::constants::SECRET_KEY_SIZE]>::decode(input)?;
         let result = secp256k1::SecretKey::from_slice(&v)
-            .map(|r| Secp256k1PrivateKey { key_data: r })
+            .map(|r| Secp256k1PrivateKey { data: r })
             .map_err(|_| serialization::Error::from("Private Key deserialization failed"));
         v.zeroize();
         result
+    }
+}
+
+impl From<secp256k1::SecretKey> for Secp256k1PrivateKey {
+    fn from(sk: secp256k1::SecretKey) -> Self {
+        Self { data: sk }
     }
 }
 
@@ -58,21 +66,21 @@ impl Secp256k1PrivateKey {
     }
 
     pub fn as_bytes(&self) -> &[u8] {
-        self.key_data.as_ref()
+        self.data.as_ref()
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Secp256k1KeyError> {
         secp256k1::SecretKey::from_slice(bytes)
-            .map(|r| Secp256k1PrivateKey { key_data: r })
+            .map(|r| Secp256k1PrivateKey { data: r })
             .map_err(|_| Secp256k1KeyError::InvalidData)
     }
 
     pub fn as_native(&self) -> &secp256k1::SecretKey {
-        &self.key_data
+        &self.data
     }
 
     pub fn from_native(native: secp256k1::SecretKey) -> Self {
-        Self { key_data: native }
+        Self { data: native }
     }
 
     pub(crate) fn sign_message(&self, msg: &[u8]) -> secp256k1::schnorr::Signature {
@@ -82,7 +90,7 @@ impl Secp256k1PrivateKey {
         let msg_hash = secp256k1::Message::from_slice(e.as_slice()).expect("Blake2b32 is 32 bytes");
         // Sign the hash
         // TODO [SECURITY] erase keypair after signing
-        let keypair = self.key_data.keypair(&secp);
+        let keypair = self.data.keypair(&secp);
         // TODO [SECURITY] examine the usage of sign_schnorr_with_rng or a RFC6979 scheme
         secp.sign_schnorr(&msg_hash, &keypair)
     }
@@ -108,6 +116,12 @@ impl Decode for Secp256k1PublicKey {
     }
 }
 
+impl From<secp256k1::XOnlyPublicKey> for Secp256k1PublicKey {
+    fn from(pk: secp256k1::XOnlyPublicKey) -> Self {
+        Self { pubkey_data: pk }
+    }
+}
+
 impl Secp256k1PublicKey {
     pub fn as_bytes(&self) -> [u8; secp256k1::constants::SCHNORR_PUBLIC_KEY_SIZE] {
         self.pubkey_data.serialize()
@@ -130,7 +144,7 @@ impl Secp256k1PublicKey {
     }
 
     pub fn from_private_key(private_key: &Secp256k1PrivateKey) -> Self {
-        Self::from_native(private_key.key_data.x_only_public_key(secp256k1::SECP256K1).0)
+        Self::from_native(private_key.data.x_only_public_key(secp256k1::SECP256K1).0)
     }
 
     pub(crate) fn verify_message(

--- a/crypto/src/key/signature/mod.rs
+++ b/crypto/src/key/signature/mod.rs
@@ -168,8 +168,8 @@ mod test {
 
         // we signed the message above and stored the encoded data. Now it has to work from decoded data
         let sig_hex = "010101aa39cdbb96b4eec724cac0400a30cf0d2b9a1040d3aa4f58a34a218d03349f730b8dc2e9b592c6eaac524bc7a5266815f47633aa6eb58708ee262667629a1b86";
-        let pk_hex = "0280283462ee4f0840e21d6de7744ba42929d1b74b7a948e8229d9551e7760ec8c52";
-        let sk_hex = "020101181b259bac04d8ec3f6ea2a86b37f39a353288a8410fc469b9f2d5c59ce30a36c10bfdc906c8343fe0fb42c2564d6b1d3bf8ae3d73f0f7e5424cb60a9639d7e0";
+        let pk_hex = "0180283462ee4f0840e21d6de7744ba42929d1b74b7a948e8229d9551e7760ec8c52";
+        let sk_hex = "010101181b259bac04d8ec3f6ea2a86b37f39a353288a8410fc469b9f2d5c59ce30a36c10bfdc906c8343fe0fb42c2564d6b1d3bf8ae3d73f0f7e5424cb60a9639d7e0";
 
         let sig_bin: Vec<u8> = FromHex::from_hex(sig_hex).unwrap();
         let pk_bin: Vec<u8> = FromHex::from_hex(pk_hex).unwrap();


### PR DESCRIPTION
This commit adds an implementation of the BIP32 derivation algorithm that supports "hard" derivations only. In addition to that the bip39 dependency is added for converting mnemonic phrases to extended master key secrets.

Note that NFKD normalisation is disabled in bip39 because of pinned dependencies and it's version should be bumped once it becomes available.