### PR TITLE
utxos: Generalize how lifetimes are handled

### DIFF
--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -34,7 +34,7 @@ use common::{
     primitives::Id,
 };
 use tx_verifier::transaction_verifier::TransactionSource;
-use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosDBMut, UtxosStorageRead};
+use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosDB, UtxosStorageRead};
 
 impl<'a, S: BlockchainStorageRead, O: OrphanBlocks, V: TransactionVerificationStrategy>
     TransactionVerifierStorageRef for ChainstateRef<'a, S, O, V>
@@ -115,7 +115,7 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocks, V: TransactionVerificationS
     FlushableUtxoView for ChainstateRef<'a, S, O, V>
 {
     fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), utxo::Error> {
-        let mut db = UtxosDBMut::new(&mut self.db_tx);
+        let mut db = UtxosDB::new(&mut self.db_tx);
         db.batch_write(utxos)
     }
 }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -55,7 +55,7 @@ use utils::{
     eventhandler::{EventHandler, EventsController},
     tap_error_log::LogError,
 };
-use utxo::UtxosDBMut;
+use utxo::UtxosDB;
 
 use self::{
     orphan_blocks::{OrphanBlocksRef, OrphanBlocksRefMut},
@@ -396,7 +396,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
         }
 
         // initialize the utxo-set by adding genesis outputs to it
-        UtxosDBMut::initialize_db(&mut db_tx, &self.chain_config);
+        UtxosDB::initialize_db(&mut db_tx, &self.chain_config);
 
         db_tx.commit().expect("Genesis database initialization failed");
         Ok(())

