### PR TITLE
Use builtin clap error handling

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -16,7 +16,7 @@
 //! Top-level node binary
 
 async fn run() -> anyhow::Result<()> {
-    let opts = node::Options::from_args(std::env::args_os())?;
+    let opts = node::Options::from_args(std::env::args_os());
     logging::init_logging::<&std::path::Path>(None);
     logging::log::info!("Command line options: {opts:?}");
     node::run(opts).await

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -17,7 +17,6 @@
 
 use std::{ffi::OsString, net::SocketAddr, num::NonZeroU64, path::PathBuf};
 
-use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use directories::UserDirs;
 
@@ -134,10 +133,9 @@ impl Options {
     /// Constructs an instance by parsing the given arguments.
     ///
     /// The data directory is created as a side-effect of the invocation.
-    pub fn from_args<A: Into<OsString> + Clone>(args: impl IntoIterator<Item = A>) -> Result<Self> {
-        let options: Options = clap::Parser::try_parse_from(args)?;
-
-        Ok(options)
+    /// Process is terminated on error.
+    pub fn from_args<A: Into<OsString> + Clone>(args: impl IntoIterator<Item = A>) -> Self {
+        clap::Parser::parse_from(args)
     }
 
     /// Returns the data directory

--- a/test/src/bin/test_node.rs
+++ b/test/src/bin/test_node.rs
@@ -17,7 +17,7 @@ use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), node::Error> {
-    let opts = node::Options::from_args(env::args_os())?;
+    let opts = node::Options::from_args(env::args_os());
     node::init_logging(&opts);
     node::run(opts).await
 }


### PR DESCRIPTION
Using `clap::Parser::parse_from` instead of `clap::Parser::try_parse_from` should be a bit better because:
- "Mintlayer node launch failed" is not printed when the node is started with "--help".
- Clap output is printed with font decorations and looks much better.