### PR TITLE
Try to fix the problem with stuck sync

### DIFF
--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -204,8 +204,8 @@ impl BanScore for ProtocolError {
             ProtocolError::DisconnectedHeaders => 20,
             ProtocolError::UnexpectedMessage(_) => 20,
             ProtocolError::ZeroBlocksInRequest => 20,
-            ProtocolError::HandshakeExpected => 20,
-            ProtocolError::AddressListLimitExceeded => 20,
+            ProtocolError::HandshakeExpected => 100,
+            ProtocolError::AddressListLimitExceeded => 100,
         }
     }
 }

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -28,7 +28,7 @@ pub enum ProtocolError {
     // TODO: This error is very generic and probably should be replaced with several different ones,
     // because it has a ban score of 100 and in many cases it is too harsh.
     #[error("Peer sent an invalid message")]
-    InvalidMessage,
+    InvalidMessage(&'static str),
     #[error("Peer is unresponsive")]
     Unresponsive,
     #[error("Locator size ({0}) exceeds allowed limit ({1})")]
@@ -188,7 +188,7 @@ impl BanScore for ProtocolError {
         match self {
             ProtocolError::DifferentNetwork(_, _) => 100,
             ProtocolError::InvalidVersion(_, _) => 100,
-            ProtocolError::InvalidMessage => 100,
+            ProtocolError::InvalidMessage(_) => 100,
             ProtocolError::Unresponsive => 100,
             ProtocolError::LocatorSizeExceeded(_, _) => 20,
             ProtocolError::BlocksRequestLimitExceeded(_, _) => 20,

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -119,7 +119,7 @@ where
                     user_agent,
                 })) = self.socket.recv().await
                 else {
-                    return Err(P2pError::ProtocolError(ProtocolError::InvalidMessage("Handshake message expected")));
+                    return Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected));
                 };
 
                 // Send PeerInfoReceived before sending handshake to remote peer!
@@ -171,7 +171,7 @@ where
                     receiver_address,
                 })) = self.socket.recv().await
                 else {
-                    return Err(P2pError::ProtocolError(ProtocolError::InvalidMessage("Handshake message expected")));
+                    return Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected));
                 };
 
                 self.tx
@@ -516,7 +516,7 @@ mod tests {
 
         assert!(matches!(
             handle.await.unwrap(),
-            Err(P2pError::ProtocolError(ProtocolError::InvalidMessage(_)))
+            Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected))
         ),);
     }
 

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -119,7 +119,7 @@ where
                     user_agent,
                 })) = self.socket.recv().await
                 else {
-                    return Err(P2pError::ProtocolError(ProtocolError::InvalidMessage));
+                    return Err(P2pError::ProtocolError(ProtocolError::InvalidMessage("Handshake message expected")));
                 };
 
                 // Send PeerInfoReceived before sending handshake to remote peer!
@@ -171,7 +171,7 @@ where
                     receiver_address,
                 })) = self.socket.recv().await
                 else {
-                    return Err(P2pError::ProtocolError(ProtocolError::InvalidMessage));
+                    return Err(P2pError::ProtocolError(ProtocolError::InvalidMessage("Handshake message expected")));
                 };
 
                 self.tx