--- a/chainstate/storage/src/internal/utxo_db.rs
+++ b/chainstate/storage/src/internal/utxo_db.rs
@@ -25,7 +25,7 @@ mod test {
     use crypto::random::{CryptoRng, Rng};
     use rstest::rstest;
     use test_utils::random::{make_seedable_rng, Seed};
-    use utxo::{Utxo, UtxosDBMut, UtxosStorageRead, UtxosStorageWrite};
+    use utxo::{Utxo, UtxosDB, UtxosStorageRead, UtxosStorageWrite};
 
     fn create_utxo(
         rng: &mut (impl Rng + CryptoRng),
@@ -58,7 +58,7 @@ mod test {
         store
             .set_best_block_for_utxos(&H256::random_using(&mut rng).into())
             .expect("Setting best block cannot fail");
-        let mut db_interface = UtxosDBMut::new(&mut store);
+        let mut db_interface = UtxosDB::new(&mut store);
 
         // utxo checking
         let val = rng.gen_range(0..u128::MAX);

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -163,13 +163,13 @@ pub struct TransactionVerifier<'a, S, U> {
     storage_ref: &'a S,
     verifier_config: TransactionVerifierConfig,
     tx_index_cache: TxIndexCache,
-    utxo_cache: UtxosCache<'a, U>,
+    utxo_cache: UtxosCache<U>,
     utxo_block_undo: BTreeMap<TransactionSource, BlockUndoEntry>,
     token_issuance_cache: TokenIssuanceCache,
     best_block: Id<GenBlock>,
 }
 
-impl<'a, S: TransactionVerifierStorageRef> TransactionVerifier<'a, S, UtxosDB<'a, S>> {
+impl<'a, S: TransactionVerifierStorageRef> TransactionVerifier<'a, S, UtxosDB<&'a S>> {
     pub fn new(
         storage_ref: &'a S,
         chain_config: &'a ChainConfig,
@@ -180,7 +180,7 @@ impl<'a, S: TransactionVerifierStorageRef> TransactionVerifier<'a, S, UtxosDB<'a
             chain_config,
             verifier_config,
             tx_index_cache: TxIndexCache::new(),
-            utxo_cache: UtxosCache::from_owned_parent(UtxosDB::new(storage_ref)),
+            utxo_cache: UtxosCache::new(UtxosDB::new(storage_ref)),
             utxo_block_undo: BTreeMap::new(),
             token_issuance_cache: TokenIssuanceCache::new(),
             best_block: storage_ref
@@ -204,7 +204,7 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView + Send + Sync>
             storage_ref,
             chain_config,
             tx_index_cache: TxIndexCache::new(),
-            utxo_cache: UtxosCache::from_owned_parent(utxos), // TODO: take utxos from handle
+            utxo_cache: UtxosCache::new(utxos), // TODO: take utxos from handle
             utxo_block_undo: BTreeMap::new(),
             token_issuance_cache: TokenIssuanceCache::new(),
             best_block: storage_ref
@@ -217,13 +217,13 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView + Send + Sync>
 }
 
 impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifier<'a, S, U> {
-    pub fn derive_child(&'a self) -> TransactionVerifier<'a, Self, UtxosCache<U>> {
+    pub fn derive_child(&'a self) -> TransactionVerifier<'a, Self, &'a UtxosCache<U>> {
         TransactionVerifier {
             storage_ref: self,
             chain_config: self.chain_config,
             verifier_config: self.verifier_config.clone(),
             tx_index_cache: TxIndexCache::new(),
-            utxo_cache: UtxosCache::from_borrowed_parent(&self.utxo_cache),
+            utxo_cache: UtxosCache::new(&self.utxo_cache),
             utxo_block_undo: BTreeMap::new(),
             token_issuance_cache: TokenIssuanceCache::new(),
             best_block: self.best_block,

--- a/utxo/src/lib.rs
+++ b/utxo/src/lib.rs
@@ -24,7 +24,7 @@ mod view;
 pub use crate::{
     cache::{ConsumedUtxoCache, UtxosCache},
     error::Error,
-    storage::{UtxosDB, UtxosDBMut, UtxosStorageRead, UtxosStorageWrite},
+    storage::{UtxosDB, UtxosStorageRead, UtxosStorageWrite},
     undo::{BlockRewardUndo, BlockUndo, BlockUndoError, TxUndo, TxUndoWithSources},
     utxo::{Utxo, UtxoSource},
     view::{flush_to_base, FlushableUtxoView, UtxosView},

--- a/utxo/src/storage/mod.rs
+++ b/utxo/src/storage/mod.rs
@@ -57,22 +57,7 @@ impl<S: UtxosStorageRead> UtxosDB<S> {
     }
 }
 
-#[must_use]
-pub struct UtxosDBMut<S>(S);
-
-impl<S: UtxosStorageWrite> UtxosDBMut<S> {
-    pub fn new(store: S) -> Self {
-        let utxos_db = Self(store);
-        debug_assert!(
-            utxos_db
-                .get_best_block_for_utxos()
-                .expect("Database error while reading utxos best block")
-                .is_some(),
-            "Attempted to load an uninitialized utxos db"
-        );
-        utxos_db
-    }
-
+impl<S: UtxosStorageWrite> UtxosDB<S> {
     pub fn initialize_db(store: S, chain_config: &ChainConfig) {
         let genesis = chain_config.genesis_block();
         let genesis_id = chain_config.genesis_block_id();

--- a/utxo/src/storage/rw_impls.rs
+++ b/utxo/src/storage/rw_impls.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{UtxosDB, UtxosDBMut, UtxosStorageRead, UtxosStorageWrite};
+use super::{UtxosDB, UtxosStorageRead, UtxosStorageWrite};
 use crate::{BlockUndo, Utxo};
 use chainstate_types::storage_result::Error as StorageError;
 use common::{
@@ -21,21 +21,7 @@ use common::{
     primitives::Id,
 };
 
-impl<S: UtxosStorageRead> UtxosStorageRead for UtxosDBMut<S> {
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, StorageError> {
-        self.0.get_utxo(outpoint)
-    }
-
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, StorageError> {
-        self.0.get_best_block_for_utxos()
-    }
-
-    fn get_undo_data(&self, id: Id<Block>) -> Result<Option<BlockUndo>, StorageError> {
-        self.0.get_undo_data(id)
-    }
-}
-
-impl<S: UtxosStorageWrite> UtxosStorageWrite for UtxosDBMut<S> {
+impl<S: UtxosStorageWrite> UtxosStorageWrite for UtxosDB<S> {
     fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), StorageError> {
         self.0.set_utxo(outpoint, entry)
     }

--- a/utxo/src/storage/rw_impls.rs
+++ b/utxo/src/storage/rw_impls.rs
@@ -21,7 +21,7 @@ use common::{
     primitives::Id,
 };
 
-impl<'a, S: UtxosStorageRead> UtxosStorageRead for UtxosDBMut<'a, S> {
+impl<S: UtxosStorageRead> UtxosStorageRead for UtxosDBMut<S> {
     fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, StorageError> {
         self.0.get_utxo(outpoint)
     }
@@ -35,7 +35,7 @@ impl<'a, S: UtxosStorageRead> UtxosStorageRead for UtxosDBMut<'a, S> {
     }
 }
 
-impl<'a, S: UtxosStorageWrite> UtxosStorageWrite for UtxosDBMut<'a, S> {
+impl<S: UtxosStorageWrite> UtxosStorageWrite for UtxosDBMut<S> {
     fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), StorageError> {
         self.0.set_utxo(outpoint, entry)
     }
@@ -56,7 +56,7 @@ impl<'a, S: UtxosStorageWrite> UtxosStorageWrite for UtxosDBMut<'a, S> {
     }
 }
 
-impl<'a, S: UtxosStorageRead> UtxosStorageRead for UtxosDB<'a, S> {
+impl<S: UtxosStorageRead> UtxosStorageRead for UtxosDB<S> {
     fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, StorageError> {
         self.0.get_utxo(outpoint)
     }

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -136,7 +136,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
     // create the TxInputs for spending.
     let expected_tx_inputs = create_tx_inputs(&mut rng, &outpoints);
     // create the UtxosDB.
-    let mut db = UtxosDBMut::new(&mut db_impl);
+    let mut db = UtxosDB::new(&mut db_impl);
 
     // let's check that each tx_input exists in the db. Secure the spent utxos.
     let spent_utxos = expected_tx_inputs
@@ -319,7 +319,7 @@ fn test_batch_write(#[case] seed: Seed) {
     let new_best_block_hash = Id::new(H256::random_using(&mut rng));
 
     let mut db_interface = UtxosDBInMemoryImpl::new(new_best_block_hash, Default::default());
-    let mut utxo_db = UtxosDBMut::new(&mut db_interface);
+    let mut utxo_db = UtxosDB::new(&mut db_interface);
 
     let utxos = ConsumedUtxoCache {
         container: utxos,
@@ -353,7 +353,7 @@ fn try_flush_non_dirty_utxo(#[case] seed: Seed) {
 
     let mut db_interface =
         UtxosDBInMemoryImpl::new(Id::new(H256::random_using(&mut rng)), Default::default());
-    let mut utxo_db = UtxosDBMut::new(&mut db_interface);
+    let mut utxo_db = UtxosDB::new(&mut db_interface);
 
     let (utxo, outpoint) = create_utxo(&mut rng, 1);
     let mut map = BTreeMap::new();
@@ -378,7 +378,7 @@ fn try_flush_spent_utxo(#[case] seed: Seed) {
 
     let mut db_interface =
         UtxosDBInMemoryImpl::new(Id::new(H256::random_using(&mut rng)), Default::default());
-    let mut utxo_db = UtxosDBMut::new(&mut db_interface);
+    let mut utxo_db = UtxosDB::new(&mut db_interface);
 
     let outpoint = OutPoint::new(
         OutPointSourceId::Transaction(Id::new(H256::random_using(&mut rng))),

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -152,7 +152,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
     // test the spend
     let (block, block_undo) = {
         // create a cache based on the db.
-        let mut cache = UtxosCache::from_borrowed_parent(&db);
+        let mut cache = UtxosCache::new(&db);
 
         // create a new block to spend.
         let block = create_block(
@@ -242,7 +242,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
         assert_eq!(block_undo.tx_undos().len(), expected_tx_inputs.len());
 
         // let's create a view.
-        let mut cache = UtxosCache::from_borrowed_parent(&db);
+        let mut cache = UtxosCache::new(&db);
 
         // get the block tx inputs, and add them to the view.
         block.transactions().iter().enumerate().for_each(|(_idx, tx)| {
@@ -301,7 +301,7 @@ fn try_spend_tx_with_no_outputs(#[case] seed: Seed) {
 
     // Create a block with 1 tx and 0 outputs in txs
     let block = create_block(&mut rng, id, tx_inputs, 0, num_of_txs as usize);
-    let mut view = UtxosCache::from_borrowed_parent(&db);
+    let mut view = UtxosCache::new(&db);
     let tx = block.transactions().get(0).unwrap();
 
     assert_eq!(

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -46,7 +46,7 @@ mod utxosdb_utxosview_impls {
     }
 }
 
-impl<'a, S: UtxosStorageRead> UtxosView for UtxosDB<'a, S> {
+impl<S: UtxosStorageRead> UtxosView for UtxosDB<S> {
     fn utxo(&self, outpoint: &OutPoint) -> Option<Utxo> {
         utxosdb_utxosview_impls::utxo(self, outpoint)
     }
@@ -64,7 +64,7 @@ impl<'a, S: UtxosStorageRead> UtxosView for UtxosDB<'a, S> {
     }
 }
 
-impl<'a, S: UtxosStorageWrite> UtxosView for UtxosDBMut<'a, S> {
+impl<S: UtxosStorageWrite> UtxosView for UtxosDBMut<S> {
     fn utxo(&self, outpoint: &OutPoint) -> Option<Utxo> {
         utxosdb_utxosview_impls::utxo(self, outpoint)
     }
@@ -82,7 +82,7 @@ impl<'a, S: UtxosStorageWrite> UtxosView for UtxosDBMut<'a, S> {
     }
 }
 
-impl<'a, S: UtxosStorageWrite> FlushableUtxoView for UtxosDBMut<'a, S> {
+impl<S: UtxosStorageWrite> FlushableUtxoView for UtxosDBMut<S> {
     fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), crate::Error> {
         // check each entry if it's dirty. Only then will the db be updated.
         for (key, entry) in utxos.container {

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{UtxosDB, UtxosDBMut, UtxosStorageRead, UtxosStorageWrite};
+use super::{UtxosDB, UtxosStorageRead, UtxosStorageWrite};
 use crate::{ConsumedUtxoCache, FlushableUtxoView, Utxo, UtxosView};
 use common::{
     chain::{GenBlock, OutPoint},
@@ -64,25 +64,7 @@ impl<S: UtxosStorageRead> UtxosView for UtxosDB<S> {
     }
 }
 
-impl<S: UtxosStorageWrite> UtxosView for UtxosDBMut<S> {
-    fn utxo(&self, outpoint: &OutPoint) -> Option<Utxo> {
-        utxosdb_utxosview_impls::utxo(self, outpoint)
-    }
-
-    fn has_utxo(&self, outpoint: &OutPoint) -> bool {
-        utxosdb_utxosview_impls::has_utxo(self, outpoint)
-    }
-
-    fn best_block_hash(&self) -> Id<GenBlock> {
-        utxosdb_utxosview_impls::best_block_hash(self)
-    }
-
-    fn estimated_size(&self) -> Option<usize> {
-        utxosdb_utxosview_impls::estimated_size(self)
-    }
-}
-
-impl<S: UtxosStorageWrite> FlushableUtxoView for UtxosDBMut<S> {
+impl<S: UtxosStorageWrite> FlushableUtxoView for UtxosDB<S> {
     fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), crate::Error> {
         // check each entry if it's dirty. Only then will the db be updated.
         for (key, entry) in utxos.container {

--- a/utxo/src/tests/simulation.rs
+++ b/utxo/src/tests/simulation.rs
@@ -35,7 +35,7 @@ fn cache_simulation_test(
     let mut rng = make_seedable_rng(seed);
     let mut result: Vec<OutPoint> = Vec::new();
     let test_view = empty_test_utxos_view(common::primitives::H256::zero().into());
-    let mut base = UtxosCache::from_owned_parent(test_view);
+    let mut base = UtxosCache::new(test_view);
 
     let new_consumed_cache = simulation_step(
         &mut rng,
@@ -78,7 +78,7 @@ fn simulation_step<P: UtxosView>(
 
     // notice that we're using a reference of a reference
     let parent: &dyn UtxosView = parent_cache;
-    let mut current_cache = UtxosCache::from_borrowed_parent(&parent);
+    let mut current_cache = UtxosCache::new(&parent);
 
     // fill a global list of outputs
     let mut current_cache_outputs =

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -53,7 +53,7 @@ fn cache_simulation_with_undo(
     let mut rng = make_seedable_rng(seed);
     let mut result: ResultWithUndo = Default::default();
     let test_view = super::empty_test_utxos_view(H256::zero().into());
-    let mut base = UtxosCache::from_owned_parent(test_view);
+    let mut base = UtxosCache::new(test_view);
 
     let new_consumed_cache = simulation_step(
         &mut rng,
@@ -96,7 +96,7 @@ fn simulation_step<P: UtxosView>(
 
     // notice that we're using a reference of a reference
     let parent: &dyn UtxosView = parent_cache;
-    let mut current_cache = UtxosCache::from_borrowed_parent(&parent);
+    let mut current_cache = UtxosCache::new(&parent);
 
     // fill a global list of outputs
     let mut current_cache_outputs =


### PR DESCRIPTION
Generalize the generic parametres of `UtxosDB`, `UtxosView`, `UtxosCache` and such. Before, the values were hard-coded to be a reference (with a lifetime associated with it). Instead use the value directly and let the user define whether the objects (such as `UtxosDB`) take the underlying storage by value, by reference, by mut reference, using `Arc` or whatever. Managed to get rid of `UtxosViewCow` in the process.

Also some mild refactoring to unify `UtxosDB` and `UtxosDBMut` which makes things a bit simpler and removes some code duplication.

This is just a first step, I'd like to do the same with the remaining objects in `TransactionVerifier` but want to gather some early feedback regarding the general approach. Hopefully it will be sufficient to make the lifetimes work in the case where the underlying storage is actually a handle to another subsystem.