### PR TITLE
Fix new clippy lints (rust 1.67)

### DIFF
--- a/common/src/primitives/amount.rs
+++ b/common/src/primitives/amount.rs
@@ -93,7 +93,7 @@ impl Amount {
             let unit = ten.pow(decimals as u32);
             let whole = self.val / unit;
             let fraction = self.val % unit;
-            let result = format!("{whole}.{fraction:00$}", decimals);
+            let result = format!("{whole}.{fraction:0decimals$}");
 
             remove_right_most_zeros_and_decimal_point(result)
         }

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -49,7 +49,7 @@ impl From<Uint256> for H256 {
 
 impl serde::Serialize for H256 {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_str(&format!("{:x}", self))
+        s.serialize_str(&format!("{self:x}"))
     }
 }
 

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -140,7 +140,6 @@ impl MempoolStore {
         spending_tx_id_for_error_msg: &Id<Transaction>,
         outpoint: &OutPoint,
     ) -> Result<Amount, TxValidationError> {
-        eprintln!("get_unconfirmed_outpoint_value: {outpoint:?}");
         let make_err = || TxValidationError::OutPointNotFound {
             outpoint: outpoint.clone(),
             spending_tx_id: *spending_tx_id_for_error_msg,

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -140,7 +140,7 @@ impl MempoolStore {
         spending_tx_id_for_error_msg: &Id<Transaction>,
         outpoint: &OutPoint,
     ) -> Result<Amount, TxValidationError> {
-        eprintln!("get_unconfirmed_outpoint_value: {:?}", outpoint);
+        eprintln!("get_unconfirmed_outpoint_value: {outpoint:?}");
         let make_err = || TxValidationError::OutPointNotFound {
             outpoint: outpoint.clone(),
             spending_tx_id: *spending_tx_id_for_error_msg,

--- a/mempool/src/pool/try_get_fee.rs
+++ b/mempool/src/pool/try_get_fee.rs
@@ -47,7 +47,7 @@ where
 
         let mut input_values = Vec::<Amount>::new();
         for (i, chainstate_input_value) in chainstate_input_values.iter().enumerate() {
-            eprintln!("chainstate input value {}: {:?}", i, chainstate_input_value);
+            eprintln!("chainstate input value {i}: {chainstate_input_value:?}");
             if let Some(value) = chainstate_input_value {
                 eprintln!("if");
                 input_values.push(*value)

--- a/mempool/src/pool/try_get_fee.rs
+++ b/mempool/src/pool/try_get_fee.rs
@@ -34,7 +34,6 @@ where
 {
     // TODO this calculation is already done in ChainState, reuse it
     async fn try_get_fee(&self, tx: &SignedTransaction) -> Result<Amount, TxValidationError> {
-        eprintln!("try_get_fee");
         let tx_clone = tx.clone();
 
         // Outputs in this vec are:
@@ -47,12 +46,9 @@ where
 
         let mut input_values = Vec::<Amount>::new();
         for (i, chainstate_input_value) in chainstate_input_values.iter().enumerate() {
-            eprintln!("chainstate input value {i}: {chainstate_input_value:?}");
             if let Some(value) = chainstate_input_value {
-                eprintln!("if");
                 input_values.push(*value)
             } else {
-                eprintln!("else");
                 let value = self.store.get_unconfirmed_outpoint_value(
                     &tx.transaction().get_id(),
                     tx.transaction().inputs().get(i).expect("index").outpoint(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -25,7 +25,7 @@ async fn run() -> anyhow::Result<()> {
 #[tokio::main]
 async fn main() {
     run().await.unwrap_or_else(|err| {
-        eprintln!("Mintlayer node launch failed: {:?}", err);
+        logging::log::error!("Mintlayer node launch failed: {err:?}");
         std::process::exit(1)
     })
 }

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -192,7 +192,7 @@ where
                 request_id: _,
                 response: SyncResponse::HeaderListResponse(_response),
             } => {}
-            msg => panic!("invalid message received: {:?}", msg),
+            msg => panic!("invalid message received: {msg:?}"),
         }
     }
 
@@ -310,7 +310,7 @@ where
                     .await
                     .unwrap();
             }
-            msg => panic!("invalid message received: {:?}", msg),
+            msg => panic!("invalid message received: {msg:?}"),
         }
     }
 
@@ -452,7 +452,7 @@ where
                     .await
                     .unwrap();
             }
-            msg => panic!("invalid message received: {:?}", msg),
+            msg => panic!("invalid message received: {msg:?}"),
         }
     }
 
@@ -596,7 +596,7 @@ where
                     .await
                     .unwrap();
             }
-            msg => panic!("invalid message received: {:?}", msg),
+            msg => panic!("invalid message received: {msg:?}"),
         }
     }
 
@@ -718,7 +718,7 @@ where
                 request_id: _,
                 response: SyncResponse::HeaderListResponse(_response),
             } => {}
-            msg => panic!("invalid message received: {:?}", msg),
+            msg => panic!("invalid message received: {msg:?}"),
         }
     }
     handle.await.unwrap();
