### PR TITLE
Fix clippy uninlined_format_args

### DIFF
--- a/chainstate/src/detail/orphan_blocks/pool.rs
+++ b/chainstate/src/detail/orphan_blocks/pool.rs
@@ -261,10 +261,7 @@ mod tests {
             if let Some(blocks) = orphans_pool.orphan_by_prev_id.get(&block.prev_block_id()) {
                 assert!(blocks.contains(&Arc::new(block.clone())))
             } else {
-                panic!(
-                    "the block {:#?} is not in `orphan_by_prev_id` field.",
-                    block
-                );
+                panic!("the block {block:#?} is not in `orphan_by_prev_id` field.");
             }
         }
 

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -541,7 +541,7 @@ fn get_ancestor(#[case] seed: Seed) {
             <Id<GenBlock>>::from(*tf.index_at(i as usize).block_id()),
             tf.chainstate
                 .get_ancestor(&split, i.into())
-                .unwrap_or_else(|_| panic!("Ancestor of height {} not reached", i))
+                .unwrap_or_else(|_| panic!("Ancestor of height {i} not reached"))
                 .block_id()
         );
     }

--- a/common/src/fixed_hash.rs
+++ b/common/src/fixed_hash.rs
@@ -708,20 +708,20 @@ mod test {
         fn check(hash: &str) {
             let h256 = H256::from_str(hash).expect("should not fail");
 
-            let debug = format!("{:?}", h256);
-            assert_eq!(debug, format!("0x{}", hash));
+            let debug = format!("{h256:?}");
+            assert_eq!(debug, format!("0x{hash}"));
 
-            let display = format!("{}", h256);
+            let display = format!("{h256}");
             let (_, last_value) = hash.split_at(hash.len() - 4);
             assert_eq!(display, format!("0x{}…{}", &hash[0..4], last_value));
 
-            let no_0x = format!("{:x}", h256);
+            let no_0x = format!("{h256:x}");
             assert_eq!(no_0x, hash.to_string());
 
-            let sharp = format!("{:#x}", h256);
+            let sharp = format!("{h256:#x}");
             assert_eq!(sharp, debug);
 
-            let upper_hex = format!("{:#010X}", h256);
+            let upper_hex = format!("{h256:#010X}");
             assert_eq!(upper_hex, format!("0X{}", hash.to_uppercase()));
         }
 

--- a/common/src/primitives/compact.rs
+++ b/common/src/primitives/compact.rs
@@ -124,7 +124,7 @@ mod tests {
         fn err_conversion(c: u32) {
             match Uint256::try_from(Compact(c)) {
                 Ok(v) => {
-                    panic!("conversion of {} should fail, not {:?}", c, v);
+                    panic!("conversion of {c} should fail, not {v:?}");
                 }
                 Err(e) => {
                     assert!(e.is_some())

--- a/common/src/primitives/encoding/tests.rs
+++ b/common/src/primitives/encoding/tests.rs
@@ -153,12 +153,12 @@ fn check_valid_addresses() {
                         assert_eq!(s.to_lowercase(), encoded.to_lowercase())
                     }
                     Err(e) => {
-                        panic!("Did not encode: {:?} Reason: {:?}", s, e)
+                        panic!("Did not encode: {s:?} Reason: {e:?}")
                     }
                 }
             }
             Err(e) => {
-                panic!("Did not decode: {:?} Reason: {:?}", s, e)
+                panic!("Did not decode: {s:?} Reason: {e:?}")
             }
         }
     });
@@ -209,11 +209,11 @@ fn check_invalid_addresses() {
                     assert_eq!(s.to_lowercase(), encoded.to_lowercase())
                 }
                 Err(e) => {
-                    panic!("Did not encode: {:?} Reason: {:?}", s, e)
+                    panic!("Did not encode: {s:?} Reason: {e:?}")
                 }
             },
             Err(e) => {
-                panic!("Did not decode: {:?} Reason: {:?}", s, e)
+                panic!("Did not decode: {s:?} Reason: {e:?}")
             }
         }
     });
@@ -234,11 +234,11 @@ fn check_valid_strings() {
                Ok(decoded) => {
                    match super::bech32m::base32_to_bech32m(decoded.hrp(), <&[bech32::u5]>::clone(&decoded.data())) {
                        Ok(encoded) => { assert_eq!(s.to_lowercase(), encoded.to_lowercase()) }
-                       Err(e) => { panic!("Did not encode: {:?} Reason: {:?}",s,e) }
+                       Err(e) => { panic!("Did not encode: {s:?} Reason: {e:?}") }
                    }
                }
                Err(e) => {
-                   panic!("Did not decode: {:?} Reason: {:?}", s, e)
+                   panic!("Did not decode: {s:?} Reason: {e:?}")
                }
            }
         });
