### PR TITLE
Enable scale code as a feature in merkletree crate

### DIFF
--- a/.github/scripts/codecheck.py
+++ b/.github/scripts/codecheck.py
@@ -149,7 +149,7 @@ def check_todos():
 
 def run_checks():
     return all([
-            disallow(SCALECODEC_RE, exclude = ['serialization/core']),
+            disallow(SCALECODEC_RE, exclude = ['serialization/core', 'merkletree']),
             disallow(JSONRPSEE_RE, exclude = ['rpc']),
             check_local_licenses(),
             check_crate_versions(),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "blake2",
  "fixed-hash",
  "itertools",
+ "parity-scale-codec",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rstest",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 crypto = { path = '../crypto'}
-merkletree = { path = "../merkletree", features = ["scale-codec-encode", "scale-codec-decode"] }
+merkletree = { path = "../merkletree", features = ["scale-codec"] }
 serialization = { path = "../serialization" }
 logging = { path = "../logging/" }
 script = { path = '../script'}

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 
 [dependencies]
 crypto = { path = '../crypto'}
-merkletree = { path = "../merkletree" }
+merkletree = { path = "../merkletree", features = ["scale-codec-encode", "scale-codec-decode"] }
 serialization = { path = "../serialization" }
 logging = { path = "../logging/" }
 script = { path = '../script'}

--- a/merkletree/Cargo.toml
+++ b/merkletree/Cargo.toml
@@ -6,8 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-scale-codec-encode = ["dep:parity-scale-codec"]
-scale-codec-decode = ["dep:parity-scale-codec"]
+scale-codec = ["dep:parity-scale-codec"]
 
 [dependencies]
 itertools = "0.10"

--- a/merkletree/Cargo.toml
+++ b/merkletree/Cargo.toml
@@ -5,9 +5,14 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+scale-codec-encode = ["dep:parity-scale-codec"]
+scale-codec-decode = ["dep:parity-scale-codec"]
+
 [dependencies]
 itertools = "0.10"
 thiserror = "1.0"
+parity-scale-codec = { version = "3.1", optional = true }
 
 [dev-dependencies]
 blake2 = "0.10"

--- a/merkletree/src/merkle/mod.rs
+++ b/merkletree/src/merkle/mod.rs
@@ -28,12 +28,12 @@ pub enum MerkleTreeFormError {
 pub enum MerkleTreeProofExtractionError {
     #[error("No leaves were provided to create a proof")]
     NoLeavesToCreateProof,
-    #[error("One or more indexes are larger than the number of leaves in the tree: {0:?} vs leaves count {1}")]
-    IndexOutOfRange(Vec<usize>, usize),
+    #[error("One or more indexes are larger than the number of leaves in the tree: {0:?} vs leaf-count {1}")]
+    IndexOutOfRange(Vec<u32>, u32),
     #[error("Leaf index out of range: {0} vs leaves count {1}")]
-    LeafIndexOutOfRange(usize, usize),
+    LeafIndexOutOfRange(u32, u32),
     #[error("Leaves indices must be sorted in ascending: {0:?}")]
-    UnsortedOrUniqueLeavesIndices(Vec<usize>),
+    UnsortedOrUniqueLeavesIndices(Vec<u32>),
     #[error("Access error: {0}")]
     AccessError(#[from] MerkleTreeAccessError),
 }
@@ -43,9 +43,9 @@ pub enum MerkleTreeAccessError {
     #[error("Invalid tree size provided is invalid: {0}")]
     InvalidTreeSize(usize),
     #[error("Invalid initial index for leaf in iterator. Provided {0} vs tree size {1}")]
-    AbsIndexOutOfRange(usize, usize),
+    AbsIndexOutOfRange(u32, u32),
     #[error("Invalid initial index for leaf in iterator. Provided {0} vs size {1}")]
-    IterStartIndexOutOfRange(usize, usize),
+    IterStartIndexOutOfRange(u32, u32),
 }
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
@@ -53,11 +53,13 @@ pub enum MerkleProofVerificationError {
     #[error("No leaves provided")]
     LeavesContainerProvidedIsEmpty,
     #[error("Invalid tree size")]
-    InvalidTreeLeavesCount(usize),
+    InvalidTreeLeavesCount(u32),
     #[error("One or more leaves have indices out of range: {0:?} vs leaves count {1}")]
-    LeavesIndicesOutOfRange(Vec<usize>, usize),
+    LeavesIndicesOutOfRange(Vec<u32>, u32),
     #[error("One or more nodes have indices out of range: {0:?} vs tree size {1}")]
-    NodesIndicesOutOfRange(Vec<usize>, usize),
+    NodesIndicesOutOfRange(Vec<u32>, u32),
     #[error("A required node is missing. Index of node: {0}")]
-    RequiredNodeMissing(usize),
+    RequiredNodeMissing(u32),
+    #[error("Tree size arithmetic error: {0}")]
+    TreeSizeArithmeticError(u32),
 }

--- a/merkletree/src/merkle/pos/mod.rs
+++ b/merkletree/src/merkle/pos/mod.rs
@@ -15,7 +15,7 @@
 
 pub mod node_kind;
 
-use std::num::NonZeroUsize;
+use std::num::NonZeroU32;
 
 use self::node_kind::NodeKind;
 
@@ -27,11 +27,11 @@ use super::tree::tree_size::TreeSize;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NodePosition {
     tree_size: TreeSize,
-    absolute_index: usize,
+    absolute_index: u32,
 }
 
 impl NodePosition {
-    pub fn from_abs_index(tree_size: TreeSize, absolute_index: usize) -> Option<Self> {
+    pub fn from_abs_index(tree_size: TreeSize, absolute_index: u32) -> Option<Self> {
         if absolute_index >= tree_size.get() {
             return None;
         }
@@ -44,8 +44,8 @@ impl NodePosition {
 
     pub fn from_position(
         tree_size: TreeSize,
-        level_from_bottom: usize,
-        index_in_level: usize,
+        level_from_bottom: u32,
+        index_in_level: u32,
     ) -> Option<Self> {
         let level_count = tree_size.level_count().get();
         if level_from_bottom >= level_count {
@@ -73,13 +73,13 @@ impl NodePosition {
         self.tree_size
     }
 
-    pub fn abs_index(&self) -> usize {
+    pub fn abs_index(&self) -> u32 {
         self.absolute_index
     }
 
     /// Returns the level and index in the level of the node, as in (level, index).
     /// Notice that the index value is capped by the number of nodes in the level.
-    pub fn position(&self) -> (usize, usize) {
+    pub fn position(&self) -> (u32, u32) {
         assert!(
             self.abs_index() < self.tree_size.get(),
             "Index must be within the tree size"
@@ -87,7 +87,7 @@ impl NodePosition {
 
         let level_from_top = (self.tree_size.get() - self.abs_index() + 1)
             .next_power_of_two()
-            .trailing_zeros() as usize;
+            .trailing_zeros();
 
         let level = self.tree_size.level_count().get() - level_from_top;
         let level_start = self.tree_size.level_start(level).expect("Abs index is valid");
@@ -107,8 +107,10 @@ impl NodePosition {
         }
     }
 
-    pub fn tree_level_count(&self) -> NonZeroUsize {
-        (self.tree_size.get().trailing_ones() as usize)
+    pub fn tree_level_count(&self) -> NonZeroU32 {
+        self.tree_size
+            .get()
+            .trailing_ones()
             .try_into()
             .expect("Cannot be zero if tree_size is not zero")
     }

--- a/merkletree/src/merkle/pos/tests.rs
+++ b/merkletree/src/merkle/pos/tests.rs
@@ -20,7 +20,7 @@ use super::*;
 
 #[test]
 fn construction_from_abs_index() {
-    for tree_size_in in 1..16 {
+    for tree_size_in in 1..16u32 {
         let tree_size: Result<TreeSize, _> = tree_size_in.try_into();
         let tree_size = match tree_size {
             Ok(t) => {
@@ -52,7 +52,7 @@ fn construction_from_abs_index() {
     }
 }
 
-const BIG_VAL: usize = 1000;
+const BIG_VAL: u32 = 1000;
 
 #[rstest]
 #[case(1,  0..1, &[0..1], true)]
@@ -68,15 +68,15 @@ const BIG_VAL: usize = 1000;
 #[case(31, 0..2, &[16..BIG_VAL, 8..BIG_VAL,  4..BIG_VAL, 2..BIG_VAL, 1..BIG_VAL], false)]
 #[case(63, 0..2, &[32..BIG_VAL, 16..BIG_VAL, 8..BIG_VAL, 4..BIG_VAL, 2..BIG_VAL, 1..BIG_VAL], false)]
 fn construction_from_position(
-    #[case] tree_size: usize,
-    #[case] levels: Range<usize>,
-    #[case] indices_in_levels: &[Range<usize>],
+    #[case] tree_size: u32,
+    #[case] levels: Range<u32>,
+    #[case] indices_in_levels: &[Range<u32>],
     #[case] success: bool,
 ) {
     let tree_size: TreeSize = tree_size.try_into().unwrap();
 
     for level in levels {
-        for index in indices_in_levels[level].clone() {
+        for index in indices_in_levels[level as usize].clone() {
             let pos = NodePosition::from_position(tree_size, level, index);
             assert_eq!(
                 pos.is_some(),
@@ -99,8 +99,8 @@ fn construction_from_position(
 #[test]
 fn abs_index_to_and_from_pos() {
     // Exhaustive to a limit to avoid making the test take too long
-    for tree_log_size in 1..10 {
-        let tree_size: TreeSize = ((1 << tree_log_size) - 1).try_into().unwrap();
+    for tree_log_size in 1..10u32 {
+        let tree_size: TreeSize = ((1 << tree_log_size) - 1u32).try_into().unwrap();
         for abs_pos in 0..tree_size.get() {
             let pos_from_abs = NodePosition::from_abs_index(tree_size, abs_pos).unwrap();
             let (level, index) = pos_from_abs.position();
@@ -112,7 +112,7 @@ fn abs_index_to_and_from_pos() {
 
 #[test]
 fn parent_iter_one_leaf() {
-    let t_size = 1.try_into().unwrap();
+    let t_size = 1u32.try_into().unwrap();
 
     let n = NodePosition::from_abs_index(t_size, 0).unwrap();
     let mut leaf0iter = n.into_iter_parents();
@@ -122,7 +122,7 @@ fn parent_iter_one_leaf() {
 
 #[test]
 fn parent_iter_two_leaves() {
-    let t_size = 3.try_into().unwrap();
+    let t_size = 3u32.try_into().unwrap();
 
     let n = NodePosition::from_abs_index(t_size, 0).unwrap();
     let mut leaf0iter = n.into_iter_parents();
@@ -139,7 +139,7 @@ fn parent_iter_two_leaves() {
 
 #[test]
 fn parent_iter_four_leaves() {
-    let t_size = 7.try_into().unwrap();
+    let t_size = 7u32.try_into().unwrap();
 
     let n = NodePosition::from_abs_index(t_size, 0).unwrap();
     let mut leaf0iter = n.into_iter_parents();
@@ -172,7 +172,7 @@ fn parent_iter_four_leaves() {
 
 #[test]
 fn parent_iter_eight_leaves() {
-    let t_size = 15.try_into().unwrap();
+    let t_size = 15u32.try_into().unwrap();
 
     let n = NodePosition::from_abs_index(t_size, 0).unwrap();
     let mut leaf0iter = n.into_iter_parents();
@@ -241,7 +241,7 @@ fn parent_iter_eight_leaves() {
 
 #[test]
 fn node_and_siblings_one_leaf() {
-    let t_size = 1.try_into().unwrap();
+    let t_size = 1u32.try_into().unwrap();
     let node = NodePosition::from_abs_index(t_size, 0).unwrap();
 
     assert_eq!(node.abs_index(), 0);
@@ -250,7 +250,7 @@ fn node_and_siblings_one_leaf() {
 
 #[test]
 fn node_and_siblings_two_leaves() {
-    let t_size = 3.try_into().unwrap();
+    let t_size = 3u32.try_into().unwrap();
 
     // To get the sibling, we use this simple function
     let flip_even_odd = |i| if i % 2 == 0 { i + 1 } else { i - 1 };
@@ -270,7 +270,7 @@ fn node_and_siblings_two_leaves() {
 
 #[test]
 fn node_and_siblings_four_leaves() {
-    let t_size = 7.try_into().unwrap();
+    let t_size = 7u32.try_into().unwrap();
 
     // To get the sibling, we use this simple function
     let flip_even_odd = |i| if i % 2 == 0 { i + 1 } else { i - 1 };
@@ -296,7 +296,7 @@ fn node_and_siblings_four_leaves() {
 
 #[test]
 fn node_and_siblings_eight_leaves() {
-    let t_size = 15.try_into().unwrap();
+    let t_size = 15u32.try_into().unwrap();
 
     // To get the sibling, we use this simple function
     let flip_even_odd = |i| if i % 2 == 0 { i + 1 } else { i - 1 };
@@ -329,7 +329,7 @@ fn node_and_siblings_eight_leaves() {
 #[test]
 fn from_abs_index_construction_boundaries() {
     for p in 1..10 {
-        let t_size: TreeSize = ((1 << p) - 1).try_into().unwrap();
+        let t_size: TreeSize = ((1 << p) - 1u32).try_into().unwrap();
 
         for i in 0..t_size.get() {
             assert!(NodePosition::from_abs_index(t_size, i).is_some());
@@ -343,18 +343,18 @@ fn from_abs_index_construction_boundaries() {
 #[test]
 fn absolute_index_from_bottom() {
     // Tree size: 1
-    let s: TreeSize = 1.try_into().expect("is not zero");
+    let s: TreeSize = 1u32.try_into().expect("is not zero");
     assert_eq!(NodePosition::from_position(s, 0, 0).unwrap().abs_index(), 0);
 
     // Tree size: 3
-    let s: TreeSize = 3.try_into().expect("is not zero");
+    let s: TreeSize = 3u32.try_into().expect("is not zero");
     assert_eq!(NodePosition::from_position(s, 0, 0).unwrap().abs_index(), 0);
     assert_eq!(NodePosition::from_position(s, 0, 1).unwrap().abs_index(), 1);
 
     assert_eq!(NodePosition::from_position(s, 1, 0).unwrap().abs_index(), 2);
 
     // Tree size: 7
-    let s: TreeSize = 7.try_into().expect("is not zero");
+    let s: TreeSize = 7u32.try_into().expect("is not zero");
     assert_eq!(NodePosition::from_position(s, 0, 0).unwrap().abs_index(), 0);
     assert_eq!(NodePosition::from_position(s, 0, 1).unwrap().abs_index(), 1);
     assert_eq!(NodePosition::from_position(s, 0, 2).unwrap().abs_index(), 2);
@@ -366,7 +366,7 @@ fn absolute_index_from_bottom() {
     assert_eq!(NodePosition::from_position(s, 2, 0).unwrap().abs_index(), 6);
 
     // Tree size: 15
-    let s: TreeSize = 15.try_into().expect("is not zero");
+    let s: TreeSize = 15u32.try_into().expect("is not zero");
     assert_eq!(NodePosition::from_position(s, 0, 0).unwrap().abs_index(), 0);
     assert_eq!(NodePosition::from_position(s, 0, 1).unwrap().abs_index(), 1);
     assert_eq!(NodePosition::from_position(s, 0, 2).unwrap().abs_index(), 2);

--- a/merkletree/src/merkle/proof/multi/mod.rs
+++ b/merkletree/src/merkle/proof/multi/mod.rs
@@ -206,8 +206,10 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> MultiProofNodes<'a, T, H> {
 /// This struct is supposed to be serialized and stored to be used later, unlike `MultiProofNodes`.
 #[must_use]
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "scale-codec-encode", derive(parity_scale_codec::Encode))]
-#[cfg_attr(feature = "scale-codec-decode", derive(parity_scale_codec::Decode))]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub struct MultiProofHashes<T, H> {
     /// The minimal set of nodes needed to recreate the root hash (in addition to the leaves)
     nodes: BTreeMap<u32, T>,

--- a/merkletree/src/merkle/proof/multi/mod.rs
+++ b/merkletree/src/merkle/proof/multi/mod.rs
@@ -18,7 +18,6 @@ mod ordered_node;
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
-    num::NonZeroUsize,
 };
 
 use itertools::Itertools;
@@ -48,7 +47,7 @@ pub struct MultiProofNodes<'a, T, H> {
     /// The minimal set of nodes needed to recreate the root hash (in addition to the leaves)
     nodes: Vec<Node<'a, T, H>>,
     /// The number of leaves in the tree, from which this proof was extracted
-    tree_leaf_count: NonZeroUsize,
+    tree_leaf_count: u32,
 }
 
 impl<T: Debug, H> Debug for MultiProofNodes<'_, T, H> {
@@ -62,8 +61,8 @@ impl<T: Debug, H> Debug for MultiProofNodes<'_, T, H> {
 }
 
 /// Ensure the leaves indices are sorted and unique
-fn is_sorted_and_unique(leaves_indices: &[usize]) -> bool {
-    leaves_indices.iter().tuple_windows::<(&usize, &usize)>().all(|(i, j)| i < j)
+fn is_sorted_and_unique(leaves_indices: &[u32]) -> bool {
+    leaves_indices.iter().tuple_windows::<(&u32, &u32)>().all(|(i, j)| i < j)
 }
 
 fn transpose<T>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
@@ -91,7 +90,7 @@ impl<'a, T, H> MultiProofNodes<'a, T, H> {
         &self.proof_leaves
     }
 
-    pub fn tree_leaf_count(&self) -> NonZeroUsize {
+    pub fn tree_leaf_count(&self) -> u32 {
         self.tree_leaf_count
     }
 }
@@ -99,7 +98,7 @@ impl<'a, T, H> MultiProofNodes<'a, T, H> {
 impl<'a, T: Clone, H: PairHasher<Type = T>> MultiProofNodes<'a, T, H> {
     pub fn from_tree_leaves(
         tree: &'a MerkleTree<T, H>,
-        leaves_indices: &[usize],
+        leaves_indices: &[u32],
     ) -> Result<Self, MerkleTreeProofExtractionError> {
         if leaves_indices.is_empty() {
             return Err(MerkleTreeProofExtractionError::NoLeavesToCreateProof);
@@ -157,7 +156,7 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> MultiProofNodes<'a, T, H> {
             let siblings = nodes_of_level
                 .iter()
                 .map(|node| node.sibling().expect(sibling_err).abs_index())
-                .collect::<BTreeSet<usize>>();
+                .collect::<BTreeSet<u32>>();
 
             // We remove leaves that are already in siblings because they will come from the verification input.
             // This happens when the leaves, for which a proof is requested, are used together to build a parent node
@@ -190,14 +189,14 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> MultiProofNodes<'a, T, H> {
                 .map(|i| tree.node_from_bottom(0, *i).expect("Leaves already checked"))
                 .collect(),
             nodes: proof,
-            tree_leaf_count: tree.leaf_count(),
+            tree_leaf_count: tree.leaf_count().get(),
         })
     }
 
     pub fn into_values(self) -> MultiProofHashes<T, H> {
         MultiProofHashes {
             nodes: self.nodes.into_iter().map(|n| (n.abs_index(), n.hash().clone())).collect(),
-            tree_leaf_count: self.proof_leaves[0].tree().leaf_count(),
+            tree_leaf_count: self.proof_leaves[0].tree().leaf_count().get(),
             _phantom: std::marker::PhantomData,
         }
     }
@@ -207,32 +206,31 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> MultiProofNodes<'a, T, H> {
 /// This struct is supposed to be serialized and stored to be used later, unlike `MultiProofNodes`.
 #[must_use]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "scale-codec-encode", derive(parity_scale_codec::Encode))]
+#[cfg_attr(feature = "scale-codec-decode", derive(parity_scale_codec::Decode))]
 pub struct MultiProofHashes<T, H> {
     /// The minimal set of nodes needed to recreate the root hash (in addition to the leaves)
-    nodes: BTreeMap<usize, T>,
+    nodes: BTreeMap<u32, T>,
     /// The number of leaves in the tree, from which this proof was extracted
-    tree_leaf_count: NonZeroUsize,
+    tree_leaf_count: u32,
     _phantom: std::marker::PhantomData<H>,
 }
 
 impl<T, H> MultiProofHashes<T, H> {
-    pub fn nodes(&self) -> &BTreeMap<usize, T> {
+    pub fn nodes(&self) -> &BTreeMap<u32, T> {
         &self.nodes
     }
 
-    pub fn tree_leaf_count(&self) -> NonZeroUsize {
+    pub fn tree_leaf_count(&self) -> u32 {
         self.tree_leaf_count
     }
 }
 
 impl<T: Eq + Clone, H: PairHasher<Type = T>> MultiProofHashes<T, H> {
     /// While verifying the multi-proof, we need to precalculate all the possible nodes that are required to build the root hash.
-    fn calculate_missing_nodes(
-        tree_size: TreeSize,
-        input: BTreeMap<&usize, &T>,
-    ) -> BTreeMap<usize, T> {
+    fn calculate_missing_nodes(tree_size: TreeSize, input: BTreeMap<&u32, &T>) -> BTreeMap<u32, T> {
         let mut result =
-            input.into_iter().map(|(a, b)| (*a, b.clone())).collect::<BTreeMap<usize, T>>();
+            input.into_iter().map(|(a, b)| (*a, b.clone())).collect::<BTreeMap<u32, T>>();
         for (index_l, index_r) in tree_size.iter_pairs_indices() {
             if !result.contains_key(&index_l) || !result.contains_key(&(index_r)) {
                 continue;
@@ -265,7 +263,7 @@ impl<T: Eq + Clone, H: PairHasher<Type = T>> MultiProofHashes<T, H> {
     /// circumventing verification by providing a proof of a single node.
     pub fn verify(
         &self,
-        leaves: BTreeMap<usize, T>,
+        leaves: BTreeMap<u32, T>,
         root: T,
     ) -> Result<ProofVerifyResult, MerkleProofVerificationError> {
         // in case it's a single-node tree, we don't need to verify or hash anything
@@ -274,21 +272,21 @@ impl<T: Eq + Clone, H: PairHasher<Type = T>> MultiProofHashes<T, H> {
             return Err(MerkleProofVerificationError::LeavesContainerProvidedIsEmpty);
         }
 
-        if !self.tree_leaf_count.get().is_power_of_two() {
+        if !self.tree_leaf_count.is_power_of_two() {
             return Err(MerkleProofVerificationError::InvalidTreeLeavesCount(
-                self.tree_leaf_count().get(),
+                self.tree_leaf_count(),
             ));
         }
 
-        if leaves.iter().any(|(index, _hash)| *index >= self.tree_leaf_count.get()) {
+        if leaves.iter().any(|(index, _hash)| *index >= self.tree_leaf_count) {
             return Err(MerkleProofVerificationError::LeavesIndicesOutOfRange(
                 leaves.keys().cloned().collect(),
-                self.tree_leaf_count.get(),
+                self.tree_leaf_count,
             ));
         }
 
-        let tree_size = TreeSize::from_value(self.tree_leaf_count.get() * 2 - 1)
-            .expect("Already proven from source");
+        let tree_size =
+            TreeSize::from_u32(self.tree_leaf_count * 2 - 1).expect("Already proven from source");
 
         if self.nodes.iter().any(|(index, _hash)| *index >= tree_size.get()) {
             return Err(MerkleProofVerificationError::NodesIndicesOutOfRange(

--- a/merkletree/src/merkle/proof/single/mod.rs
+++ b/merkletree/src/merkle/proof/single/mod.rs
@@ -111,8 +111,10 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> SingleProofNodes<'a, T, H> {
 /// This struct is supposed to be serialized, unlike `SingleProofNodes`.
 #[must_use]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "scale-codec-encode", derive(parity_scale_codec::Encode))]
-#[cfg_attr(feature = "scale-codec-decode", derive(parity_scale_codec::Decode))]
+#[cfg_attr(
+    feature = "scale-codec",
+    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
+)]
 pub struct SingleProofHashes<T, H> {
     leaf_index_in_level: u32,
     branch: Vec<T>,

--- a/merkletree/src/merkle/proof/single/mod.rs
+++ b/merkletree/src/merkle/proof/single/mod.rs
@@ -61,7 +61,7 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> SingleProofNodes<'a, T, H> {
     /// A proof doesn't contain the root.
     pub fn from_tree_leaf(
         tree: &'a MerkleTree<T, H>,
-        leaf_index: usize,
+        leaf_index: u32,
     ) -> Result<Self, MerkleTreeProofExtractionError> {
         let leaf_count = tree.leaf_count().get();
         if leaf_index > leaf_count {
@@ -82,8 +82,8 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> SingleProofNodes<'a, T, H> {
         let proof: Vec<_> = leaf.into_iter_parents().map_while(|n| n.sibling()).collect();
 
         assert_eq!(
-            proof.len(),
-            tree.level_count().get() - 1,
+            proof.len() as u32,
+            tree.level_count().get()  - 1,
             "This happens only if the we fail to find a sibling, which is only for root. In the loop, this cannot happen, so siblings must exist"
         );
 
@@ -97,7 +97,7 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> SingleProofNodes<'a, T, H> {
 
     pub fn into_values(self) -> SingleProofHashes<T, H> {
         let proof = self.branch.into_iter().map(|node| node.hash().clone()).collect::<Vec<_>>();
-        let leaf_abs_index = self.leaf.into_position().position().1 as u32;
+        let leaf_abs_index = self.leaf.into_position().position().1;
         SingleProofHashes {
             leaf_index_in_level: leaf_abs_index,
             branch: proof,
@@ -111,6 +111,8 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> SingleProofNodes<'a, T, H> {
 /// This struct is supposed to be serialized, unlike `SingleProofNodes`.
 #[must_use]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "scale-codec-encode", derive(parity_scale_codec::Encode))]
+#[cfg_attr(feature = "scale-codec-decode", derive(parity_scale_codec::Decode))]
 pub struct SingleProofHashes<T, H> {
     leaf_index_in_level: u32,
     branch: Vec<T>,

--- a/merkletree/src/merkle/tree/tests.rs
+++ b/merkletree/src/merkle/tree/tests.rs
@@ -224,11 +224,11 @@ fn merkletree_with_arbitrary_length_5() {
 fn leaf_count_from_tree_size() {
     for i in 1..30 {
         let leaf_count = 1 << (i - 1);
-        let tree_size = (1 << i) - 1;
+        let tree_size: u32 = (1 << i) - 1;
         let tree_size: TreeSize = tree_size.try_into().unwrap();
         assert_eq!(
             tree_size.leaf_count(),
-            NonZeroUsize::new(leaf_count).unwrap(),
+            NonZeroU32::new(leaf_count).unwrap(),
             "Check failed for i = {}",
             i
         );
@@ -410,11 +410,11 @@ fn bottom_access_eight_leaves() {
 
 #[test]
 fn position_from_index_1_tree_element() {
-    let tree_size: TreeSize = 1.try_into().unwrap();
+    let tree_size: TreeSize = 1u32.try_into().unwrap();
     {
         let level = 0;
         let level_start = 0;
-        let level_end: usize = 1;
+        let level_end: u32 = 1;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i).unwrap(),
@@ -426,11 +426,11 @@ fn position_from_index_1_tree_element() {
 
 #[test]
 fn position_from_index_3_tree_elements() {
-    let tree_size: TreeSize = 3.try_into().unwrap();
+    let tree_size: TreeSize = 3u32.try_into().unwrap();
     {
         let level = 0;
         let level_start = 0;
-        let level_end: usize = 2;
+        let level_end: u32 = 2;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),
@@ -441,7 +441,7 @@ fn position_from_index_3_tree_elements() {
     {
         let level = 1;
         let level_start = 2;
-        let level_end: usize = 3;
+        let level_end: u32 = 3;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),
@@ -453,11 +453,11 @@ fn position_from_index_3_tree_elements() {
 
 #[test]
 fn position_from_index_7_tree_elements() {
-    let tree_size: TreeSize = 7.try_into().unwrap();
+    let tree_size: TreeSize = 7u32.try_into().unwrap();
     {
         let level = 0;
         let level_start = 0;
-        let level_end: usize = 4;
+        let level_end: u32 = 4;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),
@@ -468,7 +468,7 @@ fn position_from_index_7_tree_elements() {
     {
         let level = 1;
         let level_start = 4;
-        let level_end: usize = 6;
+        let level_end: u32 = 6;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),
@@ -479,7 +479,7 @@ fn position_from_index_7_tree_elements() {
     {
         let level = 2;
         let level_start = 6;
-        let level_end: usize = 7;
+        let level_end: u32 = 7;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),
@@ -491,11 +491,11 @@ fn position_from_index_7_tree_elements() {
 
 #[test]
 fn position_from_index_15_tree_elements() {
-    let tree_size: TreeSize = 15.try_into().unwrap();
+    let tree_size: TreeSize = 15u32.try_into().unwrap();
     {
         let level = 0;
         let level_start = 0;
-        let level_end: usize = 8;
+        let level_end: u32 = 8;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),
@@ -506,7 +506,7 @@ fn position_from_index_15_tree_elements() {
     {
         let level = 1;
         let level_start = 8;
-        let level_end: usize = 12;
+        let level_end: u32 = 12;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),
@@ -517,7 +517,7 @@ fn position_from_index_15_tree_elements() {
     {
         let level = 2;
         let level_start = 12;
-        let level_end: usize = 14;
+        let level_end: u32 = 14;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),
@@ -528,7 +528,7 @@ fn position_from_index_15_tree_elements() {
     {
         let level = 3;
         let level_start = 14;
-        let level_end: usize = 15;
+        let level_end: u32 = 15;
         for i in level_start..level_end {
             assert_eq!(
                 NodePosition::from_abs_index(tree_size, i),


### PR DESCRIPTION
Another step to move the crate outside of mintlayer-core