### PR TITLE
Replace the deprecated 'tempdir' library with 'tempfile'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "ripemd",
  "rstest",
@@ -1079,12 +1079,6 @@ dependencies = [
  "rustix 0.35.13",
  "winapi",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -1645,7 +1639,7 @@ dependencies = [
  "hyper",
  "jsonrpsee-types",
  "parking_lot",
- "rand 0.8.5",
+ "rand",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2498,7 +2492,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2619,7 +2613,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2667,19 +2661,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -2697,15 +2678,6 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
 ]
 
 [[package]]
@@ -2752,15 +2724,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3087,7 +3050,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "secp256k1-sys",
 ]
 
@@ -3252,7 +3215,7 @@ dependencies = [
  "arraytools",
  "hex-literal",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3403,7 +3366,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "snow",
  "thiserror",
  "tokio",
@@ -3431,7 +3394,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha-1 0.9.8",
 ]
 
@@ -3522,7 +3485,7 @@ dependencies = [
  "rstest",
  "storage-backend-test-suite",
  "storage-core",
- "tempdir",
+ "tempfile",
  "test-utils",
  "utils",
 ]
@@ -3599,16 +3562,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"
@@ -3953,7 +3906,7 @@ dependencies = [
  "futures-util",
  "lazy_static",
  "radix_trie",
- "rand 0.8.5",
+ "rand",
  "thiserror",
  "time",
  "tokio",
@@ -3977,7 +3930,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "thiserror",
  "tinyvec",

--- a/storage/lmdb/Cargo.toml
+++ b/storage/lmdb/Cargo.toml
@@ -15,7 +15,7 @@ lmdb-mintlayer = { git = 'https://github.com/mintlayer/lmdb-rs-mintlayer.git', t
 [dev-dependencies]
 storage-backend-test-suite = { path = "../backend-test-suite" }
 test-utils = { path = "../../test-utils" }
-tempdir = "0.3"
+tempfile = "3.3"
 rstest = "0.16"
 
 [[test]]

--- a/storage/lmdb/src/resize_tests.rs
+++ b/storage/lmdb/src/resize_tests.rs
@@ -15,12 +15,11 @@
 
 use std::{collections::BTreeMap, sync::Mutex};
 
-use memsize::MemSize;
 use rstest::rstest;
+
+use memsize::MemSize;
 use storage_core::backend::{Backend, BackendImpl, ReadOps, TxRw, WriteOps};
-use tempdir::TempDir;
-use test_utils::random::make_seedable_rng;
-use test_utils::random::{CryptoRng, Rng, Seed};
+use test_utils::random::{make_seedable_rng, CryptoRng, Rng, Seed};
 
 use super::*;
 
@@ -71,7 +70,7 @@ fn auto_map_resize_between_txs(#[case] seed: Seed) {
             resize_trigger_percentage: 0.9,
         };
 
-        let data_dir = TempDir::new("lmdb_resize").unwrap();
+        let data_dir = tempfile::Builder::new().prefix("lmdb_resize").tempdir().unwrap();
         let lmdb = Lmdb::new(
             data_dir.path().to_owned(),
             MemSize::from_bytes(initial_map_size).into(),
@@ -142,7 +141,7 @@ fn auto_map_resize_between_puts(#[case] seed: Seed) {
             resize_trigger_percentage: 0.9,
         };
 
-        let data_dir = TempDir::new("lmdb_resize").unwrap();
+        let data_dir = tempfile::Builder::new().prefix("lmdb_resize").tempdir().unwrap();
         let lmdb = Lmdb::new(
             data_dir.path().to_owned(),
             MemSize::from_bytes(initial_map_size).into(),


### PR DESCRIPTION
The `tempdir` library is deprecated in favor of `tempfile`: https://github.com/rust-lang-deprecated/tempdir#deprecation-note