### PR TITLE
Generalize more lifetimes in `TransactionVerifier`

### DIFF
--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -782,7 +782,7 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut, V: TransactionVerificati
             .connect_block(
                 TransactionVerifier::new,
                 self,
-                self,
+                &*self,
                 self.chain_config,
                 verifier_config,
                 block_index,
@@ -802,7 +802,7 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut, V: TransactionVerificati
         };
         let cached_inputs = self.tx_verification_strategy.disconnect_block(
             TransactionVerifier::new,
-            self,
+            &*self,
             self.chain_config,
             verifier_config,
             block,

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -49,25 +49,29 @@ impl Default for DefaultTransactionVerificationStrategy {
 }
 
 impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy {
-    fn connect_block<'a, H, S, M, U>(
+    fn connect_block<CC, H, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        block_index_handle: &'a H,
+        block_index_handle: &H,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
-        block_index: &'a BlockIndex,
+        block_index: &BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<CC, S, U>, BlockError>
     where
+        CC: AsRef<ChainConfig>,
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
             calculate_median_time_past(block_index_handle, &block.prev_block_id());
+
+        let block_subsidy =
+            chain_config.as_ref().block_subsidy_at_height(&block_index.block_height());
 
         let mut tx_indices = construct_tx_indices(&verifier_config, block)?;
         let block_reward_tx_index = construct_reward_tx_indices(&verifier_config, block)?;
@@ -105,7 +109,6 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
             })
             .log_err()?;
 
-        let block_subsidy = chain_config.block_subsidy_at_height(&block_index.block_height());
         tx_verifier
             .check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy))
             .log_err()?;
@@ -115,18 +118,19 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         Ok(tx_verifier)
     }
 
-    fn disconnect_block<'a, S, M, U>(
+    fn disconnect_block<CC, S, M, U>(
         &self,
         tx_verifier_maker: M,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<CC, S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        CC: AsRef<ChainConfig>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config, verifier_config);
 

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -53,21 +53,17 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         &self,
         tx_verifier_maker: M,
         block_index_handle: &'a H,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>,
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -122,19 +118,15 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
     fn disconnect_block<'a, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>,
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config, verifier_config);
 

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -58,12 +58,16 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -122,11 +126,15 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config, verifier_config);
 

