### PR TITLE
Try to fix a flaky p2p test

### DIFF
--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -699,7 +699,7 @@ where
     // Get the first peer manager's bind address
     let (rtx, rrx) = oneshot_nofail::channel();
     tx1.send(PeerManagerEvent::GetBindAddresses(rtx)).unwrap();
-    let bind_addresses = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();
+    let bind_addresses = timeout(Duration::from_secs(20), rrx).await.unwrap().unwrap();
     assert_eq!(bind_addresses.len(), 1);
 
     // Start second peer manager and let it know about first manager via reserved


### PR DESCRIPTION
@TheQuantumPhysicist reported that the test fails here with the `Elapsed` error:

```
    let bind_addresses = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();
```

The failure happens before the actual test starts. Probably 1 second is not enough sometimes.