### PR TITLE
TransactionVerifier cleanup

### DIFF
--- a/chainstate/tx-verifier/src/transaction_verifier/block_transactable.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/block_transactable.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::{
+    chain::{Block, TxMainChainIndex},
+    primitives::id::WithId,
+};
+
+/// A BlockTransactableRef is a reference to an operation in a block that causes inputs to be spent, outputs to be created, or both
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BlockTransactableRef<'a> {
+    Transaction(&'a WithId<Block>, usize),
+    BlockReward(&'a WithId<Block>),
+}
+
+/// A BlockTransactableRef is a reference to an operation in a block that causes inputs to be spent, outputs to be created, or both
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum BlockTransactableWithIndexRef<'a> {
+    Transaction(&'a WithId<Block>, usize, Option<TxMainChainIndex>),
+    BlockReward(&'a WithId<Block>, Option<TxMainChainIndex>),
+}
+
+impl<'a> BlockTransactableWithIndexRef<'a> {
+    pub fn without_tx_index(&self) -> BlockTransactableRef<'a> {
+        match self {
+            BlockTransactableWithIndexRef::Transaction(block, index, _) => {
+                BlockTransactableRef::Transaction(block, *index)
+            }
+            BlockTransactableWithIndexRef::BlockReward(block, _) => {
+                BlockTransactableRef::BlockReward(block)
+            }
+        }
+    }
+
+    pub fn take_tx_index(self) -> Option<TxMainChainIndex> {
+        match self {
+            BlockTransactableWithIndexRef::Transaction(_, _, idx) => idx,
+            BlockTransactableWithIndexRef::BlockReward(_, idx) => idx,
+        }
+    }
+}

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::chain::{
+    signature::{verify_signature, Transactable},
+    ChainConfig,
+};
+use utxo::UtxosView;
+
+use super::error::ConnectTransactionError;
+
+pub fn verify_signatures<U: UtxosView, T: Transactable>(
+    chain_config: &ChainConfig,
+    utxo_view: &U,
+    tx: &T,
+) -> Result<(), ConnectTransactionError> {
+    let inputs = match tx.inputs() {
+        Some(ins) => ins,
+        None => return Ok(()),
+    };
+
+    let inputs_utxos = inputs
+        .iter()
+        .map(|input| {
+            let outpoint = input.outpoint();
+            utxo_view
+                .utxo(outpoint)
+                .map_err(|_| utxo::Error::ViewRead)?
+                .ok_or(ConnectTransactionError::MissingOutputOrSpent)
+                .map(|utxo| utxo.take_output())
+        })
+        .collect::<Result<Vec<_>, ConnectTransactionError>>()?;
+
+    inputs_utxos.iter().enumerate().try_for_each(|(input_idx, utxo)| {
+        // TODO: see if a different treatment should be done for different output purposes
+        // TODO: ensure that signature verification is tested in the test-suite, they seem to be tested only internally
+        match utxo.destination() {
+            Some(d) => verify_signature(
+                chain_config,
+                d,
+                tx,
+                &inputs_utxos.iter().collect::<Vec<_>>(),
+                input_idx,
+            )
+            .map_err(ConnectTransactionError::SignatureVerificationFailed),
+            None => Err(ConnectTransactionError::AttemptToSpendBurnedAmount),
+        }
+    })
+}

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
@@ -20,7 +20,7 @@ mod mock;
 use super::*;
 use common::{
     chain::{stakelock::StakePoolData, Destination, OutPoint},
-    primitives::{amount::UnsignedIntType, H256},
+    primitives::{amount::UnsignedIntType, BlockHeight, H256},
 };
 use crypto::{
     key::{KeyKind, PrivateKey},

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
@@ -27,6 +27,7 @@ use crypto::{
     random::{CryptoRng, Rng},
     vrf::{VRFKeyKind, VRFPrivateKey},
 };
+use utxo::Utxo;
 
 fn create_utxo(rng: &mut (impl Rng + CryptoRng), value: UnsignedIntType) -> (OutPoint, Utxo) {
     let outpoint = OutPoint::new(

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
@@ -19,7 +19,7 @@ mod mock;
 
 use super::*;
 use common::{
-    chain::{stakelock::StakePoolData, Destination, OutPoint},
+    chain::{stakelock::StakePoolData, tokens::OutputValue, Destination, OutPoint},
     primitives::{amount::UnsignedIntType, BlockHeight, H256},
 };
 use crypto::{

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -18,11 +18,12 @@ use std::collections::BTreeMap;
 use common::{
     chain::{
         tokens::{token_id, OutputValue, TokenData, TokenId},
-        Transaction, TxOutput,
+        OutPointSourceId, Transaction, TxInput, TxOutput,
     },
-    primitives::Amount,
+    primitives::{Amount, Id},
 };
 use fallible_iterator::FallibleIterator;
+use utxo::{Utxo, UtxosView};
 
 use super::{
     amounts_map::AmountsMap,
@@ -31,15 +32,13 @@ use super::{
     Fee,
 };
 
-pub fn get_total_fee(
+fn get_total_fee(
     inputs_total_map: &BTreeMap<CoinOrTokenId, Amount>,
     outputs_total_map: &BTreeMap<CoinOrTokenId, Amount>,
 ) -> Result<Fee, ConnectTransactionError> {
     // TODO: fees should support tokens as well in the future
-    let outputs_total =
-        *outputs_total_map.get(&CoinOrTokenId::Coin).unwrap_or(&Amount::from_atoms(0));
-    let inputs_total =
-        *inputs_total_map.get(&CoinOrTokenId::Coin).unwrap_or(&Amount::from_atoms(0));
+    let outputs_total = *outputs_total_map.get(&CoinOrTokenId::Coin).unwrap_or(&Amount::ZERO);
+    let inputs_total = *inputs_total_map.get(&CoinOrTokenId::Coin).unwrap_or(&Amount::ZERO);
     (inputs_total - outputs_total)
         .map(Fee)
         .ok_or(ConnectTransactionError::TxFeeTotalCalcFailed(
@@ -48,7 +47,7 @@ pub fn get_total_fee(
         ))
 }
 
-pub fn check_transferred_amount(
+fn check_transferred_amount(
     inputs_total_map: &BTreeMap<CoinOrTokenId, Amount>,
     outputs_total_map: &BTreeMap<CoinOrTokenId, Amount>,
 ) -> Result<(), ConnectTransactionError> {
@@ -65,6 +64,49 @@ pub fn check_transferred_amount(
         }
     }
     Ok(())
+}
+
+pub fn check_transferred_amounts_and_get_fee<U: UtxosView, IssuanceTokenIdGetterFunc>(
+    utxo_view: &U,
+    tx: &Transaction,
+    issuance_token_id_getter: IssuanceTokenIdGetterFunc,
+) -> Result<Fee, ConnectTransactionError>
+where
+    IssuanceTokenIdGetterFunc:
+        Fn(&Id<Transaction>) -> Result<Option<TokenId>, ConnectTransactionError>,
+{
+    let inputs_total_map =
+        calculate_total_inputs(utxo_view, tx.inputs(), issuance_token_id_getter)?;
+    let outputs_total_map = calculate_total_outputs(tx.outputs(), None)?;
+
+    check_transferred_amount(&inputs_total_map, &outputs_total_map)?;
+    let total_fee = get_total_fee(&inputs_total_map, &outputs_total_map)?;
+
+    Ok(total_fee)
+}
+
+pub fn calculate_total_inputs<U: UtxosView, IssuanceTokenIdGetterFunc>(
+    utxo_view: &U,
+    inputs: &[TxInput],
+    issuance_token_id_getter: IssuanceTokenIdGetterFunc,
+) -> Result<BTreeMap<CoinOrTokenId, Amount>, ConnectTransactionError>
+where
+    IssuanceTokenIdGetterFunc:
+        Fn(&Id<Transaction>) -> Result<Option<TokenId>, ConnectTransactionError>,
+{
+    let iter = inputs.iter().map(|input| {
+        let utxo = utxo_view
+            .utxo(input.outpoint())
+            .map_err(|_| utxo::Error::ViewRead)?
+            .ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
+        amount_from_outpoint(input.outpoint().tx_id(), &utxo, &issuance_token_id_getter)
+    });
+
+    let iter = fallible_iterator::convert(iter);
+
+    let amounts_map = AmountsMap::from_fallible_iter(iter)?;
+
+    Ok(amounts_map.take())
 }
 
 pub fn calculate_total_outputs(
@@ -108,7 +150,7 @@ fn get_output_token_id_and_amount(
     })
 }
 
-pub fn get_input_token_id_and_amount<IssuanceTokenIdGetterFunc>(
+fn get_input_token_id_and_amount<IssuanceTokenIdGetterFunc>(
     output_value: &OutputValue,
     issuance_token_id_getter: IssuanceTokenIdGetterFunc,
 ) -> Result<(CoinOrTokenId, Amount), ConnectTransactionError>
@@ -134,4 +176,27 @@ where
                 ))?,
         },
     })
+}
+
+fn amount_from_outpoint<IssuanceTokenIdGetterFunc>(
+    tx_id: OutPointSourceId,
+    utxo: &Utxo,
+    issuance_token_id_getter: &IssuanceTokenIdGetterFunc,
+) -> Result<(CoinOrTokenId, Amount), ConnectTransactionError>
+where
+    IssuanceTokenIdGetterFunc:
+        Fn(&Id<Transaction>) -> Result<Option<TokenId>, ConnectTransactionError>,
+{
+    match tx_id {
+        OutPointSourceId::Transaction(tx_id) => {
+            let issuance_token_id_getter =
+                || -> Result<Option<TokenId>, ConnectTransactionError> {
+                    issuance_token_id_getter(&tx_id)
+                };
+            get_input_token_id_and_amount(&utxo.output().value(), issuance_token_id_getter)
+        }
+        OutPointSourceId::BlockReward(_) => {
+            get_input_token_id_and_amount(&utxo.output().value(), || Ok(None))
+        }
+    }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/tx_source.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tx_source.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_types::BlockIndex;
+use common::{
+    chain::Block,
+    primitives::{BlockHeight, Id},
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum TransactionSource {
+    Chain(Id<Block>),
+    Mempool,
+}
+
+impl<'a> From<&TransactionSourceForConnect<'a>> for TransactionSource {
+    fn from(t: &TransactionSourceForConnect) -> Self {
+        match t {
+            TransactionSourceForConnect::Chain { new_block_index } => {
+                TransactionSource::Chain(*new_block_index.block_id())
+            }
+            TransactionSourceForConnect::Mempool { current_best: _ } => TransactionSource::Mempool,
+        }
+    }
+}
+
+pub enum TransactionSourceForConnect<'a> {
+    Chain { new_block_index: &'a BlockIndex },
+    Mempool { current_best: &'a BlockIndex },
+}
+
+impl<'a> TransactionSourceForConnect<'a> {
+    /// The block height of the transaction to be connected
+    /// For the mempool, it's the height of the next-to-be block
+    /// For the chain, it's for the block being connected
+    pub fn expected_block_height(&self) -> BlockHeight {
+        match self {
+            TransactionSourceForConnect::Chain { new_block_index } => {
+                new_block_index.block_height()
+            }
+            TransactionSourceForConnect::Mempool {
+                current_best: best_block_index,
+            } => best_block_index.block_height().next_height(),
+        }
+    }
+
+    pub fn chain_block_index(&self) -> Option<&BlockIndex> {
+        match self {
+            TransactionSourceForConnect::Chain { new_block_index } => Some(new_block_index),
+            TransactionSourceForConnect::Mempool { current_best: _ } => None,
+        }
+    }
+}

--- a/chainstate/tx-verifier/src/transaction_verifier/utils.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/utils.rs
@@ -108,12 +108,13 @@ fn get_output_token_id_and_amount(
     })
 }
 
-pub fn get_input_token_id_and_amount<
-    IssuanceTokenIdGetterFunc: Fn() -> Result<Option<TokenId>, ConnectTransactionError>,
->(
+pub fn get_input_token_id_and_amount<IssuanceTokenIdGetterFunc>(
     output_value: &OutputValue,
     issuance_token_id_getter: IssuanceTokenIdGetterFunc,
-) -> Result<(CoinOrTokenId, Amount), ConnectTransactionError> {
+) -> Result<(CoinOrTokenId, Amount), ConnectTransactionError>
+where
+    IssuanceTokenIdGetterFunc: Fn() -> Result<Option<TokenId>, ConnectTransactionError>,
+{
     Ok(match output_value {
         OutputValue::Coin(amount) => (CoinOrTokenId::Coin, *amount),
         OutputValue::Token(token_data) => match &**token_data {


### PR DESCRIPTION
Moved some code and checks to separate modules to make it cleaner and more testable in the future.

Pay attention that while moving the functions I also tried to clean up the code (e.g. in `verify_signatures` and transferred amounts)