### PR TITLE
Move PoolId and DelegationId to common

### DIFF
--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -28,14 +28,14 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId, Transaction,
+        Block, ChainConfig, DelegationId, GenBlock, GenBlockId, OutPointSourceId, PoolId,
+        Transaction,
     },
     primitives::{Amount, Id},
 };
 use pos_accounting::{
-    AccountingBlockUndo, DelegationData, DelegationId, DeltaMergeUndo, FlushablePoSAccountingView,
+    AccountingBlockUndo, DelegationData, DeltaMergeUndo, FlushablePoSAccountingView,
     PoSAccountingDB, PoSAccountingDeltaData, PoSAccountingStorageRead, PoSAccountingView, PoolData,
-    PoolId,
 };
 use tx_verifier::transaction_verifier::TransactionSource;
 use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosBlockUndo, UtxosDB, UtxosStorageRead};

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -22,13 +22,13 @@ use common::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
-        Block, GenBlock, OutPoint, OutPointSourceId,
+        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
     },
     primitives::{Amount, BlockHeight, Id},
 };
 use pos_accounting::{
-    AccountingBlockUndo, DelegationData, DelegationId, DeltaMergeUndo, PoSAccountingDeltaData,
-    PoSAccountingStorageRead, PoSAccountingStorageWrite, PoolData, PoolId,
+    AccountingBlockUndo, DelegationData, DeltaMergeUndo, PoSAccountingDeltaData,
+    PoSAccountingStorageRead, PoSAccountingStorageWrite, PoolData,
 };
 use utxo::{Utxo, UtxosBlockUndo, UtxosStorageRead, UtxosStorageWrite};
 

--- a/chainstate/storage/src/internal/store_tx.rs
+++ b/chainstate/storage/src/internal/store_tx.rs
@@ -20,13 +20,13 @@ use common::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
-        Block, GenBlock, OutPoint, OutPointSourceId,
+        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
     },
     primitives::{Amount, BlockHeight, Id, Idable, H256},
 };
 use pos_accounting::{
-    AccountingBlockUndo, DelegationData, DelegationId, DeltaMergeUndo, PoSAccountingDeltaData,
-    PoSAccountingStorageRead, PoSAccountingStorageWrite, PoolData, PoolId,
+    AccountingBlockUndo, DelegationData, DeltaMergeUndo, PoSAccountingDeltaData,
+    PoSAccountingStorageRead, PoSAccountingStorageWrite, PoolData,
 };
 use serialization::{Codec, Decode, DecodeAll, Encode, EncodeLike};
 use std::collections::BTreeMap;

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -24,13 +24,12 @@ use common::{
         block::BlockReward,
         config::EpochIndex,
         transaction::{OutPointSourceId, Transaction, TxMainChainIndex, TxMainChainPosition},
-        Block, GenBlock, OutPoint,
+        Block, DelegationId, GenBlock, OutPoint, PoolId,
     },
     primitives::{Amount, BlockHeight, Id},
 };
 use pos_accounting::{
-    AccountingBlockUndo, DelegationData, DelegationId, DeltaMergeUndo, PoSAccountingDeltaData,
-    PoolData, PoolId,
+    AccountingBlockUndo, DelegationData, DeltaMergeUndo, PoSAccountingDeltaData, PoolData,
 };
 use utxo::{Utxo, UtxosBlockUndo, UtxosStorageRead, UtxosStorageWrite};
 

--- a/chainstate/storage/src/mock/mock_impl_accounting.rs
+++ b/chainstate/storage/src/mock/mock_impl_accounting.rs
@@ -17,10 +17,12 @@
 
 use std::collections::BTreeMap;
 
-use common::primitives::Amount;
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::Amount,
+};
 use pos_accounting::{
-    DelegationData, DelegationId, PoSAccountingStorageRead, PoSAccountingStorageWrite, PoolData,
-    PoolId,
+    DelegationData, PoSAccountingStorageRead, PoSAccountingStorageWrite, PoolData,
 };
 
 use super::{MockStore, MockStoreTxRo, MockStoreTxRw};

--- a/chainstate/storage/src/schema.rs
+++ b/chainstate/storage/src/schema.rs
@@ -20,13 +20,13 @@ use common::{
     chain::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, GenBlock, OutPoint, OutPointSourceId, Transaction, TxMainChainIndex,
+        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId, Transaction,
+        TxMainChainIndex,
     },
     primitives::{Amount, BlockHeight, Id},
 };
 use pos_accounting::{
-    AccountingBlockUndo, DelegationData, DelegationId, DeltaMergeUndo, PoSAccountingDeltaData,
-    PoolData, PoolId,
+    AccountingBlockUndo, DelegationData, DeltaMergeUndo, PoSAccountingDeltaData, PoolData,
 };
 use utxo::{Utxo, UtxosBlockUndo};
 

