### PR TITLE
Minor p2p backend fixes

### DIFF
--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -548,6 +548,13 @@ where
     }
 
     fn handle_message(&mut self, peer: PeerId, message: Message) -> crate::Result<()> {
+        // Do not process remaining messages if the peer has been forcibly disconnected (for example, after being banned).
+        // Without this check, the backend might send messages to the sync and peer managers after sending the disconnect notification.
+        if !self.peers.contains_key(&peer) {
+            log::debug!("ignore received messaged from a disconnected peer");
+            return Ok(());
+        }
+
         match message {
             Message::Handshake(_) => {
                 log::error!("peer {peer} sent handshaking message");

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -209,7 +209,6 @@ where
                 biased;
 
                 event = self.rx.recv() => match event.ok_or(P2pError::ChannelClosed)? {
-                    Event::Disconnect => return Ok(()),
                     Event::Accepted => was_accepted = true,
                     Event::SendMessage(message) => self.socket.send(*message).await?,
                 },

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -77,7 +77,6 @@ pub enum PeerEvent {
 /// Events sent by the default_backend backend to peers
 #[derive(Debug)]
 pub enum Event {
-    Disconnect,
     Accepted,
     SendMessage(Box<Message>),
 }

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -108,17 +108,32 @@ pub enum HandshakeMessage {
 
 #[derive(Debug, Encode, Decode, PartialEq, Eq, Clone)]
 pub enum Message {
+    #[codec(index = 0)]
     Handshake(HandshakeMessage),
-    HeaderListRequest(HeaderListRequest),
-    BlockListRequest(BlockListRequest),
-    AddrListRequest(AddrListRequest),
-    AnnounceAddrRequest(AnnounceAddrRequest),
+
+    #[codec(index = 1)]
     PingRequest(PingRequest),
-    HeaderListResponse(HeaderListResponse),
-    BlockResponse(BlockResponse),
-    AddrListResponse(AddrListResponse),
+    #[codec(index = 2)]
     PingResponse(PingResponse),
+
+    #[codec(index = 3)]
     Announcement(Box<Announcement>),
+
+    #[codec(index = 4)]
+    HeaderListRequest(HeaderListRequest),
+    #[codec(index = 5)]
+    HeaderListResponse(HeaderListResponse),
+    #[codec(index = 6)]
+    BlockListRequest(BlockListRequest),
+    #[codec(index = 7)]
+    BlockResponse(BlockResponse),
+
+    #[codec(index = 8)]
+    AnnounceAddrRequest(AnnounceAddrRequest),
+    #[codec(index = 9)]
+    AddrListRequest(AddrListRequest),
+    #[codec(index = 10)]
+    AddrListResponse(AddrListResponse),
 }
 
 impl From<PeerManagerMessage> for Message {


### PR DESCRIPTION
Minor backend fixes:
- Use JoinHandle::abort to stop p2p peers.
- Drop remaining messages once a peer is disconnected.
- Update Message enum ordering.