### PR TITLE
Add NotFound to TransactionResponse (p2p)

### DIFF
--- a/common/src/chain/transaction/signed_transaction.rs
+++ b/common/src/chain/transaction/signed_transaction.rs
@@ -90,7 +90,7 @@ impl SignedTransaction {
     }
 
     /// provides the hash of a transaction including the witness (malleable)
-    pub fn serialized_hash(&self) -> Id<SignedTransaction> {
+    pub fn serialized_hash(&self) -> Id<Transaction> {
         Id::new(id::hash_encoded(self))
     }
 }

--- a/common/src/chain/transaction/signed_transaction.rs
+++ b/common/src/chain/transaction/signed_transaction.rs
@@ -90,7 +90,7 @@ impl SignedTransaction {
     }
 
     /// provides the hash of a transaction including the witness (malleable)
-    pub fn serialized_hash(&self) -> Id<Transaction> {
+    pub fn serialized_hash(&self) -> Id<SignedTransaction> {
         Id::new(id::hash_encoded(self))
     }
 }

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::chain::SignedTransaction;
+use common::{chain::SignedTransaction, primitives::Idable};
 
 use crate::{
     error::{ConversionError, P2pError},
@@ -98,7 +98,7 @@ where
     }
 
     async fn submit_transaction(&mut self, tx: SignedTransaction) -> crate::Result<()> {
-        let id = tx.serialized_hash();
+        let id = tx.transaction().get_id();
         self.mempool_handle.call_async_mut(|m| m.add_transaction(tx)).await??;
         self.messaging_handle.make_announcement(Announcement::Transaction(id))
     }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -32,7 +32,7 @@ pub enum SyncMessage {
     HeaderListResponse(HeaderListResponse),
     BlockResponse(BlockResponse),
     TransactionRequest(Id<Transaction>),
-    TransactionResponse(SignedTransaction),
+    TransactionResponse(TransactionResponse),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,6 +133,14 @@ impl BlockResponse {
     pub fn into_block(self) -> Block {
         *self.block
     }
+}
+
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub enum TransactionResponse {
+    #[codec(index = 0)]
+    NotFound(Id<Transaction>),
+    #[codec(index = 1)]
+    Found(SignedTransaction),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{SignedTransaction, Transaction},
+    chain::Transaction,
     primitives::{semver::SemVer, user_agent::UserAgent, Id},
 };
 use serialization::{Decode, Encode};
@@ -23,7 +23,7 @@ use crate::{
     message::{
         AddrListRequest, AddrListResponse, AnnounceAddrRequest, Announcement, BlockListRequest,
         BlockResponse, HeaderListRequest, HeaderListResponse, PeerManagerMessage, PingRequest,
-        PingResponse, SyncMessage,
+        PingResponse, SyncMessage, TransactionResponse,
     },
     net::types::services::{Service, Services},
     protocol::NetworkProtocol,
@@ -124,7 +124,7 @@ pub enum Message {
     #[codec(index = 11)]
     TransactionRequest(Id<Transaction>),
     #[codec(index = 12)]
-    TransactionResponse(SignedTransaction),
+    TransactionResponse(TransactionResponse),
 
     #[codec(index = 8)]
     AnnounceAddrRequest(AnnounceAddrRequest),

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -31,7 +31,7 @@ use test_utils::random::Seed;
 use crate::{
     config::NodeType,
     error::ProtocolError,
-    message::{Announcement, SyncMessage},
+    message::{Announcement, SyncMessage, TransactionResponse},
     sync::tests::helpers::SyncManagerHandle,
     testing_utils::test_p2p_config,
     types::peer_id::PeerId,
@@ -90,7 +90,10 @@ async fn invalid_transaction(#[case] seed: Seed) {
         SyncMessage::TransactionRequest(tx.serialized_hash())
     );
 
-    handle.send_message(peer, SyncMessage::TransactionResponse(tx));
+    handle.send_message(
+        peer,
+        SyncMessage::TransactionResponse(TransactionResponse::Found(tx)),
+    );
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -329,7 +332,10 @@ async fn valid_transaction(#[case] seed: Seed) {
         SyncMessage::TransactionRequest(tx.serialized_hash())
     );
 
-    handle.send_message(peer, SyncMessage::TransactionResponse(tx.clone()));
+    handle.send_message(
+        peer,
+        SyncMessage::TransactionResponse(TransactionResponse::Found(tx.clone())),
+    );
 
     assert_eq!(
         Announcement::Transaction(tx.serialized_hash()),

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -22,7 +22,7 @@ use common::{
         config::create_unit_test_config, signature::inputsig::InputWitness, tokens::OutputValue,
         GenBlock, OutPointSourceId, SignedTransaction, Transaction, TxInput, TxOutput,
     },
-    primitives::{Amount, Id},
+    primitives::{Amount, Id, Idable},
 };
 use mempool::error::{Error as MempoolError, TxValidationError};
 use p2p_test_utils::start_subsystems_with_chainstate;
@@ -47,7 +47,7 @@ async fn nonexistent_peer() {
 
     let tx = Transaction::new(0x00, vec![], vec![], 0x01).unwrap();
     let tx = SignedTransaction::new(tx, vec![]).unwrap();
-    handle.make_announcement(peer, Announcement::Transaction(tx.serialized_hash()));
+    handle.make_announcement(peer, Announcement::Transaction(tx.transaction().get_id()));
 
     handle.resume_panic().await;
 }
@@ -81,13 +81,13 @@ async fn invalid_transaction(#[case] seed: Seed) {
 
     let tx = Transaction::new(0x00, vec![], vec![], 0x01).unwrap();
     let tx = SignedTransaction::new(tx, vec![]).unwrap();
-    handle.make_announcement(peer, Announcement::Transaction(tx.serialized_hash()));
+    handle.make_announcement(peer, Announcement::Transaction(tx.transaction().get_id()));
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
     assert_eq!(
         message,
-        SyncMessage::TransactionRequest(tx.serialized_hash())
+        SyncMessage::TransactionRequest(tx.transaction().get_id())
     );
 
     handle.send_message(
@@ -119,7 +119,7 @@ async fn initial_block_download() {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle.make_announcement(peer, Announcement::Transaction(tx.serialized_hash()));
+    handle.make_announcement(peer, Announcement::Transaction(tx.transaction().get_id()));
 
     handle.assert_no_event().await;
     handle.assert_no_peer_manager_event().await;
@@ -174,7 +174,7 @@ async fn no_transaction_service(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle.make_announcement(peer, Announcement::Transaction(tx.serialized_hash()));
+    handle.make_announcement(peer, Announcement::Transaction(tx.transaction().get_id()));
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -233,7 +233,7 @@ async fn too_many_announcements(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle.make_announcement(peer, Announcement::Transaction(tx.serialized_hash()));
+    handle.make_announcement(peer, Announcement::Transaction(tx.transaction().get_id()));
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -272,23 +272,23 @@ async fn duplicated_announcement(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle.make_announcement(peer, Announcement::Transaction(tx.serialized_hash()));
+    handle.make_announcement(peer, Announcement::Transaction(tx.transaction().get_id()));
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
     assert_eq!(
         message,
-        SyncMessage::TransactionRequest(tx.serialized_hash())
+        SyncMessage::TransactionRequest(tx.transaction().get_id())
     );
 
-    handle.make_announcement(peer, Announcement::Transaction(tx.serialized_hash()));
+    handle.make_announcement(peer, Announcement::Transaction(tx.transaction().get_id()));
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
     assert_eq!(
         score,
         P2pError::ProtocolError(ProtocolError::DuplicatedTransactionAnnouncement(
-            tx.serialized_hash()
+            tx.transaction().get_id()
         ))
         .ban_score()
     );
@@ -323,13 +323,13 @@ async fn valid_transaction(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle.make_announcement(peer, Announcement::Transaction(tx.serialized_hash()));
+    handle.make_announcement(peer, Announcement::Transaction(tx.transaction().get_id()));
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
     assert_eq!(
         message,
-        SyncMessage::TransactionRequest(tx.serialized_hash())
+        SyncMessage::TransactionRequest(tx.transaction().get_id())
     );
 
     handle.send_message(
@@ -338,7 +338,7 @@ async fn valid_transaction(#[case] seed: Seed) {
     );
 
     assert_eq!(
-        Announcement::Transaction(tx.serialized_hash()),
+        Announcement::Transaction(tx.transaction().get_id()),
         handle.announcement().await
     );
 }


### PR DESCRIPTION
We don't send a response when a peer has requested a transaction that is no longer in the mempool. This can happen when a new block is mined and the recently announced transaction is removed from the mempool. As a result, the `announced_transactions` set will grow and the peer may be banned later.