### PR TITLE
Use unbounded channels in default p2p backend

### DIFF
--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -98,10 +98,9 @@ where
                 request_id,
                 SyncResponse::HeaderListResponse(HeaderListResponse::new(Vec::new())),
             )
-            .await
             .unwrap();
 
-        sync2.make_announcement(Announcement::Block(blocks[2].clone())).await.unwrap();
+        sync2.make_announcement(Announcement::Block(blocks[2].clone())).unwrap();
     });
 
     match rx_peer_manager.recv().await {

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -85,7 +85,6 @@ where
             )
             .unwrap(),
         ))
-        .await
         .unwrap();
 
     // Poll an event from the network for server2.
@@ -108,7 +107,6 @@ where
             )
             .unwrap(),
         ))
-        .await
         .unwrap();
 
     let block = match sync1.poll_next().await.unwrap() {
@@ -170,7 +168,6 @@ where
             )
             .unwrap(),
         ))
-        .await
         .unwrap();
 }
 
@@ -227,7 +224,7 @@ where
     let encoded_size = message.encode().len();
 
     assert_eq!(
-        sync1.make_announcement(message).await,
+        sync1.make_announcement(message),
         Err(P2pError::PublishError(PublishError::MessageTooLarge(
             encoded_size,
             ANNOUNCEMENT_MAX_SIZE

--- a/p2p/backend-test-suite/src/connect.rs
+++ b/p2p/backend-test-suite/src/connect.rs
@@ -101,7 +101,6 @@ where
     .unwrap();
 
     let conn_addr = service1.local_addresses().to_vec();
-    let (res1, res2) = tokio::join!(service1.poll_next(), service2.connect(conn_addr[0].clone()));
-    res1.unwrap();
-    res2.unwrap();
+    service2.connect(conn_addr[0].clone()).unwrap();
+    service1.poll_next().await.unwrap();
 }

--- a/p2p/backend-test-suite/src/sync.rs
+++ b/p2p/backend-test-suite/src/sync.rs
@@ -163,7 +163,6 @@ where
                         request_id,
                         SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
-                    .await
                     .unwrap()
             }
             SyncingEvent::Request {
@@ -184,7 +183,6 @@ where
                         request_id,
                         SyncResponse::BlockListResponse(BlockListResponse::new(blocks)),
                     )
-                    .await
                     .unwrap();
             }
             SyncingEvent::Response {
@@ -260,7 +258,6 @@ where
                         request_id,
                         SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
-                    .await
                     .unwrap()
             }
             SyncingEvent::Response {
@@ -282,7 +279,6 @@ where
                             peer_id,
                             SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                         )
-                        .await
                         .unwrap();
                 } else {
                     // all blocks have been downloaded
@@ -307,7 +303,6 @@ where
                         peer_id,
                         SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                     )
-                    .await
                     .unwrap();
             }
             msg => panic!("invalid message received: {msg:?}"),
@@ -385,7 +380,6 @@ where
                         request_id,
                         SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
-                    .await
                     .unwrap()
             }
             SyncingEvent::Request {
@@ -406,7 +400,6 @@ where
                         request_id,
                         SyncResponse::BlockListResponse(BlockListResponse::new(blocks)),
                     )
-                    .await
                     .unwrap();
             }
             SyncingEvent::Response {
@@ -428,7 +421,6 @@ where
                             peer_id,
                             SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                         )
-                        .await
                         .unwrap();
                 }
             }
@@ -449,7 +441,6 @@ where
                         peer_id,
                         SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                     )
-                    .await
                     .unwrap();
             }
             msg => panic!("invalid message received: {msg:?}"),
@@ -529,7 +520,6 @@ where
                         request_id,
                         SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
-                    .await
                     .unwrap()
             }
             SyncingEvent::Request {
@@ -550,7 +540,6 @@ where
                         request_id,
                         SyncResponse::BlockListResponse(BlockListResponse::new(blocks)),
                     )
-                    .await
                     .unwrap();
             }
             SyncingEvent::Response {
@@ -572,7 +561,6 @@ where
                             peer_id,
                             SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                         )
-                        .await
                         .unwrap();
                 }
             }
@@ -593,7 +581,6 @@ where
                         peer_id,
                         SyncRequest::BlockListRequest(BlockListRequest::new(vec![header])),
                     )
-                    .await
                     .unwrap();
             }
             msg => panic!("invalid message received: {msg:?}"),