@@ -514,10 +514,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
+        assert!(matches!(
             handle.await.unwrap(),
-            Err(P2pError::ProtocolError(ProtocolError::InvalidMessage)),
-        );
+            Err(P2pError::ProtocolError(ProtocolError::InvalidMessage(_)))
+        ),);
     }
 
     #[tokio::test]

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -751,7 +751,9 @@ where
             .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
         ensure!(
             addresses.len() <= MAX_ADDRESS_COUNT,
-            P2pError::ProtocolError(ProtocolError::InvalidMessage)
+            P2pError::ProtocolError(ProtocolError::InvalidMessage(
+                "More than MAX_ADDRESS_COUNT addresses sent"
+            ))
         );
         ensure!(
             peer.expect_addr_list_response,

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -751,9 +751,7 @@ where
             .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
         ensure!(
             addresses.len() <= MAX_ADDRESS_COUNT,
-            P2pError::ProtocolError(ProtocolError::InvalidMessage(
-                "More than MAX_ADDRESS_COUNT addresses sent"
-            ))
+            P2pError::ProtocolError(ProtocolError::AddressListLimitExceeded)
         );
         ensure!(
             peer.expect_addr_list_response,

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -198,9 +198,11 @@ where
 
     /// Processes the blocks request.
     async fn handle_block_request(&mut self, block_ids: Vec<Id<Block>>) -> Result<()> {
-        if block_ids.is_empty() {
-            return Ok(());
-        }
+        utils::ensure!(
+            !block_ids.is_empty(),
+            P2pError::ProtocolError(ProtocolError::InvalidMessage("Empty block list requested"))
+        );
+
         log::debug!(
             "Blocks request from peer {}: {}-{} ({})",
             self.id(),
@@ -383,7 +385,7 @@ where
         // Do not request the block if it is already known
         if self
             .chainstate_handle
-            .call(move |c| c.get_gen_block_index(&block_id.into()))
+            .call(move |c| c.get_block_index(&block_id))
             .await??
             .is_some()
         {

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -198,7 +198,16 @@ where
 
     /// Processes the blocks request.
     async fn handle_block_request(&mut self, block_ids: Vec<Id<Block>>) -> Result<()> {
-        log::debug!("Blocks request from peer {}", self.id());
+        if block_ids.is_empty() {
+            return Ok(());
+        }
+        log::debug!(
+            "Blocks request from peer {}: {}-{} ({})",
+            self.id(),
+            block_ids.first().expect("block_ids is not empty"),
+            block_ids.last().expect("block_ids is not empty"),
+            block_ids.len(),
+        );
 
         if self.is_initial_block_download.load(Ordering::Acquire) {
             log::debug!("Ignoring blocks request because the node is in initial block download");
@@ -360,10 +369,24 @@ where
     }
 
     async fn handle_block_announcement(&mut self, header: BlockHeader) -> Result<()> {
-        log::debug!("Block announcement from peer {}: {header:?}", self.id());
+        let block_id = header.block_id();
+        log::debug!(
+            "Block announcement from peer {}: {block_id}: {header:?}",
+            self.id()
+        );
 
         if !self.requested_blocks.is_empty() {
             // We will download this block as part of syncing anyway.
+            return Ok(());
+        }
+
+        // Do not request the block if it is already known
+        if self
+            .chainstate_handle
+            .call(move |c| c.get_gen_block_index(&block_id.into()))
+            .await??
+            .is_some()
+        {
             return Ok(());
         }
 
@@ -450,12 +473,22 @@ where
 
         // Remove already requested blocks.
         headers.retain(|h| !self.requested_blocks.contains(&h.get_id()));
+        if headers.is_empty() {
+            return Ok(());
+        }
 
         if headers.len() > *self.p2p_config.max_request_blocks_count {
             self.known_headers = headers.split_off(*self.p2p_config.max_request_blocks_count);
         }
 
         let block_ids: Vec<_> = headers.into_iter().map(|h| h.get_id()).collect();
+        log::debug!(
+            "Request blocks from peer {}: {}-{} ({})",
+            self.id(),
+            block_ids.first().expect("block_ids is not empty"),
+            block_ids.last().expect("block_ids is not empty"),
+            block_ids.len(),
+        );
         self.message_sender.send((
             self.id(),
             SyncMessage::BlockListRequest(BlockListRequest::new(block_ids.clone())),


### PR DESCRIPTION
Functional tests started to fail after some recent changes.
Here is one such failed run: https://github.com/mintlayer/mintlayer-core/actions/runs/4442342875
The logs show this error:
```
Adjusting the '2' peer score by 20: ProtocolError(UnexpectedMessage("Peer requested already known block"))
```

It looks like the test fails this way:
1. Two new blocks submitted on Node0.
2. Node1 connects and downloads both blocks in initial block download.
3. Node0 sends new block announcement to all connected peers (this may happen with some delay because block announcements are sent from a different even loop).
4. Node1 receives this announcement and tries to download this already known block.
5. Node0 stops syncing because of the "Peer requested already known block" error.

To fix this, I added a check to drop block announcements for already known blocks.