### PR TITLE
Generalize error handling in tx-verifier-related traits

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -115,6 +115,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::InvalidOutputTypeInReward(_) => 100,
             ConnectTransactionError::PoolDataNotFound(_) => 0,
             ConnectTransactionError::UndoFetchFailure => 0,
+            ConnectTransactionError::TxVerifierStorage => 0,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -362,6 +362,7 @@ impl BanScore for pos_accounting::Error {
             E::PledgeValueToSignedError => 100,
             E::InvariantErrorDelegationUndoFailedDataNotFound => 100,
             E::DuplicatesInDeltaAndUndo => 100,
+            E::ViewFail => 0,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -114,6 +114,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::SpendStakeError(_) => 100,
             ConnectTransactionError::InvalidOutputTypeInReward(_) => 100,
             ConnectTransactionError::PoolDataNotFound(_) => 0,
+            ConnectTransactionError::UndoFetchFailure => 0,
         }
     }
 }
@@ -319,8 +320,8 @@ impl BanScore for utxo::Error {
             utxo::Error::NoBlockchainHeightFound => 0,
             utxo::Error::MissingBlockRewardUndo(_) => 0,
             utxo::Error::InvalidBlockRewardOutputType(_) => 100,
-            utxo::Error::DBError(_) => 0,
-            utxo::Error::ViewError(_) => 0,
+            utxo::Error::ViewRead => 0,
+            utxo::Error::StorageWrite => 0,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -295,6 +295,7 @@ impl BanScore for ConsensusPoSError {
             ConsensusPoSError::TargetConversionError(_) => 100,
             ConsensusPoSError::InvalidTargetBlockTime => 100,
             ConsensusPoSError::InvariantBrokenNotMonotonicBlockTime => 100,
+            ConsensusPoSError::FailedToFetchUtxo => 0,
         }
     }
 }
