### PR TITLE
Fix functional tests launch in Windows

### DIFF
--- a/test/runner/functional.rs
+++ b/test/runner/functional.rs
@@ -50,7 +50,7 @@ impl std::fmt::Debug for Error {
     }
 }
 
-fn get_executable_from_path_env_var<P>(exe_name: P) -> Option<PathBuf>
+fn get_executable_path_from_path_env_var<P>(exe_name: P) -> Option<PathBuf>
 where
     P: AsRef<Path>,
 {
@@ -71,19 +71,18 @@ where
 fn find_python_exe() -> PathBuf {
     let possible_python_execs = ["python3", "python"];
 
-    let python_exe = {
-        let file_suffix = (env::consts::OS == "windows").then_some(".exe").unwrap_or_default();
-        possible_python_execs
-            .into_iter()
-            .filter_map(|exe| get_executable_from_path_env_var(format!("{exe}{file_suffix}")))
-            .next()
-            .unwrap_or_else(|| {
-                panic!(
-                    "Unable to find any of the executables {:?} in PATH",
-                    possible_python_execs
-                )
-            })
-    };
+    let file_suffix = (env::consts::OS == "windows").then_some(".exe").unwrap_or_default();
+
+    let python_exe = possible_python_execs
+        .into_iter()
+        .filter_map(|exe| get_executable_path_from_path_env_var(format!("{exe}{file_suffix}")))
+        .next()
+        .unwrap_or_else(|| {
+            panic!(
+                "Unable to find any of the executables {:?} in PATH",
+                possible_python_execs
+            )
+        });
 
     println!("Found python executable in path: {}", python_exe.display());
 

--- a/test/runner/functional.rs
+++ b/test/runner/functional.rs
@@ -60,12 +60,10 @@ where
         exe_name.as_ref().display()
     );
     let path_env_var = env::var_os("PATH").expect("PATH env var not found");
-    env::split_paths(&path_env_var)
-        .filter_map(|dir| {
-            let full_path = dir.join(&exe_name);
-            full_path.is_file().then_some(full_path)
-        })
-        .next()
+    env::split_paths(&path_env_var).find_map(|dir| {
+        let full_path = dir.join(&exe_name);
+        full_path.is_file().then_some(full_path)
+    })
 }
 
 fn find_python_exe() -> PathBuf {
@@ -75,8 +73,7 @@ fn find_python_exe() -> PathBuf {
 
     let python_exe = possible_python_execs
         .into_iter()
-        .filter_map(|exe| get_executable_path_from_path_env_var(format!("{exe}{file_suffix}")))
-        .next()
+        .find_map(|exe| get_executable_path_from_path_env_var(format!("{exe}{file_suffix}")))
         .unwrap_or_else(|| {
             panic!(
                 "Unable to find any of the executables {:?} in PATH",

--- a/test/runner/functional.rs
+++ b/test/runner/functional.rs
@@ -22,6 +22,7 @@
 
 use libtest_mimic::{run, Arguments as HarnessArgs, Failed, Trial};
 use std::env::consts::EXE_SUFFIX;
+use std::path::PathBuf;
 use std::{env, ffi::OsString, path::Path, process::Command};
 
 // Useful paths we get from Cargo
@@ -30,7 +31,6 @@ const TEMP_DIR: &str = env!("CARGO_TARGET_TMPDIR");
 const CRATE_DIR: &str = env!("CARGO_MANIFEST_DIR");
 const PACKAGE_NAME: &str = env!("CARGO_PKG_NAME");
 const PACKAGE_URL: &str = env!("CARGO_PKG_HOMEPAGE");
-const PYTHON_EXECUTABLE: &str = "python3";
 
 #[derive(thiserror::Error)]
 enum Error {
@@ -48,6 +48,24 @@ impl std::fmt::Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self}")
     }
+}
+
+fn get_executable_from_path_env_var<P>(exe_name: P) -> Option<PathBuf>
+where
+    P: AsRef<Path>,
+{
+    assert!(
+        exe_name.as_ref().is_relative(),
+        "Path provided for executable must be relative; {} was provided",
+        exe_name.as_ref().display()
+    );
+    let path_env_var = env::var_os("PATH").expect("PATH env var not found");
+    env::split_paths(&path_env_var)
+        .filter_map(|dir| {
+            let full_path = dir.join(&exe_name);
+            full_path.is_file().then_some(full_path)
+        })
+        .next()
 }
 
 fn do_run(runner_args: &[OsString]) -> Result<(), Failed> {
@@ -75,8 +93,23 @@ ENABLE_BITCOIND=true
     );
     std::fs::write(&config_file_path, config_str).map_err(Error::ConfigFile)?;
 
+    let possible_python_execs = ["python3", "python"];
+    let python_exe = {
+        let file_suffix = (env::consts::OS == "windows").then_some(".exe").unwrap_or_default();
+        possible_python_execs
+            .into_iter()
+            .filter_map(|exe| get_executable_from_path_env_var(format!("{exe}{file_suffix}")))
+            .next()
+            .expect(&format!(
+                "Unable to find any of the executables {:?} in PATH",
+                possible_python_execs
+            ))
+    };
+
+    println!("Found python executable in path: {}", python_exe.display());
+
     // Run the tests and get result
-    let status = Command::new(PYTHON_EXECUTABLE)
+    let status = Command::new(python_exe)
         // Add environment variables
         .env("MINTLAYER_NODE", NODE_BINARY)
         .env(

--- a/test/runner/functional.rs
+++ b/test/runner/functional.rs
@@ -100,10 +100,12 @@ ENABLE_BITCOIND=true
             .into_iter()
             .filter_map(|exe| get_executable_from_path_env_var(format!("{exe}{file_suffix}")))
             .next()
-            .expect(&format!(
-                "Unable to find any of the executables {:?} in PATH",
-                possible_python_execs
-            ))
+            .unwrap_or_else(|| {
+                panic!(
+                    "Unable to find any of the executables {:?} in PATH",
+                    possible_python_execs
+                )
+            })
     };
 
     println!("Found python executable in path: {}", python_exe.display());


### PR DESCRIPTION
There seems to be challenges in finding Python in Windows. This PR is supposed to fix that.

Instead of assuming Python exists in PATH, we locate it.