### PR TITLE
chainstate: Generalize error handling in some more traits

### DIFF
--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -129,6 +129,8 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> UtxosStor
 impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> FlushableUtxoView
     for ChainstateRef<'a, S, V>
 {
+    type Error = utxo::Error;
+
     fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), utxo::Error> {
         let mut db = UtxosDB::new(&mut self.db_tx);
         db.batch_write(utxos)

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -28,7 +28,10 @@ use common::{
 use consensus::ConsensusVerificationError;
 
 use thiserror::Error;
-use tx_verifier::transaction_verifier::error::{SpendStakeError, TxIndexError};
+use tx_verifier::transaction_verifier::{
+    error::{SpendStakeError, TxIndexError},
+    storage::HasTxIndexDisabledError,
+};
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum BlockError {
@@ -157,5 +160,11 @@ impl From<OrphanAddError> for Result<(), OrphanCheckError> {
         match err {
             OrphanAddError::BlockAlreadyInOrphanList(_) => Ok(()),
         }
+    }
+}
+
+impl HasTxIndexDisabledError for BlockError {
+    fn tx_index_disabled_error() -> Self {
+        TransactionVerifierStorageError::tx_index_disabled_error().into()
     }
 }

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -19,6 +19,7 @@ pub use detail::tx_verification_strategy::*;
 pub use interface::chainstate_interface;
 use interface::chainstate_interface_impl;
 pub use interface::chainstate_interface_impl_delegation;
+use tx_verifier::transaction_verifier::storage::HasTxIndexDisabledError;
 
 pub mod rpc;
 
@@ -63,6 +64,12 @@ pub enum ChainstateError {
     FailedToReadProperty(#[from] PropertyQueryError),
     #[error("Block import error {0}")]
     BootstrapError(#[from] BootstrapError),
+}
+
+impl HasTxIndexDisabledError for ChainstateError {
+    fn tx_index_disabled_error() -> Self {
+        BlockError::tx_index_disabled_error().into()
+    }
 }
 
 impl subsystem::Subsystem for Box<dyn ChainstateInterface> {}

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -132,124 +132,123 @@ where
     }
 }
 
-impl<C, S, U: UtxosView, A: PoSAccountingView> TransactionVerifierStorageMut
-    for TransactionVerifier<C, S, U, A>
+impl<C, S, U, A> TransactionVerifierStorageMut for TransactionVerifier<C, S, U, A>
 where
-    S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
+    S: TransactionVerifierStorageRef,
     <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
+    <S as TransactionVerifierStorageRef>::Error: From<TransactionVerifierStorageError>,
+    U: UtxosView,
+    A: PoSAccountingView,
 {
     fn set_mainchain_tx_index(
         &mut self,
         tx_id: &OutPointSourceId,
         tx_index: &TxMainChainIndex,
-    ) -> Result<(), TransactionVerifierStorageError> {
-        let tx_index_cache = self
-            .tx_index_cache
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
+        self.tx_index_cache
             .as_mut()
-            .ok_or(TransactionVerifierStorageError::TransactionIndexDisabled)?;
-        tx_index_cache
+            .ok_or(TransactionVerifierStorageError::TransactionIndexDisabled)?
             .set_tx_index(tx_id, tx_index.clone())
-            .map_err(TransactionVerifierStorageError::TxIndexError)
+            .map_err(|e| TransactionVerifierStorageError::TxIndexError(e).into())
     }
 
     fn del_mainchain_tx_index(
         &mut self,
         tx_id: &OutPointSourceId,
-    ) -> Result<(), TransactionVerifierStorageError> {
-        let tx_index_cache = self
-            .tx_index_cache
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
+        self.tx_index_cache
             .as_mut()
-            .ok_or(TransactionVerifierStorageError::TransactionIndexDisabled)?;
-        tx_index_cache
+            .ok_or(TransactionVerifierStorageError::TransactionIndexDisabled)?
             .remove_tx_index_by_id(tx_id.clone())
-            .map_err(TransactionVerifierStorageError::TxIndexError)
+            .map_err(|e| TransactionVerifierStorageError::TxIndexError(e).into())
     }
 
     fn set_token_aux_data(
         &mut self,
         token_id: &TokenId,
         data: &TokenAuxiliaryData,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.token_issuance_cache
             .set_token_aux_data(token_id, data.clone())
-            .map_err(TransactionVerifierStorageError::TokensError)
+            .map_err(|e| TransactionVerifierStorageError::TokensError(e).into())
     }
 
     fn del_token_aux_data(
         &mut self,
         token_id: &TokenId,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.token_issuance_cache
             .del_token_aux_data(token_id)
-            .map_err(TransactionVerifierStorageError::TokensError)
+            .map_err(|e| TransactionVerifierStorageError::TokensError(e).into())
     }
 
     fn set_token_id(
         &mut self,
         issuance_tx_id: &Id<Transaction>,
         token_id: &TokenId,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.token_issuance_cache
             .set_token_id(issuance_tx_id, token_id)
-            .map_err(TransactionVerifierStorageError::TokensError)
+            .map_err(|e| TransactionVerifierStorageError::TokensError(e).into())
     }
 
     fn del_token_id(
         &mut self,
         issuance_tx_id: &Id<Transaction>,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.token_issuance_cache
             .del_token_id(issuance_tx_id)
-            .map_err(TransactionVerifierStorageError::TokensError)
+            .map_err(|e| TransactionVerifierStorageError::TokensError(e).into())
     }
 
     fn set_utxo_undo_data(
         &mut self,
         tx_source: TransactionSource,
         new_undo: &UtxosBlockUndo,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.utxo_block_undo
             .set_undo_data(tx_source, new_undo)
-            .map_err(TransactionVerifierStorageError::UtxoBlockUndoError)
+            .map_err(|e| TransactionVerifierStorageError::UtxoBlockUndoError(e).into())
     }
 
     fn del_utxo_undo_data(
         &mut self,
         tx_source: TransactionSource,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.utxo_block_undo
             .del_undo_data(tx_source)
-            .map_err(TransactionVerifierStorageError::UtxoBlockUndoError)
+            .map_err(|e| TransactionVerifierStorageError::UtxoBlockUndoError(e).into())
     }
 
     fn set_accounting_undo_data(
         &mut self,
         tx_source: TransactionSource,
         new_undo: &AccountingBlockUndo,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.accounting_block_undo
             .set_undo_data(tx_source, new_undo)
-            .map_err(TransactionVerifierStorageError::AccountingBlockUndoError)
+            .map_err(|e| TransactionVerifierStorageError::AccountingBlockUndoError(e).into())
     }
 
     fn del_accounting_undo_data(
         &mut self,
         tx_source: TransactionSource,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.accounting_block_undo
             .del_undo_data(tx_source)
-            .map_err(TransactionVerifierStorageError::AccountingBlockUndoError)
+            .map_err(|e| TransactionVerifierStorageError::AccountingBlockUndoError(e).into())
     }
 
     fn apply_accounting_delta(
         &mut self,
         tx_source: TransactionSource,
         delta: &PoSAccountingDeltaData,
-    ) -> Result<(), TransactionVerifierStorageError> {
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.accounting_block_deltas
             .entry(tx_source)
             .or_default()
-            .merge_with_delta(delta.clone())?;
+            .merge_with_delta(delta.clone())
+            .map_err(TransactionVerifierStorageError::from)?;
         Ok(())
     }
 }
@@ -257,6 +256,8 @@ where
 impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView> FlushableUtxoView
     for TransactionVerifier<C, S, U, A>
 {
+    type Error = utxo::Error;
+
     fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), utxo::Error> {
         self.utxo_cache.batch_write(utxos)
     }

--- a/chainstate/tx-verifier/src/transaction_verifier/storage.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/storage.rs
@@ -110,70 +110,68 @@ where
 }
 
 pub trait TransactionVerifierStorageMut:
-    TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>
-    + FlushableUtxoView
-    + FlushablePoSAccountingView
+    TransactionVerifierStorageRef + FlushableUtxoView + FlushablePoSAccountingView
 {
     fn set_mainchain_tx_index(
         &mut self,
         tx_id: &OutPointSourceId,
         tx_index: &TxMainChainIndex,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn del_mainchain_tx_index(
         &mut self,
         tx_id: &OutPointSourceId,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn set_token_aux_data(
         &mut self,
         token_id: &TokenId,
         data: &TokenAuxiliaryData,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn del_token_aux_data(
         &mut self,
         token_id: &TokenId,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn set_token_id(
         &mut self,
         issuance_tx_id: &Id<Transaction>,
         token_id: &TokenId,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn del_token_id(
         &mut self,
         issuance_tx_id: &Id<Transaction>,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn set_utxo_undo_data(
         &mut self,
         tx_source: TransactionSource,
         undo: &utxo::UtxosBlockUndo,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn del_utxo_undo_data(
         &mut self,
         tx_source: TransactionSource,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn set_accounting_undo_data(
         &mut self,
         tx_source: TransactionSource,
         undo: &AccountingBlockUndo,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn del_accounting_undo_data(
         &mut self,
         tx_source: TransactionSource,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 
     fn apply_accounting_delta(
         &mut self,
         tx_source: TransactionSource,
         delta: &PoSAccountingDeltaData,
-    ) -> Result<(), TransactionVerifierStorageError>;
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 }
 
 impl<T: Deref> TransactionVerifierStorageRef for T

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -130,6 +130,7 @@ mockall::mock! {
     }
 
     impl FlushableUtxoView for Store {
+        type Error = utxo::Error;
         fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), utxo::Error>;
     }
 

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -413,6 +413,8 @@ impl<P: UtxosView> UtxosView for UtxosCache<P> {
 }
 
 impl<P> FlushableUtxoView for UtxosCache<P> {
+    type Error = Error;
+
     fn batch_write(&mut self, utxo_entries: ConsumedUtxoCache) -> Result<(), Error> {
         for (key, entry) in utxo_entries.container {
             // Ignore non-dirty entries (optimization).

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -41,6 +41,8 @@ impl<S: UtxosStorageRead> UtxosView for UtxosDB<S> {
 }
 
 impl<S: UtxosStorageWrite> FlushableUtxoView for UtxosDB<S> {
+    type Error = Error;
+
     fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), Error> {
         // check each entry if it's dirty. Only then will the db be updated.
         for (key, entry) in utxos.container {

--- a/utxo/src/view.rs
+++ b/utxo/src/view.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{ConsumedUtxoCache, Error, Utxo, UtxosCache};
+use crate::{ConsumedUtxoCache, Utxo, UtxosCache};
 use common::{
     chain::{GenBlock, OutPoint},
     primitives::Id,
@@ -37,8 +37,11 @@ pub trait UtxosView {
 }
 
 pub trait FlushableUtxoView {
+    /// Errors potentially triggered by flushing the view
+    type Error: std::error::Error;
+
     /// Performs bulk modification
-    fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), Error>;
+    fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), Self::Error>;
 }
 
 /// Flush the cache into the provided base. This will consume the cache and throw it away.
@@ -46,7 +49,7 @@ pub trait FlushableUtxoView {
 pub fn flush_to_base<T: FlushableUtxoView, P: UtxosView>(
     cache: UtxosCache<P>,
     base: &mut T,
-) -> Result<(), Error> {
+) -> Result<(), T::Error> {
     let consumed_cache = cache.consume();
     base.batch_write(consumed_cache)
 }


### PR DESCRIPTION
This is to support a more general way of flushing the transaction verifier state to the parent. Turns out this is also required to support having a verifier backed by a different subsystem.

* Generalize `FlushableUtxoView`
* Generalize `TransactionVerifierStorageMut`
* Tie up some loose ends here and there