### PR TITLE
Basic peer discovery

### DIFF
--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -78,6 +78,8 @@ impl From<P2pConfigFile> for P2pConfig {
                 .into(),
             node_type: c.node_type.map(Into::into).into(),
             discover_private_ips: Default::default(),
+            heartbeat_interval_min: Default::default(),
+            heartbeat_interval_max: Default::default(),
         }
     }
 }

--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -77,7 +77,7 @@ impl From<P2pConfigFile> for P2pConfig {
                 .map(|t| Duration::from_secs(t.into()))
                 .into(),
             node_type: c.node_type.map(Into::into).into(),
-            discover_private_ips: Default::default(),
+            allow_discover_private_ips: Default::default(),
             heartbeat_interval_min: Default::default(),
             heartbeat_interval_max: Default::default(),
         }

--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -77,6 +77,7 @@ impl From<P2pConfigFile> for P2pConfig {
                 .map(|t| Duration::from_secs(t.into()))
                 .into(),
             node_type: c.node_type.map(Into::into).into(),
+            discover_private_ips: Default::default(),
         }
     }
 }

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -136,7 +136,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: NodeType::Inactive.into(),
-        discover_private_ips: Default::default(),
+        allow_discover_private_ips: Default::default(),
         heartbeat_interval_min: Default::default(),
         heartbeat_interval_max: Default::default(),
     });

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -136,6 +136,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: NodeType::Inactive.into(),
+        discover_private_ips: Default::default(),
     });
     let (mut conn1, mut sync1) = S::start(
         T::make_transport(),

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -137,6 +137,8 @@ where
         outbound_connection_timeout: Default::default(),
         node_type: NodeType::Inactive.into(),
         discover_private_ips: Default::default(),
+        heartbeat_interval_min: Default::default(),
+        heartbeat_interval_max: Default::default(),
     });
     let (mut conn1, mut sync1) = S::start(
         T::make_transport(),

--- a/p2p/backend-test-suite/src/connect.rs
+++ b/p2p/backend-test-suite/src/connect.rs
@@ -61,7 +61,7 @@ where
     .await
     .unwrap();
 
-    let addresses = connectivity.local_addresses().await.unwrap();
+    let addresses = connectivity.local_addresses().to_vec();
     let res = S::start(T::make_transport(), addresses, config, Default::default())
         .await
         .expect_err("address is not in use");
@@ -100,7 +100,7 @@ where
     .await
     .unwrap();
 
-    let conn_addr = service1.local_addresses().await.unwrap();
+    let conn_addr = service1.local_addresses().to_vec();
     let (res1, res2) = tokio::join!(service1.poll_next(), service2.connect(conn_addr[0].clone()));
     res1.unwrap();
     res2.unwrap();

--- a/p2p/backend-test-suite/src/peer_manager_peerdb.rs
+++ b/p2p/backend-test-suite/src/peer_manager_peerdb.rs
@@ -61,7 +61,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
-        discover_private_ips: Default::default(),
+        allow_discover_private_ips: Default::default(),
         heartbeat_interval_min: Default::default(),
         heartbeat_interval_max: Default::default(),
     };
@@ -86,7 +86,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
-        discover_private_ips: Default::default(),
+        allow_discover_private_ips: Default::default(),
         heartbeat_interval_min: Default::default(),
         heartbeat_interval_max: Default::default(),
     };
@@ -110,7 +110,7 @@ where
         ban_duration: Duration::from_secs(2).into(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
-        discover_private_ips: Default::default(),
+        allow_discover_private_ips: Default::default(),
         heartbeat_interval_min: Default::default(),
         heartbeat_interval_max: Default::default(),
     }))

--- a/p2p/backend-test-suite/src/peer_manager_peerdb.rs
+++ b/p2p/backend-test-suite/src/peer_manager_peerdb.rs
@@ -61,6 +61,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
+        discover_private_ips: Default::default(),
     };
     let mut peerdb = PeerDb::<S>::new(Arc::new(config)).unwrap();
 
@@ -83,6 +84,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
+        discover_private_ips: Default::default(),
     };
     let mut peerdb = PeerDb::<S>::new(Arc::new(config)).unwrap();
 
@@ -104,6 +106,7 @@ where
         ban_duration: Duration::from_secs(2).into(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
+        discover_private_ips: Default::default(),
     }))
     .unwrap();
 

--- a/p2p/backend-test-suite/src/peer_manager_peerdb.rs
+++ b/p2p/backend-test-suite/src/peer_manager_peerdb.rs
@@ -62,6 +62,8 @@ where
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
         discover_private_ips: Default::default(),
+        heartbeat_interval_min: Default::default(),
+        heartbeat_interval_max: Default::default(),
     };
     let mut peerdb = PeerDb::<S>::new(Arc::new(config)).unwrap();
 
@@ -85,6 +87,8 @@ where
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
         discover_private_ips: Default::default(),
+        heartbeat_interval_min: Default::default(),
+        heartbeat_interval_max: Default::default(),
     };
     let mut peerdb = PeerDb::<S>::new(Arc::new(config)).unwrap();
 
@@ -107,6 +111,8 @@ where
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
         discover_private_ips: Default::default(),
+        heartbeat_interval_min: Default::default(),
+        heartbeat_interval_max: Default::default(),
     }))
     .unwrap();
 

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -27,7 +27,7 @@ use common::{
     primitives::{Id, Idable},
 };
 