--- a/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
@@ -25,7 +25,7 @@ use chainstate_test_framework::{
 use common::{
     chain::{
         config::Builder as ConfigBuilder, stakelock::StakePoolData, tokens::OutputValue, OutPoint,
-        OutPointSourceId, SignedTransaction, Transaction, TxInput, TxOutput,
+        OutPointSourceId, PoolId, SignedTransaction, Transaction, TxInput, TxOutput,
     },
     primitives::{signed_amount::SignedAmount, Amount, Id, Idable},
 };
@@ -33,7 +33,7 @@ use crypto::{
     key::{KeyKind, PrivateKey, PublicKey},
     vrf::{VRFKeyKind, VRFPrivateKey},
 };
-use pos_accounting::{PoolData, PoolId};
+use pos_accounting::PoolData;
 use utxo::UtxosStorageRead;
 
 fn make_tx_with_stake_pool_from_genesis(

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -23,13 +23,12 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId, Transaction, TxMainChainIndex,
+        Block, ChainConfig, DelegationId, GenBlock, GenBlockId, OutPointSourceId, PoolId,
+        Transaction, TxMainChainIndex,
     },
     primitives::{Amount, Id},
 };
-use pos_accounting::{
-    DelegationData, DelegationId, PoSAccountingStorageRead, PoSAccountingView, PoolData, PoolId,
-};
+use pos_accounting::{DelegationData, PoSAccountingStorageRead, PoSAccountingView, PoolData};
 use utxo::UtxosStorageRead;
 
 pub struct InMemoryStorageWrapper {

--- a/chainstate/test-suite/src/tests/tx_verifier_among_threads.rs
+++ b/chainstate/test-suite/src/tests/tx_verifier_among_threads.rs
@@ -16,7 +16,7 @@
 use chainstate_test_framework::{TestFramework, TestStore};
 use common::chain::config::Builder as ConfigBuilder;
 use common::{
-    chain::OutPoint,
+    chain::{DelegationId, OutPoint, PoolId},
     primitives::{Id, H256},
 };
 use pos_accounting::PoSAccountingView;
@@ -50,31 +50,29 @@ impl UtxosView for EmptyUtxosView {
 pub struct EmptyAccountingView;
 
 impl PoSAccountingView for EmptyAccountingView {
-    fn pool_exists(&self, _pool_id: pos_accounting::PoolId) -> Result<bool, pos_accounting::Error> {
+    fn pool_exists(&self, _pool_id: PoolId) -> Result<bool, pos_accounting::Error> {
         Ok(false)
     }
 
     fn get_pool_balance(
         &self,
-        _pool_id: pos_accounting::PoolId,
+        _pool_id: PoolId,
     ) -> Result<Option<common::primitives::Amount>, pos_accounting::Error> {
         Ok(None)
     }
 
     fn get_pool_data(
         &self,
-        _pool_id: pos_accounting::PoolId,
+        _pool_id: PoolId,
     ) -> Result<Option<pos_accounting::PoolData>, pos_accounting::Error> {
         Ok(None)
     }
 
     fn get_pool_delegations_shares(
         &self,
-        _pool_id: pos_accounting::PoolId,
+        _pool_id: PoolId,
     ) -> Result<
-        Option<
-            std::collections::BTreeMap<pos_accounting::DelegationId, common::primitives::Amount>,
-        >,
+        Option<std::collections::BTreeMap<DelegationId, common::primitives::Amount>>,
         pos_accounting::Error,
     > {
         Ok(None)
@@ -82,22 +80,22 @@ impl PoSAccountingView for EmptyAccountingView {
 
     fn get_delegation_balance(
         &self,
-        _delegation_id: pos_accounting::DelegationId,
+        _delegation_id: DelegationId,
     ) -> Result<Option<common::primitives::Amount>, pos_accounting::Error> {
         Ok(None)
     }
 
     fn get_delegation_data(
         &self,
-        _delegation_id: pos_accounting::DelegationId,
+        _delegation_id: DelegationId,
     ) -> Result<Option<pos_accounting::DelegationData>, pos_accounting::Error> {
         Ok(None)
     }
 
     fn get_pool_delegation_share(
         &self,
-        _pool_id: pos_accounting::PoolId,
-        _delegation_id: pos_accounting::DelegationId,
+        _pool_id: PoolId,
+        _delegation_id: DelegationId,
     ) -> Result<Option<common::primitives::Amount>, pos_accounting::Error> {
         Ok(None)
     }

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -28,13 +28,14 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, GenBlock, OutPoint, OutPointSourceId, Transaction, TxMainChainIndex,
+        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId, Transaction,
+        TxMainChainIndex,
     },
     primitives::{Amount, Id},
 };
 use pos_accounting::{
-    AccountingBlockUndo, DelegationData, DelegationId, DeltaMergeUndo, FlushablePoSAccountingView,
-    PoSAccountingDeltaData, PoSAccountingView, PoolData, PoolId,
+    AccountingBlockUndo, DelegationData, DeltaMergeUndo, FlushablePoSAccountingView,
+    PoSAccountingDeltaData, PoSAccountingView, PoolData,
 };
 use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosBlockUndo, UtxosStorageRead, UtxosView};
 

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -24,13 +24,14 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, GenBlock, OutPoint, OutPointSourceId, Transaction, TxMainChainIndex,
+        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId, Transaction,
+        TxMainChainIndex,
     },
     primitives::{Amount, Id},
 };
 use pos_accounting::{
-    DelegationData, DelegationId, DeltaMergeUndo, FlushablePoSAccountingView,
-    PoSAccountingDeltaData, PoSAccountingView, PoolData, PoolId,
+    DelegationData, DeltaMergeUndo, FlushablePoSAccountingView, PoSAccountingDeltaData,
+    PoSAccountingView, PoolData,
 };
 use utxo::{ConsumedUtxoCache, FlushableUtxoView, Utxo, UtxosStorageRead};
 

--- a/common/src/chain/pos.rs
+++ b/common/src/chain/pos.rs
@@ -13,25 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod block;
-pub mod config;
-pub mod gen_block;
-pub mod genesis;
-mod mlt;
-mod pos;
-mod pow;
-pub mod tokens;
-pub mod transaction;
-mod upgrades;
+use typename::TypeName;
 
-pub use signed_transaction::SignedTransaction;
-pub use transaction::*;
+use crate::primitives::Id;
 
-pub use block::Block;
-pub use config::ChainConfig;
-pub use gen_block::{GenBlock, GenBlockId};
-pub use genesis::Genesis;
-pub use mlt::Mlt;
-pub use pos::{DelegationId, PoolId};
-pub use pow::PoWChainConfig;
-pub use upgrades::*;
+#[derive(Eq, PartialEq, TypeName)]
+pub enum Pool {}
+pub type PoolId = Id<Pool>;
+
+#[derive(Eq, PartialEq, TypeName)]
+pub enum Delegation {}
+pub type DelegationId = Id<Delegation>;

--- a/pos_accounting/src/data.rs
+++ b/pos_accounting/src/data.rs
@@ -15,10 +15,13 @@
 
 use std::collections::BTreeMap;
 
-use common::primitives::Amount;
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::Amount,
+};
 use serialization::{Decode, Encode};
 
