### PR TITLE
p2p: Silence a clippy warning in test utils

### DIFF
--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 
 use chainstate::{


### PR DESCRIPTION
`unwrap` is acceptable in testing code, allow it to make clippy shut up