### PR TITLE
Try to fix flaky `headers_not_in_order` test

### DIFF
--- a/p2p/src/sync/tests/header_response.rs
+++ b/p2p/src/sync/tests/header_response.rs
@@ -261,7 +261,7 @@ where
     let mut headers = p2p_test_utils::create_n_blocks(
         Arc::clone(&config),
         TestBlockInfo::from_genesis(config.genesis_block()),
-        rng.gen_range(5..100),
+        rng.gen_range(50..100),
     )
     .iter()
     .map(|block| block.header().clone())


### PR DESCRIPTION
The problem:
```
2023-01-25T13:49:55.3383457Z ---- sync::tests::header_response::headers_not_in_order_noise stderr ----
2023-01-25T13:49:55.3383961Z thread 'main' panicked at 'assertion failed: `(left == right)`
2023-01-25T13:49:55.3384883Z   left: `Ok(Some(BlockHeader { version: VersionTag(Tag), prev_block_id: Id<GenBlock>{0xcea94593e3b7268e7aeb98c6513618a650ad7805607c15fef8ad918a06bc9f8f}, tx_merkle_root: 0xcd32061838d262317b154193bc32620432c966837ca1b1fa8c3ace8be139e431, witness_merkle_root: 0x9c2d08edad5b79aba0cf7b1bb851ed493809ec9f199f8d57208eff2fe2e84061, timestamp: BlockTimestamp { timestamp: 1674654593 }, consensus_data: None }))`,
2023-01-25T13:49:55.3385899Z  right: `Err(ProtocolError(InvalidMessage))`', p2p/src/sync/tests/header_response.rs:271:5
2023-01-25T13:49:55.3386377Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2023-01-25T13:49:55.3386898Z failures:
2023-01-25T13:49:55.3387255Z     sync::tests::header_response::headers_not_in_order_noise
```

The test expects an error because the headers are out of order, but sometimes no error is reported.
I started the test in a loop, but I was unable to reproduce the problem without modifications.
However, it did reproduce fast enough when I replaced randomised `gen_range` with a fixed header height of 5 blocks.
```
    let mut headers = p2p_test_utils::create_n_blocks(
        Arc::clone(&config),
        TestBlockInfo::from_genesis(config.genesis_block()),
        rng.gen_range(5..100),
    )
    .iter()
    .map(|block| block.header().clone())
    .collect::<Vec<_>>();
    headers.shuffle(&mut rng);
```
So it looks like the probability of keeping a valid headers order is high enough to sometimes fail  (for example, when `gen_range` returns 5). Let's change range to 50..100.