### PR TITLE
Add utxos to signature hash to allow not having full transactions when verifying before signing

### DIFF
--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -90,6 +90,7 @@ fn signed_tx(#[case] seed: Seed) {
                 SigHashType::try_from(SigHashType::ALL).unwrap(),
                 Destination::PublicKey(public_key),
                 &tx,
+                tx_1.transaction().outputs(),
                 0,
             )
             .unwrap();
@@ -171,8 +172,13 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
         let authorization = {
             let mut authorization = AuthorizedClassicalMultisigSpend::new_empty(challenge);
 
-            let sighash =
-                signature_hash(SigHashType::try_from(SigHashType::ALL).unwrap(), &tx, 0).unwrap();
+            let sighash = signature_hash(
+                SigHashType::try_from(SigHashType::ALL).unwrap(),
+                &tx,
+                tx_1.transaction().outputs(),
+                0,
+            )
+            .unwrap();
             let sighash = sighash.encode();
 
             for key_index in key_indexes.iter().take(min_required_signatures.get() as usize) {
@@ -191,6 +197,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
                     &authorization,
                     SigHashType::try_from(SigHashType::ALL).unwrap(),
                     &tx,
+                    tx_1.transaction().outputs(),
                     0,
                 )
                 .unwrap();
@@ -275,8 +282,13 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
         // So: Element number N has N signatures
         let mut authrorizations = vec![authorization.clone()];
 
-        let sighash =
-            signature_hash(SigHashType::try_from(SigHashType::ALL).unwrap(), &tx, 0).unwrap();
+        let sighash = signature_hash(
+            SigHashType::try_from(SigHashType::ALL).unwrap(),
+            &tx,
+            tx_1.transaction().outputs(),
+            0,
+        )
+        .unwrap();
         let sighash = sighash.encode();
 
         for key_index in key_indexes.iter().take(min_required_signatures.get() as usize) {
@@ -294,6 +306,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
                         &authorization,
                         SigHashType::try_from(SigHashType::ALL).unwrap(),
                         &tx,
+                        tx_1.transaction().outputs(),
                         0,
                     )
                     .unwrap();

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -90,7 +90,7 @@ fn signed_tx(#[case] seed: Seed) {
                 SigHashType::try_from(SigHashType::ALL).unwrap(),
                 Destination::PublicKey(public_key),
                 &tx,
-                &[tx_1.transaction().outputs()[0].clone()],
+                &[&tx_1.transaction().outputs()[0]],
                 0,
             )
             .unwrap();
@@ -175,7 +175,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
             let sighash = signature_hash(
                 SigHashType::try_from(SigHashType::ALL).unwrap(),
                 &tx,
-                &[tx_1.transaction().outputs()[0].clone()],
+                &[&tx_1.transaction().outputs()[0]],
                 0,
             )
             .unwrap();
@@ -197,7 +197,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
                     &authorization,
                     SigHashType::try_from(SigHashType::ALL).unwrap(),
                     &tx,
-                    &[tx_1.transaction().outputs()[0].clone()],
+                    &[&tx_1.transaction().outputs()[0]],
                     0,
                 )
                 .unwrap();
@@ -285,7 +285,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
         let sighash = signature_hash(
             SigHashType::try_from(SigHashType::ALL).unwrap(),
             &tx,
-            tx_1.transaction().outputs(),
+            &[&tx_1.transaction().outputs()[0]],
             0,
         )
         .unwrap();
@@ -306,7 +306,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
                         &authorization,
                         SigHashType::try_from(SigHashType::ALL).unwrap(),
                         &tx,
-                        tx_1.transaction().outputs(),
+                        &[&tx_1.transaction().outputs()[0]],
                         0,
                     )
                     .unwrap();

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -90,7 +90,7 @@ fn signed_tx(#[case] seed: Seed) {
                 SigHashType::try_from(SigHashType::ALL).unwrap(),
                 Destination::PublicKey(public_key),
                 &tx,
-                tx_1.transaction().outputs(),
+                &[tx_1.transaction().outputs()[0].clone()],
                 0,
             )
             .unwrap();
@@ -175,7 +175,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
             let sighash = signature_hash(
                 SigHashType::try_from(SigHashType::ALL).unwrap(),
                 &tx,
-                tx_1.transaction().outputs(),
+                &[tx_1.transaction().outputs()[0].clone()],
                 0,
             )
             .unwrap();
@@ -197,7 +197,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
                     &authorization,
                     SigHashType::try_from(SigHashType::ALL).unwrap(),
                     &tx,
-                    tx_1.transaction().outputs(),
+                    &[tx_1.transaction().outputs()[0].clone()],
                     0,
                 )
                 .unwrap();

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -513,10 +513,14 @@ where
             // TODO: see if a different treatment should be done for different output purposes
             // TODO: ensure that signature verification is tested in the test-suite, they seem to be tested only internally
             match utxo.output().purpose().destination() {
-                Some(d) => {
-                    verify_signature(self.chain_config.as_ref(), d, tx, &inputs_utxos, input_idx)
-                        .map_err(ConnectTransactionError::SignatureVerificationFailed)?
-                }
+                Some(d) => verify_signature(
+                    self.chain_config.as_ref(),
+                    d,
+                    tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input_idx,
+                )
+                .map_err(ConnectTransactionError::SignatureVerificationFailed)?,
                 None => return Err(ConnectTransactionError::AttemptToSpendBurnedAmount),
             }
         }

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
@@ -105,7 +105,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 1,
             );
             assert_eq!(res, Err(TransactionSigError::InvalidInputIndex(1, 1)));
