### PR TITLE
Specify Rust version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,10 @@ serialization = { path = "serialization"}
 storage = { path = "storage"}
 utxo = { path = "utxo"}
 
+[workspace.package]
+edition = "2021"
+rust-version = "1.67"
+
 [workspace.dependencies]
 async-trait = "0.1"
 futures = "0.3"

--- a/accounting/Cargo.toml
+++ b/accounting/Cargo.toml
@@ -2,7 +2,8 @@
 name = "accounting"
 license = "MIT"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/blockprod/Cargo.toml
+++ b/blockprod/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "blockprod"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 name = "chainstate"
 version = "0.1.0"

--- a/chainstate/launcher/Cargo.toml
+++ b/chainstate/launcher/Cargo.toml
@@ -2,7 +2,8 @@
 name = "chainstate-launcher"
 license = "MIT"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 

--- a/chainstate/storage/Cargo.toml
+++ b/chainstate/storage/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "chainstate-storage"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chainstate/test-framework/Cargo.toml
+++ b/chainstate/test-framework/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "chainstate-test-framework"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chainstate/test-suite/Cargo.toml
+++ b/chainstate/test-suite/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "chainstate-test-suite"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chainstate/tx-verifier/Cargo.toml
+++ b/chainstate/tx-verifier/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "tx-verifier"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/chainstate/types/Cargo.toml
+++ b/chainstate/types/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "chainstate-types"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "common"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 name = "consensus"
 version = "0.1.0"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "crypto"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 authors = ["Samer Afach <samer.afach@mintlayer.org>", "Ben Marsh <benjamin.marsh@mintlayer.org>", "Enrico Rubboli <enrico.rubboli@mintlayer.org>"]
 

--- a/dns_server/Cargo.toml
+++ b/dns_server/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "dns_server"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "logging"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "mempool"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "node"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "p2p"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [features]

--- a/p2p/backend-test-suite/Cargo.toml
+++ b/p2p/backend-test-suite/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "p2p-backend-test-suite"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/p2p/p2p-test-utils/Cargo.toml
+++ b/p2p/p2p-test-utils/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "p2p-test-utils"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/pos_accounting/Cargo.toml
+++ b/pos_accounting/Cargo.toml
@@ -2,7 +2,8 @@
 name = "pos_accounting"
 license = "MIT"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rpc"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "script"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/serialization/Cargo.toml
+++ b/serialization/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "serialization"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/serialization/core/Cargo.toml
+++ b/serialization/core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "serialization-core"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/serialization/tagged/Cargo.toml
+++ b/serialization/tagged/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "serialization-tagged"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/serialization/tagged/derive/Cargo.toml
+++ b/serialization/tagged/derive/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "serialization-tagged-derive"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [lib]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "storage"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [features]

--- a/storage/backend-test-suite/Cargo.toml
+++ b/storage/backend-test-suite/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "storage-backend-test-suite"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/storage/core/Cargo.toml
+++ b/storage/core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "storage-core"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/storage/inmemory/Cargo.toml
+++ b/storage/inmemory/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "storage-inmemory"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/storage/lmdb/Cargo.toml
+++ b/storage/lmdb/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "storage-lmdb"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/storage/sqlite/Cargo.toml
+++ b/storage/sqlite/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "storage-sqlite"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/subsystem/Cargo.toml
+++ b/subsystem/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "subsystem"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [features]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "test-utils"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "mintlayer-test"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 homepage = "https://github.com/mintlayer/mintlayer-core/issues"
 license = "MIT"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "utils"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/utils/typename-derive/Cargo.toml
+++ b/utils/typename-derive/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "typename-derive"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [lib]

--- a/utils/typename/Cargo.toml
+++ b/utils/typename/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "typename"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/utxo/Cargo.toml
+++ b/utxo/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "utxo"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "wallet"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wallet/storage/Cargo.toml
+++ b/wallet/storage/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "wallet-storage"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Nail down the minimal supported rust compiler version and edition.