### PR TITLE
Process block recursion

### DIFF
--- a/chainstate/src/detail/bootstrap.rs
+++ b/chainstate/src/detail/bootstrap.rs
@@ -22,10 +22,7 @@ use serialization::{Decode, Encode};
 
 use crate::{BlockError, ChainstateConfig};
 
-use super::{
-    orphan_blocks::OrphanBlocksRef, query::ChainstateQuery,
-    tx_verification_strategy::TransactionVerificationStrategy,
-};
+use super::{query::ChainstateQuery, tx_verification_strategy::TransactionVerificationStrategy};
 
 #[derive(thiserror::Error, Debug, Eq, PartialEq)]
 pub enum BootstrapError {
@@ -109,16 +106,11 @@ fn fill_buffer<S: std::io::Read>(
     Ok(())
 }
 
-pub fn export_bootstrap_stream<
-    'a,
-    S: BlockchainStorageRead,
-    O: OrphanBlocksRef,
-    V: TransactionVerificationStrategy,
->(
+pub fn export_bootstrap_stream<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy>(
     magic_bytes: &[u8],
     writer: &mut std::io::BufWriter<Box<dyn std::io::Write + 'a + Send>>,
     include_orphans: bool,
-    query_interface: &ChainstateQuery<'a, S, O, V>,
+    query_interface: &ChainstateQuery<'a, S, V>,
 ) -> Result<(), BootstrapError>
 where
 {

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -39,33 +39,31 @@ use tx_verifier::transaction_verifier::{config::TransactionVerifierConfig, Trans
 use utils::{ensure, tap_error_log::LogError};
 use utxo::{UtxosDB, UtxosView};
 
-use crate::{BlockError, BlockSource, ChainstateConfig};
+use crate::{BlockError, ChainstateConfig};
 
 use self::tx_verifier_storage::gen_block_index_getter;
 
 use super::{
     median_time::calculate_median_time_past,
-    orphan_blocks::{OrphanBlocksMut, OrphanBlocksRef},
     tokens::check_tokens_data,
     transaction_verifier::{error::TokensError, flush::flush_to_storage},
     tx_verification_strategy::TransactionVerificationStrategy,
-    BlockSizeError, CheckBlockError, CheckBlockTransactionsError, OrphanCheckError,
+    BlockSizeError, CheckBlockError, CheckBlockTransactionsError,
 };
 
 mod epoch_seal;
 mod tx_verifier_storage;
 
-pub struct ChainstateRef<'a, S, O, V> {
+pub struct ChainstateRef<'a, S, V> {
     chain_config: &'a ChainConfig,
     chainstate_config: &'a ChainstateConfig,
     tx_verification_strategy: &'a V,
     db_tx: S,
-    orphan_blocks: O,
     time_getter: &'a TimeGetterFn,
 }
 
-impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    BlockIndexHandle for ChainstateRef<'a, S, O, V>
+impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> BlockIndexHandle
+    for ChainstateRef<'a, S, V>
 {
     fn get_block_index(
         &self,
@@ -98,8 +96,8 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificatio
     }
 }
 
-impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    TransactionIndexHandle for ChainstateRef<'a, S, O, V>
+impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> TransactionIndexHandle
+    for ChainstateRef<'a, S, V>
 {
     fn get_mainchain_tx_index(
         &self,
@@ -116,29 +114,25 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificatio
     }
 }
 
-impl<'a, S: TransactionRw, O, V> ChainstateRef<'a, S, O, V> {
+impl<'a, S: TransactionRw, V> ChainstateRef<'a, S, V> {
     pub fn commit_db_tx(self) -> chainstate_storage::Result<()> {
         self.db_tx.commit()
     }
 }
 
-impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    ChainstateRef<'a, S, O, V>
-{
+impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> ChainstateRef<'a, S, V> {
     pub fn new_rw(
         chain_config: &'a ChainConfig,
         chainstate_config: &'a ChainstateConfig,
         tx_verification_strategy: &'a V,
         db_tx: S,
-        orphan_blocks: O,
         time_getter: &'a TimeGetterFn,
-    ) -> ChainstateRef<'a, S, O, V> {
+    ) -> ChainstateRef<'a, S, V> {
         ChainstateRef {
             chain_config,
             chainstate_config,
             db_tx,
             tx_verification_strategy,
-            orphan_blocks,
             time_getter,
         }
     }
@@ -148,15 +142,13 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificatio
         chainstate_config: &'a ChainstateConfig,
         tx_verification_strategy: &'a V,
         db_tx: S,
-        orphan_blocks: O,
         time_getter: &'a TimeGetterFn,
-    ) -> ChainstateRef<'a, S, O, V> {
+    ) -> ChainstateRef<'a, S, V> {
         ChainstateRef {
             chain_config,
             chainstate_config,
             db_tx,
             tx_verification_strategy,
-            orphan_blocks,
             time_getter,
         }
     }