--- a/chainstate/src/detail/tx_verification_strategy/mod.rs
+++ b/chainstate/src/detail/tx_verification_strategy/mod.rs
@@ -47,12 +47,16 @@ pub trait TransactionVerificationStrategy: Sized + Send {
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>;
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>;
 
     /// Disconnect the transactions given by block and block_index,
     /// and return a TransactionVerifier with an internal state
@@ -67,9 +71,13 @@ pub trait TransactionVerificationStrategy: Sized + Send {
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>;
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>;
 }

--- a/chainstate/src/detail/tx_verification_strategy/mod.rs
+++ b/chainstate/src/detail/tx_verification_strategy/mod.rs
@@ -42,21 +42,17 @@ pub trait TransactionVerificationStrategy: Sized + Send {
         &self,
         tx_verifier_maker: M,
         block_index_handle: &'a H,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>;
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>;
 
     /// Disconnect the transactions given by block and block_index,
     /// and return a TransactionVerifier with an internal state
@@ -67,17 +63,13 @@ pub trait TransactionVerificationStrategy: Sized + Send {
     fn disconnect_block<'a, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>;
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>;
 }

--- a/chainstate/src/detail/tx_verification_strategy/mod.rs
+++ b/chainstate/src/detail/tx_verification_strategy/mod.rs
@@ -38,21 +38,22 @@ pub trait TransactionVerificationStrategy: Sized + Send {
     /// state. It just returns a TransactionVerifier that can be
     /// used to update the database/storage state.
     #[allow(clippy::too_many_arguments)]
-    fn connect_block<'a, H, S, M, U>(
+    fn connect_block<CC, H, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        block_index_handle: &'a H,
+        block_index_handle: &H,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
-        block_index: &'a BlockIndex,
+        block_index: &BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<CC, S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>;
+        CC: AsRef<ChainConfig>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>;
 
     /// Disconnect the transactions given by block and block_index,
     /// and return a TransactionVerifier with an internal state
@@ -60,16 +61,17 @@ pub trait TransactionVerificationStrategy: Sized + Send {
     /// Notice that this doesn't modify the internal database/storage
     /// state. It just returns a TransactionVerifier that can be
     /// used to update the database/storage state.
-    fn disconnect_block<'a, S, M, U>(
+    fn disconnect_block<CC, S, M, U>(
         &self,
         tx_verifier_maker: M,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<CC, S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>;
+        CC: AsRef<ChainConfig>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>;
 }

--- a/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
@@ -55,21 +55,17 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
         &self,
         tx_verifier_maker: M,
         block_index_handle: &'a H,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>,
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -134,19 +130,15 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
     fn disconnect_block<'a, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>,
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
     {
         let mut base_tx_verifier =
             tx_verifier_maker(storage_backend, chain_config, verifier_config);

--- a/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
@@ -51,25 +51,28 @@ impl Default for DisposableTransactionVerificationStrategy {
 }
 
 impl TransactionVerificationStrategy for DisposableTransactionVerificationStrategy {
-    fn connect_block<'a, H, S, M, U>(
+    fn connect_block<CC, H, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        block_index_handle: &'a H,
+        block_index_handle: &H,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
-        block_index: &'a BlockIndex,
+        block_index: &BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<CC, S, U>, BlockError>
     where
+        CC: AsRef<ChainConfig>,
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
             calculate_median_time_past(block_index_handle, &block.prev_block_id());
+        let block_subsidy =
+            chain_config.as_ref().block_subsidy_at_height(&block_index.block_height());
 
         let mut tx_indices = construct_tx_indices(&verifier_config, block)?;
         let block_reward_tx_index = construct_reward_tx_indices(&verifier_config, block)?;
@@ -117,7 +120,6 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
             })
             .log_err()?;
 
-        let block_subsidy = chain_config.block_subsidy_at_height(&block_index.block_height());
         base_tx_verifier
             .check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy))
             .log_err()?;
@@ -127,18 +129,19 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
         Ok(base_tx_verifier)
     }
 
-    fn disconnect_block<'a, S, M, U>(
+    fn disconnect_block<CC, S, M, U>(
         &self,
         tx_verifier_maker: M,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<CC, S, U>, BlockError>
     where
+        CC: AsRef<ChainConfig>,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>,
     {
         let mut base_tx_verifier =
             tx_verifier_maker(storage_backend, chain_config, verifier_config);

--- a/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
@@ -60,12 +60,16 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -134,11 +138,15 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>,
     {
         let mut base_tx_verifier =
             tx_verifier_maker(storage_backend, chain_config, verifier_config);

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -64,25 +64,28 @@ impl RandomizedTransactionVerificationStrategy {
 }
 
 impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrategy {
-    fn connect_block<'a, H, S, M, U>(
+    fn connect_block<CC, H, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        block_index_handle: &'a H,
+        block_index_handle: &H,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
-        block_index: &'a BlockIndex,
+        block_index: &BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<CC, S, U>, BlockError>
     where
+        CC: AsRef<ChainConfig>,
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
             calculate_median_time_past(block_index_handle, &block.prev_block_id());
+        let block_subsidy =
+            chain_config.as_ref().block_subsidy_at_height(&block_index.block_height());
 
         let (mut tx_verifier, total_fees) = self
             .connect_with_base(
@@ -96,7 +99,6 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
             )
             .log_err()?;
 
-        let block_subsidy = chain_config.block_subsidy_at_height(&block_index.block_height());
         tx_verifier
             .check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy))
             .log_err()?;
@@ -106,18 +108,19 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
         Ok(tx_verifier)
     }
 
-    fn disconnect_block<'a, S, M, U>(
+    fn disconnect_block<CC, S, M, U>(
         &self,
         tx_verifier_maker: M,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<CC, S, U>, BlockError>
     where
+        CC: AsRef<ChainConfig>,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>,
     {
         let mut tx_verifier = self.disconnect_with_base(
             tx_verifier_maker,
@@ -135,20 +138,20 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
 
 impl RandomizedTransactionVerificationStrategy {
     #[allow(clippy::too_many_arguments)]
-    fn connect_with_base<'a, S, M, U>(
+    fn connect_with_base<CC: AsRef<ChainConfig>, S, M, U>(
         &self,
         tx_verifier_maker: M,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
-        block_index: &'a BlockIndex,
+        block_index: &BlockIndex,
         block: &WithId<Block>,
         median_time_past: &BlockTimestamp,
-    ) -> Result<(TransactionVerifier<'a, S, U>, Amount), ConnectTransactionError>
+    ) -> Result<(TransactionVerifier<CC, S, U>, Amount), ConnectTransactionError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>,
     {
         let mut tx_indices = construct_tx_indices(&verifier_config, block)?;
         let block_reward_tx_index = construct_reward_tx_indices(&verifier_config, block)?;
@@ -202,16 +205,17 @@ impl RandomizedTransactionVerificationStrategy {
         Ok((tx_verifier, total_fee))
     }
 
-    fn connect_with_derived<'a, S, U>(
+    fn connect_with_derived<CC, S, U>(
         &self,
-        base_tx_verifier: &TransactionVerifier<'a, S, U>,
+        base_tx_verifier: &TransactionVerifier<CC, S, U>,
         block: &WithId<Block>,
-        block_index: &'a BlockIndex,
+        block_index: &BlockIndex,
         median_time_past: &BlockTimestamp,
         tx_indices: &mut Option<VecDeque<TxMainChainIndex>>,
         mut tx_num: usize,
     ) -> Result<(TransactionVerifierDelta, Amount, usize), ConnectTransactionError>
     where
+        CC: AsRef<ChainConfig>,
         U: UtxosView,
         S: TransactionVerifierStorageRef,
     {
@@ -243,18 +247,19 @@ impl RandomizedTransactionVerificationStrategy {
         Ok((cache, total_fee, tx_num))
     }
 
-    fn disconnect_with_base<'a, S, M, U>(
+    fn disconnect_with_base<CC, S, M, U>(
         &self,
         tx_verifier_maker: M,
         storage_backend: S,
-        chain_config: &'a ChainConfig,
+        chain_config: CC,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, ConnectTransactionError>
+    ) -> Result<TransactionVerifier<CC, S, U>, ConnectTransactionError>
     where
+        CC: AsRef<ChainConfig>,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(S, CC, TransactionVerifierConfig) -> TransactionVerifier<CC, S, U>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config, verifier_config);
         let mut tx_num = i32::try_from(block.transactions().len()).unwrap() - 1;
@@ -284,13 +289,14 @@ impl RandomizedTransactionVerificationStrategy {
         Ok(tx_verifier)
     }
 
-    fn disconnect_with_derived<'a, S, U>(
+    fn disconnect_with_derived<CC, S, U>(
         &self,
-        base_tx_verifier: &TransactionVerifier<'a, S, U>,
+        base_tx_verifier: &TransactionVerifier<CC, S, U>,
         block: &WithId<Block>,
         mut tx_num: i32,
     ) -> Result<(TransactionVerifierDelta, i32), ConnectTransactionError>
     where
+        CC: AsRef<ChainConfig>,
         U: UtxosView,
         S: TransactionVerifierStorageRef,
     {

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -68,21 +68,17 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
         &self,
         tx_verifier_maker: M,
         block_index_handle: &'a H,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>,
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -113,19 +109,15 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
     fn disconnect_block<'a, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>,
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
     {
         let mut tx_verifier = self.disconnect_with_base(
             tx_verifier_maker,
@@ -146,21 +138,17 @@ impl RandomizedTransactionVerificationStrategy {
     fn connect_with_base<'a, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
         median_time_past: &BlockTimestamp,
-    ) -> Result<(TransactionVerifier<'a, &'a S, U>, Amount), ConnectTransactionError>
+    ) -> Result<(TransactionVerifier<'a, S, U>, Amount), ConnectTransactionError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>,
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
     {
         let mut tx_indices = construct_tx_indices(&verifier_config, block)?;
         let block_reward_tx_index = construct_reward_tx_indices(&verifier_config, block)?;
@@ -258,19 +246,15 @@ impl RandomizedTransactionVerificationStrategy {
     fn disconnect_with_base<'a, S, M, U>(
         &self,
         tx_verifier_maker: M,
-        storage_backend: &'a S,
+        storage_backend: S,
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, &'a S, U>, ConnectTransactionError>
+    ) -> Result<TransactionVerifier<'a, S, U>, ConnectTransactionError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(
-            &'a S,
-            &'a ChainConfig,
-            TransactionVerifierConfig,
-        ) -> TransactionVerifier<'a, &'a S, U>,
+        M: Fn(S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config, verifier_config);
         let mut tx_num = i32::try_from(block.transactions().len()).unwrap() - 1;

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -73,12 +73,16 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
         verifier_config: TransactionVerifierConfig,
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
     where
         H: BlockIndexHandle,
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -113,11 +117,15 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, BlockError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, BlockError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>,
     {
         let mut tx_verifier = self.disconnect_with_base(
             tx_verifier_maker,
@@ -144,11 +152,15 @@ impl RandomizedTransactionVerificationStrategy {
         block_index: &'a BlockIndex,
         block: &WithId<Block>,
         median_time_past: &BlockTimestamp,
-    ) -> Result<(TransactionVerifier<'a, S, U>, Amount), ConnectTransactionError>
+    ) -> Result<(TransactionVerifier<'a, &'a S, U>, Amount), ConnectTransactionError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>,
     {
         let mut tx_indices = construct_tx_indices(&verifier_config, block)?;
         let block_reward_tx_index = construct_reward_tx_indices(&verifier_config, block)?;
@@ -250,11 +262,15 @@ impl RandomizedTransactionVerificationStrategy {
         chain_config: &'a ChainConfig,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<'a, S, U>, ConnectTransactionError>
+    ) -> Result<TransactionVerifier<'a, &'a S, U>, ConnectTransactionError>
     where
         S: TransactionVerifierStorageRef,
         U: UtxosView,
-        M: Fn(&'a S, &'a ChainConfig, TransactionVerifierConfig) -> TransactionVerifier<'a, S, U>,
+        M: Fn(
+            &'a S,
+            &'a ChainConfig,
+            TransactionVerifierConfig,
+        ) -> TransactionVerifier<'a, &'a S, U>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config, verifier_config);
         let mut tx_num = i32::try_from(block.transactions().len()).unwrap() - 1;

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -45,7 +45,7 @@ impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
                 CachedTokenIndexOp::Read(id) => Ok(Some(*id)),
                 CachedTokenIndexOp::Erase => Ok(None),
             },
-            None => self.storage_ref.get_token_id_from_issuance_tx(tx_id),
+            None => self.storage.get_token_id_from_issuance_tx(tx_id),
         }
     }
 
@@ -53,7 +53,7 @@ impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
         &self,
         block_id: &Id<GenBlock>,
     ) -> Result<Option<GenBlockIndex>, storage_result::Error> {
-        self.storage_ref.get_gen_block_index(block_id)
+        self.storage.get_gen_block_index(block_id)
     }
 
     fn get_mainchain_tx_index(
@@ -70,7 +70,7 @@ impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
                 CachedInputsOperation::Read(idx) => Ok(Some(idx.clone())),
                 CachedInputsOperation::Erase => Ok(None),
             },
-            None => self.storage_ref.get_mainchain_tx_index(tx_id),
+            None => self.storage.get_mainchain_tx_index(tx_id),
         }
     }
 
@@ -84,7 +84,7 @@ impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
                 CachedAuxDataOp::Read(t) => Ok(Some(t.clone())),
                 CachedAuxDataOp::Erase => Ok(None),
             },
-            None => self.storage_ref.get_token_aux_data(token_id),
+            None => self.storage.get_token_aux_data(token_id),
         }
     }
 }
@@ -106,7 +106,7 @@ impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> UtxosStorageRead
     ) -> Result<Option<utxo::BlockUndo>, storage_result::Error> {
         match self.utxo_block_undo.get(&TransactionSource::Chain(id)) {
             Some(v) => Ok(Some(v.undo.clone())),
-            None => self.storage_ref.get_undo_data(id),
+            None => self.storage.get_undo_data(id),
         }
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -61,7 +61,8 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
         tx_id: &OutPointSourceId,
     ) -> Result<Option<TxMainChainIndex>, TransactionVerifierStorageError> {
         let tx_index_cache = self
-            .get_tx_cache_ref()
+            .tx_index_cache
+            .as_ref()
             .ok_or(TransactionVerifierStorageError::TransactionIndexDisabled)?;
         match tx_index_cache.get_from_cached(tx_id) {
             Some(v) => match v {
@@ -119,7 +120,8 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
         tx_index: &TxMainChainIndex,
     ) -> Result<(), TransactionVerifierStorageError> {
         let tx_index_cache = self
-            .get_tx_cache_mut()
+            .tx_index_cache
+            .as_mut()
             .ok_or(TransactionVerifierStorageError::TransactionIndexDisabled)?;
         tx_index_cache
             .set_tx_index(tx_id, tx_index.clone())
@@ -131,7 +133,8 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
         tx_id: &OutPointSourceId,
     ) -> Result<(), TransactionVerifierStorageError> {
         let tx_index_cache = self
-            .get_tx_cache_mut()
+            .tx_index_cache
+            .as_mut()
             .ok_or(TransactionVerifierStorageError::TransactionIndexDisabled)?;
         tx_index_cache
             .remove_tx_index_by_id(tx_id.clone())

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -32,8 +32,8 @@ use common::{
 };
 use utxo::{BlockUndo, ConsumedUtxoCache, FlushableUtxoView, UtxosStorageRead, UtxosView};
 
-impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStorageRef
-    for TransactionVerifier<'a, S, U>
+impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStorageRef
+    for TransactionVerifier<CC, S, U>
 {
     fn get_token_id_from_issuance_tx(
         &self,
@@ -89,8 +89,8 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
     }
 }
 
-impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> UtxosStorageRead
-    for TransactionVerifier<'a, S, U>
+impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> UtxosStorageRead
+    for TransactionVerifier<CC, S, U>
 {
     fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<utxo::Utxo>, storage_result::Error> {
         Ok(self.utxo_cache.utxo(outpoint))
@@ -111,8 +111,8 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> UtxosStorageRead
     }
 }
 
-impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStorageMut
-    for TransactionVerifier<'a, S, U>
+impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStorageMut
+    for TransactionVerifier<CC, S, U>
 {
     fn set_mainchain_tx_index(
         &mut self,
@@ -217,8 +217,8 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifierStor
     }
 }
 
-impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> FlushableUtxoView
-    for TransactionVerifier<'a, S, U>
+impl<CC, S: TransactionVerifierStorageRef, U: UtxosView> FlushableUtxoView
+    for TransactionVerifier<CC, S, U>
 {
     fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), utxo::Error> {
         self.utxo_cache.batch_write(utxos)

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -181,11 +181,11 @@ impl GuardedTxIndexCache {
     }
 
     fn as_ref(&self) -> Option<&TxIndexCache> {
-        self.enabled.then(|| &self.inner)
+        self.enabled.then_some(&self.inner)
     }
 
     fn as_mut(&mut self) -> Option<&mut TxIndexCache> {
-        self.enabled.then(|| &mut self.inner)
+        self.enabled.then_some(&mut self.inner)
     }
 
     /// Take the inner cache, even if disabled
@@ -257,9 +257,7 @@ where
     S: TransactionVerifierStorageRef,
     U: UtxosView,
 {
-    pub fn derive_child<'a>(
-        &'a self,
-    ) -> TransactionVerifier<&'a ChainConfig, &'a Self, &'a UtxosCache<U>> {
+    pub fn derive_child(&self) -> TransactionVerifier<&ChainConfig, &Self, &UtxosCache<U>> {
         TransactionVerifier {
             storage: self,
             chain_config: self.chain_config.as_ref(),

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -198,7 +198,6 @@ impl GuardedTxIndexCache {
 pub struct TransactionVerifier<'a, S, U> {
     chain_config: &'a ChainConfig,
     storage_ref: S,
-    verifier_config: TransactionVerifierConfig,
     tx_index_cache: GuardedTxIndexCache,
     utxo_cache: UtxosCache<U>,
     utxo_block_undo: BTreeMap<TransactionSource, BlockUndoEntry>,
@@ -221,7 +220,6 @@ impl<'a, S: TransactionVerifierStorageRef + Clone> TransactionVerifier<'a, S, Ut
         Self {
             storage_ref,
             chain_config,
-            verifier_config,
             tx_index_cache,
             utxo_cache,
             utxo_block_undo: BTreeMap::new(),
@@ -253,7 +251,6 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView + Send + Sync>
             utxo_block_undo: BTreeMap::new(),
             token_issuance_cache: TokenIssuanceCache::new(),
             best_block,
-            verifier_config,
         }
     }
 }
@@ -263,7 +260,6 @@ impl<'a, S: TransactionVerifierStorageRef, U: UtxosView> TransactionVerifier<'a,
         TransactionVerifier {
             storage_ref: self,
             chain_config: self.chain_config,
-            verifier_config: self.verifier_config.clone(),
             tx_index_cache: GuardedTxIndexCache::new(self.tx_index_cache.enabled),
             utxo_cache: UtxosCache::new(&self.utxo_cache),
             utxo_block_undo: BTreeMap::new(),

--- a/chainstate/tx-verifier/src/transaction_verifier/storage.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/storage.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+
 use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
@@ -122,4 +124,37 @@ pub trait TransactionVerifierStorageMut: TransactionVerifierStorageRef + Flushab
         &mut self,
         tx_source: TransactionSource,
     ) -> Result<(), TransactionVerifierStorageError>;
+}
+
+impl<T: Deref> TransactionVerifierStorageRef for T
+where
+    T::Target: TransactionVerifierStorageRef,
+{
+    fn get_token_id_from_issuance_tx(
+        &self,
+        tx_id: Id<Transaction>,
+    ) -> Result<Option<TokenId>, TransactionVerifierStorageError> {
+        self.deref().get_token_id_from_issuance_tx(tx_id)
+    }
+
+    fn get_gen_block_index(
+        &self,
+        block_id: &Id<GenBlock>,
+    ) -> Result<Option<GenBlockIndex>, storage_result::Error> {
+        self.deref().get_gen_block_index(block_id)
+    }
+
+    fn get_mainchain_tx_index(
+        &self,
+        tx_id: &OutPointSourceId,
+    ) -> Result<Option<TxMainChainIndex>, TransactionVerifierStorageError> {
+        self.deref().get_mainchain_tx_index(tx_id)
+    }
+
+    fn get_token_aux_data(
+        &self,
+        token_id: &TokenId,
+    ) -> Result<Option<TokenAuxiliaryData>, TransactionVerifierStorageError> {
+        self.deref().get_token_aux_data(token_id)
+    }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
@@ -251,7 +251,7 @@ fn hierarchy_test_tx_index(#[case] seed: Seed) {
     let verifier1 = {
         let mut verifier =
             TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
-        verifier.tx_index_cache = TxIndexCache::new_for_test(BTreeMap::from([(
+        verifier.tx_index_cache = GuardedTxIndexCache::new_for_test(BTreeMap::from([(
             outpoint1.clone(),
             CachedInputsOperation::Read(tx_index_1.clone()),
         )]));
@@ -260,7 +260,7 @@ fn hierarchy_test_tx_index(#[case] seed: Seed) {
 
     let verifier2 = {
         let mut verifier = verifier1.derive_child();
-        verifier.tx_index_cache = TxIndexCache::new_for_test(BTreeMap::from([(
+        verifier.tx_index_cache = GuardedTxIndexCache::new_for_test(BTreeMap::from([(
             outpoint2.clone(),
             CachedInputsOperation::Read(tx_index_2.clone()),
         )]));

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -163,14 +163,14 @@ fn tx_index_set_hierarchy(#[case] seed: Seed) {
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
-    verifier1.tx_index_cache = TxIndexCache::new_for_test(BTreeMap::from([(
+    verifier1.tx_index_cache = GuardedTxIndexCache::new_for_test(BTreeMap::from([(
         outpoint1,
         CachedInputsOperation::Write(tx_index_1),
     )]));
 
     let verifier2 = {
         let mut verifier = verifier1.derive_child();
-        verifier.tx_index_cache = TxIndexCache::new_for_test(BTreeMap::from([(
+        verifier.tx_index_cache = GuardedTxIndexCache::new_for_test(BTreeMap::from([(
             outpoint2,
             CachedInputsOperation::Write(tx_index_2),
         )]));
@@ -383,13 +383,17 @@ fn tx_index_del_hierarchy(#[case] seed: Seed) {
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
-    verifier1.tx_index_cache =
-        TxIndexCache::new_for_test(BTreeMap::from([(outpoint1, CachedInputsOperation::Erase)]));
+    verifier1.tx_index_cache = GuardedTxIndexCache::new_for_test(BTreeMap::from([(
+        outpoint1,
+        CachedInputsOperation::Erase,
+    )]));
 
     let verifier2 = {
         let mut verifier = verifier1.derive_child();
-        verifier.tx_index_cache =
-            TxIndexCache::new_for_test(BTreeMap::from([(outpoint2, CachedInputsOperation::Erase)]));
+        verifier.tx_index_cache = GuardedTxIndexCache::new_for_test(BTreeMap::from([(
+            outpoint2,
+            CachedInputsOperation::Erase,
+        )]));
         verifier
     };
 
@@ -624,14 +628,14 @@ fn tx_index_conflict_hierarchy(#[case] seed: Seed) {
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
-    verifier1.tx_index_cache = TxIndexCache::new_for_test(BTreeMap::from([(
+    verifier1.tx_index_cache = GuardedTxIndexCache::new_for_test(BTreeMap::from([(
         outpoint1.clone(),
         CachedInputsOperation::Write(tx_index_1),
     )]));
 
     let verifier2 = {
         let mut verifier = verifier1.derive_child();
-        verifier.tx_index_cache = TxIndexCache::new_for_test(BTreeMap::from([(
+        verifier.tx_index_cache = GuardedTxIndexCache::new_for_test(BTreeMap::from([(
             outpoint1,
             CachedInputsOperation::Write(tx_index_2),
         )]));

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -203,6 +203,12 @@ impl ChainConfig {
     }
 }
 
+impl AsRef<ChainConfig> for ChainConfig {
+    fn as_ref(&self) -> &ChainConfig {
+        self
+    }
+}
+
 // DSA allows us to have blocks up to 1mb
 const MAX_BLOCK_HEADER_SIZE: usize = 1024;
 const MAX_BLOCK_TXS_SIZE: usize = 524_288;


### PR DESCRIPTION
Similar changes as in #620 but applied to the remaining fields in `TransactionVerifier`. Also small refactoring to make it work.