### PR TITLE
Add authentication to RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,6 +3107,7 @@ dependencies = [
  "logging",
  "rstest",
  "subsystem",
+ "thiserror",
  "tokio",
  "tower",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,10 +3099,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.0",
+ "crypto",
+ "http",
+ "hyper",
  "jsonrpsee",
  "logging",
  "subsystem",
  "tokio",
+ "tower",
+ "tower-http",
  "utils",
 ]
 
@@ -4154,9 +4166,32 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,6 +3105,7 @@ dependencies = [
  "hyper",
  "jsonrpsee",
  "logging",
+ "rstest",
  "subsystem",
  "tokio",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,6 +3107,7 @@ dependencies = [
  "logging",
  "rstest",
  "subsystem",
+ "test-utils",
  "thiserror",
  "tokio",
  "tower",

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -182,6 +182,7 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
         ws_enabled,
         username,
         password,
+        cookie_file,
     } = config;
 
     let http_bind_address = options
@@ -198,6 +199,7 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
         .unwrap_or_else(|| ws_enabled.unwrap_or(DEFAULT_WS_RPC_ENABLED));
     let username = username.or(options.rpc_username.clone());
     let password = password.or(options.rpc_password.clone());
+    let cookie_file = cookie_file.or(options.rpc_cookie_file.clone());
 
     RpcConfigFile {
         http_bind_address: Some(http_bind_address),
@@ -206,6 +208,7 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
         ws_enabled: Some(ws_enabled),
         username,
         password,
+        cookie_file,
     }
 }
 

--- a/node/src/config_files/mod.rs
+++ b/node/src/config_files/mod.rs
@@ -180,6 +180,8 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
         http_enabled,
         ws_bind_address,
         ws_enabled,
+        username,
+        password,
     } = config;
 
     let http_bind_address = options
@@ -194,12 +196,16 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
     let ws_enabled = options
         .ws_rpc_enabled
         .unwrap_or_else(|| ws_enabled.unwrap_or(DEFAULT_WS_RPC_ENABLED));
+    let username = username.or(options.rpc_username.clone());
+    let password = password.or(options.rpc_password.clone());
 
     RpcConfigFile {
         http_bind_address: Some(http_bind_address),
         http_enabled: Some(http_enabled),
         ws_bind_address: Some(ws_bind_address),
         ws_enabled: Some(ws_enabled),
+        username,
+        password,
     }
 }
 

--- a/node/src/config_files/rpc.rs
+++ b/node/src/config_files/rpc.rs
@@ -37,6 +37,8 @@ pub struct RpcConfigFile {
     pub username: Option<String>,
 
     pub password: Option<String>,
+
+    pub cookie_file: Option<String>,
 }
 
 impl From<RpcConfigFile> for RpcConfig {
@@ -48,6 +50,7 @@ impl From<RpcConfigFile> for RpcConfig {
             ws_enabled: c.ws_enabled.into(),
             username: c.username,
             password: c.password,
+            cookie_file: c.cookie_file,
         }
     }
 }

--- a/node/src/config_files/rpc.rs
+++ b/node/src/config_files/rpc.rs
@@ -46,8 +46,8 @@ impl From<RpcConfigFile> for RpcConfig {
             http_enabled: c.http_enabled.into(),
             ws_bind_address: c.ws_bind_address.into(),
             ws_enabled: c.ws_enabled.into(),
-            username: c.username.clone(),
-            password: c.password.clone(),
+            username: c.username,
+            password: c.password,
         }
     }
 }

--- a/node/src/config_files/rpc.rs
+++ b/node/src/config_files/rpc.rs
@@ -33,6 +33,10 @@ pub struct RpcConfigFile {
 
     /// Whether websocket RPC is enabled
     pub ws_enabled: Option<bool>,
+
+    pub username: Option<String>,
+
+    pub password: Option<String>,
 }
 
 impl From<RpcConfigFile> for RpcConfig {
@@ -42,7 +46,8 @@ impl From<RpcConfigFile> for RpcConfig {
             http_enabled: c.http_enabled.into(),
             ws_bind_address: c.ws_bind_address.into(),
             ws_enabled: c.ws_enabled.into(),
-            credentials: None,
+            username: c.username.clone(),
+            password: c.password.clone(),
         }
     }
 }

--- a/node/src/config_files/rpc.rs
+++ b/node/src/config_files/rpc.rs
@@ -42,6 +42,7 @@ impl From<RpcConfigFile> for RpcConfig {
             http_enabled: c.http_enabled.into(),
             ws_bind_address: c.ws_bind_address.into(),
             ws_enabled: c.ws_enabled.into(),
+            credentials: None,
         }
     }
 }

--- a/node/src/config_files/rpc.rs
+++ b/node/src/config_files/rpc.rs
@@ -22,22 +22,25 @@ use serde::{Deserialize, Serialize};
 #[must_use]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct RpcConfigFile {
-    /// Address to bind http RPC to.
+    /// Address to bind http RPC to
     pub http_bind_address: Option<SocketAddr>,
 
     /// Whether http RPC is enabled
     pub http_enabled: Option<bool>,
 
-    /// Address to bind websocket RPC to.
+    /// Address to bind websocket RPC to
     pub ws_bind_address: Option<SocketAddr>,
 
     /// Whether websocket RPC is enabled
     pub ws_enabled: Option<bool>,
 
+    /// Username for RPC HTTP and WebSocket server basic authorization
     pub username: Option<String>,
 
