### PR TITLE
Workaround for race in shutdown RPC call

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -146,13 +146,13 @@ impl subsystem::Subsystem for Rpc {
     async fn shutdown(self) {
         if let Some(obj) = self.http {
             match obj.1.stop() {
-                Ok(_) => (),
+                Ok(()) => obj.1.stopped().await,
                 Err(e) => log::error!("Http RPC stop handle acquisition failed: {}", e),
             }
         }
         if let Some(obj) = self.websocket {
             match obj.1.stop() {
-                Ok(_) => (),
+                Ok(()) => obj.1.stopped().await,
                 Err(e) => log::error!("Websocket RPC stop handle acquisition failed: {}", e),
             }
         }


### PR DESCRIPTION
There was an unexpected failed functional test run: https://github.com/mintlayer/mintlayer-core/actions/runs/4582639337/attempts/1
After reading the logs and some experimentation, I'm pretty sure this happened because the `node_shutdown` RPC call can sometimes return an error. The reason is a race between processing the `jsonrpsee` response and shutting down the process. It looks like this:

```
$ curl -v -XPOST -H"Content-Type: application/json" http://localhost:3030 -d '{"jsonrpc":"2.0","id":1,"method":"node_shutdown","params":null}'                                                     
...
* Empty reply from server             
* Closing connection 0
curl: (52) Empty reply from server                                                                                                                                                                 
```

I could not find a proper fix for this problem (it looks like `jsonrpsee` does not support graceful shutdowns), so I added this workaround instead.