@@ -688,9 +675,9 @@ where
                 let msg = SyncResponse::HeaderListResponse(HeaderListResponse::new(headers));
 
                 if dest_peer_id == peer_info21.peer_id {
-                    mgr2.handle_mut().send_response(request_id, msg).await.unwrap()
+                    mgr2.handle_mut().send_response(request_id, msg).unwrap()
                 } else {
-                    mgr3.handle_mut().send_response(request_id, msg).await.unwrap()
+                    mgr3.handle_mut().send_response(request_id, msg).unwrap()
                 }
             }
             SyncingEvent::Request {
@@ -708,9 +695,9 @@ where
                     .unwrap()]));
 
                 if dest_peer_id == peer_info21.peer_id {
-                    mgr2.handle_mut().send_response(request_id, msg).await.unwrap();
+                    mgr2.handle_mut().send_response(request_id, msg).unwrap();
                 } else {
-                    mgr3.handle_mut().send_response(request_id, msg).await.unwrap();
+                    mgr3.handle_mut().send_response(request_id, msg).unwrap();
                 }
             }
             SyncingEvent::Response {
@@ -827,9 +814,9 @@ where
                 let msg = SyncResponse::HeaderListResponse(HeaderListResponse::new(headers));
 
                 if dest_peer_id == peer_info21.peer_id {
-                    mgr2.handle_mut().send_response(request_id, msg).await.unwrap()
+                    mgr2.handle_mut().send_response(request_id, msg).unwrap()
                 } else {
-                    mgr3.handle_mut().send_response(request_id, msg).await.unwrap()
+                    mgr3.handle_mut().send_response(request_id, msg).unwrap()
                 }
             }
             SyncingEvent::Request {
@@ -847,9 +834,9 @@ where
                     .unwrap()]));
 
                 if dest_peer_id == peer_info21.peer_id {
-                    mgr2.handle_mut().send_response(request_id, msg).await.unwrap();
+                    mgr2.handle_mut().send_response(request_id, msg).unwrap();
                 } else {
-                    mgr3.handle_mut().send_response(request_id, msg).await.unwrap();
+                    mgr3.handle_mut().send_response(request_id, msg).unwrap();
                 }
             }
             SyncingEvent::Response {
@@ -964,9 +951,9 @@ where
                 let msg = SyncResponse::HeaderListResponse(HeaderListResponse::new(headers));
 
                 if dest_peer_id == peer_info21.peer_id {
-                    mgr2.handle_mut().send_response(request_id, msg).await.unwrap()
+                    mgr2.handle_mut().send_response(request_id, msg).unwrap()
                 } else {
-                    mgr3.handle_mut().send_response(request_id, msg).await.unwrap()
+                    mgr3.handle_mut().send_response(request_id, msg).unwrap()
                 }
 
                 if gethdr_received.insert(dest_peer_id) {
@@ -994,9 +981,9 @@ where
                     .unwrap()]));
 
                 if dest_peer_id == peer_info21.peer_id {
-                    mgr2.handle_mut().send_response(request_id, msg).await.unwrap();
+                    mgr2.handle_mut().send_response(request_id, msg).unwrap();
                 } else {
-                    mgr3.handle_mut().send_response(request_id, msg).await.unwrap();
+                    mgr3.handle_mut().send_response(request_id, msg).unwrap();
                 }
             }
             SyncingEvent::Response {
@@ -1061,7 +1048,7 @@ where
     assert!(!mgr1_handle.call(|c| c.is_initial_block_download()).await.unwrap().unwrap());
 
     mgr1.unregister_peer(peer_info2.peer_id);
-    assert_eq!(conn1.disconnect(peer_info2.peer_id).await, Ok(()));
+    assert_eq!(conn1.disconnect(peer_info2.peer_id), Ok(()));
 
     let event = get_connectivity_event::<N>(&mut conn2).await;
     assert!(std::matches!(
@@ -1103,7 +1090,6 @@ where
                         request_id,
                         SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
                     )
-                    .await
                     .unwrap()
             }
             SyncingEvent::Request {
@@ -1124,7 +1110,6 @@ where
                         request_id,
                         SyncResponse::BlockListResponse(BlockListResponse::new(blocks)),
                     )
-                    .await
                     .unwrap();
             }
             SyncingEvent::Response {
@@ -1267,12 +1252,10 @@ where
                 .await
                 .unwrap()
                 .unwrap();
-            mgr.handle_mut()
-                .send_response(
-                    request_id,
-                    SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
-                )
-                .await
+            mgr.handle_mut().send_response(
+                request_id,
+                SyncResponse::HeaderListResponse(HeaderListResponse::new(headers)),
+            )
         }
         _ => panic!("invalid message"),
     }

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -637,10 +637,7 @@ where
         // So the first future will return a closure that takes a reference to self and returns one more future.
 
         let backend_task: BackendTask<T> = match command {
-            Command::Connect { address, response } => {
-                // For now we always respond with success
-                response.send(Ok(())).map_err(|_| P2pError::ChannelClosed)?;
-
+            Command::Connect { address } => {
                 let connection_fut = timeout(
                     *self.p2p_config.outbound_connection_timeout,
                     self.transport.connect(address.clone()),
@@ -658,13 +655,9 @@ where
                 }
                 .boxed()
             }
-            Command::Disconnect { peer_id, response } => async move {
+            Command::Disconnect { peer_id } => async move {
                 boxed_cb(move |this: &mut Self| {
-                    async move {
-                        let res = this.disconnect_peer(&peer_id).await;
-                        response.send(res).map_err(|_| P2pError::ChannelClosed)
-                    }
-                    .boxed()
+                    async move { this.disconnect_peer(&peer_id).await }.boxed()
                 })
             }
             .boxed(),

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -407,7 +407,7 @@ where
                 // Handle peer events.
                 event = self.peer_chan.1.recv() => {
                     let (peer, event) = event.ok_or(P2pError::ChannelClosed)?;
-                    self.handle_peer_event(peer, event).await?;
+                    self.handle_peer_event(peer, event)?;
                 },
                 // Handle commands.
                 command = self.cmd_rx.recv() => {
@@ -512,7 +512,7 @@ where
         Ok(false)
     }
 
-    async fn handle_peer_event(&mut self, peer_id: PeerId, event: PeerEvent) -> crate::Result<()> {
+    fn handle_peer_event(&mut self, peer_id: PeerId, event: PeerEvent) -> crate::Result<()> {
         match event {
             PeerEvent::PeerInfoReceived {
                 network,
@@ -554,7 +554,7 @@ where
                     PeerRole::Inbound => {
                         self.conn_tx
                             .send(ConnectivityEvent::InboundAccepted {
-                                address: address.clone(),
+                                address,
                                 peer_info: PeerInfo {
                                     peer_id,
                                     network,
@@ -572,7 +572,7 @@ where
                 let _ = self.request_mgr.register_peer(peer_id);
             }
             PeerEvent::MessageReceived { message } => {
-                self.handle_message(peer_id, message).await?;
+                self.handle_message(peer_id, message)?;
             }
             PeerEvent::ConnectionClosed => {
                 self.pending.remove(&peer_id);
@@ -590,7 +590,7 @@ where
         Ok(())
     }
 
-    async fn handle_message(&mut self, peer_id: PeerId, message: Message) -> crate::Result<()> {
+    fn handle_message(&mut self, peer_id: PeerId, message: Message) -> crate::Result<()> {
         match message {
             Message::Handshake(_) => {
                 log::error!("peer {peer_id} sent handshaking message");

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -183,9 +183,7 @@ where
             .remove(peer_id)
             .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
 
-        peer.tx.send(Event::Disconnect).map_err(P2pError::from)?;
-
-        Ok(())
+        peer.tx.send(Event::Disconnect).map_err(P2pError::from)
     }
 
     /// Sends a request to the remote peer. Might fail if the peer is already disconnected.
@@ -201,9 +199,7 @@ where
             .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
 
         let request = self.request_mgr.make_request(request_id, request)?;
-        peer.tx.send(Event::SendMessage(request)).map_err(P2pError::from)?;
-
-        Ok(())
+        peer.tx.send(Event::SendMessage(request)).map_err(P2pError::from)
     }
 
     /// Send response to a request. Might fail if the peer is already disconnected.
@@ -224,9 +220,7 @@ where
             .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?
             .tx
             .send(Event::SendMessage(response))
-            .map_err(P2pError::from)?;
-
-        Ok(())
+            .map_err(P2pError::from)
     }
 
     /// Sends the announcement to all peers.

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -165,17 +165,13 @@ where
             address
         );
 
-        self.cmd_tx.send(types::Command::Connect { address })?;
-
-        Ok(())
+        self.cmd_tx.send(types::Command::Connect { address }).map_err(P2pError::from)
     }
 
     fn disconnect(&mut self, peer_id: S::PeerId) -> crate::Result<()> {
         log::debug!("close connection with remote, {peer_id}");
 
-        self.cmd_tx.send(types::Command::Disconnect { peer_id })?;
-
-        Ok(())
+        self.cmd_tx.send(types::Command::Disconnect { peer_id }).map_err(P2pError::from)
     }
 
     fn send_request(
@@ -199,11 +195,12 @@ where
         request_id: S::PeerRequestId,
         response: PeerManagerResponse,
     ) -> crate::Result<()> {
-        self.cmd_tx.send(types::Command::SendResponse {
-            request_id,
-            message: response.into(),
-        })?;
-        Ok(())
+        self.cmd_tx
+            .send(types::Command::SendResponse {
+                request_id,
+                message: response.into(),
+            })
+            .map_err(P2pError::from)
     }
 
     fn local_addresses(&self) -> &[S::Address] {
@@ -308,9 +305,9 @@ where
             message::Announcement::Block(_) => PubSubTopic::Blocks,
         };
 
-        self.cmd_tx.send(types::Command::AnnounceData { topic, message })?;
-
-        Ok(())
+        self.cmd_tx
+            .send(types::Command::AnnounceData { topic, message })
+            .map_err(P2pError::from)
     }
 
     async fn poll_next(&mut self) -> crate::Result<SyncingEvent<S>> {

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -23,7 +23,7 @@ pub mod types;
 use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 
 use logging::log;
 use serialization::Encode;
@@ -164,29 +164,17 @@ where
             address
         );
 
-        let (tx, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(types::Command::Connect {
-                address,
-                response: tx,
-            })
-            .await?;
+        self.cmd_tx.send(types::Command::Connect { address }).await?;
 
-        rx.await?
+        Ok(())
     }
 
     async fn disconnect(&mut self, peer_id: S::PeerId) -> crate::Result<()> {
         log::debug!("close connection with remote, {peer_id}");
 
-        let (tx, rx) = oneshot::channel();
-        self.cmd_tx
-            .send(types::Command::Disconnect {
-                peer_id,
-                response: tx,
-            })
-            .await?;
+        self.cmd_tx.send(types::Command::Disconnect { peer_id }).await?;
 
-        rx.await?
+        Ok(())
     }
 
     async fn send_request(

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -203,6 +203,9 @@ where
 
         loop {
             tokio::select! {
+                // Sending messages should have higher priority
+                biased;
+
                 event = self.rx.recv() => match event.ok_or(P2pError::ChannelClosed)? {
                     Event::Disconnect => return Ok(()),
                     Event::SendMessage(message) => self.socket.send(*message).await?,

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -20,8 +20,6 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use tokio::sync::oneshot;
-
 use common::primitives::semver::SemVer;
 use serialization::{Decode, Encode};
 
@@ -39,11 +37,9 @@ use crate::{
 pub enum Command<T: TransportSocket> {
     Connect {
         address: T::Address,
-        response: oneshot::Sender<crate::Result<()>>,
     },
     Disconnect {
         peer_id: PeerId,
-        response: oneshot::Sender<crate::Result<()>>,
     },
     SendRequest {
         peer_id: PeerId,

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -108,20 +108,20 @@ where
     ///
     /// # Arguments
     /// `address` - socket address of the peer
-    async fn connect(&mut self, address: T::Address) -> crate::Result<()>;
+    fn connect(&mut self, address: T::Address) -> crate::Result<()>;
 
     /// Disconnect active connection
     ///
     /// # Arguments
     /// `peer_id` - Peer ID of the remote node
-    async fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()>;
+    fn disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()>;
 
     /// Send PeerManager's request to remote
     ///
     /// # Arguments
     /// * `peer_id` - Unique ID of the peer the request is sent to
     /// * `request` - Request to be sent
-    async fn send_request(
+    fn send_request(
         &mut self,
         peer_id: T::PeerId,
         request: PeerManagerRequest,
@@ -132,7 +132,7 @@ where
     /// # Arguments
     /// * `request_id` - ID of the request this is a response to
     /// * `response` - Response to be sent
-    async fn send_response(
+    fn send_response(
         &mut self,
         request_id: T::PeerRequestId,
         response: PeerManagerResponse,
@@ -162,7 +162,7 @@ where
     /// # Arguments
     /// * `peer_id` - Unique ID of the peer the request is sent to
     /// * `request` - Request to be sent
-    async fn send_request(
+    fn send_request(
         &mut self,
         peer_id: T::PeerId,
         request: SyncRequest,
@@ -173,14 +173,14 @@ where
     /// # Arguments
     /// * `request_id` - ID of the request this is a response to
     /// * `response` - Response to be sent
-    async fn send_response(
+    fn send_response(
         &mut self,
         request_id: T::PeerRequestId,
         response: SyncResponse,
     ) -> crate::Result<()>;
 
     /// Publishes an announcement on the network.
-    async fn make_announcement(&mut self, announcement: Announcement) -> crate::Result<()>;
+    fn make_announcement(&mut self, announcement: Announcement) -> crate::Result<()>;
 
     /// Poll syncing-related event from the networking service
     async fn poll_next(&mut self) -> crate::Result<types::SyncingEvent<T>>;

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -182,7 +182,7 @@ where
     /// *receiver_address* is this host socket address as seen and reported by remote peer.
     /// This should work for hosts with public IPs and for hosts behind NAT with port forwarding (same port is assumed).
     /// This won't work for majority of nodes but that should be accepted.
-    async fn handle_outbound_receiver_address(
+    fn handle_outbound_receiver_address(
         &mut self,
         peer_id: T::PeerId,
         receiver_address: PeerAddress,
@@ -218,27 +218,25 @@ where
             .collect::<Vec<_>>();
 
         for address in discovered_own_addresses {
-            self.send_announced_address(peer_id, address).await?;
+            self.send_announced_address(peer_id, address)?;
         }
 
         Ok(())
     }
 
-    async fn send_announced_address(
+    fn send_announced_address(
         &mut self,
         peer_id: T::PeerId,
         address: T::Address,
     ) -> crate::Result<()> {
         let peer_addresses = self.announced_addresses.entry(peer_id).or_default();
         if !peer_addresses.contains(&address) {
-            self.peer_connectivity_handle
-                .send_request(
-                    peer_id,
-                    PeerManagerRequest::AnnounceAddrRequest(AnnounceAddrRequest {
-                        address: address.as_peer_address(),
-                    }),
-                )
-                .await?;
+            self.peer_connectivity_handle.send_request(
+                peer_id,
+                PeerManagerRequest::AnnounceAddrRequest(AnnounceAddrRequest {
+                    address: address.as_peer_address(),
+                }),
+            )?;
             peer_addresses.insert(address);
         }
         Ok(())
@@ -249,7 +247,7 @@ where
     /// The event is received from the networking backend and it's either a result of an incoming
     /// connection from a remote peer or a response to an outbound connection that was initiated
     /// by the node as result of the peer manager maintenance.
-    async fn accept_connection(
+    fn accept_connection(
         &mut self,
         address: T::Address,
         role: Role,
@@ -282,16 +280,14 @@ where
         );
 
         if let (Some(receiver_address), Role::Outbound) = (receiver_address, role) {
-            self.handle_outbound_receiver_address(peer_id, receiver_address).await?;
+            self.handle_outbound_receiver_address(peer_id, receiver_address)?;
         }
 
         if role == Role::Outbound {
-            self.peer_connectivity_handle
-                .send_request(
-                    peer_id,
-                    PeerManagerRequest::AddrListRequest(AddrListRequest {}),
-                )
-                .await?;
+            self.peer_connectivity_handle.send_request(
+                peer_id,
+                PeerManagerRequest::AddrListRequest(AddrListRequest {}),
+            )?;
         }
 
         log::info!(
@@ -326,7 +322,7 @@ where
     /// This function verifies that neither address the nor the peer ID are on the
     /// list of banned IPs/peer IDs. It also checks that the maximum number of
     /// connections `PeerManager` is configured to have has not been reached.
-    async fn accept_inbound_connection(
+    fn accept_inbound_connection(
         &mut self,
         address: T::Address,
         info: net::types::PeerInfo<T::PeerId>,
@@ -353,7 +349,7 @@ where
             return Err(P2pError::PeerError(PeerError::TooManyPeers));
         }
 
-        self.accept_connection(address, Role::Inbound, info, receiver_address).await
+        self.accept_connection(address, Role::Inbound, info, receiver_address)
     }
 
     /// The connection to a remote peer is reported as closed.
@@ -391,7 +387,7 @@ where
     ///
     /// If peer is banned, it is removed from the connected peers
     /// and its address is marked as banned.
-    async fn adjust_peer_score(&mut self, peer_id: T::PeerId, score: u32) -> crate::Result<()> {
+    fn adjust_peer_score(&mut self, peer_id: T::PeerId, score: u32) -> crate::Result<()> {
         log::debug!("adjusting score for peer {peer_id}, adjustment {score}");
 
         let peer = match self.peers.get_mut(&peer_id) {
@@ -403,7 +399,7 @@ where
 
         if peer.score >= *self.p2p_config.ban_threshold {
             self.peerdb.ban_peer(&peer.address)?;
-            self.disconnect(peer_id, None).await?;
+            self.disconnect(peer_id, None)?;
         }
 
         Ok(())
@@ -431,7 +427,7 @@ where
     /// This function doesn't block on the call but sends a command to the
     /// networking backend which then reports at some point in the future
     /// whether the connection failed or succeeded.
-    async fn try_connect(&mut self, address: T::Address) -> crate::Result<()> {
+    fn try_connect(&mut self, address: T::Address) -> crate::Result<()> {
         ensure!(
             !self.pending_connects.contains_key(&address),
             P2pError::PeerError(PeerError::Pending(address.to_string())),
@@ -448,18 +444,18 @@ where
             P2pError::PeerError(PeerError::BannedAddress(address.to_string())),
         );
 
-        self.peer_connectivity_handle.connect(address).await
+        self.peer_connectivity_handle.connect(address)
     }
 
     /// Establish an outbound connection
-    async fn connect(
+    fn connect(
         &mut self,
         address: T::Address,
         response: Option<oneshot::Sender<crate::Result<()>>>,
     ) -> crate::Result<()> {
         log::debug!("try to establish outbound connection to peer at address {address:?}");
 
-        let res = self.try_connect(address.clone()).await;
+        let res = self.try_connect(address.clone());
 
         match res {
             Ok(()) => {
@@ -475,7 +471,7 @@ where
         Ok(())
     }
 
-    async fn try_disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()> {
+    fn try_disconnect(&mut self, peer_id: T::PeerId) -> crate::Result<()> {
         ensure!(
             !self.pending_disconnects.contains_key(&peer_id),
             P2pError::PeerError(PeerError::Pending(peer_id.to_string())),
@@ -486,7 +482,7 @@ where
             P2pError::PeerError(PeerError::PeerDisconnected),
         );
 
-        self.peer_connectivity_handle.disconnect(peer_id).await
+        self.peer_connectivity_handle.disconnect(peer_id)
     }
 
     /// Disconnect an existing connection (inbound or outbound)
@@ -494,14 +490,14 @@ where
     /// The decision to close the connection is made either by the user via RPC
     /// or by the [`PeerManager::heartbeat()`] function which has decided to cull
     /// this connection in favor of another potential connection.
-    async fn disconnect(
+    fn disconnect(
         &mut self,
         peer_id: T::PeerId,
         response: Option<oneshot::Sender<crate::Result<()>>>,
     ) -> crate::Result<()> {
         log::debug!("disconnect peer {peer_id}");
 
-        let res = self.try_disconnect(peer_id).await;
+        let res = self.try_disconnect(peer_id);
 
         match res {
             Ok(()) => {
@@ -538,7 +534,7 @@ where
     /// the number of desired connections and there are available peers, the function tries to
     /// establish new connections. After that it updates the peer scores and discards any records
     /// that no longer need to be stored.
-    async fn heartbeat(&mut self) -> crate::Result<()> {
+    fn heartbeat(&mut self) -> crate::Result<()> {
         let count = std::cmp::min(
             self.peerdb.available_addresses_count(),
             MAX_ACTIVE_CONNECTIONS
@@ -549,7 +545,7 @@ where
         let addresses = self.peerdb.random_known_addresses(count);
 
         for address in addresses {
-            self.connect(address, None).await?;
+            self.connect(address, None)?;
         }
 
         // TODO: update peer scores
@@ -557,7 +553,7 @@ where
         Ok(())
     }
 
-    async fn handle_incoming_request(
+    fn handle_incoming_request(
         &mut self,
         peer_id: T::PeerId,
         request_id: T::PeerRequestId,
@@ -573,12 +569,10 @@ where
                     .filter(|address| self.is_peer_address_valid(address))
                     .collect();
 
-                self.peer_connectivity_handle
-                    .send_response(
-                        request_id,
-                        PeerManagerResponse::AddrListResponse(AddrListResponse { addresses }),
-                    )
-                    .await
+                self.peer_connectivity_handle.send_response(
+                    request_id,
+                    PeerManagerResponse::AddrListResponse(AddrListResponse { addresses }),
+                )
             }
             PeerManagerRequest::AnnounceAddrRequest(AnnounceAddrRequest { address }) => {
                 // TODO: Rate limit announce address requests to prevent DoS attacks.
@@ -594,18 +588,16 @@ where
 
                     let peer_ids = self.random_peer_ids(ANNOUNCED_RESEND_COUNT);
                     for new_peer_id in peer_ids {
-                        self.send_announced_address(new_peer_id, address.clone()).await?;
+                        self.send_announced_address(new_peer_id, address.clone())?;
                     }
                 }
                 Ok(())
             }
             PeerManagerRequest::PingRequest(PingRequest { nonce }) => {
-                self.peer_connectivity_handle
-                    .send_response(
-                        request_id,
-                        PeerManagerResponse::PingResponse(PingResponse { nonce }),
-                    )
-                    .await
+                self.peer_connectivity_handle.send_response(
+                    request_id,
+                    PeerManagerResponse::PingResponse(PingResponse { nonce }),
+                )
             }
         }
     }
@@ -654,7 +646,7 @@ where
     /// # Arguments
     /// `peer_id` - peer ID of the remote peer, if available
     /// `result` - result of the operation that was performed
-    pub async fn handle_result(
+    pub fn handle_result(
         &mut self,
         peer_id: Option<T::PeerId>,
         result: crate::Result<()>,
@@ -670,7 +662,7 @@ where
 
                 if let Some(peer_id) = peer_id {
                     log::info!("adjust peer score for peer {peer_id}, reason {err}");
-                    return self.adjust_peer_score(peer_id, err.ban_score()).await;
+                    return self.adjust_peer_score(peer_id, err.ban_score());
                 }
 
                 Ok(())
@@ -681,19 +673,19 @@ where
     /// Handle control event.
     ///
     /// Handle events from an outside controller (rpc, for example) that sets/gets values for PeerManager
-    async fn handle_control_event(&mut self, event: PeerManagerEvent<T>) -> crate::Result<()> {
+    fn handle_control_event(&mut self, event: PeerManagerEvent<T>) -> crate::Result<()> {
         match event {
             PeerManagerEvent::Connect(address, response) => {
-                self.connect(address, Some(response)).await?;
+                self.connect(address, Some(response))?;
             }
             PeerManagerEvent::Disconnect(peer_id, response) => {
-                self.disconnect(peer_id, Some(response)).await?;
+                self.disconnect(peer_id, Some(response))?;
             }
             PeerManagerEvent::AdjustPeerScore(peer_id, score, response) => {
                 log::debug!("adjust peer {peer_id} score: {score}");
 
                 response
-                    .send(self.adjust_peer_score(peer_id, score).await)
+                    .send(self.adjust_peer_score(peer_id, score))
                     .map_err(|_| P2pError::ChannelClosed)?;
             }
             PeerManagerEvent::GetPeerCount(response) => {
@@ -718,7 +710,7 @@ where
     }
 
     /// Handle connectivity event.
-    async fn handle_connectivity_event_result(
+    fn handle_connectivity_event_result(
         &mut self,
         event_res: crate::Result<ConnectivityEvent<T>>,
     ) -> crate::Result<()> {
@@ -729,7 +721,7 @@ where
                     request_id,
                     request,
                 } => {
-                    self.handle_incoming_request(peer_id, request_id, request).await?;
+                    self.handle_incoming_request(peer_id, request_id, request)?;
                 }
                 net::types::ConnectivityEvent::Response {
                     peer_id,
@@ -745,17 +737,16 @@ where
                 } => {
                     let peer_id = peer_info.peer_id;
 
-                    match self.accept_inbound_connection(address, peer_info, receiver_address).await
-                    {
+                    match self.accept_inbound_connection(address, peer_info, receiver_address) {
                         Ok(_) => {}
                         Err(P2pError::ChannelClosed) => return Err(P2pError::ChannelClosed),
                         Err(P2pError::PeerError(err)) => {
                             log::warn!("peer error for peer {peer_id}: {err}");
-                            self.peer_connectivity_handle.disconnect(peer_id).await?;
+                            self.peer_connectivity_handle.disconnect(peer_id)?;
                         }
                         Err(P2pError::ProtocolError(err)) => {
                             log::warn!("peer error for peer {peer_id}: {err}");
-                            self.adjust_peer_score(peer_id, err.ban_score()).await?;
+                            self.adjust_peer_score(peer_id, err.ban_score())?;
                         }
                         Err(err) => {
                             log::error!("unknown error for peer {peer_id}: {err}");
@@ -768,15 +759,13 @@ where
                     receiver_address,
                 } => {
                     let peer_id = peer_info.peer_id;
-                    let res = self
-                        .accept_connection(
-                            address.clone(),
-                            Role::Outbound,
-                            peer_info,
-                            receiver_address,
-                        )
-                        .await;
-                    self.handle_result(Some(peer_id), res).await?;
+                    let res = self.accept_connection(
+                        address.clone(),
+                        Role::Outbound,
+                        peer_info,
+                        receiver_address,
+                    );
+                    self.handle_result(Some(peer_id), res)?;
 
                     match self.pending_connects.remove(&address) {
                         Some(Some(channel)) => {
@@ -788,20 +777,20 @@ where
                 }
                 net::types::ConnectivityEvent::ConnectionClosed { peer_id } => {
                     let res = self.connection_closed(peer_id);
-                    self.handle_result(Some(peer_id), res).await?;
+                    self.handle_result(Some(peer_id), res)?;
                 }
                 net::types::ConnectivityEvent::ConnectionError { address, error } => {
                     let res = self.handle_outbound_error(address, error);
-                    self.handle_result(None, res).await?;
+                    self.handle_result(None, res)?;
                 }
                 net::types::ConnectivityEvent::Misbehaved { peer_id, error } => {
-                    let res = self.adjust_peer_score(peer_id, error.ban_score()).await;
-                    self.handle_result(Some(peer_id), res).await?;
+                    let res = self.adjust_peer_score(peer_id, error.ban_score());
+                    self.handle_result(Some(peer_id), res)?;
                 }
             },
             Err(err) => {
                 log::error!("failed to read network event: {err:?}");
-                self.handle_result(None, Err(err)).await?;
+                self.handle_result(None, Err(err))?;
             }
         }
 
@@ -837,7 +826,7 @@ where
     }
 
     /// Sends ping requests and disconnects peers that do not respond in time
-    async fn ping_check(&mut self) -> crate::Result<()> {
+    fn ping_check(&mut self) -> crate::Result<()> {
         let now = Instant::now();
         let mut dead_peers = Vec::new();
         for (peer_id, peer) in self.peers.iter_mut() {
@@ -853,12 +842,10 @@ where
                 }
                 None => {
                     let nonce = make_pseudo_rng().gen();
-                    self.peer_connectivity_handle
-                        .send_request(
-                            *peer_id,
-                            PeerManagerRequest::PingRequest(PingRequest { nonce }),
-                        )
-                        .await?;
+                    self.peer_connectivity_handle.send_request(
+                        *peer_id,
+                        PeerManagerRequest::PingRequest(PingRequest { nonce }),
+                    )?;
                     peer.sent_ping = Some(SentPing {
                         nonce,
                         timestamp: now,
@@ -868,7 +855,7 @@ where
         }
 
         for peer_id in dead_peers {
-            self.disconnect(peer_id, None).await?;
+            self.disconnect(peer_id, None)?;
         }
 
         Ok(())
@@ -901,13 +888,13 @@ where
         loop {
             tokio::select! {
                 event = self.rx_peer_manager.recv() => {
-                    self.handle_control_event(event.ok_or(P2pError::ChannelClosed)?).await?;
+                    self.handle_control_event(event.ok_or(P2pError::ChannelClosed)?)?;
                 },
                 event_res = self.peer_connectivity_handle.poll_next() => {
-                    self.handle_connectivity_event_result(event_res).await?;
+                    self.handle_connectivity_event_result(event_res)?;
                 },
                 _event = ping_check_interval.tick(), if ping_check_enabled => {
-                    self.ping_check().await?;
+                    self.ping_check()?;
                 }
                 _event = tokio::time::sleep(PEER_MGR_HEARTBEAT_INTERVAL_MAX) => {}
             }
@@ -915,7 +902,7 @@ where
             // finally update peer manager state
             let now = tokio::time::Instant::now();
             if now.duration_since(self.last_heartbeat) > PEER_MGR_HEARTBEAT_INTERVAL_MIN {
-                self.heartbeat().await?;
+                self.heartbeat()?;
                 self.last_heartbeat = now;
             }
         }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -823,7 +823,7 @@ where
     /// It can be used to distribute data in the gossip protocol
     /// (for example, to relay announced addresses to a small group of peers).
     pub fn random_peer_ids(&self, count: usize) -> Vec<T::PeerId> {
-        // TODO: Optimise this
+        // TODO: Optimize this
         let all_peer_ids = self.peers.keys().cloned().collect::<Vec<_>>();
         all_peer_ids
             .choose_multiple(&mut make_pseudo_rng(), count)

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -60,7 +60,7 @@ async fn test_peer_manager_connect<T: NetworkingService>(
     let config = Arc::new(config::create_mainnet());
     let mut peer_manager = make_peer_manager::<T>(transport, bind_addr, config).await;
 
-    peer_manager.try_connect(remote_addr).await.unwrap();
+    peer_manager.try_connect(remote_addr).unwrap();
 
     assert!(matches!(
         peer_manager.peer_connectivity_handle.poll_next().await,
@@ -124,7 +124,7 @@ where
 
     // "discover" the other networking service
     pm1.peerdb.peer_discovered(&addr).unwrap();
-    pm1.heartbeat().await.unwrap();
+    pm1.heartbeat().unwrap();
 
     assert_eq!(pm1.pending_connects.len(), 1);
     assert!(std::matches!(
@@ -260,7 +260,7 @@ where
     )
     .await;
     assert_eq!(
-        pm2.accept_inbound_connection(address, peer_info, None).await,
+        pm2.accept_inbound_connection(address, peer_info, None),
         Ok(())
     );
 }
@@ -315,7 +315,7 @@ where
     .await;
 
     assert_eq!(
-        pm2.accept_inbound_connection(address, peer_info, None).await,
+        pm2.accept_inbound_connection(address, peer_info, None),
         Err(P2pError::ProtocolError(ProtocolError::DifferentNetwork(
             [1, 2, 3, 4],
             *config::create_mainnet().magic_bytes(),
@@ -379,7 +379,7 @@ where
     .await;
 
     assert_eq!(
-        pm2.peer_connectivity_handle.disconnect(peer_info.peer_id).await,
+        pm2.peer_connectivity_handle.disconnect(peer_info.peer_id),
         Ok(())
     );
     assert!(std::matches!(
@@ -419,7 +419,7 @@ where
     let mut pm2 = make_peer_manager::<T>(A::make_transport(), addr2, Arc::clone(&config)).await;
 
     for peer in peers.into_iter() {
-        pm1.accept_connection(peer.0, Role::Inbound, peer.1, None).await.unwrap();
+        pm1.accept_connection(peer.0, Role::Inbound, peer.1, None).unwrap();
     }
     assert_eq!(
         pm1.active_peer_count(),
@@ -533,7 +533,7 @@ where
     let config = Arc::new(config::create_mainnet());
     let mut pm1 = make_peer_manager::<T>(transport, addr1, Arc::clone(&config)).await;
 
-    pm1.peer_connectivity_handle.connect(addr2).await.expect("dial to succeed");
+    pm1.peer_connectivity_handle.connect(addr2).expect("dial to succeed");
 
     match timeout(
         *pm1.p2p_config.outbound_connection_timeout,

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -42,8 +42,8 @@ async fn ping_timeout() {
     let ping_check_period = *p2p_config.ping_check_period;
     let ping_timeout = *p2p_config.ping_timeout;
 
-    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel(10);
-    let (conn_tx, conn_rx) = tokio::sync::mpsc::channel(10);
+    let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel();
     let (_peer_tx, peer_rx) =
         tokio::sync::mpsc::unbounded_channel::<PeerManagerEvent<TestNetworkingService>>();
     let time_getter = P2pTestTimeGetter::new();
@@ -82,7 +82,6 @@ async fn ping_timeout() {
             },
             receiver_address: None,
         })
-        .await
         .unwrap();
 
     // Receive ping requests and send responses normally
@@ -102,7 +101,6 @@ async fn ping_timeout() {
                         request_id,
                         response: PeerManagerResponse::PingResponse(PingResponse { nonce }),
                     })
-                    .await
                     .unwrap();
             }
             _ => panic!("unexpected event: {event:?}"),
@@ -127,7 +125,7 @@ async fn ping_timeout() {
     let event = cmd_rx.recv().await.unwrap();
     match event {
         Command::Disconnect { peer_id } => {
-            conn_tx.send(ConnectivityEvent::ConnectionClosed { peer_id }).await.unwrap();
+            conn_tx.send(ConnectivityEvent::ConnectionClosed { peer_id }).unwrap();
         }
         _ => panic!("unexpected event: {event:?}"),
     }

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -126,8 +126,7 @@ async fn ping_timeout() {
     // PeerManager should ask backend to close connection
     let event = cmd_rx.recv().await.unwrap();
     match event {
-        Command::Disconnect { peer_id, response } => {
-            response.send(Ok(())).unwrap();
+        Command::Disconnect { peer_id } => {
             conn_tx.send(ConnectivityEvent::ConnectionClosed { peer_id }).await.unwrap();
         }
         _ => panic!("unexpected event: {event:?}"),

--- a/p2p/src/sync/request.rs
+++ b/p2p/src/sync/request.rs
@@ -64,12 +64,8 @@ where
     }
 
     /// Sends a request to the given peer.
-    pub async fn send_request(
-        &mut self,
-        peer_id: T::PeerId,
-        request: SyncRequest,
-    ) -> crate::Result<()> {
-        self.peer_sync_handle.send_request(peer_id, request).await.map(|_| ())
+    pub fn send_request(&mut self, peer_id: T::PeerId, request: SyncRequest) -> crate::Result<()> {
+        self.peer_sync_handle.send_request(peer_id, request).map(|_| ())
     }
 
     /// Send block request to remote peer
@@ -81,7 +77,7 @@ where
     /// * `peer_id` - peer ID of the remote node
     /// * `block_id` - ID of the block that is requested
     /// * `retry_count` - how many times the request has been resent
-    pub async fn send_block_request(
+    pub fn send_block_request(
         &mut self,
         peer_id: T::PeerId,
         block_id: Id<Block>,
@@ -95,7 +91,7 @@ where
 
         // send request to remote peer and start tracking its progress
         let wanted_blocks = self.make_block_request(vec![block_id]);
-        self.send_request(peer_id, wanted_blocks).await?;
+        self.send_request(peer_id, wanted_blocks)?;
 
         self.peers
             .get_mut(&peer_id)
@@ -113,7 +109,7 @@ where
     /// * `peer_id` - peer ID of the remote node
     /// * `locator` - local locator object
     /// * `retry_count` - how many times the request has been resent
-    pub async fn send_header_request(
+    pub fn send_header_request(
         &mut self,
         peer_id: T::PeerId,
         locator: Locator,
@@ -127,7 +123,7 @@ where
 
         // send header request and start tracking its progress
         let wanted_headers = self.make_header_request(locator.clone());
-        self.send_request(peer_id, wanted_headers).await?;
+        self.send_request(peer_id, wanted_headers)?;
 
         self.peers
             .get_mut(&peer_id)
@@ -144,7 +140,7 @@ where
     /// # Arguments
     /// * `request_id` - ID of the request that this is a response to
     /// * `headers` - headers that the remote requested
-    pub async fn send_header_response(
+    pub fn send_header_response(
         &mut self,
         request_id: T::PeerRequestId,
         headers: Vec<BlockHeader>,
@@ -153,7 +149,7 @@ where
 
         // TODO: save sent header IDs somewhere and validate future requests against those?
         let message = self.make_header_response(headers);
-        self.peer_sync_handle.send_response(request_id, message).await
+        self.peer_sync_handle.send_response(request_id, message)
     }
 
     /// Send header response to remote peer
@@ -164,7 +160,7 @@ where
     /// # Arguments
     /// * `request_id` - ID of the request that this is a response to
     /// * `headers` - headers that the remote requested
-    pub async fn send_block_response(
+    pub fn send_block_response(
         &mut self,
         request_id: T::PeerRequestId,
         blocks: Vec<Block>,
@@ -173,6 +169,6 @@ where
 
         // TODO: save sent block IDs somewhere and validate future requests against those?
         let message = self.make_block_response(blocks);
-        self.peer_sync_handle.send_response(request_id, message).await
+        self.peer_sync_handle.send_response(request_id, message)
     }
 }

--- a/p2p/src/sync/tests/request_response.rs
+++ b/p2p/src/sync/tests/request_response.rs
@@ -56,7 +56,6 @@ where
             peer_info2.peer_id,
             SyncRequest::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
-        .await
         .unwrap();
 
     if let Ok(SyncingEvent::Request {
@@ -75,7 +74,6 @@ where
                 request_id,
                 SyncResponse::HeaderListResponse(HeaderListResponse::new(vec![])),
             )
-            .await
             .unwrap();
     } else {
         panic!("invalid data received");
@@ -123,7 +121,6 @@ where
             peer_info2.peer_id,
             SyncRequest::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
-        .await
         .unwrap();
     request_ids.insert(id);
 
@@ -133,7 +130,6 @@ where
             peer_info2.peer_id,
             SyncRequest::HeaderListRequest(HeaderListRequest::new(Locator::new(vec![]))),
         )
-        .await
         .unwrap();
     request_ids.insert(id);
 
@@ -148,7 +144,6 @@ where
                             request_id,
                             SyncResponse::HeaderListResponse(HeaderListResponse::new(vec![])),
                         )
-                        .await
                         .unwrap();
                 }
                 _ => panic!("invalid event: {event:?}"),

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -161,7 +161,7 @@ where
     T::ConnectivityHandle: ConnectivityService<T>,
 {
     let addr = conn2.local_addresses();
-    conn1.connect(addr[0].clone()).await.expect("dial to succeed");
+    conn1.connect(addr[0].clone()).expect("dial to succeed");
 
     let (address, peer_info1) = match timeout(Duration::from_secs(5), conn2.poll_next()).await {
         Ok(event) => match event.unwrap() {

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -92,7 +92,6 @@ where
             )
             .unwrap(),
         ))
-        .await
         .unwrap();
 
     // Verify that all peers received the message even though they weren't directly connected.


### PR DESCRIPTION
Using unbounded channels should fix the problem with potential deadlocks in p2p (when two channels are full).
I have removed a lot of async annotations that are no longer needed.

I think to apply back-pressure on the connected peers we could do something like this: count in `p2p::net::default_backend::peer::Peer::run` how many unprocessed requests  there are and if more than some limit then stop reading from the network socket, until some responses have been processed and sent back. I think this should solve the node overload problem nicely. It may look like this:

```
response = self.cmd_rx.recv() {
    // Request was processed, send response to the peer...
    request_count -= 1;
},
// Read from the socket if only there is some free capacity
request = self.socket.recv(), if request_count < 10 => {
    // New request received, send it to backend...
    request_count += 1;
}
```

We will need to ensure that for each request received, the backend would send a response. But I suppose it should be easy enough to do.