### PR TITLE
Fix some rustdoc warnings and remove irrelevant ignores from deny.toml

### DIFF
--- a/chainstate/tx-verifier/src/transaction_verifier/config.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/config.rs
@@ -24,7 +24,7 @@ impl TransactionVerifierConfig {
     }
 
     /// If transaction index is enabled, the function f is called, otherwise Ok(None) is returned
-    /// This function returns Result<Option<T>, E> instead of Option<Result<T,E>> for convenience,
+    /// This function returns `Result<Option<T>, E>` instead of `Option<Result<T,E>>` for convenience,
     /// since error handling should happen before knowing the result
     pub fn if_tx_index_enabled<F, T, E>(&self, f: F) -> Result<Option<T>, E>
     where

--- a/deny.toml
+++ b/deny.toml
@@ -46,8 +46,4 @@ unsound = "warn"
 yanked = "warn"
 notice = "warn"
 severity-threshold = "medium"
-ignore = [
-    # time/chrono problems, have not been a problem in practice
-    "RUSTSEC-2020-0159",
-    "RUSTSEC-2020-0071",
-]
+ignore = []

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -31,7 +31,7 @@ pub enum ProtocolError {
     Unresponsive,
 }
 
-/// Peer state errors (Errors either for an individual peer or for the [`PeerManager`])
+/// Peer state errors (Errors either for an individual peer or for the [`PeerManager`](crate::peer_manager::PeerManager))
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum PeerError {
     #[error("Peer disconnected")]

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -845,8 +845,7 @@ where
     /// Runs the `PeerManager` event loop.
     ///
     /// The event loop has this main responsibilities:
-    /// - listening to and handling control events from [`crate::sync::SyncManager`]/
-    /// [`crate::pubsub::PubSubMessageHandler`]/RPC
+    /// - listening to and handling control events from [`crate::sync::BlockSyncManager`]/RPC
     /// - listening to network events
     /// - updating internal state
     /// - sending and checking ping requests
@@ -854,7 +853,8 @@ where
     /// After handling an event from one of the aforementioned sources, the event loop
     /// handles the error (if any) and runs the [`PeerManager::heartbeat()`] function
     /// to perform the peer manager maintenance. If the `PeerManager` doesn't receive any events,
-    /// [`PEER_MGR_HEARTBEAT_INTERVAL`] defines how often the heartbeat function is called.
+    /// [`PEER_MGR_HEARTBEAT_INTERVAL_MIN`] and [`PEER_MGR_HEARTBEAT_INTERVAL_MAX`] defines how
+    /// often the heartbeat function is called.
     /// This is done to prevent the `PeerManager` from stalling in case the network doesn't
     /// have any events.
     pub async fn run(&mut self) -> crate::Result<void::Void> {


### PR DESCRIPTION
I think that rustdoc warnings are not important enough to be checked on CI, but I have run into them while checking the code and decided to fix some of them.