### PR TITLE
Add network protocol version to p2p connections

### DIFF
--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -123,7 +123,8 @@ impl Builder {
             coin_decimals: Mlt::DECIMALS,
             magic_bytes: chain_type.default_magic_bytes(),
             p2p_port: chain_type.default_p2p_port(),
-            version: SemVer::new(0, 1, 0),
+            version: SemVer::try_from(env!("CARGO_PKG_VERSION"))
+                .expect("invalid CARGO_PKG_VERSION value"),
             max_block_header_size: super::MAX_BLOCK_HEADER_SIZE,
             max_block_size_with_standard_txs: super::MAX_BLOCK_TXS_SIZE,
             max_block_size_with_smart_contracts: super::MAX_BLOCK_CONTRACTS_SIZE,

--- a/dns_server/src/crawler_p2p/crawler/tests/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler/tests/mod.rs
@@ -26,6 +26,7 @@ use p2p::{
     config::NodeType,
     error::{DialError, P2pError},
     net::types::PeerInfo,
+    protocol::NETWORK_PROTOCOL_CURRENT,
     types::peer_id::PeerId,
 };
 use rstest::rstest;
@@ -59,6 +60,7 @@ fn basic(#[case] seed: Seed) {
             address: node1,
             peer_info: PeerInfo {
                 peer_id: peer1,
+                protocol: NETWORK_PROTOCOL_CURRENT,
                 network: *chain_config.magic_bytes(),
                 version: *chain_config.version(),
                 user_agent: mintlayer_core_user_agent(),
@@ -90,6 +92,7 @@ fn basic(#[case] seed: Seed) {
             address: node2,
             peer_info: PeerInfo {
                 peer_id: peer2,
+                protocol: NETWORK_PROTOCOL_CURRENT,
                 network: *chain_config.magic_bytes(),
                 version: *chain_config.version(),
                 user_agent: mintlayer_core_user_agent(),
@@ -168,6 +171,7 @@ fn randomized(#[case] seed: Seed) {
                     address,
                     peer_info: PeerInfo {
                         peer_id: PeerId::new(),
+                        protocol: NETWORK_PROTOCOL_CURRENT,
                         network: *chain_config.magic_bytes(),
                         version: *chain_config.version(),
                         user_agent: mintlayer_core_user_agent(),
@@ -186,6 +190,7 @@ fn randomized(#[case] seed: Seed) {
                     address,
                     peer_info: PeerInfo {
                         peer_id: PeerId::new(),
+                        protocol: NETWORK_PROTOCOL_CURRENT,
                         network: [255, 255, 255, 255],
                         version: *chain_config.version(),
                         user_agent: mintlayer_core_user_agent(),
@@ -236,6 +241,7 @@ fn incompatible_node(#[case] seed: Seed) {
             address: node1,
             peer_info: PeerInfo {
                 peer_id: peer1,
+                protocol: NETWORK_PROTOCOL_CURRENT,
                 network: [255, 255, 255, 255],
                 version: *chain_config.version(),
                 user_agent: mintlayer_core_user_agent(),

--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
@@ -38,6 +38,7 @@ use p2p::{
         types::{ConnectivityEvent, PeerInfo, SyncingEvent},
         ConnectivityService, NetworkingService, SyncingEventReceiver,
     },
+    protocol::NETWORK_PROTOCOL_CURRENT,
     testing_utils::P2pTokioTestTimeGetter,
     types::peer_id::PeerId,
 };
@@ -136,6 +137,7 @@ impl ConnectivityService<MockNetworkingService> for MockConnectivityHandle {
             let peer_id = PeerId::new();
             let peer_info = PeerInfo {
                 peer_id,
+                protocol: NETWORK_PROTOCOL_CURRENT,
                 network: *node.chain_config.magic_bytes(),
                 version: SemVer::new(1, 2, 3),
                 user_agent: mintlayer_core_user_agent(),

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -29,7 +29,7 @@ serde = { workspace = true, features = ["derive"] }
 toml = "0.7"
 directories = "4.0"
 paste = "1.0"
-fs4 = "0.6.3"
+fs4 = "0.6"
 
 [dev-dependencies]
 crypto = { path = "../crypto" }

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -22,14 +22,18 @@ use common::{
 };
 use mempool::error::Error as MempoolError;
 
+use crate::protocol::NetworkProtocol;
+
 /// Errors related to invalid data/peer information that results in connection getting closed
 /// and the peer getting banned.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ProtocolError {
+    #[error("Peer has an unsupported network protocol: {0:?}")]
+    UnsupportedProtocol(NetworkProtocol),
     #[error("Peer is in different network. Our network {0:?}, their network {1:?}")]
     DifferentNetwork([u8; 4], [u8; 4]),
     #[error("Peer has an unsupported version. Our version {0}, their version {1}")]
-    InvalidVersion(SemVer, SemVer),
+    UnsupportedVersion(SemVer, SemVer),
     #[error("Peer is unresponsive")]
     Unresponsive,
     #[error("Locator size ({0}) exceeds allowed limit ({1})")]
@@ -193,8 +197,9 @@ impl BanScore for P2pError {
 impl BanScore for ProtocolError {
     fn ban_score(&self) -> u32 {
         match self {
+            ProtocolError::UnsupportedProtocol(_) => 0,
             ProtocolError::DifferentNetwork(_, _) => 100,
-            ProtocolError::InvalidVersion(_, _) => 100,
+            ProtocolError::UnsupportedVersion(_, _) => 0,
             ProtocolError::Unresponsive => 100,
             ProtocolError::LocatorSizeExceeded(_, _) => 20,
             ProtocolError::BlocksRequestLimitExceeded(_, _) => 20,

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use chainstate::{ban_score::BanScore, ChainstateError};
 use common::{
     chain::{Block, Transaction},
-    primitives::{semver::SemVer, Id},
+    primitives::Id,
 };
 use mempool::error::Error as MempoolError;
 
@@ -32,8 +32,6 @@ pub enum ProtocolError {
     UnsupportedProtocol(NetworkProtocol),
     #[error("Peer is in different network. Our network {0:?}, their network {1:?}")]
     DifferentNetwork([u8; 4], [u8; 4]),
-    #[error("Peer has an unsupported version. Our version {0}, their version {1}")]
-    UnsupportedVersion(SemVer, SemVer),
     #[error("Peer is unresponsive")]
     Unresponsive,
     #[error("Locator size ({0}) exceeds allowed limit ({1})")]
@@ -199,7 +197,6 @@ impl BanScore for ProtocolError {
         match self {
             ProtocolError::UnsupportedProtocol(_) => 0,
             ProtocolError::DifferentNetwork(_, _) => 100,
-            ProtocolError::UnsupportedVersion(_, _) => 0,
             ProtocolError::Unresponsive => 100,
             ProtocolError::LocatorSizeExceeded(_, _) => 20,
             ProtocolError::BlocksRequestLimitExceeded(_, _) => 20,

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -20,12 +20,14 @@ pub mod interface;
 pub mod message;
 pub mod net;
 pub mod peer_manager;
+pub mod protocol;
 pub mod rpc;
 pub mod sync;
-#[cfg(feature = "testing_utils")]
-pub mod testing_utils;
 pub mod types;
 pub mod utils;
+
+#[cfg(feature = "testing_utils")]
+pub mod testing_utils;
 
 use std::{
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -483,17 +483,19 @@ where
     fn handle_peer_event(&mut self, peer_id: PeerId, event: PeerEvent) -> crate::Result<()> {
         match event {
             PeerEvent::PeerInfoReceived {
+                protocol,
                 network,
-                version,
                 services,
+                user_agent,
+                version,
                 receiver_address,
                 handshake_nonce,
-                user_agent,
             } => self.create_peer(
                 peer_id,
                 handshake_nonce,
                 PeerInfo {
                     peer_id,
+                    protocol,
                     network,
                     version,
                     user_agent,

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -260,12 +260,8 @@ where
                 biased;
 
                 // Handle commands.
-                command_res = self.cmd_rx.recv() => {
-                    let Some(command) = command_res
-                    else {
-                        return Ok(());
-                    };
-                    self.handle_command(command);
+                command = self.cmd_rx.recv() => {
+                    self.handle_command(command.ok_or(P2pError::ChannelClosed)?);
                 },
                 // Process pending commands
                 callback = self.command_queue.select_next_some(), if !self.command_queue.is_empty() => {

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -260,8 +260,12 @@ where
                 biased;
 
                 // Handle commands.
-                command = self.cmd_rx.recv() => {
-                    self.handle_command(command.ok_or(P2pError::ChannelClosed)?);
+                command_res = self.cmd_rx.recv() => {
+                    let Some(command) = command_res
+                    else {
+                        return Ok(());
+                    };
+                    self.handle_command(command);
                 },
                 // Process pending commands
                 callback = self.command_queue.select_next_some(), if !self.command_queue.is_empty() => {

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -141,9 +141,10 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
                 sync_tx,
             );
 
-            // TODO: Shutdown p2p if the backend unexpectedly quits
-            if let Err(err) = backend.run().await {
-                log::error!("failed to run backend: {err}");
+            let res = backend.run().await;
+            if let Err(err) = res {
+                // A false error may occur when the node is shutting down
+                log::error!("backend failed: {err}");
             }
         });
 

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -141,10 +141,9 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
                 sync_tx,
             );
 
-            let res = backend.run().await;
-            if let Err(err) = res {
-                // A false error may occur when the node is shutting down
-                log::error!("backend failed: {err}");
+            // TODO: Shutdown p2p if the backend unexpectedly quits
+            if let Err(err) = backend.run().await {
+                log::error!("failed to run backend: {err}");
             }
         });
 

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -110,14 +110,14 @@ where
     async fn handshake(&mut self) -> crate::Result<()> {
         match self.peer_role {
             PeerRole::Inbound => {
-                let Ok(types::Message::Handshake(types::HandshakeMessage::Hello {
+                let types::Message::Handshake(types::HandshakeMessage::Hello {
                     version,
                     network,
                     services,
                     receiver_address,
                     handshake_nonce,
                     user_agent,
-                })) = self.socket.recv().await
+                }) = self.socket.recv().await?
                 else {
                     return Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected));
                 };
@@ -163,13 +163,13 @@ where
                     }))
                     .await?;
 
-                let Ok(types::Message::Handshake(types::HandshakeMessage::HelloAck {
+                let types::Message::Handshake(types::HandshakeMessage::HelloAck {
                     version,
                     network,
                     user_agent,
                     services,
                     receiver_address,
-                })) = self.socket.recv().await
+                }) = self.socket.recv().await?
                 else {
                     return Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected));
                 };

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -111,7 +111,7 @@ where
     async fn handshake(&mut self) -> crate::Result<()> {
         match self.peer_role {
             PeerRole::Inbound => {
-                let types::Message::Handshake(types::HandshakeMessage::Hello {
+                let Ok(types::Message::Handshake(types::HandshakeMessage::Hello {
                     protocol,
                     network,
                     services,
@@ -119,7 +119,7 @@ where
                     version,
                     receiver_address,
                     handshake_nonce,
-                }) = self.socket.recv().await?
+                })) = self.socket.recv().await
                 else {
                     return Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected));
                 };
@@ -168,14 +168,14 @@ where
                     }))
                     .await?;
 
-                let types::Message::Handshake(types::HandshakeMessage::HelloAck {
+                let Ok(types::Message::Handshake(types::HandshakeMessage::HelloAck {
                     protocol,
                     network,
                     user_agent,
                     version,
                     services,
                     receiver_address,
-                }) = self.socket.recv().await?
+                })) = self.socket.recv().await
                 else {
                     return Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected));
                 };

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -31,6 +31,7 @@ use crate::{
         },
         types::Role,
     },
+    protocol::NETWORK_PROTOCOL_CURRENT,
     types::{peer_address::PeerAddress, peer_id::PeerId},
 };
 
@@ -111,12 +112,13 @@ where
         match self.peer_role {
             PeerRole::Inbound => {
                 let types::Message::Handshake(types::HandshakeMessage::Hello {
-                    version,
+                    protocol,
                     network,
                     services,
+                    user_agent,
+                    version,
                     receiver_address,
                     handshake_nonce,
-                    user_agent,
                 }) = self.socket.recv().await?
                 else {
                     return Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected));
@@ -129,12 +131,13 @@ where
                     .send((
                         self.peer_id,
                         PeerEvent::PeerInfoReceived {
+                            protocol,
                             network,
-                            version,
                             services,
+                            user_agent,
+                            version,
                             receiver_address,
                             handshake_nonce,
-                            user_agent,
                         },
                     ))
                     .map_err(P2pError::from)?;
@@ -142,9 +145,10 @@ where
                 self.socket
                     .send(types::Message::Handshake(
                         types::HandshakeMessage::HelloAck {
-                            version: *self.chain_config.version(),
+                            protocol: NETWORK_PROTOCOL_CURRENT,
                             network: *self.chain_config.magic_bytes(),
                             user_agent: self.p2p_config.user_agent.clone(),
+                            version: *self.chain_config.version(),
                             services: (*self.p2p_config.node_type).into(),
                             receiver_address: self.receiver_address.clone(),
                         },
@@ -154,19 +158,21 @@ where
             PeerRole::Outbound { handshake_nonce } => {
                 self.socket
                     .send(types::Message::Handshake(types::HandshakeMessage::Hello {
-                        version: *self.chain_config.version(),
+                        protocol: NETWORK_PROTOCOL_CURRENT,
                         network: *self.chain_config.magic_bytes(),
-                        user_agent: self.p2p_config.user_agent.clone(),
                         services: (*self.p2p_config.node_type).into(),
+                        user_agent: self.p2p_config.user_agent.clone(),
+                        version: *self.chain_config.version(),
                         receiver_address: self.receiver_address.clone(),
                         handshake_nonce,
                     }))
                     .await?;
 
                 let types::Message::Handshake(types::HandshakeMessage::HelloAck {
-                    version,
+                    protocol,
                     network,
                     user_agent,
+                    version,
                     services,
                     receiver_address,
                 }) = self.socket.recv().await?
@@ -178,10 +184,11 @@ where
                     .send((
                         self.peer_id,
                         PeerEvent::PeerInfoReceived {
+                            protocol,
                             network,
-                            version,
-                            user_agent,
                             services,
+                            user_agent,
+                            version,
                             receiver_address,
                             handshake_nonce,
                         },
@@ -297,6 +304,7 @@ mod tests {
         assert!(socket2.recv().now_or_never().is_none());
         assert!(socket2
             .send(types::Message::Handshake(types::HandshakeMessage::Hello {
+                protocol: NETWORK_PROTOCOL_CURRENT,
                 version: *chain_config.version(),
                 network: *chain_config.magic_bytes(),
                 user_agent: p2p_config.user_agent.clone(),
@@ -311,10 +319,11 @@ mod tests {
         assert_eq!(
             rx1.try_recv().unwrap().1,
             PeerEvent::PeerInfoReceived {
+                protocol: NETWORK_PROTOCOL_CURRENT,
                 network: *chain_config.magic_bytes(),
-                version: *chain_config.version(),
-                user_agent: p2p_config.user_agent.clone(),
                 services: [Service::Blocks, Service::Transactions].as_slice().into(),
+                user_agent: p2p_config.user_agent.clone(),
+                version: *chain_config.version(),
                 receiver_address: None,
                 handshake_nonce: 123,
             }
@@ -369,6 +378,7 @@ mod tests {
         assert!(socket2
             .send(types::Message::Handshake(
                 types::HandshakeMessage::HelloAck {
+                    protocol: NETWORK_PROTOCOL_CURRENT,
                     version: *chain_config.version(),
                     network: *chain_config.magic_bytes(),
                     user_agent: p2p_config.user_agent.clone(),
@@ -385,10 +395,11 @@ mod tests {
             Ok((
                 peer_id3,
                 PeerEvent::PeerInfoReceived {
+                    protocol: NETWORK_PROTOCOL_CURRENT,
                     network: *chain_config.magic_bytes(),
-                    version: *chain_config.version(),
-                    user_agent: p2p_config.user_agent.clone(),
                     services: [Service::Blocks, Service::Transactions].as_slice().into(),
+                    user_agent: p2p_config.user_agent.clone(),
+                    version: *chain_config.version(),
                     receiver_address: None,
                     handshake_nonce: 1,
                 }
@@ -440,6 +451,7 @@ mod tests {
         assert!(socket2.recv().now_or_never().is_none());
         assert!(socket2
             .send(types::Message::Handshake(types::HandshakeMessage::Hello {
+                protocol: NETWORK_PROTOCOL_CURRENT,
                 version: *chain_config.version(),
                 network: [1, 2, 3, 4],
                 user_agent: p2p_config.user_agent.clone(),

--- a/p2p/src/net/default_backend/tests.rs
+++ b/p2p/src/net/default_backend/tests.rs
@@ -16,6 +16,7 @@
 use super::{transport::NoiseTcpTransport, *};
 use crate::config::NodeType;
 use crate::error::DialError;
+use crate::protocol::NETWORK_PROTOCOL_CURRENT;
 use crate::testing_utils::{
     test_p2p_config, TestTransportChannel, TestTransportMaker, TestTransportTcp,
 };
@@ -23,7 +24,6 @@ use crate::{
     net::default_backend::transport::{MpscChannelTransport, TcpTransportSocket},
     testing_utils::TestTransportNoise,
 };
-use common::primitives::semver::SemVer;
 use std::fmt::Debug;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
@@ -66,7 +66,7 @@ where
     {
         assert_eq!(address, conn2.local_addresses()[0]);
         assert_eq!(peer_info.network, *config.magic_bytes());
-        assert_eq!(peer_info.version, SemVer::new(0, 1, 0));
+        assert_eq!(peer_info.version, *config.version());
         assert_eq!(peer_info.user_agent, p2p_config.user_agent);
         assert_eq!(peer_info.services, NodeType::Full.into());
     } else {
@@ -125,7 +125,7 @@ where
             receiver_address: _,
         } => {
             assert_eq!(peer_info.network, *config.magic_bytes());
-            assert_eq!(peer_info.version, SemVer::new(0, 1, 0),);
+            assert_eq!(peer_info.version, *config.version());
             assert_eq!(peer_info.user_agent, p2p_config.user_agent);
         }
         _ => panic!("invalid event received, expected incoming connection"),
@@ -250,8 +250,9 @@ where
     }) = conn1.poll_next().await
     {
         assert_eq!(address, conn2.local_addresses()[0]);
+        assert_eq!(peer_info.protocol, NETWORK_PROTOCOL_CURRENT);
         assert_eq!(peer_info.network, *config.magic_bytes());
-        assert_eq!(peer_info.version, SemVer::new(0, 1, 0));
+        assert_eq!(peer_info.version, *config.version());
         assert_eq!(peer_info.user_agent, p2p_config.user_agent);
         assert_eq!(peer_info.services, NodeType::Full.into());
     } else {

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -26,6 +26,7 @@ use crate::{
         PingResponse, SyncMessage,
     },
     net::types::services::{Service, Services},
+    protocol::NetworkProtocol,
     types::{peer_address::PeerAddress, peer_id::PeerId},
 };
 
@@ -46,10 +47,11 @@ pub type HandshakeNonce = u64;
 pub enum PeerEvent {
     /// Peer information received from remote
     PeerInfoReceived {
+        protocol: NetworkProtocol,
         network: [u8; 4],
-        version: SemVer,
-        user_agent: UserAgent,
         services: Services,
+        user_agent: UserAgent,
+        version: SemVer,
         receiver_address: Option<PeerAddress>,
 
         /// For outbound connections that is what we sent.
@@ -74,10 +76,11 @@ pub enum Event {
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum HandshakeMessage {
     Hello {
-        version: SemVer,
+        protocol: NetworkProtocol,
         network: [u8; 4],
         services: Services,
         user_agent: UserAgent,
+        version: SemVer,
 
         /// Socket address of the remote peer as seen by this node (addr_you in bitcoin)
         receiver_address: Option<PeerAddress>,
@@ -86,10 +89,11 @@ pub enum HandshakeMessage {
         handshake_nonce: HandshakeNonce,
     },
     HelloAck {
-        version: SemVer,
+        protocol: NetworkProtocol,
         network: [u8; 4],
         services: Services,
         user_agent: UserAgent,
+        version: SemVer,
 
         /// Socket address of the remote peer as seen by this node (addr_you in bitcoin)
         receiver_address: Option<PeerAddress>,

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -24,6 +24,7 @@ use common::{
 
 use crate::{
     message::{Announcement, PeerManagerMessage, SyncMessage},
+    protocol::NetworkProtocol,
     types::{peer_address::PeerAddress, peer_id::PeerId},
     P2pError,
 };
@@ -50,6 +51,8 @@ pub struct PeerInfo {
     /// Unique ID of the peer
     pub peer_id: PeerId,
 
+    pub protocol: NetworkProtocol,
+
     /// Peer network
     pub network: [u8; 4],
 
@@ -65,7 +68,7 @@ pub struct PeerInfo {
 
 impl PeerInfo {
     pub fn is_compatible(&self, chain_config: &ChainConfig) -> bool {
-        // TODO: Check version here
+        // Check node version here if necessary
         self.network == *chain_config.magic_bytes()
     }
 }
@@ -74,6 +77,7 @@ impl Display for PeerInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Peer information:")?;
         writeln!(f, "--> Peer ID: {:?}", self.peer_id)?;
+        writeln!(f, "--> Protocol: {:?}", self.protocol)?;
         writeln!(f, "--> Network: {:x?}", self.network)?;
         writeln!(f, "--> Software version: {}", self.version)?;
         writeln!(f, "--> User agent: {}", self.user_agent)?;

--- a/p2p/src/peer_manager/tests/addresses.rs
+++ b/p2p/src/peer_manager/tests/addresses.rs
@@ -28,6 +28,7 @@ use crate::{
         ConnectivityService, NetworkingService,
     },
     peer_manager::tests::make_peer_manager_custom,
+    protocol::NETWORK_PROTOCOL_CURRENT,
     testing_utils::{
         test_p2p_config, P2pBasicTestTimeGetter, RandomAddressMaker, TestTcpAddressMaker,
         TestTransportChannel, TestTransportMaker,
@@ -59,6 +60,7 @@ where
     let peer_id = PeerId::new();
     let peer_info = PeerInfo {
         peer_id,
+        protocol: NETWORK_PROTOCOL_CURRENT,
         network: *config.magic_bytes(),
         version: *config.version(),
         user_agent: mintlayer_core_user_agent(),

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -25,6 +25,7 @@ use crate::{
     config::{MaxInboundConnections, P2pConfig},
     net::types::{services::Service, Role},
     peer_manager::tests::{get_connected_peers, run_peer_manager},
+    protocol::NETWORK_PROTOCOL_CURRENT,
     testing_utils::{
         connect_and_accept_services, connect_services, get_connectivity_event,
         peerdb_inmemory_store, test_p2p_config, P2pBasicTestTimeGetter, P2pTokioTestTimeGetter,
@@ -449,8 +450,9 @@ async fn inbound_connection_too_many_peers_tcp() {
                 format!("127.0.0.1:{}", index + 10000).parse().expect("valid address"),
                 PeerInfo {
                     peer_id: PeerId::new(),
+                    protocol: NETWORK_PROTOCOL_CURRENT,
                     network: *config.magic_bytes(),
-                    version: common::primitives::semver::SemVer::new(0, 1, 0),
+                    version: *config.version(),
                     user_agent: mintlayer_core_user_agent(),
                     services: [Service::Blocks, Service::Transactions].as_slice().into(),
                 },
@@ -474,8 +476,9 @@ async fn inbound_connection_too_many_peers_channels() {
                 format!("127.0.0.1:{}", index + 10000).parse().expect("valid address"),
                 PeerInfo {
                     peer_id: PeerId::new(),
+                    protocol: NETWORK_PROTOCOL_CURRENT,
                     network: *config.magic_bytes(),
-                    version: common::primitives::semver::SemVer::new(0, 1, 0),
+                    version: *config.version(),
                     user_agent: mintlayer_core_user_agent(),
                     services: [Service::Blocks, Service::Transactions].as_slice().into(),
                 },
@@ -499,8 +502,9 @@ async fn inbound_connection_too_many_peers_noise() {
                 format!("127.0.0.1:{}", index + 10000).parse().expect("valid address"),
                 PeerInfo {
                     peer_id: PeerId::new(),
+                    protocol: NETWORK_PROTOCOL_CURRENT,
                     network: *config.magic_bytes(),
-                    version: common::primitives::semver::SemVer::new(0, 1, 0),
+                    version: *config.version(),
                     user_agent: mintlayer_core_user_agent(),
                     services: [Service::Blocks, Service::Transactions].as_slice().into(),
                 },

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -31,6 +31,7 @@ use crate::{
         types::{ConnectivityEvent, PeerInfo},
     },
     peer_manager::{tests::send_and_sync, PeerManager},
+    protocol::NETWORK_PROTOCOL_CURRENT,
     testing_utils::{peerdb_inmemory_store, P2pTokioTestTimeGetter},
     types::peer_id::PeerId,
 };
@@ -95,6 +96,7 @@ async fn ping_timeout() {
             address: "123.123.123.123:12345".parse().unwrap(),
             peer_info: PeerInfo {
                 peer_id: PeerId::new(),
+                protocol: NETWORK_PROTOCOL_CURRENT,
                 network: *chain_config.magic_bytes(),
                 version: *chain_config.version(),
                 user_agent: p2p_config.user_agent.clone(),

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Network protocol version
+///
+/// When two nodes connect, they exchange protocol versions,
+/// and the minimum version is selected as the negotiated network protocol version.
+pub type NetworkProtocol = u32;
+
+/// Initial protocol version
+pub const NETWORK_PROTOCOL_V1: NetworkProtocol = 1;
+
+/// Latest known network protocol version
+pub const NETWORK_PROTOCOL_CURRENT: NetworkProtocol = NETWORK_PROTOCOL_V1;
+
+/// Minimum supported network protocol version
+pub const NETWORK_PROTOCOL_MIN: NetworkProtocol = NETWORK_PROTOCOL_V1;

--- a/p2p/tests/block_announcement.rs
+++ b/p2p/tests/block_announcement.rs
@@ -38,6 +38,7 @@ use p2p::{
 
 // Test announcements with multiple peers and verify that the message validation is done and peers
 // don't automatically forward the messages.
+// TODO: Implement announcements resending in partially connected networks.
 async fn block_announcement_3_peers<A, S>()
 where
     A: TestTransportMaker<Transport = S::Transport, Address = S::Address>,
@@ -150,7 +151,6 @@ where
     ));
 }
 
-// TODO: Implement announcements resending in partially connected networks.
 #[ignore]
 #[tokio::test]
 async fn block_announcement_3_peers_tcp() {
@@ -158,7 +158,6 @@ async fn block_announcement_3_peers_tcp() {
         .await;
 }
 
-// TODO: Implement announcements resending in partially connected networks.
 #[tokio::test]
 #[ignore]
 async fn block_announcement_3_peers_channels() {
@@ -169,7 +168,6 @@ async fn block_announcement_3_peers_channels() {
     .await;
 }
 
-// TODO: Implement announcements resending in partially connected networks.
 #[ignore]
 #[tokio::test]
 async fn block_announcement_3_peers_noise() {

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -54,10 +54,11 @@ def init_p2p_types():
             "HandshakeHello": {
                 "type": "struct",
                 "type_mapping": [
-                    ["version", "SemVer"],
+                    ["protocol", "u32"],
                     ["network", "[u8; 4]"],
                     ["services", "u64"],
                     ["user_agent", "String"],
+                    ["version", "SemVer"],
                     ["receiver_address", "Option<PeerAddress>"],
                     ["handshake_nonce", "u64"],
                 ]
@@ -66,10 +67,11 @@ def init_p2p_types():
             "HandshakeHelloAck": {
                 "type": "struct",
                 "type_mapping": [
-                    ["version", "SemVer"],
+                    ["protocol", "u32"],
                     ["network", "[u8; 4]"],
                     ["services", "u64"],
                     ["user_agent", "String"],
+                    ["version", "SemVer"],
                     ["receiver_address", "Option<PeerAddress>"],
                 ]
             },

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -76,6 +76,8 @@ from test_framework.util import (
 
 logger = logging.getLogger("TestFramework.p2p")
 
+P2P_NETWORK_PROTOCOL = 1
+
 # The P2P user agent string that this test framework sends in its `handshake` message
 P2P_USER_AGENT = "PythonTesterP2P"
 
@@ -330,14 +332,15 @@ class P2PInterface(P2PConnection):
         vt = {
             "handshake": {
                 "Hello": {
+                    "protocol": P2P_NETWORK_PROTOCOL,
+                    "network": [0xaa, 0xbb, 0xcc, 0xdd],
+                    "services": services,
+                    "user_agent": P2P_USER_AGENT,
                     "version": {
                         "major": 0,
                         "minor": 1,
                         "patch": 0,
                     },
-                    "network": [0xaa, 0xbb, 0xcc, 0xdd],
-                    "user_agent": P2P_USER_AGENT,
-                    "services": services,
                     "receiver_address": None,
                     "handshake_nonce": 123,
                 }


### PR DESCRIPTION
I think having a separate field to negotiate the p2p network protocol will make future upgrades easier.
Bitcoin Core uses something like that too: https://github.com/bitcoin/bitcoin/blob/master/src/version.h