### PR TITLE
Add Instant to TimeGetter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,7 @@ dependencies = [
  "hex",
  "itertools",
  "logging",
+ "once_cell",
  "parity-scale-codec",
  "proptest",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ serde = "1.0"
 static_assertions = "1.1"
 thiserror = "1.0"
 tokio = "1.0"
+once_cell = "1.13"
 
 [profile.dev]
 panic = "abort" # prevent panic catching (mostly for the tokio runtime)

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -33,7 +33,7 @@ use common::{
         Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId, Transaction,
     },
     primitives::{id::WithId, BlockDistance, BlockHeight, Id, Idable},
-    time_getter::TimeGetterFn,
+    time_getter::TimeGetter,
     Uint256,
 };
 use consensus::compute_extra_consensus_data;
@@ -63,7 +63,7 @@ pub struct ChainstateRef<'a, S, V> {
     chainstate_config: &'a ChainstateConfig,
     tx_verification_strategy: &'a V,
     db_tx: S,
-    time_getter: &'a TimeGetterFn,
+    time_getter: &'a TimeGetter,
 }
 
 impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> BlockIndexHandle
@@ -116,7 +116,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         chainstate_config: &'a ChainstateConfig,
         tx_verification_strategy: &'a V,
         db_tx: S,
-        time_getter: &'a TimeGetterFn,
+        time_getter: &'a TimeGetter,
     ) -> ChainstateRef<'a, S, V> {
         ChainstateRef {
             chain_config,
@@ -132,7 +132,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         chainstate_config: &'a ChainstateConfig,
         tx_verification_strategy: &'a V,
         db_tx: S,
-        time_getter: &'a TimeGetterFn,
+        time_getter: &'a TimeGetter,
     ) -> ChainstateRef<'a, S, V> {
         ChainstateRef {
             chain_config,
@@ -153,7 +153,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     }
 
     pub fn current_time(&self) -> std::time::Duration {
-        (self.time_getter)()
+        self.time_getter.get_time()
     }
 
     pub fn get_best_block_id(&self) -> Result<Id<GenBlock>, PropertyQueryError> {

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -46,7 +46,8 @@ mod test {
         detail::tx_verification_strategy::DefaultTransactionVerificationStrategy, BlockSource,
         Chainstate, ChainstateConfig,
     };
-    use common::time_getter::TimeGetter;
+    use common::primitives::time;
+    use test_utils::mock_time_getter::mocked_time_getter_seconds;
 
     use super::*;
     use chainstate_storage::inmemory::Store;
@@ -58,12 +59,9 @@ mod test {
             },
             config::create_unit_test_config,
         },
-        primitives::{time, Idable},
+        primitives::Idable,
     };
-    use std::{
-        sync::{atomic::Ordering, Arc},
-        time::Duration,
-    };
+    use std::sync::{atomic::Ordering, Arc};
 
     fn make_block(prev_block: Id<GenBlock>, time: BlockTimestampInternalType) -> Block {
         Block::new(
@@ -115,7 +113,7 @@ mod test {
             let blocks = chain_blocks(
                 block_count,
                 chainstate.chain_config.genesis_block_id(),
-                time::get().as_secs(),
+                time::get_system_time().as_secs(),
             );
 
             for block in &blocks {
@@ -173,10 +171,7 @@ mod test {
                 chain_config.genesis_block().timestamp().as_int_seconds(),
             ));
 
-            let chainstate_current_time = Arc::clone(&current_time);
-            let time_getter = TimeGetter::new(Arc::new(move || {
-                Duration::from_secs(chainstate_current_time.load(Ordering::SeqCst))
-            }));
+            let time_getter = mocked_time_getter_seconds(Arc::clone(&current_time));
 
             let storage = Store::new_empty().unwrap();
             let chainstate_config = ChainstateConfig::new();

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -110,7 +110,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
             &self.chainstate_config,
             &self.tx_verification_strategy,
             db_tx,
-            self.time_getter.getter(),
+            &self.time_getter,
         ))
     }
 
@@ -123,7 +123,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
             &self.chainstate_config,
             &self.tx_verification_strategy,
             db_tx,
