### PR TITLE
Minor updates in address list handling (p2p)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "chainstate-test-framework",
  "common",
  "consensus",
+ "criterion",
  "crypto",
  "ctor",
  "futures",
@@ -4200,7 +4201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
  "base64 0.13.1",
- "bitflags 1.3.2",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -10,51 +10,52 @@ default = []
 testing_utils = ["dep:rlimit", "dep:ctor", "dep:test-utils", "tokio/test-util"]
 
 [dependencies]
+chainstate = { path = "../chainstate/" }
 common = { path = "../common/" }
 crypto = { path = "../crypto/" }
-chainstate = { path = "../chainstate/" }
 logging = { path = "../logging/" }
 mempool = { path = "../mempool/" }
 rpc = { path = "../rpc/" }
 serialization = { path = "../serialization/" }
-subsystem = { path = "../subsystem/" }
-utils = { path = "../utils/" }
 storage = { path = "../storage" }
+subsystem = { path = "../subsystem/" }
 test-utils = { path = "../test-utils", optional = true }
+utils = { path = "../utils/" }
 
 async-trait.workspace = true
 bytes = "1.1"
-futures.workspace = true
-itertools.workspace = true
-parity-scale-codec.workspace = true
-sscanf = "0.4"
-thiserror.workspace = true
-void = "1.0"
-tap = "1.0"
-once_cell.workspace = true
-jsonrpsee = { workspace = true, features = ["macros"] }
-tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
-tokio-util = {version = "0.7", default-features = false, features = ["codec"] }
-snowstorm = "0.4"
-serde.workspace = true
-socket2 = { version = "0.5", features = ["all"] }
-tokio-socks = { version = "0.5" }
-hex.workspace = true
-rlimit = { version = "0.9", optional = true}
 ctor = { version = "0.2", optional = true}
+futures.workspace = true
+hex.workspace = true
+itertools.workspace = true
+jsonrpsee = { workspace = true, features = ["macros"] }
+once_cell.workspace = true
+parity-scale-codec.workspace = true
+rlimit = { version = "0.9", optional = true}
+serde.workspace = true
 siphasher = "0.3"
+snowstorm = "0.4"
+socket2 = { version = "0.5", features = ["all"] }
+sscanf = "0.4"
+tap = "1.0"
+thiserror.workspace = true
+tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio-socks = { version = "0.5" }
+tokio-util = {version = "0.7", default-features = false, features = ["codec"] }
+void = "1.0"
 
 [dev-dependencies]
-chainstate-test-framework = { path = "../chainstate/test-framework" }
 chainstate-storage = { path = "../chainstate/storage" }
-crypto = { path = "../crypto/" }
-p2p-test-utils = { path = "p2p-test-utils" }
-p2p-backend-test-suite = { path = "backend-test-suite" }
-test-utils = { path = "../test-utils" }
+chainstate-test-framework = { path = "../chainstate/test-framework" }
 consensus = { path = "../consensus" }
+crypto = { path = "../crypto/" }
+p2p-backend-test-suite = { path = "backend-test-suite" }
+p2p-test-utils = { path = "p2p-test-utils" }
+test-utils = { path = "../test-utils" }
 
-rstest.workspace = true
+criterion = "0.4"
 portpicker = "0.1"
+rstest.workspace = true
 
 [[test]]
 name = "backend_tcp"
@@ -66,4 +67,8 @@ harness = false
 
 [[test]]
 name = "backend_noise"
+harness = false
+
+[[bench]]
+name = "benches"
 harness = false

--- a/p2p/benches/benches.rs
+++ b/p2p/benches/benches.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::BTreeSet,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use p2p::{
+    peer_manager::peerdb::PeerDb,
+    testing_utils::{
+        peerdb_inmemory_store, test_p2p_config, RandomAddressMaker, TestTcpAddressMaker,
+    },
+};
+
+pub fn peer_db(c: &mut Criterion) {
+    let db_store = peerdb_inmemory_store();
+    let p2p_config = Arc::new(test_p2p_config());
+    let mut peerdb =
+        PeerDb::<SocketAddr, IpAddr, _>::new(p2p_config, Default::default(), db_store).unwrap();
+
+    for _ in 0..100000 {
+        peerdb.peer_discovered(TestTcpAddressMaker::new());
+    }
+
+    for _ in 0..1000 {
+        peerdb.ban_peer(&TestTcpAddressMaker::new());
+    }
+
+    let normal_outbound = (0..5).map(|_| TestTcpAddressMaker::new()).collect::<BTreeSet<_>>();
+
+    c.bench_function("PeerDb", |b| {
+        b.iter(|| peerdb.select_new_outbound_addresses(&normal_outbound))
+    });
+}
+
+criterion_group!(benches, peer_db);
+criterion_main!(benches);

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -215,7 +215,7 @@ where
             }
         }
 
