### PR TITLE
Use biased select loop in the sync manager

### DIFF
--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -30,8 +30,8 @@ use common::chain::{config::create_mainnet, ChainConfig};
 use p2p_test_utils::start_chainstate;
 
 use crate::{
-    net::default_backend::transport::TcpTransportSocket,
-    sync::{Announcement, BlockSyncManager, SyncControlEvent, SyncMessage, SyncingEvent},
+    net::{default_backend::transport::TcpTransportSocket, types::SyncingEvent},
+    sync::{Announcement, BlockSyncManager, SyncControlEvent, SyncMessage},
     types::peer_id::PeerId,
     NetworkingService, P2pConfig, P2pError, PeerManagerEvent, Result, SyncingMessagingService,
 };


### PR DESCRIPTION
I think that this is a much simpler alternative to https://github.com/mintlayer/mintlayer-core/pull/729. I'm not sure that the same approach that is used in the backend will work for the sync manager, so I have tried something different.