-            self.time_getter.getter(),
+            &self.time_getter,
         ))
     }
 

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -13,13 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::sync::{atomic::AtomicU64, Arc};
 
 use chainstate::{BlockError, ChainstateConfig, DefaultTransactionVerificationStrategy};
 use common::{
@@ -27,10 +21,10 @@ use common::{
         config::{Builder as ChainConfigBuilder, ChainType},
         ChainConfig, Destination, NetUpgrades,
     },
-    time_getter::{TimeGetter, TimeGetterFn},
+    time_getter::TimeGetter,
 };
 use crypto::random::{CryptoRng, Rng};
-use test_utils::random::Seed;
+use test_utils::{mock_time_getter::mocked_time_getter_seconds, random::Seed};
 
 use crate::{
     tx_verification_strategy::{
@@ -122,12 +116,7 @@ impl TestFrameworkBuilder {
             self.chain_config.genesis_block().timestamp().as_int_seconds(),
         ));
 
-        let default_time_getter = {
-            let current_time = Arc::clone(&time_value);
-            let default_time_getter_fn: Arc<TimeGetterFn> =
-                Arc::new(move || Duration::from_secs(current_time.load(Ordering::SeqCst)));
-            TimeGetter::new(default_time_getter_fn)
-        };
+        let default_time_getter = mocked_time_getter_seconds(Arc::clone(&time_value));
 
         let time_getter = self.time_getter.clone().unwrap_or(default_time_getter);
 

--- a/chainstate/test-suite/src/tests/mempool_output_timelock.rs
+++ b/chainstate/test-suite/src/tests/mempool_output_timelock.rs
@@ -377,7 +377,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
                     current_best: &best_block_index,
                 },
                 &spend_locked_tx,
-                &BlockTimestamp::from_duration_since_epoch(time::get()),
+                &BlockTimestamp::from_duration_since_epoch(time::get_system_time()),
             )
             .unwrap();
     });

--- a/chainstate/test-suite/src/tests/output_timelock.rs
+++ b/chainstate/test-suite/src/tests/output_timelock.rs
@@ -13,15 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::Duration,
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
 };
 
