### PR TITLE
Fix race when peers connect

### DIFF
--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
@@ -155,6 +155,10 @@ impl ConnectivityService<MockNetworkingService> for MockConnectivityHandle {
         Ok(())
     }
 
+    fn accept(&mut self, _peer_id: PeerId) -> p2p::Result<()> {
+        Ok(())
+    }
+
     fn disconnect(&mut self, peer_id: PeerId) -> p2p::Result<()> {
         let address = *self
             .state

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -41,7 +41,7 @@ use p2p::{
         default_backend::constants::ANNOUNCEMENT_MAX_SIZE, types::SyncingEvent,
         ConnectivityService, NetworkingService, SyncingMessagingService,
     },
-    testing_utils::{connect_services, TestTransportMaker},
+    testing_utils::{connect_and_accept_services, TestTransportMaker},
 };
 
 tests![
@@ -75,7 +75,7 @@ where
     .await
     .unwrap();
 
-    connect_services::<N>(&mut conn1, &mut conn2).await;
+    connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;
 
     let block = Block::new(
         vec![],
@@ -87,6 +87,11 @@ where
     .unwrap();
     sync1.make_announcement(Announcement::Block(block.header().clone())).unwrap();
 
+    match sync2.poll_next().await.unwrap() {
+        SyncingEvent::Connected { peer_id: _ } => {}
+        event => panic!("Unexpected event: {event:?}"),
+    };
+
     // Poll an event from the network for server2.
     let header = match sync2.poll_next().await.unwrap() {
         SyncingEvent::Announcement {
@@ -95,7 +100,7 @@ where
         } => match *announcement {
             Announcement::Block(block) => block,
         },
-        _ => panic!("Unexpected event"),
+        event => panic!("Unexpected event: {event:?}"),
     };
     assert_eq!(header.timestamp().as_int_seconds(), 1337u64);
     assert_eq!(&header, block.header());
@@ -110,6 +115,11 @@ where
     .unwrap();
     sync2.make_announcement(Announcement::Block(block.header().clone())).unwrap();
 
+    match sync1.poll_next().await.unwrap() {
+        SyncingEvent::Connected { peer_id: _ } => {}
+        event => panic!("Unexpected event: {event:?}"),
+    };
+
     let header = match sync1.poll_next().await.unwrap() {
         SyncingEvent::Announcement {
             peer: _,
@@ -117,7 +127,7 @@ where
         } => match *announcement {
             Announcement::Block(block) => block,
         },
-        _ => panic!("Unexpected event"),
+        event => panic!("Unexpected event: {event:?}"),
     };
     assert_eq!(block.timestamp(), BlockTimestamp::from_int_seconds(1338u64));
     assert_eq!(&header, block.header());
@@ -164,7 +174,7 @@ where
     .await
     .unwrap();
 
-    connect_services::<N>(&mut conn1, &mut conn2).await;
+    connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;
 
     let block = Block::new(
         vec![],
@@ -206,7 +216,7 @@ where
     .await
     .unwrap();
 
-    connect_services::<N>(&mut conn1, &mut conn2).await;
+    connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;
 
     let signature = (0..ANNOUNCEMENT_MAX_SIZE).into_iter().map(|_| 0).collect::<Vec<u8>>();
     let signatures = vec![InputWitness::Standard(StandardInputSignature::new(

--- a/p2p/src/event.rs
+++ b/p2p/src/event.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::chain::block::Block;
-
 use crate::{
     interface::types::ConnectedPeer, net::NetworkingService, types::peer_id::PeerId,
     utils::oneshot_nofail,
@@ -45,19 +43,4 @@ pub enum PeerManagerEvent<T: NetworkingService> {
     AddReserved(T::Address),
 
     RemoveReserved(T::Address),
-}
-
-#[derive(Debug)]
-pub enum SyncEvent {
-    /// Publish a block to the network
-    PublishBlock(Block),
-}
-
-#[derive(Debug)]
-pub enum SyncControlEvent {
-    /// Peer connected
-    Connected(PeerId),
-
-    /// Peer disconnected
-    Disconnected(PeerId),
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -45,7 +45,7 @@ use logging::log;
 use crate::{
     config::P2pConfig,
     error::{ConversionError, P2pError},
-    event::{PeerManagerEvent, SyncEvent},
+    event::PeerManagerEvent,
     net::{
         default_backend::{
             transport::{NoiseEncryptionAdapter, NoiseTcpTransport},
@@ -62,9 +62,6 @@ struct P2p<T: NetworkingService> {
     // TODO: add abstraction for channels
     /// A sender for the peer manager events.
     pub tx_peer_manager: mpsc::UnboundedSender<PeerManagerEvent<T>>,
-
-    /// TX channel for sending syncing/pubsub events
-    pub _tx_sync: mpsc::UnboundedSender<SyncEvent>,
 }
 
 impl<T> P2p<T>
@@ -104,19 +101,17 @@ where
         // The difference between these types is that enums that contain the events *can* have
         // a `oneshot::channel` object that must be used to send the response.
         let (tx_peer_manager, rx_peer_manager) = mpsc::unbounded_channel();
-        let (tx_p2p_sync, rx_p2p_sync) = mpsc::unbounded_channel();
-        let (_tx_sync, _rx_sync) = mpsc::unbounded_channel();
 
         let mut peer_manager = peer_manager::PeerManager::<T, _>::new(
             Arc::clone(&chain_config),
             Arc::clone(&p2p_config),
             conn,
             rx_peer_manager,
-            tx_p2p_sync,
             time_getter,
             peerdb_storage,
         )?;
         tokio::spawn(async move {
+            // TODO: Shutdown p2p if PeerManager unexpectedly quits
             peer_manager.run().await.tap_err(|err| log::error!("PeerManager failed: {err}"))
         });
 
@@ -126,12 +121,12 @@ where
             let chain_config = Arc::clone(&chain_config);
 
             tokio::spawn(async move {
+                // TODO: Shutdown p2p if BlockSyncManager unexpectedly quits
                 sync::BlockSyncManager::<T>::new(
                     chain_config,
                     p2p_config,
                     sync,
                     chainstate_handle,
-                    rx_p2p_sync,
                     tx_peer_manager,
                 )
                 .run()
@@ -140,10 +135,7 @@ where
             });
         }
 
-        Ok(Self {
-            tx_peer_manager,
-            _tx_sync,
-        })
+        Ok(Self { tx_peer_manager })
     }
 }
 

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -120,6 +120,7 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
                 sync_tx,
             );
 
+            // TODO: Shutdown p2p if the backend unexpectedly quits
             if let Err(err) = backend.run().await {
                 log::error!("failed to run backend: {err}");
             }
@@ -151,8 +152,14 @@ where
         self.cmd_tx.send(types::Command::Connect { address }).map_err(P2pError::from)
     }
 
+    fn accept(&mut self, peer_id: PeerId) -> crate::Result<()> {
+        log::debug!("accept new peer, peer_id: {peer_id}");
+
+        self.cmd_tx.send(types::Command::Accept { peer_id }).map_err(P2pError::from)
+    }
+
     fn disconnect(&mut self, peer_id: PeerId) -> crate::Result<()> {
-        log::debug!("close connection with remote, {peer_id}");
+        log::debug!("close connection with remote, peer_id: {peer_id}");
 
         self.cmd_tx.send(types::Command::Disconnect { peer_id }).map_err(P2pError::from)
     }

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -33,6 +33,9 @@ pub enum Command<A> {
     Connect {
         address: A,
     },
+    Accept {
+        peer_id: PeerId,
+    },
     Disconnect {
         peer_id: PeerId,
     },
@@ -75,6 +78,7 @@ pub enum PeerEvent {
 #[derive(Debug)]
 pub enum Event {
     Disconnect,
+    Accepted,
     SendMessage(Box<Message>),
 }
 

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -99,6 +99,9 @@ where
     /// `address` - socket address of the peer
     fn connect(&mut self, address: T::Address) -> crate::Result<()>;
 
+    /// Accept the peer as valid and allow reading of network messages
+    fn accept(&mut self, peer_id: PeerId) -> crate::Result<()>;
+
     /// Disconnect active connection
     ///
     /// # Arguments

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -142,6 +142,16 @@ pub enum ConnectivityEvent<A> {
 /// Syncing-related events
 #[derive(Debug)]
 pub enum SyncingEvent {
+    /// Peer connected
+    Connected {
+        peer_id: PeerId,
+    },
+
+    /// Peer disconnected
+    Disconnected {
+        peer_id: PeerId,
+    },
+
     Message {
         peer: PeerId,
         message: SyncMessage,

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -18,9 +18,9 @@ use std::sync::Arc;
 use crate::{
     net::types::Role,
     testing_utils::{
-        connect_services, get_connectivity_event, RandomAddressMaker, TestChannelAddressMaker,
-        TestTcpAddressMaker, TestTransportChannel, TestTransportMaker, TestTransportNoise,
-        TestTransportTcp,
+        connect_and_accept_services, connect_services, get_connectivity_event, RandomAddressMaker,
+        TestChannelAddressMaker, TestTcpAddressMaker, TestTransportChannel, TestTransportMaker,
+        TestTransportNoise, TestTransportTcp,
     },
     types::peer_id::PeerId,
     utils::oneshot_nofail,
@@ -417,7 +417,7 @@ where
     )
     .await;
 
-    let (_address, peer_info, _) = connect_services::<T>(
+    let (_address, peer_info, _) = connect_and_accept_services::<T>(
         &mut pm1.peer_connectivity_handle,
         &mut pm2.peer_connectivity_handle,
     )

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -57,16 +57,12 @@ where
     .await
     .unwrap();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    let (tx_sync, mut rx_sync) = tokio::sync::mpsc::unbounded_channel();
-
-    tokio::spawn(async move { while rx_sync.recv().await.is_some() {} });
 
     let peer_manager = PeerManager::<T, _>::new(
         chain_config,
         p2p_config,
         conn,
         rx,
-        tx_sync,
         time_getter,
         peerdb_inmemory_store(),
     )

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -63,7 +63,6 @@ async fn ping_timeout() {
     let (_peer_tx, peer_rx) =
         tokio::sync::mpsc::unbounded_channel::<PeerManagerEvent<TestNetworkingService>>();
     let time_getter = P2pTokioTestTimeGetter::new();
-    let (sync_tx, _sync_rx) = tokio::sync::mpsc::unbounded_channel();
     let connectivity_handle = ConnectivityHandle::<TestNetworkingService, TcpTransportSocket>::new(
         vec![],
         cmd_tx,
@@ -75,7 +74,6 @@ async fn ping_timeout() {
         p2p_config,
         connectivity_handle,
         peer_rx,
-        sync_tx,
         time_getter.get_time_getter(),
         peerdb_inmemory_store(),
     )
@@ -99,6 +97,12 @@ async fn ping_timeout() {
             receiver_address: None,
         })
         .unwrap();
+
+    let event = cmd_rx.recv().await.unwrap();
+    match event {
+        Command::Accept { peer_id: _ } => {}
+        _ => panic!("unexpected event: {event:?}"),
+    }
 
     // Receive ping requests and send responses normally
     for _ in 0..5 {

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -31,7 +31,7 @@ use p2p_test_utils::start_chainstate;
 
 use crate::{
     net::default_backend::transport::TcpTransportSocket,
-    sync::{Announcement, BlockSyncManager, SyncControlEvent, SyncMessage, SyncingEvent},
+    sync::{Announcement, BlockSyncManager, SyncMessage, SyncingEvent},
     types::peer_id::PeerId,
     NetworkingService, P2pConfig, P2pError, PeerManagerEvent, Result, SyncingMessagingService,
 };
@@ -45,7 +45,6 @@ const SHORT_TIMEOUT: Duration = Duration::from_millis(500);
 ///
 /// Provides methods for manipulating and observing the sync manager state.
 pub struct SyncManagerHandle {
-    peer_event_sender: UnboundedSender<SyncControlEvent>,
     peer_manager_receiver: UnboundedReceiver<PeerManagerEvent<NetworkingServiceStub>>,
     sync_event_sender: UnboundedSender<SyncingEvent>,
     sync_event_receiver: UnboundedReceiver<SyncingEvent>,
@@ -68,7 +67,6 @@ impl SyncManagerHandle {
         p2p_config: Arc<P2pConfig>,
         chainstate: subsystem::Handle<Box<dyn ChainstateInterface>>,
     ) -> Self {
-        let (peer_event_sender, peer_event_receiver) = mpsc::unbounded_channel();
         let (peer_manager_sender, peer_manager_receiver) = mpsc::unbounded_channel();
 
         let (messaging_sender, handle_receiver) = mpsc::unbounded_channel();
@@ -83,7 +81,6 @@ impl SyncManagerHandle {
             p2p_config,
             messaging_handle,
             chainstate,
-            peer_event_receiver,
             peer_manager_sender,
         );
 
@@ -94,7 +91,6 @@ impl SyncManagerHandle {
         });
 
         Self {
-            peer_event_sender,
             peer_manager_receiver,
             sync_event_sender: handle_sender,
             sync_event_receiver: handle_receiver,
@@ -104,7 +100,7 @@ impl SyncManagerHandle {
 
     /// Sends the `SyncControlEvent::Connected` event without checking outgoing messages.
     pub fn try_connect_peer(&mut self, peer: PeerId) {
-        self.peer_event_sender.send(SyncControlEvent::Connected(peer)).unwrap();
+        self.sync_event_sender.send(SyncingEvent::Connected { peer_id: peer }).unwrap();
     }
 
     /// Connects a peer and checks that the header list request is sent to that peer.
@@ -118,7 +114,9 @@ impl SyncManagerHandle {
 
     /// Sends the `SyncControlEvent::Disconnected` event.
     pub fn disconnect_peer(&mut self, peer: PeerId) {
-        self.peer_event_sender.send(SyncControlEvent::Disconnected(peer)).unwrap();
+        self.sync_event_sender
+            .send(SyncingEvent::Disconnected { peer_id: peer })
+            .unwrap();
     }
 
     pub fn send_message(&mut self, peer: PeerId, message: SyncMessage) {

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -191,6 +191,23 @@ where
     (address, peer_info1, peer_info2)
 }
 
+/// Can be used in tests only, will panic in case of errors
+pub async fn connect_and_accept_services<T>(
+    conn1: &mut T::ConnectivityHandle,
+    conn2: &mut T::ConnectivityHandle,
+) -> (T::Address, PeerInfo, PeerInfo)
+where
+    T: NetworkingService + Debug,
+    T::ConnectivityHandle: ConnectivityService<T>,
+{
+    let (address, peer_info1, peer_info2) = connect_services::<T>(conn1, conn2).await;
+
+    conn1.accept(peer_info2.peer_id).unwrap();
+    conn2.accept(peer_info1.peer_id).unwrap();
+
+    (address, peer_info1, peer_info2)
+}
+
 /// Returns first event that is accepted by predicate or panics on timeout.
 pub async fn filter_connectivity_event<T, F>(
     conn: &mut T::ConnectivityHandle,

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -21,7 +21,7 @@ use common::{
 };
 
 use p2p::testing_utils::{
-    connect_services, TestTransportChannel, TestTransportMaker, TestTransportNoise,
+    connect_and_accept_services, TestTransportChannel, TestTransportMaker, TestTransportNoise,
     TestTransportTcp,
 };
 use p2p::{
@@ -77,9 +77,9 @@ where
     };
 
     // Connect peers into a partial mesh.
-    connect_services::<S>(&mut conn1, &mut peer1.0).await;
-    connect_services::<S>(&mut peer1.0, &mut peer2.0).await;
-    connect_services::<S>(&mut peer2.0, &mut peer3.0).await;
+    connect_and_accept_services::<S>(&mut conn1, &mut peer1.0).await;
+    connect_and_accept_services::<S>(&mut peer1.0, &mut peer2.0).await;
+    connect_and_accept_services::<S>(&mut peer2.0, &mut peer3.0).await;
 
     sync1
         .make_announcement(Announcement::Block(

--- a/utils/src/set_flag.rs
+++ b/utils/src/set_flag.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,16 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod blockuntilzero;
-pub mod config_setting;
-pub mod const_value;
-pub mod counttracker;
-pub mod ensure;
-pub mod eventhandler;
-pub mod newtype;
-pub mod set_flag;
-pub mod shallow_clone;
-pub mod tap_error_log;
+use std::ops::Deref;
 
-mod concurrency_impl;
-pub use concurrency_impl::*;
+/// Wrapper for the bool type that can only be set to true once
+#[derive(Default)]
+pub struct SetFlag(bool);
+
+impl SetFlag {
+    pub fn set(&mut self) {
+        self.0 = true;
+    }
+}
+
+impl Deref for SetFlag {
+    type Target = bool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}


### PR DESCRIPTION
Peers would not be allowed to read messages from the network socket until they are accepted as valid by `PeerManager`.
Notifications to `BlockSyncManager` about new accepted peers are sent from the backend (not from `PeerManager`) to avoid race conditions between accepting a new peer and starting to send messages.
This should fix https://github.com/mintlayer/mintlayer-core/issues/718.