### PR TITLE
`PeerManager` updates

### DIFF
--- a/crypto/src/random/mod.rs
+++ b/crypto/src/random/mod.rs
@@ -17,7 +17,9 @@ pub use rand::prelude::SliceRandom;
 pub use rand::{seq, CryptoRng, Rng, RngCore, SeedableRng};
 
 pub mod distributions {
-    pub use rand::distributions::{Alphanumeric, DistString, Distribution, Standard};
+    pub use rand::distributions::{
+        Alphanumeric, DistString, Distribution, Standard, WeightedIndex,
+    };
     pub mod uniform {
         pub use rand::distributions::uniform::SampleRange;
     }

--- a/dns_server/src/config.rs
+++ b/dns_server/src/config.rs
@@ -37,9 +37,9 @@ pub struct DnsServerConfig {
     #[clap(long, default_values_t = vec!["[::]:53".to_string()])]
     pub bind_addr: Vec<String>,
 
-    /// Initial node address to connect. Can be specified multiple times.
+    /// Reserved node address to connect. Can be specified multiple times.
     #[clap(long)]
-    pub add_node: Vec<String>,
+    pub reserved_node: Vec<String>,
 
     /// Hostname of the DNS seed
     #[clap(long)]

--- a/dns_server/src/crawler_p2p/crawler/address_data.rs
+++ b/dns_server/src/crawler_p2p/crawler/address_data.rs
@@ -86,8 +86,8 @@ pub struct AddressData {
     /// Connection state
     pub state: AddressState,
 
-    /// Whether the address was added from the command line
-    pub user_added: ConstValue<bool>,
+    /// Whether the address was specified from the command line as reserved_node
+    pub reserved: ConstValue<bool>,
 }
 
 impl AddressState {
@@ -215,8 +215,8 @@ impl AddressData {
                 disconnected_at,
             } => {
                 let age = now - disconnected_at;
-                if *self.user_added {
-                    // Try to connect to the user added nodes more often
+                if *self.reserved {
+                    // Try to connect to the reserved nodes more often
                     let age = now - disconnected_at;
                     match fail_count {
                         0 => true,
@@ -292,7 +292,7 @@ impl AddressData {
                         || matches!(self.state, AddressState::Disconnecting { .. })
                 );
 
-                self.state = match (*self.user_added, self.state.was_reachable()) {
+                self.state = match (*self.reserved, self.state.was_reachable()) {
                     (false, true) if self.state.fail_count() + 1 >= PURGE_REACHABLE_FAIL_COUNT => {
                         AddressState::Unreachable {
                             fail_count: self.state.fail_count() + 1,

--- a/dns_server/src/crawler_p2p/crawler/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler/mod.rs
@@ -95,12 +95,12 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
     pub fn new(
         chain_config: Arc<ChainConfig>,
         loaded_addresses: BTreeSet<A>,
-        added_addresses: BTreeSet<A>,
+        reserved_addresses: BTreeSet<A>,
     ) -> Self {
         let now = Duration::ZERO;
 
         let addresses = loaded_addresses
-            .union(&added_addresses)
+            .union(&reserved_addresses)
             .map(|addr| {
                 (
                     addr.clone(),
@@ -110,7 +110,7 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
                             was_reachable: loaded_addresses.contains(addr),
                             disconnected_at: now,
                         },
-                        user_added: added_addresses.contains(addr).into(),
+                        reserved: reserved_addresses.contains(addr).into(),
                     },
                 )
             })
@@ -174,7 +174,7 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
                     was_reachable: false,
                     disconnected_at: self.now,
                 },
-                user_added: false.into(),
+                reserved: false.into(),
             });
         }
     }

--- a/dns_server/src/crawler_p2p/crawler/tests/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler/tests/mod.rs
@@ -129,13 +129,13 @@ fn randomized(#[case] seed: Seed) {
         })
         .collect::<Vec<_>>();
 
-    let added_count = rng.gen_range(0..5);
-    let added_nodes = nodes.choose_multiple(&mut rng, added_count).cloned().collect();
+    let reserved_count = rng.gen_range(0..5);
+    let reserved_nodes = nodes.choose_multiple(&mut rng, reserved_count).cloned().collect();
 
     let loaded_count = rng.gen_range(0..10);
     let loaded_nodes = nodes.choose_multiple(&mut rng, loaded_count).cloned().collect();
 
-    let mut crawler = test_crawler(loaded_nodes, added_nodes);
+    let mut crawler = test_crawler(loaded_nodes, reserved_nodes);
 
     for _ in 0..rng.gen_range(0..100000) {
         crawler.timer(Duration::from_secs(rng.gen_range(0..100)), &mut rng);
@@ -253,7 +253,7 @@ fn long_offline(#[case] seed: Seed) {
     );
     assert!(crawler.persistent.contains(&loaded_node));
 
-    // Reachable and added nodes are offline for two month
+    // Reachable and reserved nodes are offline for two month
     for _ in 0..24 * 60 {
         crawler.timer(Duration::from_secs(3600), &mut rng);
         for address in crawler.pending_connects.clone() {

--- a/dns_server/src/crawler_p2p/crawler_manager/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/mod.rs
@@ -55,7 +55,7 @@ const STORAGE_VERSION: u32 = 1;
 #[derive(Clone)]
 pub struct CrawlerManagerConfig {
     /// Manually specified list of nodes to connect to
-    pub add_node: Vec<String>,
+    pub reserved_nodes: Vec<String>,
 
     /// Default p2p port on which nodes normally accept inbound connections;
     /// the DNS server has no way to communicate port numbers,
@@ -106,15 +106,15 @@ where
         let loaded_addresses: BTreeSet<N::Address> = Self::load_storage(&storage)?;
 
         // Addresses listed as reachable from the command line
-        let added_addresses: BTreeSet<N::Address> = config
-            .add_node
+        let reserved_addresses: BTreeSet<N::Address> = config
+            .reserved_nodes
             .iter()
             .map(|addr| addr.parse())
             .collect::<Result<BTreeSet<N::Address>, _>>()?;
 
         assert!(conn.local_addresses().is_empty());
 
-        let crawler = Crawler::new(chain_config, loaded_addresses, added_addresses);
+        let crawler = Crawler::new(chain_config, loaded_addresses, reserved_addresses);
 
         Ok(Self {
             last_crawler_timer,

--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
@@ -198,7 +198,7 @@ impl SyncingMessagingService<MockNetworkingService> for MockSyncingMessagingHand
 }
 
 pub fn test_crawler(
-    add_node: Vec<SocketAddr>,
+    reserved_nodes: Vec<SocketAddr>,
 ) -> (
     CrawlerManager<MockNetworkingService, DnsServerStorageImpl<storage::inmemory::InMemory>>,
     MockStateRef,
@@ -206,9 +206,9 @@ pub fn test_crawler(
     P2pTokioTestTimeGetter,
 ) {
     let (conn_tx, conn_rx) = mpsc::unbounded_channel();
-    let add_node = add_node.iter().map(ToString::to_string).collect();
+    let reserved_nodes = reserved_nodes.iter().map(ToString::to_string).collect();
     let crawler_config = CrawlerManagerConfig {
-        add_node,
+        reserved_nodes,
         default_p2p_port: 3031,
     };
 

--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -41,6 +41,7 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<void::Void, error::DnsServe
 
     let p2p_config = Arc::new(P2pConfig {
         bind_addresses: Vec::new(),
+        boot_nodes: Vec::new(),
         reserved_nodes: Vec::new(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),

--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -41,7 +41,7 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<void::Void, error::DnsServe
 
     let p2p_config = Arc::new(P2pConfig {
         bind_addresses: Vec::new(),
-        added_nodes: Vec::new(),
+        reserved_nodes: Vec::new(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
         ban_duration: Default::default(),
@@ -73,7 +73,7 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<void::Void, error::DnsServe
     ))?;
 
     let crawler_config = CrawlerManagerConfig {
-        add_node: config.add_node.clone(),
+        reserved_nodes: config.reserved_node.clone(),
         default_p2p_port: chain_config.p2p_port(),
     };
 

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -126,6 +126,7 @@ fn chainstate_config(
 fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
     let P2pConfigFile {
         bind_addresses,
+        boot_nodes,
         reserved_nodes,
         max_inbound_connections,
         ban_threshold,
@@ -137,6 +138,7 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
     } = config;
 
     let bind_addresses = options.p2p_addr.clone().or(bind_addresses);
+    let boot_nodes = options.p2p_boot_node.clone().or(boot_nodes);
     let reserved_nodes = options.p2p_reserved_node.clone().or(reserved_nodes);
     let max_inbound_connections = options.p2p_max_inbound_connections.or(max_inbound_connections);
     let ban_threshold = options.p2p_ban_threshold.or(ban_threshold);
@@ -148,6 +150,7 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
 
     P2pConfigFile {
         bind_addresses,
+        boot_nodes,
         reserved_nodes,
         max_inbound_connections,
         ban_threshold,

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -126,7 +126,7 @@ fn chainstate_config(
 fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
     let P2pConfigFile {
         bind_addresses,
-        added_nodes,
+        reserved_nodes,
         max_inbound_connections,
         ban_threshold,
         ban_duration,
@@ -137,7 +137,7 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
     } = config;
 
     let bind_addresses = options.p2p_addr.clone().or(bind_addresses);
-    let added_nodes = options.p2p_add_node.clone().or(added_nodes);
+    let reserved_nodes = options.p2p_reserved_node.clone().or(reserved_nodes);
     let max_inbound_connections = options.p2p_max_inbound_connections.or(max_inbound_connections);
     let ban_threshold = options.p2p_ban_threshold.or(ban_threshold);
     let ping_check_period = options.p2p_ping_check_period.or(ping_check_period);
@@ -148,7 +148,7 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
 
     P2pConfigFile {
         bind_addresses,
-        added_nodes,
+        reserved_nodes,
         max_inbound_connections,
         ban_threshold,
         ban_duration,

--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -54,6 +54,8 @@ impl FromStr for NodeTypeConfigFile {
 pub struct P2pConfigFile {
     /// Address to bind P2P to.
     pub bind_addresses: Option<Vec<String>>,
+    /// Optional list of boot node addresses to connect.
+    pub boot_nodes: Option<Vec<String>>,
     /// Optional list of reserved node addresses to connect.
     pub reserved_nodes: Option<Vec<String>>,
     /// Maximum allowed number of inbound connections.
@@ -76,6 +78,7 @@ impl From<P2pConfigFile> for P2pConfig {
     fn from(c: P2pConfigFile) -> Self {
         P2pConfig {
             bind_addresses: c.bind_addresses.clone().unwrap_or_default(),
+            boot_nodes: c.boot_nodes.clone().unwrap_or_default(),
             reserved_nodes: c.reserved_nodes.clone().unwrap_or_default(),
             max_inbound_connections: c.max_inbound_connections.into(),
             ban_threshold: c.ban_threshold.into(),

--- a/node/src/config_files/p2p.rs
+++ b/node/src/config_files/p2p.rs
@@ -54,8 +54,8 @@ impl FromStr for NodeTypeConfigFile {
 pub struct P2pConfigFile {
     /// Address to bind P2P to.
     pub bind_addresses: Option<Vec<String>>,
-    /// Optional list of initial node addresses to connect.
-    pub added_nodes: Option<Vec<String>>,
+    /// Optional list of reserved node addresses to connect.
+    pub reserved_nodes: Option<Vec<String>>,
     /// Maximum allowed number of inbound connections.
     pub max_inbound_connections: Option<usize>,
     /// The score threshold after which a peer is banned.
@@ -76,7 +76,7 @@ impl From<P2pConfigFile> for P2pConfig {
     fn from(c: P2pConfigFile) -> Self {
         P2pConfig {
             bind_addresses: c.bind_addresses.clone().unwrap_or_default(),
-            added_nodes: c.added_nodes.clone().unwrap_or_default(),
+            reserved_nodes: c.reserved_nodes.clone().unwrap_or_default(),
             max_inbound_connections: c.max_inbound_connections.into(),
             ban_threshold: c.ban_threshold.into(),
             ban_duration: c.ban_duration.map(Duration::from_secs).into(),

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -77,6 +77,10 @@ pub struct RunOptions {
     #[clap(long, value_name = "ADDR")]
     pub p2p_addr: Option<Vec<String>>,
 
+    /// Optional list of boot node addresses to connect.
+    #[clap(long, value_name = "NODE")]
+    pub p2p_boot_node: Option<Vec<String>>,
+
     /// Optional list of reserved node addresses to connect.
     #[clap(long, value_name = "NODE")]
     pub p2p_reserved_node: Option<Vec<String>>,

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -77,9 +77,9 @@ pub struct RunOptions {
     #[clap(long, value_name = "ADDR")]
     pub p2p_addr: Option<Vec<String>>,
 
-    /// Optional list of initial node addresses to connect.
+    /// Optional list of reserved node addresses to connect.
     #[clap(long, value_name = "NODE")]
-    pub p2p_add_node: Option<Vec<String>>,
+    pub p2p_reserved_node: Option<Vec<String>>,
 
     /// Maximum allowed number of inbound connections.
     #[clap(long)]

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -98,6 +98,7 @@ fn read_config_override_values() {
     let max_db_commit_attempts = 1;
     let max_orphan_blocks = 2;
     let p2p_addr = "address";
+    let p2p_boot_node = "boot_node";
     let p2p_reserved_node = "reserved_node";
     let p2p_max_inbound_connections = 123;
     let p2p_ban_threshold = 3;
@@ -117,6 +118,7 @@ fn read_config_override_values() {
         max_orphan_blocks: Some(max_orphan_blocks),
         tx_index_enabled: Some(false),
         p2p_addr: Some(vec![p2p_addr.to_owned()]),
+        p2p_boot_node: Some(vec![p2p_boot_node.to_owned()]),
         p2p_reserved_node: Some(vec![p2p_reserved_node.to_owned()]),
         p2p_max_inbound_connections: Some(p2p_max_inbound_connections),
         p2p_ban_threshold: Some(p2p_ban_threshold),
@@ -151,6 +153,10 @@ fn read_config_override_values() {
     assert_eq!(
         config.p2p.clone().unwrap().bind_addresses,
         Some(vec!(p2p_addr.to_owned()))
+    );
+    assert_eq!(
+        config.p2p.clone().unwrap().boot_nodes,
+        Some(vec!(p2p_boot_node.to_owned()))
     );
     assert_eq!(
         config.p2p.clone().unwrap().reserved_nodes,

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -98,7 +98,7 @@ fn read_config_override_values() {
     let max_db_commit_attempts = 1;
     let max_orphan_blocks = 2;
     let p2p_addr = "address";
-    let p2p_add_node = "add_node";
+    let p2p_reserved_node = "reserved_node";
     let p2p_max_inbound_connections = 123;
     let p2p_ban_threshold = 3;
     let p2p_timeout = NonZeroU64::new(10000).unwrap();
@@ -117,7 +117,7 @@ fn read_config_override_values() {
         max_orphan_blocks: Some(max_orphan_blocks),
         tx_index_enabled: Some(false),
         p2p_addr: Some(vec![p2p_addr.to_owned()]),
-        p2p_add_node: Some(vec![p2p_add_node.to_owned()]),
+        p2p_reserved_node: Some(vec![p2p_reserved_node.to_owned()]),
         p2p_max_inbound_connections: Some(p2p_max_inbound_connections),
         p2p_ban_threshold: Some(p2p_ban_threshold),
         p2p_outbound_connection_timeout: Some(p2p_timeout),
@@ -153,8 +153,8 @@ fn read_config_override_values() {
         Some(vec!(p2p_addr.to_owned()))
     );
     assert_eq!(
-        config.p2p.clone().unwrap().added_nodes,
-        Some(vec!(p2p_add_node.to_owned()))
+        config.p2p.clone().unwrap().reserved_nodes,
+        Some(vec!(p2p_reserved_node.to_owned()))
     );
     assert_eq!(
         config.p2p.clone().unwrap().max_inbound_connections,

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -133,6 +133,7 @@ where
     let chain_config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(P2pConfig {
         bind_addresses: Vec::new(),
+        boot_nodes: Vec::new(),
         reserved_nodes: Vec::new(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -133,7 +133,7 @@ where
     let chain_config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(P2pConfig {
         bind_addresses: Vec::new(),
-        added_nodes: Vec::new(),
+        reserved_nodes: Vec::new(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
         ban_duration: Default::default(),

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -66,7 +66,12 @@ impl From<NodeType> for BTreeSet<PubSubTopic> {
 pub struct P2pConfig {
     /// Address to bind P2P to.
     pub bind_addresses: Vec<String>,
-    /// Optional list of initial node addresses, could be used to specify boot nodes for example.
+    /// Optional list of initial node addresses.
+    /// Boot node addresses are added to PeerDb as regular discovered addresses.
+    pub boot_nodes: Vec<String>,
+    /// Optional list of reserved node addresses.
+    /// PeerManager will try to maintain persistent connections to the reserved nodes.
+    /// Ban scores are not adjusted for the reserved nodes.
     pub reserved_nodes: Vec<String>,
     /// Maximum allowed number of inbound connections.
     pub max_inbound_connections: MaxInboundConnections,

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -67,7 +67,7 @@ pub struct P2pConfig {
     /// Address to bind P2P to.
     pub bind_addresses: Vec<String>,
     /// Optional list of initial node addresses, could be used to specify boot nodes for example.
-    pub added_nodes: Vec<String>,
+    pub reserved_nodes: Vec<String>,
     /// Maximum allowed number of inbound connections.
     pub max_inbound_connections: MaxInboundConnections,
     /// The score threshold after which a peer is banned.

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -41,6 +41,10 @@ pub enum PeerManagerEvent<T: NetworkingService> {
     ///
     /// The peer is banned if the new score exceeds the threshold (`P2pConfig::ban_threshold`).
     AdjustPeerScore(PeerId, u32, oneshot_nofail::Sender<crate::Result<()>>),
+
+    AddReserved(T::Address),
+
+    RemoveReserved(T::Address),
 }
 
 #[derive(Debug)]

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -20,12 +20,12 @@ use super::types::ConnectedPeer;
 #[async_trait::async_trait]
 pub trait P2pInterface: Send + Sync {
     async fn connect(&mut self, addr: String) -> crate::Result<()>;
-
     async fn disconnect(&mut self, peer_id: PeerId) -> crate::Result<()>;
 
     async fn get_peer_count(&self) -> crate::Result<usize>;
-
     async fn get_bind_addresses(&self) -> crate::Result<Vec<String>>;
-
     async fn get_connected_peers(&self) -> crate::Result<Vec<ConnectedPeer>>;
+
+    async fn add_reserved_node(&mut self, addr: String) -> crate::Result<()>;
+    async fn remove_reserved_node(&mut self, addr: String) -> crate::Result<()>;
 }

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -72,4 +72,24 @@ where
             .map_err(P2pError::from)?;
         rx.await.map_err(P2pError::from)
     }
+
+    async fn add_reserved_node(&mut self, addr: String) -> crate::Result<()> {
+        let addr = addr
+            .parse::<T::Address>()
+            .map_err(|_| P2pError::ConversionError(ConversionError::InvalidAddress(addr)))?;
+        self.tx_peer_manager
+            .send(PeerManagerEvent::AddReserved(addr))
+            .map_err(|_| P2pError::ChannelClosed)?;
+        Ok(())
+    }
+
+    async fn remove_reserved_node(&mut self, addr: String) -> crate::Result<()> {
+        let addr = addr
+            .parse::<T::Address>()
+            .map_err(|_| P2pError::ConversionError(ConversionError::InvalidAddress(addr)))?;
+        self.tx_peer_manager
+            .send(PeerManagerEvent::RemoveReserved(addr))
+            .map_err(|_| P2pError::ChannelClosed)?;
+        Ok(())
+    }
 }

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -42,4 +42,12 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
     async fn get_connected_peers(&self) -> crate::Result<Vec<ConnectedPeer>> {
         self.deref().get_connected_peers().await
     }
+
+    async fn add_reserved_node(&mut self, addr: String) -> crate::Result<()> {
+        self.deref_mut().add_reserved_node(addr).await
+    }
+
+    async fn remove_reserved_node(&mut self, addr: String) -> crate::Result<()> {
+        self.deref_mut().remove_reserved_node(addr).await
+    }
 }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -838,6 +838,12 @@ where
                 let peers = self.get_connected_peers();
                 response.send(peers);
             }
+            PeerManagerEvent::AddReserved(address) => {
+                self.peerdb.add_reserved_node(address);
+            }
+            PeerManagerEvent::RemoveReserved(address) => {
+                self.peerdb.remove_reserved_node(address);
+            }
         }
     }
 

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -659,8 +659,14 @@ where
         self.peerdb.heartbeat();
 
         let pending_outbound = self.pending_outbound_connects.keys().cloned().collect();
-        let connected_outbound_count =
-            self.peers.values().filter(|peer| peer.role == Role::Outbound).count();
+        let connected_outbound_count = self
+            .peers
+            .values()
+            .filter(|peer| {
+                // Do not take into account reserved nodes
+                peer.role == Role::Outbound && !self.peerdb.is_reserved_node(&peer.address)
+            })
+            .count();
 
         let new_addresses = self
             .peerdb

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -296,7 +296,8 @@ where
 
         let bannable_address = address.as_bannable();
         ensure!(
-            !self.peerdb.is_address_banned(&bannable_address),
+            !self.peerdb.is_address_banned(&bannable_address)
+                || self.peerdb.is_reserved_node(&address),
             P2pError::PeerError(PeerError::BannedAddress(address.to_string())),
         );
 
@@ -838,7 +839,9 @@ where
                 response.send(peers);
             }
             PeerManagerEvent::AddReserved(address) => {
-                self.peerdb.add_reserved_node(address);
+                self.peerdb.add_reserved_node(address.clone());
+                // Initiate new outbound connection without waiting for `heartbeat`
+                self.connect(address, None);
             }
             PeerManagerEvent::RemoveReserved(address) => {
                 self.peerdb.remove_reserved_node(address);

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -284,6 +284,8 @@ where
             P2pError::PeerError(PeerError::BannedAddress(address.to_string())),
         );
 
+        self.peerdb.outbound_peer_connecting(address.clone());
+
         self.peer_connectivity_handle.connect(address)?;
 
         Ok(())

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -256,7 +256,7 @@ where
                 // TODO: Add whitelisted IPs option and check it here
                 false
             }
-            Role::Outbound => self.peerdb.is_user_added_node(&peer.address),
+            Role::Outbound => self.peerdb.is_reserved_node(&peer.address),
         };
 
         if whitelisted_node {
@@ -679,10 +679,9 @@ where
             new_addresses
         };
 
-        let user_added_addresses =
-            self.peerdb.select_user_added_outbound_addresses(&pending_outbound);
+        let reserved_addresses = self.peerdb.select_reserved_outbound_addresses(&pending_outbound);
 
-        for address in new_addresses.into_iter().chain(user_added_addresses.into_iter()) {
+        for address in new_addresses.into_iter().chain(reserved_addresses.into_iter()) {
             self.connect(address, None);
         }
     }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -300,8 +300,6 @@ where
             P2pError::PeerError(PeerError::BannedAddress(address.to_string())),
         );
 
-        self.peerdb.outbound_peer_connecting(address.clone());
-
         self.peer_connectivity_handle.connect(address)?;
 
         Ok(())

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -438,7 +438,7 @@ where
 
         self.validate_connection(&address, role, &info)?;
 
-        log::info!("new peer accepted, peer_id: {peer_id}, address: {address:?}, role: {role:?}",);
+        log::info!("new peer accepted, peer_id: {peer_id}, address: {address:?}, role: {role:?}");
 
         if info.subscriptions.contains(&PubSubTopic::PeerAddresses) {
             self.subscribed_to_peer_addresses.insert(info.peer_id);
@@ -654,6 +654,7 @@ where
     /// establish new connections. After that it updates the peer scores and discards any records
     /// that no longer need to be stored.
     async fn heartbeat(&mut self) {
+        // Expired banned addresses are dropped here, keep this call!
         self.peerdb.heartbeat();
 
         let pending_outbound = self.pending_outbound_connects.keys().cloned().collect();

--- a/p2p/src/peer_manager/peerdb/address_data/mod.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/mod.rs
@@ -57,23 +57,23 @@ pub enum AddressStateTransitionTo {
 pub struct AddressData {
     state: AddressState,
 
-    user_added: ConstValue<bool>,
+    reserved: ConstValue<bool>,
 }
 
 impl AddressData {
-    pub fn new(was_reachable: bool, user_added: bool, now: Instant) -> Self {
+    pub fn new(was_reachable: bool, reserved: bool, now: Instant) -> Self {
         AddressData {
             state: AddressState::Disconnected {
                 was_reachable,
                 fail_count: 0,
                 disconnected_at: now,
             },
-            user_added: user_added.into(),
+            reserved: reserved.into(),
         }
     }
 
-    pub fn user_added(&self) -> bool {
-        *self.user_added
+    pub fn reserved(&self) -> bool {
+        *self.reserved
     }
 
     /// Returns true when it is time to attempt a new outbound connection
@@ -87,8 +87,8 @@ impl AddressData {
                 was_reachable,
             } => {
                 let age = now.duration_since(disconnected_at);
-                if *self.user_added {
-                    // Try to connect to the user added nodes more often
+                if *self.reserved {
+                    // Try to connect to the user reserved nodes more often
                     let age = now - disconnected_at;
                     match fail_count {
                         0 => true,
@@ -176,7 +176,7 @@ impl AddressData {
                     disconnected_at: _,
                     was_reachable,
                 } => {
-                    if *self.user_added {
+                    if *self.reserved {
                         AddressState::Disconnected {
                             fail_count: fail_count + 1,
                             disconnected_at: now,

--- a/p2p/src/peer_manager/peerdb/address_data/mod.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/mod.rs
@@ -158,6 +158,10 @@ impl AddressData {
         matches!(self.state, AddressState::Connected { .. })
     }
 
+    pub fn is_unreachable(&self) -> bool {
+        matches!(self.state, AddressState::Unreachable { .. })
+    }
+
     pub fn transition_to(&mut self, transition: AddressStateTransitionTo, now: Instant) {
         self.state = match transition {
             AddressStateTransitionTo::Connected => match self.state {

--- a/p2p/src/peer_manager/peerdb/address_data/mod.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/mod.rs
@@ -71,6 +71,10 @@ impl AddressData {
         }
     }
 
+    pub fn user_added(&self) -> bool {
+        *self.user_added
+    }
+
     /// Returns true when it is time to attempt a new outbound connection
     pub fn connect_now(&self, now: Instant) -> bool {
         match self.state {

--- a/p2p/src/peer_manager/peerdb/address_data/tests.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/tests.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crypto::random::{
+    distributions::{Distribution, WeightedIndex},
+    Rng,
+};
+use rstest::rstest;
+use test_utils::random::{make_seedable_rng, Seed};
+
+use super::*;
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn randomized(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let started_at = Instant::now();
+
+    let weights = [100, 100, 100, 10, 10];
+    assert_eq!(weights.len(), ALL_TRANSITIONS.len());
+    let weights = WeightedIndex::new(weights).unwrap();
+
+    for _ in 0..100 {
+        let was_reachable = rng.gen_bool(0.2);
+        let reserved = rng.gen_bool(0.1);
+
+        let mut address_data = AddressData::new(was_reachable, reserved, started_at);
+
+        for _ in 0..1000 {
+            let transition = ALL_TRANSITIONS[weights.sample(&mut rng)];
+
+            let is_valid_transition = match transition {
+                AddressStateTransitionTo::Connected => !address_data.is_connected(),
+                AddressStateTransitionTo::Disconnected => address_data.is_connected(),
+                AddressStateTransitionTo::ConnectionFailed => !address_data.is_connected(),
+                AddressStateTransitionTo::SetReserved => true,
+                AddressStateTransitionTo::UnsetReserved => true,
+            };
+
+            if is_valid_transition {
+                address_data.transition_to(transition, started_at);
+            }
+        }
+    }
+}

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -200,6 +200,14 @@ where
         self.change_address_state(address, AddressStateTransitionTo::ConnectionFailed);
     }
 
+    /// Add new peer addresses if it's not known.
+    pub fn outbound_peer_connecting(&mut self, address: A) {
+        // Make sure the address is known (if the user requested to connect to the new address via RPC)
+        self.peer_discovered(address.clone());
+        // Update address state
+        self.change_address_state(address, AddressStateTransitionTo::Connecting);
+    }
+
     /// Mark peer as connected
     ///
     /// After `PeerManager` has established either an inbound or an outbound connection,

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -284,6 +284,17 @@ where
         self.reserved_nodes.contains(address)
     }
 
+    pub fn add_reserved_node(&mut self, address: A) {
+        self.peer_discovered(address.clone());
+        self.change_address_state(address.clone(), AddressStateTransitionTo::SetReserved);
+        self.reserved_nodes.insert(address.clone());
+    }
+
+    pub fn remove_reserved_node(&mut self, address: A) {
+        self.change_address_state(address.clone(), AddressStateTransitionTo::UnsetReserved);
+        self.reserved_nodes.remove(&address);
+    }
+
     /// Changes the address state to banned
     pub fn ban_peer(&mut self, address: &A) {
         let bannable_address = address.as_bannable();

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -295,7 +295,7 @@ where
 
     /// Checks if the given address is banned
     pub fn is_address_banned(&self, address: &B) -> bool {
-        self.banned_addresses.contains_key(&address)
+        self.banned_addresses.contains_key(address)
     }
 
     /// Changes the address state to banned

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -269,6 +269,10 @@ where
         false
     }
 
+    pub fn is_user_added_node(&self, address: &A) -> bool {
+        self.added_nodes.contains(address)
+    }
+
     /// Changes the address state to banned
     pub fn ban_peer(&mut self, address: &A) {
         let bannable_address = address.as_bannable();

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -58,7 +58,7 @@ pub struct PeerDb<A, B, S> {
     /// Map of all outbound peer addresses
     addresses: BTreeMap<A, AddressData>,
 
-    /// Set of addresses that have the `reserved` set.
+    /// Set of addresses that have the `reserved` flag set.
     /// Used as an optimization to not iterate over the entire `addresses` map.
     /// Every listed address must exist in the `addresses` map.
     reserved_nodes: BTreeSet<A>,
@@ -265,6 +265,20 @@ where
         }
     }
 
+    pub fn is_reserved_node(&self, address: &A) -> bool {
+        self.reserved_nodes.contains(address)
+    }
+
+    pub fn add_reserved_node(&mut self, address: A) {
+        self.change_address_state(address.clone(), AddressStateTransitionTo::SetReserved);
+        self.reserved_nodes.insert(address);
+    }
+
+    pub fn remove_reserved_node(&mut self, address: A) {
+        self.change_address_state(address.clone(), AddressStateTransitionTo::UnsetReserved);
+        self.reserved_nodes.remove(&address);
+    }
+
     /// Checks if the given address is banned
     pub fn is_address_banned(&mut self, address: &B) -> bool {
         if let Some(banned_till) = self.banned_addresses.get(address) {
@@ -283,20 +297,6 @@ where
         }
 
         false
-    }
-
-    pub fn is_reserved_node(&self, address: &A) -> bool {
-        self.reserved_nodes.contains(address)
-    }
-
-    pub fn add_reserved_node(&mut self, address: A) {
-        self.change_address_state(address.clone(), AddressStateTransitionTo::SetReserved);
-        self.reserved_nodes.insert(address);
-    }
-
-    pub fn remove_reserved_node(&mut self, address: A) {
-        self.change_address_state(address.clone(), AddressStateTransitionTo::UnsetReserved);
-        self.reserved_nodes.remove(&address);
     }
 
     /// Changes the address state to banned

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -33,7 +33,7 @@ fn unban_peer() {
     let mut peerdb = PeerDb::new(
         Arc::new(P2pConfig {
             bind_addresses: Default::default(),
-            added_nodes: Default::default(),
+            reserved_nodes: Default::default(),
             max_inbound_connections: Default::default(),
             ban_threshold: Default::default(),
             ban_duration: Duration::from_secs(60).into(),

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -62,6 +62,9 @@ fn unban_peer() {
 
     time_getter.advance_time(Duration::from_secs(120));
 
+    // Banned addresses updated in the `heartbeat` function
+    peerdb.heartbeat();
+
     assert!(!peerdb.is_address_banned(&address.as_bannable()));
     let banned_addresses = peerdb.storage.transaction_ro().unwrap().get_banned_addresses().unwrap();
     assert_eq!(banned_addresses.len(), 0);

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -33,6 +33,7 @@ fn unban_peer() {
     let mut peerdb = PeerDb::new(
         Arc::new(P2pConfig {
             bind_addresses: Default::default(),
+            boot_nodes: Default::default(),
             reserved_nodes: Default::default(),
             max_inbound_connections: Default::default(),
             ban_threshold: Default::default(),

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -660,8 +660,8 @@ async fn connection_timeout_rpc_notified_noise() {
     .await;
 }
 
-// verify that peer connection is made when valid add_node parameter is used
-async fn connection_add_node<A, T>()
+// verify that peer connection is made when valid reserved_node parameter is used
+async fn connection_reserved_node<A, T>()
 where
     A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
     T: NetworkingService + 'static + std::fmt::Debug,
@@ -673,7 +673,7 @@ where
     // Start first peer manager
     let p2p_config_1 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
-        added_nodes: Default::default(),
+        reserved_nodes: Default::default(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
         ban_duration: Default::default(),
@@ -701,10 +701,10 @@ where
     let bind_addresses = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();
     assert_eq!(bind_addresses.len(), 1);
 
-    // Start second peer manager and let it know about first manager via added_nodes
+    // Start second peer manager and let it know about first manager via reserved
     let p2p_config_2 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
-        added_nodes: bind_addresses,
+        reserved_nodes: bind_addresses,
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
         ban_duration: Default::default(),
@@ -746,18 +746,20 @@ where
 }
 
 #[tokio::test]
-async fn connection_add_node_tcp() {
-    connection_add_node::<TestTransportTcp, DefaultNetworkingService<TcpTransportSocket>>().await;
+async fn connection_reserved_node_tcp() {
+    connection_reserved_node::<TestTransportTcp, DefaultNetworkingService<TcpTransportSocket>>()
+        .await;
 }
 
 #[tokio::test]
-async fn connection_add_node_noise() {
-    connection_add_node::<TestTransportNoise, DefaultNetworkingService<NoiseTcpTransport>>().await;
+async fn connection_reserved_node_noise() {
+    connection_reserved_node::<TestTransportNoise, DefaultNetworkingService<NoiseTcpTransport>>()
+        .await;
 }
 
 #[tokio::test]
-async fn connection_add_node_channel() {
-    connection_add_node::<TestTransportChannel, DefaultNetworkingService<MpscChannelTransport>>()
+async fn connection_reserved_node_channel() {
+    connection_reserved_node::<TestTransportChannel, DefaultNetworkingService<MpscChannelTransport>>()
         .await;
 }
 
@@ -775,7 +777,7 @@ where
     // Start the first peer manager
     let p2p_config_1 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
-        added_nodes: Default::default(),
+        reserved_nodes: Default::default(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
         ban_duration: Default::default(),
@@ -804,10 +806,10 @@ where
     let bind_addresses = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();
     assert_eq!(bind_addresses.len(), 1);
 
-    // Start the second peer manager and let it know about the first peer using added_nodes
+    // Start the second peer manager and let it know about the first peer using reserved
     let p2p_config_2 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
-        added_nodes: bind_addresses.clone(),
+        reserved_nodes: bind_addresses.clone(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
         ban_duration: Default::default(),
@@ -829,10 +831,10 @@ where
     )
     .await;
 
-    // Start the third peer manager and let it know about the first peer using added_nodes
+    // Start the third peer manager and let it know about the first peer using reserved
     let p2p_config_3 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
-        added_nodes: bind_addresses,
+        reserved_nodes: bind_addresses,
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
         ban_duration: Default::default(),

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -673,6 +673,7 @@ where
     // Start first peer manager
     let p2p_config_1 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
+        boot_nodes: Default::default(),
         reserved_nodes: Default::default(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
@@ -704,6 +705,7 @@ where
     // Start second peer manager and let it know about first manager via reserved
     let p2p_config_2 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
+        boot_nodes: Default::default(),
         reserved_nodes: bind_addresses,
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
@@ -777,6 +779,7 @@ where
     // Start the first peer manager
     let p2p_config_1 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
+        boot_nodes: Default::default(),
         reserved_nodes: Default::default(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
@@ -809,6 +812,7 @@ where
     // Start the second peer manager and let it know about the first peer using reserved
     let p2p_config_2 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
+        boot_nodes: Default::default(),
         reserved_nodes: bind_addresses.clone(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
@@ -834,6 +838,7 @@ where
     // Start the third peer manager and let it know about the first peer using reserved
     let p2p_config_3 = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
+        boot_nodes: Default::default(),
         reserved_nodes: bind_addresses,
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -41,6 +41,7 @@ async fn ping_timeout() {
     let chain_config = Arc::new(config::create_mainnet());
     let p2p_config: Arc<P2pConfig> = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
+        boot_nodes: Default::default(),
         reserved_nodes: Default::default(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -41,7 +41,7 @@ async fn ping_timeout() {
     let chain_config = Arc::new(config::create_mainnet());
     let p2p_config: Arc<P2pConfig> = Arc::new(P2pConfig {
         bind_addresses: Default::default(),
-        added_nodes: Default::default(),
+        reserved_nodes: Default::default(),
         max_inbound_connections: Default::default(),
         ban_threshold: Default::default(),
         ban_duration: Default::default(),

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -18,7 +18,8 @@ use subsystem::subsystem::CallError;
 
 #[rpc::rpc(server, namespace = "p2p")]
 trait P2pRpc {
-    /// Connect to remote node
+    /// Try to connect to a remote node (just once).
+    /// For persistent connections `add_reserved_node` should be used.
     #[method(name = "connect")]
     async fn connect(&self, addr: String) -> rpc::Result<()>;
 
@@ -38,9 +39,13 @@ trait P2pRpc {
     #[method(name = "get_connected_peers")]
     async fn get_connected_peers(&self) -> rpc::Result<Vec<ConnectedPeer>>;
 
+    /// Add the address to the reserved nodes list.
+    /// The node will try to keep connections open to all reserved peers.
     #[method(name = "add_reserved_node")]
     async fn add_reserved_node(&self, addr: String) -> rpc::Result<()>;
 
+    /// Remove the address from the reserved nodes list.
+    /// Existing connection to the peer is not closed.
     #[method(name = "remove_reserved_node")]
     async fn remove_reserved_node(&self, addr: String) -> rpc::Result<()>;
 }

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -37,6 +37,12 @@ trait P2pRpc {
     /// Get details of connected peers
     #[method(name = "get_connected_peers")]
     async fn get_connected_peers(&self) -> rpc::Result<Vec<ConnectedPeer>>;
+
+    #[method(name = "add_reserved_node")]
+    async fn add_reserved_node(&self, addr: String) -> rpc::Result<()>;
+
+    #[method(name = "remove_reserved_node")]
+    async fn remove_reserved_node(&self, addr: String) -> rpc::Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -63,6 +69,16 @@ impl P2pRpcServer for super::P2pHandle {
 
     async fn get_connected_peers(&self) -> rpc::Result<Vec<ConnectedPeer>> {
         let res = self.call_async(|this| Box::pin(this.get_connected_peers())).await;
+        handle_error(res)
+    }
+
+    async fn add_reserved_node(&self, addr: String) -> rpc::Result<()> {
+        let res = self.call_async_mut(|this| Box::pin(this.add_reserved_node(addr))).await;
+        handle_error(res)
+    }
+
+    async fn remove_reserved_node(&self, addr: String) -> rpc::Result<()> {
+        let res = self.call_async_mut(move |this| Box::pin(this.remove_reserved_node(addr))).await;
         handle_error(res)
     }
 }


### PR DESCRIPTION
From @TheQuantumPhysicist 

> Connecting from RPC will need a little more work, because we want to make it possible to maintain connections with a specific peer. So it's a superset of what addnode does in bitcoin. Substrate/Parity has 3 types of peers for this.
There's an issue about this.

I looked at Substrate but did not find 3 types there. I only saw 2 types there: normal and reserved.
RPC now has two commands to add and remove "reserved" node addresses. Adding a "reserved" node address with RPC won't initiate an outbound connection until `heartbeat` is called, and removing it won't disconnect currently connected peers. Reserved nodes are not banned.
I have renamed `addnode` to `reserved_node` everywhere because it sounds a bit better.
I also added a command line option to add "normal" peer addresses (`boot_node` option) at startup. This can be used if something is wrong with the DNS seeds, for example.
I think this PR partially resolves https://github.com/mintlayer/mintlayer-core/issues/621.