### PR TITLE
Add remaining checks to p2p ping (functional tests)

### DIFF
--- a/node/src/mock_time.rs
+++ b/node/src/mock_time.rs
@@ -16,6 +16,7 @@
 use std::time::Duration;
 
 use common::chain::config::ChainType;
+use logging::log;
 
 /// Sets mock time (seconds since UNIX epoch)
 pub fn set_mock_time(chain_type: ChainType, time: u64) -> Result<(), crate::Error> {
@@ -23,6 +24,7 @@ pub fn set_mock_time(chain_type: ChainType, time: u64) -> Result<(), crate::Erro
         chain_type == ChainType::Regtest,
         "Mock time allowed on regtest chain only"
     );
+    log::debug!("set mock time to {time}");
     common::primitives::time::set(Duration::from_secs(time))?;
     Ok(())
 }

--- a/node/src/mock_time.rs
+++ b/node/src/mock_time.rs
@@ -24,7 +24,7 @@ pub fn set_mock_time(chain_type: ChainType, time: u64) -> Result<(), crate::Erro
         chain_type == ChainType::Regtest,
         "Mock time allowed on regtest chain only"
     );
-    log::debug!("set mock time to {time}");
+    log::info!("set mock time to {time}");
     common::primitives::time::set(Duration::from_secs(time))?;
     Ok(())
 }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -788,8 +788,8 @@ where
         );
     }
 
-    fn handle_ping_response(&mut self, peer: PeerId, nonce: u64) {
-        if let Some(peer) = self.peers.get_mut(&peer) {
+    fn handle_ping_response(&mut self, peer_id: PeerId, nonce: u64) {
+        if let Some(peer) = self.peers.get_mut(&peer_id) {
             if let Some(sent_ping) = peer.sent_ping.as_mut() {
                 if sent_ping.nonce == nonce {
                     // Correct reply received, clear pending request and update ping times
@@ -809,13 +809,14 @@ where
                     peer.ping_min = Some(ping_time_min);
                 } else {
                     log::debug!(
-                        "wrong nonce in ping response: {}, expected: {}",
+                        "wrong nonce in ping response: {}, expected: {} from peer {}",
                         nonce,
-                        sent_ping.nonce
+                        sent_ping.nonce,
+                        peer_id,
                     );
                 }
             } else {
-                log::debug!("unexpected ping response received");
+                log::debug!("unexpected ping response received from peer {}", peer_id);
             }
         }
     }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -809,10 +809,10 @@ where
                     peer.ping_min = Some(ping_time_min);
                 } else {
                     log::debug!(
-                        "wrong nonce in ping response: {}, expected: {} from peer {}",
+                        "wrong nonce in ping response from peer {}, received: {}, expected: {}",
+                        peer_id,
                         nonce,
                         sent_ping.nonce,
-                        peer_id,
                     );
                 }
             } else {

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -198,6 +198,8 @@ class TestNode():
         # Add a new stdout and stderr file each time bitcoind is started
         if stderr is None:
             stderr = tempfile.NamedTemporaryFile(dir=self.stderr_dir, delete=False)
+            # Save the temporary file name to be able grep the log later
+            self.stderr_file = stderr.name
         if stdout is None:
             stdout = tempfile.NamedTemporaryFile(dir=self.stdout_dir, delete=False)
         self.stderr = stderr
@@ -386,7 +388,10 @@ class TestNode():
 
     @property
     def debug_log_path(self) -> Path:
-        return self.chain_path / 'debug.log'
+        # Bitcoin Core stores logs in a separate file
+        # return self.chain_path / 'debug.log'
+        # Mintlayer output logs to stderr
+        return self.stderr_file
 
     def debug_log_bytes(self) -> int:
         with open(self.debug_log_path, encoding='utf-8') as dl:

--- a/test/runner/functional.rs
+++ b/test/runner/functional.rs
@@ -119,7 +119,7 @@ ENABLE_BITCOIND=true
         .env("MINTLAYER_NODE", NODE_BINARY)
         .env(
             "RUST_LOG",
-            &env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),
+            &env::var("RUST_LOG").unwrap_or_else(|_| "debug".into()),
         )
         // Pass command-line arguments
         .arg(runner_path)


### PR DESCRIPTION
Fix for debug output grep was trivial - just use file path created by `NamedTemporaryFile`:
```
    def start(self, extra_args=None, *, cwd=None, stdout=None, stderr=None, **kwargs):
...
        if stderr is None:
            stderr = tempfile.NamedTemporaryFile(dir=self.stderr_dir, delete=False)
            # Save the temporary file name to be able grep the log later
            self.stderr_file = stderr.name
```