### PR TITLE
Unify versions in Cargo.toml

### DIFF
--- a/.github/scripts/codecheck.py
+++ b/.github/scripts/codecheck.py
@@ -75,9 +75,13 @@ def check_workspace_and_package_versions_equal():
     workspace_version = root['package']['version']
     package_version = root['workspace']['package']['version']
 
-    if workspace_version != package_version:
+    result = workspace_version == package_version
+
+    if not result:
         print("Workspace vs package versions mismatch in Cargo.toml: '{}' != '{}'".format(workspace_version, package_version))
-    print()
+        print()
+
+    return result
 
 
 # Check crate versions

--- a/.github/scripts/codecheck.py
+++ b/.github/scripts/codecheck.py
@@ -67,6 +67,19 @@ def check_crate_version_unique(crate_name):
 
     return len(versions) == 1
 
+# Ensure that the versions in the workspace's Cargo.toml are consistent
+def check_workspace_and_package_versions_equal():
+    print("==== Ensuring workspace and package versions are equal in the workspace's Cargo.toml")
+    root = toml.load('Cargo.toml')
+
+    workspace_version = root['package']['version']
+    package_version = root['workspace']['package']['version']
+
+    if workspace_version != package_version:
+        print("Workspace vs package versions mismatch in Cargo.toml: '{}' != '{}'".format(workspace_version, package_version))
+    print()
+
+
 # Check crate versions
 def check_crate_versions():
     print("==== Checking crate versions:")
@@ -82,7 +95,7 @@ def check_crate_versions():
 # Check license header in current project crates
 def check_local_licenses():
     print("==== Checking local license headers:")
-    
+
     # list of files exempted from license check
     exempted_files = [
         "./script/src/opcodes.rs",
@@ -92,14 +105,14 @@ def check_local_licenses():
         "./common/src/uint/impls.rs",
         "./common/src/uint/mod.rs"
         ]
-    
+
     template = re.compile('(?:' + r')\n(?:'.join(LICENSE_TEMPLATE) + ')')
 
     ok = True
     for path in rs_sources():
         if any(os.path.samefile(path, exempted) for exempted in exempted_files):
             continue
-        
+
         with open(path) as file:
             if not template.search(file.read()):
                 ok = False
@@ -111,16 +124,16 @@ def check_local_licenses():
 # check TODO(PR) and FIXME instances
 def check_todos():
     print("==== Checking TODO(PR) and FIXME instances:")
-    
+
     # list of files exempted from checks
     exempted_files = [
         ]
-    
+
     ok = True
     for path in rs_sources():
         if any(os.path.samefile(path, exempted) for exempted in exempted_files):
             continue
-        
+
         with open(path) as file:
             file_data = file.read()
             if 'TODO(PR)' in file_data or 'FIXME' in file_data:
@@ -136,6 +149,7 @@ def run_checks():
             disallow(JSONRPSEE_RE, exclude = ['rpc']),
             check_local_licenses(),
             check_crate_versions(),
+            check_workspace_and_package_versions_equal(),
             check_todos()
         ])
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ utxo = { path = "utxo"}
 edition = "2021"
 rust-version = "1.67"
 version = "0.1.0"
+license = "MIT"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ utxo = { path = "utxo"}
 [workspace.package]
 edition = "2021"
 rust-version = "1.67"
+version = "0.1.0"
 
 [workspace.dependencies]
 async-trait = "0.1"

--- a/accounting/Cargo.toml
+++ b/accounting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accounting"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/accounting/Cargo.toml
+++ b/accounting/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accounting"
 license = "MIT"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/blockprod/Cargo.toml
+++ b/blockprod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockprod"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT"

--- a/blockprod/Cargo.toml
+++ b/blockprod/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "blockprod"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-edition.workspace = true
-rust-version.workspace = true
 license = "MIT"
 name = "chainstate"
-version = "0.1.0"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 chainstate-storage = {path = './storage'}

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-license = "MIT"
 name = "chainstate"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/chainstate/launcher/Cargo.toml
+++ b/chainstate/launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainstate-launcher"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/chainstate/launcher/Cargo.toml
+++ b/chainstate/launcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chainstate-launcher"
 license = "MIT"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/chainstate/storage/Cargo.toml