-        let mut was_accepted = SetFlag::default();
+        let mut was_accepted = SetFlag::new();
 
         loop {
             tokio::select! {
@@ -226,7 +226,7 @@ where
                     Event::Accepted => was_accepted.set(),
                     Event::SendMessage(message) => self.socket.send(*message).await?,
                 },
-                event = self.socket.recv(), if *was_accepted => match event {
+                event = self.socket.recv(), if was_accepted.test() => match event {
                     Err(err) => {
                         log::info!("peer connection closed, reason {err:?}");
                         return Ok(());

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -37,7 +37,7 @@ use common::{
     time_getter::TimeGetter,
 };
 use logging::log;
-use utils::{bloom_filters::rolling_bloom_filter::RollingBloomFilter, ensure};
+use utils::{bloom_filters::rolling_bloom_filter::RollingBloomFilter, ensure, set_flag::SetFlag};
 
 use crate::{
     config::P2pConfig,
@@ -463,6 +463,18 @@ where
         }
     }
 
+    /// Should we load addresses from this peer?
+    fn load_addresses_from(role: Role) -> bool {
+        // Load addresses only from outbound peers, like it's done in Bitcoin Core
+        role == Role::Outbound
+    }
+
+    /// Should we send addresses to this peer if it requests them?
+    fn send_addresses_to(role: Role) -> bool {
+        // Send addresses only to inbound peers, like it's done in Bitcoin Core
+        role == Role::Inbound
+    }
+
     /// Try accept new connection
     ///
     /// The event is received from the networking backend and it's either a result of an incoming
@@ -487,11 +499,7 @@ where
             self.subscribed_to_peer_addresses.insert(info.peer_id);
         }
 
-        // For security reasons, the address list is only requested from outbound peers.
-        // (inbound peers are generally less trustworthy than outbound peers).
-        let expect_addr_list_response = role == Role::Outbound;
-
-        if expect_addr_list_response {
+        if Self::load_addresses_from(role) {
             Self::send_peer_message(
                 &mut self.peer_connectivity_handle,
                 peer_id,
@@ -522,7 +530,8 @@ where
                 sent_ping: None,
                 ping_last: None,
                 ping_min: None,
-                expect_addr_list_response,
+                addr_list_req_received: SetFlag::new(),
+                addr_list_resp_received: SetFlag::new(),
                 announced_addresses,
                 address_rate_limiter,
             },
@@ -749,7 +758,7 @@ where
 
     fn handle_incoming_message(&mut self, peer: PeerId, message: PeerManagerMessage) {
         match message {
-            PeerManagerMessage::AddrListRequest(_) => self.handle_add_list_request(peer),
+            PeerManagerMessage::AddrListRequest(_) => self.handle_addr_list_request(peer),
             PeerManagerMessage::AnnounceAddrRequest(r) => {
                 self.handle_announce_addr_request(peer, r.address)
             }
@@ -790,7 +799,14 @@ where
         }
     }
 
-    fn handle_add_list_request(&mut self, peer: PeerId) {
+    fn handle_addr_list_request(&mut self, peer_id: PeerId) {
+        let peer = self.peers.get_mut(&peer_id).expect("peer must be known");
+        // Only one request allowed to reduce load in case of DoS attacks
+        if !Self::send_addresses_to(peer.role) || peer.addr_list_req_received.test_and_set() {
+            log::warn!("Ignore unexpected address list request from peer {peer_id}");
+            return;
+        }
+
         let addresses = self
             .peerdb
             .known_addresses()
@@ -802,7 +818,7 @@ where
 
         Self::send_peer_message(
             &mut self.peer_connectivity_handle,
-            peer,
+            peer_id,
             PeerManagerMessage::AddrListResponse(AddrListResponse { addresses }),
         );
     }
@@ -821,13 +837,11 @@ where
             P2pError::ProtocolError(ProtocolError::AddressListLimitExceeded)
         );
         ensure!(
-            peer.expect_addr_list_response,
+            Self::load_addresses_from(peer.role) && !peer.addr_list_resp_received.test_and_set(),
             P2pError::ProtocolError(ProtocolError::UnexpectedMessage(
                 "AddrListResponse".to_owned()
             ))
         );
-
-        peer.expect_addr_list_response = false;
 
         for address in addresses {
             if let Some(address) = TransportAddress::from_peer_address(

--- a/p2p/src/peer_manager/peer_context.rs
+++ b/p2p/src/peer_manager/peer_context.rs
@@ -15,7 +15,7 @@
 
 use std::time::Duration;
 
-use utils::bloom_filters::rolling_bloom_filter::RollingBloomFilter;
+use utils::{bloom_filters::rolling_bloom_filter::RollingBloomFilter, set_flag::SetFlag};
 
 use crate::{
     net::types::{self, Role},
@@ -50,10 +50,11 @@ pub struct PeerContext<A> {
     /// Min ping time
     pub ping_min: Option<Duration>,
 
-    /// Whether an address list request was sent and no response was received.
-    ///
-    /// It is used to score peers that send unsolicited address list responses.
-    pub expect_addr_list_response: bool,
+    /// Set if address list request was already received from this peer
+    pub addr_list_req_received: SetFlag,
+
+    /// Set if address list response was already received from this peer
+    pub addr_list_resp_received: SetFlag,
 
     /// All addresses that were announced to or from this peer.
     /// Used to prevent infinity loops while broadcasting addresses.

--- a/rpc/src/rpc_auth/mod.rs
+++ b/rpc/src/rpc_auth/mod.rs
@@ -94,13 +94,17 @@ impl RpcAuth {
             .map_err(CheckError::InvalidUtf8Value)?;
         let (username, password) =
             username_password.split_once(':').ok_or(CheckError::ColonNotFound)?;
+        let username_valid = SliceEqualityCheckMethod::timing_resistant_equal(
+            self.username.as_bytes(),
+            username.as_bytes(),
+        );
         let password_valid = verify_password(
             password.as_bytes(),
             self.password_hash.clone(),
             SliceEqualityCheckMethod::TimingResistant,
         )
         .map_err(CheckError::KdfError)?;
-        Ok(username == self.username && password_valid)
+        Ok(username_valid && password_valid)
     }
 }
 

--- a/rpc/src/rpc_auth/mod.rs
+++ b/rpc/src/rpc_auth/mod.rs
@@ -29,7 +29,7 @@ use tower_http::auth::AuthorizeRequest;
 ///
 /// Custom authorization is not really needed, because `tower_http`
 /// already supports it (see [`tower_http::auth::RequireAuthorizationLayer::basic`]),
-/// but it can simply things if we want to support hashed passwords.
+/// but it can simplify things if we want to support hashed passwords.
 #[derive(Clone)]
 pub struct RpcAuth {
     username: String,

--- a/utils/src/set_flag.rs
+++ b/utils/src/set_flag.rs
@@ -13,22 +13,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Deref;
-
-/// Wrapper for the bool type that can only be set to true once
-#[derive(Default)]
+/// Wrapper for the bool type that can only be set to true
 pub struct SetFlag(bool);
 
 impl SetFlag {
+    /// Creates a new unset flag
+    pub fn new() -> Self {
+        Self(false)
+    }
+
+    /// If the flag is already set
+    pub fn test(&self) -> bool {
+        self.0
+    }
+
+    /// Sets the flag
     pub fn set(&mut self) {
         self.0 = true;
     }
-}
 
-impl Deref for SetFlag {
-    type Target = bool;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    /// Sets the flag and returns the old value
+    pub fn test_and_set(&mut self) -> bool {
+        let old_value = self.0;
+        self.0 = true;
+        old_value
     }
 }


### PR DESCRIPTION
Process address list requests just once and only from inbound peers (same way it's done in Bitcoin Core).