### PR TITLE
Refactor `MockPeerId` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,6 +2779,7 @@ dependencies = [
  "parity-scale-codec",
  "portpicker",
  "rpc",
+ "serde",
  "serialization",
  "snowstorm",
  "sscanf",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -34,6 +34,7 @@ libp2p = { version = "0.46", default-features = false, features = ["gossipsub", 
 tokio = { version = "1", default-features = false, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util = {version = "0.7", default-features = false, features = ["codec"] }
 snowstorm = "0.4.0"
+serde = "1.0"
 
 [dev-dependencies]
 chainstate-storage = { path = "../chainstate/storage" }

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -74,15 +74,14 @@ where
     .await
     .unwrap();
 
-    connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, _peer_info1, peer_info2) = connect_services::<S>(&mut conn1, &mut conn2).await;
 
     // create few blocks so `sync2` has something to send to `sync1`
     let best_block = TestBlockInfo::from_genesis(chain_config.genesis_block());
     let blocks = p2p_test_utils::create_n_blocks(Arc::clone(&chain_config), best_block, 3);
 
-    let peer = *conn2.peer_id();
     tokio::spawn(async move {
-        sync1.register_peer(peer).await.unwrap();
+        sync1.register_peer(peer_info2.peer_id).await.unwrap();
         sync1.run().await
     });
 
@@ -120,7 +119,7 @@ where
 
     match rx_peer_manager.recv().await {
         Some(PeerManagerEvent::AdjustPeerScore(peer_id, score, _)) => {
-            assert_eq!(&peer_id, conn2.peer_id());
+            assert_eq!(peer_id, peer_info2.peer_id);
             assert_eq!(score, 100);
         }
         e => panic!("invalid event received: {e:?}"),
@@ -167,7 +166,7 @@ where
         tx_peer_manager,
     );
 
-    connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, peer_info, _) = connect_services::<S>(&mut conn1, &mut conn2).await;
 
     // create few blocks and offer an orphan block to the `SyncManager`
     let best_block = TestBlockInfo::from_genesis(chain_config.genesis_block());
@@ -175,7 +174,7 @@ where
 
     // register `conn2` to the `SyncManager`, process a block response
     // and verify the `PeerManager` is notified of the protocol violation
-    let remote_id = *conn2.peer_id();
+    let remote_id = peer_info.peer_id;
 
     tokio::spawn(async move {
         sync1.register_peer(remote_id).await.unwrap();

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -166,7 +166,7 @@ where
         tx_peer_manager,
     );
 
-    let (_address, peer_info, _) = connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, _peer_info, peer_info2) = connect_services::<S>(&mut conn1, &mut conn2).await;
 
     // create few blocks and offer an orphan block to the `SyncManager`
     let best_block = TestBlockInfo::from_genesis(chain_config.genesis_block());
@@ -174,7 +174,7 @@ where
 
     // register `conn2` to the `SyncManager`, process a block response
     // and verify the `PeerManager` is notified of the protocol violation
-    let remote_id = peer_info.peer_id;
+    let remote_id = peer_info2.peer_id;
 
     tokio::spawn(async move {
         sync1.register_peer(remote_id).await.unwrap();

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -1089,7 +1089,7 @@ where
     let blocks = p2p_test_utils::create_n_blocks(Arc::clone(&config), parent_info, 7);
     p2p_test_utils::import_blocks(&mgr2_handle, blocks.clone()).await;
 
-    connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, _peer_info1, peer_info2) = connect_services::<S>(&mut conn1, &mut conn2).await;
     assert_eq!(mgr1.register_peer(peer_info2.peer_id).await, Ok(()));
 
     let handle = tokio::spawn(async move {

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -36,7 +36,7 @@ use p2p::{
     message::{BlockListRequest, BlockListResponse, HeaderListResponse, Request, Response},
     net::{
         types::{ConnectivityEvent, SyncingEvent},
-        ConnectivityService, NetworkingService, SyncingMessagingService,
+        ConnectivityService, DisconnectId, NetworkingService, SyncingMessagingService,
     },
     peer_manager::helpers::connect_services,
     sync::BlockSyncManager,
@@ -1075,7 +1075,10 @@ where
     assert_eq!(mgr1.state(), &SyncState::Done);
 
     mgr1.unregister_peer(peer_info2.peer_id);
-    assert_eq!(conn1.disconnect(peer_info2.peer_id).await, Ok(()));
+    assert_eq!(
+        conn1.disconnect(DisconnectId::PeerId(peer_info2.peer_id)).await,
+        Ok(())
+    );
     assert!(std::matches!(
         conn2.poll_next().await,
         Ok(ConnectivityEvent::ConnectionClosed { .. })
@@ -1200,7 +1203,9 @@ where
     });
 
     match pm1.recv().await.unwrap() {
-        PeerManagerEvent::Disconnect(peer_id, _) => assert_eq!(peer_id, peer2_id),
+        PeerManagerEvent::Disconnect(id, _) => {
+            assert_eq!(id, DisconnectId::PeerId(peer2_id))
+        }
         e => panic!("Unexpected peer manager event: {e:?}"),
     }
 }

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -234,9 +234,9 @@ where
     assert!(!same_tip(&mgr1_handle, &mgr2_handle).await);
 
     // add peer to the hashmap of known peers and send getheaders request to them
-    connect_services::<T>(&mut conn1, &mut conn2).await;
+    let (_address, peer_info) = connect_services::<T>(&mut conn1, &mut conn2).await;
     assert_eq!(mgr1.register_peer(*conn2.peer_id()).await, Ok(()));
-    assert_eq!(mgr2.register_peer(*conn1.peer_id()).await, Ok(()));
+    assert_eq!(mgr2.register_peer(peer_info.peer_id).await, Ok(()));
 
     let handle = tokio::spawn(async move {
         for _ in 0..14 {
@@ -361,9 +361,9 @@ where
     let remote_tip = get_tip(&mgr2_handle).await;
 
     // add peer to the hashmap of known peers and send getheaders request to them
-    connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, peer_info) = connect_services::<S>(&mut conn1, &mut conn2).await;
     assert_eq!(mgr1.register_peer(*conn2.peer_id()).await, Ok(()));
-    assert_eq!(mgr2.register_peer(*conn1.peer_id()).await, Ok(()));
+    assert_eq!(mgr2.register_peer(peer_info.peer_id).await, Ok(()));
 
     let handle = tokio::spawn(async move {
         for _ in 0..24 {
@@ -507,9 +507,9 @@ where
     let remote_tip = get_tip(&mgr2_handle).await;
 
     // add peer to the hashmap of known peers and send getheaders request to them
-    connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, peer_info) = connect_services::<S>(&mut conn1, &mut conn2).await;
     assert_eq!(mgr1.register_peer(*conn2.peer_id()).await, Ok(()));
-    assert_eq!(mgr2.register_peer(*conn1.peer_id()).await, Ok(()));
+    assert_eq!(mgr2.register_peer(peer_info.peer_id).await, Ok(()));
 
     let handle = tokio::spawn(async move {
         for _ in 0..20 {
@@ -663,13 +663,13 @@ where
     let mgr3_tip = get_tip(&mgr3_handle).await;
 
     // connect remote peers to local peer
-    connect_services::<S>(&mut conn1, &mut conn2).await;
-    connect_services::<S>(&mut conn1, &mut conn3).await;
+    let (_address, peer_info2) = connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, peer_info3) = connect_services::<S>(&mut conn1, &mut conn3).await;
 
     assert_eq!(mgr1.register_peer(*conn2.peer_id()).await, Ok(()));
     assert_eq!(mgr1.register_peer(*conn3.peer_id()).await, Ok(()));
-    assert_eq!(mgr2.register_peer(*conn1.peer_id()).await, Ok(()));
-    assert_eq!(mgr3.register_peer(*conn1.peer_id()).await, Ok(()));
+    assert_eq!(mgr2.register_peer(peer_info2.peer_id).await, Ok(()));
+    assert_eq!(mgr3.register_peer(peer_info3.peer_id).await, Ok(()));
 
     let handle = tokio::spawn(async move {
         for _ in 0..18 {
@@ -794,13 +794,13 @@ where
     assert!(!same_tip(&mgr2_handle, &mgr1_handle).await);
 
     // connect remote peers to local peer
-    connect_services::<S>(&mut conn1, &mut conn2).await;
-    connect_services::<S>(&mut conn1, &mut conn3).await;
+    let (_address, peer_info2) = connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, peer_info3) = connect_services::<S>(&mut conn1, &mut conn3).await;
 
     assert_eq!(mgr1.register_peer(*conn2.peer_id()).await, Ok(()));
     assert_eq!(mgr1.register_peer(*conn3.peer_id()).await, Ok(()));
-    assert_eq!(mgr2.register_peer(*conn1.peer_id()).await, Ok(()));
-    assert_eq!(mgr3.register_peer(*conn1.peer_id()).await, Ok(()));
+    assert_eq!(mgr2.register_peer(peer_info2.peer_id).await, Ok(()));
+    assert_eq!(mgr3.register_peer(peer_info3.peer_id).await, Ok(()));
 
     let (tx, mut rx) = mpsc::unbounded_channel();
     let handle = tokio::spawn(async move {
@@ -925,13 +925,13 @@ where
     p2p_test_utils::import_blocks(&mgr3_handle, blocks).await;
 
     // connect remote peers to local peer
-    connect_services::<S>(&mut conn1, &mut conn2).await;
-    connect_services::<S>(&mut conn1, &mut conn3).await;
+    let (_address, peer_info2) = connect_services::<S>(&mut conn1, &mut conn2).await;
+    let (_address, peer_info3) = connect_services::<S>(&mut conn1, &mut conn3).await;
 
     assert_eq!(mgr1.register_peer(*conn2.peer_id()).await, Ok(()));
     assert_eq!(mgr1.register_peer(*conn3.peer_id()).await, Ok(()));
-    assert_eq!(mgr2.register_peer(*conn1.peer_id()).await, Ok(()));
-    assert_eq!(mgr3.register_peer(*conn1.peer_id()).await, Ok(()));
+    assert_eq!(mgr2.register_peer(peer_info2.peer_id).await, Ok(()));
+    assert_eq!(mgr3.register_peer(peer_info3.peer_id).await, Ok(()));
 
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut gethdr_received = HashSet::new();

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -36,7 +36,7 @@ use p2p::{
     message::{BlockListRequest, BlockListResponse, HeaderListResponse, Request, Response},
     net::{
         types::{ConnectivityEvent, SyncingEvent},
-        ConnectivityService, DisconnectId, NetworkingService, SyncingMessagingService,
+        ConnectivityService, NetworkingService, SyncingMessagingService,
     },
     peer_manager::helpers::connect_services,
     sync::BlockSyncManager,
@@ -1075,10 +1075,7 @@ where
     assert_eq!(mgr1.state(), &SyncState::Done);
 
     mgr1.unregister_peer(peer_info2.peer_id);
-    assert_eq!(
-        conn1.disconnect(DisconnectId::PeerId(peer_info2.peer_id)).await,
-        Ok(())
-    );
+    assert_eq!(conn1.disconnect(peer_info2.peer_id).await, Ok(()));
     assert!(std::matches!(
         conn2.poll_next().await,
         Ok(ConnectivityEvent::ConnectionClosed { .. })
@@ -1204,7 +1201,7 @@ where
 
     match pm1.recv().await.unwrap() {
         PeerManagerEvent::Disconnect(id, _) => {
-            assert_eq!(id, DisconnectId::PeerId(peer2_id))
+            assert_eq!(id, peer2_id)
         }
         e => panic!("Unexpected peer manager event: {e:?}"),
     }

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -17,7 +17,7 @@ use tokio::sync::oneshot;
 
 use common::chain::block::Block;
 
-use crate::{interface::p2p_interface::ConnectedPeer, net::NetworkingService};
+use crate::{interface::types::ConnectedPeer, net::NetworkingService};
 
 #[derive(Debug)]
 pub enum PeerManagerEvent<T: NetworkingService> {

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -17,15 +17,18 @@ use tokio::sync::oneshot;
 
 use common::chain::block::Block;
 
-use crate::net::NetworkingService;
+use crate::net::{DisconnectId, NetworkingService};
 
 #[derive(Debug)]
 pub enum PeerManagerEvent<T: NetworkingService> {
     /// Try to establish connection with a remote peer
     Connect(T::Address, oneshot::Sender<crate::Result<()>>),
 
-    /// Disconnect node using peer ID
-    Disconnect(T::PeerId, oneshot::Sender<crate::Result<()>>),
+    /// Disconnect node using peer ID or remote address
+    Disconnect(
+        DisconnectId<T::Address, T::PeerId>,
+        oneshot::Sender<crate::Result<()>>,
+    ),
 
     /// Get the total number of peers local node has a connection with
     GetPeerCount(oneshot::Sender<usize>),

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -17,14 +17,14 @@ use tokio::sync::oneshot;
 
 use common::chain::block::Block;
 
-use crate::net::NetworkingService;
+use crate::{interface::p2p_interface::ConnectedPeer, net::NetworkingService};
 
 #[derive(Debug)]
 pub enum PeerManagerEvent<T: NetworkingService> {
     /// Try to establish connection with a remote peer
     Connect(T::Address, oneshot::Sender<crate::Result<()>>),
 
-    /// Disconnect node using peer ID or remote address
+    /// Disconnect node using peer ID
     Disconnect(T::PeerId, oneshot::Sender<crate::Result<()>>),
 
     /// Get the total number of peers local node has a connection with
@@ -33,8 +33,8 @@ pub enum PeerManagerEvent<T: NetworkingService> {
     /// Get the bind address of the local node
     GetBindAddress(oneshot::Sender<String>),
 
-    /// Get peer IDs of connected peers
-    GetConnectedPeers(oneshot::Sender<Vec<String>>),
+    /// Get peer IDs and addresses of connected peers
+    GetConnectedPeers(oneshot::Sender<Vec<ConnectedPeer>>),
 
     /// Adjust peer score
     AdjustPeerScore(T::PeerId, u32, oneshot::Sender<crate::Result<()>>),

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -17,7 +17,7 @@ use tokio::sync::oneshot;
 
 use common::chain::block::Block;
 
-use crate::net::{DisconnectId, NetworkingService};
+use crate::net::NetworkingService;
 
 #[derive(Debug)]
 pub enum PeerManagerEvent<T: NetworkingService> {
@@ -25,10 +25,7 @@ pub enum PeerManagerEvent<T: NetworkingService> {
     Connect(T::Address, oneshot::Sender<crate::Result<()>>),
 
     /// Disconnect node using peer ID or remote address
-    Disconnect(
-        DisconnectId<T::Address, T::PeerId>,
-        oneshot::Sender<crate::Result<()>>,
-    ),
+    Disconnect(T::PeerId, oneshot::Sender<crate::Result<()>>),
 
     /// Get the total number of peers local node has a connection with
     GetPeerCount(oneshot::Sender<usize>),

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -33,9 +33,6 @@ pub enum PeerManagerEvent<T: NetworkingService> {
     /// Get the bind address of the local node
     GetBindAddress(oneshot::Sender<String>),
 
-    /// Get peer ID of the local node
-    GetPeerId(oneshot::Sender<String>),
-
     /// Get peer IDs of connected peers
     GetConnectedPeers(oneshot::Sender<Vec<String>>),
 

--- a/p2p/src/interface/mod.rs
+++ b/p2p/src/interface/mod.rs
@@ -16,3 +16,4 @@
 pub mod p2p_interface;
 pub mod p2p_interface_impl;
 pub mod p2p_interface_impl_delegation;
+pub mod types;

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -17,7 +17,7 @@
 pub trait P2pInterface: Send + Sync {
     async fn connect(&mut self, addr: String) -> crate::Result<()>;
 
-    async fn disconnect(&self, peer_id: String) -> crate::Result<()>;
+    async fn disconnect(&self, addr: String) -> crate::Result<()>;
 
     async fn get_peer_count(&self) -> crate::Result<usize>;
 

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -23,7 +23,7 @@ pub struct ConnectedPeer {
 pub trait P2pInterface: Send + Sync {
     async fn connect(&mut self, addr: String) -> crate::Result<()>;
 
-    async fn disconnect(&self, peer_id: String) -> crate::Result<()>;
+    async fn disconnect(&mut self, peer_id: String) -> crate::Result<()>;
 
     async fn get_peer_count(&self) -> crate::Result<usize>;
 

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -17,7 +17,7 @@
 pub trait P2pInterface: Send + Sync {
     async fn connect(&mut self, addr: String) -> crate::Result<()>;
 
-    async fn disconnect(&self, addr: String) -> crate::Result<()>;
+    async fn disconnect(&self, peer_id: String) -> crate::Result<()>;
 
     async fn get_peer_count(&self) -> crate::Result<usize>;
 

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -23,7 +23,5 @@ pub trait P2pInterface: Send + Sync {
 
     async fn get_bind_address(&self) -> crate::Result<String>;
 
-    async fn get_peer_id(&self) -> crate::Result<String>;
-
     async fn get_connected_peers(&self) -> crate::Result<Vec<String>>;
 }

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -13,6 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[derive(Debug, serde::Serialize)]
+pub struct ConnectedPeer {
+    pub peer_id: String,
+    pub addr: String,
+}
+
 #[async_trait::async_trait]
 pub trait P2pInterface: Send + Sync {
     async fn connect(&mut self, addr: String) -> crate::Result<()>;
@@ -23,5 +29,5 @@ pub trait P2pInterface: Send + Sync {
 
     async fn get_bind_address(&self) -> crate::Result<String>;
 
-    async fn get_connected_peers(&self) -> crate::Result<Vec<String>>;
+    async fn get_connected_peers(&self) -> crate::Result<Vec<ConnectedPeer>>;
 }

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -46,7 +46,7 @@ where
         rx.await.map_err(P2pError::from)?
     }
 
-    async fn disconnect(&self, peer_id: String) -> crate::Result<()>
+    async fn disconnect(&mut self, peer_id: String) -> crate::Result<()>
     where
         <T as NetworkingService>::PeerId: FromStr,
     {

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -24,7 +24,7 @@ use crate::{
     P2p,
 };
 
-use super::p2p_interface::{ConnectedPeer, P2pInterface};
+use super::{p2p_interface::P2pInterface, types::ConnectedPeer};
 
 #[async_trait::async_trait]
 impl<T> P2pInterface for P2p<T>

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 use crate::{
     error::{ConversionError, P2pError},
     event::PeerManagerEvent,
-    net::NetworkingService,
+    net::{DisconnectId, NetworkingService},
     P2p,
 };
 
@@ -37,28 +37,29 @@ where
         <T as NetworkingService>::PeerId: FromStr,
     {
         let (tx, rx) = oneshot::channel();
+        let addr = addr
+            .parse::<T::Address>()
+            .map_err(|_| P2pError::ConversionError(ConversionError::InvalidAddress(addr)))?;
         self.tx_peer_manager
-            .send(PeerManagerEvent::Connect(
-                addr.parse::<T::Address>().map_err(|_| {
-                    P2pError::ConversionError(ConversionError::InvalidAddress(addr))
-                })?,
-                tx,
-            ))
+            .send(PeerManagerEvent::Connect(addr, tx))
             .map_err(|_| P2pError::ChannelClosed)?;
         rx.await.map_err(P2pError::from)?
     }
 
-    async fn disconnect(&self, peer_id: String) -> crate::Result<()>
+    async fn disconnect(&self, addr: String) -> crate::Result<()>
     where
         <T as NetworkingService>::PeerId: FromStr,
     {
         let (tx, rx) = oneshot::channel();
-        let peer_id = peer_id
-            .parse::<T::PeerId>()
-            .map_err(|_| P2pError::ConversionError(ConversionError::InvalidPeerId(peer_id)))?;
+        let addr = addr
+            .parse::<T::Address>()
+            .map_err(|_| P2pError::ConversionError(ConversionError::InvalidAddress(addr)))?;
 
         self.tx_peer_manager
-            .send(PeerManagerEvent::Disconnect(peer_id, tx))
+            .send(PeerManagerEvent::Disconnect(
+                DisconnectId::Address(addr),
+                tx,
+            ))
             .map_err(|_| P2pError::ChannelClosed)?;
         rx.await.map_err(P2pError::from)?
     }

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -24,7 +24,7 @@ use crate::{
     P2p,
 };
 
-use super::p2p_interface::P2pInterface;
+use super::p2p_interface::{ConnectedPeer, P2pInterface};
 
 #[async_trait::async_trait]
 impl<T> P2pInterface for P2p<T>
@@ -77,7 +77,7 @@ where
         rx.await.map_err(P2pError::from)
     }
 
-    async fn get_connected_peers(&self) -> crate::Result<Vec<String>> {
+    async fn get_connected_peers(&self) -> crate::Result<Vec<ConnectedPeer>> {
         let (tx, rx) = oneshot::channel();
         self.tx_peer_manager
             .send(PeerManagerEvent::GetConnectedPeers(tx))

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -79,14 +79,6 @@ where
         rx.await.map_err(P2pError::from)
     }
 
-    async fn get_peer_id(&self) -> crate::Result<String> {
-        let (tx, rx) = oneshot::channel();
-        self.tx_peer_manager
-            .send(PeerManagerEvent::GetPeerId(tx))
-            .map_err(P2pError::from)?;
-        rx.await.map_err(P2pError::from)
-    }
-
     async fn get_connected_peers(&self) -> crate::Result<Vec<String>> {
         let (tx, rx) = oneshot::channel();
         self.tx_peer_manager

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -37,10 +37,6 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
         self.deref().get_bind_address().await
     }
 
-    async fn get_peer_id(&self) -> crate::Result<String> {
-        self.deref().get_peer_id().await
-    }
-
     async fn get_connected_peers(&self) -> crate::Result<Vec<String>> {
         self.deref().get_connected_peers().await
     }

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -15,7 +15,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use super::p2p_interface::P2pInterface;
+use super::p2p_interface::{ConnectedPeer, P2pInterface};
 
 #[async_trait::async_trait]
 impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> + Send + Sync>
@@ -37,7 +37,7 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
         self.deref().get_bind_address().await
     }
 
-    async fn get_connected_peers(&self) -> crate::Result<Vec<String>> {
+    async fn get_connected_peers(&self) -> crate::Result<Vec<ConnectedPeer>> {
         self.deref().get_connected_peers().await
     }
 }

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -15,7 +15,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use super::p2p_interface::{ConnectedPeer, P2pInterface};
+use super::{p2p_interface::P2pInterface, types::ConnectedPeer};
 
 #[async_trait::async_trait]
 impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> + Send + Sync>

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -25,8 +25,8 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
         self.deref_mut().connect(addr).await
     }
 
-    async fn disconnect(&self, peer_id: String) -> crate::Result<()> {
-        self.deref().disconnect(peer_id).await
+    async fn disconnect(&mut self, peer_id: String) -> crate::Result<()> {
+        self.deref_mut().disconnect(peer_id).await
     }
 
     async fn get_peer_count(&self) -> crate::Result<usize> {

--- a/p2p/src/interface/types.rs
+++ b/p2p/src/interface/types.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,17 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::types::ConnectedPeer;
-
-#[async_trait::async_trait]
-pub trait P2pInterface: Send + Sync {
-    async fn connect(&mut self, addr: String) -> crate::Result<()>;
-
-    async fn disconnect(&mut self, peer_id: String) -> crate::Result<()>;
-
-    async fn get_peer_count(&self) -> crate::Result<usize>;
-
-    async fn get_bind_address(&self) -> crate::Result<String>;
-
-    async fn get_connected_peers(&self) -> crate::Result<Vec<ConnectedPeer>>;
+// TODO: Implement From PeerContext for ConnectedPeer
+#[derive(Debug, serde::Serialize)]
+pub struct ConnectedPeer {
+    // TODO: Replace String with actual type, once libp2p removed
+    pub peer_id: String,
+    // TODO: Replace String with actual type, once libp2p removed
+    pub addr: String,
 }

--- a/p2p/src/net/libp2p/mod.rs
+++ b/p2p/src/net/libp2p/mod.rs
@@ -117,7 +117,7 @@ impl NetworkingService for Libp2pService {
             .map_err(|_| P2pError::DialError(DialError::IoError(std::io::ErrorKind::AddrInUse)))?;
 
         Ok((
-            Self::ConnectivityHandle::new(peer_id, cmd_tx.clone(), conn_rx),
+            Self::ConnectivityHandle::new(cmd_tx.clone(), conn_rx),
             Self::SyncingMessagingHandle::new(cmd_tx, sync_rx),
         ))
     }

--- a/p2p/src/net/libp2p/service/connectivity.rs
+++ b/p2p/src/net/libp2p/service/connectivity.rs
@@ -30,7 +30,7 @@ use crate::{
         self,
         libp2p::types,
         types::{ConnectivityEvent, Protocol, ProtocolType},
-        ConnectivityService, DisconnectId, NetworkingService,
+        ConnectivityService, NetworkingService,
     },
 };
 
@@ -192,15 +192,8 @@ where
         rx.await.map_err(P2pError::from)?.map_err(P2pError::from)
     }
 
-    async fn disconnect(&mut self, id: DisconnectId<T::Address, T::PeerId>) -> crate::Result<()> {
-        log::debug!("disconnect peer {:?}", id);
-
-        let peer_id = match id {
-            DisconnectId::PeerId(peer_id) => peer_id,
-            DisconnectId::Address(addr) => PeerId::try_from_multiaddr(&addr).ok_or_else(|| {
-                P2pError::ConversionError(ConversionError::InvalidAddress(addr.to_string()))
-            })?,
-        };
+    async fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()> {
+        log::debug!("disconnect peer {}", peer_id);
 
         let (tx, rx) = oneshot::channel();
         self.cmd_tx.send(types::Command::Disconnect {

--- a/p2p/src/net/libp2p/service/connectivity.rs
+++ b/p2p/src/net/libp2p/service/connectivity.rs
@@ -30,7 +30,7 @@ use crate::{
         self,
         libp2p::types,
         types::{ConnectivityEvent, Protocol, ProtocolType},
-        ConnectivityService, NetworkingService,
+        ConnectivityService, DisconnectId, NetworkingService,
     },
 };
 
@@ -192,8 +192,15 @@ where
         rx.await.map_err(P2pError::from)?.map_err(P2pError::from)
     }
 
-    async fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()> {
-        log::debug!("disconnect peer {:?}", peer_id);
+    async fn disconnect(&mut self, id: DisconnectId<T::Address, T::PeerId>) -> crate::Result<()> {
+        log::debug!("disconnect peer {:?}", id);
+
+        let peer_id = match id {
+            DisconnectId::PeerId(peer_id) => peer_id,
+            DisconnectId::Address(addr) => PeerId::try_from_multiaddr(&addr).ok_or_else(|| {
+                P2pError::ConversionError(ConversionError::InvalidAddress(addr.to_string()))
+            })?,
+        };
 
         let (tx, rx) = oneshot::channel();
         self.cmd_tx.send(types::Command::Disconnect {

--- a/p2p/src/net/libp2p/service/connectivity.rs
+++ b/p2p/src/net/libp2p/service/connectivity.rs
@@ -37,9 +37,6 @@ use crate::{
 /// Connectivity handle for libp2p
 #[derive(Debug)]
 pub struct Libp2pConnectivityHandle<T: NetworkingService> {
-    /// Peer Id of the local node
-    peer_id: PeerId,
-
     /// Channel for sending commands to libp2p backend
     cmd_tx: mpsc::UnboundedSender<types::Command>,
 
@@ -50,12 +47,10 @@ pub struct Libp2pConnectivityHandle<T: NetworkingService> {
 
 impl<T: NetworkingService> Libp2pConnectivityHandle<T> {
     pub fn new(
-        peer_id: PeerId,
         cmd_tx: mpsc::UnboundedSender<types::Command>,
         conn_rx: mpsc::UnboundedReceiver<types::ConnectivityEvent>,
     ) -> Self {
         Self {
-            peer_id,
             cmd_tx,
             conn_rx,
             _marker: Default::default(),
@@ -212,10 +207,6 @@ where
         let (tx, rx) = oneshot::channel();
         self.cmd_tx.send(types::Command::ListenAddress { response: tx })?;
         rx.await.map_err(P2pError::from)
-    }
-
-    fn peer_id(&self) -> &T::PeerId {
-        &self.peer_id
     }
 
     async fn poll_next(&mut self) -> crate::Result<ConnectivityEvent<T>> {

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -184,7 +184,7 @@ where
             Ok(event) => match event {
                 Ok(socket) => self.create_peer(
                     socket,
-                    MockPeerId::from_socket_address::<T>(&address),
+                    MockPeerId::new(),
                     peer::Role::Outbound,
                     ConnectionState::OutboundAccepted { address },
                 ),
@@ -390,7 +390,7 @@ where
                     let (stream, address) = res.map_err(|_| P2pError::Other("accept() failed"))?;
                     self.create_peer(
                         stream,
-                        MockPeerId::from_socket_address::<T>(&address),
+                        MockPeerId::new(),
                         peer::Role::Inbound,
                         ConnectionState::InboundAccepted { address }
                     )?;

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -51,9 +51,6 @@ pub struct MockConnectivityHandle<S: NetworkingService, T: TransportSocket> {
     /// The local address of a network service provider.
     local_addr: S::Address,
 
-    /// The peer ID of a local node.
-    peer_id: MockPeerId,
-
     /// TX channel for sending commands to mock backend
     cmd_tx: mpsc::Sender<types::Command<T>>,
 
@@ -152,12 +149,10 @@ impl<T: TransportSocket> NetworkingService for MockService<T> {
             }
         });
 
-        let peer_id = MockPeerId::from_socket_address::<T>(&local_addr);
         Ok((
             Self::ConnectivityHandle {
                 local_addr,
                 cmd_tx: cmd_tx.clone(),
-                peer_id,
                 conn_rx,
                 _marker: Default::default(),
             },
@@ -210,10 +205,6 @@ where
 
     async fn local_addr(&self) -> crate::Result<Option<S::Address>> {
         Ok(Some(self.local_addr.clone()))
-    }
-
-    fn peer_id(&self) -> &S::PeerId {
-        &self.peer_id
     }
 
     async fn poll_next(&mut self) -> crate::Result<ConnectivityEvent<S>> {
@@ -412,7 +403,7 @@ mod tests {
             assert_eq!(
                 peer_info,
                 net::types::PeerInfo {
-                    peer_id: *conn2.peer_id(),
+                    peer_id: peer_info.peer_id,
                     magic_bytes: *config.magic_bytes(),
                     version: common::primitives::semver::SemVer::new(0, 1, 0),
                     agent: None,

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -43,8 +43,6 @@ use crate::{
     },
 };
 
-use super::DisconnectId;
-
 #[derive(Debug)]
 pub struct MockService<T: TransportSocket>(PhantomData<T>);
 
@@ -191,11 +189,16 @@ where
         rx.await?
     }
 
-    async fn disconnect(&mut self, id: DisconnectId<S::Address, S::PeerId>) -> crate::Result<()> {
-        log::debug!("close connection with remote, {id:?}");
+    async fn disconnect(&mut self, peer_id: S::PeerId) -> crate::Result<()> {
+        log::debug!("close connection with remote, {peer_id}");
 
         let (tx, rx) = oneshot::channel();
-        self.cmd_tx.send(types::Command::Disconnect { id, response: tx }).await?;
+        self.cmd_tx
+            .send(types::Command::Disconnect {
+                peer_id,
+                response: tx,
+            })
+            .await?;
 
         rx.await?
     }
@@ -536,10 +539,7 @@ mod tests {
                 address: _,
                 peer_info,
             } => {
-                assert_eq!(
-                    conn2.disconnect(DisconnectId::PeerId(peer_info.peer_id)).await,
-                    Ok(())
-                );
+                assert_eq!(conn2.disconnect(peer_info.peer_id).await, Ok(()));
             }
             _ => panic!("invalid event received, expected incoming connection"),
         }

--- a/p2p/src/net/mock/peer.rs
+++ b/p2p/src/net/mock/peer.rs
@@ -36,6 +36,7 @@ use super::transport::BufferedTranscoder;
 
 const PEER_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
+#[derive(Debug, Clone, Copy)]
 pub enum Role {
     Inbound,
     Outbound,

--- a/p2p/src/net/mock/peer.rs
+++ b/p2p/src/net/mock/peer.rs
@@ -258,7 +258,7 @@ mod tests {
         let p2p_config = Arc::new(P2pConfig::default());
         let (tx1, mut rx1) = mpsc::channel(16);
         let (_tx2, rx2) = mpsc::channel(16);
-        let peer_id2 = MockPeerId::random();
+        let peer_id2 = MockPeerId::new();
 
         let mut peer = Peer::<T>::new(
             peer_id2,
@@ -340,7 +340,7 @@ mod tests {
         let p2p_config = Arc::new(P2pConfig::default());
         let (tx1, mut rx1) = mpsc::channel(16);
         let (_tx2, rx2) = mpsc::channel(16);
-        let peer_id3 = MockPeerId::random();
+        let peer_id3 = MockPeerId::new();
 
         let mut peer = Peer::<T>::new(
             peer_id3,
@@ -427,7 +427,7 @@ mod tests {
         let p2p_config = Arc::new(P2pConfig::default());
         let (tx1, _rx1) = mpsc::channel(16);
         let (_tx2, rx2) = mpsc::channel(16);
-        let peer_id3 = MockPeerId::random();
+        let peer_id3 = MockPeerId::new();
 
         let mut peer = Peer::<T>::new(
             peer_id3,
@@ -489,7 +489,7 @@ mod tests {
         let p2p_config = Arc::new(P2pConfig::default());
         let (tx1, _rx1) = mpsc::channel(16);
         let (_tx2, rx2) = mpsc::channel(16);
-        let peer_id2 = MockPeerId::random();
+        let peer_id2 = MockPeerId::new();
 
         let mut peer = Peer::<T>::new(
             peer_id2,

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -31,7 +31,6 @@ use crate::{
         self,
         mock::transport::TransportSocket,
         types::{Protocol, PubSubTopic},
-        DisconnectId,
     },
 };
 
@@ -41,7 +40,7 @@ pub enum Command<T: TransportSocket> {
         response: oneshot::Sender<crate::Result<()>>,
     },
     Disconnect {
-        id: DisconnectId<T::Address, MockPeerId>,
+        peer_id: MockPeerId,
         response: oneshot::Sender<crate::Result<()>>,
     },
     SendRequest {

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -191,7 +191,6 @@ pub struct MockPeerInfo {
 pub enum PeerEvent {
     /// Peer information received from remote
     PeerInfoReceived {
-        peer_id: MockPeerId,
         network: [u8; 4],
         version: semver::SemVer,
         protocols: Vec<Protocol>,
@@ -215,14 +214,12 @@ pub enum MockEvent {
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum HandshakeMessage {
     Hello {
-        peer_id: MockPeerId,
         version: common::primitives::semver::SemVer,
         network: [u8; 4],
         protocols: Vec<Protocol>,
         subscriptions: BTreeSet<PubSubTopic>,
     },
     HelloAck {
-        peer_id: MockPeerId,
         version: common::primitives::semver::SemVer,
         network: [u8; 4],
         protocols: Vec<Protocol>,

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -31,6 +31,7 @@ use crate::{
         self,
         mock::transport::TransportSocket,
         types::{Protocol, PubSubTopic},
+        DisconnectId,
     },
 };
 
@@ -40,11 +41,7 @@ pub enum Command<T: TransportSocket> {
         response: oneshot::Sender<crate::Result<()>>,
     },
     Disconnect {
-        peer_id: MockPeerId,
-        response: oneshot::Sender<crate::Result<()>>,
-    },
-    BanPeer {
-        peer_id: MockPeerId,
+        id: DisconnectId<T::Address, MockPeerId>,
         response: oneshot::Sender<crate::Result<()>>,
     },
     SendRequest {

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -114,7 +114,7 @@ where
     ///
     /// # Arguments
     /// `id` - socket address of the peer or peer id
-    async fn disconnect(&mut self, id: DisconnectId<T::Address, T::PeerId>) -> crate::Result<()>;
+    async fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()>;
 
     /// Return the socket address of the network service provider
     ///
@@ -192,10 +192,4 @@ pub trait AsBannableAddress {
 /// Checks if an address can be converted to bannable.
 pub trait IsBannableAddress {
     fn is_bannable(&self) -> bool;
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub enum DisconnectId<A, P> {
-    Address(A),
-    PeerId(P),
 }

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -113,7 +113,7 @@ where
     /// Disconnect active connection
     ///
     /// # Arguments
-    /// `id` - socket address of the peer or peer id
+    /// `peer_id` - Peer ID of the remote node
     async fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()>;
 
     /// Return the socket address of the network service provider

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -121,9 +121,6 @@ where
     /// If the address isn't available yet, `None` is returned
     async fn local_addr(&self) -> crate::Result<Option<T::Address>>;
 
-    /// Return peer id of the local node
-    fn peer_id(&self) -> &T::PeerId;
-
     /// Poll events from the network service provider
     ///
     /// There are three types of events that can be received:

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -113,8 +113,8 @@ where
     /// Disconnect active connection
     ///
     /// # Arguments
-    /// `peer_id` - Peer ID of the remote node
-    async fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()>;
+    /// `id` - socket address of the peer or peer id
+    async fn disconnect(&mut self, id: DisconnectId<T::Address, T::PeerId>) -> crate::Result<()>;
 
     /// Return the socket address of the network service provider
     ///
@@ -192,4 +192,10 @@ pub trait AsBannableAddress {
 /// Checks if an address can be converted to bannable.
 pub trait IsBannableAddress {
     fn is_bannable(&self) -> bool;
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum DisconnectId<A, P> {
+    Address(A),
+    PeerId(P),
 }

--- a/p2p/src/peer_manager/helpers.rs
+++ b/p2p/src/peer_manager/helpers.rs
@@ -48,9 +48,12 @@ where
         Err(_err) => panic!("did not receive `InboundAccepted` in time"),
     };
 
-    let (_address2, peer_info2) = match timeout(Duration::from_secs(5), conn1.poll_next()).await {
+    let peer_info2 = match timeout(Duration::from_secs(5), conn1.poll_next()).await {
         Ok(event) => match event.unwrap() {
-            ConnectivityEvent::OutboundAccepted { address, peer_info } => (address, peer_info),
+            ConnectivityEvent::OutboundAccepted {
+                address: _,
+                peer_info,
+            } => peer_info,
             event => panic!("expected `OutboundAccepted`, got {event:?}"),
         },
         Err(_err) => panic!("did not receive `OutboundAccepted` in time"),

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -458,9 +458,6 @@ where
                         let addr = addr.await?.map_or("<unavailable>".to_string(), |addr| addr.to_string());
                         response.send(addr).map_err(|_| P2pError::ChannelClosed)?;
                     }
-                    PeerManagerEvent::GetPeerId(response) => response
-                        .send(self.peer_connectivity_handle.peer_id().to_string())
-                        .map_err(|_| P2pError::ChannelClosed)?,
                     PeerManagerEvent::GetConnectedPeers(response) => {
                         let peers = self.peerdb
                             .active_peers()

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     config::P2pConfig,
     error::{P2pError, PeerError, ProtocolError},
     event::{PeerManagerEvent, SyncControlEvent},
-    interface::p2p_interface::ConnectedPeer,
+    interface::types::ConnectedPeer,
     net::{
         self,
         types::{Protocol, ProtocolType},

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -46,7 +46,7 @@ use crate::{
     net::{
         self,
         types::{Protocol, ProtocolType},
-        AsBannableAddress, ConnectivityService, DisconnectId, IsBannableAddress, NetworkingService,
+        AsBannableAddress, ConnectivityService, IsBannableAddress, NetworkingService,
     },
 };
 
@@ -269,7 +269,7 @@ where
         log::debug!("adjusting score for peer {peer_id}, adjustment {score}");
 
         if self.peerdb.adjust_peer_score(&peer_id, score) {
-            let _ = self.peer_connectivity_handle.disconnect(DisconnectId::PeerId(peer_id)).await;
+            let _ = self.peer_connectivity_handle.disconnect(peer_id).await;
         }
 
         Ok(())
@@ -477,7 +477,7 @@ where
                                 Err(P2pError::ChannelClosed) => return Err(P2pError::ChannelClosed),
                                 Err(P2pError::PeerError(err)) => {
                                     log::warn!("peer error for peer {peer_id}: {err}");
-                                    self.peer_connectivity_handle.disconnect(DisconnectId::PeerId(peer_id)).await?;
+                                    self.peer_connectivity_handle.disconnect(peer_id).await?;
                                 }
                                 Err(P2pError::ProtocolError(err)) => {
                                     log::warn!("peer error for peer {peer_id}: {err}");

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -309,7 +309,7 @@ async fn validate_invalid_outbound_connection_libp2p() {
 async fn validate_invalid_outbound_connection_mock_tcp() {
     validate_invalid_outbound_connection::<TestTransportTcp, MockService<TcpTransportSocket>>(
         "210.113.67.107:2525".parse().unwrap(),
-        MockPeerId::random(),
+        MockPeerId::new(),
     )
     .await;
 }
@@ -318,7 +318,7 @@ async fn validate_invalid_outbound_connection_mock_tcp() {
 async fn validate_invalid_outbound_connection_mock_channels() {
     validate_invalid_outbound_connection::<TestTransportChannel, MockService<MockChannelTransport>>(
         1,
-        MockPeerId::random(),
+        MockPeerId::new(),
     )
     .await;
 }
@@ -327,7 +327,7 @@ async fn validate_invalid_outbound_connection_mock_channels() {
 async fn validate_invalid_outbound_connection_mock_noise() {
     validate_invalid_outbound_connection::<TestTransportNoise, MockService<NoiseTcpTransport>>(
         "210.113.67.107:2525".parse().unwrap(),
-        MockPeerId::random(),
+        MockPeerId::new(),
     )
     .await;
 }
@@ -424,7 +424,7 @@ async fn validate_invalid_inbound_connection_libp2p() {
 async fn validate_invalid_inbound_connection_mock_tcp() {
     validate_invalid_inbound_connection::<TestTransportTcp, MockService<TcpTransportSocket>>(
         "210.113.67.107:2525".parse().unwrap(),
-        MockPeerId::random(),
+        MockPeerId::new(),
     )
     .await;
 }
@@ -433,7 +433,7 @@ async fn validate_invalid_inbound_connection_mock_tcp() {
 async fn validate_invalid_inbound_connection_mock_channels() {
     validate_invalid_inbound_connection::<TestTransportChannel, MockService<MockChannelTransport>>(
         1,
-        MockPeerId::random(),
+        MockPeerId::new(),
     )
     .await;
 }
@@ -442,7 +442,7 @@ async fn validate_invalid_inbound_connection_mock_channels() {
 async fn validate_invalid_inbound_connection_mock_noise() {
     validate_invalid_inbound_connection::<TestTransportNoise, MockService<NoiseTcpTransport>>(
         "210.113.67.107:2525".parse().unwrap(),
-        MockPeerId::random(),
+        MockPeerId::new(),
     )
     .await;
 }

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -59,9 +59,9 @@ where
         &mut pm2.peer_connectivity_handle,
     )
     .await;
+    let peer_id = peer_info.peer_id;
     pm2.accept_inbound_connection(address, peer_info).unwrap();
 
-    let peer_id = *pm1.peer_connectivity_handle.peer_id();
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addr().await.unwrap().unwrap().as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
@@ -111,9 +111,9 @@ where
         &mut pm2.peer_connectivity_handle,
     )
     .await;
+    let peer_id = peer_info.peer_id;
     pm2.accept_inbound_connection(address, peer_info).unwrap();
 
-    let peer_id = *pm1.peer_connectivity_handle.peer_id();
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addr().await.unwrap().unwrap().as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
@@ -165,9 +165,9 @@ where
         &mut pm2.peer_connectivity_handle,
     )
     .await;
+    let peer_id = peer_info.peer_id;
     pm2.accept_inbound_connection(address, peer_info).unwrap();
 
-    let peer_id = *pm1.peer_connectivity_handle.peer_id();
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addr().await.unwrap().unwrap().as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
@@ -472,12 +472,11 @@ where
     )
     .await;
 
-    connect_services::<T>(
+    let (_address, peer_info) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
         &mut pm2.peer_connectivity_handle,
     )
     .await;
-    let pm1_id = *pm1.peer_connectivity_handle.peer_id();
 
     // run the first peer manager in the background and poll events from the peer manager
     // that tries to connect to the first manager
@@ -486,7 +485,7 @@ where
     if let Ok(net::types::ConnectivityEvent::ConnectionClosed { peer_id }) =
         pm2.peer_connectivity_handle.poll_next().await
     {
-        assert_eq!(peer_id, pm1_id);
+        assert_eq!(peer_id, peer_info.peer_id);
     } else {
         panic!("invalid event received");
     }

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -424,16 +424,14 @@ where
     )
     .await;
 
-    let (_address, _peer_info) = connect_services::<T>(
+    let (_address, peer_info) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
         &mut pm2.peer_connectivity_handle,
     )
     .await;
 
     assert_eq!(
-        pm2.peer_connectivity_handle
-            .disconnect(*pm1.peer_connectivity_handle.peer_id())
-            .await,
+        pm2.peer_connectivity_handle.disconnect(peer_info.peer_id).await,
         Ok(())
     );
     assert!(std::matches!(
@@ -486,12 +484,11 @@ where
         peer_manager::MAX_ACTIVE_CONNECTIONS
     );
 
-    let (_address, _peer_info) = connect_services::<T>(
+    let (_address, peer_info) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
         &mut pm2.peer_connectivity_handle,
     )
     .await;
-    let pm1_id = *pm1.peer_connectivity_handle.peer_id();
 
     // run the first peer manager in the background and poll events from the peer manager
     // that tries to connect to the first manager
@@ -500,7 +497,7 @@ where
     if let Ok(net::types::ConnectivityEvent::ConnectionClosed { peer_id }) =
         pm2.peer_connectivity_handle.poll_next().await
     {
-        assert_eq!(peer_id, pm1_id);
+        assert_eq!(peer_id, peer_info.peer_id);
     } else {
         panic!("invalid event received");
     }

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -18,9 +18,12 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use libp2p::{Multiaddr, PeerId};
 use tokio::{sync::oneshot, time::timeout};
 
-use crate::testing_utils::{
-    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
-    TestTransportTcp,
+use crate::{
+    net::DisconnectId,
+    testing_utils::{
+        TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+        TestTransportTcp,
+    },
 };
 use common::{chain::config, primitives::semver::SemVer};
 
@@ -432,7 +435,9 @@ where
     .await;
 
     assert_eq!(
-        pm2.peer_connectivity_handle.disconnect(peer_info.peer_id).await,
+        pm2.peer_connectivity_handle
+            .disconnect(DisconnectId::PeerId(peer_info.peer_id))
+            .await,
         Ok(())
     );
     assert!(std::matches!(

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -18,12 +18,9 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use libp2p::{Multiaddr, PeerId};
 use tokio::{sync::oneshot, time::timeout};
 
-use crate::{
-    net::DisconnectId,
-    testing_utils::{
-        TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
-        TestTransportTcp,
-    },
+use crate::testing_utils::{
+    TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
+    TestTransportTcp,
 };
 use common::{chain::config, primitives::semver::SemVer};
 
@@ -435,9 +432,7 @@ where
     .await;
 
     assert_eq!(
-        pm2.peer_connectivity_handle
-            .disconnect(DisconnectId::PeerId(peer_info.peer_id))
-            .await,
+        pm2.peer_connectivity_handle.disconnect(peer_info.peer_id).await,
         Ok(())
     );
     assert!(std::matches!(

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -94,7 +94,7 @@ async fn test_peer_manager_connect_libp2p() {
 
 // verify that the auto-connect functionality works if the number of active connections
 // is below the desired threshold and there are idle peers in the peerdb
-async fn test_auto_connect<A, T>()
+async fn test_auto_connect<A, T>(peer_id: T::PeerId)
 where
     A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
@@ -110,7 +110,6 @@ where
     let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
     let addr = pm2.peer_connectivity_handle.local_addr().await.unwrap().unwrap();
-    let peer_id = todo!();
 
     tokio::spawn(async move {
         loop {
@@ -135,22 +134,24 @@ where
 
 #[tokio::test]
 async fn test_auto_connect_libp2p() {
-    test_auto_connect::<TestTransportLibp2p, Libp2pService>().await;
+    test_auto_connect::<TestTransportLibp2p, Libp2pService>(PeerId::random()).await;
 }
 
 #[tokio::test]
 async fn test_auto_connect_mock_tcp() {
-    test_auto_connect::<TestTransportTcp, MockService<TcpTransportSocket>>().await;
+    test_auto_connect::<TestTransportTcp, MockService<TcpTransportSocket>>(MockPeerId::new()).await;
 }
 
 #[tokio::test]
 async fn test_auto_connect_mock_channels() {
-    test_auto_connect::<TestTransportChannel, MockService<MockChannelTransport>>().await;
+    test_auto_connect::<TestTransportChannel, MockService<MockChannelTransport>>(MockPeerId::new())
+        .await;
 }
 
 #[tokio::test]
 async fn test_auto_connect_mock_noise() {
-    test_auto_connect::<TestTransportNoise, MockService<NoiseTcpTransport>>().await;
+    test_auto_connect::<TestTransportNoise, MockService<NoiseTcpTransport>>(MockPeerId::new())
+        .await;
 }
 
 async fn connect_outbound_same_network<A, T>()
@@ -526,7 +527,7 @@ async fn inbound_connection_too_many_peers_mock_tcp() {
     let peers = (0..peer_manager::MAX_ACTIVE_CONNECTIONS)
         .map(
             |_| net::types::PeerInfo::<MockService<TcpTransportSocket>> {
-                peer_id: MockPeerId::random(),
+                peer_id: MockPeerId::new(),
                 magic_bytes: *config.magic_bytes(),
                 version: common::primitives::semver::SemVer::new(0, 1, 0),
                 agent: None,
@@ -553,7 +554,7 @@ async fn inbound_connection_too_many_peers_mock_channels() {
     let peers = (0..peer_manager::MAX_ACTIVE_CONNECTIONS)
         .map(
             |_| net::types::PeerInfo::<MockService<MockChannelTransport>> {
-                peer_id: MockPeerId::random(),
+                peer_id: MockPeerId::new(),
                 magic_bytes: *config.magic_bytes(),
                 version: common::primitives::semver::SemVer::new(0, 1, 0),
                 agent: None,
@@ -581,7 +582,7 @@ async fn inbound_connection_too_many_peers_mock_noise() {
     let config = Arc::new(config::create_mainnet());
     let peers = (0..peer_manager::MAX_ACTIVE_CONNECTIONS)
         .map(|_| net::types::PeerInfo::<MockService<NoiseTcpTransport>> {
-            peer_id: MockPeerId::random(),
+            peer_id: MockPeerId::new(),
             magic_bytes: *config.magic_bytes(),
             version: common::primitives::semver::SemVer::new(0, 1, 0),
             agent: None,

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -110,7 +110,7 @@ where
     let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
     let addr = pm2.peer_connectivity_handle.local_addr().await.unwrap().unwrap();
-    let peer_id = *pm2.peer_connectivity_handle.peer_id();
+    let peer_id = todo!();
 
     tokio::spawn(async move {
         loop {
@@ -267,7 +267,7 @@ where
     )
     .await;
 
-    let (_address, peer_info) = connect_services::<T>(
+    let (_address, peer_info, _) = connect_services::<T>(
         &mut pm2.peer_connectivity_handle,
         &mut pm1.peer_connectivity_handle,
     )
@@ -312,7 +312,7 @@ where
     let mut pm1 = make_peer_manager::<T>(A::make_transport(), addr1, Arc::clone(&config)).await;
     let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
-    let (address, peer_info) = connect_services::<T>(
+    let (address, peer_info, _) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
         &mut pm2.peer_connectivity_handle,
     )
@@ -364,7 +364,7 @@ where
     )
     .await;
 
-    let (address, peer_info) = connect_services::<T>(
+    let (address, peer_info, _) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
         &mut pm2.peer_connectivity_handle,
     )
@@ -424,7 +424,7 @@ where
     )
     .await;
 
-    let (_address, peer_info) = connect_services::<T>(
+    let (_address, peer_info, _) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
         &mut pm2.peer_connectivity_handle,
     )
@@ -484,7 +484,7 @@ where
         peer_manager::MAX_ACTIVE_CONNECTIONS
     );
 
-    let (_address, peer_info) = connect_services::<T>(
+    let (_address, peer_info, _) = connect_services::<T>(
         &mut pm1.peer_connectivity_handle,
         &mut pm2.peer_connectivity_handle,
     )

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -34,10 +34,6 @@ trait P2pRpc {
     #[method(name = "get_bind_address")]
     async fn get_bind_address(&self) -> rpc::Result<String>;
 
-    /// Get peer ID of the local node
-    #[method(name = "get_peer_id")]
-    async fn get_peer_id(&self) -> rpc::Result<String>;
-
     /// Get peer IDs of connected peers
     #[method(name = "get_connected_peers")]
     async fn get_connected_peers(&self) -> rpc::Result<Vec<String>>;
@@ -62,11 +58,6 @@ impl P2pRpcServer for super::P2pHandle {
 
     async fn get_bind_address(&self) -> rpc::Result<String> {
         let res = self.call_async(|this| Box::pin(this.get_bind_address())).await;
-        handle_error(res)
-    }
-
-    async fn get_peer_id(&self) -> rpc::Result<String> {
-        let res = self.call_async(|this| Box::pin(this.get_peer_id())).await;
         handle_error(res)
     }
 

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -24,7 +24,7 @@ trait P2pRpc {
 
     /// Disconnect peer
     #[method(name = "disconnect")]
-    async fn disconnect(&self, peer_id: String) -> rpc::Result<()>;
+    async fn disconnect(&self, addr: String) -> rpc::Result<()>;
 
     /// Get the number of peers
     #[method(name = "get_peer_count")]
@@ -34,7 +34,7 @@ trait P2pRpc {
     #[method(name = "get_bind_address")]
     async fn get_bind_address(&self) -> rpc::Result<String>;
 
-    /// Get peer IDs of connected peers
+    /// Get addresses of connected peers
     #[method(name = "get_connected_peers")]
     async fn get_connected_peers(&self) -> rpc::Result<Vec<String>>;
 }
@@ -46,8 +46,8 @@ impl P2pRpcServer for super::P2pHandle {
         handle_error(res)
     }
 
-    async fn disconnect(&self, peer_id: String) -> rpc::Result<()> {
-        let res = self.call_async_mut(|this| Box::pin(this.disconnect(peer_id))).await;
+    async fn disconnect(&self, addr: String) -> rpc::Result<()> {
+        let res = self.call_async_mut(|this| Box::pin(this.disconnect(addr))).await;
         handle_error(res)
     }
 

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{error::P2pError, interface::p2p_interface::ConnectedPeer};
+use crate::{error::P2pError, interface::types::ConnectedPeer};
 use subsystem::subsystem::CallError;
 
 #[rpc::rpc(server, namespace = "p2p")]
@@ -34,7 +34,7 @@ trait P2pRpc {
     #[method(name = "get_bind_address")]
     async fn get_bind_address(&self) -> rpc::Result<String>;
 
-    /// Get deatils of connected peers
+    /// Get details of connected peers
     #[method(name = "get_connected_peers")]
     async fn get_connected_peers(&self) -> rpc::Result<Vec<ConnectedPeer>>;
 }

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -24,7 +24,7 @@ trait P2pRpc {
 
     /// Disconnect peer
     #[method(name = "disconnect")]
-    async fn disconnect(&self, addr: String) -> rpc::Result<()>;
+    async fn disconnect(&self, peer_id: String) -> rpc::Result<()>;
 
     /// Get the number of peers
     #[method(name = "get_peer_count")]
@@ -46,8 +46,8 @@ impl P2pRpcServer for super::P2pHandle {
         handle_error(res)
     }
 
-    async fn disconnect(&self, addr: String) -> rpc::Result<()> {
-        let res = self.call_async_mut(|this| Box::pin(this.disconnect(addr))).await;
+    async fn disconnect(&self, peer_id: String) -> rpc::Result<()> {
+        let res = self.call_async_mut(|this| Box::pin(this.disconnect(peer_id))).await;
         handle_error(res)
     }
 

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::P2pError;
+use crate::{error::P2pError, interface::p2p_interface::ConnectedPeer};
 use subsystem::subsystem::CallError;
 
 #[rpc::rpc(server, namespace = "p2p")]
@@ -34,9 +34,9 @@ trait P2pRpc {
     #[method(name = "get_bind_address")]
     async fn get_bind_address(&self) -> rpc::Result<String>;
 
-    /// Get addresses of connected peers
+    /// Get deatils of connected peers
     #[method(name = "get_connected_peers")]
-    async fn get_connected_peers(&self) -> rpc::Result<Vec<String>>;
+    async fn get_connected_peers(&self) -> rpc::Result<Vec<ConnectedPeer>>;
 }
 
 #[async_trait::async_trait]
@@ -61,7 +61,7 @@ impl P2pRpcServer for super::P2pHandle {
         handle_error(res)
     }
 
-    async fn get_connected_peers(&self) -> rpc::Result<Vec<String>> {
+    async fn get_connected_peers(&self) -> rpc::Result<Vec<ConnectedPeer>> {
         let res = self.call_async(|this| Box::pin(this.get_connected_peers())).await;
         handle_error(res)
     }

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     message::{self, Announcement},
     net::{
         types::{SyncingEvent, ValidationResult},
-        NetworkingService, SyncingMessagingService,
+        DisconnectId, NetworkingService, SyncingMessagingService,
     },
 };
 
@@ -420,7 +420,10 @@ where
 
         let (tx, rx) = oneshot::channel();
         self.tx_peer_manager
-            .send(PeerManagerEvent::Disconnect(peer_id, tx))
+            .send(PeerManagerEvent::Disconnect(
+                DisconnectId::PeerId(peer_id),
+                tx,
+            ))
             .map_err(P2pError::from)?;
         rx.await.map_err(P2pError::from)?
     }

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     message::{self, Announcement},
     net::{
         types::{SyncingEvent, ValidationResult},
-        DisconnectId, NetworkingService, SyncingMessagingService,
+        NetworkingService, SyncingMessagingService,
     },
 };
 
@@ -420,10 +420,7 @@ where
 
         let (tx, rx) = oneshot::channel();
         self.tx_peer_manager
-            .send(PeerManagerEvent::Disconnect(
-                DisconnectId::PeerId(peer_id),
-                tx,
-            ))
+            .send(PeerManagerEvent::Disconnect(peer_id, tx))
             .map_err(P2pError::from)?;
         rx.await.map_err(P2pError::from)?
     }

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -124,13 +124,9 @@ mod tests {
     use common::chain::block::{
         consensus_data::ConsensusData, timestamp::BlockTimestamp, BlockReward,
     };
-    use std::net::SocketAddr;
 
     fn new_mock_peersyncstate() -> PeerContext<MockService<TcpTransportSocket>> {
-        let addr: SocketAddr = "[::1]:8888".parse().unwrap();
-        PeerContext::<MockService<TcpTransportSocket>>::new(
-            types::MockPeerId::from_socket_address::<TcpTransportSocket>(&addr),
-        )
+        PeerContext::<MockService<TcpTransportSocket>>::new(types::MockPeerId::new())
     }
 
     #[test]

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -52,7 +52,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(A::make_transport(), addr).await;
 
@@ -93,7 +93,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
     let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(A::make_transport(), addr).await;
@@ -147,7 +147,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
     let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(A::make_transport(), addr).await;
@@ -199,7 +199,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
 
@@ -272,7 +272,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
 

--- a/p2p/src/sync/tests/connection.rs
+++ b/p2p/src/sync/tests/connection.rs
@@ -44,7 +44,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(A::make_transport(), addr).await;
     register_peer(&mut mgr, peer_id).await;
@@ -87,8 +87,8 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id1 = P::random();
-    let peer_id2 = P::random();
+    let peer_id1 = P::new();
+    let peer_id2 = P::new();
 
     let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(A::make_transport(), addr).await;
 

--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -51,7 +51,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let config = Arc::new(common::chain::config::create_unit_test_config());
     let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(A::make_transport(), addr).await;
@@ -102,7 +102,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(A::make_transport(), addr).await;
     register_peer(&mut mgr, peer_id).await;
@@ -143,7 +143,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
@@ -197,7 +197,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
@@ -265,7 +265,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
@@ -320,7 +320,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let mut rng = crypto::random::make_pseudo_rng();
     let config = Arc::new(common::chain::config::create_unit_test_config());
@@ -375,7 +375,7 @@ where
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
 {
     let addr = A::make_address();
-    let peer_id = P::random();
+    let peer_id = P::new();
 
     let (mut mgr, _conn, _sync, _pm) = make_sync_manager::<T>(A::make_transport(), addr).await;
 

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -127,6 +127,6 @@ impl MakeTestPeerId for MockPeerId {
     type PeerId = Self;
 
     fn random() -> Self::PeerId {
-        MockPeerId::random()
+        MockPeerId::new()
     }
 }

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -112,13 +112,13 @@ where
 pub trait MakeTestPeerId {
     type PeerId;
 
-    fn random() -> Self::PeerId;
+    fn new() -> Self::PeerId;
 }
 
 impl MakeTestPeerId for PeerId {
     type PeerId = Self;
 
-    fn random() -> Self::PeerId {
+    fn new() -> Self::PeerId {
         PeerId::random()
     }
 }
@@ -126,7 +126,7 @@ impl MakeTestPeerId for PeerId {
 impl MakeTestPeerId for MockPeerId {
     type PeerId = Self;
 
-    fn random() -> Self::PeerId {
+    fn new() -> Self::PeerId {
         MockPeerId::new()
     }
 }

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -19,12 +19,13 @@ use tokio::time::timeout;
 
 use chainstate::Locator;
 
+use crate::event::PeerManagerEvent;
+use crate::net::DisconnectId;
 use crate::testing_utils::{
     TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
     TestTransportTcp,
 };
 use crate::{
-    event::PeerManagerEvent,
     message::{HeaderListRequest, HeaderListResponse, Request, Response},
     net::{
         libp2p::Libp2pService,
@@ -242,7 +243,7 @@ where
     }
 
     match pm1.recv().await.unwrap() {
-        PeerManagerEvent::Disconnect(peer_id, _) => assert_eq!(peer_id, peer2_id),
+        PeerManagerEvent::Disconnect(id, _) => assert_eq!(id, DisconnectId::PeerId(peer2_id)),
         e => panic!("Unexpected peer manager event: {e:?}"),
     }
 }

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -20,7 +20,6 @@ use tokio::time::timeout;
 use chainstate::Locator;
 
 use crate::event::PeerManagerEvent;
-use crate::net::DisconnectId;
 use crate::testing_utils::{
     TestTransportChannel, TestTransportLibp2p, TestTransportMaker, TestTransportNoise,
     TestTransportTcp,
@@ -243,7 +242,7 @@ where
     }
 
     match pm1.recv().await.unwrap() {
-        PeerManagerEvent::Disconnect(id, _) => assert_eq!(id, DisconnectId::PeerId(peer2_id)),
+        PeerManagerEvent::Disconnect(id, _) => assert_eq!(id, peer2_id),
         e => panic!("Unexpected peer manager event: {e:?}"),
     }
 }

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -52,11 +52,11 @@ where
         make_sync_manager::<T>(A::make_transport(), A::make_address()).await;
 
     // connect the two managers together so that they can exchange messages
-    connect_services::<T>(&mut conn1, &mut conn2).await;
+    let (_address, _peer_info1, peer_info2) = connect_services::<T>(&mut conn1, &mut conn2).await;
 
     mgr1.peer_sync_handle
         .send_request(
-            *conn2.peer_id(),
+            peer_info2.peer_id,
             Request::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
         .await
@@ -121,13 +121,13 @@ where
         make_sync_manager::<T>(A::make_transport(), addr2).await;
 
     // connect the two managers together so that they can exchange messages
-    connect_services::<T>(&mut conn1, &mut conn2).await;
+    let (_address, _peer_info1, peer_info2) = connect_services::<T>(&mut conn1, &mut conn2).await;
     let mut request_ids = HashSet::new();
 
     let id = mgr1
         .peer_sync_handle
         .send_request(
-            *conn2.peer_id(),
+            peer_info2.peer_id,
             Request::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
         .await
@@ -137,7 +137,7 @@ where
     let id = mgr1
         .peer_sync_handle
         .send_request(
-            *conn2.peer_id(),
+            peer_info2.peer_id,
             Request::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
         .await
@@ -215,8 +215,8 @@ where
         make_sync_manager::<T>(A::make_transport(), A::make_address()).await;
 
     // connect the two managers together so that they can exchange messages
-    connect_services::<T>(&mut conn1, &mut conn2).await;
-    let peer2_id = *conn2.peer_id();
+    let (_address, _peer_info1, peer_info2) = connect_services::<T>(&mut conn1, &mut conn2).await;
+    let peer2_id = peer_info2.peer_id;
 
     tokio::spawn(async move {
         mgr1.register_peer(peer2_id).await.unwrap();

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -31,6 +31,7 @@ from .util import (
     check_json_precision,
     get_datadir_path,
     initialize_datadir,
+    p2p_url,
     wait_until_helper,
 )
 
@@ -556,11 +557,20 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
     def wait_for_node_exit(self, i, timeout):
         self.nodes[i].process.wait(timeout)
 
+    def get_node_addr_libp2p(self, a):
+        # Call p2p_get_bind_address just to get node id
+        id_a = self.nodes[a].p2p_get_bind_address().split("/p2p/")[1]
+        return p2p_url(a) + "/p2p/" + id_a
+
+    def get_node_addr_mock(a):
+        return p2p_url(a)
+
     def connect_nodes(self, a, b):
         count_a = self.nodes[a].p2p_get_peer_count()
         count_b = self.nodes[b].p2p_get_peer_count()
 
-        addr_a = self.nodes[a].p2p_get_bind_address()
+        # TODO: Replace with get_node_addr_mock once libp2p removed
+        addr_a = self.get_node_addr_libp2p(a)
         ret = self.nodes[b].p2p_connect(addr_a)
 
         wait_until_helper(lambda:
@@ -572,7 +582,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         count_b = self.nodes[b].p2p_get_peer_count()
 
         connected = self.nodes[b].p2p_get_connected_peers()
-        addr_a = self.nodes[a].p2p_get_bind_address()
+        # TODO: Replace with get_node_addr_mock once libp2p removed
+        addr_a = self.get_node_addr_libp2p(a)
         peer_id = next(item["peer_id"] for item in connected if item["addr"] == addr_a)
         ret = self.nodes[b].p2p_disconnect(peer_id)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -571,8 +571,10 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         count_a = self.nodes[a].p2p_get_peer_count()
         count_b = self.nodes[b].p2p_get_peer_count()
 
+        connected = self.nodes[b].p2p_get_connected_peers()
         addr_a = self.nodes[a].p2p_get_bind_address()
-        ret = self.nodes[b].p2p_disconnect(addr_a)
+        peer_id = next(item["peer_id"] for item in connected if item["addr"] == addr_a)
+        ret = self.nodes[b].p2p_disconnect(peer_id)
 
         wait_until_helper(lambda:
             self.nodes[a].p2p_get_peer_count() == count_a - 1 and


### PR DESCRIPTION
I noticed some issues with peer ids handling in the mock p2p backend:
- `MockPeerId` is derived from remote peer address and port (using a non-cryptographic hash functions). It's not clear how safe this approach.
- Own peer id is sent in handshake message.

I think it has been done this way because peer ids was supposed to be globally unique. After recent discussion it's decided that we don't really need peers ids to be globally unique and so we could simply things a bit. And so I made some changes in that area:
- `MockPeerId` is removed from the handshake, remote peers won't be able to set arbitrary data there.
- New `MockPeerId` generated from a counter.

This changes allowed remove `local_peer_id` which is not really needed.

We will also need to remove `peer_id` from `AddrInfo`:

```
/// Discovered peer address information
#[derive(Debug, PartialEq, Eq)]
pub struct AddrInfo<T: NetworkingService> {
    /// Unique ID of the peer
    pub peer_id: T::PeerId,

    /// List of discovered IPv4 addresses
    pub ip4: Vec<T::Address>,

    /// List of discovered IPv6 addresses
    pub ip6: Vec<T::Address>,
}
```

I will do that later.