### PR TITLE
Blocking subsystem calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3521,6 +3521,8 @@ dependencies = [
  "cfg-if",
  "futures",
  "logging",
+ "oneshot",
+ "static_assertions",
  "testing_logger",
  "thiserror",
  "tokio",

--- a/subsystem/Cargo.toml
+++ b/subsystem/Cargo.toml
@@ -12,15 +12,16 @@ time = [ "tokio/time" ]
 [dependencies]
 # Local dependencies
 logging = { path = "../logging" }
+utils = { path = "../utils" }
 
 # External dependencies
 async-trait.workspace = true
 cfg-if = "1.0"
+oneshot = "0.1"
 thiserror.workspace = true
 futures = { workspace = true, default-features = false, features = ["alloc"]}
 tokio = { workspace = true, default-features = false, features = ["macros", "rt", "rt-multi-thread", "signal", "sync"]}
 
 [dev-dependencies]
+static_assertions = "1.1"
 testing_logger = "0.1"
-
-utils = { path = "../utils" }

--- a/subsystem/src/blocking.rs
+++ b/subsystem/src/blocking.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Blocking interface to subsystem.
+
+use crate::{subsystem::CallError, CallResult, Handle};
+use futures::future::BoxFuture;
+
+/// Blocking version of [subsystem::Handle].
+///
+/// This should be used sparingly as blocking calls induce non-trivial overhead. The call takes up
+/// a thread in the runtime thread pool. If there is not enough threads for all simultaneous
+/// blocking calls, a new one is spawned.
+pub struct BlockingHandle<T: ?Sized>(Handle<T>);
+
+impl<T: 'static + Send + ?Sized> BlockingHandle<T> {
+    /// A new blocking handle with a dedicated worker
+    pub fn new(handle: Handle<T>) -> Self {
+        Self(handle)
+    }
+
+    /// Get the inner handle
+    pub fn handle(&self) -> &Handle<T> {
+        &self.0
+    }
+
+    /// Perform given closure in a worker, passing the handle to it, get the result
+    fn with_handle<R: 'static + Send>(
+        &self,
+        func: impl 'static + Send + FnOnce(&Handle<T>) -> CallResult<R>,
+    ) -> Result<R, CallError> {
+        // Get the future associated with the function call result
+        let result = func(self.handle());
+
+        // Deal with it according to the current runtime context
+        match tokio::runtime::Handle::try_current() {
+            Ok(rt) => {
+                assert_eq!(
+                    rt.runtime_flavor(),
+                    tokio::runtime::RuntimeFlavor::MultiThread,
+                    "Only multi-threaded Tokio runtime supported by blocking subsystem handle"
+                );
+                tokio::task::block_in_place(|| result.blocking_get())
+            }
+            Err(err) => {
+                if err.is_missing_context() {
+                    result.blocking_get()
+                } else {
+                    panic!("Unexpected error while getting tokio runtime")
+                }
+            }
+        }
+    }
+
+    /// Blocking variant of [Handle::call_async_mut]
+    pub fn call_async_mut<R: Send + 'static>(
+        &self,
+        func: impl FnOnce(&mut T) -> BoxFuture<R> + Send + 'static,
+    ) -> Result<R, CallError> {
+        self.with_handle(|h| h.call_async_mut(func))
+    }
+
+    /// Blocking variant of [Handle::call_async]
+    pub fn call_async<R: Send + 'static>(
+        &self,
+        func: impl FnOnce(&T) -> BoxFuture<R> + Send + 'static,
+    ) -> Result<R, CallError> {
+        self.with_handle(|h| h.call_async(func))
+    }
+
+    /// Blocking variant of [Handle::call_mut]
+    pub fn call_mut<R: Send + 'static>(
+        &self,
+        func: impl FnOnce(&mut T) -> R + Send + 'static,
+    ) -> Result<R, CallError> {
+        self.with_handle(|h| h.call_mut(func))
+    }
+
+    /// Blocking variant of [Handle::call]
+    pub fn call<R: 'static + Send>(
+        &self,
+        func: impl 'static + Send + FnOnce(&T) -> R,
+    ) -> Result<R, CallError> {
+        self.with_handle(|h| h.call(func))
+    }
+}
+
+impl<T: 'static + Send + ?Sized> From<Handle<T>> for BlockingHandle<T> {
+    fn from(handle: Handle<T>) -> Self {
+        Self::new(handle)
+    }
+}
+
+#[cfg(test)]
+mod assertions {
+    use super::BlockingHandle;
+    static_assertions::assert_impl_all!(BlockingHandle<()>: Send, Sync);
+}

