### PR TITLE
Move check_timelocks to a separate module

### DIFF
--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -28,6 +28,7 @@ pub mod flush;
 pub mod hierarchy;
 mod optional_tx_index_cache;
 pub mod storage;
+pub mod timelock_check;
 
 mod cached_operation;
 pub use cached_operation::CachedOperation;
@@ -51,7 +52,7 @@ use self::{
 };
 use ::utils::{ensure, shallow_clone::ShallowClone};
 
-use chainstate_types::{block_index_ancestor_getter, BlockIndex, GenBlockIndex};
+use chainstate_types::BlockIndex;
 use common::{
     amount_sum,
     chain::{
@@ -63,7 +64,7 @@ use common::{
         Block, ChainConfig, GenBlock, OutPointSourceId, OutputPurpose, Transaction, TxInput,
         TxMainChainIndex, TxOutput,
     },
-    primitives::{id::WithId, Amount, BlockDistance, BlockHeight, Id, Idable, H256},
+    primitives::{id::WithId, Amount, BlockHeight, Id, Idable, H256},
 };
 use consensus::ConsensusPoSError;
 use pos_accounting::{
@@ -485,51 +486,6 @@ where
         Ok(())
     }
 
-    fn check_timelock(
-        &self,
-        source_block_index: &GenBlockIndex,
-        output: &TxOutput,
-        spend_height: &BlockHeight,
-        spending_time: &BlockTimestamp,
-    ) -> Result<(), ConnectTransactionError> {
-        use common::chain::timelock::OutputTimeLock;
-
-        let timelock = match output.purpose() {
-            OutputPurpose::Transfer(_)
-            | OutputPurpose::Burn
-            | OutputPurpose::StakePool(_)
-            | OutputPurpose::ProduceBlockFromStake(_, _) => return Ok(()),
-            OutputPurpose::LockThenTransfer(_, tl) => tl,
-        };
-
-        let source_block_height = source_block_index.block_height();
-        let source_block_time = source_block_index.block_timestamp();
-
-        let past_lock = match timelock {
-            OutputTimeLock::UntilHeight(h) => spend_height >= h,
-            OutputTimeLock::UntilTime(t) => spending_time >= t,
-            OutputTimeLock::ForBlockCount(d) => {
-                let d: i64 = (*d)
-                    .try_into()
-                    .map_err(|_| ConnectTransactionError::BlockHeightArithmeticError)?;
-                let d = BlockDistance::from(d);
-                *spend_height
-                    >= (source_block_height + d)
-                        .ok_or(ConnectTransactionError::BlockHeightArithmeticError)?
-            }
-            OutputTimeLock::ForSeconds(dt) => {
-                *spending_time
-                    >= source_block_time
-                        .add_int_seconds(*dt)
-                        .ok_or(ConnectTransactionError::BlockTimestampArithmeticError)?
-            }
-        };
-
-        ensure!(past_lock, ConnectTransactionError::TimeLockViolation);
-
-        Ok(())
-    }
-
     fn verify_signatures<T: Transactable>(&self, tx: &T) -> Result<(), ConnectTransactionError> {
         let inputs = match tx.inputs() {
             Some(ins) => ins,
@@ -549,72 +505,6 @@ where
                 Some(d) => verify_signature(self.chain_config.as_ref(), d, tx, input_idx)
                     .map_err(ConnectTransactionError::SignatureVerificationFailed)?,
                 None => return Err(ConnectTransactionError::AttemptToSpendBurnedAmount),
-            }
-        }
-
-        Ok(())
-    }
-
-    fn check_timelocks<T: Transactable>(
-        &self,
-        tx_source: &TransactionSourceForConnect,
-        tx: &T,
-        spending_time: &BlockTimestamp,
-    ) -> Result<(), ConnectTransactionError> {
-        let inputs = match tx.inputs() {
-            Some(ins) => ins,
-            None => return Ok(()),
-        };
-
-        for input in inputs {
-            let outpoint = input.outpoint();
-            let utxo = self
-                .utxo_cache
-                .utxo(outpoint)
-                .ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
-
-            if utxo.output().has_timelock() {
-                let height = match utxo.source() {
-                    utxo::UtxoSource::Blockchain(h) => *h,
-                    utxo::UtxoSource::Mempool => match tx_source {
-                        TransactionSourceForConnect::Chain { new_block_index: _ } => {
-                            unreachable!("Mempool utxos can never be reached from storage while connecting local transactions")
-                        }
-                        TransactionSourceForConnect::Mempool { current_best } => {
-                            current_best.block_height().next_height()
-                        }
-                    },
-                };
-
-                let block_index_getter =
-                    |db_tx: &S, _chain_config: &ChainConfig, id: &Id<GenBlock>| {
-                        db_tx.get_gen_block_index(id)
-                    };
-
-                let starting_point: &BlockIndex = match tx_source {
-                    TransactionSourceForConnect::Chain { new_block_index } => new_block_index,
-                    TransactionSourceForConnect::Mempool { current_best } => current_best,
-                };
-
-                let source_block_index = block_index_ancestor_getter(
-                    block_index_getter,
-                    &self.storage,
-                    self.chain_config.as_ref(),
-                    (&starting_point.clone().into_gen_block_index()).into(),
-                    height,
-                )
-                .map_err(|e| {
-                    ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoadedFromHeight(
-                        e, height,
-                    )
-                })?;
-
-                self.check_timelock(
-                    &source_block_index,
-                    utxo.output(),
-                    &tx_source.expected_block_height(),
-                    spending_time,
-                )?;
             }
         }
 
@@ -740,7 +630,14 @@ where
         self.token_issuance_cache.register(block_id, tx.transaction())?;
 
         // check timelocks of the outputs and make sure there's no premature spending
-        self.check_timelocks(tx_source, tx, median_time_past)?;
+        timelock_check::check_timelocks(
+            &self.storage,
+            &self.chain_config,
+            &self.utxo_cache,
+            tx_source,
+            tx,
+            median_time_past,
+        )?;
 
         // verify input signatures
         self.verify_signatures(tx)?;

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use crate::transaction_verifier::token_issuance_cache::{CachedAuxDataOp, CachedTokenIndexOp};
 
 use super::*;
+use chainstate_types::GenBlockIndex;
 use common::{
     chain::{
         config::Builder as ConfigBuilder, tokens::TokenAuxiliaryData, TxMainChainIndex,

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -1,0 +1,142 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_types::{block_index_ancestor_getter, BlockIndex, GenBlockIndex};
+use common::{
+    chain::{
+        block::timestamp::BlockTimestamp, signature::Transactable, ChainConfig, GenBlock,
+        OutputPurpose, TxOutput,
+    },
+    primitives::{BlockDistance, BlockHeight, Id},
+};
+use utils::ensure;
+use utxo::UtxosView;
+
+use super::{
+    error::ConnectTransactionError, storage::TransactionVerifierStorageRef,
+    TransactionSourceForConnect,
+};
+
+fn check_timelock(
+    source_block_index: &GenBlockIndex,
+    output: &TxOutput,
+    spend_height: &BlockHeight,
+    spending_time: &BlockTimestamp,
+) -> Result<(), ConnectTransactionError> {
+    use common::chain::timelock::OutputTimeLock;
+
+    let timelock = match output.purpose() {
+        OutputPurpose::Transfer(_)
+        | OutputPurpose::Burn
+        | OutputPurpose::StakePool(_)
+        | OutputPurpose::ProduceBlockFromStake(_, _) => return Ok(()),
+        OutputPurpose::LockThenTransfer(_, tl) => tl,
+    };
+
+    let source_block_height = source_block_index.block_height();
+    let source_block_time = source_block_index.block_timestamp();
+
+    let past_lock = match timelock {
+        OutputTimeLock::UntilHeight(h) => spend_height >= h,
+        OutputTimeLock::UntilTime(t) => spending_time >= t,
+        OutputTimeLock::ForBlockCount(d) => {
+            let d: i64 = (*d)
+                .try_into()
+                .map_err(|_| ConnectTransactionError::BlockHeightArithmeticError)?;
+            let d = BlockDistance::from(d);
+            *spend_height
+                >= (source_block_height + d)
+                    .ok_or(ConnectTransactionError::BlockHeightArithmeticError)?
+        }
+        OutputTimeLock::ForSeconds(dt) => {
+            *spending_time
+                >= source_block_time
+                    .add_int_seconds(*dt)
+                    .ok_or(ConnectTransactionError::BlockTimestampArithmeticError)?
+        }
+    };
+
+    ensure!(past_lock, ConnectTransactionError::TimeLockViolation);
+
+    Ok(())
+}
+
+pub fn check_timelocks<
+    S: TransactionVerifierStorageRef,
+    C: AsRef<ChainConfig>,
+    T: Transactable,
+    U: UtxosView,
+>(
+    storage: &S,
+    chain_config: &C,
+    utxos_view: &U,
+    tx_source: &TransactionSourceForConnect,
+    tx: &T,
+    spending_time: &BlockTimestamp,
+) -> Result<(), ConnectTransactionError> {
+    let inputs = match tx.inputs() {
+        Some(ins) => ins,
+        None => return Ok(()),
+    };
+
+    for input in inputs {
+        let outpoint = input.outpoint();
+        let utxo =
+            utxos_view.utxo(outpoint).ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
+
+        if utxo.output().has_timelock() {
+            let height = match utxo.source() {
+                utxo::UtxoSource::Blockchain(h) => *h,
+                utxo::UtxoSource::Mempool => match tx_source {
+                    TransactionSourceForConnect::Chain { new_block_index: _ } => {
+                        unreachable!("Mempool utxos can never be reached from storage while connecting local transactions")
+                    }
+                    TransactionSourceForConnect::Mempool { current_best } => {
+                        current_best.block_height().next_height()
+                    }
+                },
+            };
+
+            let block_index_getter = |db_tx: &S, _chain_config: &ChainConfig, id: &Id<GenBlock>| {
+                db_tx.get_gen_block_index(id)
+            };
+
+            let starting_point: &BlockIndex = match tx_source {
+                TransactionSourceForConnect::Chain { new_block_index } => new_block_index,
+                TransactionSourceForConnect::Mempool { current_best } => current_best,
+            };
+
+            let source_block_index = block_index_ancestor_getter(
+                block_index_getter,
+                storage,
+                chain_config.as_ref(),
+                (&starting_point.clone().into_gen_block_index()).into(),
+                height,
+            )
+            .map_err(|e| {
+                ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoadedFromHeight(e, height)
+            })?;
+
+            check_timelock(
+                &source_block_index,
+                utxo.output(),
+                &tx_source.expected_block_height(),
+                spending_time,
+            )?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I have a complaint that the transaction verifier is becoming huge and convoluted. This is an example on how it should be split into more isolated and separately testable submodules.

Open for discussion.

NOTE: This is based on a branch that isn't master.