+++ b/chainstate/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainstate-storage"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/chainstate/storage/Cargo.toml
+++ b/chainstate/storage/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "chainstate-storage"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chainstate/test-framework/Cargo.toml
+++ b/chainstate/test-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainstate-test-framework"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/chainstate/test-framework/Cargo.toml
+++ b/chainstate/test-framework/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "chainstate-test-framework"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chainstate/test-suite/Cargo.toml
+++ b/chainstate/test-suite/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "chainstate-test-suite"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chainstate/test-suite/Cargo.toml
+++ b/chainstate/test-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainstate-test-suite"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/chainstate/tx-verifier/Cargo.toml
+++ b/chainstate/tx-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tx-verifier"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/chainstate/tx-verifier/Cargo.toml
+++ b/chainstate/tx-verifier/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "tx-verifier"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chainstate/types/Cargo.toml
+++ b/chainstate/types/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "chainstate-types"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/chainstate/types/Cargo.toml
+++ b/chainstate/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainstate-types"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "common"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "consensus"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
+name = "consensus"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
-name = "consensus"
-version = "0.1.0"
 
 [dependencies]
 common = {path = '../common'}

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "crypto"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 authors = ["Samer Afach <samer.afach@mintlayer.org>", "Ben Marsh <benjamin.marsh@mintlayer.org>", "Enrico Rubboli <enrico.rubboli@mintlayer.org>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/dns_server/Cargo.toml
+++ b/dns_server/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "dns_server"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/dns_server/Cargo.toml
+++ b/dns_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns_server"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "logging"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "mempool"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mempool"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "node"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "p2p"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [features]
 default = []

--- a/p2p/backend-test-suite/Cargo.toml
+++ b/p2p/backend-test-suite/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "p2p-backend-test-suite"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 common = { path = "../../common" }

--- a/p2p/backend-test-suite/Cargo.toml
+++ b/p2p/backend-test-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p-backend-test-suite"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/p2p/p2p-test-utils/Cargo.toml
+++ b/p2p/p2p-test-utils/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "p2p-test-utils"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 chainstate-storage = { path = "../../chainstate/storage" }

--- a/p2p/p2p-test-utils/Cargo.toml
+++ b/p2p/p2p-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p-test-utils"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/pos_accounting/Cargo.toml
+++ b/pos_accounting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pos_accounting"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/pos_accounting/Cargo.toml
+++ b/pos_accounting/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pos_accounting"
 license = "MIT"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "rpc"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "script"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 crypto = { path = '../crypto' }

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "script"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/serialization/Cargo.toml
+++ b/serialization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialization"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/serialization/Cargo.toml
+++ b/serialization/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "serialization"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 serialization-core = { path = 'core' }

--- a/serialization/core/Cargo.toml
+++ b/serialization/core/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "serialization-core"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/serialization/core/Cargo.toml
+++ b/serialization/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialization-core"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/serialization/tagged/Cargo.toml
+++ b/serialization/tagged/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "serialization-tagged"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 serialization-core = { path = '../core' }

--- a/serialization/tagged/Cargo.toml
+++ b/serialization/tagged/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialization-tagged"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/serialization/tagged/derive/Cargo.toml
+++ b/serialization/tagged/derive/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "serialization-tagged-derive"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [lib]
 proc-macro = true

--- a/serialization/tagged/derive/Cargo.toml
+++ b/serialization/tagged/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serialization-tagged-derive"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "storage"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [features]
 default = [ 'inmemory' ]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/storage/backend-test-suite/Cargo.toml
+++ b/storage/backend-test-suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage-backend-test-suite"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/storage/backend-test-suite/Cargo.toml
+++ b/storage/backend-test-suite/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "storage-backend-test-suite"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 storage-core = { path = "../core" }

--- a/storage/core/Cargo.toml
+++ b/storage/core/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "storage-core"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 

--- a/storage/core/Cargo.toml
+++ b/storage/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage-core"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/storage/inmemory/Cargo.toml
+++ b/storage/inmemory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage-inmemory"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/storage/inmemory/Cargo.toml
+++ b/storage/inmemory/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "storage-inmemory"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 

--- a/storage/lmdb/Cargo.toml
+++ b/storage/lmdb/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "storage-lmdb"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 logging = { path = '../../logging' }

--- a/storage/lmdb/Cargo.toml
+++ b/storage/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage-lmdb"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/storage/sqlite/Cargo.toml
+++ b/storage/sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage-sqlite"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/storage/sqlite/Cargo.toml
+++ b/storage/sqlite/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "storage-sqlite"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 logging = { path = '../../logging' }

--- a/subsystem/Cargo.toml
+++ b/subsystem/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "subsystem"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [features]
 default = [ "time" ]

--- a/subsystem/Cargo.toml
+++ b/subsystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subsystem"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "test-utils"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-utils"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "mintlayer-test"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 homepage = "https://github.com/mintlayer/mintlayer-core/issues"
-license = "MIT"
 
 [dependencies]
 node = { path = "../node" }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mintlayer-test"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "utils"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 logging = {path = '../logging'}

--- a/utils/typename-derive/Cargo.toml
+++ b/utils/typename-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typename-derive"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/utils/typename-derive/Cargo.toml
+++ b/utils/typename-derive/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "typename-derive"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [lib]
 proc-macro = true

--- a/utils/typename/Cargo.toml
+++ b/utils/typename/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "typename"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 [dependencies]
 typename-derive = { path = "../typename-derive" }

--- a/utils/typename/Cargo.toml
+++ b/utils/typename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typename"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/utxo/Cargo.toml
+++ b/utxo/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "utxo"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/utxo/Cargo.toml
+++ b/utxo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wallet"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/wallet/storage/Cargo.toml
+++ b/wallet/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-storage"
-license = "MIT"
+license.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/wallet/storage/Cargo.toml
+++ b/wallet/storage/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "wallet-storage"
-version = "0.1.0"
+license = "MIT"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Closes #451

I guess we can all agree at this point that having individual versions for crates is just an unnecessary burden. If we decide to isolate crates in the future, we can still do that.

And while at it, did the same for licenses.

The only issue is that I couldn't have a sinlge number for both packages and the workspace. I added a check in codechecks script.

