### PR TITLE
Return Cow<[u8]> instead of &[u8] in storage abstraction layer

### DIFF
--- a/storage/backend-test-suite/src/basic.rs
+++ b/storage/backend-test-suite/src/basic.rs
@@ -27,7 +27,10 @@ fn put_and_commit<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
 
     // Check the modification did not happen
     let dbtx = store.transaction_ro().unwrap();
-    assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"world".as_ref())));
+    assert_eq!(
+        dbtx.get(IDX.0, b"hello").unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+        b"world".as_ref()
+    );
     drop(dbtx);
 }
 
@@ -56,8 +59,14 @@ fn put_two_under_different_keys<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>)
 
     // Check the values are in place
     let dbtx = store.transaction_ro().unwrap();
-    assert_eq!(dbtx.get(IDX.0, b"a"), Ok(Some(b"0".as_ref())));
-    assert_eq!(dbtx.get(IDX.0, b"b"), Ok(Some(b"1".as_ref())));
+    assert_eq!(
+        dbtx.get(IDX.0, b"a").unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+        b"0".as_ref()
+    );
+    assert_eq!(
+        dbtx.get(IDX.0, b"b").unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+        b"1".as_ref()
+    );
     drop(dbtx);
 
     // Create a transaction, modify storage and abort
@@ -68,8 +77,14 @@ fn put_two_under_different_keys<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>)
 
     // Check the modification did not happen
     let dbtx = store.transaction_ro().unwrap();
-    assert_eq!(dbtx.get(IDX.0, b"a"), Ok(Some(b"0".as_ref())));
-    assert_eq!(dbtx.get(IDX.0, b"b"), Ok(Some(b"1".as_ref())));
+    assert_eq!(
+        dbtx.get(IDX.0, b"a").unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+        b"0".as_ref()
+    );
+    assert_eq!(
+        dbtx.get(IDX.0, b"b").unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+        b"1".as_ref()
+    );
     drop(dbtx);
 }
 
@@ -78,13 +93,22 @@ fn put_twice_then_commit_read_last<B: Backend, F: BackendFn<B>>(backend_fn: Arc<
 
     let mut dbtx = store.transaction_rw().unwrap();
     dbtx.put(IDX.0, b"hello".to_vec(), b"a".to_vec()).unwrap();
-    assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"a".as_ref())),);
+    assert_eq!(
+        dbtx.get(IDX.0, b"hello").unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+        b"a".as_ref(),
+    );
     dbtx.put(IDX.0, b"hello".to_vec(), b"b".to_vec()).unwrap();
-    assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"b".as_ref())),);
+    assert_eq!(
+        dbtx.get(IDX.0, b"hello").unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+        b"b".as_ref(),
+    );
     dbtx.commit().expect("commit to succeed");
 
     let dbtx = store.transaction_ro().unwrap();
-    assert_eq!(dbtx.get(IDX.0, b"hello"), Ok(Some(b"b".as_ref())),);
+    assert_eq!(
+        dbtx.get(IDX.0, b"hello").unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+        b"b".as_ref(),
+    );
 }
 
 fn put_iterator_count_matches<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {

--- a/storage/backend-test-suite/src/property.rs
+++ b/storage/backend-test-suite/src/property.rs
@@ -146,14 +146,14 @@ fn add_and_delete<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
             // remove all entries
             let mut dbtx = store.transaction_rw().unwrap();
             for (db, key) in entries.keys() {
-                dbtx.del(*db, &key).unwrap();
+                dbtx.del(*db, key).unwrap();
             }
             dbtx.commit().unwrap();
 
             // Check entries no longer present
             let dbtx = store.transaction_ro().unwrap();
             for (db, key) in entries.keys() {
-                assert_eq!(dbtx.get(*db, &key), Ok(None));
+                assert_eq!(dbtx.get(*db, key), Ok(None));
             }
             drop(dbtx);
         },
@@ -213,7 +213,7 @@ fn add_and_delete_some<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
             for ent @ (db, key) in entries1.keys().chain(entries2.keys()).chain(extra_keys.iter()) {
                 let expected = entries2.get(ent).or_else(|| entries1.get(ent)).map(AsRef::as_ref);
                 assert_eq!(
-                    dbtx.get(*db, &key).unwrap().as_ref().map(|v| v.as_ref()),
+                    dbtx.get(*db, key).unwrap().as_ref().map(|v| v.as_ref()),
                     expected
                 );
             }
@@ -222,7 +222,7 @@ fn add_and_delete_some<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
             // remove entries from the second set
             let mut dbtx = store.transaction_rw().unwrap();
             for (db, key) in entries2.keys() {
-                dbtx.del(*db, &key).unwrap();
+                dbtx.del(*db, key).unwrap();
             }
             dbtx.commit().unwrap();
 
