### PR TITLE
Create a proxy that keeps the orphan blocks pool in one thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "jsonrpsee",
  "logging",
  "mockall",
+ "oneshot",
  "pos_accounting",
  "rpc",
  "rstest",
@@ -1783,6 +1784,7 @@ checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
 dependencies = [
  "cfg-if",
  "generator",
+ "pin-utils",
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
@@ -2106,6 +2108,15 @@ name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "oneshot"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc22d22931513428ea6cc089e942d38600e3d00976eef8c86de6b8a3aadec6eb"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "opaque-debug"

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -18,6 +18,7 @@ subsystem = {path = '../subsystem'}
 utxo = {path = '../utxo'}
 utils = {path = '../utils'}
 consensus = {path = "../consensus"}
+oneshot = "0.1"
 
 async-trait.workspace = true
 hex.workspace = true

--- a/chainstate/src/detail/orphan_blocks/mod.rs
+++ b/chainstate/src/detail/orphan_blocks/mod.rs
@@ -18,3 +18,6 @@ pub use orphans_refs::*;
 
 mod pool;
 pub use pool::*;
+
+mod orphans_proxy;
+pub use orphans_proxy::*;

--- a/chainstate/src/detail/orphan_blocks/orphans_proxy.rs
+++ b/chainstate/src/detail/orphan_blocks/orphans_proxy.rs
@@ -29,17 +29,16 @@ pub struct OrphansProxy {
     tx: mpsc::Sender<RemoteCall>,
 }
 
-// TODO: remove #[allow(dead_code)] from the functions below
+// TODO: remove #[allow(dead_code)] from the functions below once this is integrated into chainstate
 
 impl OrphansProxy {
     #[allow(dead_code)]
     pub fn new(max_orphans: usize) -> Self {
         let (tx, rx) = mpsc::channel();
-        let stop_control = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let thread_handle = Some(std::thread::spawn(move || {
             let mut orphans_pool = OrphanBlocksPool::new(max_orphans);
             let receiver: mpsc::Receiver<RemoteCall> = rx;
-            while !stop_control.load(std::sync::atomic::Ordering::Relaxed) {
+            loop {
                 match receiver.recv() {
                     Ok(f) => match f {
                         Some(func) => func(&mut orphans_pool),

--- a/chainstate/src/detail/orphan_blocks/orphans_proxy.rs
+++ b/chainstate/src/detail/orphan_blocks/orphans_proxy.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::mpsc;
+
+use utils::tap_error_log::LogError;
+
+use super::OrphanBlocksPool;
+
+type RemoteCall = Option<Box<dyn FnOnce(&mut OrphanBlocksPool) + Send>>;
+
+/// A tool that runs OrphanBlocksPool in a separate thread
+/// and supports remote calls to it, such that it never
+/// needs to be moved among threads.
+pub struct OrphansProxy {
+    thread_handle: Option<std::thread::JoinHandle<()>>,
+    tx: mpsc::Sender<RemoteCall>,
+}
+
+impl OrphansProxy {
+    #[allow(dead_code)]
+    pub fn new(max_orphans: usize) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let stop_control = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let thread_handle = Some(std::thread::spawn(move || {
+            let mut orphans_pool = OrphanBlocksPool::new(max_orphans);
+            let receiver: mpsc::Receiver<RemoteCall> = rx;
+            while !stop_control.load(std::sync::atomic::Ordering::Relaxed) {
+                match receiver.recv() {
+                    Ok(f) => match f {
+                        Some(func) => func(&mut orphans_pool),
+                        None => break,
+                    },
+                    Err(_) => break,
+                }
+            }
+        }));
+        Self { thread_handle, tx }
+    }
+
+    #[allow(dead_code)]
+    pub fn call<R: Send + 'static>(
+        &self,
+        f: impl FnOnce(&OrphanBlocksPool) -> R + Send + 'static,
+    ) -> oneshot::Receiver<R> {
+        self.call_mut(|this| f(this))
+    }
+
+    #[allow(dead_code)]
+    pub fn call_mut<R: Send + 'static>(
+        &self,
+        f: impl FnOnce(&mut OrphanBlocksPool) -> R + Send + 'static,
+    ) -> oneshot::Receiver<R> {
+        let (tx, rx) = oneshot::channel::<R>();
+        let _ = self
+            .tx
+            .send(Some(Box::new(move |subsys| {
+                let result = f(subsys);
+                tx.send(result).unwrap();
+            })))
+            .log_err();
+        rx
+    }
+}
+
+impl Drop for OrphansProxy {
+    fn drop(&mut self) {
+        self.tx.send(None).expect("Failed to send stop control message");
+        let mut to_kill: Option<std::thread::JoinHandle<()>> = None;
+        std::mem::swap(&mut self.thread_handle, &mut to_kill);
+        to_kill.expect("Must exist after the swap").join().expect("Join failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_orphans_proxy_control() {
+        let orphans_proxy = OrphansProxy::new(500);
+        assert_eq!(orphans_proxy.call(|o| o.len()).recv().unwrap(), 0);
+    }
+}

--- a/chainstate/src/detail/orphan_blocks/orphans_proxy.rs
+++ b/chainstate/src/detail/orphan_blocks/orphans_proxy.rs
@@ -38,13 +38,10 @@ impl OrphansProxy {
         let thread_handle = Some(std::thread::spawn(move || {
             let mut orphans_pool = OrphanBlocksPool::new(max_orphans);
             let receiver: mpsc::Receiver<RemoteCall> = rx;
-            loop {
-                match receiver.recv() {
-                    Ok(f) => match f {
-                        Some(func) => func(&mut orphans_pool),
-                        None => break,
-                    },
-                    Err(_) => break,
+            while let Ok(f) = receiver.recv() {
+                match f {
+                    Some(func) => func(&mut orphans_pool),
+                    None => break,
                 }
             }
         }));

--- a/chainstate/src/detail/orphan_blocks/orphans_proxy.rs
+++ b/chainstate/src/detail/orphan_blocks/orphans_proxy.rs
@@ -96,13 +96,10 @@ mod tests {
     fn test_orphans_proxy_control() {
         let orphans_proxy = OrphansProxy::new(500);
         assert_eq!(orphans_proxy.call(|o| o.len()).recv().unwrap(), 0);
-        assert_eq!(
-            orphans_proxy
-                .call(|o| o.is_already_an_orphan(&H256::zero().into()))
-                .recv()
-                .unwrap(),
-            false
-        );
+        assert!(!orphans_proxy
+            .call(|o| o.is_already_an_orphan(&H256::zero().into()))
+            .recv()
+            .unwrap());
         assert_eq!(
             orphans_proxy
                 .call_mut(|o| o.take_all_children_of(&H256::zero().into()))


### PR DESCRIPTION
Solution to #164

Next, we'll replace OrphanBlocksPool in Chainstate with this.