### PR TITLE
Fix #599 resuscitate cargo deny check licenses

### DIFF
--- a/.github/scripts/codecheck.py
+++ b/.github/scripts/codecheck.py
@@ -79,9 +79,9 @@ def check_crate_versions():
     print()
     return ok
 
-# Check license header
-def check_licenses():
-    print("==== Checking license headers:")
+# Check license header in current project crates
+def check_local_licenses():
+    print("==== Checking local license headers:")
     
     # list of files exempted from license check
     exempted_files = [
@@ -134,7 +134,7 @@ def run_checks():
     return all([
             disallow(SCALECODEC_RE, exclude = ['serialization/core']),
             disallow(JSONRPSEE_RE, exclude = ['rpc']),
-            check_licenses(),
+            check_local_licenses(),
             check_crate_versions(),
             check_todos()
         ])

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -62,3 +62,22 @@ jobs:
       - uses: actions/checkout@v1
       - run: pip install -r ./.github/scripts/requirements.txt
       - run: ./.github/scripts/codecheck.py
+
+  cargo_deny_checks:
+    name: Cargo deny check licenses and advisories
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - licenses
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check ${{ matrix.checks }}
+

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,112 @@
+[sources.allow-org]
+github = [
+    "mintlayer", #allow any code from mintlayer's github
+]
+
+[bans]
+multiple-versions = "deny" #catch mutliple versions of a crate
+deny = []
+
+#skip quick-error for "reasons" that i cba to explain just about as much as i cba to fix
+skip = [
+    {name = "aead", version = "=0.4.3"},
+    {name = "base64", version = "=0.10.1"},
+    {name = "bech32", version = "=0.8.1"},
+    {name = "blake2", version = "=0.9.2"},
+    {name = "block-buffer", version = "=0.9.0"},
+    {name = "chacha20", version = "=0.8.2"},
+    {name = "chacha20poly1305", version = "=0.9.1"},
+    {name = "cipher", version = "=0.3.0"},
+    {name = "clap", version = "=2.34.0"},
+    {name = "curve25519-dalek", version = "=3.2.0"},
+    {name = "digest", version = "=0.9.0"},
+    {name = "getrandom", version = "0.1.16"},
+    {name = "heck", version = "=0.3.3"},
+    {name = "parking_lot", version = "=0.11.2"},
+    {name = "parking_lot_core", version = "=0.8.5"},
+    {name = "poly1305", version = "=0.7.2"},
+    {name = "quick-error", version = "=1.2.3"},
+    {name = "rand", version = "=0.7.3"},
+    {name = "rand_chacha", version = "=0.2.2"},
+    {name = "rand_core", version = "=0.5.1"},
+    {name = "rustc_version", version = "=0.3.3"},
+    {name = "semver", version = "=0.11.0"},
+    {name = "sha-1", version = "=0.9.8"},
+    {name = "sha2", version = "=0.9.9"},
+    {name = "sha3", version = "=0.9.1"},
+    {name = "strsim", version = "=0.8.0"},
+    {name = "textwrap", version = "=0.11.0"},
+    {name = "universal-hash", version = "=0.4.1"},
+    {name = "wasi", version = "=0.10.0"},
+    {name = "wasi", version = "=0.9.0"},
+    {name = "windows", version = "=0.32.0"},
+    {name = "windows-sys", version = "=0.36.1"},
+    {name = "windows-sys", version = "=0.42.0"},
+    {name = "windows_aarch64_msvc", version = "=0.34.0"},
+    {name = "windows_aarch64_msvc", version = "=0.36.1"},
+    {name = "windows_aarch64_msvc", version = "=0.42.0"},
+    {name = "windows_i686_gnu", version = "=0.34.0"},
+    {name = "windows_i686_gnu", version = "=0.36.1"},
+    {name = "windows_i686_gnu", version = "=0.42.0"},
+    {name = "windows_i686_msvc", version = "=0.34.0"},
+    {name = "windows_i686_msvc", version = "=0.36.1"},
+    {name = "windows_i686_msvc", version = "=0.42.0"},
+    {name = "windows_x86_64_gnu", version = "=0.34.0"},
+    {name = "windows_x86_64_gnu", version = "=0.36.1"},
+    {name = "windows_x86_64_gnu", version = "=0.42.0"},
+    {name = "windows_x86_64_msvc", version = "=0.34.0"},
+    {name = "windows_x86_64_msvc", version = "=0.36.1"},
+    {name = "windows_x86_64_msvc", version = "=0.42.0"},
+]
+
+[licenses]
+#we reject code without a license
+unlicensed = "deny"
+confidence-threshold = 0.92
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "LicenseRef-ring",
+    "LicenseRef-webpki",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-DFS-2016",
+    "Unlicense", #this is a specific license rather than no license at all
+    "WTFPL",
+    "Zlib",
+] #deny a license not in this set of licenses
+
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "LicenseRef-webpki"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[advisories]
+db-path = "~/.cargo/advisory-dbs"
+db-urls = [ "https://github.com/RustSec/advisory-db" ]
+vulnerability = "deny"
+unmaintained = "warn"
+unsound = "warn"
+yanked = "warn"
+notice = "warn"
+severity-threshold = "medium"
+ignore = [
+    # time/chrono problems, have not been a problem in practice
+    "RUSTSEC-2020-0159",
+    "RUSTSEC-2020-0071",
+    # TODO: remove once mintlayer/mintlayer-core#334 is fixed
+    "RUSTSEC-2022-0040",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -3,62 +3,6 @@ github = [
     "mintlayer", #allow any code from mintlayer's github
 ]
 
-[bans]
-multiple-versions = "deny" #catch mutliple versions of a crate
-deny = []
-
-#skip quick-error for "reasons" that i cba to explain just about as much as i cba to fix
-skip = [
-    {name = "aead", version = "=0.4.3"},
-    {name = "base64", version = "=0.10.1"},
-    {name = "bech32", version = "=0.8.1"},
-    {name = "blake2", version = "=0.9.2"},
-    {name = "block-buffer", version = "=0.9.0"},
-    {name = "chacha20", version = "=0.8.2"},
-    {name = "chacha20poly1305", version = "=0.9.1"},
-    {name = "cipher", version = "=0.3.0"},
-    {name = "clap", version = "=2.34.0"},
-    {name = "curve25519-dalek", version = "=3.2.0"},
-    {name = "digest", version = "=0.9.0"},
-    {name = "getrandom", version = "0.1.16"},
-    {name = "heck", version = "=0.3.3"},
-    {name = "parking_lot", version = "=0.11.2"},
-    {name = "parking_lot_core", version = "=0.8.5"},
-    {name = "poly1305", version = "=0.7.2"},
-    {name = "quick-error", version = "=1.2.3"},
-    {name = "rand", version = "=0.7.3"},
-    {name = "rand_chacha", version = "=0.2.2"},
-    {name = "rand_core", version = "=0.5.1"},
-    {name = "rustc_version", version = "=0.3.3"},
-    {name = "semver", version = "=0.11.0"},
-    {name = "sha-1", version = "=0.9.8"},
-    {name = "sha2", version = "=0.9.9"},
-    {name = "sha3", version = "=0.9.1"},
-    {name = "strsim", version = "=0.8.0"},
-    {name = "textwrap", version = "=0.11.0"},
-    {name = "universal-hash", version = "=0.4.1"},
-    {name = "wasi", version = "=0.10.0"},
-    {name = "wasi", version = "=0.9.0"},
-    {name = "windows", version = "=0.32.0"},
-    {name = "windows-sys", version = "=0.36.1"},
-    {name = "windows-sys", version = "=0.42.0"},
-    {name = "windows_aarch64_msvc", version = "=0.34.0"},
-    {name = "windows_aarch64_msvc", version = "=0.36.1"},
-    {name = "windows_aarch64_msvc", version = "=0.42.0"},
-    {name = "windows_i686_gnu", version = "=0.34.0"},
-    {name = "windows_i686_gnu", version = "=0.36.1"},
-    {name = "windows_i686_gnu", version = "=0.42.0"},
-    {name = "windows_i686_msvc", version = "=0.34.0"},
-    {name = "windows_i686_msvc", version = "=0.36.1"},
-    {name = "windows_i686_msvc", version = "=0.42.0"},
-    {name = "windows_x86_64_gnu", version = "=0.34.0"},
-    {name = "windows_x86_64_gnu", version = "=0.36.1"},
-    {name = "windows_x86_64_gnu", version = "=0.42.0"},
-    {name = "windows_x86_64_msvc", version = "=0.34.0"},
-    {name = "windows_x86_64_msvc", version = "=0.36.1"},
-    {name = "windows_x86_64_msvc", version = "=0.42.0"},
-]
-
 [licenses]
 #we reject code without a license
 unlicensed = "deny"
@@ -76,7 +20,6 @@ allow = [
     "MPL-2.0",
     "Unicode-DFS-2016",
     "Unlicense", #this is a specific license rather than no license at all
-    "WTFPL",
     "Zlib",
 ] #deny a license not in this set of licenses
 
@@ -107,6 +50,4 @@ ignore = [
     # time/chrono problems, have not been a problem in practice
     "RUSTSEC-2020-0159",
     "RUSTSEC-2020-0071",
-    # TODO: remove once mintlayer/mintlayer-core#334 is fixed
-    "RUSTSEC-2022-0040",
 ]


### PR DESCRIPTION
## Issue
#599 
## Comments
- PR aimed to run the "cargo deny" but only for the dependency license validation and advisory checking feature. 
- "cargo deny" is not used for the "crate-duplicate-validation" feature .
- Reverts the "deny.toml" from [e69fd7](https://github.com/mintlayer/mintlayer-core/commit/e69fd724e69f290b98d936a24aadc6b95c2abcc2) and changes it to avoid a warning of an unused license, and another change to make sure the "create-duplicate-validation" will never take effect.

## Possible future PRs
- I saw a warning in GitHub Actions claiming that an upgrade is needed from Node.js 12 to Node.js 16. It is straightforward to avoid that warning. Just changes in code_checks.yml.