### PR TITLE
Remove custom config file path and enforce it being under data dir + allow empty config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,7 @@ dependencies = [
  "chainstate-launcher",
  "clap",
  "common",
+ "crypto",
  "directories",
  "jsonrpsee",
  "logging",

--- a/chainstate/launcher/src/config.rs
+++ b/chainstate/launcher/src/config.rs
@@ -18,6 +18,7 @@
 use chainstate::ChainstateConfig;
 
 /// Storage type to use
+#[must_use]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StorageBackendConfig {
     Lmdb,
@@ -31,6 +32,7 @@ impl Default for StorageBackendConfig {
 }
 
 /// Storage configuration
+#[must_use]
 #[derive(Debug, Default)]
 pub struct ChainstateLauncherConfig {
     /// Storage backend to use

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -30,5 +30,7 @@ directories = "4.0"
 paste = "1.0"
 
 [dev-dependencies]
+crypto = { path = "../crypto" }
+
 assert_cmd = "2"
 tempfile = "3.3"

--- a/node/src/config_files/chainstate_launcher.rs
+++ b/node/src/config_files/chainstate_launcher.rs
@@ -54,6 +54,7 @@ impl Default for StorageBackendConfigFile {
 }
 
 /// Storage configuration
+#[must_use]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ChainstateLauncherConfigFile {
     /// Storage backend to use

--- a/node/src/config_files/chainstate_launcher.rs
+++ b/node/src/config_files/chainstate_launcher.rs
@@ -21,9 +21,10 @@ use serde::{Deserialize, Serialize};
 use super::chainstate::ChainstateConfigFile;
 
 /// Storage type to use
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub enum StorageBackendConfigFile {
     #[serde(rename = "lmdb")]
+    #[default]
     Lmdb,
     #[serde(rename = "inmemory", alias = "in-memory")]
     InMemory,
@@ -44,12 +45,6 @@ impl std::str::FromStr for StorageBackendConfigFile {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let de = serde::de::value::StrDeserializer::new(s);
         Deserialize::deserialize(de)
-    }
-}
-
-impl Default for StorageBackendConfigFile {
-    fn default() -> Self {
-        Self::Lmdb
     }
 }
 

--- a/node/src/config_files/chainstate_launcher.rs
+++ b/node/src/config_files/chainstate_launcher.rs
@@ -54,7 +54,7 @@ impl Default for StorageBackendConfigFile {
 }
 
 /// Storage configuration
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ChainstateLauncherConfigFile {
     /// Storage backend to use
     #[serde(default)]

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -45,7 +45,6 @@ pub struct NodeConfigFile {
 }
 
 impl NodeConfigFile {
-    /// Creates a new `Config` instance with the given data directory path.
     pub fn new() -> Result<Self> {
         Ok(Self {
             chainstate: None,

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -54,9 +54,28 @@ impl NodeConfigFile {
         })
     }
 
+    fn read_config_file_to_string<P: AsRef<Path>>(config_path: P) -> Result<String> {
+        let config_as_str = if config_path.as_ref().exists() {
+            if config_path.as_ref().is_file() {
+                fs::read_to_string(config_path.as_ref()).context(format!(
+                    "Config file found in '{}' but could not be read",
+                    config_path.as_ref().display()
+                ))?
+            } else {
+                return Err(anyhow::anyhow!(
+                    "An object was found at the path of the config file '{}' but it is not a file",
+                    config_path.as_ref().display()
+                ));
+            }
+        } else {
+            "".into()
+        };
+        Ok(config_as_str)
+    }
+
     /// Reads a configuration from the specified path and overrides the provided parameters.
     pub fn read(config_path: &Path, options: &RunOptions) -> Result<Self> {
-        let config_as_str = fs::read_to_string(config_path).unwrap_or_default();
+        let config_as_str = Self::read_config_file_to_string(config_path)?;
 
         let NodeConfigFile {
             chainstate,

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -35,6 +35,7 @@ use self::{
 };
 
 /// The node configuration.
+#[must_use]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NodeConfigFile {
     // Subsystems configurations.
@@ -176,5 +177,20 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
         http_enabled: Some(http_enabled),
         ws_bind_address: Some(ws_bind_address),
         ws_enabled: Some(ws_enabled),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_values_required_in_toml_files() {
+        let _config: NodeConfigFile = toml::from_str("").unwrap();
+        let _config: chainstate_launcher::ChainstateLauncherConfigFile =
+            toml::from_str("").unwrap();
+        let _config: chainstate::ChainstateConfigFile = toml::from_str("").unwrap();
+        let _config: p2p::P2pConfigFile = toml::from_str("").unwrap();
+        let _config: rpc::RpcConfigFile = toml::from_str("").unwrap();
     }
 }

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -55,17 +55,10 @@ impl NodeConfigFile {
 
     fn read_to_string_with_policy<P: AsRef<Path>>(config_path: P) -> Result<String> {
         let config_as_str = if config_path.as_ref().exists() {
-            if config_path.as_ref().is_file() {
-                fs::read_to_string(config_path.as_ref()).context(format!(
-                    "Config file found in '{}' but could not be read",
-                    config_path.as_ref().display()
-                ))?
-            } else {
-                return Err(anyhow::anyhow!(
-                    "An object was found at the path of the config file '{}' but it is not a file",
-                    config_path.as_ref().display()
-                ));
-            }
+            fs::read_to_string(config_path.as_ref()).context(format!(
+                "Unable to read config file in {}",
+                config_path.as_ref().display()
+            ))?
         } else {
             "".into()
         };

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -56,13 +56,13 @@ impl NodeConfigFile {
 
     /// Reads a configuration from the specified path and overrides the provided parameters.
     pub fn read(config_path: &Path, options: &RunOptions) -> Result<Self> {
-        let config = fs::read_to_string(config_path)
-            .with_context(|| format!("Failed to read '{config_path:?}' config"))?;
+        let config_as_str = fs::read_to_string(config_path).unwrap_or_default();
+
         let NodeConfigFile {
             chainstate,
             p2p,
             rpc,
-        } = toml::from_str(&config).context("Failed to parse config")?;
+        } = toml::from_str(&config_as_str).context("Failed to parse config")?;
 
         let chainstate = chainstate_config(chainstate.unwrap_or_default(), options);
         let p2p = p2p_config(p2p.unwrap_or_default(), options);

--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -49,7 +49,7 @@ impl FromStr for NodeTypeConfigFile {
 }
 
 /// The p2p subsystem configuration.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct P2pConfigFile {
     /// Address to bind P2P to.
     pub bind_addresses: Option<Vec<String>>,

--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -49,6 +49,7 @@ impl FromStr for NodeTypeConfigFile {
 }
 
 /// The p2p subsystem configuration.
+#[must_use]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct P2pConfigFile {
     /// Address to bind P2P to.

--- a/node/src/config_files/rpc.rs
+++ b/node/src/config_files/rpc.rs
@@ -19,6 +19,7 @@ use rpc::RpcConfig;
 use serde::{Deserialize, Serialize};
 
 /// The rpc subsystem configuration.
+#[must_use]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct RpcConfigFile {
     /// Address to bind http RPC to.

--- a/node/src/config_files/rpc.rs
+++ b/node/src/config_files/rpc.rs
@@ -19,7 +19,7 @@ use rpc::RpcConfig;
 use serde::{Deserialize, Serialize};
 
 /// The rpc subsystem configuration.
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct RpcConfigFile {
     /// Address to bind http RPC to.
     pub http_bind_address: Option<SocketAddr>,

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -15,7 +15,12 @@
 
 //! Node initialization routine.
 
-use std::{fs, path::Path, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{anyhow, Context, Result};
 use paste::paste;
@@ -35,13 +40,14 @@ use p2p::{peer_manager::peerdb::storage_impl::PeerDbStorageImpl, rpc::P2pRpcServ
 
 use crate::{
     config_files::NodeConfigFile,
-    options::{Command, Options, RunOptions},
+    options::{default_data_dir, Command, Options, RunOptions},
     regtest_options::ChainConfigOptions,
 };
 
 /// Initialize the node, giving caller the opportunity to add more subsystems before start.
 pub async fn initialize(
     chain_config: ChainConfig,
+    data_dir: PathBuf,
     node_config: NodeConfigFile,
 ) -> Result<subsystem::Manager> {
     let chain_config = Arc::new(chain_config);
@@ -53,9 +59,9 @@ pub async fn initialize(
 
     // Chainstate subsystem
     let chainstate = chainstate_launcher::make_chainstate(
-        &node_config.datadir,
+        &data_dir,
         Arc::clone(&chain_config),
-        node_config.chainstate.into(),
+        node_config.chainstate.unwrap_or_default().into(),
     )?;
     let chainstate = manager.add_subsystem("chainstate", chainstate);
 
@@ -73,7 +79,7 @@ pub async fn initialize(
     // P2P subsystem
     // TODO: Replace Lmdb with Sqlite backend when it's ready
     let peerdb_storage = PeerDbStorageImpl::new(storage_lmdb::Lmdb::new(
-        node_config.datadir.join("peerdb-lmdb"),
+        data_dir.join("peerdb-lmdb"),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -82,7 +88,7 @@ pub async fn initialize(
         "p2p",
         p2p::make_p2p(
             Arc::clone(&chain_config),
-            Arc::new(node_config.p2p.into()),
+            Arc::new(node_config.p2p.unwrap_or_default().into()),
             chainstate.clone(),
             mempool.clone(),
             Default::default(),
@@ -104,12 +110,14 @@ pub async fn initialize(
         .await?,
     );
 
+    let rpc_config = node_config.rpc.unwrap_or_default();
+
     // RPC subsystem
-    if node_config.rpc.http_enabled.unwrap_or(true) || node_config.rpc.ws_enabled.unwrap_or(true) {
+    if rpc_config.http_enabled.unwrap_or(true) || rpc_config.ws_enabled.unwrap_or(true) {
         // TODO: get rid of the unwrap_or() after fixing the issue in #446
         let _rpc = manager.add_subsystem(
             "rpc",
-            rpc::Builder::new(node_config.rpc.into())
+            rpc::Builder::new(rpc_config.into())
                 .register(crate::rpc::init(manager.make_shutdown_trigger()))
                 .register(chainstate.clone().into_rpc())
                 .register(mempool.into_rpc())
@@ -125,15 +133,6 @@ pub async fn initialize(
 /// Processes options and potentially runs the node.
 pub async fn run(options: Options) -> Result<()> {
     match options.command {
-        Command::CreateConfig => {
-            let path = options.config_path();
-            let config = NodeConfigFile::new(options.data_dir())?;
-            let config = toml::to_string(&config).context("Failed to serialize config")?;
-            log::trace!("Saving config to {path:?}\n: {config:#?}");
-            fs::write(&path, config)
-                .with_context(|| format!("Failed to write config to the '{path:?}' file"))?;
-            Ok(())
-        }
         Command::Mainnet(ref run_options) => {
             let chain_config = common::chain::config::create_mainnet();
             start(
@@ -167,16 +166,40 @@ pub async fn run(options: Options) -> Result<()> {
     }
 }
 
+// TODO(PR): write tests for this
+fn prepare_data_dir(
+    default_data_dir_maker: fn() -> PathBuf,
+    datadir_path_opt: &Option<std::path::PathBuf>,
+) -> Result<PathBuf> {
+    match datadir_path_opt {
+        Some(data_dir) => {
+            assert!(data_dir.is_dir(), "Custom data directory '{data_dir:?}' does not exist. Please create it or use the default data directory.");
+        }
+        None => std::fs::create_dir_all(default_data_dir_maker()).with_context(|| {
+            format!(
+                "Failed to create the '{:?}' data directory",
+                default_data_dir()
+            )
+        })?,
+    }
+    let data_dir = datadir_path_opt.clone().unwrap_or(default_data_dir());
+    Ok(data_dir)
+}
+
 async fn start(
     config_path: &Path,
     datadir_path_opt: &Option<std::path::PathBuf>,
     run_options: &RunOptions,
     chain_config: ChainConfig,
 ) -> Result<()> {
-    let node_config = NodeConfigFile::read(config_path, datadir_path_opt, run_options)
-        .context("Failed to initialize config")?;
+    let node_config =
+        NodeConfigFile::read(config_path, run_options).context("Failed to initialize config")?;
+
+    let data_dir = prepare_data_dir(default_data_dir, datadir_path_opt)
+        .expect("Failed to prepare data directory");
+
     log::info!("Starting with the following config:\n {node_config:#?}");
-    let manager = initialize(chain_config, node_config).await?;
+    let manager = initialize(chain_config, data_dir, node_config).await?;
     manager.main().await;
     Ok(())
 }

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -180,7 +180,7 @@ fn prepare_data_dir<F: Fn() -> PathBuf>(
             if !data_dir.exists() {
                 return Err(anyhow::anyhow!("Custom data directory '{data_dir:?}' does not exist. Please create it or use the default data directory."));
             }
-            data_dir.to_owned()
+            data_dir.clone()
         }
         None => {
             std::fs::create_dir_all(default_data_dir_getter()).with_context(|| {
@@ -306,7 +306,7 @@ mod test {
         let file_data: Vec<u8> = (0..1024).map(|_| make_pseudo_rng().gen::<u8>()).collect();
         {
             let mut file = std::fs::File::create(&file_path).unwrap();
-            file.write(&file_data).unwrap();
+            file.write_all(&file_data).unwrap();
         }
 
         test_file_data(&file_path, &file_data);
@@ -370,7 +370,7 @@ mod test {
         let file_data: Vec<u8> = (0..1024).map(|_| make_pseudo_rng().gen::<u8>()).collect();
         {
             let mut file = std::fs::File::create(&file_path).unwrap();
-            file.write(&file_data).unwrap();
+            file.write_all(&file_data).unwrap();
         }
 
         test_file_data(&file_path, &file_data);

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -178,15 +178,15 @@ fn prepare_data_dir<F: Fn() -> PathBuf>(
     let data_dir = match datadir_path_opt {
         Some(data_dir) => {
             if !data_dir.exists() {
-                return Err(anyhow::anyhow!("Custom data directory '{data_dir:?}' does not exist. Please create it or use the default data directory."));
+                return Err(anyhow::anyhow!("Custom data directory '{}' does not exist. Please create it or use the default data directory.", data_dir.display()));
             }
             data_dir.clone()
         }
         None => {
             std::fs::create_dir_all(default_data_dir_getter()).with_context(|| {
                 format!(
-                    "Failed to create the '{:?}' data directory",
-                    default_data_dir_getter()
+                    "Failed to create the '{}' data directory",
+                    default_data_dir_getter().display()
                 )
             })?;
             default_data_dir_getter()

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -130,75 +130,59 @@ fn read_config_override_values() {
     let config = NodeConfigFile::read(&config_path, &options).unwrap();
 
     assert_eq!(
-        config
-            .chainstate
-            .clone()
-            .unwrap_or_default()
-            .chainstate_config
-            .max_db_commit_attempts,
+        config.chainstate.clone().unwrap().chainstate_config.max_db_commit_attempts,
         Some(max_db_commit_attempts)
     );
     assert_eq!(
-        config
-            .chainstate
-            .clone()
-            .unwrap_or_default()
-            .chainstate_config
-            .max_orphan_blocks,
+        config.chainstate.clone().unwrap().chainstate_config.max_orphan_blocks,
         Some(max_orphan_blocks)
     );
     assert_eq!(
-        config.chainstate.clone().unwrap_or_default().chainstate_config.tx_index_enabled,
+        config.chainstate.clone().unwrap().chainstate_config.tx_index_enabled,
         Some(false)
     );
     assert_eq!(
-        config.chainstate.clone().unwrap_or_default().chainstate_config.max_tip_age,
+        config.chainstate.clone().unwrap().chainstate_config.max_tip_age,
         Some(max_tip_age)
     );
 
     assert_eq!(
-        config.p2p.clone().unwrap_or_default().bind_addresses,
+        config.p2p.clone().unwrap().bind_addresses,
         Some(vec!(p2p_addr.to_owned()))
     );
     assert_eq!(
-        config.p2p.clone().unwrap_or_default().added_nodes,
+        config.p2p.clone().unwrap().added_nodes,
         Some(vec!(p2p_add_node.to_owned()))
     );
     assert_eq!(
-        config.p2p.clone().unwrap_or_default().ban_threshold,
+        config.p2p.clone().unwrap().ban_threshold,
         Some(p2p_ban_threshold)
     );
     assert_eq!(
-        config.p2p.clone().unwrap_or_default().outbound_connection_timeout,
+        config.p2p.clone().unwrap().outbound_connection_timeout,
         Some(p2p_timeout)
     );
     assert_eq!(
-        config.p2p.clone().unwrap_or_default().ping_check_period,
+        config.p2p.clone().unwrap().ping_check_period,
         Some(p2p_ping_check_period)
     );
     assert_eq!(
-        config.p2p.clone().unwrap_or_default().ping_timeout,
+        config.p2p.clone().unwrap().ping_timeout,
         Some(p2p_ping_timeout)
     );
-    assert_eq!(
-        config.p2p.clone().unwrap_or_default().node_type,
-        Some(node_type)
-    );
+    assert_eq!(config.p2p.clone().unwrap().node_type, Some(node_type));
 
     assert_eq!(
-        config.rpc.clone().unwrap_or_default().http_bind_address,
+        config.rpc.clone().unwrap().http_bind_address,
         Some(http_rpc_addr)
     );
-    assert!(config.rpc.clone().unwrap_or_default().http_enabled.unwrap());
+    assert!(config.rpc.clone().unwrap().http_enabled.unwrap());
 
     assert_eq!(
-        config.rpc.clone().unwrap_or_default().ws_bind_address,
+        config.rpc.clone().unwrap().ws_bind_address,
         Some(ws_rpc_addr)
     );
-    assert!(!config.rpc.clone().unwrap_or_default().ws_enabled.unwrap());
+    assert!(!config.rpc.clone().unwrap().ws_enabled.unwrap());
 
-    assert_eq!(
-        config.chainstate.unwrap_or_default().storage_backend,
-        backend_type
-    );
+    assert_eq!(config.chainstate.unwrap().storage_backend, backend_type);
 }

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -16,7 +16,6 @@
 use std::{net::SocketAddr, num::NonZeroU64, path::Path, str::FromStr};
 
 use assert_cmd::Command;
-use directories::UserDirs;
 use tempfile::TempDir;
 
 use node::{NodeConfigFile, NodeTypeConfigFile, RunOptions, StorageBackendConfigFile};
@@ -36,36 +35,54 @@ fn no_args() {
     Command::new(BIN_NAME).assert().failure();
 }
 
+fn create_empty_file(path: impl AsRef<Path>) {
+    let path = path.as_ref();
+    let _file = std::fs::File::create(path).unwrap();
+}
+
+// TODO(PR): ensure that no subconfigs are required when only the section in a toml file is specified
+
 #[test]
 fn create_default_config() {
     let data_dir = TempDir::new().unwrap();
 
-    Command::new(BIN_NAME)
-        .arg("--datadir")
-        .arg(data_dir.path().to_str().unwrap())
-        .arg("create-config")
-        .assert()
-        .success();
+    create_empty_file(data_dir.path().join(CONFIG_NAME));
+
     let config_path = data_dir.path().join(CONFIG_NAME);
     assert!(config_path.is_file());
 
-    let options = default_run_options();
-    let config = NodeConfigFile::read(&config_path, &None, &options).unwrap();
-
-    assert_eq!(config.datadir, data_dir.path());
+    let options = RunOptions::default();
+    let config = NodeConfigFile::read(&config_path, &options).unwrap();
 
     assert_eq!(
-        config.chainstate.chainstate_config.max_db_commit_attempts,
+        config
+            .chainstate
+            .clone()
+            .unwrap_or_default()
+            .chainstate_config
+            .max_db_commit_attempts,
         None
     );
-    assert_eq!(config.chainstate.chainstate_config.max_orphan_blocks, None);
+    assert_eq!(
+        config.chainstate.unwrap_or_default().chainstate_config.max_orphan_blocks,
+        None
+    );
 
-    assert!(config.p2p.bind_addresses.unwrap_or_default().is_empty());
-    assert_eq!(config.p2p.ban_threshold, None);
-    assert_eq!(config.p2p.outbound_connection_timeout, None);
+    assert!(config
+        .p2p
+        .clone()
+        .unwrap_or_default()
+        .bind_addresses
+        .unwrap_or_default()
+        .is_empty());
+    assert_eq!(config.p2p.clone().unwrap_or_default().ban_threshold, None);
+    assert_eq!(
+        config.p2p.clone().unwrap_or_default().outbound_connection_timeout,
+        None
+    );
 
     assert_eq!(
-        config.rpc.http_bind_address,
+        config.rpc.unwrap_or_default().http_bind_address,
         Some(SocketAddr::from_str("127.0.0.1:3030").unwrap())
     );
 }
@@ -75,12 +92,8 @@ fn create_default_config() {
 fn read_config_override_values() {
     let data_dir = TempDir::new().unwrap();
 
-    Command::new(BIN_NAME)
-        .arg("--datadir")
-        .arg(data_dir.path().to_str().unwrap())
-        .arg("create-config")
-        .assert()
-        .success();
+    create_empty_file(data_dir.path().join(CONFIG_NAME));
+
     let config_path = data_dir.path().join(CONFIG_NAME);
     assert!(config_path.is_file());
 
@@ -116,107 +129,78 @@ fn read_config_override_values() {
         ws_rpc_addr: Some(ws_rpc_addr),
         ws_rpc_enabled: Some(false),
     };
-    let datadir_opt = Some(data_dir.path().into());
-    let config = NodeConfigFile::read(&config_path, &datadir_opt, &options).unwrap();
-
-    assert_eq!(config.datadir, data_dir.path());
+    let config = NodeConfigFile::read(&config_path, &options).unwrap();
 
     assert_eq!(
-        config.chainstate.chainstate_config.max_db_commit_attempts,
+        config
+            .chainstate
+            .clone()
+            .unwrap_or_default()
+            .chainstate_config
+            .max_db_commit_attempts,
         Some(max_db_commit_attempts)
     );
     assert_eq!(
-        config.chainstate.chainstate_config.max_orphan_blocks,
+        config
+            .chainstate
+            .clone()
+            .unwrap_or_default()
+            .chainstate_config
+            .max_orphan_blocks,
         Some(max_orphan_blocks)
     );
     assert_eq!(
-        config.chainstate.chainstate_config.tx_index_enabled,
+        config.chainstate.clone().unwrap_or_default().chainstate_config.tx_index_enabled,
         Some(false)
     );
     assert_eq!(
-        config.chainstate.chainstate_config.max_tip_age,
+        config.chainstate.clone().unwrap_or_default().chainstate_config.max_tip_age,
         Some(max_tip_age)
     );
 
-    assert_eq!(config.p2p.bind_addresses, Some(vec!(p2p_addr.to_owned())));
-    assert_eq!(config.p2p.added_nodes, Some(vec!(p2p_add_node.to_owned())));
-    assert_eq!(config.p2p.ban_threshold, Some(p2p_ban_threshold));
-    assert_eq!(config.p2p.outbound_connection_timeout, Some(p2p_timeout));
-    assert_eq!(config.p2p.ping_check_period, Some(p2p_ping_check_period));
-    assert_eq!(config.p2p.ping_timeout, Some(p2p_ping_timeout));
-    assert_eq!(config.p2p.node_type, Some(node_type));
+    assert_eq!(
+        config.p2p.clone().unwrap_or_default().bind_addresses,
+        Some(vec!(p2p_addr.to_owned()))
+    );
+    assert_eq!(
+        config.p2p.clone().unwrap_or_default().added_nodes,
+        Some(vec!(p2p_add_node.to_owned()))
+    );
+    assert_eq!(
+        config.p2p.clone().unwrap_or_default().ban_threshold,
+        Some(p2p_ban_threshold)
+    );
+    assert_eq!(
+        config.p2p.clone().unwrap_or_default().outbound_connection_timeout,
+        Some(p2p_timeout)
+    );
+    assert_eq!(
+        config.p2p.clone().unwrap_or_default().ping_check_period,
+        Some(p2p_ping_check_period)
+    );
+    assert_eq!(
+        config.p2p.clone().unwrap_or_default().ping_timeout,
+        Some(p2p_ping_timeout)
+    );
+    assert_eq!(
+        config.p2p.clone().unwrap_or_default().node_type,
+        Some(node_type)
+    );
 
-    assert_eq!(config.rpc.http_bind_address, Some(http_rpc_addr));
-    assert!(config.rpc.http_enabled.unwrap());
+    assert_eq!(
+        config.rpc.clone().unwrap_or_default().http_bind_address,
+        Some(http_rpc_addr)
+    );
+    assert!(config.rpc.clone().unwrap_or_default().http_enabled.unwrap());
 
-    assert_eq!(config.rpc.ws_bind_address, Some(ws_rpc_addr));
-    assert!(!config.rpc.ws_enabled.unwrap());
+    assert_eq!(
+        config.rpc.clone().unwrap_or_default().ws_bind_address,
+        Some(ws_rpc_addr)
+    );
+    assert!(!config.rpc.clone().unwrap_or_default().ws_enabled.unwrap());
 
-    assert_eq!(config.chainstate.storage_backend, backend_type);
-}
-
-// Check that the `--conf` option has the precedence over the default data directory value.
-#[test]
-fn custom_config_path() {
-    let temp_dir = TempDir::new().unwrap();
-    let config_path = temp_dir.path().join(CONFIG_NAME);
-
-    Command::new(BIN_NAME)
-        .arg("--conf")
-        .arg(config_path.to_str().unwrap())
-        .arg("create-config")
-        .assert()
-        .success();
-    let data_dir = UserDirs::new().unwrap().home_dir().join(".mintlayer");
-    assert!(data_dir.is_dir());
-    assert!(config_path.is_file());
-
-    let options = default_run_options();
-    let config = NodeConfigFile::read(&config_path, &None, &options).unwrap();
-
-    assert_eq!(config.datadir, data_dir);
-}
-
-// Check that the `--conf` option has the precedence over the `--datadir` option.
-#[test]
-fn custom_config_path_and_data_dir() {
-    let data_dir = TempDir::new().unwrap();
-    let temp_dir = TempDir::new().unwrap();
-    let config_path = temp_dir.path().join(CONFIG_NAME);
-
-    Command::new(BIN_NAME)
-        .arg("--datadir")
-        .arg(data_dir.path().to_str().unwrap())
-        .arg("--conf")
-        .arg(config_path.to_str().unwrap())
-        .arg("create-config")
-        .assert()
-        .success();
-    assert!(config_path.is_file());
-
-    let options = default_run_options();
-    let config = NodeConfigFile::read(&config_path, &None, &options).unwrap();
-
-    assert_eq!(config.datadir, data_dir.path());
-}
-
-fn default_run_options() -> RunOptions {
-    RunOptions {
-        storage_backend: None,
-        node_type: None,
-        max_db_commit_attempts: None,
-        max_orphan_blocks: None,
-        tx_index_enabled: None,
-        p2p_addr: None,
-        p2p_add_node: None,
-        p2p_ban_threshold: None,
-        p2p_outbound_connection_timeout: None,
-        p2p_ping_check_period: None,
-        p2p_ping_timeout: None,
-        max_tip_age: None,
-        http_rpc_addr: None,
-        http_rpc_enabled: None,
-        ws_rpc_addr: None,
-        ws_rpc_enabled: None,
-    }
+    assert_eq!(
+        config.chainstate.unwrap_or_default().storage_backend,
+        backend_type
+    );
 }

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -40,8 +40,6 @@ fn create_empty_file(path: impl AsRef<Path>) {
     let _file = std::fs::File::create(path).unwrap();
 }
 
-// TODO(PR): ensure that no subconfigs are required when only the section in a toml file is specified
-
 #[test]
 fn create_default_config() {
     let data_dir = TempDir::new().unwrap();

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -99,14 +99,11 @@ class TestNode():
         rpc_addr = self.init_rpc_url.split("http://")[-1].split('@')[-1]
         p2p_addr = p2p_url(self.index)
 
-        config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), ".mintlayer", "config.toml")
-
         # Configuration for logging is set as command-line args rather than in the bitcoin.conf file.
         # This means that starting a bitcoind using the temp dir to debug a failed test won't
         # spam debug.log.
         self.args = [
             self.binary,
-            "--conf={}".format(config_path),
             "--datadir={}".format(datadir),
             "regtest",
             "--http-rpc-addr={}".format(rpc_addr),


### PR DESCRIPTION
- Configuration must stricly be in data directory
- Data directory cannot be specified in configuration
- All configuration options are optional. Options that aren't specified revert to default values
- Data directory is only created if the default path is used, to avoid mistakes where one uses different data directory due to typos

Closes #446 and closes #498