@@ -689,29 +681,7 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificatio
     }
 }
 
-impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut, V: TransactionVerificationStrategy>
-    ChainstateRef<'a, S, O, V>
-{
-    pub fn check_legitimate_orphan(
-        &mut self,
-        block_source: BlockSource,
-        block: WithId<Block>,
-    ) -> Result<WithId<Block>, OrphanCheckError> {
-        let prev_block_id = block.prev_block_id();
-
-        let block_index_found = self
-            .get_gen_block_index(&prev_block_id)
-            .map_err(OrphanCheckError::PrevBlockIndexNotFound)
-            .log_err()?
-            .is_some();
-
-        if block_source == BlockSource::Local && !block_index_found {
-            self.new_orphan_block(block).log_err()?;
-            return Err(OrphanCheckError::LocalOrphan);
-        }
-        Ok(block)
-    }
-
+impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> ChainstateRef<'a, S, V> {
     fn disconnect_until(
         &mut self,
         to_disconnect: &BlockIndex,
@@ -955,13 +925,5 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksMut, V: TransactionVerificati
         self.db_tx.set_block_index(&block_index).map_err(BlockError::from).log_err()?;
         self.db_tx.add_block(block).map_err(BlockError::from).log_err()?;
         Ok(block_index)
-    }
-
-    /// Mark new block as an orphan
-    fn new_orphan_block(&mut self, block: WithId<Block>) -> Result<(), OrphanCheckError> {
-        match self.orphan_blocks.add_block(block) {
-            Ok(_) => Ok(()),
-            Err(err) => (*err).into(),
-        }
     }
 }

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -17,7 +17,6 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::detail::{
     chainstateref::ChainstateRef,
-    orphan_blocks::OrphanBlocksRef,
     transaction_verifier::storage::{
         TransactionVerifierStorageError, TransactionVerifierStorageMut,
         TransactionVerifierStorageRef,
@@ -41,8 +40,8 @@ use pos_accounting::{
 use tx_verifier::transaction_verifier::TransactionSource;
 use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosBlockUndo, UtxosDB, UtxosStorageRead};
 
-impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    TransactionVerifierStorageRef for ChainstateRef<'a, S, O, V>
+impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> TransactionVerifierStorageRef
+    for ChainstateRef<'a, S, V>
 {
     fn get_token_id_from_issuance_tx(
         &self,
@@ -101,8 +100,8 @@ pub fn gen_block_index_getter<S: BlockchainStorageRead>(
     }
 }
 
-impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    UtxosStorageRead for ChainstateRef<'a, S, O, V>
+impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> UtxosStorageRead
+    for ChainstateRef<'a, S, V>
 {
     fn get_utxo(
         &self,
@@ -123,8 +122,8 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificatio
     }
 }
 
-impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    FlushableUtxoView for ChainstateRef<'a, S, O, V>
+impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> FlushableUtxoView
+    for ChainstateRef<'a, S, V>
 {
     fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), utxo::Error> {
         let mut db = UtxosDB::new(&mut self.db_tx);
@@ -132,8 +131,8 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksRef, V: TransactionVerificati
     }
 }
 
-impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    TransactionVerifierStorageMut for ChainstateRef<'a, S, O, V>
+impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
+    TransactionVerifierStorageMut for ChainstateRef<'a, S, V>
 {
     fn set_mainchain_tx_index(
         &mut self,
@@ -291,8 +290,8 @@ impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksRef, V: TransactionVerificati
     }
 }
 
-impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    PoSAccountingView for ChainstateRef<'a, S, O, V>
+impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> PoSAccountingView
+    for ChainstateRef<'a, S, V>
 {
     fn pool_exists(&self, pool_id: PoolId) -> Result<bool, pos_accounting::Error> {
         self.get_pool_data(pool_id).map(|v| v.is_some())
@@ -349,8 +348,8 @@ impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificatio
     }
 }
 
-impl<'a, S: BlockchainStorageWrite, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    FlushablePoSAccountingView for ChainstateRef<'a, S, O, V>
+impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> FlushablePoSAccountingView
+    for ChainstateRef<'a, S, V>
 {
     fn batch_write_delta(
         &mut self,

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -328,7 +328,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
 
         let mut orphan_process_queue: VecDeque<_> = vec![block_id].into();
         while let Some(block_id) = orphan_process_queue.pop_front() {
-            let orphans = (&mut self.orphan_blocks).take_all_children_of(&block_id.into());
+            let orphans = self.orphan_blocks.take_all_children_of(&block_id.into());
             // whatever was pulled from orphans should be processed next in the queue
             orphan_process_queue.extend(orphans.iter().map(|b| b.get_id()));
             let (orphan_block_indexes, block_errors): (Vec<Option<BlockIndex>>, Vec<BlockError>) =
@@ -510,7 +510,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
 
     /// Mark new block as an orphan
     fn new_orphan_block(&mut self, block: WithId<Block>) -> Result<(), OrphanCheckError> {
-        match (&mut self.orphan_blocks).add_block(block) {
+        match self.orphan_blocks.add_block(block) {
             Ok(_) => Ok(()),
             Err(err) => (*err).into(),
         }

--- a/chainstate/src/detail/orphan_blocks/orphans_proxy_impl.rs
+++ b/chainstate/src/detail/orphan_blocks/orphans_proxy_impl.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::{Deref, DerefMut};
-
 use common::{
     chain::{Block, GenBlock},
     primitives::{id::WithId, Id},
@@ -24,58 +22,31 @@ use super::{OrphanAddError, OrphanBlocksMut, OrphanBlocksRef, OrphansProxy};
 
 const RECV_ERR_MSG: &str = "Failed to recv from orphan blocks proxy. This should never happen as the destruction of the proxy should end the communication; but something else did";
 
-mod orphans_proxy_ref_impls {
-    use super::*;
-
-    pub fn len(this: &OrphansProxy) -> usize {
-        this.deref().call(move |o| o.len()).recv().expect(RECV_ERR_MSG)
+impl OrphanBlocksRef for OrphansProxy {
+    fn len(&self) -> usize {
+        self.call(move |o| o.len()).recv().expect(RECV_ERR_MSG)
     }
 
-    pub fn is_already_an_orphan(this: &OrphansProxy, block_id: &Id<Block>) -> bool {
+    fn is_already_an_orphan(&self, block_id: &Id<Block>) -> bool {
         let block_id = *block_id;
-        this.deref()
-            .call(move |o| o.is_already_an_orphan(&block_id))
+        self.call(move |o| o.is_already_an_orphan(&block_id))
             .recv()
             .expect(RECV_ERR_MSG)
     }
 }
 
-impl OrphanBlocksRef for &OrphansProxy {
-    fn len(&self) -> usize {
-        orphans_proxy_ref_impls::len(self)
-    }
-
-    fn is_already_an_orphan(&self, block_id: &Id<Block>) -> bool {
-        orphans_proxy_ref_impls::is_already_an_orphan(self, block_id)
-    }
-}
-
-impl OrphanBlocksRef for &mut OrphansProxy {
-    fn len(&self) -> usize {
-        orphans_proxy_ref_impls::len(self)
-    }
-
-    fn is_already_an_orphan(&self, block_id: &Id<Block>) -> bool {
-        orphans_proxy_ref_impls::is_already_an_orphan(self, block_id)
-    }
-}
-
-impl OrphanBlocksMut for &mut OrphansProxy {
+impl OrphanBlocksMut for OrphansProxy {
     fn clear(&mut self) {
-        self.deref_mut().call_mut(move |o| o.clear()).recv().expect(RECV_ERR_MSG)
+        self.call_mut(move |o| o.clear()).recv().expect(RECV_ERR_MSG)
     }
 
     fn add_block(&mut self, block: WithId<Block>) -> Result<(), Box<OrphanAddError>> {
-        self.deref_mut()
-            .call_mut(move |o| o.add_block(block))
-            .recv()
-            .expect(RECV_ERR_MSG)
+        self.call_mut(move |o| o.add_block(block)).recv().expect(RECV_ERR_MSG)
     }
 
     fn take_all_children_of(&mut self, block_id: &Id<GenBlock>) -> Vec<WithId<Block>> {
         let block_id = *block_id;
-        self.deref_mut()
-            .call_mut(move |o| o.take_all_children_of(&block_id))
+        self.call_mut(move |o| o.take_all_children_of(&block_id))
             .recv()
             .expect(RECV_ERR_MSG)
     }

--- a/chainstate/src/detail/orphan_blocks/pool_impl.rs
+++ b/chainstate/src/detail/orphan_blocks/pool_impl.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::{Deref, DerefMut};
-
 use common::{
     chain::{Block, GenBlock},
     primitives::{id::WithId, Id},
@@ -22,36 +20,26 @@ use common::{
 
 use super::{OrphanAddError, OrphanBlocksMut, OrphanBlocksPool, OrphanBlocksRef};
 
-impl OrphanBlocksRef for &OrphanBlocksPool {
+impl OrphanBlocksRef for OrphanBlocksPool {
     fn len(&self) -> usize {
-        self.deref().len()
+        self.len()
     }
 
     fn is_already_an_orphan(&self, block_id: &Id<Block>) -> bool {
-        self.deref().is_already_an_orphan(block_id)
+        self.is_already_an_orphan(block_id)
     }
 }
 
-impl OrphanBlocksRef for &mut OrphanBlocksPool {
-    fn len(&self) -> usize {
-        self.deref().len()
-    }
-
-    fn is_already_an_orphan(&self, block_id: &Id<Block>) -> bool {
-        self.deref().is_already_an_orphan(block_id)
-    }
-}
-
-impl OrphanBlocksMut for &mut OrphanBlocksPool {
+impl OrphanBlocksMut for OrphanBlocksPool {
     fn clear(&mut self) {
-        self.deref_mut().clear()
+        self.clear()
     }
 
     fn add_block(&mut self, block: WithId<Block>) -> Result<(), Box<OrphanAddError>> {
-        self.deref_mut().add_block(block)
+        self.add_block(block)
     }
 
     fn take_all_children_of(&mut self, block_id: &Id<GenBlock>) -> Vec<WithId<Block>> {
-        self.deref_mut().take_all_children_of(block_id)
+        self.take_all_children_of(block_id)
     }
 }

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -28,22 +28,19 @@ use common::{
 };
 
 use super::{
-    chainstateref, orphan_blocks::OrphanBlocksRef,
-    tx_verification_strategy::TransactionVerificationStrategy, HEADER_LIMIT,
+    chainstateref, tx_verification_strategy::TransactionVerificationStrategy, HEADER_LIMIT,
 };
 
 pub fn locator_tip_distances() -> impl Iterator<Item = BlockDistance> {
     itertools::iterate(0, |&i| std::cmp::max(1, i * 2)).map(BlockDistance::new)
 }
 
-pub struct ChainstateQuery<'a, S, O, V> {
-    chainstate_ref: chainstateref::ChainstateRef<'a, S, O, V>,
+pub struct ChainstateQuery<'a, S, V> {
+    chainstate_ref: chainstateref::ChainstateRef<'a, S, V>,
 }
 
-impl<'a, S: BlockchainStorageRead, O: OrphanBlocksRef, V: TransactionVerificationStrategy>
-    ChainstateQuery<'a, S, O, V>
-{
-    pub(crate) fn new(chainstate_ref: chainstateref::ChainstateRef<'a, S, O, V>) -> Self {
+impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> ChainstateQuery<'a, S, V> {
+    pub(crate) fn new(chainstate_ref: chainstateref::ChainstateRef<'a, S, V>) -> Self {
         Self { chainstate_ref }
     }
 


### PR DESCRIPTION
For both orphans and retries for database commit failures, for those who faced stack overflow issues, we change the algorithm to iterative instead of recursive.

This made me also realize that orphan processing doesn't need to be in ChainstateRef, so I moved it to Chainstate.