### PR TITLE
Fix problem with failed outbound connections

### DIFF
--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -468,10 +468,10 @@ where
                     match pending_peer.peer_role {
                         PeerRole::Inbound => {
                             // Just log the error
-                            log::debug!("inbound pending connection closed unexpectedly");
+                            log::warn!("inbound pending connection closed unexpectedly");
                         }
                         PeerRole::Outbound { handshake_nonce: _ } => {
-                            log::debug!("outbound pending connection closed unexpectedly");
+                            log::warn!("outbound pending connection closed unexpectedly");
 
                             self.conn_tx
                                 .send(ConnectivityEvent::ConnectionError {

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -598,6 +598,10 @@ where
             ChainType::Regtest | ChainType::Signet => &[],
         };
 
+        if dns_seed.is_empty() {
+            return;
+        }
+
         log::debug!("Resolve DNS seed...");
         let results = futures::future::join_all(
             dns_seed


### PR DESCRIPTION
`ConnectionError` was not reported if connecting to some broken peer