### PR TITLE
Fix: Check PoW target in block

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -255,6 +255,7 @@ impl BanScore for ConsensusPoWError {
             ConsensusPoWError::NoPowDataInPreviousBlock => 100,
             ConsensusPoWError::DecodingBitsFailed(_) => 100,
             ConsensusPoWError::PreviousBitsDecodingFailed(_) => 0,
+            ConsensusPoWError::InvalidTargetBits(_) => 100,
         }
     }
 }

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -105,7 +105,7 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         // TODO: reconsider the order of connect txs and check block reward.
         //       Ideally we want to check everything before mutating the state.
         //       Previously check block reward was done before the reward was connected, but
-        //       the connection of reward spends the putput preventing proper validation.
+        //       the connection of reward spends the output preventing proper validation.
         tx_verifier
             .check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy))
             .log_err()?;

--- a/consensus/src/pow/error.rs
+++ b/consensus/src/pow/error.rs
@@ -38,4 +38,6 @@ pub enum ConsensusPoWError {
     DecodingBitsFailed(Compact),
     #[error("Previous bits conversion failed: `{0:?}`")]
     PreviousBitsDecodingFailed(Compact),
+    #[error("Invalid target value: `{0:?}`")]
+    InvalidTargetBits(Compact),
 }

--- a/consensus/src/pow/work.rs
+++ b/consensus/src/pow/work.rs
@@ -49,11 +49,18 @@ pub fn check_proof_of_work(
 pub fn check_pow_consensus<H: BlockIndexHandle>(
     chain_config: &ChainConfig,
     header: &BlockHeader,
+    block_pow_data: &PoWData,
     pow_status: &PoWStatus,
     block_index_handle: &H,
 ) -> Result<(), ConsensusPoWError> {
     let work_required =
         calculate_work_required(chain_config, header, pow_status, block_index_handle)?;
+
+    // TODO: add test for a block with invalid target
+    if work_required != block_pow_data.bits() {
+        return Err(ConsensusPoWError::InvalidTargetBits(block_pow_data.bits()));
+    }
+
     if check_proof_of_work(header.block_id().get(), work_required)? {
         Ok(())
     } else {

--- a/consensus/src/validator/mod.rs
+++ b/consensus/src/validator/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     pow::check_pow_consensus,
 };
 
-/// Checks if the given block identified by the header contains the correct consensus data.  
+/// Checks if the given block identified by the header contains the correct consensus data.
 pub fn validate_consensus<H, U, P>(
     chain_config: &ChainConfig,
     header: &BlockHeader,
@@ -135,10 +135,14 @@ fn validate_pow_consensus<H: BlockIndexHandle>(
                 "Chain configuration says we are PoW but block consensus data is not PoW.".into(),
             ))
         }
-        ConsensusData::PoW(_) => {
-            check_pow_consensus(chain_config, header, pow_status, block_index_handle)
-                .map_err(Into::into)
-        }
+        ConsensusData::PoW(pow_data) => check_pow_consensus(
+            chain_config,
+            header,
+            pow_data,
+            pow_status,
+            block_index_handle,
+        )
+        .map_err(Into::into),
     }
 }
 

--- a/pos_accounting/src/pool/tests/operations_tests.rs
+++ b/pos_accounting/src/pool/tests/operations_tests.rs
@@ -105,7 +105,7 @@ fn decomission_unknown_pool(#[case] seed: Seed) {
     }
 }
 
-// Create pool in db -> decomission pool in delta -> undo in delta -> merge -> merge
+// Create pool in db -> decommission pool in delta -> undo in delta -> merge -> merge
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -134,7 +134,7 @@ fn create_pool_decomission_pool_undo_merge(#[case] seed: Seed) {
     assert_eq!(storage, expected_storage);
 }
 
-// Create pool in db -> decomission pool in delta -> merge -> undo in delta -> merge
+// Create pool in db -> decommission pool in delta -> merge -> undo in delta -> merge
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]


### PR DESCRIPTION
I just noticed this. There's no place where this check is done. Basically a block producer can put any target they want.

This glosses on the issue that we discussed before, on whether we want to remove the target altogether. But this doesn't look nice for PoW, since block PoW should allow being checked independently, without the history.