@@ -319,6 +320,7 @@ impl BanScore for utxo::Error {
             utxo::Error::MissingBlockRewardUndo(_) => 0,
             utxo::Error::InvalidBlockRewardOutputType(_) => 100,
             utxo::Error::DBError(_) => 0,
+            utxo::Error::ViewError(_) => 0,
         }
     }
 }

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -19,8 +19,8 @@ use chainstate_storage::{
     BlockchainStorageRead, BlockchainStorageWrite, SealedStorageTag, TransactionRw,
 };
 use chainstate_types::{
-    block_index_ancestor_getter, get_skip_height, storage_result, BlockIndex, BlockIndexHandle,
-    EpochData, GenBlockIndex, GetAncestorError, PropertyQueryError,
+    block_index_ancestor_getter, get_skip_height, BlockIndex, BlockIndexHandle, EpochData,
+    GenBlockIndex, GetAncestorError, PropertyQueryError,
 };
 use common::{
     chain::{
@@ -143,7 +143,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     }
 
     // TODO: When the mempool incorporates the transaction-verifier, this won't be needed anymore
-    pub fn make_utxo_view(&self) -> impl UtxosView<Error = storage_result::Error> + '_ {
+    pub fn make_utxo_view(&self) -> impl UtxosView<Error = S::Error> + '_ {
         UtxosDB::new(&self.db_tx)
     }
 

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -19,8 +19,8 @@ use chainstate_storage::{
     BlockchainStorageRead, BlockchainStorageWrite, SealedStorageTag, TransactionRw,
 };
 use chainstate_types::{
-    block_index_ancestor_getter, get_skip_height, BlockIndex, BlockIndexHandle, EpochData,
-    GenBlockIndex, GetAncestorError, PropertyQueryError,
+    block_index_ancestor_getter, get_skip_height, storage_result, BlockIndex, BlockIndexHandle,
+    EpochData, GenBlockIndex, GetAncestorError, PropertyQueryError,
 };
 use common::{
     chain::{
@@ -143,7 +143,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     }
 
     // TODO: When the mempool incorporates the transaction-verifier, this won't be needed anymore
-    pub fn make_utxo_view(&self) -> impl UtxosView + '_ {
+    pub fn make_utxo_view(&self) -> impl UtxosView<Error = storage_result::Error> + '_ {
         UtxosDB::new(&self.db_tx)
     }
 

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -43,6 +43,8 @@ use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosBlockUndo, UtxosDB, UtxosS
 impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> TransactionVerifierStorageRef
     for ChainstateRef<'a, S, V>
 {
+    type Error = TransactionVerifierStorageError;
+
     fn get_token_id_from_issuance_tx(
         &self,
         tx_id: Id<Transaction>,

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -103,6 +103,8 @@ pub fn gen_block_index_getter<S: BlockchainStorageRead>(
 impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> UtxosStorageRead
     for ChainstateRef<'a, S, V>
 {
+    type Error = storage_result::Error;
+
     fn get_utxo(
         &self,
         outpoint: &common::chain::OutPoint,

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -295,6 +295,8 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
 impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> PoSAccountingView
     for ChainstateRef<'a, S, V>
 {
+    type Error = pos_accounting::Error;
+
     fn pool_exists(&self, pool_id: PoolId) -> Result<bool, pos_accounting::Error> {
         self.get_pool_data(pool_id).map(|v| v.is_some())
     }

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -67,6 +67,7 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -138,6 +139,7 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config, verifier_config);
 

--- a/chainstate/src/detail/tx_verification_strategy/mod.rs
+++ b/chainstate/src/detail/tx_verification_strategy/mod.rs
@@ -68,7 +68,8 @@ pub trait TransactionVerificationStrategy: Sized + Send {
         U: UtxosView,
         C: AsRef<ChainConfig>,
         A: PoSAccountingView,
-        M: TransactionVerifierMakerFn<C, S, U, A>;
+        M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>;
 
     /// Disconnect the transactions given by block and block_index,
     /// and return a TransactionVerifier with an internal state
@@ -89,5 +90,6 @@ pub trait TransactionVerificationStrategy: Sized + Send {
         S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
-        M: TransactionVerifierMakerFn<C, S, U, A>;
+        M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>;
 }

--- a/chainstate/src/detail/tx_verification_strategy/mod.rs
+++ b/chainstate/src/detail/tx_verification_strategy/mod.rs
@@ -27,7 +27,9 @@ use common::{
     primitives::id::WithId,
 };
 use tx_verifier::transaction_verifier::{
-    config::TransactionVerifierConfig, storage::TransactionVerifierStorageRef, TransactionVerifier,
+    config::TransactionVerifierConfig,
+    storage::{TransactionVerifierStorageError, TransactionVerifierStorageRef},
+    TransactionVerifier,
 };
 
 // TODO: replace with trait_alias when stabilized
@@ -62,7 +64,7 @@ pub trait TransactionVerificationStrategy: Sized + Send {
     ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
     where
         H: BlockIndexHandle,
-        S: TransactionVerifierStorageRef,
+        S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         C: AsRef<ChainConfig>,
         A: PoSAccountingView,
@@ -84,7 +86,7 @@ pub trait TransactionVerificationStrategy: Sized + Send {
     ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
     where
         C: AsRef<ChainConfig>,
-        S: TransactionVerifierStorageRef,
+        S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>;

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -251,6 +251,7 @@ impl<B: storage::Backend> BlockchainStorageRead for Store<B> {
 }
 
 impl<B: storage::Backend> UtxosStorageRead for Store<B> {
+    type Error = crate::Error;
     delegate_to_transaction! {
         fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
         fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>>;

--- a/chainstate/storage/src/internal/store_tx.rs
+++ b/chainstate/storage/src/internal/store_tx.rs
@@ -204,6 +204,8 @@ macro_rules! impl_read_ops {
         }
 
         impl<'st, B: storage::Backend> UtxosStorageRead for $TxType<'st, B> {
+            type Error = crate::Error;
+
             fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>> {
                 self.read::<db::DBUtxo, _, _>(outpoint)
             }

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -54,7 +54,7 @@ impl pos_accounting::StorageTag for SealedStorageTag {}
 
 /// Queries on persistent blockchain data
 pub trait BlockchainStorageRead:
-    UtxosStorageRead
+    UtxosStorageRead<Error = crate::Error>
     + PoSAccountingStorageRead<SealedStorageTag>
     + PoSAccountingStorageRead<TipStorageTag>
 {

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -90,6 +90,7 @@ mockall::mock! {
     }
 
     impl UtxosStorageRead for Store {
+        type Error = crate::Error;
         fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
         fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
@@ -328,6 +329,7 @@ mockall::mock! {
     }
 
     impl crate::UtxosStorageRead for StoreTxRo {
+        type Error = crate::Error;
         fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
         fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
@@ -434,6 +436,7 @@ mockall::mock! {
     }
 
     impl UtxosStorageRead for StoreTxRw {
+        type Error = crate::Error;
         fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
         fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;

--- a/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
@@ -70,6 +70,7 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -146,6 +147,7 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         let mut base_tx_verifier =
             tx_verifier_maker(storage_backend, chain_config, verifier_config);

--- a/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
@@ -19,6 +19,7 @@ use chainstate::{
         construct_reward_tx_indices, construct_tx_indices, take_front_tx_index,
     },
     BlockError, TransactionVerificationStrategy, TransactionVerifierMakerFn,
+    TransactionVerifierStorageError,
 };
 use chainstate_types::{BlockIndex, BlockIndexHandle};
 use common::{
@@ -65,7 +66,7 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
     where
         C: AsRef<ChainConfig>,
         H: BlockIndexHandle,
-        S: TransactionVerifierStorageRef,
+        S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
@@ -141,7 +142,7 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
     ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
     where
         C: AsRef<ChainConfig>,
-        S: TransactionVerifierStorageRef,
+        S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -21,6 +21,7 @@ use chainstate::{
         construct_reward_tx_indices, construct_tx_indices, take_front_tx_index,
     },
     BlockError, TransactionVerificationStrategy, TransactionVerifierMakerFn,
+    TransactionVerifierStorageError,
 };
 use chainstate_types::{BlockIndex, BlockIndexHandle};
 use common::{
@@ -78,7 +79,7 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
     where
         C: AsRef<ChainConfig>,
         H: BlockIndexHandle,
-        S: TransactionVerifierStorageRef,
+        S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
@@ -114,7 +115,7 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
     ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
     where
         C: AsRef<ChainConfig>,
-        S: TransactionVerifierStorageRef,
+        S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
@@ -146,7 +147,7 @@ impl RandomizedTransactionVerificationStrategy {
         median_time_past: &BlockTimestamp,
     ) -> Result<TransactionVerifier<C, S, U, A>, ConnectTransactionError>
     where
-        S: TransactionVerifierStorageRef,
+        S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
@@ -262,7 +263,7 @@ impl RandomizedTransactionVerificationStrategy {
     ) -> Result<TransactionVerifier<C, S, U, A>, ConnectTransactionError>
     where
         C: AsRef<ChainConfig>,
-        S: TransactionVerifierStorageRef,
+        S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -83,6 +83,7 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
         let median_time_past =
@@ -119,6 +120,7 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         let mut tx_verifier = self.disconnect_with_base(
             tx_verifier_maker,
@@ -151,6 +153,7 @@ impl RandomizedTransactionVerificationStrategy {
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         let block_subsidy =
             chain_config.as_ref().block_subsidy_at_height(&block_index.block_height());
@@ -224,6 +227,7 @@ impl RandomizedTransactionVerificationStrategy {
         U: UtxosView,
         A: PoSAccountingView,
         S: TransactionVerifierStorageRef,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         let mut tx_verifier = base_tx_verifier.derive_child();
         let mut total_fee = Amount::ZERO;
@@ -267,6 +271,7 @@ impl RandomizedTransactionVerificationStrategy {
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config, verifier_config);
         let mut tx_num = i32::try_from(block.transactions().len()).unwrap() - 1;
@@ -307,6 +312,7 @@ impl RandomizedTransactionVerificationStrategy {
         U: UtxosView,
         A: PoSAccountingView,
         S: TransactionVerifierStorageRef,
+        <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         let mut tx_verifier = base_tx_verifier.derive_child();
         while tx_num >= 0 {

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -118,6 +118,8 @@ impl UtxosStorageRead for InMemoryStorageWrapper {
 }
 
 impl PoSAccountingView for InMemoryStorageWrapper {
+    type Error = pos_accounting::Error;
+
     fn pool_exists(&self, pool_id: PoolId) -> Result<bool, pos_accounting::Error> {
         self.get_pool_data(pool_id).map(|v| v.is_some())
     }

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -46,6 +46,8 @@ impl InMemoryStorageWrapper {
 }
 
 impl TransactionVerifierStorageRef for InMemoryStorageWrapper {
+    type Error = TransactionVerifierStorageError;
+
     fn get_token_id_from_issuance_tx(
         &self,
         tx_id: Id<Transaction>,

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -96,6 +96,8 @@ impl TransactionVerifierStorageRef for InMemoryStorageWrapper {
 }
 
 impl UtxosStorageRead for InMemoryStorageWrapper {
+    type Error = storage_result::Error;
+
     fn get_utxo(
         &self,
         outpoint: &common::chain::OutPoint,

--- a/chainstate/test-suite/src/tests/tx_verifier_among_threads.rs
+++ b/chainstate/test-suite/src/tests/tx_verifier_among_threads.rs
@@ -27,19 +27,21 @@ use utxo::{Utxo, UtxosView};
 
 use super::helpers::in_memory_storage_wrapper::InMemoryStorageWrapper;
 
-pub struct EmptyUtxosView;
+struct EmptyUtxosView;
 
 impl UtxosView for EmptyUtxosView {
-    fn utxo(&self, _outpoint: &OutPoint) -> Option<Utxo> {
-        None
+    type Error = std::convert::Infallible;
+
+    fn utxo(&self, _outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
+        Ok(None)
     }
 
-    fn has_utxo(&self, _outpoint: &OutPoint) -> bool {
-        false
+    fn has_utxo(&self, _outpoint: &OutPoint) -> Result<bool, Self::Error> {
+        Ok(false)
     }
 
-    fn best_block_hash(&self) -> Id<common::chain::GenBlock> {
-        H256::zero().into()
+    fn best_block_hash(&self) -> Result<Id<common::chain::GenBlock>, Self::Error> {
+        Ok(H256::zero().into())
     }
 
     fn estimated_size(&self) -> Option<usize> {
@@ -47,7 +49,7 @@ impl UtxosView for EmptyUtxosView {
     }
 }
 
-pub struct EmptyAccountingView;
+struct EmptyAccountingView;
 
 impl PoSAccountingView for EmptyAccountingView {
     fn pool_exists(&self, _pool_id: PoolId) -> Result<bool, pos_accounting::Error> {

--- a/chainstate/test-suite/src/tests/tx_verifier_among_threads.rs
+++ b/chainstate/test-suite/src/tests/tx_verifier_among_threads.rs
@@ -52,6 +52,8 @@ impl UtxosView for EmptyUtxosView {
 struct EmptyAccountingView;
 
 impl PoSAccountingView for EmptyAccountingView {
+    type Error = pos_accounting::Error;
+
     fn pool_exists(&self, _pool_id: PoolId) -> Result<bool, pos_accounting::Error> {
         Ok(false)
     }

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -104,7 +104,8 @@ pub enum ConnectTransactionError {
     #[error("Data of pool {0} not found")]
     PoolDataNotFound(PoolId),
 
-    // TODO The following should contain more granullar inner error information
+    // TODO The following should contain more granular inner error information
+    //      https://github.com/mintlayer/mintlayer-core/issues/811
     #[error("Fetching undo data failed")]
     UndoFetchFailure,
     #[error("Some transaction verifier storage error")]

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -107,6 +107,8 @@ pub enum ConnectTransactionError {
     // TODO The following should contain more granullar inner error information
     #[error("Fetching undo data failed")]
     UndoFetchFailure,
+    #[error("Some transaction verifier storage error")]
+    TxVerifierStorage,
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -103,6 +103,10 @@ pub enum ConnectTransactionError {
     InvalidOutputTypeInReward(Id<Block>),
     #[error("Data of pool {0} not found")]
     PoolDataNotFound(PoolId),
+
+    // TODO The following should contain more granullar inner error information
+    #[error("Fetching undo data failed")]
+    UndoFetchFailure,
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {

--- a/chainstate/tx-verifier/src/transaction_verifier/flush.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/flush.rs
@@ -73,8 +73,8 @@ fn flush_tokens(
     Ok(())
 }
 
-pub fn flush_to_storage(
-    storage: &mut impl TransactionVerifierStorageMut,
+pub fn flush_to_storage<S: TransactionVerifierStorageMut>(
+    storage: &mut S,
     consumed: TransactionVerifierDelta,
 ) -> Result<(), TransactionVerifierStorageError> {
     for (tx_id, tx_index_op) in consumed.tx_index_cache {

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -257,36 +257,38 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView> Fl
 impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView> PoSAccountingView
     for TransactionVerifier<C, S, U, A>
 {
-    fn pool_exists(&self, pool_id: PoolId) -> Result<bool, pos_accounting::Error> {
+    type Error = pos_accounting::Error;
+
+    fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Self::Error> {
         self.accounting_delta.pool_exists(pool_id)
     }
 
-    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, pos_accounting::Error> {
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {
         self.accounting_delta.get_pool_balance(pool_id)
     }
 
-    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, pos_accounting::Error> {
+    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Self::Error> {
         self.accounting_delta.get_pool_data(pool_id)
     }
 
     fn get_delegation_balance(
         &self,
         delegation_id: DelegationId,
-    ) -> Result<Option<Amount>, pos_accounting::Error> {
+    ) -> Result<Option<Amount>, Self::Error> {
         self.accounting_delta.get_delegation_balance(delegation_id)
     }
 
     fn get_delegation_data(
         &self,
         delegation_id: DelegationId,
-    ) -> Result<Option<DelegationData>, pos_accounting::Error> {
+    ) -> Result<Option<DelegationData>, Self::Error> {
         self.accounting_delta.get_delegation_data(delegation_id)
     }
 
     fn get_pool_delegations_shares(
         &self,
         pool_id: PoolId,
-    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, pos_accounting::Error> {
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Self::Error> {
         self.accounting_delta.get_pool_delegations_shares(pool_id)
     }
 
@@ -294,7 +296,7 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView> Po
         &self,
         pool_id: PoolId,
         delegation_id: DelegationId,
-    ) -> Result<Option<Amount>, pos_accounting::Error> {
+    ) -> Result<Option<Amount>, Self::Error> {
         self.accounting_delta.get_pool_delegation_share(pool_id, delegation_id)
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -106,24 +106,23 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView>
     }
 }
 
-impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView> UtxosStorageRead
+impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A> UtxosStorageRead
     for TransactionVerifier<C, S, U, A>
 {
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<utxo::Utxo>, storage_result::Error> {
-        Ok(self.utxo_cache.utxo(outpoint).expect("TODO(PR)"))
+    type Error = U::Error;
+
+    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<utxo::Utxo>, Self::Error> {
+        self.utxo_cache.utxo(outpoint)
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, storage_result::Error> {
+    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Self::Error> {
         Ok(Some(self.best_block))
     }
 
-    fn get_undo_data(
-        &self,
-        id: Id<Block>,
-    ) -> Result<Option<UtxosBlockUndo>, storage_result::Error> {
+    fn get_undo_data(&self, id: Id<Block>) -> Result<Option<UtxosBlockUndo>, Self::Error> {
         match self.utxo_block_undo.data().get(&TransactionSource::Chain(id)) {
             Some(v) => Ok(Some(v.undo.clone())),
-            None => self.storage.get_undo_data(id),
+            None => self.storage.get_undo_data(id).map_err(|_| todo!("PR")),
         }
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -42,10 +42,12 @@ use utxo::{ConsumedUtxoCache, FlushableUtxoView, UtxosBlockUndo, UtxosStorageRea
 impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView>
     TransactionVerifierStorageRef for TransactionVerifier<C, S, U, A>
 {
+    type Error = <S as TransactionVerifierStorageRef>::Error;
+
     fn get_token_id_from_issuance_tx(
         &self,
         tx_id: Id<Transaction>,
-    ) -> Result<Option<TokenId>, TransactionVerifierStorageError> {
+    ) -> Result<Option<TokenId>, <Self as TransactionVerifierStorageRef>::Error> {
         match self.token_issuance_cache.txid_from_issuance().get(&tx_id) {
             Some(v) => match v {
                 CachedTokenIndexOp::Write(id) => Ok(Some(*id)),
@@ -66,11 +68,8 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView>
     fn get_mainchain_tx_index(
         &self,
         tx_id: &OutPointSourceId,
-    ) -> Result<Option<TxMainChainIndex>, TransactionVerifierStorageError> {
-        let tx_index_cache = self
-            .tx_index_cache
-            .as_ref()
-            .ok_or(TransactionVerifierStorageError::TransactionIndexDisabled)?;
+    ) -> Result<Option<TxMainChainIndex>, <Self as TransactionVerifierStorageRef>::Error> {
+        let tx_index_cache = self.tx_index_cache.as_ref().ok_or_else(|| todo!())?;
         match tx_index_cache.get_from_cached(tx_id) {
             Some(v) => match v {
                 CachedInputsOperation::Write(idx) => Ok(Some(idx.clone())),
@@ -84,7 +83,7 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView>
     fn get_token_aux_data(
         &self,
         token_id: &TokenId,
-    ) -> Result<Option<TokenAuxiliaryData>, TransactionVerifierStorageError> {
+    ) -> Result<Option<TokenAuxiliaryData>, <Self as TransactionVerifierStorageRef>::Error> {
         match self.token_issuance_cache.data().get(token_id) {
             Some(v) => match v {
                 CachedAuxDataOp::Write(t) => Ok(Some(t.clone())),
@@ -98,7 +97,7 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView>
     fn get_accounting_undo(
         &self,
         id: Id<Block>,
-    ) -> Result<Option<AccountingBlockUndo>, TransactionVerifierStorageError> {
+    ) -> Result<Option<AccountingBlockUndo>, <Self as TransactionVerifierStorageRef>::Error> {
         match self.accounting_block_undo.data().get(&TransactionSource::Chain(id)) {
             Some(v) => Ok(Some(v.undo.clone())),
             None => self.storage.get_accounting_undo(id),
@@ -127,8 +126,10 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A> UtxosStorageRead
     }
 }
 
-impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView>
-    TransactionVerifierStorageMut for TransactionVerifier<C, S, U, A>
+impl<C, S, U: UtxosView, A: PoSAccountingView> TransactionVerifierStorageMut
+    for TransactionVerifier<C, S, U, A>
+where
+    S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
 {
     fn set_mainchain_tx_index(
         &mut self,

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use super::{
     cached_inputs_operation::CachedInputsOperation,
     storage::{
-        TransactionVerifierStorageError, TransactionVerifierStorageMut,
+        HasTxIndexDisabledError, TransactionVerifierStorageError, TransactionVerifierStorageMut,
         TransactionVerifierStorageRef,
     },
     token_issuance_cache::{CachedAuxDataOp, CachedTokenIndexOp},
@@ -69,7 +69,9 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView>
         &self,
         tx_id: &OutPointSourceId,
     ) -> Result<Option<TxMainChainIndex>, <Self as TransactionVerifierStorageRef>::Error> {
-        let tx_index_cache = self.tx_index_cache.as_ref().ok_or_else(|| todo!())?;
+        let tx_index_cache = self.tx_index_cache.as_ref().ok_or_else(|| {
+            <<Self as TransactionVerifierStorageRef>::Error>::tx_index_disabled_error()
+        })?;
         match tx_index_cache.get_from_cached(tx_id) {
             Some(v) => match v {
                 CachedInputsOperation::Write(idx) => Ok(Some(idx.clone())),

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -110,7 +110,7 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView> Ut
     for TransactionVerifier<C, S, U, A>
 {
     fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<utxo::Utxo>, storage_result::Error> {
-        Ok(self.utxo_cache.utxo(outpoint))
+        Ok(self.utxo_cache.utxo(outpoint).expect("TODO(PR)"))
     }
 
     fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, storage_result::Error> {

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
@@ -60,7 +60,7 @@ fn check_inputs_can_be_used_in_tx(
         .map(|input| {
             utxo_view
                 .utxo(input.outpoint())
-                .map_err(utxo::Error::from_view)?
+                .map_err(|_| utxo::Error::ViewRead)?
                 .ok_or(ConnectTransactionError::MissingOutputOrSpent)
         })
         .collect::<Result<Vec<_>, _>>()?

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
@@ -60,6 +60,7 @@ fn check_inputs_can_be_used_in_tx(
         .map(|input| {
             utxo_view
                 .utxo(input.outpoint())
+                .map_err(utxo::Error::from_view)?
                 .ok_or(ConnectTransactionError::MissingOutputOrSpent)
         })
         .collect::<Result<Vec<_>, _>>()?

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -194,8 +194,8 @@ pub struct TransactionVerifier<C, S, U, A> {
 impl<C, S: TransactionVerifierStorageRef + ShallowClone> TransactionVerifier<C, S, UtxosDB<S>, S> {
     pub fn new(storage: S, chain_config: C, verifier_config: TransactionVerifierConfig) -> Self {
         let accounting_delta = PoSAccountingDelta::new(S::clone(&storage));
-        let utxo_cache =
-            UtxosCache::new(UtxosDB::new(S::clone(&storage))).expect("Utxo cache setup failed");
+        let utxo_cache = UtxosCache::new(UtxosDB::new(storage.shallow_clone()))
+            .expect("Utxo cache setup failed");
         let best_block = storage
             .get_best_block_for_utxos()
             .expect("Database error while reading utxos best block")

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -255,6 +255,7 @@ where
     S: TransactionVerifierStorageRef,
     U: UtxosView,
     A: PoSAccountingView,
+    <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
 {
     pub fn derive_child(
         &self,

--- a/chainstate/tx-verifier/src/transaction_verifier/storage.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/storage.rs
@@ -63,10 +63,12 @@ pub enum TransactionVerifierStorageError {
 // TODO(Gosha): PoSAccountingView should be replaced with PoSAccountingStorageRead in which the
 //              return error type can handle both storage_result::Error and pos_accounting::Error
 pub trait TransactionVerifierStorageRef: UtxosStorageRead + PoSAccountingView {
+    type Error;
+
     fn get_token_id_from_issuance_tx(
         &self,
         tx_id: Id<Transaction>,
-    ) -> Result<Option<TokenId>, TransactionVerifierStorageError>;
+    ) -> Result<Option<TokenId>, <Self as TransactionVerifierStorageRef>::Error>;
 
     // TODO: Study whether moving this to a closure on tx_verifier construction is helpful.
     //       The issue here is that looking into history prevents testing the tx_verifier independently
@@ -81,21 +83,23 @@ pub trait TransactionVerifierStorageRef: UtxosStorageRead + PoSAccountingView {
     fn get_mainchain_tx_index(
         &self,
         tx_id: &OutPointSourceId,
-    ) -> Result<Option<TxMainChainIndex>, TransactionVerifierStorageError>;
+    ) -> Result<Option<TxMainChainIndex>, <Self as TransactionVerifierStorageRef>::Error>;
 
     fn get_token_aux_data(
         &self,
         token_id: &TokenId,
-    ) -> Result<Option<TokenAuxiliaryData>, TransactionVerifierStorageError>;
+    ) -> Result<Option<TokenAuxiliaryData>, <Self as TransactionVerifierStorageRef>::Error>;
 
     fn get_accounting_undo(
         &self,
         id: Id<Block>,
-    ) -> Result<Option<AccountingBlockUndo>, TransactionVerifierStorageError>;
+    ) -> Result<Option<AccountingBlockUndo>, <Self as TransactionVerifierStorageRef>::Error>;
 }
 
 pub trait TransactionVerifierStorageMut:
-    TransactionVerifierStorageRef + FlushableUtxoView + FlushablePoSAccountingView
+    TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>
+    + FlushableUtxoView
+    + FlushablePoSAccountingView
 {
     fn set_mainchain_tx_index(
         &mut self,
@@ -163,10 +167,12 @@ impl<T: Deref> TransactionVerifierStorageRef for T
 where
     T::Target: TransactionVerifierStorageRef,
 {
+    type Error = <T::Target as TransactionVerifierStorageRef>::Error;
+
     fn get_token_id_from_issuance_tx(
         &self,
         tx_id: Id<Transaction>,
-    ) -> Result<Option<TokenId>, TransactionVerifierStorageError> {
+    ) -> Result<Option<TokenId>, <Self as TransactionVerifierStorageRef>::Error> {
         self.deref().get_token_id_from_issuance_tx(tx_id)
     }
 
@@ -180,21 +186,21 @@ where
     fn get_mainchain_tx_index(
         &self,
         tx_id: &OutPointSourceId,
-    ) -> Result<Option<TxMainChainIndex>, TransactionVerifierStorageError> {
+    ) -> Result<Option<TxMainChainIndex>, <Self as TransactionVerifierStorageRef>::Error> {
         self.deref().get_mainchain_tx_index(tx_id)
     }
 
     fn get_token_aux_data(
         &self,
         token_id: &TokenId,
-    ) -> Result<Option<TokenAuxiliaryData>, TransactionVerifierStorageError> {
+    ) -> Result<Option<TokenAuxiliaryData>, <Self as TransactionVerifierStorageRef>::Error> {
         self.deref().get_token_aux_data(token_id)
     }
 
     fn get_accounting_undo(
         &self,
         id: Id<Block>,
-    ) -> Result<Option<AccountingBlockUndo>, TransactionVerifierStorageError> {
+    ) -> Result<Option<AccountingBlockUndo>, <Self as TransactionVerifierStorageRef>::Error> {
         self.deref().get_accounting_undo(id)
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/storage.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/storage.rs
@@ -60,10 +60,23 @@ pub enum TransactionVerifierStorageError {
     AccountingBlockUndoError(#[from] pos_accounting::AccountingBlockUndoError),
 }
 
+pub trait HasTxIndexDisabledError {
+    fn tx_index_disabled_error() -> Self;
+}
+
+impl HasTxIndexDisabledError for TransactionVerifierStorageError {
+    fn tx_index_disabled_error() -> Self {
+        Self::TransactionIndexDisabled
+    }
+}
+
 // TODO(Gosha): PoSAccountingView should be replaced with PoSAccountingStorageRead in which the
 //              return error type can handle both storage_result::Error and pos_accounting::Error
-pub trait TransactionVerifierStorageRef: UtxosStorageRead + PoSAccountingView {
-    type Error;
+pub trait TransactionVerifierStorageRef: UtxosStorageRead + PoSAccountingView
+where
+    <Self as TransactionVerifierStorageRef>::Error: HasTxIndexDisabledError,
+{
+    type Error: std::error::Error;
 
     fn get_token_id_from_issuance_tx(
         &self,

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -39,6 +39,8 @@ mockall::mock! {
     pub Store {}
 
     impl TransactionVerifierStorageRef for Store {
+        type Error = TransactionVerifierStorageError;
+
         fn get_token_id_from_issuance_tx(
             &self,
             tx_id: Id<Transaction>,

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -121,6 +121,7 @@ mockall::mock! {
     }
 
     impl UtxosStorageRead for Store {
+        type Error = storage_result::Error;
         fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, storage_result::Error>;
         fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>,storage_result::Error>;
         fn get_undo_data(&self, id: Id<Block>) -> Result<Option<utxo::UtxosBlockUndo>, storage_result::Error>;

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -132,6 +132,7 @@ mockall::mock! {
     }
 
     impl PoSAccountingView for Store {
+        type Error = pos_accounting::Error;
         fn pool_exists(&self, pool_id: PoolId) -> Result<bool, pos_accounting::Error>;
         fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, pos_accounting::Error>;
         fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, pos_accounting::Error>;

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -92,8 +92,10 @@ pub fn check_timelocks<
 
     for input in inputs {
         let outpoint = input.outpoint();
-        let utxo =
-            utxos_view.utxo(outpoint).ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
+        let utxo = utxos_view
+            .utxo(outpoint)
+            .map_err(utxo::Error::from_view)?
+            .ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
 
         if utxo.output().has_timelock() {
             let height = match utxo.source() {

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -94,7 +94,7 @@ pub fn check_timelocks<
         let outpoint = input.outpoint();
         let utxo = utxos_view
             .utxo(outpoint)
-            .map_err(utxo::Error::from_view)?
+            .map_err(|_| utxo::Error::ViewRead)?
             .ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
 
         if utxo.output().has_timelock() {

--- a/chainstate/tx-verifier/src/transaction_verifier/token_issuance_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/token_issuance_cache.rs
@@ -25,7 +25,6 @@ use common::{
 
 use super::{
     error::{ConnectTransactionError, TokensError},
-    storage::TransactionVerifierStorageError,
     CachedOperation,
 };
 
@@ -139,13 +138,14 @@ impl TokenIssuanceCache {
         Ok(())
     }
 
-    pub fn precache_token_issuance<
-        F: Fn(&TokenId) -> Result<Option<TokenAuxiliaryData>, TransactionVerifierStorageError>,
-    >(
+    pub fn precache_token_issuance<E>(
         &mut self,
-        token_data_getter: F,
+        token_data_getter: impl Fn(&TokenId) -> Result<Option<TokenAuxiliaryData>, E>,
         tx: &Transaction,
-    ) -> Result<(), ConnectTransactionError> {
+    ) -> Result<(), ConnectTransactionError>
+    where
+        ConnectTransactionError: From<E>,
+    {
         let has_token_issuance =
             tx.outputs().iter().any(|output| is_tokens_issuance(&output.value()));
         if has_token_issuance {

--- a/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
@@ -16,9 +16,9 @@
 use std::collections::btree_map::Entry;
 
 use super::{
+    cached_inputs_operation::CachedInputsOperation,
     error::{ConnectTransactionError, TxIndexError},
-    storage::TransactionVerifierStorageError,
-    {cached_inputs_operation::CachedInputsOperation, BlockTransactableRef},
+    BlockTransactableRef,
 };
 use common::{
     chain::{signature::Signable, OutPointSourceId, Spender, TxInput, TxMainChainIndex},
@@ -160,15 +160,14 @@ impl TxIndexCache {
         Ok(())
     }
 
-    pub fn precache_inputs<F>(
+    pub fn precache_inputs<F, E>(
         &mut self,
         inputs: &[TxInput],
         fetcher_func: F,
     ) -> Result<(), ConnectTransactionError>
     where
-        F: Fn(
-            &OutPointSourceId,
-        ) -> Result<Option<TxMainChainIndex>, TransactionVerifierStorageError>,
+        F: Fn(&OutPointSourceId) -> Result<Option<TxMainChainIndex>, E>,
+        ConnectTransactionError: From<E>,
     {
         inputs.iter().try_for_each(|input| {
             let outpoint = input.outpoint();

--- a/chainstate/types/src/storage_result.rs
+++ b/chainstate/types/src/storage_result.rs
@@ -26,5 +26,11 @@ impl From<storage::Error> for Error {
     }
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(inf: std::convert::Infallible) -> Self {
+        match inf {}
+    }
+}
+
 /// Possibly failing result of blockchain storage query
 pub type Result<T> = core::result::Result<T, Error>;

--- a/consensus/src/pos/error.rs
+++ b/consensus/src/pos/error.rs
@@ -62,6 +62,7 @@ pub enum ConsensusPoSError {
     InvariantBrokenNotMonotonicBlockTime,
 
     // TODO the following error should include the corresponding error from UtxosView
+    //      https://github.com/mintlayer/mintlayer-core/issues/811
     #[error("Failed to fetch utxo")]
     FailedToFetchUtxo,
 }

--- a/consensus/src/pos/error.rs
+++ b/consensus/src/pos/error.rs
@@ -60,4 +60,8 @@ pub enum ConsensusPoSError {
     InvalidTargetBlockTime,
     #[error("CRITICAL: Block time must be monotonic")]
     InvariantBrokenNotMonotonicBlockTime,
+
+    // TODO the following error should include the corresponding error from UtxosView
+    #[error("Failed to fetch utxo")]
+    FailedToFetchUtxo,
 }

--- a/consensus/src/pos/kernel.rs
+++ b/consensus/src/pos/kernel.rs
@@ -26,8 +26,10 @@ pub fn get_kernel_output<U: UtxosView>(
         [] => Err(ConsensusPoSError::NoKernel),
         [kernel_input] => {
             let kernel_outpoint = kernel_input.outpoint();
-            let kernel_output =
-                utxos_view.utxo(kernel_outpoint).ok_or(ConsensusPoSError::NoKernel)?;
+            let kernel_output = utxos_view
+                .utxo(kernel_outpoint)
+                .map_err(|_| ConsensusPoSError::FailedToFetchUtxo)?
+                .ok_or(ConsensusPoSError::NoKernel)?;
 
             Ok(kernel_output.output().clone())
         }

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -108,7 +108,7 @@ pub fn check_proof_of_stake<H, U, P>(
 where
     H: BlockIndexHandle,
     U: UtxosView,
-    P: PoSAccountingView,
+    P: PoSAccountingView<Error = pos_accounting::Error>,
 {
     let target = target::calculate_target_required(
         chain_config,

--- a/consensus/src/validator.rs
+++ b/consensus/src/validator.rs
@@ -40,7 +40,7 @@ pub fn validate_consensus<H, U, P>(
 where
     H: BlockIndexHandle,
     U: UtxosView,
-    P: PoSAccountingView,
+    P: PoSAccountingView<Error = pos_accounting::Error>,
 {
     let prev_block_id = *header.prev_block_id();
 
@@ -115,7 +115,7 @@ fn validate_pos_consensus<H, U, P>(
 where
     H: BlockIndexHandle,
     U: UtxosView,
-    P: PoSAccountingView,
+    P: PoSAccountingView<Error = pos_accounting::Error>,
 {
     match header.consensus_data() {
         ConsensusData::None | ConsensusData::PoW(_) => {

--- a/pos_accounting/src/error.rs
+++ b/pos_accounting/src/error.rs
@@ -79,4 +79,8 @@ pub enum Error {
     InvariantErrorDelegationUndoFailedDataNotFound,
     #[error("Delta reverts merge failed due to duplicates")]
     DuplicatesInDeltaAndUndo,
+
+    // TODO: Need a more granular error reporting in the following
+    #[error("PoS accounting view query failed")]
+    ViewFail,
 }

--- a/pos_accounting/src/error.rs
+++ b/pos_accounting/src/error.rs
@@ -80,7 +80,8 @@ pub enum Error {
     #[error("Delta reverts merge failed due to duplicates")]
     DuplicatesInDeltaAndUndo,
 
-    // TODO: Need a more granular error reporting in the following
+    // TODO Need a more granular error reporting in the following
+    //      https://github.com/mintlayer/mintlayer-core/issues/811
     #[error("PoS accounting view query failed")]
     ViewFail,
 }

--- a/pos_accounting/src/pool/delta/operator_impls.rs
+++ b/pos_accounting/src/pool/delta/operator_impls.rs
@@ -49,7 +49,7 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
     ) -> Result<(PoolId, PoSAccountingUndo), Error> {
         let pool_id = make_pool_id(input0_outpoint);
 
-        if self.get_pool_balance(pool_id)?.is_some() {
+        if self.get_pool_balance(pool_id).map_err(|_| Error::ViewFail)?.is_some() {
             // This should never happen since it's based on an unspent input
             return Err(Error::InvariantErrorPoolBalanceAlreadyExists);
         }

--- a/pos_accounting/src/pool/storage/view_impls.rs
+++ b/pos_accounting/src/pool/storage/view_impls.rs
@@ -33,6 +33,8 @@ use crate::{
 };
 
 impl<S: PoSAccountingStorageRead<T>, T: StorageTag> PoSAccountingView for PoSAccountingDB<S, T> {
+    type Error = Error;
+
     fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Error> {
         self.get_pool_data(pool_id).map(|v| v.is_some())
     }

--- a/pos_accounting/src/pool/view.rs
+++ b/pos_accounting/src/pool/view.rs
@@ -25,29 +25,34 @@ use crate::{error::Error, DeltaMergeUndo};
 use super::{delegation::DelegationData, delta::data::PoSAccountingDeltaData, pool_data::PoolData};
 
 pub trait PoSAccountingView {
-    fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Error>;
+    type Error: std::error::Error;
 
-    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Error>;
+    fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Self::Error>;
 
-    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Error>;
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error>;
+
+    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Self::Error>;
 
     fn get_pool_delegations_shares(
         &self,
         pool_id: PoolId,
-    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Error>;
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Self::Error>;
 
-    fn get_delegation_balance(&self, delegation_id: DelegationId) -> Result<Option<Amount>, Error>;
+    fn get_delegation_balance(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, Self::Error>;
 
     fn get_delegation_data(
         &self,
         delegation_id: DelegationId,
-    ) -> Result<Option<DelegationData>, Error>;
+    ) -> Result<Option<DelegationData>, Self::Error>;
 
     fn get_pool_delegation_share(
         &self,
         pool_id: PoolId,
         delegation_id: DelegationId,
-    ) -> Result<Option<Amount>, Error>;
+    ) -> Result<Option<Amount>, Self::Error>;
 }
 
 pub trait FlushablePoSAccountingView {
@@ -59,33 +64,38 @@ where
     T: Deref,
     <T as Deref>::Target: PoSAccountingView,
 {
-    fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Error> {
+    type Error = <T::Target as PoSAccountingView>::Error;
+
+    fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Self::Error> {
         self.deref().pool_exists(pool_id)
     }
 
-    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Error> {
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {
         self.deref().get_pool_balance(pool_id)
     }
 
-    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Error> {
+    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Self::Error> {
         self.deref().get_pool_data(pool_id)
     }
 
     fn get_pool_delegations_shares(
         &self,
         pool_id: PoolId,
-    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Error> {
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Self::Error> {
         self.deref().get_pool_delegations_shares(pool_id)
     }
 
-    fn get_delegation_balance(&self, delegation_id: DelegationId) -> Result<Option<Amount>, Error> {
+    fn get_delegation_balance(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, Self::Error> {
         self.deref().get_delegation_balance(delegation_id)
     }
 
     fn get_delegation_data(
         &self,
         delegation_id: DelegationId,
-    ) -> Result<Option<DelegationData>, Error> {
+    ) -> Result<Option<DelegationData>, Self::Error> {
         self.deref().get_delegation_data(delegation_id)
     }
 
@@ -93,7 +103,7 @@ where
         &self,
         pool_id: PoolId,
         delegation_id: DelegationId,
-    ) -> Result<Option<Amount>, Error> {
+    ) -> Result<Option<Amount>, Self::Error> {
         self.deref().get_pool_delegation_share(pool_id, delegation_id)
     }
 }

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -88,7 +88,7 @@ impl<P: UtxosView> UtxosCache<P> {
         let entry = self
             .parent
             .utxo(outpoint)
-            .map_err(Error::from_view)?
+            .map_err(|_| Error::ViewRead)?
             .map(|utxo| UtxoEntry::new(Some(utxo), IsFresh::No, IsDirty::No));
         if let Some(entry) = &entry {
             self.utxos.insert(outpoint.clone(), entry.clone());
@@ -122,7 +122,7 @@ impl<P: UtxosView> UtxosCache<P> {
             let outpoint = OutPoint::new(OutPointSourceId::BlockReward(*block_id), idx as u32);
             // block reward transactions can always be overwritten
             let overwrite = if check_for_overwrite {
-                self.has_utxo(&outpoint).map_err(Error::from_view)?
+                self.has_utxo(&outpoint).map_err(|_| Error::ViewRead)?
             } else {
                 true
             };
@@ -150,7 +150,7 @@ impl<P: UtxosView> UtxosCache<P> {
             .try_for_each(|(idx, output)| {
                 let outpoint = OutPoint::new(id.clone(), idx as u32);
                 // by default no overwrite allowed.
-                let has_utxo = self.has_utxo(&outpoint).map_err(Error::from_view)?;
+                let has_utxo = self.has_utxo(&outpoint).map_err(|_| Error::ViewRead)?;
                 let overwrite = check_for_overwrite && has_utxo;
                 let utxo = Utxo::new(output.clone(), false, source.clone());
 

--- a/utxo/src/error.rs
+++ b/utxo/src/error.rs
@@ -38,12 +38,13 @@ pub enum Error {
     #[error("Block reward type is invalid `{0}`")]
     InvalidBlockRewardOutputType(Id<GenBlock>),
 
-    // TODO: This is a temporary solution. It does not provide much information, the exact utxo
-    //       view error is lost. The concrete error type depends on the UtxoView used. The error
-    //       enum here should be parametrized by the error type rather than hide it, so the error
-    //       type information is available at compilation time and the exact error emitted from
-    //       UtxoView is available to the caller at run time. That, however, leads to many call
-    //       sites having to be updated so it's left for future improvements.
+    // TODO This is a temporary solution. It does not provide much information, the exact utxo
+    //      view error is lost. The concrete error type depends on the UtxoView used. The error
+    //      enum here should be parametrized by the error type rather than hide it, so the error
+    //      type information is available at compilation time and the exact error emitted from
+    //      UtxoView is available to the caller at run time. That, however, leads to many call
+    //      sites having to be updated so it's left for future improvements.
+    //      https://github.com/mintlayer/mintlayer-core/issues/811
     #[error("UTXO view query failed `for some reason (TM)`")]
     ViewRead,
     #[error("UTXO storage write failed `for some reason (TM)`")]

--- a/utxo/src/error.rs
+++ b/utxo/src/error.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use chainstate_types::storage_result;
 use common::{
     chain::{block::GenBlock, OutPointSourceId},
@@ -40,4 +42,50 @@ pub enum Error {
     InvalidBlockRewardOutputType(Id<GenBlock>),
     #[error("Database error: `{0}`")]
     DBError(#[from] storage_result::Error),
+
+    /// Error when querying a UtxoView
+    ///
+    /// TODO: This is a temporary solution. It uses a trait object to handle many possible error
+    /// types. The concrete error type depends on the UtxoView used. The error enum here should be
+    /// parametrized by the error type rather than hide it, so the information is available at
+    /// compilation time. That, however, leads to many call sites having to be updated so it's left
+    /// for future updates.
+    #[error("View query failed: `{0}`")]
+    ViewError(BoxedViewError),
 }
+
+impl Error {
+    pub fn from_view(e: impl ViewError) -> Self {
+        Self::ViewError(BoxedViewError::new(e))
+    }
+}
+
+/// Trait for arrors that can happen when querying a `UtxosView`
+pub trait ViewError: 'static + Send + Sync + std::error::Error {}
+
+impl ViewError for chainstate_types::storage_result::Error {}
+impl ViewError for std::convert::Infallible {}
+
+/// Boxed view error is used to suppot the temporary hack mentioned in [Error::ViewError]
+#[derive(Debug, Clone)]
+pub struct BoxedViewError(Arc<Box<dyn ViewError>>);
+
+impl BoxedViewError {
+    fn new(e: impl ViewError) -> Self {
+        Self(Arc::new(Box::new(e)))
+    }
+}
+
+impl std::fmt::Display for BoxedViewError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl PartialEq for BoxedViewError {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
+    }
+}
+
+impl Eq for BoxedViewError {}

--- a/utxo/src/storage/in_memory.rs
+++ b/utxo/src/storage/in_memory.rs
@@ -15,7 +15,7 @@
 
 use super::{UtxosStorageRead, UtxosStorageWrite};
 use crate::{Utxo, UtxosBlockUndo, UtxosView};
-use chainstate_types::storage_result::Error;
+use chainstate_types::storage_result::{self, Error};
 use common::{
     chain::{Block, GenBlock, OutPoint},
     primitives::Id,
@@ -40,6 +40,8 @@ impl UtxosDBInMemoryImpl {
 }
 
 impl UtxosStorageRead for UtxosDBInMemoryImpl {
+    type Error = storage_result::Error;
+
     fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Error> {
         let res = self.store.get(outpoint);
         Ok(res.cloned())

--- a/utxo/src/storage/in_memory.rs
+++ b/utxo/src/storage/in_memory.rs
@@ -81,16 +81,18 @@ impl UtxosStorageWrite for UtxosDBInMemoryImpl {
 }
 
 impl UtxosView for UtxosDBInMemoryImpl {
-    fn utxo(&self, outpoint: &OutPoint) -> Option<Utxo> {
-        self.store.get(outpoint).cloned()
+    type Error = std::convert::Infallible;
+
+    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
+        Ok(self.store.get(outpoint).cloned())
     }
 
-    fn has_utxo(&self, outpoint: &OutPoint) -> bool {
-        self.store.get(outpoint).is_some()
+    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Self::Error> {
+        Ok(self.store.get(outpoint).is_some())
     }
 
-    fn best_block_hash(&self) -> Id<GenBlock> {
-        self.best_block_id
+    fn best_block_hash(&self) -> Result<Id<GenBlock>, Self::Error> {
+        Ok(self.best_block_id)
     }
 
     fn estimated_size(&self) -> Option<usize> {

--- a/utxo/src/storage/mod.rs
+++ b/utxo/src/storage/mod.rs
@@ -75,7 +75,7 @@ impl<S: UtxosStorageWrite> UtxosDB<S> {
         // before deriving cache, there has to be a best block
         utxos_db.set_best_block_for_utxos(&genesis_id).expect("Setting genesis failed");
 
-        let mut utxos_cache = UtxosCache::new(&utxos_db);
+        let mut utxos_cache = UtxosCache::new(&utxos_db).expect("Utxo cache setup failed");
 
         for (index, output) in genesis.utxos().iter().enumerate() {
             utxos_cache

--- a/utxo/src/storage/mod.rs
+++ b/utxo/src/storage/mod.rs
@@ -25,13 +25,13 @@ use common::{
 use std::ops::{Deref, DerefMut};
 
 pub trait UtxosStorageRead {
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, storage_result::Error>;
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, storage_result::Error>;
-    fn get_undo_data(&self, id: Id<Block>)
-        -> Result<Option<UtxosBlockUndo>, storage_result::Error>;
+    type Error: std::error::Error;
+    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error>;
+    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Self::Error>;
+    fn get_undo_data(&self, id: Id<Block>) -> Result<Option<UtxosBlockUndo>, Self::Error>;
 }
 
-pub trait UtxosStorageWrite: UtxosStorageRead {
+pub trait UtxosStorageWrite: UtxosStorageRead<Error = storage_result::Error> {
     fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), storage_result::Error>;
     fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), storage_result::Error>;
 
@@ -100,18 +100,20 @@ where
     T: Deref,
     <T as Deref>::Target: UtxosStorageRead,
 {
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, storage_result::Error> {
+    type Error = <T::Target as UtxosStorageRead>::Error;
+
+    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
         self.deref().get_utxo(outpoint)
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, storage_result::Error> {
+    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Self::Error> {
         self.deref().get_best_block_for_utxos()
     }
 
     fn get_undo_data(
         &self,
         id: Id<Block>,
-    ) -> Result<Option<UtxosBlockUndo>, storage_result::Error> {
+    ) -> Result<Option<UtxosBlockUndo>, Self::Error> {
         self.deref().get_undo_data(id)
     }
 }

--- a/utxo/src/storage/mod.rs
+++ b/utxo/src/storage/mod.rs
@@ -17,7 +17,6 @@ mod rw_impls;
 mod view_impls;
 
 use crate::{FlushableUtxoView, Utxo, UtxosBlockUndo, UtxosCache};
-use chainstate_types::storage_result;
 use common::{
     chain::{Block, ChainConfig, GenBlock, OutPoint},
     primitives::{BlockHeight, Id},
@@ -31,21 +30,14 @@ pub trait UtxosStorageRead {
     fn get_undo_data(&self, id: Id<Block>) -> Result<Option<UtxosBlockUndo>, Self::Error>;
 }
 
-pub trait UtxosStorageWrite: UtxosStorageRead<Error = storage_result::Error> {
-    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), storage_result::Error>;
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), storage_result::Error>;
+pub trait UtxosStorageWrite: UtxosStorageRead {
+    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), Self::Error>;
+    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), Self::Error>;
 
-    fn set_best_block_for_utxos(
-        &mut self,
-        block_id: &Id<GenBlock>,
-    ) -> Result<(), storage_result::Error>;
+    fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> Result<(), Self::Error>;
 
-    fn set_undo_data(
-        &mut self,
-        id: Id<Block>,
-        undo: &UtxosBlockUndo,
-    ) -> Result<(), storage_result::Error>;
-    fn del_undo_data(&mut self, id: Id<Block>) -> Result<(), storage_result::Error>;
+    fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> Result<(), Self::Error>;
+    fn del_undo_data(&mut self, id: Id<Block>) -> Result<(), Self::Error>;
 }
 
 #[must_use]
@@ -110,10 +102,7 @@ where
         self.deref().get_best_block_for_utxos()
     }
 
-    fn get_undo_data(
-        &self,
-        id: Id<Block>,
-    ) -> Result<Option<UtxosBlockUndo>, Self::Error> {
+    fn get_undo_data(&self, id: Id<Block>) -> Result<Option<UtxosBlockUndo>, Self::Error> {
         self.deref().get_undo_data(id)
     }
 }
@@ -123,30 +112,23 @@ where
     T: DerefMut,
     <T as Deref>::Target: UtxosStorageWrite,
 {
-    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), storage_result::Error> {
+    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), Self::Error> {
         self.deref_mut().set_utxo(outpoint, entry)
     }
 
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), storage_result::Error> {
+    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), Self::Error> {
         self.deref_mut().del_utxo(outpoint)
     }
 
-    fn set_best_block_for_utxos(
-        &mut self,
-        block_id: &Id<GenBlock>,
-    ) -> Result<(), storage_result::Error> {
+    fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> Result<(), Self::Error> {
         self.deref_mut().set_best_block_for_utxos(block_id)
     }
 
-    fn set_undo_data(
-        &mut self,
-        id: Id<Block>,
-        undo: &UtxosBlockUndo,
-    ) -> Result<(), storage_result::Error> {
+    fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> Result<(), Self::Error> {
         self.deref_mut().set_undo_data(id, undo)
     }
 
-    fn del_undo_data(&mut self, id: Id<Block>) -> Result<(), storage_result::Error> {
+    fn del_undo_data(&mut self, id: Id<Block>) -> Result<(), Self::Error> {
         self.deref_mut().del_undo_data(id)
     }
 }

--- a/utxo/src/storage/rw_impls.rs
+++ b/utxo/src/storage/rw_impls.rs
@@ -15,29 +15,28 @@
 
 use super::{UtxosDB, UtxosStorageRead, UtxosStorageWrite};
 use crate::{Utxo, UtxosBlockUndo};
-use chainstate_types::storage_result::Error as StorageError;
 use common::{
     chain::{Block, GenBlock, OutPoint},
     primitives::Id,
 };
 
 impl<S: UtxosStorageWrite> UtxosStorageWrite for UtxosDB<S> {
-    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), StorageError> {
+    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), Self::Error> {
         self.0.set_utxo(outpoint, entry)
     }
 
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), StorageError> {
+    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), Self::Error> {
         self.0.del_utxo(outpoint)
     }
 
-    fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> Result<(), StorageError> {
+    fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> Result<(), Self::Error> {
         self.0.set_best_block_for_utxos(block_id)
     }
-    fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> Result<(), StorageError> {
+    fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> Result<(), Self::Error> {
         self.0.set_undo_data(id, undo)
     }
 
-    fn del_undo_data(&mut self, id: Id<Block>) -> Result<(), StorageError> {
+    fn del_undo_data(&mut self, id: Id<Block>) -> Result<(), Self::Error> {
         self.0.del_undo_data(id)
     }
 }

--- a/utxo/src/storage/rw_impls.rs
+++ b/utxo/src/storage/rw_impls.rs
@@ -43,15 +43,17 @@ impl<S: UtxosStorageWrite> UtxosStorageWrite for UtxosDB<S> {
 }
 
 impl<S: UtxosStorageRead> UtxosStorageRead for UtxosDB<S> {
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, StorageError> {
+    type Error = S::Error;
+
+    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
         self.0.get_utxo(outpoint)
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, StorageError> {
+    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Self::Error> {
         self.0.get_best_block_for_utxos()
     }
 
-    fn get_undo_data(&self, id: Id<Block>) -> Result<Option<UtxosBlockUndo>, StorageError> {
+    fn get_undo_data(&self, id: Id<Block>) -> Result<Option<UtxosBlockUndo>, Self::Error> {
         self.0.get_undo_data(id)
     }
 }

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -54,7 +54,9 @@ impl<S: UtxosStorageWrite> FlushableUtxoView for UtxosDB<S> {
                 };
             }
         }
-        self.0.set_best_block_for_utxos(&utxos.best_block).map_err(|_| Error::StorageWrite)?;
+        self.0
+            .set_best_block_for_utxos(&utxos.best_block)
+            .map_err(|_| Error::StorageWrite)?;
         Ok(())
     }
 }

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -15,25 +15,25 @@
 
 use super::{UtxosDB, UtxosStorageRead, UtxosStorageWrite};
 use crate::{ConsumedUtxoCache, FlushableUtxoView, Utxo, UtxosView};
+use chainstate_types::storage_result;
 use common::{
     chain::{GenBlock, OutPoint},
     primitives::Id,
 };
 
 impl<S: UtxosStorageRead> UtxosView for UtxosDB<S> {
-    fn utxo(&self, outpoint: &OutPoint) -> Option<Utxo> {
+    type Error = storage_result::Error;
+
+    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
         self.get_utxo(outpoint)
-            .expect("Database error while attempting to retrieve utxo")
     }
 
-    fn has_utxo(&self, outpoint: &OutPoint) -> bool {
-        self.utxo(outpoint).is_some()
+    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Self::Error> {
+        self.utxo(outpoint).map(|u| u.is_some())
     }
 
-    fn best_block_hash(&self) -> Id<GenBlock> {
-        self.get_best_block_for_utxos()
-            .expect("Database error while attempting to retrieve utxo set best block hash")
-            .expect("Failed to get best block hash")
+    fn best_block_hash(&self) -> Result<Id<GenBlock>, Self::Error> {
+        Ok(self.get_best_block_for_utxos()?.expect("Failed to get best block hash"))
     }
 
     fn estimated_size(&self) -> Option<usize> {

--- a/utxo/src/view.rs
+++ b/utxo/src/view.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{error::ViewError, ConsumedUtxoCache, Error, Utxo, UtxosCache};
+use crate::{ConsumedUtxoCache, Error, Utxo, UtxosCache};
 use common::{
     chain::{GenBlock, OutPoint},
     primitives::Id,
@@ -21,7 +21,7 @@ use common::{
 
 pub trait UtxosView {
     /// Error that can occur during utxo queries
-    type Error: ViewError;
+    type Error: std::error::Error;
 
     /// Retrieves utxo.
     fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error>;

--- a/utxo/src/view.rs
+++ b/utxo/src/view.rs
@@ -13,21 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{ConsumedUtxoCache, Error, Utxo, UtxosCache};
+use crate::{error::ViewError, ConsumedUtxoCache, Error, Utxo, UtxosCache};
 use common::{
     chain::{GenBlock, OutPoint},
     primitives::Id,
 };
 
 pub trait UtxosView {
+    /// Error that can occur during utxo queries
+    type Error: ViewError;
+
     /// Retrieves utxo.
-    fn utxo(&self, outpoint: &OutPoint) -> Option<Utxo>;
+    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error>;
 
     /// Checks whether outpoint is unspent.
-    fn has_utxo(&self, outpoint: &OutPoint) -> bool;
+    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Self::Error>;
 
     /// Retrieves the block hash of the best block in this view
-    fn best_block_hash(&self) -> Id<GenBlock>;
+    fn best_block_hash(&self) -> Result<Id<GenBlock>, Self::Error>;
 
     /// Estimated size of the whole view (None if not implemented)
     fn estimated_size(&self) -> Option<usize>;


### PR DESCRIPTION
Make error handling of some traits more general. This is to prepare the traits to be callable from a different subsystem where more error states are possible.

Sadly this resulted in loss of error information granularity in some places (see `TODO`s in the code), as a temporary workaround to keep the scope creep of the PR in check. Could be addressed in subsequent development.