-use crate::{DelegationData, DelegationId, PoolData, PoolId};
+use crate::{DelegationData, PoolData};
 
 #[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
 pub struct PoSAccountingData {

--- a/pos_accounting/src/lib.rs
+++ b/pos_accounting/src/lib.rs
@@ -13,21 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::primitives::Id;
-use typename::TypeName;
-
 mod data;
 mod error;
 mod pool;
 mod storage;
-
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, TypeName)]
-pub struct Pool;
-pub type PoolId = Id<Pool>;
-
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, TypeName)]
-pub struct Delegation;
-pub type DelegationId = Id<Delegation>;
 
 pub use crate::{
     data::PoSAccountingData,

--- a/pos_accounting/src/pool/delegation.rs
+++ b/pos_accounting/src/pool/delegation.rs
@@ -13,10 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common::chain::PoolId;
 use crypto::key::PublicKey;
 use serialization::{Decode, Encode};
-
-use crate::PoolId;
 
 #[derive(Debug, Eq, PartialEq, Clone, Encode, Decode)]
 pub struct DelegationData {

--- a/pos_accounting/src/pool/delta/data.rs
+++ b/pos_accounting/src/pool/delta/data.rs
@@ -14,10 +14,11 @@
 // limitations under the License.
 
 use accounting::{DeltaAmountCollection, DeltaDataCollection};
+use common::chain::{DelegationId, PoolId};
 
 use crate::{
     pool::{delegation::DelegationData, pool_data::PoolData},
-    DelegationId, DeltaMergeUndo, Error, PoolId,
+    DeltaMergeUndo, Error,
 };
 
 use serialization::{Decode, Encode};

--- a/pos_accounting/src/pool/delta/mod.rs
+++ b/pos_accounting/src/pool/delta/mod.rs
@@ -16,10 +16,13 @@
 use std::collections::BTreeMap;
 
 use accounting::{DeltaAmountCollection, DeltaDataUndoCollection};
-use common::primitives::{signed_amount::SignedAmount, Amount, H256};
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::{signed_amount::SignedAmount, Amount, H256},
+};
 use serialization::{Decode, Encode};
 
-use crate::{error::Error, DelegationId, PoolId};
+use crate::error::Error;
 
 use self::data::PoSAccountingDeltaData;
 

--- a/pos_accounting/src/pool/delta/operator_impls.rs
+++ b/pos_accounting/src/pool/delta/operator_impls.rs
@@ -14,7 +14,10 @@
 // limitations under the License.
 
 use accounting::DataDelta;
-use common::{chain::OutPoint, primitives::Amount};
+use common::{
+    chain::{DelegationId, OutPoint, PoolId},
+    primitives::Amount,
+};
 use crypto::key::PublicKey;
 
 use crate::{
@@ -30,7 +33,6 @@ use crate::{
         pool_data::PoolData,
         view::PoSAccountingView,
     },
-    DelegationId, PoolId,
 };
 
 use super::PoSAccountingDelta;

--- a/pos_accounting/src/pool/delta/view_impl.rs
+++ b/pos_accounting/src/pool/delta/view_impl.rs
@@ -16,7 +16,10 @@
 use std::collections::BTreeMap;
 
 use accounting::combine_amount_delta;
-use common::primitives::{signed_amount::SignedAmount, Amount};
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::{signed_amount::SignedAmount, Amount},
+};
 
 use crate::{
     error::Error,
@@ -25,7 +28,7 @@ use crate::{
         pool_data::PoolData,
         view::{FlushablePoSAccountingView, PoSAccountingView},
     },
-    DelegationId, DeltaMergeUndo, PoolId,
+    DeltaMergeUndo,
 };
 
 use super::{data::PoSAccountingDeltaData, PoSAccountingDelta};