@@ -133,7 +133,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -166,7 +166,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 rng.gen_range(0..INPUTS),
             )
             .unwrap();
@@ -206,14 +206,19 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 input,
             )
             .unwrap();
             let spender_signature =
                 AuthorizedPublicKeySpend::from_data(witness.raw_signature()).unwrap();
-            let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
+            let sighash = signature_hash(
+                witness.sighash_type(),
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                input,
+            )
+            .unwrap();
             verify_public_key_spending(&public_key, &spender_signature, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
         }
@@ -240,12 +245,17 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 input,
             )
             .unwrap();
-            let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
+            let sighash = signature_hash(
+                witness.sighash_type(),
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                input,
+            )
+            .unwrap();
             sign_pubkey_spending(&private_key, &public_key, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
         }

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
@@ -114,7 +114,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 1,
             );
             assert_eq!(res, Err(TransactionSigError::InvalidInputIndex(1, 1)));
@@ -142,7 +142,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -177,7 +177,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -220,14 +220,19 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 input,
             )
             .unwrap();
             let spender_signature =
                 AuthorizedPublicKeyHashSpend::from_data(witness.raw_signature()).unwrap();
-            let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
+            let sighash = signature_hash(
+                witness.sighash_type(),
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                input,
+            )
+            .unwrap();
 
             verify_address_spending(&pubkey_hash, &spender_signature, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
@@ -256,12 +261,17 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 input,
             )
             .unwrap();