@@ -274,7 +274,7 @@ fn check_invalid_strings() {
             ("tb1qgk665m2auw09rc7pqyf7aulcuhmatz9xqtr5mxew7zuysacaascqs9v0vn", Bech32Error::FailedChecksum)
         ).iter().for_each(|(s,b_err)| {
             match super::decode(*s) {
-                Ok(_) => { panic!("Should be invalid: {:?}", s) }
+                Ok(_) => { panic!("Should be invalid: {s:?}") }
                 Err(e) => { assert_eq!(*b_err,e) }
             }
         });

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -242,8 +242,8 @@ mod tests {
             let hash_value = H256::from_str(value).expect("nothing wrong");
             let uint_value = Uint256::from(hash_value);
 
-            let hash_str = format!("{:?}", hash_value);
-            let uint_str = format!("{:?}", uint_value);
+            let hash_str = format!("{hash_value:?}");
+            let uint_str = format!("{uint_value:?}");
             assert_eq!(hash_str, uint_str);
 
             // make sure the position of the bytes are the same.
@@ -281,7 +281,7 @@ mod tests {
             serde_test::assert_tokens(&hash, &[serde_test::Token::Str(hex)]);
             assert_eq!(
                 serde_json::to_value(hash).ok(),
-                Some(Value::String(format!("{:x}", hash)))
+                Some(Value::String(format!("{hash:x}")))
             );
         }
         SAMPLE_HASHES.iter().cloned().for_each(check)

--- a/common/src/uint/impls.rs
+++ b/common/src/uint/impls.rs
@@ -675,7 +675,7 @@ mod tests {
             0xFFFFFFFFFFFFFFFF,
         ]);
         assert_eq!(
-            format!("{:?}", max_val),
+            format!("{max_val:?}"),
             "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         );
     }

--- a/crypto/src/key/secp256k1/extended_keys.rs
+++ b/crypto/src/key/secp256k1/extended_keys.rs
@@ -262,11 +262,11 @@ mod test {
             assert_eq!(sk.chain_code, pk.chain_code);
             assert_eq!(
                 sk.encode().encode_hex::<String>(),
-                format!("{}{}", chaincode, secret)
+                format!("{chaincode}{secret}")
             );
             assert_eq!(
                 pk.encode().encode_hex::<String>(),
-                format!("{}{}", chaincode, public)
+                format!("{chaincode}{public}")
             );
         }
     }

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -480,8 +480,7 @@ async fn tx_spend_several_inputs<M: GetMemoryUsage + Send + Sync>(
 
     let available_for_spending = (input_value - fee).ok_or_else(|| {
         let msg = format!(
-            "tx_spend_several_inputs: input_value ({:?}) lower than fee ({:?})",
-            input_value, fee
+            "tx_spend_several_inputs: input_value ({input_value:?}) lower than fee ({fee:?})"
         );
         log::error!("{}", msg);
         anyhow::Error::msg(msg)
@@ -627,7 +626,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         .into_iter()
         .map(|i| {
             SignedTransaction::new(
-                Transaction::new(i, vec![], vec![], 0).unwrap_or_else(|_| panic!("tx {}", i)),
+                Transaction::new(i, vec![], vec![], 0).unwrap_or_else(|_| panic!("tx {i}")),
                 vec![],
             )
             .expect("invalid witness count")

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -846,11 +846,7 @@ where
 
         assert!(
             Instant::now().duration_since(started_at) < Duration::from_secs(10),
-            "Unexpected peer counts: {}, {}, {}, expected: {}",
-            connected_peers_1,
-            connected_peers_2,
-            connected_peers_3,
-            expected_count,
+            "Unexpected peer counts: {connected_peers_1}, {connected_peers_2}, {connected_peers_3}, expected: {expected_count}"
         );
     }
 }

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -151,9 +151,9 @@ where
                         .await
                         .unwrap();
                 }
-                _ => panic!("invalid event: {:?}", event),
+                _ => panic!("invalid event: {event:?}"),
             },
-            Err(_) => panic!("did not receive `Request` in time, iter {}", i),
+            Err(_) => panic!("did not receive `Request` in time, iter {i}"),
         }
     }
 
@@ -163,9 +163,9 @@ where
                 Ok(SyncingEvent::Response { request_id, .. }) => {
                     request_ids.remove(&request_id);
                 }
-                _ => panic!("invalid event: {:?}", event),
+                _ => panic!("invalid event: {event:?}"),
             },
-            Err(_) => panic!("did not receive `Response` in time, iter {}", i),
+            Err(_) => panic!("did not receive `Response` in time, iter {i}"),
         }
     }
 

