### PR TITLE
Update channel type used in `PeerManagerEvent`

### DIFF
--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -13,31 +13,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use tokio::sync::oneshot;
-
 use common::chain::block::Block;
 
-use crate::{interface::types::ConnectedPeer, net::NetworkingService};
+use crate::{interface::types::ConnectedPeer, net::NetworkingService, utils::oneshot_nofail};
 
 #[derive(Debug)]
 pub enum PeerManagerEvent<T: NetworkingService> {
     /// Try to establish connection with a remote peer
-    Connect(T::Address, oneshot::Sender<crate::Result<()>>),
+    Connect(T::Address, oneshot_nofail::Sender<crate::Result<()>>),
 
     /// Disconnect node using peer ID
-    Disconnect(T::PeerId, oneshot::Sender<crate::Result<()>>),
+    Disconnect(T::PeerId, oneshot_nofail::Sender<crate::Result<()>>),
 
     /// Get the total number of peers local node has a connection with
-    GetPeerCount(oneshot::Sender<usize>),
+    GetPeerCount(oneshot_nofail::Sender<usize>),
 
     /// Get the bind address of the local node
-    GetBindAddresses(oneshot::Sender<Vec<String>>),
+    GetBindAddresses(oneshot_nofail::Sender<Vec<String>>),
 
     /// Get peer IDs and addresses of connected peers
-    GetConnectedPeers(oneshot::Sender<Vec<ConnectedPeer>>),
+    GetConnectedPeers(oneshot_nofail::Sender<Vec<ConnectedPeer>>),
 
     /// Adjust peer score
-    AdjustPeerScore(T::PeerId, u32, oneshot::Sender<crate::Result<()>>),
+    AdjustPeerScore(T::PeerId, u32, oneshot_nofail::Sender<crate::Result<()>>),
 }
 
 #[derive(Debug)]

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -26,6 +26,7 @@ pub mod sync;
 #[cfg(feature = "testing_utils")]
 pub mod testing_utils;
 pub mod types;
+pub mod utils;
 
 use std::sync::Arc;
 

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -22,9 +22,9 @@ use crate::{
         TestTcpAddressMaker, TestTransportChannel, TestTransportMaker, TestTransportNoise,
         TestTransportTcp,
     },
+    utils::oneshot_nofail,
 };
 use common::{chain::config, primitives::semver::SemVer};
-use tokio::sync::oneshot;
 
 use crate::{
     error::{P2pError, PeerError},
@@ -180,7 +180,7 @@ where
     }
     pm2.handle_connectivity_event_result(event).unwrap();
 
-    let (tx, rx) = oneshot::channel();
+    let (tx, rx) = oneshot_nofail::channel();
     pm2.connect(remote_addr, Some(tx)).unwrap();
     let res = rx.await.unwrap();
     match res {

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -19,7 +19,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tokio::{sync::oneshot, time::timeout};
+use tokio::time::timeout;
 
 use crate::{
     config::P2pConfig,
@@ -29,6 +29,7 @@ use crate::{
         connect_services, get_connectivity_event, peerdb_inmemory_store, P2pTestTimeGetter,
         TestTransportChannel, TestTransportMaker, TestTransportNoise, TestTransportTcp,
     },
+    utils::oneshot_nofail,
 };
 use common::chain::config;
 
@@ -623,7 +624,7 @@ async fn connection_timeout_rpc_notified<T>(
         peer_manager.run().await.unwrap();
     });
 