-            let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
+            let sighash = signature_hash(
+                witness.sighash_type(),
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                input,
+            )
+            .unwrap();
 
             sign_address_spending(&private_key, &pubkey_hash, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
@@ -78,6 +78,7 @@ pub fn sign_address_spending(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::chain::signature::tests::utils::generate_inputs_utxos;
     use crate::chain::{
         signature::{inputsig::StandardInputSignature, signature_hash},
         transaction::signature::tests::utils::{generate_unsigned_tx, sig_hash_types},
@@ -102,7 +103,10 @@ mod test {
             PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let pubkey_hash = PublicKeyHash::from(&public_key);
         let destination = Destination::Address(pubkey_hash);
-        let tx = generate_unsigned_tx(&mut rng, &destination, 1, 2).unwrap();
+
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
 
         for sighash_type in sig_hash_types() {
             let res = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -110,6 +114,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
+                &inputs_utxos,
                 1,
             );
             assert_eq!(res, Err(TransactionSigError::InvalidInputIndex(1, 1)));
@@ -126,7 +131,10 @@ mod test {
         let (private_key, public_key) =
             PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let destination = Destination::PublicKey(public_key);
-        let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
+
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -134,7 +142,8 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                rng.gen_range(0..INPUTS),
+                &inputs_utxos,
+                rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
             assert!(
@@ -157,7 +166,10 @@ mod test {
             PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let pubkey_hash = PublicKeyHash::from(&public_key);
         let destination = Destination::Address(pubkey_hash);
-        let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
+
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -165,7 +177,8 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                rng.gen_range(0..INPUTS),
+                &inputs_utxos,
+                rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
 
@@ -195,7 +208,10 @@ mod test {
             PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let pubkey_hash = PublicKeyHash::from(&public_key);
         let destination = Destination::Address(pubkey_hash);
-        let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
+
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let input = rng.gen_range(0..INPUTS);
@@ -204,12 +220,14 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
+                &inputs_utxos,
                 input,
             )
             .unwrap();
             let spender_signature =
                 AuthorizedPublicKeyHashSpend::from_data(witness.raw_signature()).unwrap();
-            let sighash = signature_hash(witness.sighash_type(), &tx, input).unwrap();
+            let sighash =
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
 
             verify_address_spending(&pubkey_hash, &spender_signature, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
@@ -226,19 +244,24 @@ mod test {
             PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let destination = Destination::PublicKey(public_key.clone());
         let pubkey_hash = PublicKeyHash::from(&public_key);
-        let tx = generate_unsigned_tx(&mut rng, &destination, INPUTS, OUTPUTS).unwrap();
+
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
-            let input = rng.gen_range(0..INPUTS);
+            let input = rng.gen_range(0..inputs_utxos.len());
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
                 &private_key,
                 sighash_type,
                 destination.clone(),
                 &tx,
+                &inputs_utxos,
                 input,
             )
             .unwrap();
-            let sighash = signature_hash(witness.sighash_type(), &tx, input).unwrap();
+            let sighash =
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
 
             sign_address_spending(&private_key, &pubkey_hash, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));

--- a/common/src/chain/transaction/signature/inputsig/standard_signature.rs
+++ b/common/src/chain/transaction/signature/inputsig/standard_signature.rs
@@ -100,7 +100,7 @@ impl StandardInputSignature {
         sighash_type: SigHashType,
         outpoint_destination: Destination,
         tx: &Transaction,
-        inputs_utxos: &[TxOutput],
+        inputs_utxos: &[&TxOutput],
         input_num: usize,
     ) -> Result<Self, TransactionSigError> {
         let sighash = signature_hash(sighash_type, tx, inputs_utxos, input_num)?;
@@ -135,7 +135,7 @@ impl StandardInputSignature {
         authorization: &AuthorizedClassicalMultisigSpend,
         sighash_type: SigHashType,
         tx: &Transaction,
-        inputs_utxos: &[TxOutput],
+        inputs_utxos: &[&TxOutput],
         input_num: usize,
     ) -> Result<Self, TransactionSigError> {
         let sighash = signature_hash(sighash_type, tx, inputs_utxos, input_num)?;
@@ -244,7 +244,7 @@ mod test {
                     sighash_type,
                     destination.clone(),
                     &tx,
-                    &inputs_utxos,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
                     INPUT_NUM,
                 ),
                 "{sighash_type:X?}"
@@ -274,7 +274,7 @@ mod test {
                     sighash_type,
                     destination.clone(),
                     &tx,
-                    &inputs_utxos,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
                     INPUT_NUM,
                 ),
                 "{sighash_type:X?}"
@@ -306,13 +306,18 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 INPUT_NUM,
             )
             .unwrap();
 
-            let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, INPUT_NUM).unwrap();
+            let sighash = signature_hash(
+                witness.sighash_type(),
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                INPUT_NUM,
+            )
+            .unwrap();
             witness
                 .verify_signature(&chain_config, &destination, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?} {destination:?}"));

--- a/common/src/chain/transaction/signature/inputsig/standard_signature.rs
+++ b/common/src/chain/transaction/signature/inputsig/standard_signature.rs
@@ -20,7 +20,7 @@ use serialization::{Decode, DecodeAll, Encode};
 use crate::{
     chain::{
         signature::{sighashtype::SigHashType, signature_hash, TransactionSigError},
-        ChainConfig, Destination, Transaction,
+        ChainConfig, Destination, Transaction, TxOutput,
     },
     primitives::H256,
 };
@@ -100,9 +100,10 @@ impl StandardInputSignature {
         sighash_type: SigHashType,
         outpoint_destination: Destination,
         tx: &Transaction,
+        inputs_utxos: &[TxOutput],
         input_num: usize,
     ) -> Result<Self, TransactionSigError> {
-        let sighash = signature_hash(sighash_type, tx, input_num)?;
+        let sighash = signature_hash(sighash_type, tx, inputs_utxos, input_num)?;
         let serialized_sig = match outpoint_destination {
             Destination::Address(ref addr) => {
                 let sig = sign_address_spending(private_key, addr, &sighash)?;
@@ -134,9 +135,10 @@ impl StandardInputSignature {
         authorization: &AuthorizedClassicalMultisigSpend,
         sighash_type: SigHashType,
         tx: &Transaction,
+        inputs_utxos: &[TxOutput],
         input_num: usize,
     ) -> Result<Self, TransactionSigError> {
-        let sighash = signature_hash(sighash_type, tx, input_num)?;
+        let sighash = signature_hash(sighash_type, tx, inputs_utxos, input_num)?;
         let message = sighash.encode();
 
         let verifier =
@@ -210,6 +212,7 @@ mod test {
     };
 
     use super::*;
+    use crate::chain::signature::tests::utils::generate_inputs_utxos;
     use crate::chain::signature::{signature_hash, TransactionSigError};
     use crate::chain::Destination;
     use crypto::key::{KeyKind, PrivateKey};
@@ -228,7 +231,10 @@ mod test {
         let (private_key, _) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let destination = Destination::Address(PublicKeyHash::from(&public_key));
-        let tx = generate_unsigned_tx(&mut rng, &destination, 1, 2).unwrap();
+
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
 
         for sighash_type in sig_hash_types() {
             assert_eq!(
@@ -238,6 +244,7 @@ mod test {
                     sighash_type,
                     destination.clone(),
                     &tx,
+                    &inputs_utxos,
                     INPUT_NUM,
                 ),
                 "{sighash_type:X?}"
@@ -254,7 +261,10 @@ mod test {
         let (private_key, _) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
         let destination = Destination::PublicKey(public_key);
-        let tx = generate_unsigned_tx(&mut rng, &destination, 1, 2).unwrap();
+
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
 
         for sighash_type in sig_hash_types() {
             assert_eq!(
@@ -264,6 +274,7 @@ mod test {
                     sighash_type,
                     destination.clone(),
                     &tx,
+                    &inputs_utxos,
                     INPUT_NUM,
                 ),
                 "{sighash_type:X?}"
@@ -288,17 +299,20 @@ mod test {
 
         for (sighash_type, destination) in sig_hash_types().cartesian_product(outpoints.into_iter())
         {
-            let tx = generate_unsigned_tx(&mut rng, &destination, 1, 2).unwrap();
+            let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
+            let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
                 &private_key,
                 sighash_type,
                 destination.clone(),
                 &tx,
+                &inputs_utxos,
                 INPUT_NUM,
             )
             .unwrap();
 
-            let sighash = signature_hash(witness.sighash_type(), &tx, INPUT_NUM).unwrap();
+            let sighash =
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, INPUT_NUM).unwrap();
             witness
                 .verify_signature(&chain_config, &destination, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?} {destination:?}"));

--- a/common/src/chain/transaction/signature/mod.rs
+++ b/common/src/chain/transaction/signature/mod.rs
@@ -268,7 +268,7 @@ impl Transactable for SignedTransaction {
 
 fn stream_signature_hash<T: Signable>(
     tx: &T,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     stream: &mut DefaultHashAlgoStream,
     mode: sighashtype::SigHashType,
     target_input_num: usize,
@@ -316,7 +316,7 @@ fn stream_signature_hash<T: Signable>(
 pub fn signature_hash<T: Signable>(
     mode: sighashtype::SigHashType,
     tx: &T,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     input_num: usize,
 ) -> Result<H256, TransactionSigError> {
     let mut stream = DefaultHashAlgoStream::new();
@@ -332,7 +332,7 @@ fn verify_standard_input_signature<T: Transactable>(
     outpoint_destination: &Destination,
     witness: &StandardInputSignature,
     tx: &T,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     input_num: usize,
 ) -> Result<(), TransactionSigError> {
     let sighash = signature_hash(witness.sighash_type(), tx, inputs_utxos, input_num)?;
@@ -344,7 +344,7 @@ pub fn verify_signature<T: Transactable>(
     chain_config: &ChainConfig,
     outpoint_destination: &Destination,
     tx: &T,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     input_num: usize,
 ) -> Result<(), TransactionSigError> {
     let inputs = tx.inputs().ok_or(TransactionSigError::SignatureVerificationWithoutInputs)?;

--- a/common/src/chain/transaction/signature/mod.rs
+++ b/common/src/chain/transaction/signature/mod.rs
@@ -268,9 +268,9 @@ impl Transactable for SignedTransaction {
 
 fn stream_signature_hash<T: Signable>(
     tx: &T,
+    inputs_utxos: &[TxOutput],
     stream: &mut DefaultHashAlgoStream,
     mode: sighashtype::SigHashType,
-    inputs_utxos: &[TxOutput],
     target_input_num: usize,
 ) -> Result<(), TransactionSigError> {
     // TODO: even though this works fine, we need to make this function
@@ -321,7 +321,7 @@ pub fn signature_hash<T: Signable>(
 ) -> Result<H256, TransactionSigError> {
     let mut stream = DefaultHashAlgoStream::new();
 
-    stream_signature_hash(tx, &mut stream, mode, inputs_utxos, input_num)?;
+    stream_signature_hash(tx, inputs_utxos, &mut stream, mode, input_num)?;
 
     let result = stream.finalize().into();
     Ok(result)

--- a/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
+++ b/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
@@ -46,6 +46,7 @@ fn mixed_sighash_types(#[case] seed: Seed) {
         sig_hash_types(),
         sig_hash_types()
     ) {
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 6);
         let tx = generate_unsigned_tx(&mut rng, &destination, 6, 6).unwrap();
 
         let sigs = [
@@ -60,15 +61,22 @@ fn mixed_sighash_types(#[case] seed: Seed) {
         .enumerate()
         .map(|(input, sighash_type)| {
             InputWitness::Standard(
-                make_signature(&tx, input, &private_key, sighash_type, destination.clone())
-                    .unwrap(),
+                make_signature(
+                    &tx,
+                    &inputs_utxos,
+                    input,
+                    &private_key,
+                    sighash_type,
+                    destination.clone(),
+                )
+                .unwrap(),
             )
         })
         .collect::<Vec<_>>();
 
         let signed_tx = tx.with_signatures(sigs).unwrap();
 
-        verify_signed_tx(&chain_config, &signed_tx, &destination)
+        verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
             .expect("Signature verification failed")
     }
 }

--- a/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
+++ b/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
@@ -76,7 +76,12 @@ fn mixed_sighash_types(#[case] seed: Seed) {
 
         let signed_tx = tx.with_signatures(sigs).unwrap();
 
-        verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
-            .expect("Signature verification failed")
+        verify_signed_tx(
+            &chain_config,
+            &signed_tx,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &destination,
+        )
+        .expect("Signature verification failed")
     }
 }

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -70,7 +70,12 @@ fn sign_and_verify_different_sighash_types(#[case] seed: Seed) {
         )
         .unwrap();
         assert_eq!(
-            verify_signed_tx(&chain_config, &tx, &inputs_utxos, &destination),
+            verify_signed_tx(
+                &chain_config,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &destination
+            ),
             Ok(()),
             "{sighash_type:?}"
         );
@@ -98,7 +103,13 @@ fn verify_no_signature(#[case] seed: Seed) {
             .collect_vec();
         let signed_tx = tx.with_signatures(witnesses).unwrap();
         assert_eq!(
-            verify_signature(&chain_config, &destination, &signed_tx, &inputs_utxos, 0),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &signed_tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                0
+            ),
             Err(TransactionSigError::SignatureNotFound),
             "{destination:?}"
         );
@@ -135,7 +146,13 @@ fn verify_invalid_signature(#[case] seed: Seed) {
         let signed_tx = tx.with_signatures(witnesses).unwrap();
 
         assert_eq!(
-            verify_signature(&chain_config, &destination, &signed_tx, &inputs_utxos, 0),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &signed_tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                0
+            ),
             Err(TransactionSigError::InvalidSignatureEncoding),
             "{sighash_type:?}, signature = {raw_signature:?}"
         );
@@ -172,7 +189,7 @@ fn verify_signature_invalid_signature_index(#[case] seed: Seed) {
                 &chain_config,
                 &destination,
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
                 INVALID_SIGNATURE_INDEX
             ),
             Err(TransactionSigError::InvalidSignatureIndex(
@@ -211,7 +228,13 @@ fn verify_signature_wrong_destination(#[case] seed: Seed) {
         )
         .unwrap();
         assert_eq!(
-            verify_signature(&chain_config, &different_outpoint, &tx, &inputs_utxos, 0),
+            verify_signature(
+                &chain_config,
+                &different_outpoint,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                0
+            ),
             Err(TransactionSigError::SignatureVerificationFailed),
             "{sighash_type:?}"
         );
@@ -234,7 +257,7 @@ fn mutate_all(#[case] seed: Seed) {
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -244,7 +267,7 @@ fn mutate_all(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -252,7 +275,7 @@ fn mutate_all(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -260,14 +283,14 @@ fn mutate_all(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -289,7 +312,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -299,7 +322,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
@@ -307,7 +330,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -315,14 +338,14 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -344,7 +367,7 @@ fn mutate_none(#[case] seed: Seed) {
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -354,7 +377,7 @@ fn mutate_none(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -362,7 +385,7 @@ fn mutate_none(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -370,14 +393,14 @@ fn mutate_none(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
@@ -400,7 +423,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -410,7 +433,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
@@ -418,7 +441,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -426,14 +449,14 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
@@ -455,7 +478,7 @@ fn mutate_single(#[case] seed: Seed) {
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -465,7 +488,7 @@ fn mutate_single(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -473,7 +496,7 @@ fn mutate_single(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -481,14 +504,14 @@ fn mutate_single(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -511,7 +534,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -521,7 +544,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
@@ -529,7 +552,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -537,14 +560,14 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         false,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         &outpoint_dest,
         true,
     );
@@ -553,7 +576,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
 fn sign_mutate_then_verify(
     chain_config: &ChainConfig,
     rng: &mut (impl Rng + CryptoRng),
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     private_key: &PrivateKey,
     sighash_type: SigHashType,
     destination: &Destination,
@@ -570,7 +593,7 @@ fn sign_mutate_then_verify(
     )
     .unwrap();
     assert_eq!(
-        verify_signed_tx(chain_config, &original_tx, inputs_utxos, destination),
+        verify_signed_tx(chain_config, &original_tx, &inputs_utxos, destination),
         Ok(())
     );
 
@@ -583,7 +606,7 @@ fn sign_mutate_then_verify(
 fn check_change_flags(
     chain_config: &ChainConfig,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     destination: &Destination,
 ) {
     let mut tx_updater = MutableTransaction::from(original_tx);
@@ -600,7 +623,7 @@ fn check_change_flags(
 fn check_change_locktime(
     chain_config: &ChainConfig,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     outpoint_dest: &Destination,
 ) {
     let mut tx_updater = MutableTransaction::from(original_tx);
@@ -618,7 +641,7 @@ fn check_insert_input(
     chain_config: &ChainConfig,
     rng: &mut impl Rng,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     destination: &Destination,
     should_fail: bool,
 ) {
@@ -640,7 +663,7 @@ fn check_insert_input(
 fn check_mutate_witness(
     chain_config: &ChainConfig,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     outpoint_dest: &Destination,
 ) {
     let mut tx_updater = MutableTransaction::from(original_tx);
@@ -667,7 +690,7 @@ fn check_insert_output(
     chain_config: &ChainConfig,
     rng: &mut (impl Rng + CryptoRng),
     original_tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     destination: &Destination,
     should_fail: bool,
 ) {
@@ -689,7 +712,7 @@ fn check_insert_output(
 fn check_mutate_output(
     chain_config: &ChainConfig,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     destination: &Destination,
     should_fail: bool,
 ) {
@@ -717,7 +740,7 @@ fn check_mutate_input(
     chain_config: &ChainConfig,
     rng: &mut impl Rng,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     destination: &Destination,
     should_fail: bool,
 ) {

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -81,13 +81,23 @@ fn test_mutate_tx_internal_data(#[case] seed: Seed) {
                 // Test flags change.
                 let updated_tx = change_flags(&mut rng, &signed_tx, 1234567890);
                 assert_eq!(
-                    verify_signed_tx(&chain_config, &updated_tx, &inputs_utxos, &destination),
+                    verify_signed_tx(
+                        &chain_config,
+                        &updated_tx,
+                        &inputs_utxos.iter().collect::<Vec<_>>(),
+                        &destination
+                    ),
                     expected
                 );
                 // Test locktime change.
                 let updated_tx = change_locktime(&mut rng, &signed_tx, 1234567890);
                 assert_eq!(
-                    verify_signed_tx(&chain_config, &updated_tx, &inputs_utxos, &destination),
+                    verify_signed_tx(
+                        &chain_config,
+                        &updated_tx,
+                        &inputs_utxos.iter().collect::<Vec<_>>(),
+                        &destination
+                    ),
                     expected
                 )
             }
@@ -123,7 +133,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &private_key,
             sighash_type,
             &destination,
@@ -132,7 +142,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -140,7 +150,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -148,11 +158,17 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
+        check_mutate_output(
+            &chain_config,
+            &tx,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &destination,
+            true,
+        );
     }
 
     {
@@ -162,7 +178,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &private_key,
             sighash_type,
             &destination,
@@ -171,7 +187,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             false,
         );
@@ -179,7 +195,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -187,11 +203,17 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
+        check_mutate_output(
+            &chain_config,
+            &tx,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &destination,
+            true,
+        );
     }
 
     {
@@ -200,7 +222,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &private_key,
             sighash_type,
             &destination,
@@ -209,7 +231,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -217,7 +239,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -225,11 +247,17 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             false,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, false);
+        check_mutate_output(
+            &chain_config,
+            &tx,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &destination,
+            false,
+        );
     }
 
     {
@@ -239,7 +267,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &private_key,
             sighash_type,
             &destination,
@@ -248,7 +276,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             false,
         );
@@ -256,7 +284,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -264,11 +292,17 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             false,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, false);
+        check_mutate_output(
+            &chain_config,
+            &tx,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &destination,
+            false,
+        );
     }
 
     {
@@ -277,7 +311,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &private_key,
             sighash_type,
             &destination,
@@ -286,7 +320,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -294,7 +328,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -302,11 +336,17 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             false,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
+        check_mutate_output(
+            &chain_config,
+            &tx,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &destination,
+            true,
+        );
     }
 
     {
@@ -316,7 +356,7 @@ fn modify_and_verify(#[case] seed: Seed) {
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &private_key,
             sighash_type,
             &destination,
@@ -325,7 +365,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             false,
         );
@@ -333,7 +373,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             true,
         );
@@ -341,11 +381,17 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
             &destination,
             false,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
+        check_mutate_output(
+            &chain_config,
+            &tx,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &destination,
+            true,
+        );
     }
 }
 
@@ -441,7 +487,13 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     {
         let tx = mutate_input(&mut rng, &tx);
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, 0),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                0
+            ),
             Err(TransactionSigError::SignatureVerificationFailed),
         );
     }
@@ -545,12 +597,24 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         let inputs = tx.inputs().len();
 
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, 0),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                0
+            ),
             Err(TransactionSigError::SignatureVerificationFailed),
         );
         for input in 1..inputs {
             assert_eq!(
-                verify_signature(&chain_config, &destination, &tx, &inputs_utxos, input),
+                verify_signature(
+                    &chain_config,
+                    &destination,
+                    &tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input
+                ),
                 Ok(())
             );
         }
@@ -617,12 +681,24 @@ fn mutate_single(#[case] seed: Seed) {
         // result in the different error.
         for input in 0..inputs - 1 {
             assert_eq!(
-                verify_signature(&chain_config, &destination, &tx, &inputs_utxos, input),
+                verify_signature(
+                    &chain_config,
+                    &destination,
+                    &tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input
+                ),
                 Err(TransactionSigError::SignatureVerificationFailed)
             );
         }
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, inputs),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                inputs
+            ),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
         );
     }
@@ -636,12 +712,24 @@ fn mutate_single(#[case] seed: Seed) {
         // result in the `InvalidInputIndex` error.
         for input in 0..inputs - 1 {
             assert_eq!(
-                verify_signature(&chain_config, &destination, &tx, &inputs_utxos, input),
+                verify_signature(
+                    &chain_config,
+                    &destination,
+                    &tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input
+                ),
                 Ok(())
             );
         }
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, inputs),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                inputs
+            ),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
         );
     }
@@ -652,17 +740,35 @@ fn mutate_single(#[case] seed: Seed) {
 
         // Mutation of the first output makes signature invalid.
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, 0),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                0
+            ),
             Err(TransactionSigError::SignatureVerificationFailed),
         );
         for input in 1..inputs - 1 {
             assert_eq!(
-                verify_signature(&chain_config, &destination, &tx, &inputs_utxos, input),
+                verify_signature(
+                    &chain_config,
+                    &destination,
+                    &tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input
+                ),
                 Ok(())
             );
         }
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, inputs),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                inputs
+            ),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
         );
     }
@@ -701,13 +807,25 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         // result in the `InvalidInputIndex` error.
         for input in 0..inputs - 1 {
             assert_eq!(
-                verify_signature(&chain_config, &destination, &tx, &inputs_utxos, input),
+                verify_signature(
+                    &chain_config,
+                    &destination,
+                    &tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input
+                ),
                 Ok(()),
                 "{input}"
             );
         }
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, inputs),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                inputs
+            ),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs))
         );
     }
@@ -718,18 +836,36 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         let inputs = tx.inputs().len();
 
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, 0),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                0
+            ),
             Err(TransactionSigError::SignatureVerificationFailed),
         );
         for input in 1..inputs - 1 {
             assert_eq!(
-                verify_signature(&chain_config, &destination, &tx, &inputs_utxos, input),
+                verify_signature(
+                    &chain_config,
+                    &destination,
+                    &tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input
+                ),
                 Ok(()),
                 "## {input}"
             );
         }
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, inputs),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                inputs
+            ),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
         );
     }
@@ -743,13 +879,25 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         // result in the `InvalidInputIndex` error.
         for input in 0..inputs - 1 {
             assert_eq!(
-                verify_signature(&chain_config, &destination, &tx, &inputs_utxos, input),
+                verify_signature(
+                    &chain_config,
+                    &destination,
+                    &tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input
+                ),
                 Err(TransactionSigError::SignatureVerificationFailed),
                 "{input}"
             );
         }
         assert_eq!(
-            verify_signature(&chain_config, &destination, &tx, &inputs_utxos, inputs),
+            verify_signature(
+                &chain_config,
+                &destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                inputs
+            ),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
         );
     }
@@ -773,7 +921,13 @@ fn check_mutations<M, R>(
         let inputs = tx.inputs().len();
 
         assert_eq!(
-            verify_signature(chain_config, destination, &tx, inputs_utxos, INVALID_INPUT),
+            verify_signature(
+                chain_config,
+                destination,
+                &tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                INVALID_INPUT
+            ),
             Err(TransactionSigError::InvalidSignatureIndex(
                 INVALID_INPUT,
                 inputs
@@ -781,7 +935,13 @@ fn check_mutations<M, R>(
         );
         for input in 0..inputs {
             assert_eq!(
-                verify_signature(chain_config, destination, &tx, inputs_utxos, input),
+                verify_signature(
+                    chain_config,
+                    destination,
+                    &tx,
+                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    input
+                ),
                 expected
             );
         }

--- a/common/src/chain/transaction/signature/tests/sign_and_verify.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_verify.rs
@@ -52,8 +52,9 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
         .cartesian_product(sig_hash_types().filter(|t| t.outputs_mode() != OutputsMode::Single))
         .cartesian_product(test_data)
     {
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
-        let signed_tx = sign_whole_tx(tx, &private_key, sighash_type, &destination);
+        let signed_tx = sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination);
         // `sign_whole_tx` does nothing if there no inputs.
         if destination == Destination::AnyoneCanSpend && inputs > 0 {
             assert_eq!(
@@ -65,7 +66,7 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
             assert_eq!(signed_tx, Err(TransactionSigError::Unsupported));
         } else {
             let signed_tx = signed_tx.expect("{sighash_type:?} {destination:?}");
-            verify_signed_tx(&chain_config, &signed_tx, &destination)
+            verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
                 .expect("{sighash_type:?} {destination:?}")
         }
     }
@@ -236,10 +237,13 @@ fn sign_and_verify_single(#[case] seed: Seed) {
     ];
 
     for (destination, sighash_type, inputs, outputs, expected) in test_data.into_iter() {
+        let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
-        match sign_whole_tx(tx, &private_key, sighash_type, &destination) {
-            Ok(signed_tx) => verify_signed_tx(&chain_config, &signed_tx, &destination)
-                .expect("{sighash_type:X?}, {destination:?}"),
+        match sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination) {
+            Ok(signed_tx) => {
+                verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
+                    .expect("{sighash_type:X?}, {destination:?}")
+            }
             Err(err) => assert_eq!(Err(err), expected, "{sighash_type:X?}, {destination:?}"),
         }
     }

--- a/common/src/chain/transaction/signature/tests/sign_and_verify.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_verify.rs
@@ -66,8 +66,13 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
             assert_eq!(signed_tx, Err(TransactionSigError::Unsupported));
         } else {
             let signed_tx = signed_tx.expect("{sighash_type:?} {destination:?}");
-            verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
-                .expect("{sighash_type:?} {destination:?}")
+            verify_signed_tx(
+                &chain_config,
+                &signed_tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &destination,
+            )
+            .expect("{sighash_type:?} {destination:?}")
         }
     }
 }
@@ -240,10 +245,13 @@ fn sign_and_verify_single(#[case] seed: Seed) {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
         match sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination) {
-            Ok(signed_tx) => {
-                verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
-                    .expect("{sighash_type:X?}, {destination:?}")
-            }
+            Ok(signed_tx) => verify_signed_tx(
+                &chain_config,
+                &signed_tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &destination,
+            )
+            .expect("{sighash_type:X?}, {destination:?}"),
             Err(err) => assert_eq!(Err(err), expected, "{sighash_type:X?}, {destination:?}"),
         }
     }

--- a/common/src/chain/transaction/signature/tests/utils.rs
+++ b/common/src/chain/transaction/signature/tests/utils.rs
@@ -164,7 +164,12 @@ pub fn generate_and_sign_tx(
     let signed_tx =
         sign_whole_tx(tx, &inputs_utxos, private_key, sighash_type, destination).unwrap();
     assert_eq!(
-        verify_signed_tx(chain_config, &signed_tx, &inputs_utxos, destination),
+        verify_signed_tx(
+            chain_config,
+            &signed_tx,
+            &inputs_utxos.iter().collect::<Vec<_>>(),
+            destination
+        ),
         Ok(())
     );
     Ok(signed_tx)
@@ -183,7 +188,7 @@ pub fn make_signature(
         sighash_type,
         outpoint_dest,
         tx,
-        inputs_utxos,
+        &inputs_utxos.iter().collect::<Vec<_>>(),
         input_num,
     )?;
     Ok(input_sig)
@@ -192,7 +197,7 @@ pub fn make_signature(
 pub fn verify_signed_tx(
     chain_config: &ChainConfig,
     tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[&TxOutput],
     destination: &Destination,
 ) -> Result<(), TransactionSigError> {
     for i in 0..tx.inputs().len() {

--- a/common/src/chain/transaction/signature/tests/utils.rs
+++ b/common/src/chain/transaction/signature/tests/utils.rs
@@ -16,8 +16,8 @@
 use itertools::Itertools;
 
 use crypto::{
-    key::{PrivateKey, PublicKey},
-    random::Rng,
+    key::{KeyKind, PrivateKey, PublicKey},
+    random::{CryptoRng, Rng},
 };
 use script::Script;
 
@@ -36,6 +36,27 @@ use crate::{
     },
     primitives::{amount::UnsignedIntType, Amount, Id, H256},
 };
+
+pub fn generate_input_utxo(
+    rng: &mut (impl Rng + CryptoRng),
+) -> (TxOutput, crypto::key::PrivateKey) {
+    let (private_key, public_key) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
+    let destination = Destination::PublicKey(public_key);
+    let output_value =
+        crate::chain::tokens::OutputValue::Coin(Amount::from_atoms(rng.next_u64() as u128));
+    let utxo = TxOutput::new(
+        output_value,
+        crate::chain::OutputPurpose::Transfer(destination),
+    );
+    (utxo, private_key)
+}
+
+pub fn generate_inputs_utxos(
+    rng: &mut (impl Rng + CryptoRng),
+    input_count: usize,
+) -> (Vec<TxOutput>, Vec<PrivateKey>) {
+    (0..input_count).map(|_| generate_input_utxo(rng)).unzip()
+}
 
 // This is required because we can't access private fields of the Transaction class
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -104,6 +125,7 @@ pub fn generate_unsigned_tx(
 
 pub fn sign_whole_tx(
     tx: Transaction,
+    inputs_utxos: &[TxOutput],
     private_key: &PrivateKey,
     sighash_type: SigHashType,
     destination: &Destination,
@@ -112,7 +134,16 @@ pub fn sign_whole_tx(
         .inputs()
         .iter()
         .enumerate()
-        .map(|(i, _input)| make_signature(&tx, i, private_key, sighash_type, destination.clone()))
+        .map(|(i, _input)| {
+            make_signature(
+                &tx,
+                inputs_utxos,
+                i,
+                private_key,
+                sighash_type,
+                destination.clone(),
+            )
+        })
         .collect();
     let witnesses = sigs?.into_iter().map(InputWitness::Standard).collect_vec();
 
@@ -121,17 +152,19 @@ pub fn sign_whole_tx(
 
 pub fn generate_and_sign_tx(
     chain_config: &ChainConfig,
-    rng: &mut impl Rng,
+    rng: &mut (impl Rng + CryptoRng),
     destination: &Destination,
     inputs: usize,
     outputs: usize,
     private_key: &PrivateKey,
     sighash_type: SigHashType,
 ) -> Result<SignedTransaction, TransactionCreationError> {
-    let tx = generate_unsigned_tx(rng, destination, inputs, outputs).unwrap();
-    let signed_tx = sign_whole_tx(tx, private_key, sighash_type, destination).unwrap();
+    let (inputs_utxos, _priv_keys) = generate_inputs_utxos(rng, inputs);
+    let tx = generate_unsigned_tx(rng, destination, inputs_utxos.len(), outputs).unwrap();
+    let signed_tx =
+        sign_whole_tx(tx, &inputs_utxos, private_key, sighash_type, destination).unwrap();
     assert_eq!(
-        verify_signed_tx(chain_config, &signed_tx, destination),
+        verify_signed_tx(chain_config, &signed_tx, &inputs_utxos, destination),
         Ok(())
     );
     Ok(signed_tx)
@@ -139,6 +172,7 @@ pub fn generate_and_sign_tx(
 
 pub fn make_signature(
     tx: &Transaction,
+    inputs_utxos: &[TxOutput],
     input_num: usize,
     private_key: &PrivateKey,
     sighash_type: SigHashType,
@@ -149,6 +183,7 @@ pub fn make_signature(
         sighash_type,
         outpoint_dest,
         tx,
+        inputs_utxos,
         input_num,
     )?;
     Ok(input_sig)
@@ -157,10 +192,11 @@ pub fn make_signature(
 pub fn verify_signed_tx(
     chain_config: &ChainConfig,
     tx: &SignedTransaction,
+    inputs_utxos: &[TxOutput],
     destination: &Destination,
 ) -> Result<(), TransactionSigError> {
     for i in 0..tx.inputs().len() {
-        verify_signature(chain_config, destination, tx, i)?
+        verify_signature(chain_config, destination, tx, inputs_utxos, i)?
     }
     Ok(())
 }

--- a/utxo/src/utxo.rs
+++ b/utxo/src/utxo.rs
@@ -92,6 +92,10 @@ impl Utxo {
         &self.output
     }
 
+    pub fn take_output(self) -> TxOutput {
+        self.output
+    }
+
     pub fn set_height(&mut self, value: UtxoSource) {
         self.source = value
     }


### PR DESCRIPTION
When creating transactions, we usually need to download the full transactions of the inputs to verify the information provided by the signing software. This becomes an issue when internet connection isn't available or is weak, because transactions can be very large (like those coming from exchanges with way too many outputs). A solution to this problem is including all utxos of the current transaction's inputs in signature hash so that the wallet/software in question can't lie about the amounts claimed to be spent.

Closes #303 