+    /// Password for RPC HTTP and WebSocket server basic authorization
     pub password: Option<String>,
 
+    /// Custom file path for the RPC cookie file
     pub cookie_file: Option<String>,
 }
 

--- a/node/src/config_files/rpc.rs
+++ b/node/src/config_files/rpc.rs
@@ -48,9 +48,6 @@ impl From<RpcConfigFile> for RpcConfig {
             http_enabled: c.http_enabled.into(),
             ws_bind_address: c.ws_bind_address.into(),
             ws_enabled: c.ws_enabled.into(),
-            username: c.username,
-            password: c.password,
-            cookie_file: c.cookie_file,
         }
     }
 }

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -143,6 +143,14 @@ pub struct RunOptions {
     /// Enable/Disable websocket RPC.
     #[clap(long)]
     pub ws_rpc_enabled: Option<bool>,
+
+    /// Optional username for RPC HTTP and WebSocket basic authorization.
+    #[clap(long)]
+    pub rpc_username: Option<String>,
+
+    /// Optional password for RPC HTTP and WebSocket basic authorization.
+    #[clap(long)]
+    pub rpc_password: Option<String>,
 }
 
 impl Options {

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -145,10 +145,12 @@ pub struct RunOptions {
     pub ws_rpc_enabled: Option<bool>,
 
     /// Optional username for RPC HTTP and WebSocket basic authorization.
+    /// If not, set the cookie file will be created.
     #[clap(long)]
     pub rpc_username: Option<String>,
 
     /// Optional password for RPC HTTP and WebSocket basic authorization.
+    /// If not, set the cookie file will be created.
     #[clap(long)]
     pub rpc_password: Option<String>,
 }

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -153,6 +153,9 @@ pub struct RunOptions {
     /// If not, set the cookie file will be created.
     #[clap(long)]
     pub rpc_password: Option<String>,
+
+    #[clap(long)]
+    pub rpc_cookie_file: Option<String>,
 }
 
 impl Options {

--- a/node/src/options.rs
+++ b/node/src/options.rs
@@ -144,16 +144,18 @@ pub struct RunOptions {
     #[clap(long)]
     pub ws_rpc_enabled: Option<bool>,
 
-    /// Optional username for RPC HTTP and WebSocket basic authorization.
-    /// If not, set the cookie file will be created.
+    /// Username for RPC HTTP and WebSocket server basic authorization.
+    /// If not set, the cookie file is created.
     #[clap(long)]
     pub rpc_username: Option<String>,
 
-    /// Optional password for RPC HTTP and WebSocket basic authorization.
-    /// If not, set the cookie file will be created.
+    /// Password for RPC HTTP and WebSocket server basic authorization.
+    /// If not set, the RPC cookie file is created.
     #[clap(long)]
     pub rpc_password: Option<String>,
 
+    /// Custom file path for the RPC cookie file.
+    /// If not set, the cookie file is created in the data dir.
     #[clap(long)]
     pub rpc_cookie_file: Option<String>,
 }

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -126,7 +126,7 @@ pub async fn initialize(
         // TODO: get rid of the unwrap_or() after fixing the issue in #446
         let _rpc = manager.add_subsystem(
             "rpc",
-            rpc::Builder::new(rpc_config.into(), Some(rpc_creds))?
+            rpc::Builder::new(rpc_config.into(), Some(rpc_creds))
                 .register(crate::rpc::init(
                     manager.make_shutdown_trigger(),
                     chain_config,

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -121,6 +121,7 @@ pub async fn initialize(
             &data_dir,
             rpc_config.username.as_deref(),
             rpc_config.password.as_deref(),
+            rpc_config.cookie_file.as_deref(),
         )?;
         // TODO: get rid of the unwrap_or() after fixing the issue in #446
         let _rpc = manager.add_subsystem(

--- a/node/src/runner.rs
+++ b/node/src/runner.rs
@@ -38,6 +38,7 @@ use logging::log;
 use mempool::{rpc::MempoolRpcServer, MempoolSubsystemInterface};
 
 use p2p::{peer_manager::peerdb::storage_impl::PeerDbStorageImpl, rpc::P2pRpcServer};
+use rpc::rpc_creds::RpcCreds;
 
 use crate::{
     config_files::NodeConfigFile,
@@ -116,10 +117,15 @@ pub async fn initialize(
 
     // RPC subsystem
     if rpc_config.http_enabled.unwrap_or(true) || rpc_config.ws_enabled.unwrap_or(true) {
+        let rpc_creds = RpcCreds::new(
+            &data_dir,
+            rpc_config.username.as_deref(),
+            rpc_config.password.as_deref(),
+        )?;
         // TODO: get rid of the unwrap_or() after fixing the issue in #446
         let _rpc = manager.add_subsystem(
             "rpc",
-            rpc::Builder::new(rpc_config.into())
+            rpc::Builder::new(rpc_config.into(), Some(rpc_creds))?
                 .register(crate::rpc::init(
                     manager.make_shutdown_trigger(),
                     chain_config,

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -112,6 +112,8 @@ fn read_config_override_values() {
     let backend_type = StorageBackendConfigFile::InMemory;
     let node_type = NodeTypeConfigFile::FullNode;
     let max_tip_age = 1000;
+    let rpc_username = "username";
+    let rpc_password = "password";
 
     let options = RunOptions {
         storage_backend: Some(backend_type.clone()),
@@ -135,6 +137,8 @@ fn read_config_override_values() {
         http_rpc_enabled: Some(true),
         ws_rpc_addr: Some(ws_rpc_addr),
         ws_rpc_enabled: Some(false),
+        rpc_username: Some(rpc_username.to_owned()),
+        rpc_password: Some(rpc_password.to_owned()),
     };
     let config = NodeConfigFile::read(&config_path, &options).unwrap();
 
@@ -208,6 +212,15 @@ fn read_config_override_values() {
         Some(ws_rpc_addr)
     );
     assert!(!config.rpc.clone().unwrap().ws_enabled.unwrap());
+
+    assert_eq!(
+        config.rpc.as_ref().unwrap().username.as_deref(),
+        Some(rpc_username)
+    );
+    assert_eq!(
+        config.rpc.as_ref().unwrap().password.as_deref(),
+        Some(rpc_password)
+    );
 
     assert_eq!(config.chainstate.unwrap().storage_backend, backend_type);
 }

--- a/node/tests/cli.rs
+++ b/node/tests/cli.rs
@@ -114,6 +114,7 @@ fn read_config_override_values() {
     let max_tip_age = 1000;
     let rpc_username = "username";
     let rpc_password = "password";
+    let rpc_cookie_file = "cookie_file";
 
     let options = RunOptions {
         storage_backend: Some(backend_type.clone()),
@@ -139,6 +140,7 @@ fn read_config_override_values() {
         ws_rpc_enabled: Some(false),
         rpc_username: Some(rpc_username.to_owned()),
         rpc_password: Some(rpc_password.to_owned()),
+        rpc_cookie_file: Some(rpc_cookie_file.to_owned()),
     };
     let config = NodeConfigFile::read(&config_path, &options).unwrap();
 
@@ -220,6 +222,10 @@ fn read_config_override_values() {
     assert_eq!(
         config.rpc.as_ref().unwrap().password.as_deref(),
         Some(rpc_password)
+    );
+    assert_eq!(
+        config.rpc.as_ref().unwrap().cookie_file.as_deref(),
+        Some(rpc_cookie_file)
     );
 
     assert_eq!(config.chainstate.unwrap().storage_backend, backend_type);

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -16,6 +16,7 @@ crypto = { path = "../crypto/" }
 
 # External dependencies
 anyhow = "1.0"
+thiserror.workspace = true
 async-trait.workspace = true
 jsonrpsee = { workspace = true, features = ["full"] }
 tower-http = { version = "0.3", features = ["auth"] }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -26,3 +26,4 @@ base64 = "0.21"
 
 [dev-dependencies]
 tokio.workspace = true
+rstest.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,11 +12,17 @@ rust-version.workspace = true
 subsystem = { path = "../subsystem" }
 logging = { path = "../logging" }
 utils = { path = "../utils/" }
+crypto = { path = "../crypto/" }
 
 # External dependencies
 anyhow = "1.0"
 async-trait.workspace = true
 jsonrpsee = { workspace = true, features = ["full"] }
+tower-http = { version = "0.3", features = ["auth"] }
+tower = { version = "0.4", features = ["util"] }
+hyper = "0.14"
+http = "0.2"
+base64 = "0.21"
 
 [dev-dependencies]
 tokio.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -24,5 +24,7 @@ tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.3", features = ["auth"] }
 
 [dev-dependencies]
+test-utils = { path = "../test-utils" }
+
 rstest.workspace = true
 tokio.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -8,23 +8,21 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# Local dependencies
-subsystem = { path = "../subsystem" }
-logging = { path = "../logging" }
-utils = { path = "../utils/" }
 crypto = { path = "../crypto/" }
+logging = { path = "../logging" }
+subsystem = { path = "../subsystem" }
+utils = { path = "../utils/" }
 
-# External dependencies
 anyhow = "1.0"
-thiserror.workspace = true
 async-trait.workspace = true
-jsonrpsee = { workspace = true, features = ["full"] }
-tower-http = { version = "0.3", features = ["auth"] }
-tower = { version = "0.4", features = ["util"] }
-hyper = "0.14"
-http = "0.2"
 base64 = "0.21"
+http = "0.2"
+hyper = "0.14"
+jsonrpsee = { workspace = true, features = ["full"] }
+thiserror.workspace = true
+tower = { version = "0.4", features = ["util"] }
+tower-http = { version = "0.3", features = ["auth"] }
 
 [dev-dependencies]
-tokio.workspace = true
 rstest.workspace = true
+tokio.workspace = true

--- a/rpc/examples/simple_server.rs
+++ b/rpc/examples/simple_server.rs
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
     let rpc_config = rpc::RpcConfig::default();
     let _rpc_subsystem = app.add_subsystem(
         "rpc",
-        rpc::Builder::new(rpc_config, None)?
+        rpc::Builder::new(rpc_config, None)
             .register(some_subsystem.clone().into_rpc())
             .build()
             .await?,

--- a/rpc/examples/simple_server.rs
+++ b/rpc/examples/simple_server.rs
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
     let rpc_config = rpc::RpcConfig::default();
     let _rpc_subsystem = app.add_subsystem(
         "rpc",
-        rpc::Builder::new(rpc_config)
+        rpc::Builder::new(rpc_config, None)?
             .register(some_subsystem.clone().into_rpc())
             .build()
             .await?,

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -51,4 +51,6 @@ pub struct RpcConfig {
     pub username: Option<String>,
 
     pub password: Option<String>,
+
+    pub cookie_file: Option<String>,
 }

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{net::SocketAddr, str::FromStr};
+use std::{fmt::Debug, net::SocketAddr, str::FromStr};
 
 use utils::make_config_setting;
 
@@ -33,6 +33,20 @@ make_config_setting!(
 
 make_config_setting!(WebsocketRpcEnabled, bool, true);
 
+pub struct RpcCredentials {
+    pub username: String,
+    pub password: String,
+}
+
+impl Debug for RpcCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RpcAuth")
+            .field("username", &self.username)
+            .field("password", &"<...>")
+            .finish()
+    }
+}
+
 /// The rpc subsystem configuration.
 #[derive(Debug, Default)]
 pub struct RpcConfig {
@@ -47,4 +61,6 @@ pub struct RpcConfig {
 
     /// Whether websocket RPC is enabled
     pub ws_enabled: WebsocketRpcEnabled,
+
+    pub credentials: Option<RpcCredentials>,
 }

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -47,10 +47,4 @@ pub struct RpcConfig {
 
     /// Whether websocket RPC is enabled
     pub ws_enabled: WebsocketRpcEnabled,
-
-    pub username: Option<String>,
-
-    pub password: Option<String>,
-
-    pub cookie_file: Option<String>,
 }

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -33,20 +33,6 @@ make_config_setting!(
 
 make_config_setting!(WebsocketRpcEnabled, bool, true);
 
-pub struct RpcCredentials {
-    pub username: String,
-    pub password: String,
-}
-
-impl Debug for RpcCredentials {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RpcAuth")
-            .field("username", &self.username)
-            .field("password", &"<...>")
-            .finish()
-    }
-}
-
 /// The rpc subsystem configuration.
 #[derive(Debug, Default)]
 pub struct RpcConfig {
@@ -62,5 +48,7 @@ pub struct RpcConfig {
     /// Whether websocket RPC is enabled
     pub ws_enabled: WebsocketRpcEnabled,
 
-    pub credentials: Option<RpcCredentials>,
+    pub username: Option<String>,
+
+    pub password: Option<String>,
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -72,7 +72,7 @@ impl Builder {
     /// New builder pre-populated with RPC info methods.
     ///
     /// If `creds` is set, basic HTTP authentication is required.
-    pub fn new(rpc_config: RpcConfig, creds: Option<RpcCreds>) -> anyhow::Result<Self> {
+    pub fn new(rpc_config: RpcConfig, creds: Option<RpcCreds>) -> Self {
         let http_bind_address = if *rpc_config.http_enabled {
             Some(*rpc_config.http_bind_address)
         } else {
@@ -85,13 +85,13 @@ impl Builder {
             None
         };
 
-        Ok(Self {
+        Self {
             http_bind_address,
             ws_bind_address,
             methods: Methods::new(),
             creds,
         }
-        .register(RpcInfo.into_rpc()))
+        .register(RpcInfo.into_rpc())
     }
 
     /// Add methods handlers to the RPC server
@@ -249,7 +249,6 @@ mod tests {
         };
 
         let rpc = Builder::new(rpc_config, None)
-            .unwrap()
             .register(SubsystemRpcImpl.into_rpc())
             .build()
             .await?;
@@ -349,9 +348,16 @@ mod tests {
         let data_dir: PathBuf = ".".into();
         let rpc = Builder::new(
             rpc_config,
-            Some(RpcCreds::new(&data_dir, Some(GOOD_USERNAME), Some(GOOD_PASSWORD), None).unwrap()),
+            Some(
+                RpcCreds::new(
+                    &data_dir,
+                    Some(GOOD_USERNAME),
+                    Some(GOOD_PASSWORD),
+                    Option::<String>::None,
+                )
+                .unwrap(),
+            ),
         )
-        .unwrap()
         .register(SubsystemRpcImpl.into_rpc())
         .build()
         .await

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -233,6 +233,7 @@ mod tests {
             ws_enabled: false.into(),
             username: None,
             password: None,
+            cookie_file: None,
         };
         let rpc = Builder::new(rpc_config, None)
             .unwrap()
@@ -265,6 +266,7 @@ mod tests {
             ws_enabled: true.into(),
             username: None,
             password: None,
+            cookie_file: None,
         };
         let rpc = Builder::new(rpc_config, None)
             .unwrap()
@@ -297,6 +299,7 @@ mod tests {
             ws_enabled: true.into(),
             username: None,
             password: None,
+            cookie_file: None,
         };
 
         let rpc = Builder::new(rpc_config, None)

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -231,9 +231,6 @@ mod tests {
             http_enabled: true.into(),
             ws_bind_address: "127.0.0.1:0".parse::<SocketAddr>().unwrap().into(),
             ws_enabled: false.into(),
-            username: None,
-            password: None,
-            cookie_file: None,
         };
         let rpc = Builder::new(rpc_config, None)
             .unwrap()
@@ -264,9 +261,6 @@ mod tests {
             http_enabled: false.into(),
             ws_bind_address: "127.0.0.1:0".parse::<SocketAddr>().unwrap().into(),
             ws_enabled: true.into(),
-            username: None,
-            password: None,
-            cookie_file: None,
         };
         let rpc = Builder::new(rpc_config, None)
             .unwrap()
@@ -297,9 +291,6 @@ mod tests {
             http_enabled: true.into(),
             ws_bind_address: "127.0.0.1:3033".parse::<SocketAddr>().unwrap().into(),
             ws_enabled: true.into(),
-            username: None,
-            password: None,
-            cookie_file: None,
         };
 
         let rpc = Builder::new(rpc_config, None)

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -69,7 +69,9 @@ impl Builder {
         }
     }
 
-    /// New builder pre-populated with RPC info methods
+    /// New builder pre-populated with RPC info methods.
+    ///
+    /// If `creds` is set, basic HTTP authentication is required.
     pub fn new(rpc_config: RpcConfig, creds: Option<RpcCreds>) -> anyhow::Result<Self> {
         let http_bind_address = if *rpc_config.http_enabled {
             Some(*rpc_config.http_bind_address)
@@ -114,10 +116,14 @@ impl Builder {
 pub struct Rpc {
     http: Option<(SocketAddr, ServerHandle)>,
     websocket: Option<(SocketAddr, ServerHandle)>,
+    // Stored here to remove the cookie file when the node is stopped
     _creds: Option<RpcCreds>,
 }
 
 impl Rpc {
+    /// Rpc constructor.
+    ///
+    /// If `creds` is set, basic HTTP authentication is required.
     async fn new(
         http_bind_addr: Option<&SocketAddr>,
         ws_bind_addr: Option<&SocketAddr>,

--- a/rpc/src/rpc_auth/mod.rs
+++ b/rpc/src/rpc_auth/mod.rs
@@ -26,7 +26,11 @@ use hyper::{Body, Request, Response};
 use logging::log;
 use tower_http::auth::AuthorizeRequest;
 
-/// HTTP authentication helper
+/// Custom HTTP authentication layer implementation
+///
+/// Custom authorization is not really needed, because `tower_http`
+/// already supports it (see [`tower_http::auth::RequireAuthorizationLayer::basic`]),
+/// but it can simply things if we want to support hashed passwords.
 #[derive(Clone)]
 pub struct RpcAuth {
     username: String,

--- a/rpc/src/rpc_auth/mod.rs
+++ b/rpc/src/rpc_auth/mod.rs
@@ -25,8 +25,6 @@ use crypto::{
 use hyper::{Body, Request, Response};
 use tower_http::auth::AuthorizeRequest;
 
-use crate::config::RpcCredentials;
-
 #[derive(Clone)]
 pub struct RpcAuth {
     username: String,
@@ -50,16 +48,13 @@ const RPC_KDF_CONFIG: KdfConfig = KdfConfig::Argon2id {
 };
 
 impl RpcAuth {
-    pub fn new(creds: &RpcCredentials) -> Self {
-        let password_hash = hash_password(
-            &mut make_true_rng(),
-            RPC_KDF_CONFIG,
-            creds.password.as_bytes(),
-        )
-        .expect("hash_password failed unexpectedly");
+    pub fn new(username: &str, password: &str) -> Self {
+        let password_hash =
+            hash_password(&mut make_true_rng(), RPC_KDF_CONFIG, password.as_bytes())
+                .expect("hash_password failed unexpectedly");
 
         Self {
-            username: creds.username.clone(),
+            username: username.to_owned(),
             password_hash,
         }
     }

--- a/rpc/src/rpc_auth/mod.rs
+++ b/rpc/src/rpc_auth/mod.rs
@@ -100,7 +100,7 @@ impl<B> AuthorizeRequest<B> for RpcAuth {
         match res {
             Ok(true) => Ok(()),
             Ok(false) => {
-                log::error!("unauthorized RPC request {:?}", request.uri());
+                log::error!("Unauthorized RPC request {:?}", request.uri());
                 Err(Response::builder()
                     .status(http::StatusCode::UNAUTHORIZED)
                     .header(http::header::WWW_AUTHENTICATE, "Basic")
@@ -108,7 +108,7 @@ impl<B> AuthorizeRequest<B> for RpcAuth {
                     .expect("must be valid"))
             }
             Err(e) => {
-                log::error!("invalid RPC request {:?}: {e}", request.uri());
+                log::error!("Invalid RPC request {:?}: {e}", request.uri());
                 Err(Response::builder()
                     .status(http::StatusCode::BAD_REQUEST)
                     .body(e.to_string().into())
@@ -117,3 +117,5 @@ impl<B> AuthorizeRequest<B> for RpcAuth {
         }
     }
 }
+
+// TODO: Write tests

--- a/rpc/src/rpc_auth/mod.rs
+++ b/rpc/src/rpc_auth/mod.rs
@@ -26,6 +26,7 @@ use hyper::{Body, Request, Response};
 use logging::log;
 use tower_http::auth::AuthorizeRequest;
 
+/// HTTP authentication helper
 #[derive(Clone)]
 pub struct RpcAuth {
     username: String,

--- a/rpc/src/rpc_auth/mod.rs
+++ b/rpc/src/rpc_auth/mod.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::num::NonZeroUsize;
+
+use anyhow::anyhow;
+use base64::Engine;
+use crypto::{
+    kdf::{argon2::Argon2Config, hash_password, verify_password, KdfConfig, KdfResult},
+    random::make_true_rng,
+    util::eq::SliceEqualityCheckMethod,
+};
+use hyper::{Body, Request, Response};
+use tower_http::auth::AuthorizeRequest;
+
+use crate::config::RpcCredentials;
+
+#[derive(Clone)]
+pub struct RpcAuth {
+    username: String,
+    password_hash: KdfResult,
+}
+
+const RPC_KDF_CONFIG: KdfConfig = KdfConfig::Argon2id {
+    config: Argon2Config {
+        m_cost_memory_size: 200,
+        t_cost_iterations: 10,
+        p_cost_parallelism: 2,
+    },
+    hash_length: match NonZeroUsize::new(32) {
+        Some(v) => v,
+        None => unreachable!(),
+    },
+    salt_length: match NonZeroUsize::new(16) {
+        Some(v) => v,
+        None => unreachable!(),
+    },
+};
+
+impl RpcAuth {
+    pub fn new(creds: &RpcCredentials) -> Self {
+        let password_hash = hash_password(
+            &mut make_true_rng(),
+            RPC_KDF_CONFIG,
+            creds.password.as_bytes(),
+        )
+        .expect("hash_password failed unexpectedly");
+
+        Self {
+            username: creds.username.clone(),
+            password_hash,
+        }
+    }
+
+    fn check_auth<B>(&self, request: &Request<B>) -> anyhow::Result<bool> {
+        let header = match request.headers().get(http::header::AUTHORIZATION) {
+            Some(v) => v,
+            None => return Ok(false),
+        };
+        let username_password_encoded = header
+            .as_bytes()
+            .strip_prefix("Basic ".as_bytes())
+            .ok_or_else(|| anyhow!("basic authentication expected"))?;
+        let username_password = base64::engine::general_purpose::STANDARD
+            .decode(username_password_encoded)
+            .map_err(|e| anyhow!("base64 decoding of the authorization header failed: {e}"))?;
+        let username_password = std::str::from_utf8(username_password.as_slice())
+            .map_err(|e| anyhow!("invalid utf8 in the authorization header: {e}"))?;
+        let (username, password) = username_password
+            .split_once(':')
+            .ok_or_else(|| anyhow!("invalid authorization header: ':' not found"))?;
+        let password_valid = verify_password(
+            password.as_bytes(),
+            self.password_hash.clone(),
+            SliceEqualityCheckMethod::TimingResistant,
+        )
+        .map_err(|e| anyhow!("verify_password failed unexpectedly: {e}"))?;
+        Ok(username == self.username && password_valid)
+    }
+}
+
+impl<B> AuthorizeRequest<B> for RpcAuth {
+    type ResponseBody = Body;
+
+    fn authorize(&mut self, request: &mut Request<B>) -> Result<(), Response<Self::ResponseBody>> {
+        let res = self.check_auth(request);
+        match res {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(Response::builder()
+                .status(http::StatusCode::UNAUTHORIZED)
+                .header(http::header::WWW_AUTHENTICATE, "Basic")
+                .body(Body::empty())
+                .expect("must be valid")),
+            Err(e) => Err(Response::builder()
+                .status(http::StatusCode::BAD_REQUEST)
+                .body(e.to_string().into())
+                .expect("must be valid")),
+        }
+    }
+}

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -26,6 +26,8 @@ const COOKIE_PASSWORD_LEN: usize = 32;
 const COOKIE_FILENAME: &str = ".cookie";
 const COOKIE_USERNAME: &str = "__cookie__";
 
+// TODO: Add support for hashed passwords (--rpcauth in Bitcoin Core)
+
 pub struct RpcCreds {
     username: String,
     password: String,
@@ -64,6 +66,10 @@ impl RpcCreds {
                 anyhow::ensure!(
                     cookie_file.is_none(),
                     "cookie file can't be used with username/password"
+                );
+                anyhow::ensure!(
+                    username.find(':').is_none(),
+                    "invalid symbol ':' in RPC username"
                 );
                 Ok(Self {
                     username: username.to_owned(),

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -48,7 +48,7 @@ fn write_file(path: &Path, data: &str) -> Result<(), std::io::Error> {
         options.mode(0o600);
     }
 
-    options.create(true).write(true).open(&path)?.write_all(data.as_bytes())
+    options.create(true).write(true).open(path)?.write_all(data.as_bytes())
 }
 
 impl RpcCreds {

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -59,11 +59,17 @@ impl RpcCreds {
         cookie_file: Option<&str>,
     ) -> anyhow::Result<Self> {
         match (username, password) {
-            (Some(username), Some(password)) => Ok(Self {
-                username: username.to_owned(),
-                password: password.to_owned(),
-                cookie_file: None,
-            }),
+            (Some(username), Some(password)) => {
+                anyhow::ensure!(
+                    cookie_file.is_none(),
+                    "cookie file can't be used with username/password"
+                );
+                Ok(Self {
+                    username: username.to_owned(),
+                    password: password.to_owned(),
+                    cookie_file: None,
+                })
+            }
 
             (None, None) => {
                 let username = COOKIE_USERNAME.to_owned();
@@ -75,7 +81,7 @@ impl RpcCreds {
                 let cookie = format!("{username}:{password}");
 
                 write_file(&cookie_file, &cookie)
-                    .with_context(|| format!("Failed to create cookie file {cookie_file:?}"))?;
+                    .with_context(|| format!("failed to create cookie file {cookie_file:?}"))?;
 
                 Ok(Self {
                     username,

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -18,7 +18,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crypto::random::{make_true_rng, CryptoRng, Rng};
+use crypto::random::{distributions::DistString, make_true_rng, CryptoRng, Rng};
 use logging::log;
 
 const COOKIE_PASSWORD_LEN: usize = 32;
@@ -33,11 +33,8 @@ pub struct RpcCreds {
     cookie_file: Option<PathBuf>,
 }
 
-fn gen_password<R: Rng + CryptoRng>(rng: &mut R, len: usize) -> String {
-    rng.sample_iter(&crypto::random::distributions::Alphanumeric)
-        .take(len)
-        .map(char::from)
-        .collect()
+fn gen_password(rng: &mut (impl Rng + CryptoRng), len: usize) -> String {
+    crypto::random::distributions::Alphanumeric.sample_string(rng, len)
 }
 
 fn write_file(path: &Path, data: &str) -> Result<(), std::io::Error> {

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -44,6 +44,7 @@ fn write_file(path: &Path, data: &str) -> Result<(), std::io::Error> {
 
     #[cfg(unix)]
     {
+        // Prevent other users from reading the file
         use std::os::unix::prelude::OpenOptionsExt;
         options.mode(0o600);
     }

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use crypto::random::{make_true_rng, CryptoRng, Rng};
+use logging::log;
+
+const COOKIE_PASSWORD_LEN: usize = 32;
+const COOKIE_FILENAME: &str = ".cookie";
+const COOKIE_USERNAME: &str = "__cookie__";
+
+pub struct RpcCreds {
+    username: String,
+    password: String,
+    cookie_file: Option<PathBuf>,
+}
+
+fn gen_password<R: Rng + CryptoRng>(rng: &mut R, len: usize) -> String {
+    rng.sample_iter(&crypto::random::distributions::Alphanumeric)
+        .take(len)
+        .map(char::from)
+        .collect()
+}
+
+impl RpcCreds {
+    pub fn new(
+        data_dir: &Path,
+        username: Option<&str>,
+        password: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        match (username, password) {
+            (Some(username), Some(password)) => Ok(Self {
+                username: username.to_owned(),
+                password: password.to_owned(),
+                cookie_file: None,
+            }),
+            (None, None) => {
+                let username = COOKIE_USERNAME.to_owned();
+                let password = gen_password(&mut make_true_rng(), COOKIE_PASSWORD_LEN);
+                let cookie_file = data_dir.join(COOKIE_FILENAME);
+                let cookie = format!("{username}:{password}");
+
+                std::fs::write(&cookie_file, cookie)
+                    .with_context(|| format!("Failed to create cookie file {cookie_file:?}"))?;
+
+                Ok(Self {
+                    username,
+                    password,
+                    cookie_file: Some(cookie_file),
+                })
+            }
+            _ => anyhow::bail!("both RPC username and password must be set"),
+        }
+    }
+
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    pub fn password(&self) -> &str {
+        &self.password
+    }
+}
+
+impl Drop for RpcCreds {
+    fn drop(&mut self) {
+        if let Some(cookie_file) = &self.cookie_file {
+            let res = std::fs::remove_file(cookie_file);
+            if let Err(e) = res {
+                log::error!("removing cookie file {cookie_file:?} failed: {e}");
+            }
+        }
+    }
+}

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -70,7 +70,7 @@ impl RpcCreds {
         data_dir: impl AsRef<Path>,
         username: Option<impl AsRef<str>>,
         password: Option<impl AsRef<str>>,
-        cookie_file: Option<&str>,
+        cookie_file: Option<impl AsRef<str>>,
     ) -> Result<Self, RpcCredsError> {
         match (username, password) {
             (Some(username), Some(password)) => {
@@ -93,7 +93,7 @@ impl RpcCreds {
                 let username = COOKIE_USERNAME.to_owned();
                 let password = gen_password(&mut make_true_rng(), COOKIE_PASSWORD_LEN);
                 let cookie_file = match cookie_file {
-                    Some(cookie_file) => cookie_file.into(),
+                    Some(cookie_file) => cookie_file.as_ref().into(),
                     None => data_dir.as_ref().join(COOKIE_FILENAME),
                 };
                 let cookie = format!("{username}:{password}");

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -56,6 +56,7 @@ impl RpcCreds {
         data_dir: &Path,
         username: Option<&str>,
         password: Option<&str>,
+        cookie_file: Option<&str>,
     ) -> anyhow::Result<Self> {
         match (username, password) {
             (Some(username), Some(password)) => Ok(Self {
@@ -63,10 +64,14 @@ impl RpcCreds {
                 password: password.to_owned(),
                 cookie_file: None,
             }),
+
             (None, None) => {
                 let username = COOKIE_USERNAME.to_owned();
                 let password = gen_password(&mut make_true_rng(), COOKIE_PASSWORD_LEN);
-                let cookie_file = data_dir.join(COOKIE_FILENAME);
+                let cookie_file = match cookie_file {
+                    Some(cookie_file) => cookie_file.into(),
+                    None => data_dir.join(COOKIE_FILENAME),
+                };
                 let cookie = format!("{username}:{password}");
 
                 write_file(&cookie_file, &cookie)
@@ -78,6 +83,7 @@ impl RpcCreds {
                     cookie_file: Some(cookie_file),
                 })
             }
+
             _ => anyhow::bail!("both RPC username and password must be set"),
         }
     }

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -91,8 +91,8 @@ class AuthServiceProxy():
         self.__url = urllib.parse.urlparse(service_url)
         user = None if self.__url.username is None else self.__url.username.encode('utf8')
         passwd = None if self.__url.password is None else self.__url.password.encode('utf8')
-        #authpair = user + b':' + passwd
-        #self.__auth_header = b'Basic ' + base64.b64encode(authpair)
+        authpair = user + b':' + passwd
+        self.__auth_header = b'Basic ' + base64.b64encode(authpair)
         self.timeout = timeout
         self._set_conn(connection)
 
@@ -111,7 +111,7 @@ class AuthServiceProxy():
         '''
         headers = {'Host': self.__url.hostname,
                    'User-Agent': USER_AGENT,
-                   #'Authorization': self.__auth_header,
+                   'Authorization': self.__auth_header,
                    'Content-type': 'application/json'}
         if os.name == 'nt':
             # Windows somehow does not like to re-use connections

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -32,6 +32,7 @@ from .util import (
     delete_cookie_file,
     get_auth_cookie,
     get_rpc_proxy,
+    rpc_addr,
     rpc_url,
     wait_until_helper,
     p2p_port,
@@ -86,7 +87,6 @@ class TestNode():
         self.coverage_dir = coverage_dir
         self.cwd = cwd
         self.descriptors = descriptors
-        self.init_rpc_url = rpc_url(self.datadir, self.index, self.chain, self.rpchost)
         if extra_conf is not None:
             append_config(datadir, extra_conf)
         # Most callers will just need to add extra args to the standard list below.
@@ -96,7 +96,7 @@ class TestNode():
         self.version = version
 
         # Calculate RPC address to be passed into the command line
-        rpc_addr = self.init_rpc_url.split("http://")[-1].split('@')[-1]
+        rpc_address = rpc_addr(self.index)
         p2p_addr = p2p_url(self.index)
 
         # Configuration for logging is set as command-line args rather than in the bitcoin.conf file.
@@ -106,7 +106,7 @@ class TestNode():
             self.binary,
             "--datadir={}".format(datadir),
             "regtest",
-            "--http-rpc-addr={}".format(rpc_addr),
+            "--http-rpc-addr={}".format(rpc_address),
             "--p2p-addr={}".format(p2p_addr),
             #"-X",
             #"-logtimemicros",
@@ -236,7 +236,7 @@ class TestNode():
                     'bitcoind exited with status {} during initialization'.format(self.process.returncode)))
             try:
                 rpc = get_rpc_proxy(
-                    self.init_rpc_url,
+                    rpc_url(self.datadir, self.index, self.chain, self.rpchost),
                     self.index,
                     timeout=self.rpc_timeout // 2,  # Shorter timeout to allow for one retry in case of ETIMEDOUT
                     coveragedir=self.coverage_dir,

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -330,10 +330,13 @@ def p2p_url(n):
 def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
+def rpc_addr(n):
+    return "127.0.0.1:" + str(rpc_port(n))
 
 def rpc_url(datadir, i, chain, rpchost):
-    # TODO re-enable authentication
-    #rpc_u, rpc_p = get_auth_cookie(datadir, chain)
+    rpc_u, rpc_p = get_auth_cookie(datadir, chain)
+    print(rpc_u)
+    print(rpc_p)
     host = '127.0.0.1'
     port = rpc_port(i)
     if rpchost:
@@ -342,9 +345,7 @@ def rpc_url(datadir, i, chain, rpchost):
             host, port = parts
         else:
             host = rpchost
-    # TODO re-enable authentication
-    #return "http://%s:%s@%s:%d" % (rpc_u, rpc_p, host, int(port))
-    return "http://%s:%d" % (host, int(port))
+    return "http://%s:%s@%s:%d" % (rpc_u, rpc_p, host, int(port))
 
 
 # Node functions
@@ -422,7 +423,7 @@ def get_auth_cookie(datadir, chain):
                     assert password is None  # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
     try:
-        with open(os.path.join(datadir, chain, ".cookie"), 'r', encoding="ascii") as f:
+        with open(os.path.join(datadir, ".cookie"), 'r', encoding="ascii") as f:
             userpass = f.read()
             split_userpass = userpass.split(':')
             user = split_userpass[0]

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -65,7 +65,6 @@ pub async fn start_subsystems(
     };
 
     let rpc_subsys = rpc::Builder::new(rpc_config, None)
-        .unwrap()
         .register(chainstate_subsys.clone().into_rpc())
         .build()
         .await

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -64,6 +64,7 @@ pub async fn start_subsystems(
         ws_enabled: false.into(),
         username: None,
         password: None,
+        cookie_file: None,
     };
 
     let rpc_subsys = rpc::Builder::new(rpc_config, None)

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -62,9 +62,6 @@ pub async fn start_subsystems(
             .expect("Address must be correct")
             .into(),
         ws_enabled: false.into(),
-        username: None,
-        password: None,
-        cookie_file: None,
     };
 
     let rpc_subsys = rpc::Builder::new(rpc_config, None)

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -62,7 +62,8 @@ pub async fn start_subsystems(
             .expect("Address must be correct")
             .into(),
         ws_enabled: false.into(),
-        credentials: None,
+        username: None,
+        password: None,
     };
 
     let rpc_subsys = rpc::Builder::new(rpc_config)

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -66,7 +66,8 @@ pub async fn start_subsystems(
         password: None,
     };
 
-    let rpc_subsys = rpc::Builder::new(rpc_config)
+    let rpc_subsys = rpc::Builder::new(rpc_config, None)
+        .unwrap()
         .register(chainstate_subsys.clone().into_rpc())
         .build()
         .await

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -62,6 +62,7 @@ pub async fn start_subsystems(
             .expect("Address must be correct")
             .into(),
         ws_enabled: false.into(),
+        credentials: None,
     };
 
     let rpc_subsys = rpc::Builder::new(rpc_config)


### PR DESCRIPTION
To keep things simple, the password is specified in plaintext. This can be problematic because it allows the password to be read from the config file or from the process list (at least on Linux). I think Bitcoin Core is migrating to hashed passwords for this reason. We can add this later.

This should resolve https://github.com/mintlayer/mintlayer-core/issues/192