--- a/pos_accounting/src/pool/helpers.rs
+++ b/pos_accounting/src/pool/helpers.rs
@@ -14,12 +14,10 @@
 // limitations under the License.
 
 use common::{
-    chain::OutPoint,
+    chain::{DelegationId, OutPoint, PoolId},
     primitives::id::{hash_encoded_to, DefaultHashAlgoStream},
 };
 use crypto::hash::StreamHasher;
-
-use crate::{DelegationId, PoolId};
 
 pub fn pool_id_preimage_suffix() -> u32 {
     // arbitrary, we use this to create different values when hashing with no security requirements

--- a/pos_accounting/src/pool/operations.rs
+++ b/pos_accounting/src/pool/operations.rs
@@ -14,11 +14,14 @@
 // limitations under the License.
 
 use accounting::DataDeltaUndo;
-use common::{chain::OutPoint, primitives::Amount};
+use common::{
+    chain::{DelegationId, OutPoint, PoolId},
+    primitives::Amount,
+};
 use crypto::key::PublicKey;
 use serialization::{Decode, Encode};
 
-use crate::{error::Error, DelegationId, PoolId};
+use crate::error::Error;
 
 #[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub(crate) enum PoolDataUndo {

--- a/pos_accounting/src/pool/storage/mod.rs
+++ b/pos_accounting/src/pool/storage/mod.rs
@@ -20,11 +20,14 @@ use accounting::{
     DeltaDataUndoCollection,
 };
 use chainstate_types::storage_result;
-use common::primitives::{signed_amount::SignedAmount, Amount};
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::{signed_amount::SignedAmount, Amount},
+};
 
 use crate::{
     error::Error, pool::delta::data::PoSAccountingDeltaData, storage::PoSAccountingStorageWrite,
-    DelegationId, DeltaMergeUndo, PoolId, StorageTag,
+    DeltaMergeUndo, StorageTag,
 };
 
 pub mod operator_impls;

--- a/pos_accounting/src/pool/storage/operator_impls.rs
+++ b/pos_accounting/src/pool/storage/operator_impls.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::{chain::OutPoint, primitives::Amount};
+use common::{
+    chain::{DelegationId, OutPoint, PoolId},
+    primitives::Amount,
+};
 use crypto::key::PublicKey;
 
 use crate::{
@@ -30,7 +33,7 @@ use crate::{
         view::PoSAccountingView,
     },
     storage::PoSAccountingStorageWrite,
-    DelegationId, PoSAccountingDB, PoolId, StorageTag,
+    PoSAccountingDB, StorageTag,
 };
 
 impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingOperations

--- a/pos_accounting/src/pool/storage/view_impls.rs
+++ b/pos_accounting/src/pool/storage/view_impls.rs
@@ -15,7 +15,10 @@
 
 use std::collections::BTreeMap;
 
-use common::primitives::Amount;
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::Amount,
+};
 
 use crate::{
     error::Error,
@@ -26,7 +29,7 @@ use crate::{
         view::{FlushablePoSAccountingView, PoSAccountingView},
     },
     storage::{PoSAccountingStorageRead, PoSAccountingStorageWrite},
-    DelegationId, DeltaMergeUndo, PoSAccountingDB, PoolId, StorageTag,
+    DeltaMergeUndo, PoSAccountingDB, StorageTag,
 };
 
 impl<S: PoSAccountingStorageRead<T>, T: StorageTag> PoSAccountingView for PoSAccountingDB<S, T> {

--- a/pos_accounting/src/pool/tests/mod.rs
+++ b/pos_accounting/src/pool/tests/mod.rs
@@ -15,15 +15,16 @@
 
 use std::collections::BTreeMap;
 
-use common::primitives::{Amount, H256};
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::{Amount, H256},
+};
 use crypto::{
     key::{KeyKind, PrivateKey, PublicKey},
     random::{CryptoRng, Rng},
 };
 
-use crate::{
-    storage::in_memory::InMemoryPoSAccounting, DelegationData, DelegationId, PoolData, PoolId,
-};
+use crate::{storage::in_memory::InMemoryPoSAccounting, DelegationData, PoolData};
 
 mod delta_tests;
 mod operations_tests;

--- a/pos_accounting/src/pool/tests/undo_tests.rs
+++ b/pos_accounting/src/pool/tests/undo_tests.rs
@@ -16,7 +16,7 @@
 use std::collections::BTreeMap;
 
 use common::{
-    chain::{OutPoint, OutPointSourceId},
+    chain::{DelegationId, OutPoint, OutPointSourceId, PoolId},
     primitives::{Amount, Id, H256},
 };
 use crypto::{
@@ -38,7 +38,6 @@ use crate::{
         view::{FlushablePoSAccountingView, PoSAccountingView},
     },
     storage::in_memory::InMemoryPoSAccounting,
-    DelegationId, PoolId,
 };
 
 fn create_pool(

--- a/pos_accounting/src/pool/view.rs
+++ b/pos_accounting/src/pool/view.rs
@@ -15,9 +15,12 @@
 
 use std::{collections::BTreeMap, ops::Deref};
 
-use common::primitives::Amount;
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::Amount,
+};
 
-use crate::{error::Error, DelegationId, DeltaMergeUndo, PoolId};
+use crate::{error::Error, DeltaMergeUndo};
 
 use super::{delegation::DelegationData, delta::data::PoSAccountingDeltaData, pool_data::PoolData};
 

--- a/pos_accounting/src/storage/in_memory.rs
+++ b/pos_accounting/src/storage/in_memory.rs
@@ -16,12 +16,12 @@
 use std::collections::BTreeMap;
 
 use chainstate_types::storage_result::Error;
-use common::primitives::{Amount, H256};
-
-use crate::{
-    pool::{delegation::DelegationData, pool_data::PoolData},
-    DelegationId, PoolId,
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::{Amount, H256},
 };
+
+use crate::pool::{delegation::DelegationData, pool_data::PoolData};
 
 use super::{PoSAccountingStorageRead, PoSAccountingStorageWrite};
 

--- a/pos_accounting/src/storage/mod.rs
+++ b/pos_accounting/src/storage/mod.rs
@@ -18,12 +18,12 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use common::primitives::Amount;
-
-use crate::{
-    pool::{delegation::DelegationData, pool_data::PoolData},
-    DelegationId, PoolId,
+use common::{
+    chain::{DelegationId, PoolId},
+    primitives::Amount,
 };
+
+use crate::pool::{delegation::DelegationData, pool_data::PoolData};
 
 use chainstate_types::storage_result;
 


### PR DESCRIPTION
I'll need to use `PoolId` in `consensus` package in upcoming PR with PoS. To avoid `consensus` dependency on `pos_accounting` decided to move these types to `common`.

Publishing as a separate PR to avoid spoiling PoS PR with boilerplate.