@@ -857,7 +857,7 @@ where
                 request_id: _,
                 response: SyncResponse::HeaderListResponse(_response),
             } => {}
-            msg => panic!("invalid message received: {:?}", msg),
+            msg => panic!("invalid message received: {msg:?}"),
         }
     }
     handle.await.unwrap();
@@ -1004,7 +1004,7 @@ where
                 request_id: _,
                 response: SyncResponse::HeaderListResponse(_response),
             } => {}
-            msg => panic!("invalid message received: {:?}", msg),
+            msg => panic!("invalid message received: {msg:?}"),
         }
     }
     let (mgr1_handle, _) = handle.await.unwrap();
@@ -1132,7 +1132,7 @@ where
                 request_id: _,
                 response: SyncResponse::HeaderListResponse(_response),
             } => {}
-            msg => panic!("invalid message received: {:?}", msg),
+            msg => panic!("invalid message received: {msg:?}"),
         }
     }
 

--- a/script/src/opcodes.rs
+++ b/script/src/opcodes.rs
@@ -662,7 +662,7 @@ impl fmt::Debug for All {
             All { code: x } if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code => {
                 write!(f, "NOP{}", x - all::OP_NOP1.code + 1)
             }
-            All { code: x } => write!(f, "RETURN_{}", x),
+            All { code: x } => write!(f, "RETURN_{x}"),
         }
     }
 }

--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -80,7 +80,7 @@ impl fmt::Display for Script {
 impl fmt::LowerHex for Script {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for &ch in self.0.iter() {
-            write!(f, "{:02x}", ch)?;
+            write!(f, "{ch:02x}")?;
         }
         Ok(())
     }
@@ -89,7 +89,7 @@ impl fmt::LowerHex for Script {
 impl fmt::UpperHex for Script {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for &ch in self.0.iter() {
-            write!(f, "{:02X}", ch)?;
+            write!(f, "{ch:02x}")?;
         }
         Ok(())
     }
@@ -392,14 +392,14 @@ impl Script {
             if opcode == opcodes::all::OP_PUSHBYTES_0 {
                 f.write_str("OP_0")?;
             } else {
-                write!(f, "{:?}", opcode)?;
+                write!(f, "{opcode:?}")?;
             }
             // Write any pushdata
             if data_len > 0 {
                 f.write_str(" ")?;
                 if index + data_len <= script.len() {
                     for ch in &script[index..index + data_len] {
-                        write!(f, "{:02x}", ch)?;
+                        write!(f, "{ch:02x}")?;
                     }
                     index += data_len;
                 } else {

--- a/storage/backend-test-suite/src/basic.rs
+++ b/storage/backend-test-suite/src/basic.rs
@@ -158,7 +158,7 @@ fn put_and_iterate_over_prefixes<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>
         let dbtx = store.transaction_ro().unwrap();
         let vals: Vec<_> = dbtx.prefix_iter(IDX.0, prefix.clone()).unwrap().map(|x| x.1).collect();
         let expected: Vec<_> = range.map(|x| Data::from(x.to_string())).collect();
-        assert_eq!(vals, expected, "prefix={:?}", prefix);
+        assert_eq!(vals, expected, "prefix={prefix:?}");
         drop(dbtx);
     };
 

--- a/storage/backend-test-suite/src/prelude.rs
+++ b/storage/backend-test-suite/src/prelude.rs
@@ -34,7 +34,7 @@ pub const IDX: (DbIndex, DbIndex) = (DbIndex::new(0), DbIndex::new(1));
 
 /// Sample database description with `n` maps
 pub fn desc(n: usize) -> DbDesc {
-    (0..n).map(|x| MapDesc::new(format!("map_{:02}", x))).collect()
+    (0..n).map(|x| MapDesc::new(format!("map_{x:02}"))).collect()
 }
 
 /// Run tests with backend using proptest

--- a/storage/core/src/error.rs
+++ b/storage/core/src/error.rs
@@ -67,8 +67,8 @@ impl Error {
         match self {
             Self::Recoverable(e) => e,
             Self::Fatal(e) => {
-                logging::log::error!("Fatal database error: {}", e);
-                panic!("Fatal database error: {}", e)
+                logging::log::error!("Fatal database error: {e}");
+                panic!("Fatal database error: {e}")
             }
         }
     }

--- a/test-utils/src/test_dir.rs
+++ b/test-utils/src/test_dir.rs
@@ -112,7 +112,7 @@ impl TestRoot {
     pub fn fresh_test_dir(&self, name: impl AsRef<str>) -> TestDir {
         let seq_no = self.0.counter.fetch_add(1, Ordering::SeqCst);
         let name = name.as_ref().replace(['/', ':', '\\'], "_");
-        let path = self.0.path.join(format!("case_{:08x}_{}", seq_no, name));
+        let path = self.0.path.join(format!("case_{seq_no:08x}_{name}"));
         fs::create_dir(&path).expect("directory creation to succeed");
         TestDir { path }
     }


### PR DESCRIPTION
By the way, there is a bunch of `eprintln` in `mempool`. Should these be replaced by proper logging?