### PR TITLE
Unify DeltaMergeUndo and DataMergeUndo

### DIFF
--- a/accounting/src/delta/combine.rs
+++ b/accounting/src/delta/combine.rs
@@ -15,18 +15,18 @@
 
 use common::primitives::{signed_amount::SignedAmount, Amount};
 
-use crate::{delta::delta_data_collection::DeltaMapElement, error::Error};
+use crate::{error::Error, DataDelta};
 
 /// Combine data with an element of `DeltaDataCollection`.
 /// An element can be either a Delta or a result of delta undo.
 pub fn combine_data_with_delta<T: Clone + Eq>(
     lhs: Option<T>,
-    rhs: Option<DeltaMapElement<T>>,
+    rhs: Option<DataDelta<T>>,
 ) -> Result<Option<T>, Error> {
     match (lhs, rhs) {
         (lhs, None) => Ok(lhs),
         (None, Some(d)) => {
-            let (prev, next) = d.consume().consume();
+            let (prev, next) = d.consume();
             match (prev, next) {
                 (None, next) => Ok(next),
                 (Some(_), None) => Err(Error::RemoveNonexistingData),
@@ -34,7 +34,7 @@ pub fn combine_data_with_delta<T: Clone + Eq>(
             }
         }
         (Some(data), Some(d)) => {
-            let (prev, next) = d.consume().consume();
+            let (prev, next) = d.consume();
             match (prev, next) {
                 (None, None) => Err(Error::DeltaDataMismatch),
                 (None, Some(_)) => Err(Error::DataCreatedMultipleTimes),
@@ -74,7 +74,7 @@ pub fn combine_amount_delta(
 
 #[cfg(test)]
 pub mod test {
-    use crate::{DataDelta, DataDeltaUndo};
+    use crate::DataDelta;
 
     use super::*;
     use common::primitives::{amount::UnsignedIntType, signed_amount::SignedIntType};
@@ -101,15 +101,7 @@ pub mod test {
         #[case] expected_result: Result<Option<char>, Error>,
     ) {
         assert_eq!(
-            combine_data_with_delta(data, delta.clone().map(DeltaMapElement::Delta)),
-            expected_result
-        );
-
-        assert_eq!(
-            combine_data_with_delta(
-                data,
-                delta.map(|d| DeltaMapElement::DeltaUndo(DataDeltaUndo::new(d)))
-            ),
+            combine_data_with_delta(data, delta.clone()),
             expected_result
         );
     }

--- a/accounting/src/delta/combine.rs
+++ b/accounting/src/delta/combine.rs
@@ -101,7 +101,7 @@ pub mod test {
         #[case] expected_result: Result<Option<char>, Error>,
     ) {
         assert_eq!(
-            combine_data_with_delta(data, delta.clone()),
+            combine_data_with_delta(data, delta),
             expected_result
         );
     }

--- a/accounting/src/delta/delta_data_collection/mod.rs
+++ b/accounting/src/delta/delta_data_collection/mod.rs
@@ -58,29 +58,6 @@ impl<T: Clone> DataDelta<T> {
     }
 }
 
-/// Elements inside `DeltaDataCollection` can store either a delta or an undo.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, Debug)]
-pub enum DeltaMapElement<T> {
-    Delta(DataDelta<T>),
-    DeltaUndo(DataDeltaUndo<T>),
-}
-
-impl<T> DeltaMapElement<T> {
-    pub fn get_data_delta(&self) -> &DataDelta<T> {
-        match self {
-            DeltaMapElement::Delta(d) => d,
-            DeltaMapElement::DeltaUndo(d) => d.as_delta(),
-        }
-    }
-
-    pub fn consume(self) -> DataDelta<T> {
-        match self {
-            DeltaMapElement::Delta(d) => d,
-            DeltaMapElement::DeltaUndo(u) => u.consume(),
-        }
-    }
-}
-
 /// `GetDataResult` is represented by 3 states instead of typical 2 states, because it is
 /// important to distinguish the case when data was explicitly deleted from the case when the data is just not there.
 pub enum GetDataResult<T> {
@@ -93,7 +70,7 @@ pub enum GetDataResult<T> {
 #[must_use]
 #[derive(PartialEq, Eq, Clone, Encode, Decode, Debug)]
 pub struct DeltaDataCollection<K, T> {
-    data: BTreeMap<K, DeltaMapElement<T>>,
+    data: BTreeMap<K, DataDelta<T>>,
 }
 
 impl<K: Ord + Copy, T: Clone + Eq> DeltaDataCollection<K, T> {
@@ -103,23 +80,20 @@ impl<K: Ord + Copy, T: Clone + Eq> DeltaDataCollection<K, T> {
         }
     }
 
-    pub fn data(&self) -> &BTreeMap<K, DeltaMapElement<T>> {
+    pub fn data(&self) -> &BTreeMap<K, DataDelta<T>> {
         &self.data
     }
 
-    pub fn consume(self) -> BTreeMap<K, DeltaMapElement<T>> {
+    pub fn consume(self) -> BTreeMap<K, DataDelta<T>> {
         self.data
     }
 
     pub fn get_data(&self, key: &K) -> GetDataResult<&T> {
         match self.data.get(key) {
-            Some(d) => {
-                let delta = d.get_data_delta();
-                match &delta.new {
-                    None => GetDataResult::Deleted,
-                    Some(d) => GetDataResult::Present(d),
-                }
-            }
+            Some(delta) => match &delta.new {
+                None => GetDataResult::Deleted,
+                Some(d) => GetDataResult::Present(d),
+            },
             None => GetDataResult::Missing,
         }
     }
@@ -131,11 +105,8 @@ impl<K: Ord + Copy, T: Clone + Eq> DeltaDataCollection<K, T> {
         let data_undo = other
             .data
             .into_iter()
-            .filter_map(|(key, other_pool_data)| {
-                match self.merge_delta_data_element_impl(key, other_pool_data) {
-                    Ok(delta_op) => delta_op.map(|d| Ok((key, d))),
-                    Err(e) => Some(Err(e)),
-                }
+            .map(|(key, other_pool_data)| {
+                Ok((key, self.merge_delta_data_element(key, other_pool_data)?))
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
@@ -146,24 +117,11 @@ impl<K: Ord + Copy, T: Clone + Eq> DeltaDataCollection<K, T> {
         &mut self,
         key: K,
         other: DataDelta<T>,
-    ) -> Result<Option<DataDeltaUndo<T>>, Error> {
-        self.merge_delta_data_element_impl(key, DeltaMapElement::Delta(other))
-    }
-
-    fn merge_delta_data_element_impl(
-        &mut self,
-        key: K,
-        other: DeltaMapElement<T>,
-    ) -> Result<Option<DataDeltaUndo<T>>, Error> {
-        let undo = match &other {
-            DeltaMapElement::Delta(other_delta) => Some(other_delta.clone().invert()),
-            DeltaMapElement::DeltaUndo(_) => None,
-        };
+    ) -> Result<DataDeltaUndo<T>, Error> {
+        let undo = other.clone().invert();
 
         let el = match self.data.entry(key) {
-            Entry::Occupied(e) => {
-                DeltaMapElement::Delta(combine_delta_data(e.remove().consume(), other.consume())?)
-            }
+            Entry::Occupied(e) => combine_delta_data(e.remove(), other)?,
             Entry::Vacant(_) => other,
         };
 
@@ -187,25 +145,14 @@ impl<K: Ord + Copy, T: Clone + Eq> DeltaDataCollection<K, T> {
         key: K,
         undo: DataDeltaUndo<T>,
     ) -> Result<(), Error> {
-        self.merge_delta_data_element_impl(key, DeltaMapElement::DeltaUndo(undo))
-            .map(|_| ())
-    }
-}
-
-impl<K: Ord + Copy, T: Clone> FromIterator<(K, DeltaMapElement<T>)> for DeltaDataCollection<K, T> {
-    fn from_iter<I: IntoIterator<Item = (K, DeltaMapElement<T>)>>(iter: I) -> Self {
-        DeltaDataCollection {
-            data: BTreeMap::<K, DeltaMapElement<T>>::from_iter(iter),
-        }
+        self.merge_delta_data_element(key, undo.consume()).map(|_| ())
     }
 }
 
 impl<K: Ord + Copy, T: Clone> FromIterator<(K, DataDelta<T>)> for DeltaDataCollection<K, T> {
     fn from_iter<I: IntoIterator<Item = (K, DataDelta<T>)>>(iter: I) -> Self {
         DeltaDataCollection {
-            data: BTreeMap::<K, DeltaMapElement<T>>::from_iter(
-                iter.into_iter().map(|(k, d)| (k, DeltaMapElement::Delta(d))),
-            ),
+            data: BTreeMap::<K, DataDelta<T>>::from_iter(iter.into_iter()),
         }
     }
 }

--- a/accounting/src/delta/delta_data_collection/mod.rs
+++ b/accounting/src/delta/delta_data_collection/mod.rs
@@ -110,7 +110,7 @@ impl<K: Ord + Copy, T: Clone + Eq> DeltaDataCollection<K, T> {
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
-        Ok(DeltaDataUndoCollection::new(data_undo))
+        Ok(DeltaDataUndoCollection::from_data(data_undo))
     }
 
     pub fn merge_delta_data_element(

--- a/accounting/src/delta/delta_data_collection/mod.rs
+++ b/accounting/src/delta/delta_data_collection/mod.rs
@@ -49,7 +49,7 @@ impl<T: Clone> DataDelta<T> {
 
     /// Returns an invert delta that has the opposite effect of the provided delta
     /// and serves as an undo object
-    fn invert(self) -> DataDeltaUndo<T> {
+    pub fn invert(self) -> DataDeltaUndo<T> {
         DataDeltaUndo::new(Self::new(self.new, self.old))
     }
 

--- a/accounting/src/delta/delta_data_collection/tests/delta_delta_undo_tests.rs
+++ b/accounting/src/delta/delta_data_collection/tests/delta_delta_undo_tests.rs
@@ -28,9 +28,9 @@ fn make_collections_with_undo(
     let collection1 = DeltaDataCollection::from_iter([(1, delta1)]);
 
     let mut collection2 = DeltaDataCollection::new();
-    let undo = collection2.merge_delta_data_element(1, delta2).unwrap().unwrap();
+    let undo = collection2.merge_delta_data_element(1, delta2).unwrap();
 
-    let collection3 = DeltaDataCollection::from_iter([(1, DeltaMapElement::DeltaUndo(undo))]);
+    let collection3 = DeltaDataCollection::from_iter([(1, undo.consume())]);
 
     (collection1, collection2, collection3)
 }
@@ -78,7 +78,7 @@ fn delta_delta_undo_associativity(
         let mut collection = DeltaDataCollection::new();
         let _ = collection.merge_delta_data_element(1, delta1).unwrap();
 
-        let undo = collection.merge_delta_data_element(1, delta2).unwrap().unwrap();
+        let undo = collection.merge_delta_data_element(1, delta2).unwrap();
         collection.undo_merge_delta_data_element(1, undo).unwrap();
 
         assert_eq!(collection, expected_collection);

--- a/accounting/src/delta/delta_data_collection/tests/delta_delta_undo_undo_tests.rs
+++ b/accounting/src/delta/delta_data_collection/tests/delta_delta_undo_undo_tests.rs
@@ -24,10 +24,10 @@ type FourCollections = (
 
 fn make_collections_with_undo(delta1: DataDelta<char>, delta2: DataDelta<char>) -> FourCollections {
     let mut collection1 = DeltaDataCollection::new();
-    let undo_delta1 = collection1.merge_delta_data_element(1, delta1).unwrap().unwrap();
+    let undo_delta1 = collection1.merge_delta_data_element(1, delta1).unwrap();
 
     let mut collection2 = DeltaDataCollection::new();
-    let undo_delta2 = collection2.merge_delta_data_element(1, delta2).unwrap().unwrap();
+    let undo_delta2 = collection2.merge_delta_data_element(1, delta2).unwrap();
 
     let mut collection3 = DeltaDataCollection::new();
     collection3.undo_merge_delta_data_element(1, undo_delta2).unwrap();
@@ -103,8 +103,8 @@ fn delta_delta_undo_undo_associativity(
         // ((Delta1 + Delta2) + Undo1) + Undo2 = Delta
         // every delta is applied to the same collection
         let mut collection = DeltaDataCollection::new();
-        let undo1 = collection.merge_delta_data_element(1, delta1).unwrap().unwrap();
-        let undo2 = collection.merge_delta_data_element(1, delta2).unwrap().unwrap();
+        let undo1 = collection.merge_delta_data_element(1, delta1).unwrap();
+        let undo2 = collection.merge_delta_data_element(1, delta2).unwrap();
         collection.undo_merge_delta_data_element(1, undo2).unwrap();
         collection.undo_merge_delta_data_element(1, undo1).unwrap();
 

--- a/accounting/src/delta/delta_data_collection/tests/mod.rs
+++ b/accounting/src/delta/delta_data_collection/tests/mod.rs
@@ -105,10 +105,7 @@ fn merge_delta_into_empty_collection(#[case] delta: DataDelta<char>) {
     collection.merge_delta_data_element(0, delta.clone()).unwrap();
 
     assert_eq!(collection.data.len(), 1);
-    assert_eq!(
-        collection.data.into_iter().next().unwrap().1.consume(),
-        delta
-    );
+    assert_eq!(collection.data.into_iter().next().unwrap().1, delta);
 }
 
 #[rstest]
@@ -123,10 +120,7 @@ fn merge_delta_undo_into_empty_collection(#[case] delta: DataDelta<char>) {
         .unwrap();
 
     assert_eq!(collection.data.len(), 1);
-    assert_eq!(
-        collection.data.into_iter().next().unwrap().1.consume(),
-        delta
-    );
+    assert_eq!(collection.data.into_iter().next().unwrap().1, delta);
 }
 
 #[rstest]
@@ -139,7 +133,7 @@ fn merge_delta_undo_into_empty_collection(#[case] delta: DataDelta<char>) {
 #[case(new_delta(Some('a'), Some('b')), new_delta(Some('b'), Some('c')))]
 fn delta_over_undo_is_an_error(#[case] delta1: DataDelta<char>, #[case] delta2: DataDelta<char>) {
     let mut collection1 = DeltaDataCollection::new();
-    let undo = collection1.merge_delta_data_element(1, delta1).unwrap().unwrap();
+    let undo = collection1.merge_delta_data_element(1, delta1).unwrap();
 
     let mut collection2 = DeltaDataCollection::new();
     collection2.undo_merge_delta_data_element(1, undo).unwrap();

--- a/accounting/src/delta/delta_data_collection/undo.rs
+++ b/accounting/src/delta/delta_data_collection/undo.rs
@@ -37,7 +37,7 @@ impl<T> DataDeltaUndo<T> {
 }
 
 #[must_use]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
 pub struct DeltaDataUndoCollection<K, T> {
     data: BTreeMap<K, DataDeltaUndo<T>>,
 }

--- a/accounting/src/delta/delta_data_collection/undo.rs
+++ b/accounting/src/delta/delta_data_collection/undo.rs
@@ -43,7 +43,13 @@ pub struct DeltaDataUndoCollection<K, T> {
 }
 
 impl<K: Ord, T: Clone> DeltaDataUndoCollection<K, T> {
-    pub fn new(data: BTreeMap<K, DataDeltaUndo<T>>) -> Self {
+    pub fn new() -> Self {
+        Self {
+            data: BTreeMap::new(),
+        }
+    }
+
+    pub fn from_data(data: BTreeMap<K, DataDeltaUndo<T>>) -> Self {
         Self { data }
     }
 

--- a/accounting/src/delta/tests.rs
+++ b/accounting/src/delta/tests.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{combine_data_with_delta, DataDelta, DeltaDataCollection, DeltaMapElement};
+use crate::{combine_data_with_delta, DataDelta, DeltaDataCollection};
 
 use rstest::rstest;
 
@@ -24,7 +24,7 @@ use rstest::rstest;
 #[case(Some('a'), DataDelta::new(Some('a'), Some('b')))]
 fn data_delta_undo_associativity(#[case] origin_data: Option<char>, #[case] delta: DataDelta<char>) {
     let mut collection_with_delta = DeltaDataCollection::new();
-    let undo_create = collection_with_delta.merge_delta_data_element(1, delta).unwrap().unwrap();
+    let undo_create = collection_with_delta.merge_delta_data_element(1, delta).unwrap();
 
     let mut collection_with_undo = DeltaDataCollection::new();
     collection_with_undo.undo_merge_delta_data_element(1, undo_create).unwrap();
@@ -221,7 +221,7 @@ fn data_delta_delta_undo_associativity(
     {
         let collection1 = DeltaDataCollection::from_iter([(1, delta1.clone())]);
         let mut collection2 = DeltaDataCollection::new();
-        let undo = collection2.merge_delta_data_element(1, delta2.clone()).unwrap().unwrap();
+        let undo = collection2.merge_delta_data_element(1, delta2.clone()).unwrap();
         let mut collection3 = DeltaDataCollection::new();
         collection3.undo_merge_delta_data_element(1, undo).unwrap();
 
@@ -249,7 +249,7 @@ fn data_delta_delta_undo_associativity(
     {
         let mut collection1 = DeltaDataCollection::from_iter([(1, delta1.clone())]);
         let mut collection2 = DeltaDataCollection::new();
-        let undo = collection2.merge_delta_data_element(1, delta2.clone()).unwrap().unwrap();
+        let undo = collection2.merge_delta_data_element(1, delta2.clone()).unwrap();
         let mut collection3 = DeltaDataCollection::new();
         collection3.undo_merge_delta_data_element(1, undo).unwrap();
 
@@ -268,7 +268,7 @@ fn data_delta_delta_undo_associativity(
     {
         let collection1 = DeltaDataCollection::from_iter([(1, delta1.clone())]);
         let mut collection2 = DeltaDataCollection::new();
-        let undo = collection2.merge_delta_data_element(1, delta2.clone()).unwrap().unwrap();
+        let undo = collection2.merge_delta_data_element(1, delta2.clone()).unwrap();
         let mut collection3 = DeltaDataCollection::new();
         collection3.undo_merge_delta_data_element(1, undo).unwrap();
 
@@ -292,7 +292,7 @@ fn data_delta_delta_undo_associativity(
     {
         let mut collection1 = DeltaDataCollection::from_iter([(1, delta1)]);
         let mut collection2 = DeltaDataCollection::new();
-        let undo = collection2.merge_delta_data_element(1, delta2).unwrap().unwrap();
+        let undo = collection2.merge_delta_data_element(1, delta2).unwrap();
         let mut collection3 = DeltaDataCollection::new();
         collection3.undo_merge_delta_data_element(1, undo).unwrap();
 
@@ -330,8 +330,7 @@ fn data_and_delta_gives_error_as_delta_and_delta(
     let delta1 = DataDelta::new(x0, x1);
     let delta2 = DataDelta::new(x2, x3);
 
-    let is_err_1 =
-        combine_data_with_delta(x1, Some(DeltaMapElement::Delta(delta2.clone()))).is_err();
+    let is_err_1 = combine_data_with_delta(x1, Some(delta2.clone())).is_err();
 
     let is_err_2 = {
         let mut collection = DeltaDataCollection::from_iter([(1, delta1)]);

--- a/accounting/src/lib.rs
+++ b/accounting/src/lib.rs
@@ -22,7 +22,7 @@ pub use crate::{
         delta_amount_collection::DeltaAmountCollection,
         delta_data_collection::{
             undo::{DataDeltaUndo, DeltaDataUndoCollection},
-            DataDelta, DeltaDataCollection, DeltaMapElement, GetDataResult,
+            DataDelta, DeltaDataCollection, GetDataResult,
         },
     },
     error::Error,

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -313,7 +313,6 @@ impl BanScore for pos_accounting::Error {
             E::PledgeValueToSignedError => 100,
             E::InvariantErrorDelegationUndoFailedDataNotFound => 100,
             E::DuplicatesInDeltaAndUndo => 100,
-            E::FailedToCreateDeltaUndo => 100,
         }
     }
 }

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -34,8 +34,8 @@ use common::{
     primitives::{Amount, Id},
 };
 use pos_accounting::{
-    AccountingBlockUndo, DelegationData, DelegationId, FlushablePoSAccountingView, PoSAccountingDB,
-    PoSAccountingDeltaData, PoSAccountingView, PoolData, PoolId,
+    AccountingBlockUndo, DelegationData, DelegationId, DeltaMergeUndo, FlushablePoSAccountingView,
+    PoSAccountingDB, PoSAccountingDeltaData, PoSAccountingView, PoolData, PoolId,
 };
 use tx_verifier::transaction_verifier::TransactionSource;
 use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosBlockUndo, UtxosDB, UtxosStorageRead};
@@ -321,7 +321,7 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocks, V: TransactionVerificationS
     fn batch_write_delta(
         &mut self,
         data: PoSAccountingDeltaData,
-    ) -> Result<(), pos_accounting::Error> {
+    ) -> Result<DeltaMergeUndo, pos_accounting::Error> {
         let mut db = PoSAccountingDB::new(&mut self.db_tx);
         db.batch_write_delta(data)
     }

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -33,7 +33,7 @@ use common::{
     primitives::{Amount, Id},
 };
 use pos_accounting::{
-    AccountingBlockUndo, DelegationData, DelegationId, FlushablePoSAccountingView,
+    AccountingBlockUndo, DelegationData, DelegationId, DeltaMergeUndo, FlushablePoSAccountingView,
     PoSAccountingDeltaData, PoSAccountingView, PoolData, PoolId,
 };
 use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosBlockUndo, UtxosStorageRead, UtxosView};
@@ -291,7 +291,7 @@ impl<C, S, U, A: PoSAccountingView> FlushablePoSAccountingView for TransactionVe
     fn batch_write_delta(
         &mut self,
         data: PoSAccountingDeltaData,
-    ) -> Result<(), pos_accounting::Error> {
+    ) -> Result<DeltaMergeUndo, pos_accounting::Error> {
         self.accounting_delta.batch_write_delta(data)
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -24,7 +24,7 @@ use common::chain::{
     TxMainChainPosition,
 };
 use mockall::predicate::eq;
-use pos_accounting::{AccountingBlockUndo, AccountingTxUndo};
+use pos_accounting::{AccountingBlockUndo, AccountingTxUndo, DeltaMergeUndo};
 use rstest::rstest;
 use test_utils::random::Seed;
 use utxo::{UtxosBlockRewardUndo, UtxosBlockUndo, UtxosTxUndoWithSources};
@@ -75,7 +75,10 @@ fn utxo_set_from_chain_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_utxo_undo_data()
         .with(
@@ -152,7 +155,10 @@ fn tx_index_set_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_mainchain_tx_index()
         .with(eq(outpoint1.clone()), eq(tx_index_1.clone()))
@@ -219,7 +225,10 @@ fn tokens_set_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_token_aux_data()
         .with(eq(token_id_1), eq(token_data_1.clone()))
@@ -319,7 +328,10 @@ fn utxo_del_from_chain_hierarchy(#[case] seed: Seed) {
         .times(1)
         .return_const(Ok(()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
@@ -375,7 +387,10 @@ fn tx_index_del_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_del_mainchain_tx_index()
         .with(eq(outpoint1.clone()))
@@ -435,7 +450,10 @@ fn tokens_del_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_del_token_aux_data()
         .with(eq(token_id_1))
@@ -495,7 +513,10 @@ fn utxo_conflict_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
@@ -577,7 +598,10 @@ fn block_undo_from_chain_conflict_hierarchy(#[case] seed: Seed) {
         .times(1)
         .return_const(Ok(()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
@@ -635,7 +659,10 @@ fn tx_index_conflict_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_mainchain_tx_index()
         .with(eq(outpoint1.clone()), eq(tx_index_2.clone()))
@@ -696,7 +723,10 @@ fn tokens_conflict_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_token_aux_data()
         .with(eq(token_id_1), eq(token_data_1.clone()))
@@ -766,7 +796,10 @@ fn pos_accounting_stake_pool_set_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
 
     store
         .expect_get_pool_balance()
@@ -826,7 +859,10 @@ fn pos_accounting_stake_pool_undo_set_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
 
     store.expect_get_pool_balance().return_const(Ok(None));
     store.expect_get_pool_data().return_const(Ok(None));
@@ -909,7 +945,10 @@ fn pos_accounting_stake_pool_undo_del_hierarchy(#[case] seed: Seed) {
         .expect_get_best_block_for_utxos()
         .return_const(Ok(Some(H256::zero().into())));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store.expect_batch_write_delta().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
 
     store.expect_get_pool_balance().return_const(Ok(None));
     store.expect_get_pool_data().return_const(Ok(None));

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -29,8 +29,8 @@ use common::{
     primitives::{Amount, Id},
 };
 use pos_accounting::{
-    DelegationData, DelegationId, FlushablePoSAccountingView, PoSAccountingDeltaData,
-    PoSAccountingView, PoolData, PoolId,
+    DelegationData, DelegationId, DeltaMergeUndo, FlushablePoSAccountingView,
+    PoSAccountingDeltaData, PoSAccountingView, PoolData, PoolId,
 };
 use utxo::{ConsumedUtxoCache, FlushableUtxoView, Utxo, UtxosStorageRead};
 
@@ -147,6 +147,6 @@ mockall::mock! {
     }
 
     impl FlushablePoSAccountingView for Store {
-        fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<(), pos_accounting::Error>;
+        fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<DeltaMergeUndo, pos_accounting::Error>;
     }
 }

--- a/pos_accounting/src/error.rs
+++ b/pos_accounting/src/error.rs
@@ -79,6 +79,4 @@ pub enum Error {
     InvariantErrorDelegationUndoFailedDataNotFound,
     #[error("Delta reverts merge failed due to duplicates")]
     DuplicatesInDeltaAndUndo,
-    #[error("Could not create delta undo")]
-    FailedToCreateDeltaUndo,
 }

--- a/pos_accounting/src/lib.rs
+++ b/pos_accounting/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::{
     pool::{
         block_undo::{AccountingBlockUndo, AccountingBlockUndoError, AccountingTxUndo},
         delegation::DelegationData,
-        delta::{data::PoSAccountingDeltaData, PoSAccountingDelta},
+        delta::{data::PoSAccountingDeltaData, DeltaMergeUndo, PoSAccountingDelta},
         helpers::make_pool_id,
         operations::{PoSAccountingOperations, PoSAccountingUndo},
         pool_data::PoolData,

--- a/pos_accounting/src/pool/delta/mod.rs
+++ b/pos_accounting/src/pool/delta/mod.rs
@@ -37,11 +37,11 @@ pub struct PoSAccountingDelta<P> {
 /// All the operations we have to do with the accounting state to undo a delta
 #[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
 pub struct DeltaMergeUndo {
-    pool_data_undo: DeltaDataUndoCollection<PoolId, PoolData>,
-    delegation_data_undo: DeltaDataUndoCollection<DelegationId, DelegationData>,
-    pool_balances_undo: DeltaAmountCollection<PoolId>,
-    pool_delegation_shares_undo: DeltaAmountCollection<(PoolId, DelegationId)>,
-    delegation_balances_undo: DeltaAmountCollection<DelegationId>,
+    pub(crate) pool_data_undo: DeltaDataUndoCollection<PoolId, PoolData>,
+    pub(crate) delegation_data_undo: DeltaDataUndoCollection<DelegationId, DelegationData>,
+    pub(crate) pool_balances_undo: DeltaAmountCollection<PoolId>,
+    pub(crate) pool_delegation_shares_undo: DeltaAmountCollection<(PoolId, DelegationId)>,
+    pub(crate) delegation_balances_undo: DeltaAmountCollection<DelegationId>,
 }
 
 impl<P: PoSAccountingView> PoSAccountingDelta<P> {

--- a/pos_accounting/src/pool/delta/mod.rs
+++ b/pos_accounting/src/pool/delta/mod.rs
@@ -44,6 +44,18 @@ pub struct DeltaMergeUndo {
     pub(crate) delegation_balances_undo: DeltaAmountCollection<DelegationId>,
 }
 
+impl DeltaMergeUndo {
+    pub fn new() -> Self {
+        Self {
+            pool_data_undo: DeltaDataUndoCollection::new(),
+            delegation_data_undo: DeltaDataUndoCollection::new(),
+            pool_balances_undo: DeltaAmountCollection::new(),
+            pool_delegation_shares_undo: DeltaAmountCollection::new(),
+            delegation_balances_undo: DeltaAmountCollection::new(),
+        }
+    }
+}
+
 impl<P: PoSAccountingView> PoSAccountingDelta<P> {
     pub fn new(parent: P) -> Self {
         Self {

--- a/pos_accounting/src/pool/delta/operator_impls.rs
+++ b/pos_accounting/src/pool/delta/operator_impls.rs
@@ -55,14 +55,10 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
         }
 
         self.data.pool_balances.add_unsigned(pool_id, pledge_amount)?;
-        let undo_data = self
-            .data
-            .pool_data
-            .merge_delta_data_element(
-                pool_id,
-                DataDelta::new(None, Some(PoolData::new(decommission_key, pledge_amount))),
-            )?
-            .ok_or(Error::FailedToCreateDeltaUndo)?;
+        let undo_data = self.data.pool_data.merge_delta_data_element(
+            pool_id,
+            DataDelta::new(None, Some(PoolData::new(decommission_key, pledge_amount))),
+        )?;
 
         Ok((
             pool_id,
@@ -86,8 +82,7 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
         let data_undo = self
             .data
             .pool_data
-            .merge_delta_data_element(pool_id, DataDelta::new(Some(last_data), None))?
-            .ok_or(Error::FailedToCreateDeltaUndo)?;
+            .merge_delta_data_element(pool_id, DataDelta::new(Some(last_data), None))?;
 
         Ok(PoSAccountingUndo::DecommissionPool(DecommissionPoolUndo {
             pool_id,
@@ -117,8 +112,7 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
         let data_undo = self
             .data
             .delegation_data
-            .merge_delta_data_element(delegation_id, DataDelta::new(None, Some(delegation_data)))?
-            .ok_or(Error::FailedToCreateDeltaUndo)?;
+            .merge_delta_data_element(delegation_id, DataDelta::new(None, Some(delegation_data)))?;
 
         Ok((
             delegation_id,

--- a/pos_accounting/src/pool/delta/view_impl.rs
+++ b/pos_accounting/src/pool/delta/view_impl.rs
@@ -25,7 +25,7 @@ use crate::{
         pool_data::PoolData,
         view::{FlushablePoSAccountingView, PoSAccountingView},
     },
-    DelegationId, PoolId,
+    DelegationId, DeltaMergeUndo, PoolId,
 };
 
 use super::{data::PoSAccountingDeltaData, PoSAccountingDelta};
@@ -131,7 +131,7 @@ impl<P: PoSAccountingView> PoSAccountingView for PoSAccountingDelta<P> {
 }
 
 impl<P: PoSAccountingView> FlushablePoSAccountingView for PoSAccountingDelta<P> {
-    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<(), Error> {
-        self.merge_with_delta(data).map(|_| ())
+    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<DeltaMergeUndo, Error> {
+        self.merge_with_delta(data)
     }
 }

--- a/pos_accounting/src/pool/storage/mod.rs
+++ b/pos_accounting/src/pool/storage/mod.rs
@@ -15,16 +15,17 @@
 
 use std::{collections::BTreeMap, ops::Neg};
 
-use accounting::{combine_amount_delta, combine_data_with_delta, DeltaDataCollection};
+use accounting::{
+    combine_amount_delta, combine_data_with_delta, DeltaAmountCollection, DeltaDataCollection,
+    DeltaDataUndoCollection,
+};
 use chainstate_types::storage_result;
 use common::primitives::{signed_amount::SignedAmount, Amount};
 
 use crate::{
     error::Error, pool::delta::data::PoSAccountingDeltaData, storage::PoSAccountingStorageWrite,
-    DelegationId, PoolId,
+    DelegationId, DeltaMergeUndo, PoolId,
 };
-
-use super::{delegation::DelegationData, pool_data::PoolData};
 
 pub mod operator_impls;
 pub mod view_impls;
@@ -42,19 +43,11 @@ impl<S> PoSAccountingDB<S> {
     }
 }
 
-pub struct DataMergeUndo {
-    pool_data_undo: BTreeMap<PoolId, Option<PoolData>>,
-    delegation_data_undo: BTreeMap<DelegationId, Option<DelegationData>>,
-    pool_balances_undo: BTreeMap<PoolId, SignedAmount>,
-    pool_delegation_shares_undo: BTreeMap<(PoolId, DelegationId), SignedAmount>,
-    delegation_balances_undo: BTreeMap<DelegationId, SignedAmount>,
-}
-
 impl<S: PoSAccountingStorageWrite> PoSAccountingDB<S> {
     pub fn merge_with_delta(
         &mut self,
         other: PoSAccountingDeltaData,
-    ) -> Result<DataMergeUndo, Error> {
+    ) -> Result<DeltaMergeUndo, Error> {
         let pool_data_undo = self.merge_data_generic(
             other.pool_data,
             |s, id| s.get_pool_data(id),
@@ -92,7 +85,7 @@ impl<S: PoSAccountingStorageWrite> PoSAccountingDB<S> {
             |s, (pool_id, delegation_id)| s.del_pool_delegation_share(pool_id, delegation_id),
         )?;
 
-        Ok(DataMergeUndo {
+        Ok(DeltaMergeUndo {
             pool_data_undo,
             delegation_data_undo,
             pool_balances_undo,
@@ -101,37 +94,37 @@ impl<S: PoSAccountingStorageWrite> PoSAccountingDB<S> {
         })
     }
 
-    pub fn undo_merge_with_delta(&mut self, undo: DataMergeUndo) -> Result<(), Error> {
+    pub fn undo_merge_with_delta(&mut self, undo: DeltaMergeUndo) -> Result<(), Error> {
         self.undo_merge_data_generic(
-            undo.pool_data_undo.into_iter(),
-            |_, _| unreachable!(),
+            undo.pool_data_undo,
+            |s, id| s.get_pool_data(id),
             |s, id, data| s.set_pool_data(id, data),
             |s, id| s.del_pool_data(id),
         )?;
 
         self.undo_merge_data_generic(
-            undo.delegation_data_undo.into_iter(),
-            |_, _| unreachable!(),
+            undo.delegation_data_undo,
+            |s, id| s.get_delegation_data(id),
             |s, id, data| s.set_delegation_data(id, data),
             |s, id| s.del_delegation_data(id),
         )?;
 
         self.merge_balances_generic(
-            undo.pool_balances_undo.into_iter(),
+            undo.pool_balances_undo.consume().into_iter(),
             |s, id| s.get_pool_balance(id),
             |s, id, amount| s.set_pool_balance(id, amount),
             |s, id| s.del_pool_balance(id),
         )?;
 
         self.merge_balances_generic(
-            undo.delegation_balances_undo.into_iter(),
+            undo.delegation_balances_undo.consume().into_iter(),
             |s, id| s.get_delegation_balance(id),
             |s, id, amount| s.set_delegation_balance(id, amount),
             |s, id| s.del_delegation_balance(id),
         )?;
 
         self.merge_balances_generic(
-            undo.pool_delegation_shares_undo.into_iter(),
+            undo.pool_delegation_shares_undo.consume().into_iter(),
             |s, (pool_id, delegation_id)| s.get_pool_delegation_share(pool_id, delegation_id),
             |s, (pool_id, delegation_id), amount| {
                 s.set_pool_delegation_share(pool_id, delegation_id, amount)
@@ -148,7 +141,7 @@ impl<S: PoSAccountingStorageWrite> PoSAccountingDB<S> {
         getter: Getter,
         setter: Setter,
         deleter: Deleter,
-    ) -> Result<BTreeMap<K, SignedAmount>, Error>
+    ) -> Result<DeltaAmountCollection<K>, Error>
     where
         Iter: Iterator<Item = (K, SignedAmount)>,
         Getter: Fn(&S, K) -> Result<Option<Amount>, storage_result::Error>,
@@ -156,22 +149,24 @@ impl<S: PoSAccountingStorageWrite> PoSAccountingDB<S> {
         Deleter: FnMut(&mut S, K) -> Result<(), storage_result::Error>,
     {
         let mut store = BorrowedStorageValue::new(&mut self.store, getter, setter, deleter);
-        iter.map(|(id, delta)| -> Result<_, Error> {
-            let balance = store.get(id)?;
-            match combine_amount_delta(&balance, &Some(delta))? {
-                Some(result) => {
-                    if result > Amount::ZERO {
-                        store.set(id, result)?
-                    } else {
-                        store.delete(id)?
+        let undo = iter
+            .map(|(id, delta)| -> Result<_, Error> {
+                let balance = store.get(id)?;
+                match combine_amount_delta(&balance, &Some(delta))? {
+                    Some(result) => {
+                        if result > Amount::ZERO {
+                            store.set(id, result)?
+                        } else {
+                            store.delete(id)?
+                        }
                     }
-                }
-                None => store.delete(id)?,
-            };
-            let balance_undo = delta.neg().expect("amount negation some");
-            Ok((id, balance_undo))
-        })
-        .collect::<Result<BTreeMap<_, _>, _>>()
+                    None => store.delete(id)?,
+                };
+                let balance_undo = delta.neg().expect("amount negation some");
+                Ok((id, balance_undo))
+            })
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        Ok(DeltaAmountCollection::from_iter(undo.into_iter()))
     }
 
     fn merge_data_generic<K: Ord + Copy, T: Clone + Eq, Getter, Setter, Deleter>(
@@ -180,44 +175,49 @@ impl<S: PoSAccountingStorageWrite> PoSAccountingDB<S> {
         getter: Getter,
         setter: Setter,
         deleter: Deleter,
-    ) -> Result<BTreeMap<K, Option<T>>, Error>
+    ) -> Result<DeltaDataUndoCollection<K, T>, Error>
     where
         Getter: Fn(&S, K) -> Result<Option<T>, storage_result::Error>,
         Setter: FnMut(&mut S, K, &T) -> Result<(), storage_result::Error>,
         Deleter: FnMut(&mut S, K) -> Result<(), storage_result::Error>,
     {
         let mut store = BorrowedStorageValue::new(&mut self.store, getter, setter, deleter);
-        delta
+        let undo = delta
             .consume()
             .into_iter()
             .map(|(id, delta)| -> Result<_, Error> {
+                let undo = delta.clone().invert();
                 let old_data = store.get(id)?;
                 match combine_data_with_delta(old_data.clone(), Some(delta))? {
                     Some(result) => store.set(id, &result)?,
                     None => store.delete(id)?,
                 };
-                Ok((id, old_data))
+                Ok((id, undo))
             })
-            .collect::<Result<BTreeMap<_, _>, _>>()
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
+        Ok(DeltaDataUndoCollection::new(undo))
     }
 
-    fn undo_merge_data_generic<K: Ord + Copy, T: Clone, Iter, Getter, Setter, Deleter>(
+    fn undo_merge_data_generic<K: Ord + Copy, T: Clone + Eq, Getter, Setter, Deleter>(
         &mut self,
-        mut iter: Iter,
+        undo: DeltaDataUndoCollection<K, T>,
         getter: Getter,
         setter: Setter,
         deleter: Deleter,
     ) -> Result<(), Error>
     where
-        Iter: Iterator<Item = (K, Option<T>)>,
         Getter: Fn(&S, K) -> Result<Option<T>, storage_result::Error>,
         Setter: FnMut(&mut S, K, &T) -> Result<(), storage_result::Error>,
         Deleter: FnMut(&mut S, K) -> Result<(), storage_result::Error>,
     {
         let mut store = BorrowedStorageValue::new(&mut self.store, getter, setter, deleter);
-        iter.try_for_each(|(key, undo_data)| match undo_data {
-            Some(data) => store.set(key, &data),
-            None => store.delete(key),
+        undo.consume().into_iter().try_for_each(|(id, delta)| {
+            let old_data = store.get(id)?;
+            match combine_data_with_delta(old_data.clone(), Some(delta.consume()))? {
+                Some(result) => store.set(id, &result)?,
+                None => store.delete(id)?,
+            };
+            Ok(())
         })
     }
 

--- a/pos_accounting/src/pool/storage/view_impls.rs
+++ b/pos_accounting/src/pool/storage/view_impls.rs
@@ -26,7 +26,7 @@ use crate::{
         view::{FlushablePoSAccountingView, PoSAccountingView},
     },
     storage::{PoSAccountingStorageRead, PoSAccountingStorageWrite},
-    DelegationId, PoSAccountingDB, PoolId,
+    DelegationId, DeltaMergeUndo, PoSAccountingDB, PoolId,
 };
 
 impl<S: PoSAccountingStorageRead> PoSAccountingView for PoSAccountingDB<S> {
@@ -72,7 +72,7 @@ impl<S: PoSAccountingStorageRead> PoSAccountingView for PoSAccountingDB<S> {
 }
 
 impl<S: PoSAccountingStorageWrite> FlushablePoSAccountingView for PoSAccountingDB<S> {
-    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<(), Error> {
-        self.merge_with_delta(data).map(|_| ())
+    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<DeltaMergeUndo, Error> {
+        self.merge_with_delta(data)
     }
 }

--- a/pos_accounting/src/pool/view.rs
+++ b/pos_accounting/src/pool/view.rs
@@ -17,7 +17,7 @@ use std::{collections::BTreeMap, ops::Deref};
 
 use common::primitives::Amount;
 
-use crate::{error::Error, DelegationId, PoolId};
+use crate::{error::Error, DelegationId, DeltaMergeUndo, PoolId};
 
 use super::{delegation::DelegationData, delta::data::PoSAccountingDeltaData, pool_data::PoolData};
 
@@ -48,7 +48,7 @@ pub trait PoSAccountingView {
 }
 
 pub trait FlushablePoSAccountingView {
-    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<(), Error>;
+    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<DeltaMergeUndo, Error>;
 }
 
 impl<T> PoSAccountingView for T


### PR DESCRIPTION
1. The main purpose of this PR is to return undo object from `FlushablePoSAccountingView::batch_write_delta`, which I want to use in #647 . To do that it needs a single undo object to return because both `PoSAccountingDB` and `PoSAccountingDelta` can flush. I reimplemented `PoSAccountingDB::merge_with_delta` to utilize Delta as an undo object, where previously undo was done by setting previous state.
2. While doing step 1 I also simplified the code in `accounting` by removing `DeltaMapElement` enum. It played intermediary role but I don't see how it helps now after the last big refactoring. 

Closes #654 