### PR TITLE
storage: Mark storage types as `ShallowClone`

### DIFF
--- a/storage/core/src/adaptor/locking/mod.rs
+++ b/storage/core/src/adaptor/locking/mod.rs
@@ -119,6 +119,8 @@ impl<T> Clone for TransactionLockImpl<T> {
     }
 }
 
+impl<T> utils::shallow_clone::ShallowClone for TransactionLockImpl<T> {}
+
 impl<'tx, T: 'tx + ReadOps> backend::TransactionalRo<'tx> for TransactionLockImpl<T> {
     type TxRo = TxRo<'tx, T>;
 

--- a/storage/core/src/backend.rs
+++ b/storage/core/src/backend.rs
@@ -15,6 +15,8 @@
 
 //! Low-level interface implemented by storage backends.
 
+use utils::shallow_clone::ShallowClone;
+
 pub use crate::{
     info::{DbDesc, DbIndex},
     Data,
@@ -76,8 +78,12 @@ pub trait TransactionalRw<'tx> {
 }
 
 /// Storage backend internal implementation type
-pub trait BackendImpl:
-    'static + for<'tx> TransactionalRo<'tx> + for<'tx> TransactionalRw<'tx> + Send + Sync + Clone
+pub trait BackendImpl
+where
+    Self: 'static + Send + Sync,
+    Self: for<'tx> TransactionalRo<'tx>,
+    Self: for<'tx> TransactionalRw<'tx>,
+    Self: ShallowClone,
 {
 }
 

--- a/storage/lmdb/src/lib.rs
+++ b/storage/lmdb/src/lib.rs
@@ -177,6 +177,7 @@ impl<'tx> TransactionalRw<'tx> for LmdbImpl {
     }
 }
 
+impl utils::shallow_clone::ShallowClone for LmdbImpl {}
 impl backend::BackendImpl for LmdbImpl {}
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/storage/src/database/mod.rs
+++ b/storage/src/database/mod.rs
@@ -42,6 +42,11 @@ where
     }
 }
 
+impl<B: Backend, Sch> utils::shallow_clone::ShallowClone for Storage<B, Sch> where
+    B::Impl: utils::shallow_clone::ShallowClone
+{
+}
+
 impl<B: Backend, Sch: Schema> Storage<B, Sch> {
     /// Create new storage with given backend
     pub fn new(backend: B) -> crate::Result<Self> {


### PR DESCRIPTION
To make them usable in contexts where `ShallowClone` is expected