### PR TITLE
Use clippy to find the leftover `todo!()`s

### DIFF
--- a/.github/scripts/codecheck.py
+++ b/.github/scripts/codecheck.py
@@ -139,7 +139,7 @@ def check_todos():
 
         with open(path) as file:
             file_data = file.read()
-            if 'TODO(PR)' in file_data or 'FIXME' in file_data or 'todo!()' in file_data:
+            if 'TODO(PR)' in file_data or 'FIXME' in file_data:
                 ok = False
                 print("{}: Found TODO(PR) or FIXME or todo!() instances".format(path))
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -35,6 +35,7 @@ jobs:
             -W clippy::manual_assert
             -W clippy::unused_async
             -W clippy::mut_mut
+            -W clippy::todo
 
       # Checks that only apply to production code
       - uses: actions-rs/clippy-check@v1

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -30,7 +30,7 @@ impl ChainType {
     fn default_genesis_init(&self) -> GenesisBlockInit {
         match self {
             ChainType::Mainnet => GenesisBlockInit::Mainnet,
-            ChainType::Testnet => todo!("Testnet genesis"),
+            ChainType::Testnet => unimplemented!("Testnet genesis"),
             ChainType::Regtest => GenesisBlockInit::TEST,
             ChainType::Signet => GenesisBlockInit::TEST,
         }
@@ -54,7 +54,7 @@ impl ChainType {
                 ];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
-            ChainType::Testnet => todo!("Testnet upgrades"),
+            ChainType::Testnet => unimplemented!("Testnet upgrades"),
             ChainType::Signet => NetUpgrades::unit_tests(),
         }
     }

--- a/do_checks.sh
+++ b/do_checks.sh
@@ -3,5 +3,5 @@ cargo fmt --check &&
 PYTHON=$(which python || which python3)
 $PYTHON .github/scripts/codecheck.py &&
 cargo deny check --hide-inclusion-graph
-cargo clippy --all-features --workspace --all-targets -- -D warnings -A clippy::new_without_default -W clippy::implicit_saturating_sub -W clippy::implicit_clone -W clippy::map_unwrap_or -W clippy::unnested_or_patterns -W clippy::manual_assert -W clippy::unused_async -W clippy::mut_mut &&
+cargo clippy --all-features --workspace --all-targets -- -D warnings -A clippy::new_without_default -W clippy::implicit_saturating_sub -W clippy::implicit_clone -W clippy::map_unwrap_or -W clippy::unnested_or_patterns -W clippy::manual_assert -W clippy::unused_async -W clippy::mut_mut -W clippy::todo &&
 cargo clippy --all-features --workspace --lib --bins --examples -- -A clippy::all -D clippy::float_arithmetic -W clippy::unwrap_used -W clippy::dbg_macro -W clippy::items_after_statements -W clippy::fallible_impl_from -W clippy::string_slice


### PR DESCRIPTION
As per discussion in #809.

Had to change some existing code to make it pass, the idea is to establish the following convention:

* Use `todo!` for short-term todos that are supposed to be fixed in the current PR.
* Use `unimplemented!` for stuff that is not implemented and will stay unimplemented beyond the current PR.