### PR TITLE
Prevent cargo deny checks running twice

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -76,6 +76,11 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
+      - id: skip-check
+        uses: fkirc/skip-duplicate-actions@v5.3.0
+        with:
+          concurrent_skipping: "same_content_newer"
+          skip_after_successful_duplicate: "true"
       - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -72,9 +72,6 @@ jobs:
           - advisories
           - licenses
 
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
-
     steps:
       - id: skip-check
         uses: fkirc/skip-duplicate-actions@v5.3.0


### PR DESCRIPTION
As it stands the new `cargo deny` stuff runs on both pull request and push. Well... Not anymore.