@@ -230,7 +230,7 @@ fn add_and_delete_some<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
 
             // Check entries from the second set are absent
             for (db, key) in entries2.keys() {
-                assert_eq!(dbtx.get(*db, &key), Ok(None));
+                assert_eq!(dbtx.get(*db, key), Ok(None));
             }
 
             // Check entries from the first set have correct value, unless deleted

--- a/storage/backend-test-suite/src/property.rs
+++ b/storage/backend-test-suite/src/property.rs
@@ -35,7 +35,7 @@ mod gen {
         proptest::collection::btree_map((idx(num_dbs), big_key()), any::<Data>(), num_entries)
     }
 
-    // Generate key from a set of keys with given cardianlity. Lower cardinality encourages
+    // Generate key from a set of keys with given cardinality. Lower cardinality encourages
     // generation of conflicting keys, causing value overwrites and deletions to be more likely.
     pub fn key(key_cardinality: u32) -> impl Strategy<Value = Data> {
         (0..key_cardinality).prop_map(|x| format!("{x:x}").into())
@@ -82,7 +82,10 @@ fn overwrite_and_abort<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
 
             // Check the values are in place
             let dbtx = store.transaction_ro().unwrap();
-            assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(Some(val0.as_ref())));
+            assert_eq!(
+                dbtx.get(IDX.0, key.as_ref()).unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+                val0.as_ref() as &[u8]
+            );
             drop(dbtx);
 
             // Create a transaction, modify storage and abort
@@ -92,7 +95,10 @@ fn overwrite_and_abort<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
 
             // Check the store still contains the original value
             let dbtx = store.transaction_ro().unwrap();
-            assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(Some(val0.as_ref())));
+            assert_eq!(
+                dbtx.get(IDX.0, key.as_ref()).unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+                val0.as_ref() as &[u8]
+            );
             drop(dbtx);
 
             // Create a transaction, overwrite the value and commit
@@ -102,7 +108,10 @@ fn overwrite_and_abort<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
 
             // Check the key now stores the new value
             let dbtx = store.transaction_ro().unwrap();
-            assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(Some(val1.as_ref())));
+            assert_eq!(
+                dbtx.get(IDX.0, key.as_ref()).unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+                val1.as_ref() as &[u8]
+            );
             drop(dbtx);
         },
     )
@@ -127,21 +136,24 @@ fn add_and_delete<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
             // check all entries have been added
             let dbtx = store.transaction_ro().unwrap();
             for ((db, key), val) in &entries {
-                assert_eq!(dbtx.get(*db, key), Ok(Some(val.as_ref())));
+                assert_eq!(
+                    dbtx.get(*db, key).unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+                    val.as_ref() as &[u8]
+                );
             }
             drop(dbtx);
 
             // remove all entries
             let mut dbtx = store.transaction_rw().unwrap();
             for (db, key) in entries.keys() {
-                dbtx.del(*db, key).unwrap();
+                dbtx.del(*db, &key).unwrap();
             }
             dbtx.commit().unwrap();
 
             // Check entries no longer present
             let dbtx = store.transaction_ro().unwrap();
             for (db, key) in entries.keys() {
-                assert_eq!(dbtx.get(*db, key), Ok(None));
+                assert_eq!(dbtx.get(*db, &key), Ok(None));
             }
             drop(dbtx);
         },
@@ -168,7 +180,10 @@ fn last_write_wins<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
             dbtx.commit().unwrap();
 
             let dbtx = store.transaction_ro().unwrap();
-            assert_eq!(dbtx.get(IDX.0, key.as_ref()), Ok(last.as_deref()));
+            assert_eq!(
+                dbtx.get(IDX.0, key.as_ref()).unwrap().as_ref().map(|v| v.as_ref()),
+                last.as_deref()
+            );
         },
     )
 }
@@ -197,14 +212,17 @@ fn add_and_delete_some<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
             let dbtx = store.transaction_ro().unwrap();
             for ent @ (db, key) in entries1.keys().chain(entries2.keys()).chain(extra_keys.iter()) {
                 let expected = entries2.get(ent).or_else(|| entries1.get(ent)).map(AsRef::as_ref);
-                assert_eq!(dbtx.get(*db, key), Ok(expected));
+                assert_eq!(
+                    dbtx.get(*db, &key).unwrap().as_ref().map(|v| v.as_ref()),
+                    expected
+                );
             }
             drop(dbtx);
 
             // remove entries from the second set
             let mut dbtx = store.transaction_rw().unwrap();
             for (db, key) in entries2.keys() {
-                dbtx.del(*db, key).unwrap();
+                dbtx.del(*db, &key).unwrap();
             }
             dbtx.commit().unwrap();
 
