### PR TITLE
Basic peer discovery

### DIFF
--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -21,7 +21,7 @@ use p2p::{
     config::P2pConfig,
     error::{P2pError, PublishError},
     event::PeerManagerEvent,
-    message::{Announcement, HeaderListResponse, Request, Response},
+    message::{Announcement, HeaderListResponse, Response, SyncRequest},
     net::{types::SyncingEvent, ConnectivityService, NetworkingService, SyncingMessagingService},
     sync::BlockSyncManager,
     testing_utils::{connect_services, TestTransportMaker},
@@ -90,7 +90,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(_),
+                request: SyncRequest::HeaderListRequest(_),
             } => request_id,
             e => panic!("Unexpected event type: {e:?}"),
         };

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -20,7 +20,7 @@ use tokio::sync::mpsc;
 use p2p::{
     config::P2pConfig,
     event::PeerManagerEvent,
-    message::{Announcement, HeaderListResponse, Response, SyncRequest},
+    message::{Announcement, HeaderListResponse, SyncRequest, SyncResponse},
     net::{types::SyncingEvent, ConnectivityService, NetworkingService, SyncingMessagingService},
     sync::BlockSyncManager,
     testing_utils::{connect_services, TestTransportMaker},
@@ -96,7 +96,7 @@ where
         sync2
             .send_response(
                 request_id,
-                Response::HeaderListResponse(HeaderListResponse::new(Vec::new())),
+                SyncResponse::HeaderListResponse(HeaderListResponse::new(Vec::new())),
             )
             .await
             .unwrap();

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -19,7 +19,6 @@ use tokio::sync::mpsc;
 
 use p2p::{
     config::P2pConfig,
-    error::{P2pError, PublishError},
     event::PeerManagerEvent,
     message::{Announcement, HeaderListResponse, Response, SyncRequest},
     net::{types::SyncingEvent, ConnectivityService, NetworkingService, SyncingMessagingService},
@@ -102,18 +101,8 @@ where
             .await
             .unwrap();
 
-        loop {
-            let res = sync2.make_announcement(Announcement::Block(blocks[2].clone())).await;
-
-            if res.is_ok() {
-                break;
-            } else {
-                assert_eq!(
-                    res,
-                    Err(P2pError::PublishError(PublishError::InsufficientPeers))
-                );
-            }
-        }
+        let res = sync2.make_announcement(Announcement::Block(blocks[2].clone())).await;
+        assert!(res.is_ok());
     });
 
     match rx_peer_manager.recv().await {

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -101,8 +101,7 @@ where
             .await
             .unwrap();
 
-        let res = sync2.make_announcement(Announcement::Block(blocks[2].clone())).await;
-        assert!(res.is_ok());
+        sync2.make_announcement(Announcement::Block(blocks[2].clone())).await.unwrap();
     });
 
     match rx_peer_manager.recv().await {

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -74,8 +74,7 @@ where
 
     connect_services::<S>(&mut conn1, &mut conn2).await;
 
-    // Spam the message until until we have a peer.
-    let res = sync1
+    sync1
         .make_announcement(Announcement::Block(
             Block::new(
                 vec![],
@@ -86,8 +85,8 @@ where
             )
             .unwrap(),
         ))
-        .await;
-    assert!(res.is_ok());
+        .await
+        .unwrap();
 
     // Poll an event from the network for server2.
     let block = match sync2.poll_next().await.unwrap() {
@@ -157,7 +156,7 @@ where
 
     connect_services::<S>(&mut conn1, &mut conn2).await;
 
-    let res = sync1
+    sync1
         .make_announcement(Announcement::Block(
             Block::new(
                 vec![],
@@ -168,8 +167,8 @@ where
             )
             .unwrap(),
         ))
-        .await;
-    assert!(res.is_ok());
+        .await
+        .unwrap();
 }
 
 async fn block_announcement_too_big_message<T, S, A>()

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -1160,7 +1160,7 @@ where
     T: NetworkingService,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
-    T::SyncingPeerRequestId: 'static,
+    T::PeerRequestId: 'static,
     T::PeerId: 'static,
 {
     let (tx_p2p_sync, rx_p2p_sync) = mpsc::unbounded_channel();
@@ -1256,7 +1256,7 @@ async fn process_header_request<T>(
 where
     T: NetworkingService,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
-    T::SyncingPeerRequestId: 'static,
+    T::PeerRequestId: 'static,
     T::PeerId: 'static,
 {
     match mgr.handle_mut().poll_next().await.unwrap() {
@@ -1285,7 +1285,7 @@ async fn advance_mgr_state<T>(mgr: &mut BlockSyncManager<T>) -> Result<(), P2pEr
 where
     T: NetworkingService,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
-    T::SyncingPeerRequestId: 'static,
+    T::PeerRequestId: 'static,
     T::PeerId: 'static,
 {
     match mgr.handle_mut().poll_next().await.unwrap() {

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -1067,7 +1067,7 @@ where
     assert_eq!(conn1.disconnect(peer_info2.peer_id).await, Ok(()));
 
     let event = filter_connectivity_event::<S, _>(&mut conn2, |event| {
-        !std::matches!(event, Ok(ConnectivityEvent::Discovered { .. }))
+        !std::matches!(event, Ok(ConnectivityEvent::AddressDiscovered { .. }))
     })
     .await;
     assert!(std::matches!(

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -32,7 +32,10 @@ use p2p::{
     config::P2pConfig,
     error::P2pError,
     event::{PeerManagerEvent, SyncControlEvent},
-    message::{BlockListRequest, BlockListResponse, HeaderListResponse, Request, Response},
+    message::{
+        BlockListRequest, BlockListResponse, HeaderListResponse, Request, Response, SyncRequest,
+        SyncResponse,
+    },
     net::{
         types::{ConnectivityEvent, SyncingEvent},
         ConnectivityService, NetworkingService, SyncingMessagingService,
@@ -151,7 +154,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(request),
+                request: SyncRequest::HeaderListRequest(request),
             } => {
                 let headers = mgr2_handle
                     .call(move |this| this.get_headers(request.into_locator()))
@@ -169,7 +172,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::BlockListRequest(request),
+                request: SyncRequest::BlockListRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
@@ -190,7 +193,7 @@ where
             SyncingEvent::Response {
                 peer_id: _,
                 request_id: _,
-                response: Response::HeaderListResponse(_response),
+                response: SyncResponse::HeaderListResponse(_response),
             } => {}
             msg => panic!("invalid message received: {:?}", msg),
         }
@@ -248,7 +251,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(request),
+                request: SyncRequest::HeaderListRequest(request),
             } => {
                 let headers = mgr2_handle
                     .call(move |this| this.get_headers(request.into_locator()))
@@ -266,7 +269,7 @@ where
             SyncingEvent::Response {
                 peer_id,
                 request_id: _,
-                response: Response::BlockListResponse(response),
+                response: SyncResponse::BlockListResponse(response),
             } => {
                 assert_eq!(response.blocks().len(), 1);
                 let block = response.blocks()[0].clone();
@@ -292,7 +295,7 @@ where
             SyncingEvent::Response {
                 peer_id,
                 request_id: _,
-                response: Response::HeaderListResponse(response),
+                response: SyncResponse::HeaderListResponse(response),
             } => {
                 assert_eq!(response.headers().len(), 12);
                 let headers = mgr2_handle
@@ -373,7 +376,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(request),
+                request: SyncRequest::HeaderListRequest(request),
             } => {
                 let headers = mgr2_handle
                     .call(move |this| this.get_headers(request.into_locator()))
@@ -391,7 +394,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::BlockListRequest(request),
+                request: SyncRequest::BlockListRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
@@ -412,7 +415,7 @@ where
             SyncingEvent::Response {
                 peer_id,
                 request_id: _,
-                response: Response::BlockListResponse(response),
+                response: SyncResponse::BlockListResponse(response),
             } => {
                 assert_eq!(response.blocks().len(), 1);
                 let block = response.blocks()[0].clone();
@@ -435,7 +438,7 @@ where
             SyncingEvent::Response {
                 peer_id,
                 request_id: _,
-                response: Response::HeaderListResponse(response),
+                response: SyncResponse::HeaderListResponse(response),
             } => {
                 let headers = mgr2_handle
                     .call(move |this| this.filter_already_existing_blocks(response.into_headers()))
@@ -517,7 +520,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(request),
+                request: SyncRequest::HeaderListRequest(request),
             } => {
                 let headers = mgr2_handle
                     .call(move |this| this.get_headers(request.into_locator()))
@@ -535,7 +538,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::BlockListRequest(request),
+                request: SyncRequest::BlockListRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
@@ -556,7 +559,7 @@ where
             SyncingEvent::Response {
                 peer_id,
                 request_id: _,
-                response: Response::BlockListResponse(response),
+                response: SyncResponse::BlockListResponse(response),
             } => {
                 assert_eq!(response.blocks().len(), 1);
                 let block = response.blocks()[0].clone();
@@ -579,7 +582,7 @@ where
             SyncingEvent::Response {
                 peer_id,
                 request_id: _,
-                response: Response::HeaderListResponse(response),
+                response: SyncResponse::HeaderListResponse(response),
             } => {
                 let headers = mgr2_handle
                     .call(move |this| this.filter_already_existing_blocks(response.into_headers()))
@@ -678,7 +681,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(request),
+                request: SyncRequest::HeaderListRequest(request),
             } => {
                 let headers = mgr_handle
                     .call(move |this| this.get_headers(request.into_locator()))
@@ -696,7 +699,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::BlockListRequest(request),
+                request: SyncRequest::BlockListRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
@@ -716,7 +719,7 @@ where
             SyncingEvent::Response {
                 peer_id: _,
                 request_id: _,
-                response: Response::HeaderListResponse(_response),
+                response: SyncResponse::HeaderListResponse(_response),
             } => {}
             msg => panic!("invalid message received: {:?}", msg),
         }
@@ -817,7 +820,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(request),
+                request: SyncRequest::HeaderListRequest(request),
             } => {
                 let headers = mgr_handle
                     .call(move |this| this.get_headers(request.into_locator()))
@@ -835,7 +838,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::BlockListRequest(request),
+                request: SyncRequest::BlockListRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
@@ -855,7 +858,7 @@ where
             SyncingEvent::Response {
                 peer_id: _,
                 request_id: _,
-                response: Response::HeaderListResponse(_response),
+                response: SyncResponse::HeaderListResponse(_response),
             } => {}
             msg => panic!("invalid message received: {:?}", msg),
         }
@@ -954,7 +957,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(request),
+                request: SyncRequest::HeaderListRequest(request),
             } => {
                 let headers = mgr_handle
                     .call(move |this| this.get_headers(request.into_locator()))
@@ -982,7 +985,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::BlockListRequest(request),
+                request: SyncRequest::BlockListRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
@@ -1002,7 +1005,7 @@ where
             SyncingEvent::Response {
                 peer_id: _,
                 request_id: _,
-                response: Response::HeaderListResponse(_response),
+                response: SyncResponse::HeaderListResponse(_response),
             } => {}
             msg => panic!("invalid message received: {:?}", msg),
         }
@@ -1094,7 +1097,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::HeaderListRequest(request),
+                request: SyncRequest::HeaderListRequest(request),
             } => {
                 let headers = mgr2_handle
                     .call(move |this| this.get_headers(request.into_locator()))
@@ -1112,7 +1115,7 @@ where
             SyncingEvent::Request {
                 peer_id: _,
                 request_id,
-                request: Request::BlockListRequest(request),
+                request: SyncRequest::BlockListRequest(request),
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
@@ -1133,7 +1136,7 @@ where
             SyncingEvent::Response {
                 peer_id: _,
                 request_id: _,
-                response: Response::HeaderListResponse(_response),
+                response: SyncResponse::HeaderListResponse(_response),
             } => {}
             msg => panic!("invalid message received: {:?}", msg),
         }
@@ -1263,7 +1266,7 @@ where
         SyncingEvent::Request {
             peer_id: _,
             request_id,
-            request: Request::HeaderListRequest(request),
+            request: SyncRequest::HeaderListRequest(request),
         } => {
             let headers = handle
                 .call(move |this| this.get_headers(request.into_locator()))
@@ -1294,10 +1297,10 @@ where
             request_id,
             request,
         } => match request {
-            Request::HeaderListRequest(request) => {
+            SyncRequest::HeaderListRequest(request) => {
                 mgr.process_header_request(peer_id, request_id, request.into_locator()).await?;
             }
-            Request::BlockListRequest(request) => {
+            SyncRequest::BlockListRequest(request) => {
                 mgr.process_block_request(peer_id, request_id, request.into_block_ids()).await?;
             }
         },
@@ -1306,10 +1309,10 @@ where
             request_id: _,
             response,
         } => match response {
-            Response::HeaderListResponse(response) => {
+            SyncResponse::HeaderListResponse(response) => {
                 mgr.process_header_response(peer_id, response.into_headers()).await?;
             }
-            Response::BlockListResponse(response) => {
+            SyncResponse::BlockListResponse(response) => {
                 mgr.process_block_response(peer_id, response.into_blocks()).await?;
             }
         },

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -32,10 +32,7 @@ use p2p::{
     config::P2pConfig,
     error::P2pError,
     event::{PeerManagerEvent, SyncControlEvent},
-    message::{
-        BlockListRequest, BlockListResponse, HeaderListResponse, Request, Response, SyncRequest,
-        SyncResponse,
-    },
+    message::{BlockListRequest, BlockListResponse, HeaderListResponse, SyncRequest, SyncResponse},
     net::{
         types::{ConnectivityEvent, SyncingEvent},
         ConnectivityService, NetworkingService, SyncingMessagingService,
@@ -164,7 +161,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::HeaderListResponse(HeaderListResponse::new(headers)),
+                        SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
                     .await
                     .unwrap()
@@ -185,7 +182,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::BlockListResponse(BlockListResponse::new(blocks)),
+                        SyncResponse::BlockListResponse(BlockListResponse::new(blocks)),
                     )
                     .await
                     .unwrap();
@@ -261,7 +258,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::HeaderListResponse(HeaderListResponse::new(headers)),
+                        SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
                     .await
                     .unwrap()
@@ -283,7 +280,7 @@ where
                     mgr2.handle_mut()
                         .send_request(
                             peer_id,
-                            Request::BlockListRequest(BlockListRequest::new(vec![header])),
+                            SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                         )
                         .await
                         .unwrap();
@@ -308,7 +305,7 @@ where
                 mgr2.handle_mut()
                     .send_request(
                         peer_id,
-                        Request::BlockListRequest(BlockListRequest::new(vec![header])),
+                        SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                     )
                     .await
                     .unwrap();
@@ -386,7 +383,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::HeaderListResponse(HeaderListResponse::new(headers)),
+                        SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
                     .await
                     .unwrap()
@@ -407,7 +404,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::BlockListResponse(BlockListResponse::new(blocks)),
+                        SyncResponse::BlockListResponse(BlockListResponse::new(blocks)),
                     )
                     .await
                     .unwrap();
@@ -429,7 +426,7 @@ where
                     mgr2.handle_mut()
                         .send_request(
                             peer_id,
-                            Request::BlockListRequest(BlockListRequest::new(vec![header])),
+                            SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                         )
                         .await
                         .unwrap();
@@ -450,7 +447,7 @@ where
                 mgr2.handle_mut()
                     .send_request(
                         peer_id,
-                        Request::BlockListRequest(BlockListRequest::new(vec![header])),
+                        SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                     )
                     .await
                     .unwrap();
@@ -530,7 +527,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::HeaderListResponse(HeaderListResponse::new(headers)),
+                        SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
                     .await
                     .unwrap()
@@ -551,7 +548,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::BlockListResponse(BlockListResponse::new(blocks)),
+                        SyncResponse::BlockListResponse(BlockListResponse::new(blocks)),
                     )
                     .await
                     .unwrap();
@@ -573,7 +570,7 @@ where
                     mgr2.handle_mut()
                         .send_request(
                             peer_id,
-                            Request::BlockListRequest(BlockListRequest::new(vec![header])),
+                            SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                         )
                         .await
                         .unwrap();
@@ -594,7 +591,7 @@ where
                 mgr2.handle_mut()
                     .send_request(
                         peer_id,
-                        Request::BlockListRequest(BlockListRequest::new(vec![header])),
+                        SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                     )
                     .await
                     .unwrap();
@@ -688,7 +685,7 @@ where
                     .await
                     .unwrap()
                     .unwrap();
-                let msg = Response::HeaderListResponse(HeaderListResponse::new(headers));
+                let msg = SyncResponse::HeaderListResponse(HeaderListResponse::new(headers));
 
                 if dest_peer_id == peer_info21.peer_id {
                     mgr2.handle_mut().send_response(request_id, msg).await.unwrap()
@@ -703,7 +700,7 @@ where
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
-                let msg = Response::BlockListResponse(BlockListResponse::new(vec![mgr_handle
+                let msg = SyncResponse::BlockListResponse(BlockListResponse::new(vec![mgr_handle
                     .call(move |this| this.get_block(id))
                     .await
                     .unwrap()
@@ -827,7 +824,7 @@ where
                     .await
                     .unwrap()
                     .unwrap();
-                let msg = Response::HeaderListResponse(HeaderListResponse::new(headers));
+                let msg = SyncResponse::HeaderListResponse(HeaderListResponse::new(headers));
 
                 if dest_peer_id == peer_info21.peer_id {
                     mgr2.handle_mut().send_response(request_id, msg).await.unwrap()
@@ -842,7 +839,7 @@ where
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
-                let msg = Response::BlockListResponse(BlockListResponse::new(vec![mgr_handle
+                let msg = SyncResponse::BlockListResponse(BlockListResponse::new(vec![mgr_handle
                     .call(move |this| this.get_block(id))
                     .await
                     .unwrap()
@@ -964,7 +961,7 @@ where
                     .await
                     .unwrap()
                     .unwrap();
-                let msg = Response::HeaderListResponse(HeaderListResponse::new(headers));
+                let msg = SyncResponse::HeaderListResponse(HeaderListResponse::new(headers));
 
                 if dest_peer_id == peer_info21.peer_id {
                     mgr2.handle_mut().send_response(request_id, msg).await.unwrap()
@@ -989,7 +986,7 @@ where
             } => {
                 assert_eq!(request.block_ids().len(), 1);
                 let id = request.block_ids()[0];
-                let msg = Response::BlockListResponse(BlockListResponse::new(vec![mgr_handle
+                let msg = SyncResponse::BlockListResponse(BlockListResponse::new(vec![mgr_handle
                     .call(move |this| this.get_block(id))
                     .await
                     .unwrap()
@@ -1107,7 +1104,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::HeaderListResponse(HeaderListResponse::new(headers)),
+                        SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
                     .await
                     .unwrap()
@@ -1128,7 +1125,7 @@ where
                 mgr2.handle_mut()
                     .send_response(
                         request_id,
-                        Response::BlockListResponse(BlockListResponse::new(blocks)),
+                        SyncResponse::BlockListResponse(BlockListResponse::new(blocks)),
                     )
                     .await
                     .unwrap();
@@ -1276,7 +1273,7 @@ where
             mgr.handle_mut()
                 .send_response(
                     request_id,
-                    Response::HeaderListResponse(HeaderListResponse::new(headers)),
+                    SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                 )
                 .await
         }

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -57,8 +57,6 @@ pub enum PeerError {
 pub enum PublishError {
     #[error("Failed to sign message")]
     SigningFailed,
-    #[error("No peers in topic")]
-    InsufficientPeers,
     #[error("Message is too large. Tried to send {0:?} bytes when limit is {1:?}")]
     MessageTooLarge(usize, usize),
     #[error("Failed to compress the message")]
@@ -209,7 +207,6 @@ impl BanScore for PublishError {
     fn ban_score(&self) -> u32 {
         match self {
             PublishError::SigningFailed => 0,
-            PublishError::InsufficientPeers => 0,
             PublishError::MessageTooLarge(_, _) => 100,
             PublishError::TransformFailed => 0,
         }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -79,6 +79,11 @@ pub enum SyncRequest {
     BlockListRequest(BlockListRequest),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum PeerManagerRequest {
+    AddrListRequest(AddrListRequest),
+}
+
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct HeaderListResponse {
     headers: Vec<BlockHeader>,
@@ -136,6 +141,11 @@ pub enum Response {
 pub enum SyncResponse {
     HeaderListResponse(HeaderListResponse),
     BlockListResponse(BlockListResponse),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum PeerManagerResponse {
+    AddrListResponse(AddrListResponse),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -73,13 +73,13 @@ pub enum Request {
     AddrListRequest(AddrListRequest),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SyncRequest {
     HeaderListRequest(HeaderListRequest),
     BlockListRequest(BlockListRequest),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerManagerRequest {
     AddrListRequest(AddrListRequest),
 }
@@ -147,13 +147,13 @@ pub enum Response {
     AddrListResponse(AddrListResponse),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SyncResponse {
     HeaderListResponse(HeaderListResponse),
     BlockListResponse(BlockListResponse),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerManagerResponse {
     AddrListResponse(AddrListResponse),
 }
@@ -162,4 +162,38 @@ pub enum PeerManagerResponse {
 pub enum Announcement {
     #[codec(index = 0)]
     Block(Block),
+}
+
+impl From<PeerManagerRequest> for Request {
+    fn from(request: PeerManagerRequest) -> Self {
+        match request {
+            PeerManagerRequest::AddrListRequest(request) => Request::AddrListRequest(request),
+        }
+    }
+}
+
+impl From<PeerManagerResponse> for Response {
+    fn from(response: PeerManagerResponse) -> Self {
+        match response {
+            PeerManagerResponse::AddrListResponse(response) => Response::AddrListResponse(response),
+        }
+    }
+}
+
+impl From<SyncRequest> for Request {
+    fn from(request: SyncRequest) -> Self {
+        match request {
+            SyncRequest::HeaderListRequest(request) => Request::HeaderListRequest(request),
+            SyncRequest::BlockListRequest(request) => Request::BlockListRequest(request),
+        }
+    }
+}
+
+impl From<SyncResponse> for Response {
+    fn from(response: SyncResponse) -> Self {
+        match response {
+            SyncResponse::HeaderListResponse(response) => Response::HeaderListResponse(response),
+            SyncResponse::BlockListResponse(response) => Response::BlockListResponse(response),
+        }
+    }
 }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -127,6 +127,16 @@ pub struct AddrListResponse {
     addresses: Vec<PeerAddress>,
 }
 
+impl AddrListResponse {
+    pub fn new(addresses: Vec<PeerAddress>) -> Self {
+        Self { addresses }
+    }
+
+    pub fn addresses(&self) -> &Vec<PeerAddress> {
+        &self.addresses
+    }
+}
+
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum Response {
     #[codec(index = 0)]

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -51,7 +51,7 @@ impl BlockListRequest {
         Self { block_ids }
     }
 
-    pub fn block_ids(&self) -> &Vec<Id<Block>> {
+    pub fn block_ids(&self) -> &[Id<Block>] {
         &self.block_ids
     }
 
@@ -94,7 +94,7 @@ impl HeaderListResponse {
         Self { headers }
     }
 
-    pub fn headers(&self) -> &Vec<BlockHeader> {
+    pub fn headers(&self) -> &[BlockHeader] {
         &self.headers
     }
 
@@ -113,7 +113,7 @@ impl BlockListResponse {
         Self { blocks }
     }
 
-    pub fn blocks(&self) -> &Vec<Block> {
+    pub fn blocks(&self) -> &[Block] {
         &self.blocks
     }
 
@@ -132,7 +132,7 @@ impl AddrListResponse {
         Self { addresses }
     }
 
-    pub fn addresses(&self) -> &Vec<PeerAddress> {
+    pub fn addresses(&self) -> &[PeerAddress] {
         &self.addresses
     }
 }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -20,6 +20,8 @@ use common::{
 };
 use serialization::{Decode, Encode};
 
+use crate::types::peer_address::PeerAddress;
+
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct HeaderListRequest {
     locator: Locator,
@@ -59,10 +61,21 @@ impl BlockListRequest {
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct AddrListRequest {}
+
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum Request {
     #[codec(index = 0)]
     HeaderListRequest(HeaderListRequest),
     #[codec(index = 1)]
+    BlockListRequest(BlockListRequest),
+    #[codec(index = 2)]
+    AddrListRequest(AddrListRequest),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SyncRequest {
+    HeaderListRequest(HeaderListRequest),
     BlockListRequest(BlockListRequest),
 }
 
@@ -105,10 +118,23 @@ impl BlockListResponse {
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct AddrListResponse {
+    addresses: Vec<PeerAddress>,
+}
+
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum Response {
     #[codec(index = 0)]
     HeaderListResponse(HeaderListResponse),
     #[codec(index = 1)]
+    BlockListResponse(BlockListResponse),
+    #[codec(index = 2)]
+    AddrListResponse(AddrListResponse),
+}
+
+#[derive(Debug)]
+pub enum SyncResponse {
+    HeaderListResponse(HeaderListResponse),
     BlockListResponse(BlockListResponse),
 }
 

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -15,11 +15,7 @@
 
 //! Mock networking backend
 //!
-//! The backend is modeled after libp2p.
-//!
-//! The peers are required to have unique IDs which they self-assign to themselves
-//! and advertise via the `Hello` message. Until the peer ID has been received, the
-//! peers are distinguished by their socket addresses.
+//! Every connected peer gets unique ID (generated locally from a counter).
 
 use std::{
     collections::{BTreeSet, HashMap},
@@ -509,7 +505,7 @@ where
                     self.pending.remove(&outbound_peer_id).expect("peer must exist");
 
                 log::info!(
-                    "self-connection detect on address {:?}",
+                    "self-connection detected on address {:?}",
                     outbound_pending.address
                 );
 

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -49,10 +49,9 @@ use crate::{
                 MockRequestId, PeerEvent, SyncingEvent,
             },
         },
-        types::{PubSubTopic, Role},
+        types::PubSubTopic,
         Announcement,
     },
-    types::peer_address::PeerAddress,
 };
 
 use super::{peer::PeerRole, transport::TransportAddress, types::HandshakeNonce};
@@ -401,19 +400,6 @@ where
         }
     }
 
-    /// Handle received listening port from inbound remote peer
-    fn handle_own_receiver_address(
-        &mut self,
-        receiver_address: PeerAddress,
-        role: Role,
-    ) -> crate::Result<()> {
-        log::debug!("new own receiver address {receiver_address} found from {role:?} connection");
-
-        // TODO: Handle receiver address
-
-        Ok(())
-    }
-
     /// Create new peer
     ///
     /// Move the connection to `pending` where it stays until either the connection is closed
@@ -547,6 +533,7 @@ where
                                     agent: None,
                                     subscriptions: subscriptions.clone(),
                                 },
+                                receiver_address,
                             })
                             .await
                             .map_err(P2pError::from)?;
@@ -562,14 +549,11 @@ where
                                     agent: None,
                                     subscriptions: subscriptions.clone(),
                                 },
+                                receiver_address,
                             })
                             .await
                             .map_err(P2pError::from)?;
                     }
-                }
-
-                if let Some(receiver_address) = receiver_address {
-                    self.handle_own_receiver_address(receiver_address, peer_role.into())?;
                 }
 
                 self.peers.insert(peer_id, PeerContext { subscriptions, tx });

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -238,7 +238,7 @@ where
 
     /// Sends the announcement to all peers.
     ///
-    /// It not an error if there are no peers that subscribed to the related topic.
+    /// It is not an error if there are no peers that subscribed to the related topic.
     async fn announce_data(&mut self, topic: PubSubTopic, message: Vec<u8>) -> crate::Result<()> {
         let announcement = message::Announcement::decode(&mut &message[..])?;
 
@@ -684,8 +684,8 @@ where
             } => async move {
                 boxed_cb(move |this| {
                     async move {
-                        let res = this.send_request(peer_id, message).await;
-                        response.send(res).map_err(|_| P2pError::ChannelClosed)
+                        let _res = this.send_request(request_id, peer_id, message).await;
+                        Ok(())
                     }
                     .boxed()
                 })
@@ -694,26 +694,21 @@ where
             Command::SendResponse {
                 request_id,
                 message,
-                response,
             } => async move {
                 boxed_cb(move |this| {
                     async move {
-                        let res = this.send_response(request_id, message).await;
-                        response.send(res).map_err(|_| P2pError::ChannelClosed)
+                        let _res = this.send_response(request_id, message).await;
+                        Ok(())
                     }
                     .boxed()
                 })
             }
             .boxed(),
-            Command::AnnounceData {
-                topic,
-                message,
-                response,
-            } => async move {
+            Command::AnnounceData { topic, message } => async move {
                 boxed_cb(move |this| {
                     async move {
-                        let res = this.announce_data(topic, message).await;
-                        response.send(res).map_err(|_| P2pError::ChannelClosed)
+                        let _res = this.announce_data(topic, message).await;
+                        Ok(())
                     }
                     .boxed()
                 })

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -646,7 +646,10 @@ where
             } => async move {
                 boxed_cb(move |this| {
                     async move {
-                        let _res = this.send_request(request_id, peer_id, message).await;
+                        let res = this.send_request(request_id, peer_id, message).await;
+                        if let Err(e) = res {
+                            log::debug!("Failed to send request to peer {peer_id}: {e}")
+                        }
                         Ok(())
                     }
                     .boxed()
@@ -659,7 +662,10 @@ where
             } => async move {
                 boxed_cb(move |this| {
                     async move {
-                        let _res = this.send_response(request_id, message).await;
+                        let res = this.send_response(request_id, message).await;
+                        if let Err(e) = res {
+                            log::debug!("Failed to send response to peer: {e}")
+                        }
                         Ok(())
                     }
                     .boxed()
@@ -669,7 +675,10 @@ where
             Command::AnnounceData { topic, message } => async move {
                 boxed_cb(move |this| {
                     async move {
-                        let _res = this.announce_data(topic, message).await;
+                        let res = this.announce_data(topic, message).await;
+                        if let Err(e) = res {
+                            log::error!("Failed to send announce data: {e}")
+                        }
                         Ok(())
                     }
                     .boxed()

--- a/p2p/src/net/mock/backend.rs
+++ b/p2p/src/net/mock/backend.rs
@@ -238,8 +238,7 @@ where
 
     /// Sends the announcement to all peers.
     ///
-    /// Returns the `InsufficientPeers` error if there are no peers that subscribed to the related
-    /// topic.
+    /// It not an error if there are no peers that subscribed to the related topic.
     async fn announce_data(&mut self, topic: PubSubTopic, message: Vec<u8>) -> crate::Result<()> {
         let announcement = message::Announcement::decode(&mut &message[..])?;
 
@@ -260,14 +259,9 @@ where
             .collect();
         futures.shuffle(&mut make_pseudo_rng());
 
-        // TODO: We don't really need to return an error here. It is only needed temporarily in
-        // order to mimic the libp2p behavior.
-        if futures.is_empty() {
-            Err(P2pError::PublishError(PublishError::InsufficientPeers))
-        } else {
-            join_all(futures).await;
-            Ok(())
-        }
+        join_all(futures).await;
+
+        Ok(())
     }
 
     /// Handle incoming request

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -227,7 +227,7 @@ where
                 Ok(ConnectivityEvent::Misbehaved { peer_id, error })
             }
             types::ConnectivityEvent::AddressDiscovered { address } => {
-                Ok(ConnectivityEvent::Discovered {
+                Ok(ConnectivityEvent::AddressDiscovered {
                     addresses: vec![address],
                 })
             }

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -264,15 +264,13 @@ where
         request_id: S::SyncingPeerRequestId,
         response: message::Response,
     ) -> crate::Result<()> {
-        let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(types::Command::SendResponse {
                 request_id,
                 message: response,
-                response: tx,
             })
             .await?;
-        rx.await?
+        Ok(())
     }
 
     async fn make_announcement(

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -31,7 +31,7 @@ use serialization::Encode;
 use crate::{
     config,
     error::{P2pError, PublishError},
-    message,
+    message::{self, PeerManagerRequest, PeerManagerResponse, SyncRequest, SyncResponse},
     net::{
         mock::{
             constants::ANNOUNCEMENT_MAX_SIZE,
@@ -206,7 +206,7 @@ where
     async fn send_request(
         &mut self,
         peer_id: S::PeerId,
-        request: message::Request,
+        request: PeerManagerRequest,
     ) -> crate::Result<S::SyncingPeerRequestId> {
         let request_id = MockRequestId::new();
 
@@ -214,7 +214,7 @@ where
             .send(types::Command::SendRequest {
                 peer_id,
                 request_id,
-                message: request,
+                message: request.into(),
             })
             .await?;
 
@@ -224,12 +224,12 @@ where
     async fn send_response(
         &mut self,
         request_id: S::SyncingPeerRequestId,
-        response: message::Response,
+        response: PeerManagerResponse,
     ) -> crate::Result<()> {
         self.cmd_tx
             .send(types::Command::SendResponse {
                 request_id,
-                message: response,
+                message: response.into(),
             })
             .await?;
         Ok(())
@@ -296,7 +296,7 @@ where
     async fn send_request(
         &mut self,
         peer_id: S::PeerId,
-        request: message::Request,
+        request: SyncRequest,
     ) -> crate::Result<S::SyncingPeerRequestId> {
         let request_id = MockRequestId::new();
 
@@ -304,7 +304,7 @@ where
             .send(types::Command::SendRequest {
                 peer_id,
                 request_id,
-                message: request,
+                message: request.into(),
             })
             .await?;
 
@@ -314,12 +314,12 @@ where
     async fn send_response(
         &mut self,
         request_id: S::SyncingPeerRequestId,
-        response: message::Response,
+        response: SyncResponse,
     ) -> crate::Result<()> {
         self.cmd_tx
             .send(types::Command::SendResponse {
                 request_id,
-                message: response,
+                message: response.into(),
             })
             .await?;
         Ok(())

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -246,16 +246,17 @@ where
         peer_id: S::PeerId,
         request: message::Request,
     ) -> crate::Result<S::SyncingPeerRequestId> {
-        let (tx, rx) = oneshot::channel();
+        let request_id = MockRequestId::new();
 
         self.cmd_tx
             .send(types::Command::SendRequest {
                 peer_id,
+                request_id,
                 message: request,
-                response: tx,
             })
             .await?;
-        rx.await?
+
+        Ok(request_id)
     }
 
     async fn send_response(

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -111,7 +111,7 @@ impl<T: TransportSocket> NetworkingService for MockService<T> {
     type Address = T::Address;
     type BannableAddress = T::BannableAddress;
     type PeerId = MockPeerId;
-    type SyncingPeerRequestId = MockRequestId;
+    type PeerRequestId = MockRequestId;
     type ConnectivityHandle = MockConnectivityHandle<Self, T>;
     type SyncingMessagingHandle = MockSyncingMessagingHandle<Self, T>;
 
@@ -164,11 +164,8 @@ impl<T: TransportSocket> NetworkingService for MockService<T> {
 #[async_trait]
 impl<S, T> ConnectivityService<S> for MockConnectivityHandle<S, T>
 where
-    S: NetworkingService<
-            Address = T::Address,
-            PeerId = MockPeerId,
-            SyncingPeerRequestId = MockRequestId,
-        > + Send,
+    S: NetworkingService<Address = T::Address, PeerId = MockPeerId, PeerRequestId = MockRequestId>
+        + Send,
     MockPeerInfo: TryInto<PeerInfo<S>, Error = P2pError>,
     T: TransportSocket,
 {
@@ -207,7 +204,7 @@ where
         &mut self,
         peer_id: S::PeerId,
         request: PeerManagerRequest,
-    ) -> crate::Result<S::SyncingPeerRequestId> {
+    ) -> crate::Result<S::PeerRequestId> {
         let request_id = MockRequestId::new();
 
         self.cmd_tx
@@ -223,7 +220,7 @@ where
 
     async fn send_response(
         &mut self,
-        request_id: S::SyncingPeerRequestId,
+        request_id: S::PeerRequestId,
         response: PeerManagerResponse,
     ) -> crate::Result<()> {
         self.cmd_tx
@@ -296,14 +293,14 @@ where
 #[async_trait]
 impl<S, T> SyncingMessagingService<S> for MockSyncingMessagingHandle<S, T>
 where
-    S: NetworkingService<PeerId = MockPeerId, SyncingPeerRequestId = MockRequestId> + Send,
+    S: NetworkingService<PeerId = MockPeerId, PeerRequestId = MockRequestId> + Send,
     T: TransportSocket,
 {
     async fn send_request(
         &mut self,
         peer_id: S::PeerId,
         request: SyncRequest,
-    ) -> crate::Result<S::SyncingPeerRequestId> {
+    ) -> crate::Result<S::PeerRequestId> {
         let request_id = MockRequestId::new();
 
         self.cmd_tx
@@ -319,7 +316,7 @@ where
 
     async fn send_response(
         &mut self,
-        request_id: S::SyncingPeerRequestId,
+        request_id: S::PeerRequestId,
         response: SyncResponse,
     ) -> crate::Result<()> {
         self.cmd_tx

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -291,15 +291,9 @@ where
             message::Announcement::Block(_) => PubSubTopic::Blocks,
         };
 
-        let (response, receiver) = oneshot::channel();
-        self.cmd_tx
-            .send(types::Command::AnnounceData {
-                topic,
-                message,
-                response,
-            })
-            .await?;
-        receiver.await?
+        self.cmd_tx.send(types::Command::AnnounceData { topic, message }).await?;
+
+        Ok(())
     }
 
     async fn poll_next(&mut self) -> crate::Result<SyncingEvent<S>> {

--- a/p2p/src/net/mock/peer.rs
+++ b/p2p/src/net/mock/peer.rs
@@ -493,7 +493,7 @@ mod tests {
         assert!(socket2.recv().now_or_never().is_none());
         socket2
             .send(types::Message::Request {
-                request_id: types::MockRequestId::new(1337u64),
+                request_id: types::MockRequestId::new(),
                 request: message::Request::HeaderListRequest(message::HeaderListRequest::new(
                     Locator::new(vec![]),
                 )),

--- a/p2p/src/net/mock/request_manager.rs
+++ b/p2p/src/net/mock/request_manager.rs
@@ -119,7 +119,6 @@ impl RequestManager {
         &mut self,
         peer_id: &types::MockPeerId,
         request_id: &types::MockRequestId,
-        _request: &message::Request,
     ) -> crate::Result<types::MockRequestId> {
         let peer_ephemerals = self
             .ephemerals

--- a/p2p/src/net/mock/request_manager.rs
+++ b/p2p/src/net/mock/request_manager.rs
@@ -105,6 +105,7 @@ impl RequestManager {
     ///
     /// The request ID is stored into a temporary storage holding all pending
     /// inbound requests.
+    // TODO: Use different type in result so it's not possible to mixup ephemeral and real request ids.
     pub fn register_request(
         &mut self,
         peer_id: &types::MockPeerId,

--- a/p2p/src/net/mock/request_manager.rs
+++ b/p2p/src/net/mock/request_manager.rs
@@ -36,12 +36,6 @@ pub struct RequestManager {
     /// Active ephemeral IDs
     ephemerals: HashMap<types::MockPeerId, HashSet<types::MockRequestId>>,
 
-    /// The next ID for an outbound request.
-    next_request_id: types::MockRequestId,
-
-    /// Next ephemeral request ID
-    next_ephemeral_id: types::MockRequestId,
-
     /// Ephemeral requests IDs which are mapped to remote peer ID/request ID pair
     ephemeral: HashMap<types::MockRequestId, (types::MockPeerId, types::MockRequestId)>,
 }
@@ -78,7 +72,7 @@ impl RequestManager {
         &mut self,
         request: message::Request,
     ) -> crate::Result<(types::MockRequestId, Box<types::Message>)> {
-        let request_id = self.next_request_id.fetch_and_inc();
+        let request_id = types::MockRequestId::new();
 
         Ok((
             request_id,
@@ -125,7 +119,7 @@ impl RequestManager {
             .get_mut(peer_id)
             .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
 
-        let ephemeral_id = self.next_ephemeral_id.fetch_and_inc();
+        let ephemeral_id = types::MockRequestId::new();
 
         peer_ephemerals.insert(ephemeral_id);
         self.ephemeral.insert(ephemeral_id, (*peer_id, *request_id));

--- a/p2p/src/net/mock/request_manager.rs
+++ b/p2p/src/net/mock/request_manager.rs
@@ -70,17 +70,13 @@ impl RequestManager {
     /// Create new outgoing request
     pub fn make_request(
         &mut self,
+        request_id: types::MockRequestId,
         request: message::Request,
-    ) -> crate::Result<(types::MockRequestId, Box<types::Message>)> {
-        let request_id = types::MockRequestId::new();
-
-        Ok((
+    ) -> crate::Result<Box<types::Message>> {
+        Ok(Box::new(types::Message::Request {
             request_id,
-            Box::new(types::Message::Request {
-                request_id,
-                request,
-            }),
-        ))
+            request,
+        }))
     }
 
     /// Create new outgoing response

--- a/p2p/src/net/mock/transport/impls/channel.rs
+++ b/p2p/src/net/mock/transport/impls/channel.rs
@@ -198,9 +198,9 @@ impl AsBannableAddress for Address {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::net::{
-        message::{BlockListRequest, Request},
-        mock::{
+    use crate::{
+        message::{BlockListRequest, SyncRequest},
+        net::mock::{
             transport::BufferedTranscoder,
             types::{Message, MockRequestId},
         },
@@ -218,12 +218,12 @@ mod tests {
         let peer_stream = peer_res.unwrap();
 
         let request_id = MockRequestId::new();
-        let request = Request::BlockListRequest(BlockListRequest::new(vec![]));
+        let request = SyncRequest::BlockListRequest(BlockListRequest::new(vec![]));
         let mut peer_stream = BufferedTranscoder::new(peer_stream);
         peer_stream
             .send(Message::Request {
                 request_id,
-                request: request.clone(),
+                request: request.clone().into(),
             })
             .await
             .unwrap();
@@ -233,7 +233,7 @@ mod tests {
             server_stream.recv().await.unwrap(),
             Message::Request {
                 request_id,
-                request,
+                request: request.into(),
             }
         );
     }

--- a/p2p/src/net/mock/transport/impls/channel.rs
+++ b/p2p/src/net/mock/transport/impls/channel.rs
@@ -217,7 +217,7 @@ mod tests {
         let server_stream = server_res.unwrap().0;
         let peer_stream = peer_res.unwrap();
 
-        let request_id = MockRequestId::new(1337u64);
+        let request_id = MockRequestId::new();
         let request = Request::BlockListRequest(BlockListRequest::new(vec![]));
         let mut peer_stream = BufferedTranscoder::new(peer_stream);
         peer_stream

--- a/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/tests.rs
+++ b/p2p/src/net/mock/transport/impls/stream_adapter/wrapped_transport/tests.rs
@@ -208,7 +208,7 @@ async fn send_2_reqs() {
     let server_stream = server_res.unwrap().0;
     let peer_stream = peer_res.unwrap();
 
-    let id_1 = MockRequestId::new(1337u64);
+    let id_1 = MockRequestId::new();
     let request = Request::BlockListRequest(BlockListRequest::new(vec![]));
     let mut peer_stream = BufferedTranscoder::new(peer_stream);
     peer_stream
@@ -219,7 +219,7 @@ async fn send_2_reqs() {
         .await
         .unwrap();
 
-    let id_2 = MockRequestId::new(1338u64);
+    let id_2 = MockRequestId::new();
     peer_stream
         .send(Message::Request {
             request_id: id_2,

--- a/p2p/src/net/mock/transport/impls/tcp.rs
+++ b/p2p/src/net/mock/transport/impls/tcp.rs
@@ -158,15 +158,15 @@ impl PeerStream for TcpTransportStream {}
 
 #[cfg(test)]
 mod tests {
-    use crate::testing_utils::{TestTransportMaker, TestTransportTcp};
+    use crate::{
+        message::{BlockListRequest, SyncRequest},
+        testing_utils::{TestTransportMaker, TestTransportTcp},
+    };
 
     use super::*;
-    use crate::net::{
-        message::{BlockListRequest, Request},
-        mock::{
-            transport::BufferedTranscoder,
-            types::{Message, MockRequestId},
-        },
+    use crate::net::mock::{
+        transport::BufferedTranscoder,
+        types::{Message, MockRequestId},
     };
 
     #[tokio::test]
@@ -180,12 +180,12 @@ mod tests {
         let peer_stream = peer_res.unwrap();
 
         let request_id = MockRequestId::new();
-        let request = Request::BlockListRequest(BlockListRequest::new(vec![]));
+        let request = SyncRequest::BlockListRequest(BlockListRequest::new(vec![]));
         let mut peer_stream = BufferedTranscoder::new(peer_stream);
         peer_stream
             .send(Message::Request {
                 request_id,
-                request: request.clone(),
+                request: request.clone().into(),
             })
             .await
             .unwrap();
@@ -195,7 +195,7 @@ mod tests {
             server_stream.recv().await.unwrap(),
             Message::Request {
                 request_id,
-                request,
+                request: request.into(),
             }
         );
     }
@@ -211,12 +211,12 @@ mod tests {
         let peer_stream = peer_res.unwrap();
 
         let id_1 = MockRequestId::new();
-        let request = Request::BlockListRequest(BlockListRequest::new(vec![]));
+        let request = SyncRequest::BlockListRequest(BlockListRequest::new(vec![]));
         let mut peer_stream = BufferedTranscoder::new(peer_stream);
         peer_stream
             .send(Message::Request {
                 request_id: id_1,
-                request: request.clone(),
+                request: request.clone().into(),
             })
             .await
             .unwrap();
@@ -225,7 +225,7 @@ mod tests {
         peer_stream
             .send(Message::Request {
                 request_id: id_2,
-                request: request.clone(),
+                request: request.clone().into(),
             })
             .await
             .unwrap();
@@ -235,14 +235,14 @@ mod tests {
             server_stream.recv().await.unwrap(),
             Message::Request {
                 request_id: id_1,
-                request: request.clone(),
+                request: request.clone().into(),
             }
         );
         assert_eq!(
             server_stream.recv().await.unwrap(),
             Message::Request {
                 request_id: id_2,
-                request,
+                request: request.into(),
             }
         );
     }

--- a/p2p/src/net/mock/transport/impls/tcp.rs
+++ b/p2p/src/net/mock/transport/impls/tcp.rs
@@ -179,7 +179,7 @@ mod tests {
         let server_stream = server_res.unwrap().0;
         let peer_stream = peer_res.unwrap();
 
-        let request_id = MockRequestId::new(1337u64);
+        let request_id = MockRequestId::new();
         let request = Request::BlockListRequest(BlockListRequest::new(vec![]));
         let mut peer_stream = BufferedTranscoder::new(peer_stream);
         peer_stream
@@ -210,7 +210,7 @@ mod tests {
         let server_stream = server_res.unwrap().0;
         let peer_stream = peer_res.unwrap();
 
-        let id_1 = MockRequestId::new(1337u64);
+        let id_1 = MockRequestId::new();
         let request = Request::BlockListRequest(BlockListRequest::new(vec![]));
         let mut peer_stream = BufferedTranscoder::new(peer_stream);
         peer_stream
@@ -221,7 +221,7 @@ mod tests {
             .await
             .unwrap();
 
-        let id_2 = MockRequestId::new(1338u64);
+        let id_2 = MockRequestId::new();
         peer_stream
             .send(Message::Request {
                 request_id: id_2,

--- a/p2p/src/net/mock/transport/traits/socket.rs
+++ b/p2p/src/net/mock/transport/traits/socket.rs
@@ -52,6 +52,6 @@ pub trait TransportSocket: Send + Sync + 'static {
     /// Creates a new listener bound to the specified address.
     async fn bind(&self, address: Vec<Self::Address>) -> Result<Self::Listener>;
 
-    /// Open a connection to the given address.
+    /// Returns a future that opens a connection to the given address.
     fn connect(&self, address: Self::Address) -> BoxFuture<'static, crate::Result<Self::Stream>>;
 }

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -112,18 +112,14 @@ pub enum PubSubEvent<T: TransportSocket> {
     },
 }
 
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Encode, Decode, Default)]
 pub struct MockRequestId(u64);
 
 impl MockRequestId {
-    pub fn new(request_id: u64) -> Self {
-        Self(request_id)
-    }
-
-    pub fn fetch_and_inc(&mut self) -> Self {
-        let id = self.0;
-        self.0 += 1;
-
+    pub fn new() -> Self {
+        let id = NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
         Self(id)
     }
 }

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -49,7 +49,6 @@ pub enum Command<T: TransportSocket> {
     SendResponse {
         request_id: MockRequestId,
         message: message::Response,
-        response: oneshot::Sender<crate::Result<()>>,
     },
     AnnounceData {
         topic: PubSubTopic,

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -88,10 +88,12 @@ pub enum ConnectivityEvent<T: TransportSocket> {
     InboundAccepted {
         address: T::Address,
         peer_info: MockPeerInfo,
+        receiver_address: Option<PeerAddress>,
     },
     OutboundAccepted {
         address: T::Address,
         peer_info: MockPeerInfo,
+        receiver_address: Option<PeerAddress>,
     },
     ConnectionError {
         address: T::Address,

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -62,12 +62,12 @@ pub enum SyncingEvent {
     Request {
         peer_id: MockPeerId,
         request_id: MockRequestId,
-        request: message::Request,
+        request: message::SyncRequest,
     },
     Response {
         peer_id: MockPeerId,
         request_id: MockRequestId,
-        response: message::Response,
+        response: message::SyncResponse,
     },
     Announcement {
         peer_id: MockPeerId,

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -42,8 +42,8 @@ pub enum Command<T: TransportSocket> {
     },
     SendRequest {
         peer_id: MockPeerId,
+        request_id: MockRequestId,
         message: message::Request,
-        response: oneshot::Sender<crate::Result<MockRequestId>>,
     },
     /// Send response to remote peer
     SendResponse {

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -75,6 +75,16 @@ pub enum SyncingEvent {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ConnectivityEvent<T: TransportSocket> {
+    Request {
+        peer_id: MockPeerId,
+        request_id: MockRequestId,
+        request: message::PeerManagerRequest,
+    },
+    Response {
+        peer_id: MockPeerId,
+        request_id: MockRequestId,
+        response: message::PeerManagerResponse,
+    },
     InboundAccepted {
         address: T::Address,
         peer_info: MockPeerInfo,

--- a/p2p/src/net/mock/types.rs
+++ b/p2p/src/net/mock/types.rs
@@ -54,7 +54,6 @@ pub enum Command<T: TransportSocket> {
     AnnounceData {
         topic: PubSubTopic,
         message: Vec<u8>,
-        response: oneshot::Sender<crate::Result<()>>,
     },
 }
 

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -71,7 +71,7 @@ pub trait NetworkingService {
     type PeerId: Copy + Debug + Display + Eq + Hash + Send + Sync + ToString + FromStr;
 
     /// Unique ID assigned to each received request from a peer
-    type SyncingPeerRequestId: Copy + Debug + Eq + Hash + Send + Sync;
+    type PeerRequestId: Copy + Debug + Eq + Hash + Send + Sync;
 
     /// Handle for sending/receiving connectivity-related events
     type ConnectivityHandle: Send;
@@ -124,7 +124,7 @@ where
         &mut self,
         peer_id: T::PeerId,
         request: PeerManagerRequest,
-    ) -> crate::Result<T::SyncingPeerRequestId>;
+    ) -> crate::Result<T::PeerRequestId>;
 
     /// Send response to remote
     ///
@@ -133,7 +133,7 @@ where
     /// * `response` - Response to be sent
     async fn send_response(
         &mut self,
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
         response: PeerManagerResponse,
     ) -> crate::Result<()>;
 
@@ -167,7 +167,7 @@ where
         &mut self,
         peer_id: T::PeerId,
         request: SyncRequest,
-    ) -> crate::Result<T::SyncingPeerRequestId>;
+    ) -> crate::Result<T::PeerRequestId>;
 
     /// Send block/header response to remote
     ///
@@ -176,7 +176,7 @@ where
     /// * `response` - Response to be sent
     async fn send_response(
         &mut self,
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
         response: SyncResponse,
     ) -> crate::Result<()>;
 

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -25,7 +25,11 @@ use std::{
 
 use async_trait::async_trait;
 
-use crate::{config, message, message::Announcement};
+use crate::{
+    config,
+    message::{Announcement, PeerManagerRequest},
+    message::{PeerManagerResponse, SyncRequest, SyncResponse},
+};
 
 use self::mock::transport::TransportAddress;
 
@@ -119,7 +123,7 @@ where
     async fn send_request(
         &mut self,
         peer_id: T::PeerId,
-        request: message::Request,
+        request: PeerManagerRequest,
     ) -> crate::Result<T::SyncingPeerRequestId>;
 
     /// Send response to remote
@@ -130,7 +134,7 @@ where
     async fn send_response(
         &mut self,
         request_id: T::SyncingPeerRequestId,
-        response: message::Response,
+        response: PeerManagerResponse,
     ) -> crate::Result<()>;
 
     /// Return the socket address of the network service provider
@@ -162,7 +166,7 @@ where
     async fn send_request(
         &mut self,
         peer_id: T::PeerId,
-        request: message::Request,
+        request: SyncRequest,
     ) -> crate::Result<T::SyncingPeerRequestId>;
 
     /// Send block/header response to remote
@@ -173,7 +177,7 @@ where
     async fn send_response(
         &mut self,
         request_id: T::SyncingPeerRequestId,
-        response: message::Response,
+        response: SyncResponse,
     ) -> crate::Result<()>;
 
     /// Publishes an announcement on the network.

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -108,6 +108,28 @@ where
     /// `peer_id` - Peer ID of the remote node
     async fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()>;
 
+    /// Send PeerManager's request to remote
+    ///
+    /// # Arguments
+    /// * `peer_id` - Unique ID of the peer the request is sent to
+    /// * `request` - Request to be sent
+    async fn send_request(
+        &mut self,
+        peer_id: T::PeerId,
+        request: message::Request,
+    ) -> crate::Result<T::SyncingPeerRequestId>;
+
+    /// Send response to remote
+    ///
+    /// # Arguments
+    /// * `request_id` - ID of the request this is a response to
+    /// * `message` - Response to be sent
+    async fn send_response(
+        &mut self,
+        request_id: T::SyncingPeerRequestId,
+        response: message::Response,
+    ) -> crate::Result<()>;
+
     /// Return the socket address of the network service provider
     ///
     /// If the address isn't available yet, `None` is returned

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -27,6 +27,8 @@ use async_trait::async_trait;
 
 use crate::{config, message, message::Announcement};
 
+use self::mock::transport::TransportAddress;
+
 /// [NetworkingService] provides the low-level network interface
 /// that each network service provider must implement
 #[async_trait]
@@ -52,6 +54,7 @@ pub trait NetworkingService {
         + Sync
         + ToString
         + FromStr
+        + TransportAddress
         + AsBannableAddress<BannableAddress = Self::BannableAddress>;
 
     /// An address type that can be banned.
@@ -123,7 +126,7 @@ where
     ///
     /// # Arguments
     /// * `request_id` - ID of the request this is a response to
-    /// * `message` - Response to be sent
+    /// * `response` - Response to be sent
     async fn send_response(
         &mut self,
         request_id: T::SyncingPeerRequestId,
@@ -166,7 +169,7 @@ where
     ///
     /// # Arguments
     /// * `request_id` - ID of the request this is a response to
-    /// * `message` - Response to be sent
+    /// * `response` - Response to be sent
     async fn send_response(
         &mut self,
         request_id: T::SyncingPeerRequestId,

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -111,7 +111,7 @@ pub enum ConnectivityEvent<T: NetworkingService> {
         addresses: Vec<T::Address>,
     },
 
-    /// One one more peers have expired (libp2p defines expired addresses as addresses that haven't appeared in later refreshes of available addresses)
+    /// One one more peers have expired
     Expired {
         /// Address information
         addresses: Vec<T::Address>,

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -106,7 +106,7 @@ pub enum ConnectivityEvent<T: NetworkingService> {
     },
 
     /// One or more peers discovered
-    Discovered {
+    AddressDiscovered {
         /// Address information
         addresses: Vec<T::Address>,
     },

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -139,7 +139,7 @@ pub enum SyncingEvent<T: NetworkingService> {
         request_id: T::SyncingPeerRequestId,
 
         /// Received request
-        request: message::Request,
+        request: message::SyncRequest,
     },
     /// An incoming response.
     Response {
@@ -150,7 +150,7 @@ pub enum SyncingEvent<T: NetworkingService> {
         request_id: T::SyncingPeerRequestId,
 
         /// Received response
-        response: message::Response,
+        response: message::SyncResponse,
     },
     /// An announcement that is broadcast to all peers.
     Announcement {

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -111,12 +111,6 @@ pub enum ConnectivityEvent<T: NetworkingService> {
         addresses: Vec<T::Address>,
     },
 
-    /// One one more peers have expired
-    Expired {
-        /// Address information
-        addresses: Vec<T::Address>,
-    },
-
     /// Protocol violation
     Misbehaved {
         /// Unique ID of the peer

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -18,7 +18,7 @@ use std::{collections::BTreeSet, fmt::Display};
 use common::primitives::semver::SemVer;
 use serialization::{Decode, Encode};
 
-use crate::{message, NetworkingService, P2pError};
+use crate::{message, types::peer_address::PeerAddress, NetworkingService, P2pError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Role {
@@ -101,6 +101,9 @@ pub enum ConnectivityEvent<T: NetworkingService> {
 
         /// Peer information
         peer_info: PeerInfo<T>,
+
+        /// Socket address of this node as seen by remote peer
+        receiver_address: Option<PeerAddress>,
     },
 
     /// Inbound connection received
@@ -110,6 +113,9 @@ pub enum ConnectivityEvent<T: NetworkingService> {
 
         /// Peer information
         peer_info: PeerInfo<T>,
+
+        /// Socket address of this node as seen by remote peer
+        receiver_address: Option<PeerAddress>,
     },
 
     /// Outbound connection failed

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -72,6 +72,28 @@ impl<T: NetworkingService> Display for PeerInfo<T> {
 /// Connectivity-related events received from the network
 #[derive(Debug)]
 pub enum ConnectivityEvent<T: NetworkingService> {
+    /// An incoming request.
+    Request {
+        /// Unique ID of the sender
+        peer_id: T::PeerId,
+
+        /// Unique ID of the request
+        request_id: T::SyncingPeerRequestId,
+
+        /// Received request
+        request: message::PeerManagerRequest,
+    },
+    /// An incoming response.
+    Response {
+        /// Unique ID of the sender
+        peer_id: T::PeerId,
+
+        /// Unique ID of the request this message is a response to
+        request_id: T::SyncingPeerRequestId,
+
+        /// Received response
+        response: message::PeerManagerResponse,
+    },
     /// Outbound connection accepted
     OutboundAccepted {
         /// Peer address
@@ -105,10 +127,10 @@ pub enum ConnectivityEvent<T: NetworkingService> {
         peer_id: T::PeerId,
     },
 
-    /// One or more peers discovered
+    /// New peer discovered
     AddressDiscovered {
         /// Address information
-        addresses: Vec<T::Address>,
+        address: T::Address,
     },
 
     /// Protocol violation

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -78,7 +78,7 @@ pub enum ConnectivityEvent<T: NetworkingService> {
         peer_id: T::PeerId,
 
         /// Unique ID of the request
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
 
         /// Received request
         request: message::PeerManagerRequest,
@@ -89,7 +89,7 @@ pub enum ConnectivityEvent<T: NetworkingService> {
         peer_id: T::PeerId,
 
         /// Unique ID of the request this message is a response to
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
 
         /// Received response
         response: message::PeerManagerResponse,
@@ -158,7 +158,7 @@ pub enum SyncingEvent<T: NetworkingService> {
         peer_id: T::PeerId,
 
         /// Unique ID of the request
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
 
         /// Received request
         request: message::SyncRequest,
@@ -169,7 +169,7 @@ pub enum SyncingEvent<T: NetworkingService> {
         peer_id: T::PeerId,
 
         /// Unique ID of the request this message is a response to
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
 
         /// Received response
         response: message::SyncResponse,

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -40,9 +40,7 @@ use crate::{
     config::P2pConfig,
     error::{P2pError, PeerError, ProtocolError},
     event::{PeerManagerEvent, SyncControlEvent},
-    message::{
-        AddrListRequest, AddrListResponse, PeerManagerRequest, PeerManagerResponse, Response,
-    },
+    message::{AddrListRequest, AddrListResponse, PeerManagerRequest, PeerManagerResponse},
     net::{
         self, mock::transport::TransportAddress, types::Role, AsBannableAddress,
         ConnectivityService, NetworkingService,
@@ -333,7 +331,7 @@ where
                 self.peer_connectivity_handle
                     .send_response(
                         request_id,
-                        Response::AddrListResponse(AddrListResponse::new(addresses)),
+                        PeerManagerResponse::AddrListResponse(AddrListResponse::new(addresses)),
                     )
                     .await
             }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -322,7 +322,7 @@ where
     /// not disturb the operation of `PeerManager`.
     ///
     /// If an error has ban score greater than zero, the peer score is updated and connection
-    /// to that peer is possibly closed if their scored crossed the ban threshold.
+    /// to that peer is possibly closed if their score crossed the ban threshold.
     ///
     /// # Arguments
     /// `peer_id` - peer ID of the remote peer, if available

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -110,13 +110,6 @@ where
         })
     }
 
-    /// Update the list of known peers or known peer's list of addresses
-    fn peer_expired(&mut self, addresses: &[T::Address]) {
-        addresses.iter().for_each(|peer| {
-            self.peerdb.peer_expired(peer);
-        })
-    }
-
     /// Verify software version compatibility
     ///
     /// Make sure that local and remote peer have the same software version
@@ -456,9 +449,6 @@ where
                         }
                         net::types::ConnectivityEvent::Discovered { addresses } => {
                             self.peer_discovered(&addresses);
-                        }
-                        net::types::ConnectivityEvent::Expired { addresses } => {
-                            self.peer_expired(&addresses);
                         }
                         net::types::ConnectivityEvent::Misbehaved { peer_id, error } => {
                             let res = self.adjust_peer_score(peer_id, error.ban_score()).await;

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -325,7 +325,7 @@ where
     async fn handle_incoming_request(
         &mut self,
         _peer_id: T::PeerId,
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
         request: PeerManagerRequest,
     ) -> crate::Result<()> {
         match request {
@@ -346,7 +346,7 @@ where
     fn handle_incoming_response(
         &mut self,
         _peer_id: T::PeerId,
-        _request_id: T::SyncingPeerRequestId,
+        _request_id: T::PeerRequestId,
         response: PeerManagerResponse,
     ) -> crate::Result<()> {
         match response {

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -447,7 +447,7 @@ where
                             let res = self.handle_outbound_error(address, error);
                             self.handle_result(None, res).await?;
                         }
-                        net::types::ConnectivityEvent::Discovered { addresses } => {
+                        net::types::ConnectivityEvent::AddressDiscovered { addresses } => {
                             self.peer_discovered(&addresses);
                         }
                         net::types::ConnectivityEvent::Misbehaved { peer_id, error } => {

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -170,11 +170,6 @@ impl<T: NetworkingService> PeerDb<T> {
         self.available.insert(address.clone());
     }
 
-    /// Expire discovered peer addresses
-    pub fn peer_expired(&mut self, address: &T::Address) {
-        self.available.remove(address);
-    }
-
     /// Report outbound connection failure
     ///
     /// When [`crate::peer_manager::PeerManager::heartbeat()`] has initiated an outbound connection

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -38,9 +38,11 @@ use crate::{
     error::{ConversionError, P2pError},
     interface::types::ConnectedPeer,
     net::{
+        mock::transport::TransportAddress,
         types::{self, Role},
         AsBannableAddress, NetworkingService,
     },
+    types::peer_address::PeerAddress,
 };
 
 #[derive(Debug)]
@@ -130,6 +132,10 @@ impl<T: NetworkingService> PeerDb<T> {
     /// Checks if the given address is already connected.
     pub fn is_address_connected(&self, address: &T::Address) -> bool {
         self.addresses.contains(address)
+    }
+
+    pub fn known_addresses(&self) -> Vec<PeerAddress> {
+        self.addresses.iter().map(TransportAddress::as_peer_address).collect()
     }
 
     /// Checks if the given address is banned.

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -68,7 +68,10 @@ where
         .as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
     let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(event, Ok(net::types::ConnectivityEvent::Discovered { .. }))
+        !std::matches!(
+            event,
+            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
+        )
     })
     .await;
     assert!(std::matches!(
@@ -119,7 +122,10 @@ where
         .as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
     let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(event, Ok(net::types::ConnectivityEvent::Discovered { .. }))
+        !std::matches!(
+            event,
+            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
+        )
     })
     .await;
     assert!(std::matches!(
@@ -172,7 +178,10 @@ where
         .as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
     let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(event, Ok(net::types::ConnectivityEvent::Discovered { .. }))
+        !std::matches!(
+            event,
+            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
+        )
     })
     .await;
     assert!(matches!(
@@ -425,7 +434,10 @@ where
     tokio::spawn(async move { pm1.run().await });
 
     let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(event, Ok(net::types::ConnectivityEvent::Discovered { .. }))
+        !std::matches!(
+            event,
+            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
+        )
     })
     .await;
     if let Ok(net::types::ConnectivityEvent::ConnectionClosed { peer_id }) = event {

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -60,7 +60,7 @@ where
     )
     .await;
     let peer_id = peer_info.peer_id;
-    pm2.accept_inbound_connection(address, peer_info).unwrap();
+    pm2.accept_inbound_connection(address, peer_info, None).unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addresses().await.unwrap()[0]
@@ -114,7 +114,7 @@ where
     )
     .await;
     let peer_id = peer_info.peer_id;
-    pm2.accept_inbound_connection(address, peer_info).unwrap();
+    pm2.accept_inbound_connection(address, peer_info, None).unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addresses().await.unwrap()[0]
@@ -170,7 +170,7 @@ where
     )
     .await;
     let peer_id = peer_info1.peer_id;
-    pm2.accept_inbound_connection(address, peer_info1).unwrap();
+    pm2.accept_inbound_connection(address, peer_info1, None).unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addresses().await.unwrap()[0]
@@ -246,6 +246,7 @@ where
             agent: None,
             subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
         },
+        None,
     );
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!peer_manager.peerdb.is_active_peer(&peer_id));
@@ -261,6 +262,7 @@ where
             agent: None,
             subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
         },
+        None,
     );
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!peer_manager.peerdb.is_active_peer(&peer_id));
@@ -277,6 +279,7 @@ where
             agent: None,
             subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
         },
+        None,
     );
     assert!(res.is_ok());
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
@@ -335,6 +338,7 @@ where
             agent: None,
             subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
         },
+        None,
     );
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!peer_manager.peerdb.is_active_peer(&peer_id));
@@ -349,6 +353,7 @@ where
             agent: None,
             subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
         },
+        None,
     );
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!peer_manager.peerdb.is_active_peer(&peer_id));
@@ -364,6 +369,7 @@ where
             agent: None,
             subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
         },
+        None,
     );
     assert!(res.is_ok());
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -105,7 +105,7 @@ where
     });
 
     // "discover" the other networking service
-    pm1.peer_discovered(&[addr]);
+    pm1.peer_discovered(&addr);
     pm1.heartbeat().await.unwrap();
 
     assert_eq!(pm1.pending.len(), 1);

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -227,7 +227,10 @@ where
         &mut pm2.peer_connectivity_handle,
     )
     .await;
-    assert_eq!(pm2.accept_inbound_connection(address, peer_info), Ok(()));
+    assert_eq!(
+        pm2.accept_inbound_connection(address, peer_info, None),
+        Ok(())
+    );
 }
 
 #[tokio::test]
@@ -274,7 +277,7 @@ where
     .await;
 
     assert_eq!(
-        pm2.accept_inbound_connection(address, peer_info),
+        pm2.accept_inbound_connection(address, peer_info, None),
         Err(P2pError::ProtocolError(ProtocolError::DifferentNetwork(
             [1, 2, 3, 4],
             *config::create_mainnet().magic_bytes(),

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -383,7 +383,10 @@ where
     tokio::spawn(async move { pm1.run().await });
 
     let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(event, Ok(net::types::ConnectivityEvent::Discovered { .. }))
+        !std::matches!(
+            event,
+            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
+        )
     })
     .await;
     if let Ok(net::types::ConnectivityEvent::ConnectionClosed { peer_id }) = event {

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -86,7 +86,7 @@ impl<T> BlockSyncManager<T>
 where
     T: NetworkingService,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
-    T::SyncingPeerRequestId: 'static,
+    T::PeerRequestId: 'static,
     T::PeerId: 'static,
 {
     pub fn new(
@@ -147,7 +147,7 @@ where
     pub async fn process_header_request(
         &mut self,
         peer_id: T::PeerId,
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
         locator: Locator,
     ) -> crate::Result<()> {
         log::debug!("send header response to peer {peer_id}, request_id: {request_id:?}");
@@ -161,7 +161,7 @@ where
     pub async fn process_block_request(
         &mut self,
         peer_id: T::PeerId,
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
         headers: Vec<Id<Block>>,
     ) -> crate::Result<()> {
         ensure!(
@@ -328,7 +328,7 @@ where
     pub async fn process_response(
         &mut self,
         peer_id: T::PeerId,
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
         response: message::SyncResponse,
     ) -> crate::Result<()> {
         match response {

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     config::P2pConfig,
     error::{P2pError, PeerError, ProtocolError},
     event::{PeerManagerEvent, SyncControlEvent},
-    message::{self, Announcement},
+    message::{self, Announcement, SyncRequest},
     net::{types::SyncingEvent, NetworkingService, SyncingMessagingService},
 };
 
@@ -127,7 +127,7 @@ where
 
         self.send_request(
             peer_id,
-            message::Request::HeaderListRequest(message::HeaderListRequest::new(locator.clone())),
+            SyncRequest::HeaderListRequest(message::HeaderListRequest::new(locator.clone())),
         )
         .await
         .map(|_| {

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -329,17 +329,17 @@ where
         &mut self,
         peer_id: T::PeerId,
         request_id: T::SyncingPeerRequestId,
-        response: message::Response,
+        response: message::SyncResponse,
     ) -> crate::Result<()> {
         match response {
-            message::Response::HeaderListResponse(response) => {
+            message::SyncResponse::HeaderListResponse(response) => {
                 log::debug!("process header response (id {request_id:?}) from peer {peer_id}");
                 log::trace!("received headers: {:#?}", response.headers());
 
                 let result = self.process_header_response(peer_id, response.into_headers()).await;
                 self.handle_error(peer_id, result).await?;
             }
-            message::Response::BlockListResponse(response) => {
+            message::SyncResponse::BlockListResponse(response) => {
                 log::debug!("process block response (id {request_id:?}) from peer {peer_id}");
                 log::trace!(
                     "# of received blocks: {}, block ids: {:#?}",
@@ -450,7 +450,7 @@ where
                         request_id,
                         request,
                     } => match request {
-                        message::Request::HeaderListRequest(request) => {
+                        message::SyncRequest::HeaderListRequest(request) => {
                             log::debug!("process header request (id {request_id:?}) from peer {peer_id}");
                             log::trace!("locator: {:#?}", request.locator());
 
@@ -461,7 +461,7 @@ where
                             ).await;
                             self.handle_error(peer_id, result).await?;
                         }
-                        message::Request::BlockListRequest(request) => {
+                        message::SyncRequest::BlockListRequest(request) => {
                             log::debug!("process block request (id {request_id:?}) from peer {peer_id}");
                             log::trace!("requested block ids: {:#?}", request.block_ids());
 

--- a/p2p/src/sync/request.rs
+++ b/p2p/src/sync/request.rs
@@ -25,7 +25,7 @@ use utils::ensure;
 
 use crate::{
     error::{P2pError, PeerError},
-    message,
+    message::{self, SyncRequest, SyncResponse},
     sync::{peer::PeerSyncState, BlockSyncManager},
     NetworkingService, SyncingMessagingService,
 };
@@ -38,36 +38,36 @@ where
     T::PeerId: 'static,
 {
     /// Creates a blocks request message.
-    pub fn make_block_request(&self, block_ids: Vec<Id<Block>>) -> message::Request {
-        message::Request::BlockListRequest(message::BlockListRequest::new(block_ids))
+    pub fn make_block_request(&self, block_ids: Vec<Id<Block>>) -> SyncRequest {
+        SyncRequest::BlockListRequest(message::BlockListRequest::new(block_ids))
     }
 
     /// Creates a headers request message with the given locator.
-    pub fn make_header_request(&self, locator: Locator) -> message::Request {
-        message::Request::HeaderListRequest(message::HeaderListRequest::new(locator))
+    pub fn make_header_request(&self, locator: Locator) -> SyncRequest {
+        SyncRequest::HeaderListRequest(message::HeaderListRequest::new(locator))
     }
 
     /// Make header response
     ///
     /// # Arguments
     /// * `headers` - the headers that were requested
-    pub fn make_header_response(&self, headers: Vec<BlockHeader>) -> message::Response {
-        message::Response::HeaderListResponse(message::HeaderListResponse::new(headers))
+    pub fn make_header_response(&self, headers: Vec<BlockHeader>) -> SyncResponse {
+        SyncResponse::HeaderListResponse(message::HeaderListResponse::new(headers))
     }
 
     /// Make block response
     ///
     /// # Arguments
     /// * `blocks` - the blocks that were requested
-    pub fn make_block_response(&self, blocks: Vec<Block>) -> message::Response {
-        message::Response::BlockListResponse(message::BlockListResponse::new(blocks))
+    pub fn make_block_response(&self, blocks: Vec<Block>) -> SyncResponse {
+        SyncResponse::BlockListResponse(message::BlockListResponse::new(blocks))
     }
 
     /// Sends a request to the given peer.
     pub async fn send_request(
         &mut self,
         peer_id: T::PeerId,
-        request: message::Request,
+        request: SyncRequest,
     ) -> crate::Result<()> {
         self.peer_sync_handle.send_request(peer_id, request).await.map(|_| ())
     }

--- a/p2p/src/sync/request.rs
+++ b/p2p/src/sync/request.rs
@@ -34,7 +34,7 @@ impl<T> BlockSyncManager<T>
 where
     T: NetworkingService,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
-    T::SyncingPeerRequestId: 'static,
+    T::PeerRequestId: 'static,
     T::PeerId: 'static,
 {
     /// Creates a blocks request message.
@@ -146,7 +146,7 @@ where
     /// * `headers` - headers that the remote requested
     pub async fn send_header_response(
         &mut self,
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
         headers: Vec<BlockHeader>,
     ) -> crate::Result<()> {
         log::trace!("send header response, request id {request_id:?}");
@@ -166,7 +166,7 @@ where
     /// * `headers` - headers that the remote requested
     pub async fn send_block_response(
         &mut self,
-        request_id: T::SyncingPeerRequestId,
+        request_id: T::PeerRequestId,
         blocks: Vec<Block>,
     ) -> crate::Result<()> {
         log::trace!("send block response, request id {request_id:?}");

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -45,7 +45,7 @@ where
     T: NetworkingService,
     T::ConnectivityHandle: ConnectivityService<T>,
     T::SyncingMessagingHandle: SyncingMessagingService<T>,
-    T::SyncingPeerRequestId: 'static,
+    T::PeerRequestId: 'static,
     T::PeerId: 'static,
 {
     let (tx_p2p_sync, rx_p2p_sync) = mpsc::unbounded_channel();

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -20,7 +20,7 @@ use tokio::time::timeout;
 use chainstate::Locator;
 
 use crate::{
-    message::{HeaderListRequest, HeaderListResponse, Request, Response, SyncRequest},
+    message::{HeaderListRequest, HeaderListResponse, SyncRequest, SyncResponse},
     net::{
         mock::{
             transport::{MockChannelTransport, NoiseTcpTransport, TcpTransportSocket},
@@ -54,7 +54,7 @@ where
     mgr1.peer_sync_handle
         .send_request(
             peer_info2.peer_id,
-            Request::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
+            SyncRequest::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
         .await
         .unwrap();
@@ -73,7 +73,7 @@ where
         mgr2.peer_sync_handle
             .send_response(
                 request_id,
-                Response::HeaderListResponse(HeaderListResponse::new(vec![])),
+                SyncResponse::HeaderListResponse(HeaderListResponse::new(vec![])),
             )
             .await
             .unwrap();
@@ -120,7 +120,7 @@ where
         .peer_sync_handle
         .send_request(
             peer_info2.peer_id,
-            Request::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
+            SyncRequest::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
         .await
         .unwrap();
@@ -130,7 +130,7 @@ where
         .peer_sync_handle
         .send_request(
             peer_info2.peer_id,
-            Request::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
+            SyncRequest::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
         .await
         .unwrap();
@@ -145,7 +145,7 @@ where
                     mgr2.peer_sync_handle
                         .send_response(
                             request_id,
-                            Response::HeaderListResponse(HeaderListResponse::new(vec![])),
+                            SyncResponse::HeaderListResponse(HeaderListResponse::new(vec![])),
                         )
                         .await
                         .unwrap();

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -20,7 +20,7 @@ use tokio::time::timeout;
 use chainstate::Locator;
 
 use crate::{
-    message::{HeaderListRequest, HeaderListResponse, Request, Response},
+    message::{HeaderListRequest, HeaderListResponse, Request, Response, SyncRequest},
     net::{
         mock::{
             transport::{MockChannelTransport, NoiseTcpTransport, TcpTransportSocket},
@@ -67,7 +67,7 @@ where
     {
         assert_eq!(
             request,
-            Request::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![])))
+            SyncRequest::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![])))
         );
 
         mgr2.peer_sync_handle

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -159,7 +159,11 @@ where
 
     let (address, peer_info1) = match timeout(Duration::from_secs(5), conn2.poll_next()).await {
         Ok(event) => match event.unwrap() {
-            ConnectivityEvent::InboundAccepted { address, peer_info } => (address, peer_info),
+            ConnectivityEvent::InboundAccepted {
+                address,
+                peer_info,
+                receiver_address: _,
+            } => (address, peer_info),
             event => panic!("expected `InboundAccepted`, got {event:?}"),
         },
         Err(_err) => panic!("did not receive `InboundAccepted` in time"),
@@ -170,6 +174,7 @@ where
             ConnectivityEvent::OutboundAccepted {
                 address: _,
                 peer_info,
+                receiver_address: _,
             } => peer_info,
             event => panic!("expected `OutboundAccepted`, got {event:?}"),
         },

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -25,7 +25,6 @@ use p2p::testing_utils::{
     TestTransportTcp,
 };
 use p2p::{
-    error::{P2pError, PublishError},
     message::Announcement,
     net::{
         mock::{
@@ -83,29 +82,19 @@ where
     connect_services::<S>(&mut peer2.0, &mut peer3.0).await;
 
     // Spam the message until we have a peer.
-    loop {
-        let res = sync1
-            .make_announcement(Announcement::Block(
-                Block::new(
-                    vec![],
-                    Id::new(H256([0x03; 32])),
-                    BlockTimestamp::from_int_seconds(1337u64),
-                    ConsensusData::None,
-                    BlockReward::new(Vec::new()),
-                )
-                .unwrap(),
-            ))
-            .await;
-
-        if res.is_ok() {
-            break;
-        } else {
-            assert_eq!(
-                res,
-                Err(P2pError::PublishError(PublishError::InsufficientPeers))
-            );
-        }
-    }
+    let res = sync1
+        .make_announcement(Announcement::Block(
+            Block::new(
+                vec![],
+                Id::new(H256([0x03; 32])),
+                BlockTimestamp::from_int_seconds(1337u64),
+                ConsensusData::None,
+                BlockReward::new(Vec::new()),
+            )
+            .unwrap(),
+        ))
+        .await;
+    assert!(res.is_ok());
 
     // Verify that all peers received the message even though they weren't directly connected.
     let event = peer1.1.poll_next().await.unwrap();

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -81,8 +81,7 @@ where
     connect_services::<S>(&mut peer1.0, &mut peer2.0).await;
     connect_services::<S>(&mut peer2.0, &mut peer3.0).await;
 
-    // Spam the message until we have a peer.
-    let res = sync1
+    sync1
         .make_announcement(Announcement::Block(
             Block::new(
                 vec![],
@@ -93,8 +92,8 @@ where
             )
             .unwrap(),
         ))
-        .await;
-    assert!(res.is_ok());
+        .await
+        .unwrap();
 
     // Verify that all peers received the message even though they weren't directly connected.
     let event = peer1.1.poll_next().await.unwrap();


### PR DESCRIPTION
This PR adds new `AddrList` request and response types. With this nodes will be able query peers for newly discovered addresses. This new messages are sent to `PeerManager` because it's where `PeerDB` is used and where peers list maintenance happens. For now actual requests handling is very basic, just to show how it might look. Actual implementation will be done in next PR (`p2p/README.md` also needs some updates).
