### PR TITLE
Randomize reconnect delays (p2p)

### DIFF
--- a/p2p/src/peer_manager/peerdb/address_data/tests.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/tests.rs
@@ -51,7 +51,7 @@ fn randomized(#[case] seed: Seed) {
             };
 
             if is_valid_transition {
-                address_data.transition_to(transition, started_at);
+                address_data.transition_to(transition, started_at, &mut rng);
             }
         }
     }

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -278,7 +278,7 @@ where
             transition,
         );
 
-        address_data.transition_to(transition, now);
+        address_data.transition_to(transition, now, &mut make_pseudo_rng());
 
         let is_persistent_new = address_data.is_persistent();
 

--- a/utils/src/exp_rand/mod.rs
+++ b/utils/src/exp_rand/mod.rs
@@ -17,6 +17,7 @@ use crypto::random::Rng;
 
 /// Returns a value sampled from an exponential distribution with a mean of 1.0
 pub fn exponential_rand(rng: &mut impl Rng) -> f64 {
+    #[allow(clippy::float_arithmetic)]
     -rng.gen::<f64>().ln()
 }
 

--- a/utils/src/exp_rand/mod.rs
+++ b/utils/src/exp_rand/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,18 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod blockuntilzero;
-pub mod bloom_filters;
-pub mod config_setting;
-pub mod const_value;
-pub mod counttracker;
-pub mod ensure;
-pub mod eventhandler;
-pub mod exp_rand;
-pub mod newtype;
-pub mod set_flag;
-pub mod shallow_clone;
-pub mod tap_error_log;
+use crypto::random::Rng;
 
-mod concurrency_impl;
-pub use concurrency_impl::*;
+/// Returns a value sampled from an exponential distribution with a mean of 1.0
+pub fn exponential_rand(rng: &mut impl Rng) -> f64 {
+    -rng.gen::<f64>().ln()
+}
+
+#[cfg(test)]
+mod test;

--- a/utils/src/exp_rand/test.rs
+++ b/utils/src/exp_rand/test.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,18 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod blockuntilzero;
-pub mod bloom_filters;
-pub mod config_setting;
-pub mod const_value;
-pub mod counttracker;
-pub mod ensure;
-pub mod eventhandler;
-pub mod exp_rand;
-pub mod newtype;
-pub mod set_flag;
-pub mod shallow_clone;
-pub mod tap_error_log;
+use super::*;
 
-mod concurrency_impl;
-pub use concurrency_impl::*;
+use rstest::rstest;
+use test_utils::random::{make_seedable_rng, Seed};
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn test_exponential_rand(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let count = 1000;
+    let sum: f64 = (0..count).map(|_| exponential_rand(&mut rng)).sum();
+    let average = sum / count as f64;
+    assert!(0.8 < average && average < 1.2);
+}


### PR DESCRIPTION
Right now p2p reconnect logic uses fixed delays. This can cause issues if there is something wrong with the host's Internet connection. If all peers are disconnected at the same time, then later reconnect attempts will be highly correlated in time. Applying some randomization should help. Sampling from the exponential distribution is used for this (Bitcoin Core uses it).
Exponential distribution sampler can be found in the `rand_distr` crate. I decided to not to introduce an extra dependency just for this. At first I copied this function from Bitcoin Core:
```
    double unscaled = -std::log1p(GetRand(uint64_t{1} << 48) * -0.0000000000000035527136788 /* -1/2^48 */);
```
But then I noticed a better looking variant in the `rand_distr` crate:
```
pub fn exponential_rand(rng: &mut impl Rng) -> f64 {
    -rng.gen::<f64>().ln()
}
```