### PR TITLE
Fix new Clippy lints (1.68)

### DIFF
--- a/chainstate/src/detail/orphan_blocks/pool.rs
+++ b/chainstate/src/detail/orphan_blocks/pool.rs
@@ -171,7 +171,7 @@ mod tests {
         use crypto::random::Rng;
 
         pub fn gen_random_blocks(rng: &mut impl Rng, count: u32) -> Vec<Block> {
-            (0..count).into_iter().map(|_| gen_random_block(rng)).collect::<Vec<_>>()
+            (0..count).map(|_| gen_random_block(rng)).collect::<Vec<_>>()
         }
 
         pub fn gen_random_block(rng: &mut impl Rng) -> Block {
@@ -202,7 +202,7 @@ mod tests {
         ) -> Vec<Block> {
             let mut blocks = vec![gen_block_from_id(rng, prev_block_id)];
 
-            (1..count).into_iter().for_each(|_| {
+            (1..count).for_each(|_| {
                 let prev_block_id = blocks.last().map(|block| block.get_id());
                 blocks.push(gen_block_from_id(rng, prev_block_id.map(Into::into)));
             });
@@ -222,10 +222,7 @@ mod tests {
             let prev_block_id =
                 prev_block_id.unwrap_or_else(|| H256::from_low_u64_be(rng.gen()).into());
 
-            (0..count)
-                .into_iter()
-                .map(|_| gen_block_from_id(rng, Some(prev_block_id.into())))
-                .collect()
+            (0..count).map(|_| gen_block_from_id(rng, Some(prev_block_id.into()))).collect()
         }
     }
 

--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -280,7 +280,6 @@ pub fn create_rand_block_undo(
 ) -> UtxosBlockUndo {
     let utxo_rng = rng.gen_range(1..max_lim_of_utxos);
     let reward_utxos = (0..utxo_rng)
-        .into_iter()
         .enumerate()
         .map(|(i, _)| create_rand_utxo(rng, i as u64).0)
         .collect();
@@ -291,7 +290,6 @@ pub fn create_rand_block_undo(
     for _ in 0..undo_rng {
         let utxo_rng = rng.gen_range(1..max_lim_of_utxos);
         let tx_utxos = (0..utxo_rng)
-            .into_iter()
             .enumerate()
             .map(|(i, _)| create_rand_utxo(rng, i as u64).0)
             .collect();

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -136,7 +136,6 @@ pub fn create_multiple_utxo_data(
             } else {
                 // spend the coin with multiple outputs
                 (0..num_outputs)
-                    .into_iter()
                     .map(|_| {
                         let new_value = Amount::from_atoms(output_value.into_atoms() / num_outputs);
                         debug_assert!(new_value >= Amount::from_atoms(1));
@@ -170,7 +169,6 @@ pub fn create_multiple_utxo_data(
                     if transfer.amount.into_atoms() >= num_outputs {
                         // transfer with multiple outputs
                         (0..num_outputs)
-                            .into_iter()
                             .map(|_| {
                                 let amount =
                                     Amount::from_atoms(transfer.amount.into_atoms() / num_outputs);

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -79,7 +79,6 @@ fn verify_no_signature(#[case] seed: Seed) {
     {
         let tx = generate_unsigned_tx(&mut rng, &destination, 3, 3).unwrap();
         let witnesses = (0..tx.inputs().len())
-            .into_iter()
             .map(|_| InputWitness::NoSignature(Some(vec![1, 2, 3, 4, 5, 6, 7, 8, 9])))
             .collect_vec();
         let signed_tx = tx.with_signatures(witnesses).unwrap();
@@ -108,7 +107,6 @@ fn verify_invalid_signature(#[case] seed: Seed) {
     {
         let tx = generate_unsigned_tx(&mut rng, &destination, 3, 3).unwrap();
         let witnesses = (0..tx.inputs().len())
-            .into_iter()
             .map(|_| {
                 InputWitness::Standard(StandardInputSignature::new(
                     sighash_type,

--- a/common/src/chain/transaction/transaction_index/tests.rs
+++ b/common/src/chain/transaction/transaction_index/tests.rs
@@ -223,7 +223,6 @@ fn generate_random_bytes(rng: &mut impl Rng, length: usize) -> Vec<u8> {
 
 fn generate_random_invalid_witness(count: usize, rng: &mut impl Rng) -> Vec<InputWitness> {
     (0..count)
-        .into_iter()
         .map(|_| {
             let witness_size = rng.next_u32();
             let witness_size = 1 + witness_size % 1000;
@@ -257,16 +256,12 @@ fn generate_random_invalid_output(rng: &mut (impl Rng + CryptoRng)) -> TxOutput 
 fn generate_random_invalid_transaction(rng: &mut (impl Rng + CryptoRng)) -> Transaction {
     let inputs = {
         let input_count = 1 + (rng.next_u32() as usize) % 10;
-        (0..input_count)
-            .into_iter()
-            .map(|_| generate_random_invalid_input(rng))
-            .collect::<Vec<_>>()
+        (0..input_count).map(|_| generate_random_invalid_input(rng)).collect::<Vec<_>>()
     };
 
     let outputs = {
         let output_count = 1 + (rng.next_u32() as usize) % 10;
         (0..output_count)
-            .into_iter()
             .map(|_| generate_random_invalid_output(rng))
             .collect::<Vec<_>>()
     };
@@ -281,7 +276,6 @@ fn generate_random_invalid_block(rng: &mut (impl Rng + CryptoRng)) -> Block {
     let transactions = {
         let transaction_count = rng.next_u32() % 20;
         (0..transaction_count)
-            .into_iter()
             .map(|_| generate_random_invalid_transaction(rng))
             .collect::<Vec<_>>()
     };

--- a/common/src/primitives/merkle/proof/multi/tests.rs
+++ b/common/src/primitives/merkle/proof/multi/tests.rs
@@ -551,7 +551,6 @@ fn multi_proof_verification(
     };
 
     let mut cases = gen_leaves_indices_combinations(leaf_count)
-        .into_iter()
         .take(max_test_cases.unwrap_or(usize::MAX))
         .collect::<Vec<_>>();
     cases.shuffle(&mut rng);
@@ -636,7 +635,6 @@ fn multi_proof_verification_tampered_nodes(
     };
 
     let mut cases = gen_leaves_indices_combinations(leaf_count)
-        .into_iter()
         .take(max_test_cases.unwrap_or(usize::MAX))
         .collect::<Vec<_>>();
     cases.shuffle(&mut rng);
@@ -702,7 +700,6 @@ fn multi_proof_verification_tampered_leaves(
     };
 
     let mut cases = gen_leaves_indices_combinations(leaf_count)
-        .into_iter()
         .take(max_test_cases.unwrap_or(usize::MAX))
         .collect::<Vec<_>>();
     cases.shuffle(&mut rng);
@@ -768,7 +765,6 @@ fn multi_proof_verification_tampered_tree_size_into_invalid_value(
     };
 
     let mut cases = gen_leaves_indices_combinations(leaf_count)
-        .into_iter()
         .take(max_test_cases.unwrap_or(usize::MAX))
         .collect::<Vec<_>>();
     cases.shuffle(&mut rng);
@@ -831,7 +827,6 @@ fn multi_proof_verification_tampered_tree_size_into_wrong_value(
     };
 
     let mut cases = gen_leaves_indices_combinations(leaf_count)
-        .into_iter()
         .take(max_test_cases.unwrap_or(usize::MAX))
         .collect::<Vec<_>>();
     cases.shuffle(&mut rng);

--- a/crypto/src/util/eq.rs
+++ b/crypto/src/util/eq.rs
@@ -28,7 +28,7 @@ impl SliceEqualityCheckMethod {
         if b.is_empty() {
             return a.is_empty();
         }
-        let accumulated = (0..a.len()).into_iter().fold(a.len() ^ b.len(), |accumulated, idx| {
+        let accumulated = (0..a.len()).fold(a.len() ^ b.len(), |accumulated, idx| {
             let step: usize = (a[idx] ^ b[idx % b.len()]).into();
             accumulated | step
         });

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -626,7 +626,6 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
     // Input different flag values just to make the hashes of these dummy transactions
     // different
     let txs = (1..=6)
-        .into_iter()
         .map(|i| {
             SignedTransaction::new(
                 Transaction::new(i, vec![], vec![], 0).unwrap_or_else(|_| panic!("tx {i}")),

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -55,10 +55,9 @@ fn dummy_output() -> TxOutput {
 }
 
 pub fn estimate_tx_size(num_inputs: usize, num_outputs: usize) -> usize {
-    let witnesses: Vec<InputWitness> =
-        (0..num_inputs).into_iter().map(|_| dummy_witness()).collect();
-    let inputs = (0..num_inputs).into_iter().map(|_| dummy_input()).collect();
-    let outputs = (0..num_outputs).into_iter().map(|_| dummy_output()).collect();
+    let witnesses: Vec<InputWitness> = (0..num_inputs).map(|_| dummy_witness()).collect();
+    let inputs = (0..num_inputs).map(|_| dummy_input()).collect();
+    let outputs = (0..num_outputs).map(|_| dummy_output()).collect();
     let flags = 0;
     let locktime = 0;
     let size = SignedTransaction::new(

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -219,7 +219,7 @@ where
 
     connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;
 
-    let signature = (0..ANNOUNCEMENT_MAX_SIZE).into_iter().map(|_| 0).collect::<Vec<u8>>();
+    let signature = (0..ANNOUNCEMENT_MAX_SIZE).map(|_| 0).collect::<Vec<u8>>();
     let signatures = vec![InputWitness::Standard(StandardInputSignature::new(
         sighashtype::SigHashType::try_from(sighashtype::SigHashType::ALL).unwrap(),
         signature,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -52,7 +52,6 @@ pub fn gen_text_with_non_ascii(c: u8, rng: &mut impl Rng, max_len: usize) -> Vec
     let text_len = 1 + rng.gen::<usize>() % max_len;
     let random_index_to_replace = rng.gen::<usize>() % text_len;
     let token_ticker: Vec<u8> = (0..text_len)
-        .into_iter()
         .map(|idx| {
             if idx != random_index_to_replace {
                 rng.sample(crypto::random::distributions::Alphanumeric)

--- a/utils/src/blockuntilzero.rs
+++ b/utils/src/blockuntilzero.rs
@@ -97,7 +97,6 @@ mod test {
         threads_count: usize,
     ) -> Vec<JoinHandle<()>> {
         (0..threads_count)
-            .into_iter()
             .map(|_| {
                 let count = blocker.count_one();
                 std::thread::spawn(move || {

--- a/utils/typename-derive/src/lib.rs
+++ b/utils/typename-derive/src/lib.rs
@@ -40,7 +40,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let type_name = ident.to_string();
 
-        let gen_params = generics.type_params().into_iter().cloned().map(|t| {
+        let gen_params = generics.type_params().cloned().map(|t| {
             let ident = t.ident;
             quote!(#ident::typename_str().as_ref())
         });
@@ -54,7 +54,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
         // We create the where-clause for the implementation, where we create an iterator that we expand in the quote.
         // The iterator is simply of token streams that look like this (A: TypeName, B: TypeName, ...) for every generic parameter.
-        let where_clause_params = generics.type_params().into_iter().cloned().map(|t| {
+        let where_clause_params = generics.type_params().cloned().map(|t| {
             let ident = t.ident;
             quote!(#ident: TypeName)
         });

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -46,7 +46,6 @@ fn create_transactions(
     // create the multiple transactions based on the inputs.
     inputs
         .chunks(input_size)
-        .into_iter()
         .map(|inputs| {
             let outputs = if max_num_of_outputs > 1 {
                 let rnd = rng.gen_range(1..max_num_of_outputs);
@@ -58,10 +57,7 @@ fn create_transactions(
             SignedTransaction::new(
                 Transaction::new(0x00, inputs.to_vec(), outputs, 0)
                     .expect("should create a transaction successfully"),
-                (0..inputs.len())
-                    .into_iter()
-                    .map(|_| InputWitness::NoSignature(None))
-                    .collect::<Vec<_>>(),
+                (0..inputs.len()).map(|_| InputWitness::NoSignature(None)).collect::<Vec<_>>(),
             )
         })
         .collect::<Result<Vec<_>, _>>()
@@ -288,7 +284,6 @@ fn try_spend_tx_with_no_outputs(#[case] seed: Seed) {
     let db = UtxosDB::new(&db_impl);
 
     let tx_inputs: Vec<TxInput> = (0..rng.gen_range(num_of_txs..20))
-        .into_iter()
         .map(|i| {
             let id: Id<GenBlock> = Id::new(H256::random_using(&mut rng));
             let id = OutPointSourceId::BlockReward(id);


### PR DESCRIPTION
As far as I can see, all changes are related to the improved `useless_conversion` lint.