-use p2p::testing_utils::{connect_services, filter_connectivity_event, TestTransportMaker};
+use p2p::testing_utils::{connect_services, get_connectivity_event, TestTransportMaker};
 use p2p::{
     config::P2pConfig,
     error::P2pError,
@@ -1063,10 +1063,7 @@ where
     mgr1.unregister_peer(peer_info2.peer_id);
     assert_eq!(conn1.disconnect(peer_info2.peer_id).await, Ok(()));
 
-    let event = filter_connectivity_event::<S, _>(&mut conn2, |event| {
-        !std::matches!(event, Ok(ConnectivityEvent::AddressDiscovered { .. }))
-    })
-    .await;
+    let event = get_connectivity_event::<S>(&mut conn2).await;
     assert!(std::matches!(
         event,
         Ok(ConnectivityEvent::ConnectionClosed { .. })

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -31,6 +31,8 @@ make_config_setting!(
 );
 make_config_setting!(NodeTypeSetting, NodeType, NodeType::Full);
 make_config_setting!(DiscoverPrivateIps, bool, false);
+make_config_setting!(HeartbeatIntervalMin, Duration, Duration::from_secs(5));
+make_config_setting!(HeartbeatIntervalMax, Duration, Duration::from_secs(30));
 
 /// A node type.
 #[derive(Debug, Copy, Clone)]
@@ -74,4 +76,8 @@ pub struct P2pConfig {
     pub node_type: NodeTypeSetting,
     /// Allow announcing and discovering local and private IPs. Should be used for testing only.
     pub discover_private_ips: DiscoverPrivateIps,
+    /// Lower bound for how often `PeerManager::heartbeat` is called. Should be used for testing only.
+    pub heartbeat_interval_min: HeartbeatIntervalMin,
+    /// Upper bound for how often `PeerManager::heartbeat` is called. Should be used for testing only.
+    pub heartbeat_interval_max: HeartbeatIntervalMin,
 }

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -30,7 +30,7 @@ make_config_setting!(
     [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect()
 );
 make_config_setting!(NodeTypeSetting, NodeType, NodeType::Full);
-make_config_setting!(DiscoverPrivateIps, bool, false);
+make_config_setting!(AllowDiscoverPrivateIps, bool, false);
 make_config_setting!(HeartbeatIntervalMin, Duration, Duration::from_secs(5));
 make_config_setting!(HeartbeatIntervalMax, Duration, Duration::from_secs(30));
 
@@ -75,7 +75,7 @@ pub struct P2pConfig {
     /// A node type.
     pub node_type: NodeTypeSetting,
     /// Allow announcing and discovering local and private IPs. Should be used for testing only.
-    pub discover_private_ips: DiscoverPrivateIps,
+    pub allow_discover_private_ips: AllowDiscoverPrivateIps,
     /// Lower bound for how often `PeerManager::heartbeat` is called. Should be used for testing only.
     pub heartbeat_interval_min: HeartbeatIntervalMin,
     /// Upper bound for how often `PeerManager::heartbeat` is called. Should be used for testing only.

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -30,6 +30,7 @@ make_config_setting!(
     [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect()
 );
 make_config_setting!(NodeTypeSetting, NodeType, NodeType::Full);
+make_config_setting!(DiscoverPrivateIps, bool, false);
 
 /// A node type.
 #[derive(Debug, Copy, Clone)]
@@ -71,4 +72,6 @@ pub struct P2pConfig {
     pub outbound_connection_timeout: OutboundConnectionTimeout,
     /// A node type.
     pub node_type: NodeTypeSetting,
+    /// Allow announcing and discovering local and private IPs. Should be used for testing only.
+    pub discover_private_ips: DiscoverPrivateIps,
 }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -61,10 +61,10 @@ impl BlockListRequest {
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct PullAddrListRequest {}
+pub struct AddrListRequest {}
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct PushAddrRequest {
+pub struct AnnounceAddrRequest {
     pub address: PeerAddress,
 }
 
@@ -75,9 +75,9 @@ pub enum Request {
     #[codec(index = 1)]
     BlockListRequest(BlockListRequest),
     #[codec(index = 2)]
-    PullAddrListRequest(PullAddrListRequest),
+    AddrListRequest(AddrListRequest),
     #[codec(index = 3)]
-    PushAddrRequest(PushAddrRequest),
+    AnnounceAddrRequest(AnnounceAddrRequest),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -88,8 +88,8 @@ pub enum SyncRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerManagerRequest {
-    PullAddrListRequest(PullAddrListRequest),
-    PushAddrRequest(PushAddrRequest),
+    AddrListRequest(AddrListRequest),
+    AnnounceAddrRequest(AnnounceAddrRequest),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -131,10 +131,10 @@ impl BlockListResponse {
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct PushAddrResponse {}
+pub struct AnnounceAddrResponse {}
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct PullAddrListResponse {
+pub struct AddrListResponse {
     pub addresses: Vec<PeerAddress>,
 }
 
@@ -145,9 +145,9 @@ pub enum Response {
     #[codec(index = 1)]
     BlockListResponse(BlockListResponse),
     #[codec(index = 2)]
-    PullAddrListResponse(PullAddrListResponse),
+    AddrListResponse(AddrListResponse),
     #[codec(index = 3)]
-    PushAddrResponse(PushAddrResponse),
+    AnnounceAddrResponse(AnnounceAddrResponse),
 }
 
 #[derive(Debug, Clone)]
@@ -158,8 +158,8 @@ pub enum SyncResponse {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerManagerResponse {
-    PullAddrListResponse(PullAddrListResponse),
-    PushAddrResponse(PushAddrResponse),
+    AddrListResponse(AddrListResponse),
+    AnnounceAddrResponse(AnnounceAddrResponse),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -171,10 +171,10 @@ pub enum Announcement {
 impl From<PeerManagerRequest> for Request {
     fn from(request: PeerManagerRequest) -> Self {
         match request {
-            PeerManagerRequest::PullAddrListRequest(request) => {
-                Request::PullAddrListRequest(request)
+            PeerManagerRequest::AddrListRequest(request) => Request::AddrListRequest(request),
+            PeerManagerRequest::AnnounceAddrRequest(request) => {
+                Request::AnnounceAddrRequest(request)
             }
-            PeerManagerRequest::PushAddrRequest(request) => Request::PushAddrRequest(request),
         }
     }
 }
@@ -182,10 +182,10 @@ impl From<PeerManagerRequest> for Request {
 impl From<PeerManagerResponse> for Response {
     fn from(response: PeerManagerResponse) -> Self {
         match response {
-            PeerManagerResponse::PullAddrListResponse(response) => {
-                Response::PullAddrListResponse(response)
+            PeerManagerResponse::AddrListResponse(response) => Response::AddrListResponse(response),
+            PeerManagerResponse::AnnounceAddrResponse(response) => {
+                Response::AnnounceAddrResponse(response)
             }
-            PeerManagerResponse::PushAddrResponse(response) => Response::PushAddrResponse(response),
         }
     }
 }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -64,8 +64,8 @@ impl BlockListRequest {
 pub struct PullAddrListRequest {}
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct PushAddrListRequest {
-    pub addresses: Vec<PeerAddress>,
+pub struct PushAddrRequest {
+    pub address: PeerAddress,
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -77,7 +77,7 @@ pub enum Request {
     #[codec(index = 2)]
     PullAddrListRequest(PullAddrListRequest),
     #[codec(index = 3)]
-    PushAddrListRequest(PushAddrListRequest),
+    PushAddrRequest(PushAddrRequest),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,7 +89,7 @@ pub enum SyncRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerManagerRequest {
     PullAddrListRequest(PullAddrListRequest),
-    PushAddrListRequest(PushAddrListRequest),
+    PushAddrRequest(PushAddrRequest),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -131,7 +131,7 @@ impl BlockListResponse {
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct PushAddrListResponse {}
+pub struct PushAddrResponse {}
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct PullAddrListResponse {
@@ -147,7 +147,7 @@ pub enum Response {
     #[codec(index = 2)]
     PullAddrListResponse(PullAddrListResponse),
     #[codec(index = 3)]
-    PushAddrListResponse(PushAddrListResponse),
+    PushAddrResponse(PushAddrResponse),
 }
 
 #[derive(Debug, Clone)]
@@ -159,7 +159,7 @@ pub enum SyncResponse {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerManagerResponse {
     PullAddrListResponse(PullAddrListResponse),
-    PushAddrListResponse(PushAddrListResponse),
+    PushAddrResponse(PushAddrResponse),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -174,9 +174,7 @@ impl From<PeerManagerRequest> for Request {
             PeerManagerRequest::PullAddrListRequest(request) => {
                 Request::PullAddrListRequest(request)
             }
-            PeerManagerRequest::PushAddrListRequest(request) => {
-                Request::PushAddrListRequest(request)
-            }
+            PeerManagerRequest::PushAddrRequest(request) => Request::PushAddrRequest(request),
         }
     }
 }
@@ -187,9 +185,7 @@ impl From<PeerManagerResponse> for Response {
             PeerManagerResponse::PullAddrListResponse(response) => {
                 Response::PullAddrListResponse(response)
             }
-            PeerManagerResponse::PushAddrListResponse(response) => {
-                Response::PushAddrListResponse(response)
-            }
+            PeerManagerResponse::PushAddrResponse(response) => Response::PushAddrResponse(response),
         }
     }
 }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -61,18 +61,11 @@ impl BlockListRequest {
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct AddrListRequest {
-    addresses: Vec<PeerAddress>,
-}
+pub struct PullAddrListRequest {}
 
-impl AddrListRequest {
-    pub fn new(addresses: Vec<PeerAddress>) -> Self {
-        Self { addresses }
-    }
-
-    pub fn addresses(&self) -> &[PeerAddress] {
-        &self.addresses
-    }
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct PushAddrListRequest {
+    pub addresses: Vec<PeerAddress>,
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -82,7 +75,9 @@ pub enum Request {
     #[codec(index = 1)]
     BlockListRequest(BlockListRequest),
     #[codec(index = 2)]
-    AddrListRequest(AddrListRequest),
+    PullAddrListRequest(PullAddrListRequest),
+    #[codec(index = 3)]
+    PushAddrListRequest(PushAddrListRequest),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,7 +88,8 @@ pub enum SyncRequest {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerManagerRequest {
-    AddrListRequest(AddrListRequest),
+    PullAddrListRequest(PullAddrListRequest),
+    PushAddrListRequest(PushAddrListRequest),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -135,18 +131,11 @@ impl BlockListResponse {
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct AddrListResponse {
-    addresses: Vec<PeerAddress>,
-}
+pub struct PushAddrListResponse {}
 
-impl AddrListResponse {
-    pub fn new(addresses: Vec<PeerAddress>) -> Self {
-        Self { addresses }
-    }
-
-    pub fn addresses(&self) -> &[PeerAddress] {
-        &self.addresses
-    }
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct PullAddrListResponse {
+    pub addresses: Vec<PeerAddress>,
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -156,7 +145,9 @@ pub enum Response {
     #[codec(index = 1)]
     BlockListResponse(BlockListResponse),
     #[codec(index = 2)]
-    AddrListResponse(AddrListResponse),
+    PullAddrListResponse(PullAddrListResponse),
+    #[codec(index = 3)]
+    PushAddrListResponse(PushAddrListResponse),
 }
 
 #[derive(Debug, Clone)]
@@ -167,7 +158,8 @@ pub enum SyncResponse {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PeerManagerResponse {
-    AddrListResponse(AddrListResponse),
+    PullAddrListResponse(PullAddrListResponse),
+    PushAddrListResponse(PushAddrListResponse),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -179,7 +171,12 @@ pub enum Announcement {
 impl From<PeerManagerRequest> for Request {
     fn from(request: PeerManagerRequest) -> Self {
         match request {
-            PeerManagerRequest::AddrListRequest(request) => Request::AddrListRequest(request),
+            PeerManagerRequest::PullAddrListRequest(request) => {
+                Request::PullAddrListRequest(request)
+            }
+            PeerManagerRequest::PushAddrListRequest(request) => {
+                Request::PushAddrListRequest(request)
+            }
         }
     }
 }
@@ -187,7 +184,12 @@ impl From<PeerManagerRequest> for Request {
 impl From<PeerManagerResponse> for Response {
     fn from(response: PeerManagerResponse) -> Self {
         match response {
-            PeerManagerResponse::AddrListResponse(response) => Response::AddrListResponse(response),
+            PeerManagerResponse::PullAddrListResponse(response) => {
+                Response::PullAddrListResponse(response)
+            }
+            PeerManagerResponse::PushAddrListResponse(response) => {
+                Response::PushAddrListResponse(response)
+            }
         }
     }
 }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -61,7 +61,19 @@ impl BlockListRequest {
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
-pub struct AddrListRequest {}
+pub struct AddrListRequest {
+    addresses: Vec<PeerAddress>,
+}
+
+impl AddrListRequest {
+    pub fn new(addresses: Vec<PeerAddress>) -> Self {
+        Self { addresses }
+    }
+
+    pub fn addresses(&self) -> &[PeerAddress] {
+        &self.addresses
+    }
+}
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum Request {

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -292,12 +292,12 @@ where
                 })
                 .await
                 .map_err(P2pError::from),
-            message::Request::PushAddrListRequest(request) => self
+            message::Request::PushAddrRequest(request) => self
                 .conn_tx
                 .send(ConnectivityEvent::Request {
                     peer_id,
                     request_id,
-                    request: PeerManagerRequest::PushAddrListRequest(request),
+                    request: PeerManagerRequest::PushAddrRequest(request),
                 })
                 .await
                 .map_err(P2pError::from),
@@ -341,12 +341,12 @@ where
                 })
                 .await
                 .map_err(P2pError::from),
-            message::Response::PushAddrListResponse(response) => self
+            message::Response::PushAddrResponse(response) => self
                 .conn_tx
                 .send(ConnectivityEvent::Response {
                     peer_id,
                     request_id,
-                    response: PeerManagerResponse::PushAddrListResponse(response),
+                    response: PeerManagerResponse::PushAddrResponse(response),
                 })
                 .await
                 .map_err(P2pError::from),

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -283,12 +283,21 @@ where
                 })
                 .await
                 .map_err(P2pError::from),
-            message::Request::AddrListRequest(request) => self
+            message::Request::PullAddrListRequest(request) => self
                 .conn_tx
                 .send(ConnectivityEvent::Request {
                     peer_id,
                     request_id,
-                    request: PeerManagerRequest::AddrListRequest(request),
+                    request: PeerManagerRequest::PullAddrListRequest(request),
+                })
+                .await
+                .map_err(P2pError::from),
+            message::Request::PushAddrListRequest(request) => self
+                .conn_tx
+                .send(ConnectivityEvent::Request {
+                    peer_id,
+                    request_id,
+                    request: PeerManagerRequest::PushAddrListRequest(request),
                 })
                 .await
                 .map_err(P2pError::from),
@@ -323,12 +332,21 @@ where
                 })
                 .await
                 .map_err(P2pError::from),
-            message::Response::AddrListResponse(response) => self
+            message::Response::PullAddrListResponse(response) => self
                 .conn_tx
                 .send(ConnectivityEvent::Response {
                     peer_id,
                     request_id,
-                    response: PeerManagerResponse::AddrListResponse(response),
+                    response: PeerManagerResponse::PullAddrListResponse(response),
+                })
+                .await
+                .map_err(P2pError::from),
+            message::Response::PushAddrListResponse(response) => self
+                .conn_tx
+                .send(ConnectivityEvent::Response {
+                    peer_id,
+                    request_id,
+                    response: PeerManagerResponse::PushAddrListResponse(response),
                 })
                 .await
                 .map_err(P2pError::from),

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -283,21 +283,21 @@ where
                 })
                 .await
                 .map_err(P2pError::from),
-            message::Request::PullAddrListRequest(request) => self
+            message::Request::AddrListRequest(request) => self
                 .conn_tx
                 .send(ConnectivityEvent::Request {
                     peer_id,
                     request_id,
-                    request: PeerManagerRequest::PullAddrListRequest(request),
+                    request: PeerManagerRequest::AddrListRequest(request),
                 })
                 .await
                 .map_err(P2pError::from),
-            message::Request::PushAddrRequest(request) => self
+            message::Request::AnnounceAddrRequest(request) => self
                 .conn_tx
                 .send(ConnectivityEvent::Request {
                     peer_id,
                     request_id,
-                    request: PeerManagerRequest::PushAddrRequest(request),
+                    request: PeerManagerRequest::AnnounceAddrRequest(request),
                 })
                 .await
                 .map_err(P2pError::from),
@@ -332,21 +332,21 @@ where
                 })
                 .await
                 .map_err(P2pError::from),
-            message::Response::PullAddrListResponse(response) => self
+            message::Response::AddrListResponse(response) => self
                 .conn_tx
                 .send(ConnectivityEvent::Response {
                     peer_id,
                     request_id,
-                    response: PeerManagerResponse::PullAddrListResponse(response),
+                    response: PeerManagerResponse::AddrListResponse(response),
                 })
                 .await
                 .map_err(P2pError::from),
-            message::Response::PushAddrResponse(response) => self
+            message::Response::AnnounceAddrResponse(response) => self
                 .conn_tx
                 .send(ConnectivityEvent::Response {
                     peer_id,
                     request_id,
-                    response: PeerManagerResponse::PushAddrResponse(response),
+                    response: PeerManagerResponse::AnnounceAddrResponse(response),
                 })
                 .await
                 .map_err(P2pError::from),

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -262,9 +262,6 @@ where
             types::ConnectivityEvent::Misbehaved { peer_id, error } => {
                 Ok(ConnectivityEvent::Misbehaved { peer_id, error })
             }
-            types::ConnectivityEvent::AddressDiscovered { address } => {
-                Ok(ConnectivityEvent::AddressDiscovered { address })
-            }
         }
     }
 }

--- a/p2p/src/net/default_backend/transport/impls/channel.rs
+++ b/p2p/src/net/default_backend/transport/impls/channel.rs
@@ -56,8 +56,11 @@ impl TransportAddress for Address {
         })
     }
 
-    fn from_peer_address(_address: &PeerAddress) -> Option<Self> {
-        None
+    fn from_peer_address(address: &PeerAddress) -> Option<Self> {
+        match address {
+            PeerAddress::Ip4(socket) => Some(std::net::Ipv4Addr::from(socket.ip).into()),
+            PeerAddress::Ip6(_) => None,
+        }
     }
 }
 

--- a/p2p/src/net/default_backend/transport/traits/socket.rs
+++ b/p2p/src/net/default_backend/transport/traits/socket.rs
@@ -33,6 +33,7 @@ pub trait TransportSocket: Send + Sync + 'static {
         + Clone
         + Debug
         + Eq
+        + Ord
         + Hash
         + Send
         + Sync

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -111,9 +111,6 @@ pub enum ConnectivityEvent<T: TransportSocket> {
         peer_id: PeerId,
         error: error::P2pError,
     },
-    AddressDiscovered {
-        address: T::Address,
-    },
 }
 
 // TODO: use two events, one for txs and one for blocks?

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -141,7 +141,7 @@ impl std::fmt::Display for RequestId {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Encode, Decode)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Debug, Encode, Decode)]
 pub struct PeerId(u64);
 
 impl FromStr for PeerId {

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -53,6 +53,7 @@ pub trait NetworkingService {
     type Address: Clone
         + Debug
         + Eq
+        + Ord
         + Hash
         + Send
         + Sync
@@ -68,7 +69,7 @@ pub trait NetworkingService {
     type BannableAddress: Debug + Eq + Ord + Send;
 
     /// Unique ID assigned to a peer on the network
-    type PeerId: Copy + Debug + Display + Eq + Hash + Send + Sync + ToString + FromStr;
+    type PeerId: Copy + Debug + Display + Eq + Ord + Hash + Send + Sync + ToString + FromStr;
 
     /// Unique ID assigned to each received request from a peer
     type PeerRequestId: Copy + Debug + Eq + Hash + Send + Sync;

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -137,10 +137,8 @@ where
         response: PeerManagerResponse,
     ) -> crate::Result<()>;
 
-    /// Return the socket address of the network service provider
-    ///
-    /// If the address isn't available yet, `None` is returned
-    async fn local_addresses(&self) -> crate::Result<Vec<T::Address>>;
+    /// Return the socket addresses of the network service provider
+    fn local_addresses(&self) -> &[T::Address];
 
     /// Poll events from the network service provider
     ///

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -136,12 +136,6 @@ pub enum ConnectivityEvent<T: NetworkingService> {
         peer_id: T::PeerId,
     },
 
-    /// New peer discovered
-    AddressDiscovered {
-        /// Address information
-        address: T::Address,
-    },
-
     /// Protocol violation
     Misbehaved {
         /// Unique ID of the peer

--- a/p2p/src/peer_manager/global_ip.rs
+++ b/p2p/src/peer_manager/global_ip.rs
@@ -1,0 +1,146 @@
+// Copyright 2021 Protocol Labs.
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Based on libp2p sources:
+// https://github.com/libp2p/rust-libp2p/blob/73cbbe29679f5d56d81d5477d3796e82712f9ac2/protocols/autonat/src/behaviour.rs
+
+pub trait GlobalIp {
+    fn is_global_unicast_ip(&self) -> bool;
+}
+
+impl GlobalIp for std::net::Ipv4Addr {
+    // NOTE: The below logic is based on `std::net::Ipv4Addr::is_global`,
+    // which is at the time of writing behind the unstable `ip` feature.
+    // See https://github.com/rust-lang/rust/issues/27709 for more info.
+    fn is_global_unicast_ip(&self) -> bool {
+        // Copied from the unstable method `std::net::Ipv4Addr::is_shared`.
+        fn is_shared(addr: &std::net::Ipv4Addr) -> bool {
+            addr.octets()[0] == 100 && (addr.octets()[1] & 0b1100_0000 == 0b0100_0000)
+        }
+
+        // Copied from the unstable method `std::net::Ipv4Addr::is_reserved`.
+        fn is_reserved(addr: &std::net::Ipv4Addr) -> bool {
+            addr.octets()[0] & 240 == 240 && !addr.is_broadcast()
+        }
+
+        // Copied from the unstable method `std::net::Ipv4Addr::is_benchmarking`.
+        fn is_benchmarking(addr: &std::net::Ipv4Addr) -> bool {
+            addr.octets()[0] == 198 && (addr.octets()[1] & 0xfe) == 18
+        }
+
+        // Addresses reserved for future protocols (`192.0.0.0/24`)
+        fn is_future_protocol(addr: &std::net::Ipv4Addr) -> bool {
+            addr.octets()[0] == 192 && addr.octets()[1] == 0 && addr.octets()[2] == 0
+        }
+
+        // The 0.0.0.0/8 block is reserved
+        fn is_reserved2(addr: &std::net::Ipv4Addr) -> bool {
+            addr.octets()[0] == 0
+        }
+
+        !self.is_multicast()
+            && !self.is_private()
+            && !self.is_loopback()
+            && !self.is_link_local()
+            && !self.is_broadcast()
+            && !self.is_documentation()
+            && !is_shared(self)
+            && !is_future_protocol(self)
+            && !is_reserved(self)
+            && !is_benchmarking(self)
+            && !is_reserved2(self)
+    }
+}
+
+impl GlobalIp for std::net::Ipv6Addr {
+    // NOTE: The below logic is based on `std::net::Ipv6Addr::is_global`,
+    // which is at the time of writing behind the unstable `ip` feature.
+    // See https://github.com/rust-lang/rust/issues/27709 for more info.
+    fn is_global_unicast_ip(&self) -> bool {
+        // Copied from the unstable method `std::net::Ipv6Addr::is_unicast_link_local`.
+        fn is_unicast_link_local(addr: &std::net::Ipv6Addr) -> bool {
+            (addr.segments()[0] & 0xffc0) == 0xfe80
+        }
+        // Copied from the unstable method `std::net::Ipv6Addr::is_unique_local`.
+        fn is_unique_local(addr: &std::net::Ipv6Addr) -> bool {
+            (addr.segments()[0] & 0xfe00) == 0xfc00
+        }
+        // Copied from the unstable method `std::net::Ipv6Addr::is_documentation`.
+        fn is_documentation(addr: &std::net::Ipv6Addr) -> bool {
+            (addr.segments()[0] == 0x2001) && (addr.segments()[1] == 0xdb8)
+        }
+
+        // Copied from the unstable method `std::net::Ipv6Addr::is_unicast_global`.
+        !self.is_multicast()
+            && !self.is_loopback()
+            && !self.is_unspecified()
+            && !is_unicast_link_local(self)
+            && !is_unique_local(self)
+            && !is_documentation(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GlobalIp;
+
+    fn is_global_unicast(ip: &str) -> bool {
+        match ip.parse::<std::net::IpAddr>().unwrap() {
+            std::net::IpAddr::V4(ip) => ip.is_global_unicast_ip(),
+            std::net::IpAddr::V6(ip) => ip.is_global_unicast_ip(),
+        }
+    }
+
+    #[test]
+    fn test_addresses() {
+        let global_unicast_ips = ["142.250.184.142", "2a00:1450:4017:815::200e"];
+
+        let non_global_unicast_ips = [
+            "0.0.0.0",             // Unspecified
+            "255.255.255.255",     // Broadcast
+            "127.0.0.0",           // Local
+            "127.255.255.255",     // Local
+            "10.0.0.0",            // Private
+            "10.255.255.255",      // Private
+            "100.64.0.0",          // Private
+            "100.127.255.255",     // Private
+            "172.16.0.0",          // Private
+            "172.31.255.255",      // Private
+            "192.168.0.0",         // Private
+            "192.168.255.255",     // Private
+            "169.254.1.0",         // Link-local
+            "224.0.0.0",           // Multicast
+            "239.255.255.255",     // Multicast
+            "::",                  // Unspecified
+            "::1",                 // Local
+            "fd12:3456:789a:1::1", // Private
+            "ff02::1",             // Multicast
+        ];
+
+        for ip in global_unicast_ips {
+            assert!(
+                is_global_unicast(ip),
+                "{ip} is expected to be global unicast IP address"
+            );
+        }
+        for ip in non_global_unicast_ips {
+            assert!(
+                !is_global_unicast(ip),
+                "{ip} is expected to be not global unicast IP address"
+            );
+        }
+    }
+}

--- a/p2p/src/peer_manager/global_ip.rs
+++ b/p2p/src/peer_manager/global_ip.rs
@@ -17,11 +17,11 @@
 // Based on libp2p sources:
 // https://github.com/libp2p/rust-libp2p/blob/73cbbe29679f5d56d81d5477d3796e82712f9ac2/protocols/autonat/src/behaviour.rs
 
-pub trait GlobalIp {
+pub trait IsGlobalIp {
     fn is_global_unicast_ip(&self) -> bool;
 }
 
-impl GlobalIp for std::net::Ipv4Addr {
+impl IsGlobalIp for std::net::Ipv4Addr {
     // NOTE: The below logic is based on `std::net::Ipv4Addr::is_global`,
     // which is at the time of writing behind the unstable `ip` feature.
     // See https://github.com/rust-lang/rust/issues/27709 for more info.
@@ -65,7 +65,7 @@ impl GlobalIp for std::net::Ipv4Addr {
     }
 }
 
-impl GlobalIp for std::net::Ipv6Addr {
+impl IsGlobalIp for std::net::Ipv6Addr {
     // NOTE: The below logic is based on `std::net::Ipv6Addr::is_global`,
     // which is at the time of writing behind the unstable `ip` feature.
     // See https://github.com/rust-lang/rust/issues/27709 for more info.
@@ -95,7 +95,7 @@ impl GlobalIp for std::net::Ipv6Addr {
 
 #[cfg(test)]
 mod tests {
-    use super::GlobalIp;
+    use super::IsGlobalIp;
 
     fn is_global_unicast(ip: &str) -> bool {
         match ip.parse::<std::net::IpAddr>().unwrap() {

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -55,7 +55,7 @@ use crate::{
     types::peer_address::{PeerAddress, PeerAddressIp4, PeerAddressIp6},
 };
 
-use self::global_ip::GlobalIp;
+use self::global_ip::IsGlobalIp;
 
 /// Maximum number of connections the [`PeerManager`] is allowed to have open
 const MAX_ACTIVE_CONNECTIONS: usize = 128;
@@ -96,7 +96,7 @@ where
 
     /// All addresses that were announced to or from some peer.
     /// Used to prevent infinity loops while broadcasting addresses.
-    /// Bitcoin Core uses bloom filter for that.
+    // TODO: Use bloom filter (like it's done in Bitcoin Core).
     announced_addresses: HashMap<T::PeerId, HashSet<T::Address>>,
 }
 
@@ -138,11 +138,11 @@ where
         match &address {
             PeerAddress::Ip4(socket) => {
                 std::net::Ipv4Addr::from(socket.ip).is_global_unicast_ip()
-                    || *self.p2p_config.discover_private_ips
+                    || *self.p2p_config.allow_discover_private_ips
             }
             PeerAddress::Ip6(socket) => {
                 std::net::Ipv6Addr::from(socket.ip).is_global_unicast_ip()
-                    || *self.p2p_config.discover_private_ips
+                    || *self.p2p_config.allow_discover_private_ips
             }
         }
     }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -110,11 +110,6 @@ where
         })
     }
 
-    /// Update the list of known peers or known peer's list of addresses
-    fn peer_discovered(&mut self, address: &T::Address) {
-        self.peerdb.peer_discovered(address);
-    }
-
     /// Verify software version compatibility
     ///
     /// Make sure that local and remote peer have the same software version
@@ -501,9 +496,6 @@ where
                         net::types::ConnectivityEvent::ConnectionError { address, error } => {
                             let res = self.handle_outbound_error(address, error);
                             self.handle_result(None, res).await?;
-                        }
-                        net::types::ConnectivityEvent::AddressDiscovered { address } => {
-                            self.peer_discovered(&address);
                         }
                         net::types::ConnectivityEvent::Misbehaved { peer_id, error } => {
                             let res = self.adjust_peer_score(peer_id, error.ban_score()).await;

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -431,10 +431,9 @@ where
                     .map_err(|_| P2pError::ChannelClosed)?;
             }
             PeerManagerEvent::GetBindAddresses(response) => {
-                let addr = self.peer_connectivity_handle.local_addresses();
-                let addr = addr
-                    .await
-                    .unwrap_or_default()
+                let addr = self
+                    .peer_connectivity_handle
+                    .local_addresses()
                     .into_iter()
                     .map(|addr| addr.to_string())
                     .collect();

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -147,7 +147,7 @@ where
         }
     }
 
-    /// Discover public addresses for this node after new outbound connection is made
+    /// Discover public addresses for this node after a new outbound connection is made
     ///
     /// *receiver_address* is this host socket address as seen and reported by remote peer.
     /// This should work for hosts with public IPs and for hosts behind NAT with port forwarding (same port is assumed).

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -329,7 +329,7 @@ where
     /// is checked and updated at least once every 30 seconds. In high-traffic scenarios the
     /// update interval is clamped to a sensible lower bound. `PeerManager` will keep track of
     /// when it last update its own state and if the time since last update is less than the
-    /// configured lower bound, it exits early from the function.
+    /// configured lower bound, *heartbeat* won't be called.
     ///
     /// This function maintains the overall connectivity state of peers by culling
     /// low-reputation peers and establishing new connections with peers that have higher

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -369,7 +369,7 @@ where
         match request {
             // TODO: Rework this
             PeerManagerRequest::AddrListRequest(AddrListRequest {}) => {
-                let addresses = self.peerdb.known_addresses();
+                let addresses = self.peerdb.known_addresses().collect();
 
                 self.peer_connectivity_handle
                     .send_response(

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -41,7 +41,7 @@ use crate::{
     config::P2pConfig,
     error::{P2pError, PeerError, ProtocolError},
     event::{PeerManagerEvent, SyncControlEvent},
-    message::{AddrListRequest, AddrListResponse, PeerManagerRequest, PeerManagerResponse},
+    message::{AddrListResponse, PeerManagerRequest, PeerManagerResponse},
     net::{
         self,
         default_backend::transport::TransportAddress,
@@ -378,7 +378,13 @@ where
     ) -> crate::Result<()> {
         match request {
             // TODO: Rework this
-            PeerManagerRequest::AddrListRequest(AddrListRequest {}) => {
+            PeerManagerRequest::AddrListRequest(request) => {
+                for address in request.addresses() {
+                    if let Some(address) = TransportAddress::from_peer_address(address) {
+                        self.peerdb.peer_discovered(&address);
+                    }
+                }
+
                 let addresses = self.peerdb.known_addresses().collect();
 
                 self.peer_connectivity_handle

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -353,10 +353,14 @@ where
     /// networking backend which then reports at some point in the future
     /// whether the connection failed or succeeded.
     async fn connect(&mut self, address: T::Address) -> crate::Result<()> {
-        // TODO: verify that the peer is not already part of our swarm (needs peerdb)
         ensure!(
             !self.pending.contains_key(&address),
             P2pError::PeerError(PeerError::Pending(address.to_string())),
+        );
+
+        ensure!(
+            !self.peerdb.is_address_connected(&address),
+            P2pError::PeerError(PeerError::PeerAlreadyExists),
         );
 
         let bannable_address = address.as_bannable();

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -135,6 +135,7 @@ impl<T: NetworkingService> PeerDb<T> {
     }
 
     pub fn random_known_addresses(&self, count: usize) -> Vec<T::Address> {
+        // TODO: Use something more efficient
         let mut addresses = self.known_addresses.iter().cloned().collect::<Vec<_>>();
         addresses.shuffle(&mut make_pseudo_rng());
         addresses.truncate(count);
@@ -142,6 +143,7 @@ impl<T: NetworkingService> PeerDb<T> {
     }
 
     pub fn random_peer_ids(&self, count: usize) -> Vec<T::PeerId> {
+        // TODO: Use something more efficient
         let mut peer_ids = self.peers.keys().cloned().collect::<Vec<_>>();
         peer_ids.shuffle(&mut make_pseudo_rng());
         peer_ids.truncate(count);

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -173,12 +173,8 @@ impl<T: NetworkingService> PeerDb<T> {
 
     /// Get socket address of the next best peer (TODO: in terms of peer score).
     // TODO: Rewrite this.
-    pub fn take_best_peer_addr(&mut self) -> Option<T::Address> {
-        let address = self.known_addresses.iter().next().cloned();
-        if let Some(address) = &address {
-            self.known_addresses.remove(address);
-        }
-        address
+    pub fn get_best_peer_addr(&mut self) -> Option<T::Address> {
+        self.random_known_addresses(1).into_iter().next()
     }
 
     /// Add new peer addresses

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -145,6 +145,7 @@ impl<T: NetworkingService> PeerDb<T> {
             .collect::<Vec<_>>()
     }
 
+    /// Selects requested count of connected peer ids randomly.
     pub fn random_peer_ids(&self, count: usize) -> Vec<T::PeerId> {
         // There are normally not many connected peers, so iterating over the whole list should be OK
         let all_peer_ids = self.peers.keys().cloned().collect::<Vec<_>>();

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -134,6 +134,8 @@ impl<T: NetworkingService> PeerDb<T> {
         self.connected_addresses.contains(address)
     }
 
+    /// Selects requested count of peer addresses from the DB randomly.
+    /// Result could be shared with remote peers over network.
     pub fn random_known_addresses(&self, count: usize) -> Vec<T::Address> {
         // TODO: Use something more efficient
         let mut addresses = self.known_addresses.iter().cloned().collect::<Vec<_>>();

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -134,8 +134,8 @@ impl<T: NetworkingService> PeerDb<T> {
         self.addresses.contains(address)
     }
 
-    pub fn known_addresses(&self) -> Vec<PeerAddress> {
-        self.addresses.iter().map(TransportAddress::as_peer_address).collect()
+    pub fn known_addresses(&self) -> impl Iterator<Item = PeerAddress> + '_ {
+        self.addresses.iter().map(TransportAddress::as_peer_address)
     }
 
     /// Checks if the given address is banned.

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -26,7 +26,7 @@
 //! if the actual number of active connection is less than the desired number of connections.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -78,13 +78,13 @@ pub struct PeerDb<T: NetworkingService> {
     p2p_config: Arc<config::P2pConfig>,
 
     /// Set of active peers
-    peers: HashMap<T::PeerId, PeerContext<T>>,
+    peers: BTreeMap<T::PeerId, PeerContext<T>>,
 
     /// Set of currently connected addresses
-    connected_addresses: HashSet<T::Address>,
+    connected_addresses: BTreeSet<T::Address>,
 
     /// Set of all known addresses
-    known_addresses: HashSet<T::Address>,
+    known_addresses: BTreeSet<T::Address>,
 
     /// Banned addresses along with the duration of the ban.
     ///
@@ -103,7 +103,7 @@ impl<T: NetworkingService> PeerDb<T> {
                     P2pError::ConversionError(ConversionError::InvalidAddress(addr.clone()))
                 })
             })
-            .collect::<Result<HashSet<_>, _>>()?;
+            .collect::<Result<BTreeSet<_>, _>>()?;
         Ok(Self {
             peers: Default::default(),
             connected_addresses: Default::default(),

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -125,6 +125,7 @@ impl<T: NetworkingService> PeerDb<T> {
         self.peers.len()
     }
 
+    /// Returns short info about all connected peers
     pub fn get_connected_peers(&self) -> Vec<ConnectedPeer> {
         self.peers.values().map(Into::into).collect()
     }
@@ -135,6 +136,7 @@ impl<T: NetworkingService> PeerDb<T> {
     }
 
     /// Selects requested count of peer addresses from the DB randomly.
+    ///
     /// Result could be shared with remote peers over network.
     pub fn random_known_addresses(&self, count: usize) -> Vec<T::Address> {
         // TODO: Use something more efficient (without iterating over the all addresses first)
@@ -146,6 +148,9 @@ impl<T: NetworkingService> PeerDb<T> {
     }
 
     /// Selects requested count of connected peer ids randomly.
+    ///
+    /// It can be used to distribute data in the gossip protocol
+    /// (for example, to relay announced addresses to a small group of peers).
     pub fn random_peer_ids(&self, count: usize) -> Vec<T::PeerId> {
         // There are normally not many connected peers, so iterating over the whole list should be OK
         let all_peer_ids = self.peers.keys().cloned().collect::<Vec<_>>();

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -137,19 +137,21 @@ impl<T: NetworkingService> PeerDb<T> {
     /// Selects requested count of peer addresses from the DB randomly.
     /// Result could be shared with remote peers over network.
     pub fn random_known_addresses(&self, count: usize) -> Vec<T::Address> {
-        // TODO: Use something more efficient
-        let mut addresses = self.known_addresses.iter().cloned().collect::<Vec<_>>();
-        addresses.shuffle(&mut make_pseudo_rng());
-        addresses.truncate(count);
-        addresses
+        // TODO: Use something more efficient (without iterating over the all addresses first)
+        let all_addresses = self.known_addresses.iter().cloned().collect::<Vec<_>>();
+        all_addresses
+            .choose_multiple(&mut make_pseudo_rng(), count)
+            .cloned()
+            .collect::<Vec<_>>()
     }
 
     pub fn random_peer_ids(&self, count: usize) -> Vec<T::PeerId> {
-        // TODO: Use something more efficient
-        let mut peer_ids = self.peers.keys().cloned().collect::<Vec<_>>();
-        peer_ids.shuffle(&mut make_pseudo_rng());
-        peer_ids.truncate(count);
-        peer_ids
+        // There are normally not many connected peers, so iterating over the whole list should be OK
+        let all_peer_ids = self.peers.keys().cloned().collect::<Vec<_>>();
+        all_peer_ids
+            .choose_multiple(&mut make_pseudo_rng(), count)
+            .cloned()
+            .collect::<Vec<_>>()
     }
 
     /// Checks if the given address is banned.

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -63,9 +63,7 @@ where
     pm2.accept_inbound_connection(address, peer_info, None).unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
-    let addr1 = pm1.peer_connectivity_handle.local_addresses().await.unwrap()[0]
-        .clone()
-        .as_bannable();
+    let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
     let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
     assert!(std::matches!(
@@ -112,9 +110,7 @@ where
     pm2.accept_inbound_connection(address, peer_info, None).unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
-    let addr1 = pm1.peer_connectivity_handle.local_addresses().await.unwrap()[0]
-        .clone()
-        .as_bannable();
+    let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
     let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
     assert!(std::matches!(
@@ -169,9 +165,7 @@ where
     pm2.accept_inbound_connection(address, peer_info1, None).unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
-    let addr1 = pm1.peer_connectivity_handle.local_addresses().await.unwrap()[0]
-        .clone()
-        .as_bannable();
+    let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
     let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
     assert!(matches!(
@@ -179,7 +173,7 @@ where
         Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })
     ));
 
-    let remote_addr = pm1.peer_connectivity_handle.local_addresses().await.unwrap()[0].clone();
+    let remote_addr = pm1.peer_connectivity_handle.local_addresses()[0].clone();
 
     tokio::spawn(async move {
         loop {

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -60,7 +60,7 @@ where
     )
     .await;
     let peer_id = peer_info.peer_id;
-    pm2.accept_inbound_connection(address, peer_info, None).unwrap();
+    pm2.accept_inbound_connection(address, peer_info, None).await.unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
@@ -107,7 +107,7 @@ where
     )
     .await;
     let peer_id = peer_info.peer_id;
-    pm2.accept_inbound_connection(address, peer_info, None).unwrap();
+    pm2.accept_inbound_connection(address, peer_info, None).await.unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
@@ -162,7 +162,7 @@ where
     )
     .await;
     let peer_id = peer_info1.peer_id;
-    pm2.accept_inbound_connection(address, peer_info1, None).unwrap();
+    pm2.accept_inbound_connection(address, peer_info1, None).await.unwrap();
 
     assert_eq!(pm2.adjust_peer_score(peer_id, 1000).await, Ok(()));
     let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
@@ -224,51 +224,63 @@ where
         make_peer_manager::<S>(A::make_transport(), A::make_address(), Arc::clone(&config)).await;
 
     // invalid magic bytes
-    let res = peer_manager.accept_connection(
-        B::new(),
-        Role::Outbound,
-        net::types::PeerInfo::<S::PeerId> {
-            peer_id,
-            network: [1, 2, 3, 4],
-            version: SemVer::new(0, 1, 0),
-            agent: None,
-            subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
-        },
-        None,
-    );
+    let res = peer_manager
+        .accept_connection(
+            B::new(),
+            Role::Outbound,
+            net::types::PeerInfo::<S::PeerId> {
+                peer_id,
+                network: [1, 2, 3, 4],
+                version: SemVer::new(0, 1, 0),
+                agent: None,
+                subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions]
+                    .into_iter()
+                    .collect(),
+            },
+            None,
+        )
+        .await;
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!peer_manager.peerdb.is_active_peer(&peer_id));
 
     // invalid version
-    let res = peer_manager.accept_connection(
-        B::new(),
-        Role::Outbound,
-        net::types::PeerInfo::<S::PeerId> {
-            peer_id,
-            network: *config.magic_bytes(),
-            version: SemVer::new(1, 1, 1),
-            agent: None,
-            subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
-        },
-        None,
-    );
+    let res = peer_manager
+        .accept_connection(
+            B::new(),
+            Role::Outbound,
+            net::types::PeerInfo::<S::PeerId> {
+                peer_id,
+                network: *config.magic_bytes(),
+                version: SemVer::new(1, 1, 1),
+                agent: None,
+                subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions]
+                    .into_iter()
+                    .collect(),
+            },
+            None,
+        )
+        .await;
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!peer_manager.peerdb.is_active_peer(&peer_id));
 
     // valid connection
     let address = B::new();
-    let res = peer_manager.accept_connection(
-        address.clone(),
-        Role::Outbound,
-        net::types::PeerInfo::<S::PeerId> {
-            peer_id,
-            network: *config.magic_bytes(),
-            version: SemVer::new(0, 1, 0),
-            agent: None,
-            subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
-        },
-        None,
-    );
+    let res = peer_manager
+        .accept_connection(
+            address.clone(),
+            Role::Outbound,
+            net::types::PeerInfo::<S::PeerId> {
+                peer_id,
+                network: *config.magic_bytes(),
+                version: SemVer::new(0, 1, 0),
+                agent: None,
+                subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions]
+                    .into_iter()
+                    .collect(),
+            },
+            None,
+        )
+        .await;
     assert!(res.is_ok());
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(peer_manager.peerdb.is_active_peer(&peer_id));
@@ -317,48 +329,60 @@ where
         make_peer_manager::<S>(A::make_transport(), A::make_address(), Arc::clone(&config)).await;
 
     // invalid magic bytes
-    let res = peer_manager.accept_inbound_connection(
-        B::new(),
-        net::types::PeerInfo::<S::PeerId> {
-            peer_id,
-            network: [1, 2, 3, 4],
-            version: SemVer::new(0, 1, 0),
-            agent: None,
-            subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
-        },
-        None,
-    );
+    let res = peer_manager
+        .accept_inbound_connection(
+            B::new(),
+            net::types::PeerInfo::<S::PeerId> {
+                peer_id,
+                network: [1, 2, 3, 4],
+                version: SemVer::new(0, 1, 0),
+                agent: None,
+                subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions]
+                    .into_iter()
+                    .collect(),
+            },
+            None,
+        )
+        .await;
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!peer_manager.peerdb.is_active_peer(&peer_id));
 
     // invalid version
-    let res = peer_manager.accept_inbound_connection(
-        B::new(),
-        net::types::PeerInfo::<S::PeerId> {
-            peer_id,
-            network: *config.magic_bytes(),
-            version: SemVer::new(1, 1, 1),
-            agent: None,
-            subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
-        },
-        None,
-    );
+    let res = peer_manager
+        .accept_inbound_connection(
+            B::new(),
+            net::types::PeerInfo::<S::PeerId> {
+                peer_id,
+                network: *config.magic_bytes(),
+                version: SemVer::new(1, 1, 1),
+                agent: None,
+                subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions]
+                    .into_iter()
+                    .collect(),
+            },
+            None,
+        )
+        .await;
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(!peer_manager.peerdb.is_active_peer(&peer_id));
 
     // valid connection
     let address = B::new();
-    let res = peer_manager.accept_inbound_connection(
-        address.clone(),
-        net::types::PeerInfo::<S::PeerId> {
-            peer_id,
-            network: *config.magic_bytes(),
-            version: SemVer::new(0, 1, 0),
-            agent: None,
-            subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions].into_iter().collect(),
-        },
-        None,
-    );
+    let res = peer_manager
+        .accept_inbound_connection(
+            address.clone(),
+            net::types::PeerInfo::<S::PeerId> {
+                peer_id,
+                network: *config.magic_bytes(),
+                version: SemVer::new(0, 1, 0),
+                agent: None,
+                subscriptions: [PubSubTopic::Blocks, PubSubTopic::Transactions]
+                    .into_iter()
+                    .collect(),
+            },
+            None,
+        )
+        .await;
     assert!(res.is_ok());
     assert_eq!(peer_manager.handle_result(Some(peer_id), res).await, Ok(()));
     assert!(peer_manager.peerdb.is_active_peer(&peer_id));

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use crate::{
     net::types::Role,
     testing_utils::{
-        connect_services, filter_connectivity_event, RandomAddressMaker, TestChannelAddressMaker,
+        connect_services, get_connectivity_event, RandomAddressMaker, TestChannelAddressMaker,
         TestTcpAddressMaker, TestTransportChannel, TestTransportMaker, TestTransportNoise,
         TestTransportTcp,
     },
@@ -67,13 +67,7 @@ where
         .clone()
         .as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
-    let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(
-            event,
-            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
-        )
-    })
-    .await;
+    let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
     assert!(std::matches!(
         event,
         Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })
@@ -122,13 +116,7 @@ where
         .clone()
         .as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
-    let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(
-            event,
-            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
-        )
-    })
-    .await;
+    let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
     assert!(std::matches!(
         event,
         Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })
@@ -185,13 +173,7 @@ where
         .clone()
         .as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
-    let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(
-            event,
-            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
-        )
-    })
-    .await;
+    let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
     assert!(matches!(
         event,
         Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })
@@ -451,13 +433,7 @@ where
     // that tries to connect to the first manager
     tokio::spawn(async move { pm1.run().await });
 
-    let event = filter_connectivity_event::<T, _>(&mut pm2.peer_connectivity_handle, |event| {
-        !std::matches!(
-            event,
-            Ok(net::types::ConnectivityEvent::AddressDiscovered { .. })
-        )
-    })
-    .await;
+    let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
     if let Ok(net::types::ConnectivityEvent::ConnectionClosed { peer_id }) = event {
         assert_eq!(peer_id, peer_info.peer_id);
     } else {

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -260,7 +260,7 @@ where
     )
     .await;
     assert_eq!(
-        pm2.accept_inbound_connection(address, peer_info, None),
+        pm2.accept_inbound_connection(address, peer_info, None).await,
         Ok(())
     );
 }
@@ -315,7 +315,7 @@ where
     .await;
 
     assert_eq!(
-        pm2.accept_inbound_connection(address, peer_info, None),
+        pm2.accept_inbound_connection(address, peer_info, None).await,
         Err(P2pError::ProtocolError(ProtocolError::DifferentNetwork(
             [1, 2, 3, 4],
             *config::create_mainnet().magic_bytes(),

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -536,7 +536,7 @@ where
     pm1.peer_connectivity_handle.connect(addr2).await.expect("dial to succeed");
 
     match timeout(
-        *pm1._p2p_config.outbound_connection_timeout,
+        *pm1.p2p_config.outbound_connection_timeout,
         pm1.peer_connectivity_handle.poll_next(),
     )
     .await
@@ -693,6 +693,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
+        discover_private_ips: Default::default(),
     });
     let tx1 = run_peer_manager::<T>(
         A::make_transport(),

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -677,7 +677,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
-        discover_private_ips: Default::default(),
+        allow_discover_private_ips: Default::default(),
         heartbeat_interval_min: Default::default(),
         heartbeat_interval_max: Default::default(),
     });
@@ -703,7 +703,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
-        discover_private_ips: Default::default(),
+        allow_discover_private_ips: Default::default(),
         heartbeat_interval_min: Default::default(),
         heartbeat_interval_max: Default::default(),
     });
@@ -766,7 +766,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
-        discover_private_ips: true.into(),
+        allow_discover_private_ips: true.into(),
         heartbeat_interval_min: Duration::from_secs(1).into(),
         heartbeat_interval_max: Duration::from_secs(2).into(),
     });
@@ -792,7 +792,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
-        discover_private_ips: true.into(),
+        allow_discover_private_ips: true.into(),
         heartbeat_interval_min: Duration::from_secs(1).into(),
         heartbeat_interval_max: Duration::from_secs(2).into(),
     });
@@ -812,7 +812,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: Default::default(),
-        discover_private_ips: true.into(),
+        allow_discover_private_ips: true.into(),
         heartbeat_interval_min: Duration::from_secs(1).into(),
         heartbeat_interval_max: Duration::from_secs(2).into(),
     });

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -114,7 +114,7 @@ where
     let mut pm1 = make_peer_manager::<T>(A::make_transport(), addr1, Arc::clone(&config)).await;
     let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
-    let addr = pm2.peer_connectivity_handle.local_addresses().await.unwrap()[0].clone();
+    let addr = pm2.peer_connectivity_handle.local_addresses()[0].clone();
 
     tokio::spawn(async move {
         loop {

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -709,14 +709,12 @@ where
         let (rtx, rrx) = oneshot::channel();
         tx1.send(PeerManagerEvent::GetConnectedPeers(rtx)).unwrap();
         let connected_peers = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();
-        // The backend will also make reverse connection.
-        if connected_peers.len() == 1 || connected_peers.len() == 2 {
+        if connected_peers.len() == 1 {
             break;
         }
-        assert!(
-            Instant::now().duration_since(started_at) < Duration::from_secs(10),
-            "no peer connected on time"
-        );
+        if Instant::now().duration_since(started_at) > Duration::from_secs(10) {
+            panic!("Unexpected peer count: {}", connected_peers.len());
+        }
     }
 }
 

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -712,9 +712,11 @@ where
         if connected_peers.len() == 1 {
             break;
         }
-        if Instant::now().duration_since(started_at) > Duration::from_secs(10) {
-            panic!("Unexpected peer count: {}", connected_peers.len());
-        }
+        assert!(
+            Instant::now().duration_since(started_at) < Duration::from_secs(10),
+            "Unexpected peer count: {}",
+            connected_peers.len()
+        );
     }
 }
 

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -76,7 +76,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: NodeType::Full.into(),
-        discover_private_ips: Default::default(),
+        allow_discover_private_ips: Default::default(),
         heartbeat_interval_min: Default::default(),
         heartbeat_interval_max: Default::default(),
     });

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -77,6 +77,8 @@ where
         outbound_connection_timeout: Default::default(),
         node_type: NodeType::Full.into(),
         discover_private_ips: Default::default(),
+        heartbeat_interval_min: Default::default(),
+        heartbeat_interval_max: Default::default(),
     });
     let (conn, sync) = T::start(
         transport,

--- a/p2p/src/sync/tests/mod.rs
+++ b/p2p/src/sync/tests/mod.rs
@@ -76,6 +76,7 @@ where
         ban_duration: Default::default(),
         outbound_connection_timeout: Default::default(),
         node_type: NodeType::Full.into(),
+        discover_private_ips: Default::default(),
     });
     let (conn, sync) = T::start(
         transport,

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -152,10 +152,7 @@ where
     T: NetworkingService + Debug,
     T::ConnectivityHandle: ConnectivityService<T>,
 {
-    let addr = timeout(Duration::from_secs(5), conn2.local_addresses())
-        .await
-        .expect("local address fetch not to timeout")
-        .unwrap();
+    let addr = conn2.local_addresses();
     conn1.connect(addr[0].clone()).await.expect("dial to succeed");
 
     let (address, peer_info1) = match timeout(Duration::from_secs(5), conn2.poll_next()).await {

--- a/p2p/src/types/peer_address.rs
+++ b/p2p/src/types/peer_address.rs
@@ -35,7 +35,7 @@ pub struct PeerAddressIp6 {
 ///
 /// Same as std::net::SocketAddr for now but can be later extended with other address types.
 /// Use custom type to be able implement Encode and Decode.
-#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum PeerAddress {
     #[codec(index = 0)]
     Ip4(PeerAddressIp4),

--- a/p2p/src/types/peer_address.rs
+++ b/p2p/src/types/peer_address.rs
@@ -35,7 +35,7 @@ pub struct PeerAddressIp6 {
 ///
 /// Same as std::net::SocketAddr for now but can be later extended with other address types.
 /// Use custom type to be able implement Encode and Decode.
-#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, Hash)]
 pub enum PeerAddress {
     #[codec(index = 0)]
     Ip4(PeerAddressIp4),


### PR DESCRIPTION
This adds a basic peer discovery mechanism similar to Bitcoin's. When a node connects somewhere, it tries to load addresses from remote peers and also advertises its own discovered address. Such advertised addresses are relayed to random peers (two peers) and spread across the network this way.