### PR TITLE
Use different default data dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,6 +2245,7 @@ dependencies = [
  "common",
  "crypto",
  "directories 4.0.1",
+ "fs4",
  "jsonrpsee",
  "logging",
  "mempool",

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -55,6 +55,15 @@ pub enum ChainType {
 }
 
 impl ChainType {
+    pub const fn name(&self) -> &'static str {
+        match self {
+            ChainType::Mainnet => "mainnet",
+            ChainType::Testnet => "testnet",
+            ChainType::Regtest => "regtest",
+            ChainType::Signet => "signet",
+        }
+    }
+
     const fn default_address_prefix(&self) -> &'static str {
         match self {
             ChainType::Mainnet => "mtc",

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -34,7 +34,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[allow(clippy::eq_op)]
     fn initialize_twice() {
         init_logging::<&std::path::Path>(None);
         init_logging::<&std::path::Path>(None);

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -29,6 +29,7 @@ serde = { workspace = true, features = ["derive"] }
 toml = "0.7"
 directories = "4.0"
 paste = "1.0"
+fs4 = "0.6.3"
 
 [dev-dependencies]
 crypto = { path = "../crypto" }

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -18,6 +18,7 @@
 use std::{ffi::OsString, net::SocketAddr, num::NonZeroU64, path::PathBuf};
 
 use clap::{Args, Parser, Subcommand};
+use common::chain::config::ChainType;
 use directories::UserDirs;
 
 use crate::{
@@ -158,15 +159,19 @@ impl Options {
     }
 
     /// Returns a path to the config file
-    pub fn config_path(&self) -> PathBuf {
-        self.data_dir.clone().unwrap_or_else(default_data_dir).join(CONFIG_NAME)
+    pub fn config_path(&self, chain_type: ChainType) -> PathBuf {
+        self.data_dir
+            .clone()
+            .unwrap_or_else(|| default_data_dir(chain_type))
+            .join(CONFIG_NAME)
     }
 }
 
-pub fn default_data_dir() -> PathBuf {
+pub fn default_data_dir(chain_type: ChainType) -> PathBuf {
     UserDirs::new()
         // Expect here is OK because `Parser::parse_from` panics anyway in case of error.
         .expect("Unable to get home directory")
         .home_dir()
         .join(DATA_DIR_NAME)
+        .join(chain_type.name())
 }


### PR DESCRIPTION
We use the same default data directories for all networks, which is wrong.
For example, if you run mainnet first and then regtest, you will get this confusing error:
```
Mintlayer node launch failed: Initialization error: Not at genesis but block at height 1 not available

Caused by:
    Not at genesis but block at height 1 not available
```
Let's change that and use different default data directories for different networks (like it's done in Bitcoin Core).

I also added file locking to prevent users from starting multiple node instances using the same data dir.