-    let (rtx, rrx) = oneshot::channel();
+    let (rtx, rrx) = oneshot_nofail::channel();
     tx.send(PeerManagerEvent::Connect(addr2, rtx)).unwrap();
 
     match timeout(*p2p_config.outbound_connection_timeout, rrx).await {
@@ -697,7 +698,7 @@ where
     .await;
 
     // Get the first peer manager's bind address
-    let (rtx, rrx) = oneshot::channel();
+    let (rtx, rrx) = oneshot_nofail::channel();
     tx1.send(PeerManagerEvent::GetBindAddresses(rtx)).unwrap();
     let bind_addresses = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();
     assert_eq!(bind_addresses.len(), 1);
@@ -728,7 +729,7 @@ where
     loop {
         tokio::time::sleep(Duration::from_millis(10)).await;
         time_getter.advance_time(Duration::from_secs(1)).await;
-        let (rtx, rrx) = oneshot::channel();
+        let (rtx, rrx) = oneshot_nofail::channel();
         tx1.send(PeerManagerEvent::GetConnectedPeers(rtx)).unwrap();
         let connected_peers = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();
         if connected_peers.len() == 1 {
@@ -791,7 +792,7 @@ where
     .await;
 
     // Get the first peer manager's bind address
-    let (rtx, rrx) = oneshot::channel();
+    let (rtx, rrx) = oneshot_nofail::channel();
     tx1.send(PeerManagerEvent::GetBindAddresses(rtx)).unwrap();
 
     let bind_addresses = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -20,10 +20,7 @@ mod ping;
 use std::{sync::Arc, time::Duration};
 
 use common::time_getter::TimeGetter;
-use tokio::{
-    sync::{mpsc::UnboundedSender, oneshot},
-    time::timeout,
-};
+use tokio::{sync::mpsc::UnboundedSender, time::timeout};
 
 use crate::{
     event::PeerManagerEvent,
@@ -31,6 +28,7 @@ use crate::{
     net::{ConnectivityService, NetworkingService},
     peer_manager::PeerManager,
     testing_utils::peerdb_inmemory_store,
+    utils::oneshot_nofail,
     P2pConfig,
 };
 
@@ -120,7 +118,7 @@ where
 async fn get_connected_peers<T: NetworkingService + std::fmt::Debug>(
     tx: &UnboundedSender<PeerManagerEvent<T>>,
 ) -> Vec<ConnectedPeer> {
-    let (rtx, rrx) = oneshot::channel();
+    let (rtx, rrx) = oneshot_nofail::channel();
     tx.send(PeerManagerEvent::GetConnectedPeers(rtx)).unwrap();
     timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap()
 }

--- a/p2p/src/utils/mod.rs
+++ b/p2p/src/utils/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod oneshot_nofail;

--- a/p2p/src/utils/oneshot_nofail.rs
+++ b/p2p/src/utils/oneshot_nofail.rs
@@ -15,6 +15,9 @@
 
 //! Simple wrapper for the `tokio::sync::oneshot` channel
 //! that does not return an error if the receiver is disconnected.
+//!
+//! The wrapper could be used when sending to a closed channel is not considered an error
+//! (for example, when the async receiver was canceled for some reason).
 
 use std::{
     future::Future,

--- a/p2p/src/utils/oneshot_nofail.rs
+++ b/p2p/src/utils/oneshot_nofail.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Simple wrapper for the `tokio::sync::oneshot` channel
+//! that does not return an error if the receiver is disconnected.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::sync::oneshot;
+
+#[derive(Debug)]
+pub struct Sender<T>(oneshot::Sender<T>);
+
+impl<T> Sender<T> {
+    pub fn send(self, t: T) {
+        let _ = self.0.send(t);
+    }
+}
+
+#[derive(Debug)]
+pub struct Receiver<T>(oneshot::Receiver<T>);
+
+impl<T> Future for Receiver<T> {
+    type Output = Result<T, oneshot::error::RecvError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let (sender, receiver) = oneshot::channel();
+    (Sender(sender), Receiver(receiver))
+}


### PR DESCRIPTION
I think using the `oneshot` channel in `PeerManagerEvent` is not very safe.
It's easy to imagine a situation where the receiver is dropped before the event is processed.
For example here:

```
#[async_trait::async_trait]
impl<T> P2pInterface for P2p<T>
where
    T: NetworkingService,
{
    async fn connect(&mut self, addr: String) -> crate::Result<()> {
        let (tx, rx) = oneshot_nofail::channel();
        let addr = addr
            .parse::<T::Address>()
            .map_err(|_| P2pError::ConversionError(ConversionError::InvalidAddress(addr)))?;
        self.tx_peer_manager
            .send(PeerManagerEvent::Connect(addr, tx))
            .map_err(|_| P2pError::ChannelClosed)?;
        rx.await.map_err(P2pError::from)?
    }
...    
```

Here `connect` is async and so can be cancelled at any `await` point (I think we are not doing this now, but this could easily change later).
And yet, sending to a closed channel in `PeerManager` is considered a fatal error and `PeerManager` would stop working.
One fix would be to review all `oneshot` usages and fix them accordingly. However, I decided to write a small wrapper for the `oneshot` channel that ignores send errors, as this should be safer.
It would be nice if you could suggest a better name (than `oneshot_nofail`) for the new wrapper.