@@ -212,12 +230,15 @@ fn add_and_delete_some<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
 
             // Check entries from the second set are absent
             for (db, key) in entries2.keys() {
-                assert_eq!(dbtx.get(*db, key), Ok(None));
+                assert_eq!(dbtx.get(*db, &key), Ok(None));
             }
 
             // Check entries from the first set have correct value, unless deleted
             for ((db, key), val) in entries1.iter().filter(|e| !entries2.contains_key(e.0)) {
-                assert_eq!(dbtx.get(*db, key), Ok(Some(val.as_ref())));
+                assert_eq!(
+                    dbtx.get(*db, key).unwrap().as_ref().map(|v| v.as_ref()).unwrap(),
+                    val.as_ref() as &[u8]
+                );
             }
         },
     )
@@ -236,7 +257,7 @@ fn add_modify_abort_modify_commit<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F
             let model = Model::from_actions(to_prepopulate.clone());
             let store = backend.open(desc(1)).expect("db open to succeed");
 
-            // Pre-populate the db with initial data, check the contents agains the model
+            // Pre-populate the db with initial data, check the contents against the model
             let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, to_prepopulate.into_iter());
             dbtx.commit().unwrap();
@@ -276,7 +297,7 @@ fn add_modify_abort_replay_commit<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F
         |backend, (initial, actions)| {
             let store = backend.open(desc(1)).expect("db open to succeed");
 
-            // Pre-populate the db with initial data, check the contents agains the model
+            // Pre-populate the db with initial data, check the contents against the model
             let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, initial.into_iter());
             dbtx.commit().unwrap();
