### PR TITLE
Add mock time RPC

### DIFF
--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -113,7 +113,7 @@ mod test {
             let blocks = chain_blocks(
                 block_count,
                 chainstate.chain_config.genesis_block_id(),
-                time::get_system_time().as_secs(),
+                time::get_time().as_secs(),
             );
 
             for block in &blocks {

--- a/chainstate/test-suite/src/tests/mempool_output_timelock.rs
+++ b/chainstate/test-suite/src/tests/mempool_output_timelock.rs
@@ -377,7 +377,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
                     current_best: &best_block_index,
                 },
                 &spend_locked_tx,
-                &BlockTimestamp::from_duration_since_epoch(time::get_system_time()),
+                &BlockTimestamp::from_duration_since_epoch(time::get_time()),
             )
             .unwrap();
     });

--- a/common/src/primitives/time.rs
+++ b/common/src/primitives/time.rs
@@ -18,12 +18,12 @@ use std::time::{Duration, Instant, SystemTime};
 
 use once_cell::sync::Lazy;
 
-fn duration_to_int(d: &Duration) -> Result<u64, Box<dyn std::error::Error>> {
+pub fn duration_to_int(d: &Duration) -> Result<u64, std::num::TryFromIntError> {
     let r = d.as_millis().try_into()?;
     Ok(r)
 }
 
-fn duration_from_int(v: u64) -> Duration {
+pub fn duration_from_int(v: u64) -> Duration {
     Duration::from_millis(v)
 }
 
@@ -50,7 +50,7 @@ pub fn reset() {
 }
 
 /// Set current time as a Duration since SystemTime::UNIX_EPOCH
-pub fn set(now: Duration) -> Result<(), Box<dyn std::error::Error>> {
+pub fn set(now: Duration) -> Result<(), std::num::TryFromIntError> {
     TIME_SOURCE.store(duration_to_int(&now)?, Ordering::SeqCst);
     Ok(())
 }

--- a/common/src/primitives/time.rs
+++ b/common/src/primitives/time.rs
@@ -14,9 +14,7 @@
 // limitations under the License.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant, SystemTime};
-
-use once_cell::sync::Lazy;
+use std::time::{Duration, SystemTime};
 
 pub fn duration_to_int(d: &Duration) -> Result<u64, std::num::TryFromIntError> {
     let r = d.as_millis().try_into()?;
@@ -30,12 +28,8 @@ pub fn duration_from_int(v: u64) -> Duration {
 /// Will be used in functional tests
 static TIME_SOURCE: AtomicU64 = AtomicU64::new(0);
 
-/// Instant can only be constructed from the `Instant::now' call.
-/// Store a lazily initialized constant that can be used later with the mocked time.
-static BASE_MOCK_INSTANT: Lazy<Instant> = Lazy::new(Instant::now);
-
 /// Return mocked time if set, otherwise return `None`
-fn get_mocked_system_time() -> Option<Duration> {
+fn get_mocked_time() -> Option<Duration> {
     let value = TIME_SOURCE.load(Ordering::SeqCst);
     if value != 0 {
         Some(duration_from_int(value))
@@ -56,20 +50,12 @@ pub fn set(now: Duration) -> Result<(), std::num::TryFromIntError> {
 }
 
 /// Either gets the current time or panics
-pub fn get_system_time() -> Duration {
-    match get_mocked_system_time() {
+pub fn get_time() -> Duration {
+    match get_mocked_time() {
         Some(mocked_time) => mocked_time,
         None => SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("Time went backwards"),
-    }
-}
-
-/// Return instant (monotonic) time
-pub fn get_instant_time() -> Instant {
-    match get_mocked_system_time() {
-        Some(mocked_time) => *BASE_MOCK_INSTANT + mocked_time,
-        None => Instant::now(),
     }
 }
 
@@ -85,43 +71,36 @@ mod tests {
         logging::init_logging::<&std::path::Path>(None);
         set(Duration::from_secs(1337)).unwrap();
 
-        log::info!("p2p time: {}", get_system_time().as_secs());
+        log::info!("p2p time: {}", get_time().as_secs());
         std::thread::sleep(Duration::from_secs(1));
 
-        log::info!("p2p time: {}", get_system_time().as_secs());
-        assert_eq!(get_system_time().as_secs(), 1337);
+        log::info!("p2p time: {}", get_time().as_secs());
+        assert_eq!(get_time().as_secs(), 1337);
         std::thread::sleep(Duration::from_secs(1));
 
-        log::info!("rpc time: {}", get_system_time().as_secs());
+        log::info!("rpc time: {}", get_time().as_secs());
         std::thread::sleep(Duration::from_millis(500));
 
-        assert_eq!(get_system_time().as_secs(), 1337);
-        log::info!("rpc time: {}", get_system_time().as_secs());
+        assert_eq!(get_time().as_secs(), 1337);
+        log::info!("rpc time: {}", get_time().as_secs());
         std::thread::sleep(Duration::from_millis(500));
 
         reset();
-        assert_ne!(get_system_time().as_secs(), 1337);
-        log::info!("rpc time: {}", get_system_time().as_secs());
+        assert_ne!(get_time().as_secs(), 1337);
+        log::info!("rpc time: {}", get_time().as_secs());
     }
 
     #[test]
     #[serial_test::serial]
     fn test_mocked() {
-        assert_eq!(get_mocked_system_time(), None);
+        assert_eq!(get_mocked_time(), None);
 
         set(Duration::from_secs(1337)).unwrap();
-        assert_eq!(get_system_time().as_secs(), 1337);
-        assert_eq!(get_mocked_system_time(), Some(Duration::from_secs(1337)));
-
-        let time = get_instant_time();
-        set(Duration::from_secs(1338)).unwrap();
-        assert_eq!(
-            get_instant_time().duration_since(time),
-            Duration::from_secs(1)
-        );
+        assert_eq!(get_time().as_secs(), 1337);
+        assert_eq!(get_mocked_time(), Some(Duration::from_secs(1337)));
 
         reset();
-        assert_eq!(get_mocked_system_time(), None);
+        assert_eq!(get_mocked_time(), None);
     }
 
     #[test]

--- a/common/src/time_getter.rs
+++ b/common/src/time_getter.rs
@@ -13,17 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 
 use crate::primitives::time;
 
 pub trait TimeGetterFn: Send + Sync {
-    fn system_time(&self) -> Duration;
-
-    fn instant(&self) -> Instant;
+    fn get_time(&self) -> Duration;
 }
 
 /// A function wrapper that contains the function that will be used to get the current time in chainstate
@@ -38,11 +33,7 @@ impl TimeGetter {
     }
 
     pub fn get_time(&self) -> Duration {
-        self.f.system_time()
-    }
-
-    pub fn get_instant(&self) -> Instant {
-        self.f.instant()
+        self.f.get_time()
     }
 
     pub fn getter(&self) -> &dyn TimeGetterFn {
@@ -65,11 +56,7 @@ impl DefaultTimeGetterFn {
 }
 
 impl TimeGetterFn for DefaultTimeGetterFn {
-    fn system_time(&self) -> Duration {
-        time::get_system_time()
-    }
-
-    fn instant(&self) -> Instant {
-        time::get_instant_time()
+    fn get_time(&self) -> Duration {
+        time::get_time()
     }
 }

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -645,7 +645,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx1_parents,
         entry_1_ancestors,
-        time::get_system_time(),
+        time::get_time(),
     )
     .unwrap();
     let tx2_parents = BTreeSet::default();
@@ -655,7 +655,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx2_parents,
         entry_2_ancestors,
-        time::get_system_time(),
+        time::get_time(),
     )
     .unwrap();
 
@@ -667,7 +667,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx3_parents,
         tx3_ancestors,
-        time::get_system_time(),
+        time::get_time(),
     )
     .unwrap();
 
@@ -681,7 +681,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx4_parents,
         tx4_ancestors,
-        time::get_system_time(),
+        time::get_time(),
     )
     .unwrap();
     let entry5 = TxMempoolEntry::new(
@@ -689,7 +689,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx5_parents,
         tx5_ancestors,
-        time::get_system_time(),
+        time::get_time(),
     )
     .unwrap();
 
@@ -704,7 +704,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         fee,
         tx6_parents,
         tx6_ancestors,
-        time::get_system_time(),
+        time::get_time(),
     )
     .unwrap();
 

--- a/node/src/mock_time.rs
+++ b/node/src/mock_time.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,21 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Top-level node runner as a library
+use common::chain::config::ChainType;
 
-mod config_files;
-mod mock_time;
-mod options;
-mod regtest_options;
-mod rpc;
-mod runner;
-
-pub type Error = anyhow::Error;
-
-pub use config_files::{NodeConfigFile, NodeTypeConfigFile, StorageBackendConfigFile};
-pub use options::{Command, Options, RunOptions};
-pub use runner::{initialize, run};
-
-pub fn init_logging(_opts: &Options) {
-    logging::init_logging::<&std::path::Path>(None)
+pub fn set_mock_time(chain_type: ChainType, time: u64) -> Result<(), crate::Error> {
+    anyhow::ensure!(
+        chain_type == ChainType::Regtest,
+        "Mock time allowed on regtest chain only"
+    );
+    anyhow::ensure!(time != 0, "Mock time cannot be 0");
+    common::primitives::time::set(common::primitives::time::duration_from_int(time))?;
+    Ok(())
 }

--- a/node/src/mock_time.rs
+++ b/node/src/mock_time.rs
@@ -20,7 +20,6 @@ pub fn set_mock_time(chain_type: ChainType, time: u64) -> Result<(), crate::Erro
         chain_type == ChainType::Regtest,
         "Mock time allowed on regtest chain only"
     );
-    anyhow::ensure!(time != 0, "Mock time cannot be 0");
     common::primitives::time::set(common::primitives::time::duration_from_int(time))?;
     Ok(())
 }

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -62,6 +62,7 @@ pub struct RunOptions {
 
     /// Mock time.
     #[clap(long)]
+    #[arg(hide = true)]
     pub mock_time: Option<u64>,
 
     /// The number of maximum attempts to process a block.

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -60,6 +60,10 @@ pub struct RunOptions {
     #[clap(long)]
     pub node_type: Option<NodeTypeConfigFile>,
 
+    /// Mock time.
+    #[clap(long)]
+    pub mock_time: Option<u64>,
+
     /// The number of maximum attempts to process a block.
     #[clap(long)]
     pub max_db_commit_attempts: Option<usize>,

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -15,6 +15,7 @@
 
 //! Node RPC methods
 
+use common::chain::config::ChainType;
 use subsystem::manager::ShutdownTrigger;
 
 #[rpc::rpc(server, namespace = "node")]
@@ -26,15 +27,22 @@ trait NodeRpc {
     /// Get node software version
     #[method(name = "version")]
     fn version(&self) -> rpc::Result<String>;
+
+    #[method(name = "set_mock_time")]
+    fn set_mock_time(&self, time: u64) -> rpc::Result<()>;
 }
 
 struct NodeRpc {
     shutdown_trigger: ShutdownTrigger,
+    chain_type: ChainType,
 }
 
 impl NodeRpc {
-    fn new(shutdown_trigger: ShutdownTrigger) -> Self {
-        Self { shutdown_trigger }
+    fn new(shutdown_trigger: ShutdownTrigger, chain_type: ChainType) -> Self {
+        Self {
+            shutdown_trigger,
+            chain_type,
+        }
     }
 }
 
@@ -47,8 +55,13 @@ impl NodeRpcServer for NodeRpc {
     fn version(&self) -> rpc::Result<String> {
         Ok(env!("CARGO_PKG_VERSION").into())
     }
+
+    fn set_mock_time(&self, time: u64) -> rpc::Result<()> {
+        crate::mock_time::set_mock_time(self.chain_type, time)?;
+        Ok(())
+    }
 }
 
-pub fn init(shutdown_trigger: ShutdownTrigger) -> rpc::Methods {
-    NodeRpc::new(shutdown_trigger).into_rpc().into()
+pub fn init(shutdown_trigger: ShutdownTrigger, chain_type: ChainType) -> rpc::Methods {
+    NodeRpc::new(shutdown_trigger, chain_type).into_rpc().into()
 }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -15,7 +15,9 @@
 
 //! Node RPC methods
 
-use common::chain::config::ChainType;
+use std::sync::Arc;
+
+use chainstate_launcher::ChainConfig;
 use subsystem::manager::ShutdownTrigger;
 
 #[rpc::rpc(server, namespace = "node")]
@@ -34,14 +36,14 @@ trait NodeRpc {
 
 struct NodeRpc {
     shutdown_trigger: ShutdownTrigger,
-    chain_type: ChainType,
+    chain_config: Arc<ChainConfig>,
 }
 
 impl NodeRpc {
-    fn new(shutdown_trigger: ShutdownTrigger, chain_type: ChainType) -> Self {
+    fn new(shutdown_trigger: ShutdownTrigger, chain_config: Arc<ChainConfig>) -> Self {
         Self {
             shutdown_trigger,
-            chain_type,
+            chain_config,
         }
     }
 }
@@ -57,11 +59,11 @@ impl NodeRpcServer for NodeRpc {
     }
 
     fn set_mock_time(&self, time: u64) -> rpc::Result<()> {
-        crate::mock_time::set_mock_time(self.chain_type, time)?;
+        crate::mock_time::set_mock_time(*self.chain_config.chain_type(), time)?;
         Ok(())
     }
 }
 
-pub fn init(shutdown_trigger: ShutdownTrigger, chain_type: ChainType) -> rpc::Methods {
-    NodeRpc::new(shutdown_trigger, chain_type).into_rpc().into()
+pub fn init(shutdown_trigger: ShutdownTrigger, chain_config: Arc<ChainConfig>) -> rpc::Methods {
+    NodeRpc::new(shutdown_trigger, chain_config).into_rpc().into()
 }

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -121,7 +121,7 @@ pub async fn initialize(
             rpc::Builder::new(rpc_config.into())
                 .register(crate::rpc::init(
                     manager.make_shutdown_trigger(),
-                    *chain_config.chain_type(),
+                    chain_config,
                 ))
                 .register(chainstate.clone().into_rpc())
                 .register(mempool.into_rpc())

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -115,6 +115,7 @@ fn read_config_override_values() {
     let options = RunOptions {
         storage_backend: Some(backend_type.clone()),
         node_type: Some(node_type),
+        mock_time: None,
         max_db_commit_attempts: Some(max_db_commit_attempts),
         max_orphan_blocks: Some(max_orphan_blocks),
         tx_index_enabled: Some(false),

--- a/p2p/src/peer_manager/peer_context.rs
+++ b/p2p/src/peer_manager/peer_context.rs
@@ -13,9 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
-
-use tokio::time::Instant;
+use std::{collections::HashSet, time::Duration};
 
 use crate::{
     interface::types::ConnectedPeer,
@@ -25,7 +23,7 @@ use crate::{
 #[derive(Debug)]
 pub struct SentPing {
     pub nonce: u64,
-    pub timestamp: Instant,
+    pub timestamp: Duration,
 }
 
 #[derive(Debug)]

--- a/p2p/src/peer_manager/peerdb/address_data/tests.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/tests.rs
@@ -27,7 +27,7 @@ use super::*;
 #[case(Seed::from_entropy())]
 fn randomized(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
-    let started_at = Instant::now();
+    let started_at = Duration::ZERO;
 
     let weights = [100, 100, 100, 10, 10];
     assert_eq!(weights.len(), ALL_TRANSITIONS.len());

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -735,7 +735,7 @@ where
         time_getter.advance_time(Duration::from_secs(1)).await;
         let (rtx, rrx) = oneshot_nofail::channel();
         tx1.send(PeerManagerEvent::GetConnectedPeers(rtx)).unwrap();
-        let connected_peers = timeout(Duration::from_secs(1), rrx).await.unwrap().unwrap();
+        let connected_peers = timeout(Duration::from_secs(10), rrx).await.unwrap().unwrap();
         if connected_peers.len() == 1 {
             break;
         }


### PR DESCRIPTION
This PR adds the mock time RPC and command line option for functional tests.
Making mocked instant time work consistently complicated the code, so I removed it from the time getter (as it was before my recent changes). Small backward and any forward system clock corrections (for example after suspend) should not be a problem for the node to work properly.