--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -835,7 +835,7 @@ mod test {
             .push_opcode(opcodes::all::OP_CHECKSIG)
             .into_script();
         assert_eq!(
-            &format!("{:x}", script),
+            &format!("{script:x}"),
             "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac"
         );
     }
@@ -843,51 +843,51 @@ mod test {
     #[test]
     fn script_builder_verify() {
         let simple = Builder::new().push_verify().into_script();
-        assert_eq!(format!("{:x}", simple), "69");
+        assert_eq!(format!("{simple:x}"), "69");
         let simple2 = Builder::from(vec![]).push_verify().into_script();
-        assert_eq!(format!("{:x}", simple2), "69");
+        assert_eq!(format!("{simple2:x}"), "69");
 
         let nonverify = Builder::new().push_verify().push_verify().into_script();
-        assert_eq!(format!("{:x}", nonverify), "6969");
+        assert_eq!(format!("{nonverify:x}"), "6969");
         let nonverify2 = Builder::from(vec![0x69]).push_verify().into_script();
-        assert_eq!(format!("{:x}", nonverify2), "6969");
+        assert_eq!(format!("{nonverify2:x}"), "6969");
 
         let equal = Builder::new().push_opcode(opcodes::all::OP_EQUAL).push_verify().into_script();
-        assert_eq!(format!("{:x}", equal), "88");
+        assert_eq!(format!("{equal:x}"), "88");
         let equal2 = Builder::from(vec![0x87]).push_verify().into_script();
-        assert_eq!(format!("{:x}", equal2), "88");
+        assert_eq!(format!("{equal2:x}"), "88");
 
         let numequal = Builder::new()
             .push_opcode(opcodes::all::OP_NUMEQUAL)
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", numequal), "9d");
+        assert_eq!(format!("{numequal:x}"), "9d");
         let numequal2 = Builder::from(vec![0x9c]).push_verify().into_script();
-        assert_eq!(format!("{:x}", numequal2), "9d");
+        assert_eq!(format!("{numequal2:x}"), "9d");
 
         let checksig = Builder::new()
             .push_opcode(opcodes::all::OP_CHECKSIG)
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", checksig), "ad");
+        assert_eq!(format!("{checksig:x}"), "ad");
         let checksig2 = Builder::from(vec![0xac]).push_verify().into_script();
-        assert_eq!(format!("{:x}", checksig2), "ad");
+        assert_eq!(format!("{checksig2:x}"), "ad");
 
         let checkmultisig = Builder::new()
             .push_opcode(opcodes::all::OP_CHECKMULTISIG)
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", checkmultisig), "af");
+        assert_eq!(format!("{checkmultisig:x}"), "af");
         let checkmultisig2 = Builder::from(vec![0xae]).push_verify().into_script();
-        assert_eq!(format!("{:x}", checkmultisig2), "af");
+        assert_eq!(format!("{checkmultisig2:x}"), "af");
 
         let trick_slice = Builder::new()
             .push_slice(&[0xae]) // OP_CHECKMULTISIG
             .push_verify()
             .into_script();
-        assert_eq!(format!("{:x}", trick_slice), "01ae69");
+        assert_eq!(format!("{trick_slice:x}"), "01ae69");
         let trick_slice2 = Builder::from(vec![0x01, 0xae]).push_verify().into_script();
-        assert_eq!(format!("{:x}", trick_slice2), "01ae69");
+        assert_eq!(format!("{trick_slice2:x}"), "01ae69");
     }
 
     #[test]

--- a/script/src/test/mod.rs
+++ b/script/src/test/mod.rs
@@ -67,5 +67,5 @@ fn test_4opc_sequences() {
     }
 
     // Let the test fail if we have at least one mismatch.
-    assert!(fails == 0, "{} tests failed", fails);
+    assert!(fails == 0, "{fails} tests failed");
 }

--- a/test/runner/functional.rs
+++ b/test/runner/functional.rs
@@ -46,7 +46,7 @@ enum Error {
 
 impl std::fmt::Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -86,7 +86,7 @@ ENABLE_BITCOIND=true
         // Pass command-line arguments
         .arg(runner_path)
         .arg(format!("--configfile={}", config_file_path.display()))
-        .arg(format!("--tmpdirprefix={}", TEMP_DIR))
+        .arg(format!("--tmpdirprefix={TEMP_DIR}"))
         // Forward the rest of the arguments from this executable
         .args(runner_args)
         // Wait for exit status


### PR DESCRIPTION
For some reason our CI doesn't complain, but locally when I run `do_checks.sh` script I get a bunch of `clippy::uninlined_format_args` errors. 