-use common::time_getter::TimeGetter;
 use common::{
     chain::{
         block::{timestamp::BlockTimestamp, GenBlock},
@@ -41,7 +37,10 @@ use chainstate::ConnectTransactionError;
 use chainstate_test_framework::anyonecanspend_address;
 use chainstate_test_framework::TestFramework;
 use chainstate_test_framework::TransactionBuilder;
-use test_utils::random::{make_seedable_rng, Seed};
+use test_utils::{
+    mock_time_getter::mocked_time_getter_seconds,
+    random::{make_seedable_rng, Seed},
+};
 
 #[rstest]
 #[trace]
@@ -398,10 +397,7 @@ fn output_lock_for_block_count_attempted_overflow(#[case] seed: Seed) {
 fn output_lock_until_time(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let current_time = Arc::new(AtomicU64::new(1));
-        let current_time_ = Arc::clone(&current_time);
-        let time_getter = TimeGetter::new(Arc::new(move || {
-            Duration::from_secs(current_time_.load(Ordering::SeqCst))
-        }));
+        let time_getter = mocked_time_getter_seconds(Arc::clone(&current_time));
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).with_time_getter(time_getter).build();
 
@@ -549,10 +545,7 @@ fn output_lock_until_time_but_spend_at_same_block(#[case] seed: Seed) {
 fn output_lock_for_seconds(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let current_time = Arc::new(AtomicU64::new(1));
-        let current_time_ = Arc::clone(&current_time);
-        let time_getter = TimeGetter::new(Arc::new(move || {
-            Duration::from_secs(current_time_.load(Ordering::SeqCst))
-        }));
+        let time_getter = mocked_time_getter_seconds(Arc::clone(&current_time));
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).with_time_getter(time_getter).build();
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -24,6 +24,7 @@ static_assertions.workspace = true
 thiserror.workspace = true
 hex.workspace = true
 itertools.workspace = true
+once_cell.workspace = true
 
 # for fixed_hash
 arbitrary = "1.1"

--- a/common/src/primitives/time.rs
+++ b/common/src/primitives/time.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
+
+use once_cell::sync::Lazy;
 
 fn duration_to_int(d: &Duration) -> Result<u64, Box<dyn std::error::Error>> {
     let r = d.as_millis().try_into()?;
@@ -25,28 +27,21 @@ fn duration_from_int(v: u64) -> Duration {
     Duration::from_millis(v)
 }
 
+/// Will be used in functional tests
 static TIME_SOURCE: AtomicU64 = AtomicU64::new(0);
 
-/// Either gets the current time or panics
-pub fn get() -> Duration {
-    let value = TIME_SOURCE.load(Ordering::SeqCst);
-    if value == 0 {
-        return SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time went backwards");
-    }
-
-    duration_from_int(value)
-}
+/// Instant can only be constructed from the `Instant::now' call.
+/// Store a lazily initialized constant that can be used later with the mocked time.
+static BASE_MOCK_INSTANT: Lazy<Instant> = Lazy::new(Instant::now);
 
 /// Return mocked time if set, otherwise return `None`
-pub fn get_mocked() -> Option<Duration> {
+fn get_mocked_system_time() -> Option<Duration> {
     let value = TIME_SOURCE.load(Ordering::SeqCst);
-    if value == 0 {
-        return None;
+    if value != 0 {
+        Some(duration_from_int(value))
+    } else {
+        None
     }
-
-    Some(duration_from_int(value))
 }
 
 /// Reset time source to use `SystemTime::UNIX_EPOCH`
@@ -58,6 +53,24 @@ pub fn reset() {
 pub fn set(now: Duration) -> Result<(), Box<dyn std::error::Error>> {
     TIME_SOURCE.store(duration_to_int(&now)?, Ordering::SeqCst);
     Ok(())
+}
+
+/// Either gets the current time or panics
+pub fn get_system_time() -> Duration {
+    match get_mocked_system_time() {
+        Some(mocked_time) => mocked_time,
+        None => SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards"),
+    }
+}
+
+/// Return instant (monotonic) time
+pub fn get_instant_time() -> Instant {
+    match get_mocked_system_time() {
+        Some(mocked_time) => *BASE_MOCK_INSTANT + mocked_time,
+        None => Instant::now(),
+    }
 }
 
 #[cfg(test)]
@@ -72,36 +85,43 @@ mod tests {
         logging::init_logging::<&std::path::Path>(None);
         set(Duration::from_secs(1337)).unwrap();
 
-        log::info!("p2p time: {}", get().as_secs());
+        log::info!("p2p time: {}", get_system_time().as_secs());
         std::thread::sleep(Duration::from_secs(1));
 
-        log::info!("p2p time: {}", get().as_secs());
-        assert_eq!(get().as_secs(), 1337);
+        log::info!("p2p time: {}", get_system_time().as_secs());
+        assert_eq!(get_system_time().as_secs(), 1337);
         std::thread::sleep(Duration::from_secs(1));
 
-        log::info!("rpc time: {}", get().as_secs());
+        log::info!("rpc time: {}", get_system_time().as_secs());
         std::thread::sleep(Duration::from_millis(500));
 
-        assert_eq!(get().as_secs(), 1337);
-        log::info!("rpc time: {}", get().as_secs());
+        assert_eq!(get_system_time().as_secs(), 1337);
+        log::info!("rpc time: {}", get_system_time().as_secs());
         std::thread::sleep(Duration::from_millis(500));
 
         reset();
-        assert_ne!(get().as_secs(), 1337);
-        log::info!("rpc time: {}", get().as_secs());
+        assert_ne!(get_system_time().as_secs(), 1337);
+        log::info!("rpc time: {}", get_system_time().as_secs());
     }
 
     #[test]
     #[serial_test::serial]
     fn test_mocked() {
-        assert_eq!(get_mocked(), None);
+        assert_eq!(get_mocked_system_time(), None);
 
         set(Duration::from_secs(1337)).unwrap();
-        assert_eq!(get().as_secs(), 1337);
-        assert_eq!(get_mocked(), Some(Duration::from_secs(1337)));
+        assert_eq!(get_system_time().as_secs(), 1337);
+        assert_eq!(get_mocked_system_time(), Some(Duration::from_secs(1337)));
+
+        let time = get_instant_time();
+        set(Duration::from_secs(1338)).unwrap();
+        assert_eq!(
+            get_instant_time().duration_since(time),
+            Duration::from_secs(1)
+        );
 
         reset();
-        assert_eq!(get_mocked(), None);
+        assert_eq!(get_mocked_system_time(), None);
     }
 
     #[test]

--- a/mempool/src/pool/tests/expiry.rs
+++ b/mempool/src/pool/tests/expiry.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use common::chain::tokens::OutputValue;
+use test_utils::mock_time_getter::mocked_time_getter_seconds;
 
 use super::*;
 use crate::SystemUsageEstimator;
@@ -24,10 +25,7 @@ use crate::SystemUsageEstimator;
 #[tokio::test]
 async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
     let mock_time = Arc::new(AtomicU64::new(0));
-    let mock_time_clone = Arc::clone(&mock_time);
-    let mock_clock = TimeGetter::new(Arc::new(move || {
-        Duration::from_secs(mock_time_clone.load(Ordering::SeqCst))
-    }));
+    let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     logging::init_logging::<&str>(None);
 
     let mut rng = make_seedable_rng(seed);
@@ -111,10 +109,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
     let parent = tx_builder.build();
 
     let mock_time = Arc::new(AtomicU64::new(0));
-    let mock_time_clone = Arc::clone(&mock_time);
-    let mock_clock = TimeGetter::new(Arc::new(move || {
-        Duration::from_secs(mock_time_clone.load(Ordering::SeqCst))
-    }));
+    let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     let chainstate = tf.chainstate();
     let config = chainstate.get_chain_config();
     let chainstate_interface = start_chainstate(chainstate).await;

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -41,7 +41,10 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
-use test_utils::random::{make_seedable_rng, Seed};
+use test_utils::{
+    mock_time_getter::mocked_time_getter_seconds,
+    random::{make_seedable_rng, Seed},
+};
 
 mod expiry;
 mod replacement;
@@ -642,7 +645,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx1_parents,
         entry_1_ancestors,
-        time::get(),
+        time::get_system_time(),
     )
     .unwrap();
     let tx2_parents = BTreeSet::default();
@@ -652,7 +655,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx2_parents,
         entry_2_ancestors,
-        time::get(),
+        time::get_system_time(),
     )
     .unwrap();
 
@@ -664,7 +667,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx3_parents,
         tx3_ancestors,
-        time::get(),
+        time::get_system_time(),
     )
     .unwrap();
 
@@ -678,7 +681,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx4_parents,
         tx4_ancestors,
-        time::get(),
+        time::get_system_time(),
     )
     .unwrap();
     let entry5 = TxMempoolEntry::new(
@@ -686,7 +689,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx5_parents,
         tx5_ancestors,
-        time::get(),
+        time::get_system_time(),
     )
     .unwrap();
 
@@ -701,7 +704,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx6_parents,
         tx6_ancestors,
-        time::get(),
+        time::get_system_time(),
     )
     .unwrap();
 
@@ -905,10 +908,7 @@ async fn spends_new_unconfirmed(#[case] seed: Seed) -> anyhow::Result<()> {
 async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     logging::init_logging::<&str>(None);
     let mock_time = Arc::new(AtomicU64::new(0));
-    let mock_time_clone = Arc::clone(&mock_time);
-    let mock_clock = TimeGetter::new(Arc::new(move || {
-        Duration::from_secs(mock_time_clone.load(Ordering::SeqCst))
-    }));
+    let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     let mut mock_usage = MockGetMemoryUsage::new();
     // Add parent
     // Add first child

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 
 [features]
 default = []
-testing_utils = ["tokio/test-util"]
+testing_utils = ["dep:test-utils", "tokio/test-util"]
 
 [dependencies]
 common = { path = "../common/" }
@@ -20,6 +20,7 @@ serialization = { path = "../serialization/" }
 subsystem = { path = "../subsystem/" }
 utils = { path = "../utils/" }
 storage = { path = "../storage" }
+test-utils = { path = "../test-utils", optional = true }
 
 async-trait.workspace = true
 bytes = "1.1"
@@ -30,7 +31,7 @@ sscanf = "0.4"
 thiserror.workspace = true
 void = "1.0"
 tap = "1.0"
-once_cell = "1.13"
+once_cell.workspace = true
 jsonrpsee = { workspace = true, features = ["macros"] }
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util = {version = "0.7", default-features = false, features = ["codec"] }

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -27,6 +27,7 @@ use std::{
 
 use common::time_getter::TimeGetter;
 use crypto::random::{make_pseudo_rng, Rng};
+use test_utils::mock_time_getter::mocked_time_getter_milliseconds;
 use tokio::time::timeout;
 
 use crate::{
@@ -246,10 +247,7 @@ impl P2pBasicTestTimeGetter {
     }
 
     pub fn get_time_getter(&self) -> TimeGetter {
-        let current_time = Arc::clone(&self.current_time_millis);
-        TimeGetter::new(Arc::new(move || {
-            Duration::from_millis(current_time.load(Ordering::SeqCst))
-        }))
+        mocked_time_getter_milliseconds(Arc::clone(&self.current_time_millis))
     }
 
     pub fn advance_time(&self, duration: Duration) {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod mock_time_getter;
 pub mod nft_utils;
 pub mod random;
 pub mod test_dir;

--- a/test-utils/src/mock_time_getter.rs
+++ b/test-utils/src/mock_time_getter.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::time_getter::{TimeGetter, TimeGetterFn};
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+// NOTE: `get_instant` won't work correctly if the counter goes backwards
+pub fn mocked_time_getter_seconds(seconds: Arc<AtomicU64>) -> TimeGetter {
+    TimeGetter::new(Arc::new(MockedMsecTimeGetterFn::new(seconds, 1000)))
+}
+
+// NOTE: `get_instant` won't work correctly if the counter goes backwards
+pub fn mocked_time_getter_milliseconds(milliseconds: Arc<AtomicU64>) -> TimeGetter {
+    TimeGetter::new(Arc::new(MockedMsecTimeGetterFn::new(milliseconds, 1)))
+}
+
+struct MockedMsecTimeGetterFn {
+    count: Arc<AtomicU64>,
+    multiplier: u64,
+    started_at: Instant,
+}
+
+impl MockedMsecTimeGetterFn {
+    fn new(count: Arc<AtomicU64>, multiplier: u64) -> Self {
+        Self {
+            count,
+            multiplier,
+            started_at: Instant::now(),
+        }
+    }
+}
+
+impl TimeGetterFn for MockedMsecTimeGetterFn {
+    fn system_time(&self) -> Duration {
+        Duration::from_millis(self.multiplier * self.count.load(Ordering::SeqCst))
+    }
+
+    fn instant(&self) -> Instant {
+        self.started_at + self.system_time()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::atomic::Ordering;
+
+    use crate::mock_time_getter::mocked_time_getter_seconds;
+
+    use super::*;
+
+    #[test]
+    fn test_mocked_time_getter_seconds() {
+        let seconds = Arc::new(AtomicU64::new(12345));
+        let time_getter = mocked_time_getter_seconds(Arc::clone(&seconds));
+        let time = time_getter.get_time();
+        let instant = time_getter.get_instant();
+        seconds.fetch_add(123, Ordering::SeqCst);
+        assert_eq!(time_getter.get_time() - time, Duration::from_secs(123));
+        assert_eq!(
+            time_getter.get_instant().duration_since(instant),
+            Duration::from_secs(123)
+        );
+    }
+
+    #[test]
+    fn test_mocked_time_getter_milliseconds() {
+        let milliseconds = Arc::new(AtomicU64::new(12345));
+        let time_getter = mocked_time_getter_milliseconds(Arc::clone(&milliseconds));
+        let time = time_getter.get_time();
+        let instant = time_getter.get_instant();
+        milliseconds.fetch_add(123, Ordering::SeqCst);
+        assert_eq!(time_getter.get_time() - time, Duration::from_millis(123));
+        assert_eq!(
+            time_getter.get_instant().duration_since(instant),
+            Duration::from_millis(123)
+        );
+    }
+}


### PR DESCRIPTION
I need a monotonic clock in `PeerDb` where we can only use `TimeGetter`. Using the system clock is not a good option because it can go backwards. To fix this, I added the instant clock to `TimeGetter`.
I removed global `TIME_SOURCE` variable because it is not used in tests and is generally not very useful (doesn't work properly if tests run in parallel).