--- a/subsystem/src/blocking.rs
+++ b/subsystem/src/blocking.rs
@@ -32,7 +32,7 @@ impl<T: ?Sized> Clone for BlockingHandle<T> {
     }
 }
 
-impl<T> ShallowClone for BlockingHandle<T> {
+impl<T: ?Sized> ShallowClone for BlockingHandle<T> {
     fn shallow_clone(&self) -> Self {
         Self::new(self.0.shallow_clone())
     }

--- a/subsystem/src/lib.rs
+++ b/subsystem/src/lib.rs
@@ -33,6 +33,7 @@
 //!    request by shutting themselves down.
 //! 3. The main task waits for all subsystems to terminate.
 
+pub mod blocking;
 pub mod manager;
 pub mod subsystem;
 

--- a/subsystem/src/lib.rs
+++ b/subsystem/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2022-2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;

--- a/subsystem/src/manager.rs
+++ b/subsystem/src/manager.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2022-2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;

--- a/subsystem/src/subsystem.rs
+++ b/subsystem/src/subsystem.rs
@@ -130,7 +130,7 @@ pub enum CallError {
 ///
 /// Calls happen asynchronously. A value of this type represents the return value of the call of
 /// type `T`. To actually fetch the return value, use `.await`. Alternatively, use
-/// [CallResult::response] to verify if the call submission suceeded and get the return value at
+/// [CallResult::response] to verify if the call submission succeeded and get the return value at
 /// a later time.
 pub struct CallResult<T>(Result<CallResponse<T>, CallError>);
 

--- a/subsystem/src/subsystem.rs
+++ b/subsystem/src/subsystem.rs
@@ -18,6 +18,7 @@ use std::{pin::Pin, task};
 use futures::future::BoxFuture;
 use logging::log;
 use tokio::sync::{broadcast, mpsc, oneshot};
+use utils::shallow_clone::ShallowClone;
 
 /// Defines hooks into a subsystem lifecycle.
 #[async_trait::async_trait]
@@ -105,6 +106,12 @@ pub struct Handle<T: ?Sized> {
 
 impl<T: ?Sized> Clone for Handle<T> {
     fn clone(&self) -> Self {
+        self.shallow_clone()
+    }
+}
+
+impl<T: ?Sized> ShallowClone for Handle<T> {
+    fn shallow_clone(&self) -> Self {
         Self {
             action_tx: self.action_tx.clone(),
         }

--- a/subsystem/src/subsystem.rs
+++ b/subsystem/src/subsystem.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2022-2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;

--- a/subsystem/tests/basic.rs
+++ b/subsystem/tests/basic.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod helpers;
+mod sample_subsystems;
+
+use sample_subsystems::{Counter, Substringer};
+
+#[test]
+fn basic_passive_shutdown() {
+    let runtime = helpers::init_test_runtime();
+    utils::concurrency::model(move || {
+        runtime.block_on(async {
+            let mut app = subsystem::Manager::new("app");
+
+            let _substr = app.add_subsystem("substr", Substringer::new("abc".into()));
+            let _counter = app.add_subsystem("counter", Counter::new());
+
+            // Start a subsystem that immediately terminates, instructing the remaining subsystems
+            // to terminate too.
+            let _shut: subsystem::Handle<()> =
+                app.add_subsystem_with_custom_eventloop("terminator", |_, _| async {});
+
+            app.main().await
+        })
+    })
+}
+
+#[test]
+fn separate_call_and_result() {
+    let runtime = helpers::init_test_runtime();
+    utils::concurrency::model(move || {
+        runtime.block_on(async {
+            let mut app = subsystem::Manager::new("app");
+            let shutdown = app.make_shutdown_trigger();
+
+            let substr = app.add_subsystem("substr", Substringer::new("abc".into()));
+
+            // The API allows for the submission of closure to call to be separate form retrieval
+            // of the result. This task verifies the behavior is as expected.
+            tokio::task::spawn(async move {
+                // Submit three calls to the substr without waiting for results
+                let responses: Vec<_> = (0..3)
+                    .map(|i| substr.call(move |this| this.substr(i, i + 1)).response().unwrap())
+                    .collect();
+
+                // Expected values
+                let expected = ["a", "b", "c"];
+                assert_eq!(responses.len(), expected.len());
+
+                // Gather and verify results
+                for (response, expected) in responses.into_iter().zip(expected.into_iter()) {
+                    assert_eq!(response.await.unwrap(), expected);
+                }
+
+                // Shut down the manager once done
+                shutdown.initiate();
+            });
+
+            app.main().await
+        })
+    })
+}

--- a/subsystem/tests/blocking.rs
+++ b/subsystem/tests/blocking.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2022-2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod helpers;
+mod sample_subsystems;
+
+use sample_subsystems::{Counter, Substringer};
+use subsystem::subsystem::{CallRequest, ShutdownRequest};
+
+// The subsystem testing the other two subsystems
+pub struct Tester {
+    substringer: subsystem::blocking::BlockingHandle<Substringer>,
+    counter: subsystem::blocking::BlockingHandle<Counter>,
+}
+
+impl Tester {
+    fn new(
+        substringer: subsystem::blocking::BlockingHandle<Substringer>,
+        counter: subsystem::blocking::BlockingHandle<Counter>,
+    ) -> Self {
+        Self {
+            substringer,
+            counter,
+        }
+    }
+
+    async fn run(self, _: CallRequest<()>, _shutdown: ShutdownRequest) {
+        let res0 = self.substringer.call_mut(|this| this.append_get("xyz"));
+        assert_eq!(res0, Ok("abcxyz".to_string()));
+        assert_eq!(self.substringer.call(Substringer::size), Ok(6));
+        tokio::task::yield_now().await;
+
+        let res1 = self.substringer.call(|this| this.substr(2, 5));
+        assert_eq!(res1, Ok("cxy".to_string()));
+        tokio::task::yield_now().await;
+
+        let res2 = self.counter.call(Counter::get);
+        assert_eq!(res2, Ok(13));
+        tokio::task::yield_now().await;
+
+        let res3 = self.counter.call_mut(|this| this.add_and_get(3));
+        assert_eq!(res3, Ok(16));
+    }
+}
+
+static_assertions::assert_impl_all!(Tester: Send);
+
+#[test]
+fn basic_passive_subsystem_blocking() {
+    let runtime = helpers::init_test_runtime();
+    utils::concurrency::model(move || {
+        runtime.block_on(async {
+            let mut app = subsystem::Manager::new("app");
+
+            let substr = app.add_subsystem("substr", Substringer::new("abc".into()));
+            let counter = app.add_subsystem("counter", Counter::new());
+
+            let tester1 = Tester::new(substr.into(), counter.into());
+            app.add_subsystem_with_custom_eventloop("test", |call_rq, shut_rq| async move {
+                tester1.run(call_rq, shut_rq).await
+            });
+
+            app.main().await
+        })
+    })
+}

--- a/subsystem/tests/helpers/mod.rs
+++ b/subsystem/tests/helpers/mod.rs
@@ -18,8 +18,10 @@ static INIT: std::sync::Once = std::sync::Once::new();
 pub fn init_test_runtime() -> tokio::runtime::Runtime {
     INIT.call_once(|| logging::init_logging::<&std::path::Path>(None));
 
+    //let mut runtime = tokio::runtime::Builder::new_current_thread();
     let mut runtime = tokio::runtime::Builder::new_multi_thread();
     #[cfg(not(loom))]
     runtime.enable_all();
-    runtime.worker_threads(4).build().unwrap()
+    //runtime.worker_threads(4).build().unwrap()
+    runtime.build().unwrap()
 }

--- a/subsystem/tests/helpers/mod.rs
+++ b/subsystem/tests/helpers/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2022-2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;

--- a/subsystem/tests/passive.rs
+++ b/subsystem/tests/passive.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2022-2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,59 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(clippy::new_without_default)]
-
-use subsystem::subsystem::{CallRequest, ShutdownRequest};
-
 mod helpers;
+mod sample_subsystems;
 
-// The substringer passive subsystem (for testing)
-pub struct Substringer {
-    value: String,
-}
-
-impl subsystem::Subsystem for Substringer {}
-
-impl Substringer {
-    pub fn new(value: String) -> Self {
-        Self { value }
-    }
-
-    pub fn append_get(&mut self, other: &str) -> String {
-        self.value += other;
-        self.value.clone()
-    }
-
-    pub fn substr(&self, begin: usize, end: usize) -> String {
-        self.value.get(begin..end).map_or_else(String::new, str::to_string)
-    }
-
-    pub fn size(&self) -> usize {
-        self.value.len()
-    }
-}
-
-// The counter passive subsystem (for testing)
-pub struct Counter {
-    value: u64,
-}
-
-impl subsystem::Subsystem for Counter {}
-
-impl Counter {
-    pub fn new() -> Self {
-        Self { value: 13 }
-    }
-
-    pub fn get(&self) -> u64 {
-        self.value
-    }
-
-    pub fn add_and_get(&mut self, amount: u64) -> u64 {
-        self.value += amount;
-        self.value
-    }
-}
+use sample_subsystems::{Counter, Substringer};
+use subsystem::subsystem::{CallRequest, ShutdownRequest};
 
 // The subsystem testing the other two subsystems
 pub struct Tester {
@@ -113,62 +65,6 @@ fn basic_passive_subsystem() {
             let tester = Tester::new(substr, counter);
             app.add_subsystem_with_custom_eventloop("test", |call_rq, shut_rq| async move {
                 tester.run(call_rq, shut_rq).await
-            });
-
-            app.main().await
-        })
-    })
-}
-
-#[test]
-fn basic_passive_shutdown() {
-    let runtime = helpers::init_test_runtime();
-    utils::concurrency::model(move || {
-        runtime.block_on(async {
-            let mut app = subsystem::Manager::new("app");
-
-            let _substr = app.add_subsystem("substr", Substringer::new("abc".into()));
-            let _counter = app.add_subsystem("counter", Counter::new());
-
-            // Start a subsystem that immediately terminates, instructing the remaining subsystems
-            // to terminate too.
-            let _shut: subsystem::Handle<()> =
-                app.add_subsystem_with_custom_eventloop("terminator", |_, _| async {});
-
-            app.main().await
-        })
-    })
-}
-
-#[test]
-fn separate_call_and_result() {
-    let runtime = helpers::init_test_runtime();
-    utils::concurrency::model(move || {
-        runtime.block_on(async {
-            let mut app = subsystem::Manager::new("app");
-            let shutdown = app.make_shutdown_trigger();
-
-            let substr = app.add_subsystem("substr", Substringer::new("abc".into()));
-
-            // The API allows for the submission of closure to call to be separate form retrieval
-            // of the result. This task verifies the behavior is as expected.
-            tokio::task::spawn(async move {
-                // Submit three calls to the substr without waiting for results
-                let responses: Vec<_> = (0..3)
-                    .map(|i| substr.call(move |this| this.substr(i, i + 1)).response().unwrap())
-                    .collect();
-
-                // Expected values
-                let expected = ["a", "b", "c"];
-                assert_eq!(responses.len(), expected.len());
-
-                // Gather and verify results
-                for (response, expected) in responses.into_iter().zip(expected.into_iter()) {
-                    assert_eq!(response.await.unwrap(), expected);
-                }
-
-                // Shut down the manager once done
-                shutdown.initiate();
             });
 
             app.main().await

--- a/subsystem/tests/sample_subsystems/mod.rs
+++ b/subsystem/tests/sample_subsystems/mod.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::new_without_default)]
+#![allow(unused)]
+
+/// The substringer passive subsystem
+pub struct Substringer {
+    value: String,
+}
+
+impl subsystem::Subsystem for Substringer {}
+
+impl Substringer {
+    pub fn new(value: String) -> Self {
+        Self { value }
+    }
+
+    pub fn append_get(&mut self, other: &str) -> String {
+        self.value += other;
+        self.value.clone()
+    }
+
+    pub fn substr(&self, begin: usize, end: usize) -> String {
+        self.value.get(begin..end).map_or_else(String::new, str::to_string)
+    }
+
+    pub fn size(&self) -> usize {
+        self.value.len()
+    }
+}
+
+/// The counter passive subsystem
+pub struct Counter {
+    value: u64,
+}
+
+impl subsystem::Subsystem for Counter {}
+
+impl Counter {
+    pub fn new() -> Self {
+        Self { value: 13 }
+    }
+
+    pub fn get(&self) -> u64 {
+        self.value
+    }
+
+    pub fn add_and_get(&mut self, amount: u64) -> u64 {
+        self.value += amount;
+        self.value
+    }
+}


### PR DESCRIPTION
Introduces a wrapper over `subsystem::Handle` that blocks, so can be used without `async`. Not intended for merge yet, just filing a draft PR to gather early feedback.