### PR TITLE
Better outbound and inbound peers selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,6 +2444,7 @@ dependencies = [
  "rstest",
  "serde",
  "serialization",
+ "siphasher",
  "snowstorm",
  "socket2 0.5.1",
  "sscanf",

--- a/common/src/primitives/user_agent.rs
+++ b/common/src/primitives/user_agent.rs
@@ -62,9 +62,6 @@ impl TryFrom<Vec<u8>> for UserAgent {
     type Error = UserAgentError;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(UserAgentError::Empty);
-        }
         ensure!(!value.is_empty(), UserAgentError::Empty);
         ensure!(
             value.len() <= MAX_LENGTH,

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -42,6 +42,7 @@ tokio-socks = { version = "0.5.1" }
 hex.workspace = true
 rlimit = { version = "0.9.1", optional = true}
 ctor = { version = "0.2.0", optional = true}
+siphasher = "0.3.10"
 
 [dev-dependencies]
 chainstate-test-framework = { path = "../chainstate/test-framework" }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -218,6 +218,8 @@ pub async fn make_p2p<S: PeerDbStorage + 'static>(
     time_getter: TimeGetter,
     peerdb_storage: S,
 ) -> Result<Box<dyn P2pInterface>> {
+    assert!(cfg!(not(feature = "testing_utils")));
+
     let bind_addresses = get_p2p_bind_addresses(
         &p2p_config.bind_addresses,
         chain_config.p2p_port(),

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -218,6 +218,8 @@ pub async fn make_p2p<S: PeerDbStorage + 'static>(
     time_getter: TimeGetter,
     peerdb_storage: S,
 ) -> Result<Box<dyn P2pInterface>> {
+    // Check that the `testing_utils` feature is not enabled when the node is built
+    // (`testing_utils` turns on time mocking in tokio and also calls `setrlimit` when loaded).
     assert!(cfg!(not(feature = "testing_utils")));
 
     let bind_addresses = get_p2p_bind_addresses(

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -71,8 +71,6 @@ pub enum Event {
     SendMessage(Box<Message>),
 }
 
-// TODO: Decide what to do about protocol upgrades.
-// For example adding new address type to PeerAddress might break handshakes with older nodes.
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum HandshakeMessage {
     Hello {

--- a/p2p/src/peer_manager/address_groups.rs
+++ b/p2p/src/peer_manager/address_groups.rs
@@ -44,7 +44,9 @@ pub fn get_address_group(address: &PeerAddress) -> AddressGroup {
         PeerAddress::Ip4(addr) => {
             let ip = Ipv4Addr::from(addr.ip);
             if ip.is_global_unicast_ip() {
-                AddressGroup::PublicV4(ip.octets()[0..IPV4_GROUP_BYTES].try_into().unwrap())
+                AddressGroup::PublicV4(
+                    ip.octets()[0..IPV4_GROUP_BYTES].try_into().expect("must be valid"),
+                )
             } else if ip.is_loopback() {
                 AddressGroup::Local
             } else {
@@ -54,7 +56,9 @@ pub fn get_address_group(address: &PeerAddress) -> AddressGroup {
         PeerAddress::Ip6(addr) => {
             let ip = Ipv6Addr::from(addr.ip);
             if ip.is_global_unicast_ip() {
-                AddressGroup::PublicV6(ip.octets()[0..IPV6_GROUP_BYTES].try_into().unwrap())
+                AddressGroup::PublicV6(
+                    ip.octets()[0..IPV6_GROUP_BYTES].try_into().expect("must be valid"),
+                )
             } else if ip.is_loopback() {
                 AddressGroup::Local
             } else {

--- a/p2p/src/peer_manager/address_groups.rs
+++ b/p2p/src/peer_manager/address_groups.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use crate::types::peer_address::PeerAddress;
+
+use super::global_ip::IsGlobalIp;
+
+// IPv4 addresses /16 groups
+const IPV4_GROUP_BYTES: usize = 2;
+// IPv4 addresses /32 groups
+const IPV6_GROUP_BYTES: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AddressGroup {
+    Local,
+    Private,
+    PublicV4([u8; IPV4_GROUP_BYTES]),
+    PublicV6([u8; IPV6_GROUP_BYTES]),
+}
+
+/// Get the canonical identifier of the network group for address.
+///
+/// The groups are assigned in a way where it should be costly for an attacker to
+/// obtain addresses with many different group identifiers, even if it is cheap
+/// to obtain addresses with the same identifier.
+///
+/// See `NetGroupManager::GetGroup` in Bitcoin Core for a reference.
+pub fn get_address_group(address: &PeerAddress) -> AddressGroup {
+    match address {
+        PeerAddress::Ip4(addr) => {
+            let ip = Ipv4Addr::from(addr.ip);
+            if ip.is_global_unicast_ip() {
+                AddressGroup::PublicV4(ip.octets()[0..IPV4_GROUP_BYTES].try_into().unwrap())
+            } else if ip.is_loopback() {
+                AddressGroup::Local
+            } else {
+                AddressGroup::Private
+            }
+        }
+        PeerAddress::Ip6(addr) => {
+            let ip = Ipv6Addr::from(addr.ip);
+            if ip.is_global_unicast_ip() {
+                AddressGroup::PublicV6(ip.octets()[0..IPV6_GROUP_BYTES].try_into().unwrap())
+            } else if ip.is_loopback() {
+                AddressGroup::Local
+            } else {
+                AddressGroup::Private
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use crate::net::default_backend::transport::TransportAddress;
+
+    use super::*;
+
+    fn check_group(ip: &str, expected: AddressGroup) {
+        let addr = SocketAddr::new(ip.parse().unwrap(), 12345).as_peer_address();
+        let group = get_address_group(&addr);
+        assert_eq!(group, expected, "check failed for {ip}");
+    }
+
+    #[test]
+    fn address_group() {
+        check_group("127.0.0.1", AddressGroup::Local);
+        check_group("::1", AddressGroup::Local);
+
+        check_group("192.168.0.1", AddressGroup::Private);
+        check_group("fe80::", AddressGroup::Private);
+
+        check_group("1.2.3.4", AddressGroup::PublicV4([1, 2]));
+        check_group(
+            "2a00:1450:4017:815::200e",
+            AddressGroup::PublicV6([0x2a, 0x00, 0x14, 0x50]),
+        );
+    }
+}

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -967,8 +967,14 @@ where
         self.peers.values().any(|peer| peer.address == *address)
     }
 
+    /// The number of active inbound peers (all inbound connected peers that are not in `pending_disconnects`)
     fn inbound_peer_count(&self) -> usize {
-        self.peers.values().filter(|peer| peer.role == Role::Inbound).count()
+        self.peers
+            .iter()
+            .filter(|(peer_id, peer)| {
+                peer.role == Role::Inbound && !self.pending_disconnects.contains_key(peer_id)
+            })
+            .count()
     }
 
     /// Sends ping requests and disconnects peers that do not respond in time

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -15,6 +15,7 @@
 
 //! Peer manager
 
+pub mod address_groups;
 pub mod global_ip;
 pub mod peer_context;
 pub mod peerdb;

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -451,10 +451,12 @@ where
             .collect::<Vec<peers_eviction::EvictionCandidate>>();
 
         if let Some(peer_id) = peers_eviction::select_for_eviction(candidates) {
+            log::info!("peer {peer_id} is selected for eviction");
             self.disconnect(peer_id, None);
 
             true
         } else {
+            log::info!("no peer is selected for eviction, new connection is dropped");
             false
         }
     }

--- a/p2p/src/peer_manager/peers_eviction.rs
+++ b/p2p/src/peer_manager/peers_eviction.rs
@@ -105,9 +105,11 @@ pub fn select_for_eviction(mut candidates: Vec<EvictionCandidate>) -> Option<Pee
     let selected_group: NetGroupKeyed =
         *counts.iter().max_by_key(|(_group_id, count)| *count).expect("must exist").0;
 
+    // Evict the youngest peer (with max `peer_id`) in the selected group
     let peer_id = candidates
         .iter()
-        .find(|c| c.net_group_keyed == selected_group)
+        .filter(|c| c.net_group_keyed == selected_group)
+        .max_by_key(|peer| peer.peer_id)
         .expect("must exist")
         .peer_id;
 

--- a/p2p/src/peer_manager/peers_eviction.rs
+++ b/p2p/src/peer_manager/peers_eviction.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeMap, hash::Hasher};
+
+use crypto::random::Rng;
+
+use crate::{
+    net::{default_backend::transport::TransportAddress, types::Role},
+    peer_manager::address_groups::get_address_group,
+    types::peer_id::PeerId,
+};
+
+use super::peer_context::PeerContext;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+struct NetGroupKeyed(u64);
+
+pub struct EvictionCandidate {
+    peer_id: PeerId,
+
+    /// Deterministically randomized address group ID
+    net_group_keyed: NetGroupKeyed,
+
+    /// Minimum ping time in microseconds (or i64::MAX if not known yet)
+    ping_min: i64,
+
+    /// Inbound or Outbound
+    role: Role,
+}
+
+pub struct RandomState(u64, u64);
+
+impl RandomState {
+    pub fn new<R: Rng>(rng: &mut R) -> Self {
+        Self(rng.gen(), rng.gen())
+    }
+
+    fn get_hash<A: std::hash::Hash>(&self, value: &A) -> u64 {
+        let mut hasher = siphasher::sip::SipHasher::new_with_keys(self.0, self.1);
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl EvictionCandidate {
+    pub fn new<A: TransportAddress>(peer: &PeerContext<A>, random_state: &RandomState) -> Self {
+        EvictionCandidate {
+            peer_id: peer.info.peer_id,
+            net_group_keyed: NetGroupKeyed(
+                random_state.get_hash(&get_address_group(&peer.address.as_peer_address())),
+            ),
+            ping_min: peer.ping_min.map_or(i64::MAX, |val| val.as_micros() as i64),
+            role: peer.role,
+        }
+    }
+}
+
+/// Based on `SelectNodeToEvict` from Bitcoin Core:
+///
+/// Select an inbound peer to evict after filtering out (protecting) peers having
+/// distinct, difficult-to-forge characteristics. The protection logic picks out
+/// fixed numbers of desirable peers per various criteria.
+/// ...
+/// If any eviction candidates remain, the selection logic chooses a peer to evict.
+pub fn select_for_eviction(mut candidates: Vec<EvictionCandidate>) -> Option<PeerId> {
+    // TODO: Do not evict connections from whitelisted IPs
+    candidates.retain(|peer| peer.role == Role::Inbound);
+
+    // Deterministically select 4 peers to protect by netgroup.
+    // An attacker cannot predict which netgroups will be protected
+    candidates.sort_unstable_by_key(|peer| peer.net_group_keyed);
+    candidates.truncate(candidates.len().saturating_sub(4));
+
+    // Protect the 8 nodes with the lowest minimum ping time.
+    // An attacker cannot manipulate this metric without physically moving nodes closer to the target.
+    candidates.sort_unstable_by_key(|peer| -peer.ping_min);
+    candidates.truncate(candidates.len().saturating_sub(8));
+
+    // TODO: Protect 4 nodes that most recently sent us novel transactions accepted into our mempool.
+    // TODO: Protect up to 8 peers that have sent us novel blocks.
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // Identify the network group with the most connections
+    let counts = candidates.iter().fold(BTreeMap::<NetGroupKeyed, usize>::new(), |mut acc, c| {
+        *acc.entry(c.net_group_keyed).or_insert(0) += 1;
+        acc
+    });
+    let selected_group: NetGroupKeyed =
+        *counts.iter().max_by_key(|(_group_id, count)| *count).expect("must exist").0;
+
+    let peer_id = candidates
+        .iter()
+        .find(|c| c.net_group_keyed == selected_group)
+        .expect("must exist")
+        .peer_id;
+
+    Some(peer_id)
+}

--- a/p2p/src/peer_manager/peers_eviction/mod.rs
+++ b/p2p/src/peer_manager/peers_eviction/mod.rs
@@ -28,6 +28,8 @@ use super::{address_groups::AddressGroup, peer_context::PeerContext};
 struct NetGroupKeyed(u64);
 
 /// A copy of `PeerContext` with fields relevant to the eviction logic
+///
+/// See `select_for_eviction` for more details.
 #[derive(Debug, PartialEq, Eq)]
 pub struct EvictionCandidate {
     peer_id: PeerId,

--- a/p2p/src/peer_manager/peers_eviction/mod.rs
+++ b/p2p/src/peer_manager/peers_eviction/mod.rs
@@ -27,11 +27,11 @@ use super::{address_groups::AddressGroup, peer_context::PeerContext};
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 struct NetGroupKeyed(u64);
 
-const PROTECTED_COUNT_ADDRESS_GROUP: usize = 4;
-const PROTECTED_COUNT_PING: usize = 8;
+const PRESERVED_COUNT_ADDRESS_GROUP: usize = 4;
+const PRESERVED_COUNT_PING: usize = 8;
 
 #[cfg(test)]
-const PROTECTED_COUNT_TOTAL: usize = PROTECTED_COUNT_ADDRESS_GROUP + PROTECTED_COUNT_PING;
+const PRESERVED_COUNT_TOTAL: usize = PRESERVED_COUNT_ADDRESS_GROUP + PRESERVED_COUNT_PING;
 
 /// A copy of `PeerContext` with fields relevant to the eviction logic
 ///
@@ -140,8 +140,8 @@ pub fn select_for_eviction(candidates: Vec<EvictionCandidate>) -> Option<PeerId>
     // TODO: Preserve connections from whitelisted IPs
 
     let candidates = filter_inbound(candidates);
-    let candidates = filter_address_group(candidates, PROTECTED_COUNT_ADDRESS_GROUP);
-    let candidates = filter_fast_ping(candidates, PROTECTED_COUNT_PING);
+    let candidates = filter_address_group(candidates, PRESERVED_COUNT_ADDRESS_GROUP);
+    let candidates = filter_fast_ping(candidates, PRESERVED_COUNT_PING);
 
     // TODO: Preserve 4 nodes that most recently sent us novel transactions accepted into our mempool.
     // TODO: Preserve up to 8 peers that have sent us novel blocks.

--- a/p2p/src/peer_manager/peers_eviction/tests.rs
+++ b/p2p/src/peer_manager/peers_eviction/tests.rs
@@ -1,0 +1,288 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[test]
+fn test_filter_inbound() {
+    let peer1 = PeerId::new();
+    let peer2 = PeerId::new();
+    assert_eq!(
+        filter_inbound(vec![
+            EvictionCandidate {
+                peer_id: peer1,
+                net_group_keyed: NetGroupKeyed(123),
+                ping_min: 0,
+                role: Role::Inbound
+            },
+            EvictionCandidate {
+                peer_id: peer2,
+                net_group_keyed: NetGroupKeyed(123),
+                ping_min: 0,
+                role: Role::Outbound
+            }
+        ]),
+        vec![EvictionCandidate {
+            peer_id: peer1,
+            net_group_keyed: NetGroupKeyed(123),
+            ping_min: 0,
+            role: Role::Inbound
+        },]
+    );
+}
+
+#[test]
+fn test_filter_address_group() {
+    let peer1 = PeerId::new();
+    let peer2 = PeerId::new();
+    let peer3 = PeerId::new();
+
+    assert_eq!(
+        filter_address_group(
+            vec![EvictionCandidate {
+                peer_id: peer1,
+                net_group_keyed: NetGroupKeyed(1),
+                ping_min: 0,
+                role: Role::Inbound
+            },],
+            1
+        ),
+        vec![]
+    );
+
+    assert_eq!(
+        filter_address_group(
+            vec![
+                EvictionCandidate {
+                    peer_id: peer1,
+                    net_group_keyed: NetGroupKeyed(1),
+                    ping_min: 0,
+                    role: Role::Inbound
+                },
+                EvictionCandidate {
+                    peer_id: peer2,
+                    net_group_keyed: NetGroupKeyed(2),
+                    ping_min: 0,
+                    role: Role::Inbound
+                },
+            ],
+            1
+        ),
+        vec![EvictionCandidate {
+            peer_id: peer1,
+            net_group_keyed: NetGroupKeyed(1),
+            ping_min: 0,
+            role: Role::Inbound
+        },]
+    );
+
+    assert_eq!(
+        filter_address_group(
+            vec![
+                EvictionCandidate {
+                    peer_id: peer2,
+                    net_group_keyed: NetGroupKeyed(2),
+                    ping_min: 0,
+                    role: Role::Inbound
+                },
+                EvictionCandidate {
+                    peer_id: peer1,
+                    net_group_keyed: NetGroupKeyed(1),
+                    ping_min: 0,
+                    role: Role::Inbound
+                },
+            ],
+            1
+        ),
+        vec![EvictionCandidate {
+            peer_id: peer1,
+            net_group_keyed: NetGroupKeyed(1),
+            ping_min: 0,
+            role: Role::Inbound
+        },]
+    );
+
+    assert_eq!(
+        filter_address_group(
+            vec![
+                EvictionCandidate {
+                    peer_id: peer1,
+                    net_group_keyed: NetGroupKeyed(2),
+                    ping_min: 0,
+                    role: Role::Inbound
+                },
+                EvictionCandidate {
+                    peer_id: peer2,
+                    net_group_keyed: NetGroupKeyed(1),
+                    ping_min: 0,
+                    role: Role::Inbound
+                },
+                EvictionCandidate {
+                    peer_id: peer3,
+                    net_group_keyed: NetGroupKeyed(2),
+                    ping_min: 0,
+                    role: Role::Inbound
+                },
+            ],
+            2
+        ),
+        vec![EvictionCandidate {
+            peer_id: peer2,
+            net_group_keyed: NetGroupKeyed(1),
+            ping_min: 0,
+            role: Role::Inbound
+        },]
+    );
+}
+
+#[test]
+fn test_ping() {
+    let peer1 = PeerId::new();
+    let peer2 = PeerId::new();
+    let peer3 = PeerId::new();
+
+    assert_eq!(
+        filter_fast_ping(
+            vec![EvictionCandidate {
+                peer_id: peer1,
+                net_group_keyed: NetGroupKeyed(1),
+                ping_min: 123,
+                role: Role::Inbound
+            },],
+            1
+        ),
+        vec![]
+    );
+
+    assert_eq!(
+        filter_fast_ping(
+            vec![
+                EvictionCandidate {
+                    peer_id: peer1,
+                    net_group_keyed: NetGroupKeyed(1),
+                    ping_min: 123,
+                    role: Role::Inbound
+                },
+                EvictionCandidate {
+                    peer_id: peer2,
+                    net_group_keyed: NetGroupKeyed(1),
+                    ping_min: 234,
+                    role: Role::Inbound
+                },
+            ],
+            1
+        ),
+        vec![EvictionCandidate {
+            peer_id: peer2,
+            net_group_keyed: NetGroupKeyed(1),
+            ping_min: 234,
+            role: Role::Inbound
+        },]
+    );
+
+    assert_eq!(
+        filter_fast_ping(
+            vec![
+                EvictionCandidate {
+                    peer_id: peer1,
+                    net_group_keyed: NetGroupKeyed(1),
+                    ping_min: 123,
+                    role: Role::Inbound
+                },
+                EvictionCandidate {
+                    peer_id: peer2,
+                    net_group_keyed: NetGroupKeyed(1),
+                    ping_min: 234,
+                    role: Role::Inbound
+                },
+                EvictionCandidate {
+                    peer_id: peer3,
+                    net_group_keyed: NetGroupKeyed(1),
+                    ping_min: 123,
+                    role: Role::Inbound
+                },
+            ],
+            2
+        ),
+        vec![EvictionCandidate {
+            peer_id: peer2,
+            net_group_keyed: NetGroupKeyed(1),
+            ping_min: 234,
+            role: Role::Inbound
+        },]
+    );
+}
+
+#[test]
+fn test_find_group_most_connections() {
+    let peer1 = PeerId::new();
+    let peer2 = PeerId::new();
+    let peer3 = PeerId::new();
+
+    assert_eq!(find_group_most_connections(vec![]), None);
+
+    assert_eq!(
+        find_group_most_connections(vec![EvictionCandidate {
+            peer_id: peer1,
+            net_group_keyed: NetGroupKeyed(1),
+            ping_min: 123,
+            role: Role::Inbound
+        }]),
+        Some(peer1)
+    );
+
+    // The yungest peer is selected (with the latest id)
+    assert_eq!(
+        find_group_most_connections(vec![
+            EvictionCandidate {
+                peer_id: peer1,
+                net_group_keyed: NetGroupKeyed(1),
+                ping_min: 123,
+                role: Role::Inbound
+            },
+            EvictionCandidate {
+                peer_id: peer2,
+                net_group_keyed: NetGroupKeyed(1),
+                ping_min: 123,
+                role: Role::Inbound
+            }
+        ]),
+        Some(peer2)
+    );
+
+    assert_eq!(
+        find_group_most_connections(vec![
+            EvictionCandidate {
+                peer_id: peer1,
+                net_group_keyed: NetGroupKeyed(1),
+                ping_min: 123,
+                role: Role::Inbound
+            },
+            EvictionCandidate {
+                peer_id: peer2,
+                net_group_keyed: NetGroupKeyed(1),
+                ping_min: 123,
+                role: Role::Inbound
+            },
+            EvictionCandidate {
+                peer_id: peer3,
+                net_group_keyed: NetGroupKeyed(2),
+                ping_min: 123,
+                role: Role::Inbound
+            },
+        ]),
+        Some(peer2)
+    );
+}

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -878,11 +878,12 @@ where
 
     // All peers should discover each other
     loop {
-        let counts = [
-            get_connected_peers(&tx1).await.len(),
-            get_connected_peers(&tx2).await.len(),
-            get_connected_peers(&tx3).await.len(),
-        ];
+        let connected_peers = tokio::join!(
+            get_connected_peers(&tx1),
+            get_connected_peers(&tx2),
+            get_connected_peers(&tx3)
+        );
+        let counts = [connected_peers.0.len(), connected_peers.1.len(), connected_peers.2.len()];
 
         // There should be:
         // - 2 outbound and 2 inbound connections to/from reserved peers.

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -763,9 +763,7 @@ async fn connection_reserved_node_channel() {
 }
 
 // Verify that peers announce own addresses and are discovered by other peers.
-// All listening addresses are discovered and multiple connections are made:
-// For example, A makes outbound connections to B and C and accepts connections from B and C.
-// So there will be 4 connections reported for A.
+// All listening addresses are discovered and multiple connections are made.
 async fn discovered_node<A, T>()
 where
     A: TestTransportMaker<Transport = T::Transport, Address = T::Address>,
@@ -880,15 +878,19 @@ where
 
     // All peers should discover each other
     loop {
-        let connected_peers_1 = get_connected_peers(&tx1).await.len();
-        let connected_peers_2 = get_connected_peers(&tx2).await.len();
-        let connected_peers_3 = get_connected_peers(&tx3).await.len();
+        let counts = [
+            get_connected_peers(&tx1).await.len(),
+            get_connected_peers(&tx2).await.len(),
+            get_connected_peers(&tx3).await.len(),
+        ];
 
-        const EXPECTED_COUNT: usize = 4;
-        if connected_peers_1 == EXPECTED_COUNT
-            && connected_peers_2 == EXPECTED_COUNT
-            && connected_peers_3 == EXPECTED_COUNT
-        {
+        // There should be:
+        // - 2 outbound and 2 inbound connections to/from reserved peers.
+        // - 3 outbound connections to the discovered addresses
+        //   (each peer can make only one outbound connection because all discovered addresses are in the same address group).
+        // - 3 inbound connections to the discovered addresses.
+        // Since outbound connections are random, we don't know which peer will get 4 connections.
+        if counts == [3, 3, 4] || counts == [3, 4, 3] || counts == [4, 3, 3] {
             break;
         }
 
@@ -897,7 +899,7 @@ where
 
         assert!(
             Instant::now().duration_since(started_at) < Duration::from_secs(60),
-            "Unexpected peer counts: {connected_peers_1}, {connected_peers_2}, {connected_peers_3}, expected: {EXPECTED_COUNT}"
+            "Unexpected peer counts: {counts:?}"
         );
     }
 }

--- a/p2p/src/types/peer_address.rs
+++ b/p2p/src/types/peer_address.rs
@@ -17,6 +17,8 @@ use std::fmt::Display;
 
 use serialization::{Decode, Encode};
 
+use crate::peer_manager::global_ip::IsGlobalIp;
+
 use super::ip_address::{Ip4, Ip6};
 
 #[derive(Debug, Encode, Decode, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -41,6 +43,16 @@ pub enum PeerAddress {
     Ip4(PeerAddressIp4),
     #[codec(index = 1)]
     Ip6(PeerAddressIp6),
+}
+
+impl PeerAddress {
+    pub fn is_loopback(&self) -> bool {
+        std::net::SocketAddr::from(self).ip().is_loopback()
+    }
+
+    pub fn is_global_unicast_ip(&self) -> bool {
+        std::net::SocketAddr::from(self).ip().is_global_unicast_ip()
+    }
 }
 
 impl Display for PeerAddress {


### PR DESCRIPTION
Port some logic from Bitcoin Core related to outbound and inbound peer selection:

- Make outbound connections to different subnets.
- Evict inbound connections when the node is full.