### PR TITLE
Remove more unused error variants

### DIFF
--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -36,16 +36,12 @@ pub enum ProtocolError {
 pub enum PeerError {
     #[error("Peer disconnected")]
     PeerDisconnected,
-    #[error("No peers")]
-    NoPeers,
     #[error("Peer doesn't exist")]
     PeerDoesntExist,
     #[error("Peer already exists")]
     PeerAlreadyExists,
     #[error("Address {0} is banned")]
     BannedAddress(String),
-    #[error("Peer {0} is banned")]
-    BannedPeer(String),
     #[error("PeerManager has too many peers")]
     TooManyPeers,
     #[error("Connection to address {0} already pending")]
@@ -55,33 +51,17 @@ pub enum PeerError {
 /// PubSub errors for announcements
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum PublishError {
-    #[error("Failed to sign message")]
-    SigningFailed,
     #[error("Message is too large. Tried to send {0:?} bytes when limit is {1:?}")]
     MessageTooLarge(usize, usize),
-    #[error("Failed to compress the message")]
-    TransformFailed,
 }
 
 /// Errors related to establishing a connection with a remote peer
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum DialError {
-    #[error("Peer is banned")]
-    Banned,
-    #[error("Limit for outgoing connections reached: {0}")]
-    ConnectionLimit(usize),
     #[error("Tried to dial self")]
     AttemptToDialSelf,
     #[error("Peer doesn't have any known addresses")]
     NoAddresses,
-    #[error("Peer state not correct for dialing")]
-    DialPeerConditionFalse,
-    #[error("Connection has been aborted")]
-    Aborted,
-    #[error("Invalid PeerId")]
-    InvalidPeerId,
-    #[error("PeerId doesn't match the PeerId of endpoint")]
-    WrongPeerId,
     #[error("Connection refused or timed out")]
     ConnectionRefusedOrTimedOut,
     #[error("I/O error: `{0:?}`")]
@@ -194,9 +174,7 @@ impl BanScore for ProtocolError {
 impl BanScore for PublishError {
     fn ban_score(&self) -> u32 {
         match self {
-            PublishError::SigningFailed => 0,
             PublishError::MessageTooLarge(_, _) => 100,
-            PublishError::TransformFailed => 0,
         }
     }
 }


### PR DESCRIPTION
I found more unused errors during my p2p error handling refactoring (which I decided to drop by the way). Perhaps we will need some of these errors in the future, but I prefer to add a new entity when it is needed and not to dial whit the dead code.