@@ -340,7 +361,10 @@ fn empty_after_abort<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>) {
             let mut dbtx = store.transaction_rw().unwrap();
             dbtx.apply_actions(IDX.0, actions.into_iter());
             for key in &keys {
-                assert_eq!(dbtx.get(IDX.0, key), Ok(model.get(key)));
+                assert_eq!(
+                    dbtx.get(IDX.0, key).unwrap().as_ref().map(|v| v.as_ref()),
+                    model.get(key)
+                );
             }
             drop(dbtx);
 

--- a/storage/core/src/backend.rs
+++ b/storage/core/src/backend.rs
@@ -15,6 +15,8 @@
 
 //! Low-level interface implemented by storage backends.
 
+use std::borrow::Cow;
+
 use utils::shallow_clone::ShallowClone;
 
 pub use crate::{
@@ -34,7 +36,7 @@ pub trait PrefixIter<'i> {
 /// Read-only database operations
 pub trait ReadOps: for<'i> PrefixIter<'i> {
     /// Get value associated with given key.
-    fn get(&self, idx: DbIndex, key: &[u8]) -> crate::Result<Option<&[u8]>>;
+    fn get(&self, idx: DbIndex, key: &[u8]) -> crate::Result<Option<Cow<[u8]>>>;
 }
 
 /// Write database operation

--- a/storage/inmemory/src/lib.rs
+++ b/storage/inmemory/src/lib.rs
@@ -15,7 +15,7 @@
 
 use storage_core::{adaptor, backend, util, Data, DbDesc, DbIndex};
 
-use std::collections::BTreeMap;
+use std::{borrow::Cow, collections::BTreeMap};
 
 type Map = BTreeMap<Data, Data>;
 
@@ -32,8 +32,8 @@ impl<'i> Iterator for PrefixIter<'i> {
 pub struct StorageMaps(Vec<Map>);
 
 impl backend::ReadOps for StorageMaps {
-    fn get(&self, idx: DbIndex, key: &[u8]) -> storage_core::Result<Option<&[u8]>> {
-        Ok(self.0[idx.get()].get(key).map(AsRef::as_ref))
+    fn get(&self, idx: DbIndex, key: &[u8]) -> storage_core::Result<Option<Cow<[u8]>>> {
+        Ok(self.0[idx.get()].get(key).map(|p| p[..].into()))
     }
 }
 

--- a/storage/inmemory/src/lib.rs
+++ b/storage/inmemory/src/lib.rs
@@ -33,7 +33,7 @@ pub struct StorageMaps(Vec<Map>);
 
 impl backend::ReadOps for StorageMaps {
     fn get(&self, idx: DbIndex, key: &[u8]) -> storage_core::Result<Option<Cow<[u8]>>> {
-        Ok(self.0[idx.get()].get(key).map(|p| p[..].into()))
+        Ok(self.0[idx.get()].get(key).map(|p| p.into()))
     }
 }
 

--- a/storage/lmdb/src/lib.rs
+++ b/storage/lmdb/src/lib.rs
@@ -18,7 +18,7 @@ mod remap;
 
 pub use remap::MemSize;
 
-use std::path::PathBuf;
+use std::{borrow::Cow, path::PathBuf};
 
 use lmdb::Cursor;
 use storage_core::{
@@ -93,10 +93,10 @@ impl<'s, 'i, Tx: lmdb::Transaction> backend::PrefixIter<'i> for DbTx<'s, Tx> {
 }
 
 impl<Tx: lmdb::Transaction> backend::ReadOps for DbTx<'_, Tx> {
-    fn get(&self, idx: DbIndex, key: &[u8]) -> storage_core::Result<Option<&[u8]>> {
+    fn get(&self, idx: DbIndex, key: &[u8]) -> storage_core::Result<Option<Cow<[u8]>>> {
         self.tx
             .get(self.dbs[idx], &key)
-            .map_or_else(error::process_with_none, |x| Ok(Some(x)))
+            .map_or_else(error::process_with_none, |x| Ok(Some(x.into())))
     }
 }
 

--- a/storage/src/database/internal.rs
+++ b/storage/src/database/internal.rs
@@ -39,6 +39,7 @@ impl<'tx, B: Backend, Sch> TxImpl for super::TransactionRw<'tx, B, Sch> {
 }
 
 /// Get a value from the database backend as a SCALE-encoded object
+#[allow(clippy::type_complexity)]
 pub fn get<DbMap: schema::DbMap, Tx: ReadOps, K: EncodeLike<DbMap::Key>>(
     dbtx: &Tx,
     idx: DbIndex,

--- a/storage/src/database/internal.rs
+++ b/storage/src/database/internal.rs
@@ -15,6 +15,8 @@
 
 //! Internal database implementation utils
 
+use std::borrow::Cow;
+
 use crate::schema;
 use serialization::{encoded::Encoded, EncodeLike};
 use storage_core::{
@@ -41,7 +43,7 @@ pub fn get<DbMap: schema::DbMap, Tx: ReadOps, K: EncodeLike<DbMap::Key>>(
     dbtx: &Tx,
     idx: DbIndex,
     key: K,
-) -> crate::Result<Option<Encoded<&[u8], DbMap::Value>>> {
+) -> crate::Result<Option<Encoded<Cow<[u8]>, DbMap::Value>>> {
     key.using_encoded(|key| dbtx.get(idx, key).map(|x| x.map(Encoded::from_bytes_unchecked)))
 }
 

--- a/storage/src/database/mod.rs
+++ b/storage/src/database/mod.rs
@@ -18,6 +18,8 @@
 mod internal;
 pub mod raw;
 
+use std::borrow::Cow;
+
 use internal::{EntryIterator, TxImpl};
 
 use crate::schema::{self, Schema};
@@ -159,7 +161,7 @@ where
     pub fn get<K: EncodeLike<DbMap::Key>>(
         &self,
         key: K,
-    ) -> crate::Result<Option<Encoded<&[u8], DbMap::Value>>> {
+    ) -> crate::Result<Option<Encoded<Cow<[u8]>, DbMap::Value>>> {
         internal::get::<DbMap, _, _>(self.dbtx, self.idx, key)
     }
 
@@ -212,7 +214,7 @@ where
     pub fn get<K: EncodeLike<DbMap::Key>>(
         &self,
         key: K,
-    ) -> crate::Result<Option<Encoded<&[u8], DbMap::Value>>> {
+    ) -> crate::Result<Option<Encoded<Cow<[u8]>, DbMap::Value>>> {
         internal::get::<DbMap, _, _>(self.dbtx, self.idx, key)
     }
 

--- a/storage/src/database/mod.rs
+++ b/storage/src/database/mod.rs
@@ -158,6 +158,7 @@ where
     Tx::Impl: backend::ReadOps,
 {
     /// Get value associated with given key
+    #[allow(clippy::type_complexity)]
     pub fn get<K: EncodeLike<DbMap::Key>>(
         &self,
         key: K,
@@ -211,6 +212,7 @@ where
     Tx::Impl: backend::ReadOps,
 {
     /// Get value associated with given key
+    #[allow(clippy::type_complexity)]
     pub fn get<K: EncodeLike<DbMap::Key>>(
         &self,
         key: K,


### PR DESCRIPTION
Generally speaking, it's not possible to get a slice of bytes from all storage backends with arbitrary lifetime. This is because this assumes that all the data is readily available for reading directly from the database. This is more of a wish.

In this PR we return `Cow<[u8]>` instead of `&[u8]` from the storage interface's get() function. 

Using an owned value would be the last resort if a storage layer does not provide solutions for getting values by reference.