### PR TITLE
Remove remains of references to mDNS

### DIFF
--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -35,10 +35,8 @@ use serde::{Deserialize, Serialize};
 use crate::RunOptions;
 
 use self::{
-    chainstate::ChainstateConfigFile,
-    chainstate_launcher::ChainstateLauncherConfigFile,
-    p2p::{MdnsConfigFile, P2pConfigFile},
-    rpc::RpcConfigFile,
+    chainstate::ChainstateConfigFile, chainstate_launcher::ChainstateLauncherConfigFile,
+    p2p::P2pConfigFile, rpc::RpcConfigFile,
 };
 
 /// The node configuration.
@@ -141,7 +139,6 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
         ban_threshold,
         ban_duration,
         outbound_connection_timeout,
-        mdns_config: _,
         node_type,
     } = config;
 
@@ -152,19 +149,12 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
         options.p2p_outbound_connection_timeout.or(outbound_connection_timeout);
     let node_type = options.node_type.or(node_type);
 
-    let mdns_config = MdnsConfigFile::from_options(
-        options.p2p_enable_mdns,
-        options.p2p_mdns_query_interval,
-        options.p2p_enable_ipv6_mdns_discovery,
-    );
-
     P2pConfigFile {
         bind_addresses,
         added_nodes,
         ban_threshold,
         ban_duration,
         outbound_connection_timeout,
-        mdns_config,
         node_type,
     }
 }

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -91,18 +91,6 @@ pub struct RunOptions {
     #[clap(long)]
     pub p2p_ban_threshold: Option<u32>,
 
-    /// Use IPv6 instead of IPv4 for mDNS.
-    #[clap(long)]
-    pub p2p_enable_ipv6_mdns_discovery: Option<bool>,
-
-    /// Enable multicast DNS peer discovery
-    #[clap(long)]
-    pub p2p_enable_mdns: Option<bool>,
-
-    /// Interval (in milliseconds) at which to poll the network for new peers.
-    #[clap(long)]
-    pub p2p_mdns_query_interval: Option<u64>,
-
     /// The p2p timeout value in seconds.
     #[clap(long)]
     pub p2p_outbound_connection_timeout: Option<u64>,

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -92,7 +92,6 @@ fn read_config_override_values() {
     let p2p_timeout = 10000;
     let http_rpc_addr = SocketAddr::from_str("127.0.0.1:5432").unwrap();
     let ws_rpc_addr = SocketAddr::from_str("127.0.0.1:5433").unwrap();
-    let enable_mdns = false;
     let backend_type = StorageBackendConfigFile::InMemory;
     let node_type = NodeTypeConfigFile::FullNode;
     let max_tip_age = 1000;
@@ -105,9 +104,6 @@ fn read_config_override_values() {
         p2p_add_node: Some(vec![p2p_add_node.to_owned()]),
         p2p_ban_threshold: Some(p2p_ban_threshold),
         p2p_outbound_connection_timeout: Some(p2p_timeout),
-        p2p_enable_mdns: Some(enable_mdns),
-        p2p_mdns_query_interval: None,
-        p2p_enable_ipv6_mdns_discovery: None,
         http_rpc_addr: Some(http_rpc_addr),
         http_rpc_enabled: Some(true),
         ws_rpc_addr: Some(ws_rpc_addr),
@@ -207,9 +203,6 @@ fn default_run_options() -> RunOptions {
         p2p_add_node: None,
         p2p_ban_threshold: None,
         p2p_outbound_connection_timeout: None,
-        p2p_enable_mdns: None,
-        p2p_mdns_query_interval: None,
-        p2p_enable_ipv6_mdns_discovery: None,
         http_rpc_addr: None,
         http_rpc_enabled: None,
         ws_rpc_addr: None,

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -144,7 +144,6 @@ where
         ban_threshold: Default::default(),
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
-        mdns_config: Default::default(),
         node_type: NodeType::Inactive.into(),
     });
     let (mut conn1, mut sync1) = S::start(

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -21,40 +21,15 @@ use crate::net::types::PubSubTopic;
 
 pub const DEFAULT_BIND_PORT: u16 = 3031;
 
-// TODO: does this constant make sense to be zero? Find the justification for it.
-pub const MDNS_DEFAULT_QUERY_INTERVAL: u64 = 0;
-pub const MDNS_DEFAULT_IPV6_STATE: bool = false;
-
 make_config_setting!(BanThreshold, u32, 100);
 make_config_setting!(BanDuration, Duration, Duration::from_secs(60 * 60 * 24));
 make_config_setting!(OutboundConnectionTimeout, u64, 10);
-make_config_setting!(MdnsConfigSetting, MdnsConfig, MdnsConfig::Disabled);
-make_config_setting!(MdnsQueryInterval, u64, MDNS_DEFAULT_QUERY_INTERVAL);
-make_config_setting!(MdnsEnableIpV6Discovery, bool, MDNS_DEFAULT_IPV6_STATE);
 make_config_setting!(
     AnnouncementSubscriptions,
     BTreeSet<PubSubTopic>,
     [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect()
 );
 make_config_setting!(NodeTypeSetting, NodeType, NodeType::Full);
-
-/// Multicast DNS configuration.
-#[derive(Debug, Clone)]
-pub enum MdnsConfig {
-    Enabled {
-        /// Interval (in milliseconds) at which to poll the network for new peers.
-        query_interval: MdnsQueryInterval,
-        /// Use IPv6 for multicast DNS
-        enable_ipv6_mdns_discovery: MdnsEnableIpV6Discovery,
-    },
-    Disabled,
-}
-
-impl Default for MdnsConfig {
-    fn default() -> Self {
-        MdnsConfig::Disabled
-    }
-}
 
 /// A node type.
 #[derive(Debug, Copy, Clone)]
@@ -94,8 +69,6 @@ pub struct P2pConfig {
     pub ban_duration: BanDuration,
     /// The outbound connection timeout value in seconds.
     pub outbound_connection_timeout: OutboundConnectionTimeout,
-    /// Multicast DNS configuration.
-    pub mdns_config: MdnsConfigSetting,
     /// A node type.
     pub node_type: NodeTypeSetting,
 }

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -105,7 +105,7 @@ pub enum ConnectivityEvent<T: NetworkingService> {
         peer_id: T::PeerId,
     },
 
-    /// One or more peers discovered (libp2p defines discovering as finding new addresses through mDNS or otherwise)
+    /// One or more peers discovered
     Discovered {
         /// Address information
         addresses: Vec<T::Address>,

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -100,7 +100,6 @@ where
         ban_threshold: 200.into(),
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
-        mdns_config: Default::default(),
         node_type: Default::default(),
     };
     let mut peerdb = PeerDb::<S>::new(Arc::new(config)).unwrap();
@@ -139,7 +138,6 @@ where
         ban_threshold: 20.into(),
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
-        mdns_config: Default::default(),
         node_type: Default::default(),
     };
     let mut peerdb = PeerDb::<S>::new(Arc::new(config)).unwrap();
@@ -177,7 +175,6 @@ where
         ban_threshold: Default::default(),
         ban_duration: Duration::from_secs(2).into(),
         outbound_connection_timeout: Default::default(),
-        mdns_config: Default::default(),
         node_type: Default::default(),
     }))
     .unwrap();

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -639,7 +639,6 @@ where
         ban_threshold: Default::default(),
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
-        mdns_config: Default::default(),
         node_type: Default::default(),
     });
     let tx1 = run_peer_manager::<T>(

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -25,7 +25,7 @@ use tokio::sync::mpsc;
 use chainstate::{make_chainstate, ChainstateConfig, DefaultTransactionVerificationStrategy};
 
 use crate::{
-    config::{MdnsConfig, NodeType, P2pConfig},
+    config::{NodeType, P2pConfig},
     event::{PeerManagerEvent, SyncControlEvent},
     net::{mock::types::MockPeerId, ConnectivityService},
     sync::{peer, BlockSyncManager},
@@ -75,7 +75,6 @@ where
         ban_threshold: 100.into(),
         ban_duration: Default::default(),
         outbound_connection_timeout: 10.into(),
-        mdns_config: MdnsConfig::Disabled.into(),
         node_type: NodeType::Full.into(),
     });
     let (conn, sync) = T::start(

--- a/test/functional/test_framework/.mintlayer/config.toml
+++ b/test/functional/test_framework/.mintlayer/config.toml
@@ -9,8 +9,5 @@ bind_address = ["[::1]:3031"]
 ban_threshold = 100
 outbound_connection_timeout = 10
 
-[p2p.mdns_config]
-state = "Disabled"
-
 [rpc]
 bind_address = "127.0.0.1:3030"


### PR DESCRIPTION
mDNS was only used with libp2p. And we are not going to use mDNS in the mock backend.