### PR TITLE
Non-zero p2p timeouts and small cleanup

### DIFF
--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -146,7 +146,7 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
     let added_nodes = options.p2p_add_node.clone().or(added_nodes);
     let ban_threshold = options.p2p_ban_threshold.or(ban_threshold);
     let outbound_connection_timeout =
-        options.p2p_outbound_connection_timeout.or(outbound_connection_timeout.into());
+        options.p2p_outbound_connection_timeout.or(outbound_connection_timeout);
     let node_type = options.node_type.or(node_type);
 
     P2pConfigFile {

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -146,7 +146,7 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
     let added_nodes = options.p2p_add_node.clone().or(added_nodes);
     let ban_threshold = options.p2p_ban_threshold.or(ban_threshold);
     let outbound_connection_timeout =
-        options.p2p_outbound_connection_timeout.or(outbound_connection_timeout);
+        options.p2p_outbound_connection_timeout.or(outbound_connection_timeout.into());
     let node_type = options.node_type.or(node_type);
 
     P2pConfigFile {

--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{str::FromStr, time::Duration};
+use std::{num::NonZeroU64, str::FromStr, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
@@ -60,7 +60,7 @@ pub struct P2pConfigFile {
     /// Duration of bans in seconds.
     pub ban_duration: Option<u64>,
     /// The outbound connection timeout value in seconds.
-    pub outbound_connection_timeout: Option<u64>,
+    pub outbound_connection_timeout: Option<NonZeroU64>,
     /// A node type.
     pub node_type: Option<NodeTypeConfigFile>,
 }
@@ -72,7 +72,10 @@ impl From<P2pConfigFile> for P2pConfig {
             added_nodes: c.added_nodes.clone().unwrap_or_default(),
             ban_threshold: c.ban_threshold.into(),
             ban_duration: c.ban_duration.map(Duration::from_secs).into(),
-            outbound_connection_timeout: c.outbound_connection_timeout.into(),
+            outbound_connection_timeout: c
+                .outbound_connection_timeout
+                .map(|t| Duration::from_secs(t.into()))
+                .into(),
             node_type: c.node_type.map(Into::into).into(),
         }
     }

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -15,7 +15,7 @@
 
 //! The node command line options.
 
-use std::{ffi::OsString, fs, net::SocketAddr, path::PathBuf};
+use std::{ffi::OsString, fs, net::SocketAddr, num::NonZeroU64, path::PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
@@ -93,7 +93,7 @@ pub struct RunOptions {
 
     /// The p2p timeout value in seconds.
     #[clap(long)]
-    pub p2p_outbound_connection_timeout: Option<u64>,
+    pub p2p_outbound_connection_timeout: Option<NonZeroU64>,
 
     /// A maximum tip age in seconds.
     ///

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{net::SocketAddr, path::Path, str::FromStr};
+use std::{net::SocketAddr, num::NonZeroU64, path::Path, str::FromStr};
 
 use assert_cmd::Command;
 use directories::UserDirs;
@@ -89,7 +89,7 @@ fn read_config_override_values() {
     let p2p_addr = "address";
     let p2p_add_node = "add_node";
     let p2p_ban_threshold = 3;
-    let p2p_timeout = 10000;
+    let p2p_timeout = NonZeroU64::new(10000).unwrap();
     let http_rpc_addr = SocketAddr::from_str("127.0.0.1:5432").unwrap();
     let ws_rpc_addr = SocketAddr::from_str("127.0.0.1:5433").unwrap();
     let backend_type = StorageBackendConfigFile::InMemory;

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_BIND_PORT: u16 = 3031;
 
 make_config_setting!(BanThreshold, u32, 100);
 make_config_setting!(BanDuration, Duration, Duration::from_secs(60 * 60 * 24));
-make_config_setting!(OutboundConnectionTimeout, u64, 10);
+make_config_setting!(OutboundConnectionTimeout, Duration, Duration::from_secs(10));
 make_config_setting!(
     AnnouncementSubscriptions,
     BTreeSet<PubSubTopic>,

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -65,15 +65,6 @@ pub enum PublishError {
     TransformFailed,
 }
 
-/// PubSub errors for subscriptions
-#[derive(Error, Debug, PartialEq, Eq)]
-pub enum SubscriptionError {
-    #[error("Failed to publish subscription: {0}")]
-    FailedToPublish(PublishError),
-    #[error("Not allowed to subscribe to this topic")]
-    NotAllowed,
-}
-
 /// Errors related to establishing a connection with a remote peer
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum DialError {
@@ -116,8 +107,6 @@ pub enum P2pError {
     ProtocolError(ProtocolError),
     #[error("Failed to publish message: `{0}`")]
     PublishError(PublishError),
-    #[error("Failed to subscribe to pubsub topic: `{0}`")]
-    SubscriptionError(SubscriptionError),
     #[error("Failed to dial peer: `{0}`")]
     DialError(DialError),
     #[error("Connection to other task lost")]
@@ -179,7 +168,6 @@ impl BanScore for P2pError {
         match self {
             P2pError::ProtocolError(err) => err.ban_score(),
             P2pError::PublishError(err) => err.ban_score(),
-            P2pError::SubscriptionError(err) => err.ban_score(),
             P2pError::DialError(_) => 0,
             P2pError::ChannelClosed => 0,
             P2pError::PeerError(_) => 0,
@@ -212,15 +200,6 @@ impl BanScore for PublishError {
             PublishError::InsufficientPeers => 0,
             PublishError::MessageTooLarge(_, _) => 100,
             PublishError::TransformFailed => 0,
-        }
-    }
-}
-
-impl BanScore for SubscriptionError {
-    fn ban_score(&self) -> u32 {
-        match self {
-            SubscriptionError::FailedToPublish(err) => err.ban_score(),
-            SubscriptionError::NotAllowed => 0,
         }
     }
 }

--- a/p2p/src/net/mock/mod.rs
+++ b/p2p/src/net/mock/mod.rs
@@ -128,7 +128,6 @@ impl<T: TransportSocket> NetworkingService for MockService<T> {
         let local_addresses = socket.local_addresses().expect("to have bind address available");
 
         tokio::spawn(async move {
-            let timeout = *p2p_config.outbound_connection_timeout;
             let mut backend = backend::Backend::<T>::new(
                 transport,
                 socket,
@@ -137,7 +136,6 @@ impl<T: TransportSocket> NetworkingService for MockService<T> {
                 cmd_rx,
                 conn_tx,
                 sync_tx,
-                std::time::Duration::from_secs(timeout),
             );
 
             if let Err(err) = backend.run().await {

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -478,7 +478,7 @@ where
     pm1.peer_connectivity_handle.connect(addr2).await.expect("dial to succeed");
 
     match timeout(
-        Duration::from_secs(*pm1._p2p_config.outbound_connection_timeout),
+        *pm1._p2p_config.outbound_connection_timeout,
         pm1.peer_connectivity_handle.poll_next(),
     )
     .await
@@ -563,12 +563,7 @@ async fn connection_timeout_rpc_notified<T>(
     let (rtx, rrx) = oneshot::channel();
     tx.send(PeerManagerEvent::Connect(addr2, rtx)).unwrap();
 
-    match timeout(
-        Duration::from_secs(*p2p_config.outbound_connection_timeout),
-        rrx,
-    )
-    .await
-    {
+    match timeout(*p2p_config.outbound_connection_timeout, rrx).await {
         Ok(res) => assert!(std::matches!(
             res.unwrap(),
             Err(P2pError::DialError(DialError::ConnectionRefusedOrTimedOut))

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -74,7 +74,7 @@ where
         added_nodes: Vec::new(),
         ban_threshold: 100.into(),
         ban_duration: Default::default(),
-        outbound_connection_timeout: 10.into(),
+        outbound_connection_timeout: Default::default(),
         node_type: NodeType::Full.into(),
     });
     let (conn, sync) = T::start(


### PR DESCRIPTION
Allowing zero `outbound_connection_timeout` doesn't makes sense because a connection can never be established with such value.