### PR TITLE
storage: Use GATs to simplify backend traits

### DIFF
--- a/storage/backend-test-suite/src/model.rs
+++ b/storage/backend-test-suite/src/model.rs
@@ -79,8 +79,8 @@ impl Model {
     }
 
     /// New model obtained by dumping a database in a transaction. May contain uncommitted changes.
-    pub fn from_tx<Tx: for<'tx> backend::PrefixIter<'tx>>(tx: &Tx, map_id: DbMapId) -> Self {
-        Model(backend::PrefixIter::prefix_iter(tx, map_id, Data::new()).unwrap().collect())
+    pub fn from_tx<Tx: backend::ReadOps>(tx: &Tx, map_id: DbMapId) -> Self {
+        Model(backend::ReadOps::prefix_iter(tx, map_id, Data::new()).unwrap().collect())
     }
 
     /// Get the inner map

--- a/storage/backend-test-suite/src/prelude.rs
+++ b/storage/backend-test-suite/src/prelude.rs
@@ -16,9 +16,7 @@
 // Re-export a bunch of often used items
 pub use crate::model::{ApplyActions, Model, WriteAction};
 pub use storage_core::{
-    backend::{
-        Backend, Data, PrefixIter, ReadOps, TransactionalRo, TransactionalRw, TxRo, TxRw, WriteOps,
-    },
+    backend::{Backend, BackendImpl, Data, ReadOps, TxRo, TxRw, WriteOps},
     DbDesc, DbMapCount, DbMapDesc, DbMapId, DbMapsData,
 };
 pub use utils::{sync, thread};

--- a/storage/inmemory/src/lib.rs
+++ b/storage/inmemory/src/lib.rs
@@ -32,19 +32,17 @@ impl<'i> Iterator for PrefixIter<'i> {
 pub struct StorageMaps(DbMapsData<Map>);
 
 impl backend::ReadOps for StorageMaps {
+    type PrefixIter<'i> = PrefixIter<'i>;
+
     fn get(&self, map_id: DbMapId, key: &[u8]) -> storage_core::Result<Option<Cow<[u8]>>> {
         Ok(self.0[map_id].get(key).map(|p| p.into()))
     }
-}
 
-impl<'i> backend::PrefixIter<'i> for StorageMaps {
-    type Iterator = PrefixIter<'i>;
-
-    fn prefix_iter<'m: 'i>(
-        &'m self,
+    fn prefix_iter(
+        &self,
         map_id: DbMapId,
         prefix: Data,
-    ) -> storage_core::Result<Self::Iterator> {
+    ) -> storage_core::Result<Self::PrefixIter<'_>> {
         Ok(PrefixIter(util::PrefixIter::new(&self.0[map_id], prefix)))
     }
 }

--- a/storage/lmdb/src/resize_tests.rs
+++ b/storage/lmdb/src/resize_tests.rs
@@ -17,10 +17,7 @@ use std::{collections::BTreeMap, sync::Mutex};
 
 use memsize::MemSize;
 use rstest::rstest;
-use storage_core::{
-    backend::{ReadOps, TxRw, WriteOps},
-    Backend,
-};
+use storage_core::backend::{Backend, BackendImpl, ReadOps, TxRw, WriteOps};
 use tempdir::TempDir;
 use test_utils::random::make_seedable_rng;
 use test_utils::random::{CryptoRng, Rng, Seed};

--- a/storage/src/database/mod.rs
+++ b/storage/src/database/mod.rs
@@ -71,18 +71,15 @@ impl<B: Backend, Sch: Schema> Storage<B, Sch> {
     }
 
     /// Start a read-only transaction
-    pub fn transaction_ro<'tx, 'st: 'tx>(&'st self) -> crate::Result<TransactionRo<'tx, B, Sch>> {
-        let dbtx = backend::TransactionalRo::transaction_ro(&self.backend)?;
+    pub fn transaction_ro(&self) -> crate::Result<TransactionRo<'_, B, Sch>> {
+        let dbtx = backend::BackendImpl::transaction_ro(&self.backend)?;
         let _schema = std::marker::PhantomData;
         Ok(TransactionRo { dbtx, _schema })
     }
 
     /// Start a read-write transaction
-    pub fn transaction_rw<'tx, 'st: 'tx>(
-        &'st self,
-        size: Option<usize>,
-    ) -> crate::Result<TransactionRw<'tx, B, Sch>> {
-        let dbtx = backend::TransactionalRw::transaction_rw(&self.backend, size)?;
+    pub fn transaction_rw(&self, size: Option<usize>) -> crate::Result<TransactionRw<'_, B, Sch>> {
+        let dbtx = backend::BackendImpl::transaction_rw(&self.backend, size)?;
         let _schema = std::marker::PhantomData;
         Ok(TransactionRw { dbtx, _schema })
     }

--- a/storage/src/database/raw.rs
+++ b/storage/src/database/raw.rs
@@ -20,7 +20,7 @@ use crate::{
     Backend, Storage,
 };
 use std::collections::BTreeMap;
-use storage_core::backend::PrefixIter;
+use storage_core::backend::ReadOps;
 
 pub use storage_core::Data;
 


### PR DESCRIPTION
These traits have been introduced as a workaround to the lack of higher-ranked types in Rust. Now a limited version of higher-ranked types is available in form of Generic Associated Types so the workaround is no longer necessary.