### PR TITLE
Remove amount from TxOutput::ProduceBlockFromStake

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -115,6 +115,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::InvalidInputTypeInReward => 100,
             ConnectTransactionError::InvalidOutputTypeInTx => 100,
             ConnectTransactionError::InvalidOutputTypeInReward => 100,
+            ConnectTransactionError::PoolBalanceNotFound(_) => 0,
             ConnectTransactionError::PoolDataNotFound(_) => 0,
             ConnectTransactionError::MissingTxInputs => 100,
             ConnectTransactionError::UndoFetchFailure => 0,

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -151,7 +151,7 @@ fn create_randomness_from_block<S: BlockchainStorageRead>(
             ));
         }
         TxOutput::StakePool(d) => d.as_ref().vrf_public_key().clone(),
-        TxOutput::ProduceBlockFromStake(_, _, pool_id) => {
+        TxOutput::ProduceBlockFromStake(_, pool_id) => {
             let pos_view = PoSAccountingDB::<_, TipStorageTag>::new(db_tx);
             let pool_data = pos_view
                 .get_pool_data(*pool_id)?

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -217,9 +217,11 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             .outputs()
             .iter()
             // Filter tokens
-            .filter_map(|output| match output.value() {
-                OutputValue::Coin(_) => None,
-                OutputValue::Token(token_data) => Some(token_data),
+            .filter_map(|output| {
+                output.value().and_then(|value| match value {
+                    OutputValue::Coin(_) => None,
+                    OutputValue::Token(token_data) => Some(token_data),
+                })
             })
             // Find issuance data and return RPCTokenInfo
             .find_map(|token_data| match &*token_data {

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -19,10 +19,10 @@ use common::{
     chain::{
         block::{BlockHeader, BlockReward},
         tokens::{
-            OutputValue, RPCFungibleTokenInfo, RPCNonFungibleTokenInfo, RPCTokenInfo,
-            TokenAuxiliaryData, TokenData, TokenId,
+            RPCFungibleTokenInfo, RPCNonFungibleTokenInfo, RPCTokenInfo, TokenAuxiliaryData,
+            TokenData, TokenId,
         },
-        Block, GenBlock, OutPointSourceId, Transaction, TxMainChainIndex,
+        Block, GenBlock, OutPointSourceId, Transaction, TxMainChainIndex, TxOutput,
     },
     primitives::{BlockDistance, BlockHeight, Id, Idable},
 };
@@ -217,14 +217,16 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             .outputs()
             .iter()
             // Filter tokens
-            .filter_map(|output| {
-                output.value().and_then(|value| match value {
-                    OutputValue::Coin(_) => None,
-                    OutputValue::Token(token_data) => Some(token_data),
-                })
+            .filter_map(|output| match output {
+                TxOutput::Transfer(v, _)
+                | TxOutput::LockThenTransfer(v, _, _)
+                | TxOutput::Burn(v) => v.token_data(),
+                TxOutput::StakePool(_)
+                | TxOutput::ProduceBlockFromStake(_, _)
+                | TxOutput::DecommissionPool(_, _, _, _) => None,
             })
             // Find issuance data and return RPCTokenInfo
-            .find_map(|token_data| match &*token_data {
+            .find_map(|token_data| match token_data {
                 TokenData::TokenIssuance(issuance) => {
                     Some(RPCTokenInfo::new_fungible(RPCFungibleTokenInfo::new(
                         token_id,

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -20,6 +20,7 @@ use crate::detail::BlockSource;
 use crate::{ChainstateConfig, ChainstateError, ChainstateEvent};
 
 use chainstate_types::{BlockIndex, GenBlockIndex, Locator};
+use common::chain::TxOutput;
 use common::{
     chain::{
         block::{timestamp::BlockTimestamp, Block, BlockHeader, BlockReward, GenBlock},
@@ -137,9 +138,14 @@ pub trait ChainstateInterface: Send {
     fn available_inputs(&self, tx: &Transaction) -> Result<Vec<Option<TxInput>>, ChainstateError>;
 
     /// Returns the values of the outpoints spent by a transaction
-    fn get_inputs_outpoints_values(
+    fn get_inputs_outpoints_coin_amount(
         &self,
-        tx: &Transaction,
+        inputs: &[TxInput],
+    ) -> Result<Vec<Option<Amount>>, ChainstateError>;
+
+    fn get_outputs_coin_amount(
+        &self,
+        outputs: &[TxOutput],
     ) -> Result<Vec<Option<Amount>>, ChainstateError>;
 
     /// Returns a list of all block ids in mainchain in order (starting from block of height 1, hence the result length is best_height - 1)

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -137,12 +137,15 @@ pub trait ChainstateInterface: Send {
     /// Returns all spendable inputs of a Transaction
     fn available_inputs(&self, tx: &Transaction) -> Result<Vec<Option<TxInput>>, ChainstateError>;
 
-    /// Returns the values of the outpoints spent by a transaction
+    /// Returns the coin amounts of the outpoints spent by a transaction.
+    /// If a utxo for an input was not found or contains tokens the result is `None`.
     fn get_inputs_outpoints_coin_amount(
         &self,
         inputs: &[TxInput],
     ) -> Result<Vec<Option<Amount>>, ChainstateError>;
 
+    /// Returns the coin amounts of the outputs.
+    /// If an output contains tokens the result is `None`.
     fn get_outputs_coin_amount(
         &self,
         outputs: &[TxOutput],

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -27,11 +27,12 @@ use crate::{
 };
 use chainstate_storage::BlockchainStorage;
 use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
+use common::chain::TxOutput;
 use common::{
     chain::{
         block::{Block, BlockHeader, BlockReward, GenBlock},
         config::ChainConfig,
-        tokens::{OutputValue, RPCTokenInfo, TokenAuxiliaryData, TokenId},
+        tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
         DelegationId, OutPoint, OutPointSourceId, PoolId, Transaction, TxInput, TxMainChainIndex,
     },
     primitives::{id::WithId, Amount, BlockHeight, Id},
@@ -342,36 +343,44 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
             .map_err(|e| ChainstateError::FailedToReadProperty(e.into()))
     }
 
-    fn get_inputs_outpoints_values(
+    fn get_inputs_outpoints_coin_amount(
         &self,
-        tx: &Transaction,
+        inputs: &[TxInput],
     ) -> Result<Vec<Option<Amount>>, ChainstateError> {
         let chainstate_ref = self
             .chainstate
             .make_db_tx_ro()
             .map_err(|e| ChainstateError::from(PropertyQueryError::from(e)))?;
         let utxo_view = chainstate_ref.make_utxo_view();
+        let pos_accounting_view = chainstate_ref.make_pos_accounting_view();
 
-        tx.inputs()
+        inputs
             .iter()
             .map(|input| {
                 let utxo = utxo_view
                     .utxo(input.outpoint())
                     .map_err(|e| ChainstateError::FailedToReadProperty(e.into()))?;
                 match utxo {
-                    Some(utxo) => utxo
-                        .output()
-                        .value()
-                        .map(|v| match v {
-                            OutputValue::Coin(amount) => Ok(amount),
-                            OutputValue::Token(_) => Err(ChainstateError::FailedToReadProperty(
-                                PropertyQueryError::ExpectedCoinOutpointAndFoundToken,
-                            )),
-                        })
-                        .transpose(),
+                    Some(utxo) => get_output_coin_amount(&pos_accounting_view, utxo.output()),
                     None => Ok(None),
                 }
             })
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    fn get_outputs_coin_amount(
+        &self,
+        outputs: &[TxOutput],
+    ) -> Result<Vec<Option<Amount>>, ChainstateError> {
+        let chainstate_ref = self
+            .chainstate
+            .make_db_tx_ro()
+            .map_err(|e| ChainstateError::from(PropertyQueryError::from(e)))?;
+        let pos_accounting_view = chainstate_ref.make_pos_accounting_view();
+
+        outputs
+            .iter()
+            .map(|output| get_output_coin_amount(&pos_accounting_view, output))
             .collect::<Result<Vec<_>, _>>()
     }
 
@@ -514,4 +523,32 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
             .get_pool_delegation_share(pool_id, delegation_id)
             .map_err(|e| ChainstateError::ProcessBlockError(e.into()))
     }
+}
+
+fn get_output_coin_amount(
+    pos_accounting_view: &impl PoSAccountingView,
+    output: &TxOutput,
+) -> Result<Option<Amount>, ChainstateError> {
+    let amount = match output {
+        TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
+            v.coin_amount()
+        }
+        TxOutput::StakePool(data) => Some(data.value()),
+        TxOutput::ProduceBlockFromStake(_, pool_id) => {
+            let pool_balance = pos_accounting_view
+                .get_pool_balance(*pool_id)
+                .map_err(|_| {
+                    ChainstateError::FailedToReadProperty(PropertyQueryError::PoolBalanceNotFound(
+                        *pool_id,
+                    ))
+                })?
+                .ok_or(ChainstateError::FailedToReadProperty(
+                    PropertyQueryError::PoolBalanceNotFound(*pool_id),
+                ))?;
+            Some(pool_balance)
+        }
+        TxOutput::DecommissionPool(v, _, _, _) => Some(*v),
+    };
+
+    Ok(amount)
 }

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -25,7 +25,7 @@ use common::chain::{
     block::{timestamp::BlockTimestamp, BlockReward},
     config::ChainConfig,
     tokens::TokenAuxiliaryData,
-    OutPointSourceId, TxMainChainIndex,
+    OutPointSourceId, TxMainChainIndex, TxOutput,
 };
 use common::chain::{OutPoint, Transaction};
 use common::{
@@ -230,11 +230,19 @@ where
     fn available_inputs(&self, tx: &Transaction) -> Result<Vec<Option<TxInput>>, ChainstateError> {
         self.deref().available_inputs(tx)
     }
-    fn get_inputs_outpoints_values(
+
+    fn get_inputs_outpoints_coin_amount(
         &self,
-        tx: &Transaction,
+        inputs: &[TxInput],
     ) -> Result<Vec<Option<Amount>>, ChainstateError> {
-        self.deref().get_inputs_outpoints_values(tx)
+        self.deref().get_inputs_outpoints_coin_amount(inputs)
+    }
+
+    fn get_outputs_coin_amount(
+        &self,
+        outputs: &[TxOutput],
+    ) -> Result<Vec<Option<Amount>>, ChainstateError> {
+        self.deref().get_outputs_coin_amount(outputs)
     }
 
     fn get_mainchain_blocks_list(&self) -> Result<Vec<Id<Block>>, ChainstateError> {

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -29,7 +29,7 @@ pub type TestStore = chainstate_storage::inmemory::Store;
 pub type TestChainstate = Box<dyn chainstate::chainstate_interface::ChainstateInterface>;
 
 pub use {
-    crate::utils::{anyonecanspend_address, empty_witness},
+    crate::utils::{anyonecanspend_address, empty_witness, get_output_value},
     block_builder::BlockBuilder,
     framework::TestFramework,
     framework_builder::{OrphanErrorHandler, TestFrameworkBuilder, TxVerificationStrategy},

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -58,7 +58,7 @@ pub fn create_utxo_data(
     output: &TxOutput,
     rng: &mut impl Rng,
 ) -> Option<(InputWitness, TxInput, TxOutput)> {
-    let new_output = match output.value() {
+    let new_output = match output.value()? {
         OutputValue::Coin(output_value) => {
             let spent_value = Amount::from_atoms(rng.gen_range(0..output_value.into_atoms()));
             let new_value = (output_value - spent_value).unwrap();
@@ -94,7 +94,7 @@ pub fn create_multiple_utxo_data(
     rng: &mut (impl Rng + CryptoRng),
 ) -> Option<(InputWitness, TxInput, Vec<TxOutput>)> {
     let num_outputs = rng.gen_range(1..10);
-    let new_outputs = match output.value() {
+    let new_outputs = match output.value()? {
         OutputValue::Coin(output_value) => {
             let switch = rng.gen_range(0..3);
             if switch == 0 {

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -37,6 +37,17 @@ pub fn anyonecanspend_address() -> Destination {
     Destination::AnyoneCanSpend
 }
 
+fn get_output_value(output: &TxOutput) -> Option<OutputValue> {
+    match output {
+        TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
+            Some(v.clone())
+        }
+        TxOutput::StakePool(_)
+        | TxOutput::ProduceBlockFromStake(_, _)
+        | TxOutput::DecommissionPool(_, _, _, _) => None,
+    }
+}
+
 pub fn create_new_outputs(
     chainstate: &TestChainstate,
     srcid: OutPointSourceId,
@@ -58,7 +69,7 @@ pub fn create_utxo_data(
     output: &TxOutput,
     rng: &mut impl Rng,
 ) -> Option<(InputWitness, TxInput, TxOutput)> {
-    let new_output = match output.value()? {
+    let new_output = match get_output_value(output)? {
         OutputValue::Coin(output_value) => {
             let spent_value = Amount::from_atoms(rng.gen_range(0..output_value.into_atoms()));
             let new_value = (output_value - spent_value).unwrap();
@@ -94,7 +105,7 @@ pub fn create_multiple_utxo_data(
     rng: &mut (impl Rng + CryptoRng),
 ) -> Option<(InputWitness, TxInput, Vec<TxOutput>)> {
     let num_outputs = rng.gen_range(1..10);
-    let new_outputs = match output.value()? {
+    let new_outputs = match get_output_value(output)? {
         OutputValue::Coin(output_value) => {
             let switch = rng.gen_range(0..3);
             if switch == 0 {

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -37,7 +37,7 @@ pub fn anyonecanspend_address() -> Destination {
     Destination::AnyoneCanSpend
 }
 
-fn get_output_value(output: &TxOutput) -> Option<OutputValue> {
+pub fn get_output_value(output: &TxOutput) -> Option<OutputValue> {
     match output {
         TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
             Some(v.clone())

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -40,6 +40,8 @@ use test_utils::{
     random_string,
 };
 
+use super::helpers::get_output_value;
+
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -355,7 +357,7 @@ fn token_issue_test(#[case] seed: Seed) {
 
         let block = tf.block(*block_index.block_id());
         assert_eq!(
-            block.transactions()[0].transaction().outputs()[0].value().unwrap(),
+            get_output_value(&block.transactions()[0].transaction().outputs()[0]).unwrap(),
             output_value.into()
         );
     });
@@ -403,7 +405,7 @@ fn token_transfer_test(#[case] seed: Seed) {
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
         assert_eq!(
-            block.transactions()[0].transaction().outputs()[0].value().unwrap(),
+            get_output_value(&block.transactions()[0].transaction().outputs()[0]).unwrap(),
             output_value.clone().into()
         );
         let issuance_outpoint_id: OutPointSourceId =
@@ -616,7 +618,7 @@ fn multiple_token_issuance_in_one_tx(#[case] seed: Seed) {
 
         let block = tf.block(*block_index.block_id());
         assert_eq!(
-            block.transactions()[0].transaction().outputs()[0].value().unwrap(),
+            get_output_value(&block.transactions()[0].transaction().outputs()[0]).unwrap(),
             issuance_value.into()
         );
     })
@@ -631,9 +633,11 @@ fn token_issuance_with_insufficient_fee(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let total_funds = Amount::from_atoms(rng.gen_range(1..u128::MAX));
         let token_min_issuance_fee = tf.chainstate.get_chain_config().token_min_issuance_fee();
-        let coins_value = (tf.genesis().utxos()[0].value().unwrap().coin_amount().unwrap()
-            - token_min_issuance_fee)
-            .unwrap();
+
+        let coins_value =
+            (get_output_value(&tf.genesis().utxos()[0]).unwrap().coin_amount().unwrap()
+                - token_min_issuance_fee)
+                .unwrap();
         let genesis_outpoint_id = tf.genesis().get_id().into();
 
         // Issuance data
@@ -1696,11 +1700,11 @@ fn tokens_reorgs_and_cleanup_data(#[case] seed: Seed) {
         );
         // Check issuance storage in the chain and in the storage
         assert_eq!(
-            issuance_tx.transaction().outputs()[0].value().unwrap(),
+            get_output_value(&issuance_tx.transaction().outputs()[0]).unwrap(),
             issuance_value.clone().into()
         );
         assert_eq!(
-            token_aux_data.issuance_tx().outputs()[0].value().unwrap(),
+            get_output_value(&token_aux_data.issuance_tx().outputs()[0]).unwrap(),
             issuance_value.into()
         );
 

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -355,7 +355,7 @@ fn token_issue_test(#[case] seed: Seed) {
 
         let block = tf.block(*block_index.block_id());
         assert_eq!(
-            block.transactions()[0].transaction().outputs()[0].value(),
+            block.transactions()[0].transaction().outputs()[0].value().unwrap(),
             output_value.into()
         );
     });
@@ -403,7 +403,7 @@ fn token_transfer_test(#[case] seed: Seed) {
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
         assert_eq!(
-            block.transactions()[0].transaction().outputs()[0].value(),
+            block.transactions()[0].transaction().outputs()[0].value().unwrap(),
             output_value.clone().into()
         );
         let issuance_outpoint_id: OutPointSourceId =
@@ -616,7 +616,7 @@ fn multiple_token_issuance_in_one_tx(#[case] seed: Seed) {
 
         let block = tf.block(*block_index.block_id());
         assert_eq!(
-            block.transactions()[0].transaction().outputs()[0].value(),
+            block.transactions()[0].transaction().outputs()[0].value().unwrap(),
             issuance_value.into()
         );
     })
@@ -631,7 +631,7 @@ fn token_issuance_with_insufficient_fee(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let total_funds = Amount::from_atoms(rng.gen_range(1..u128::MAX));
         let token_min_issuance_fee = tf.chainstate.get_chain_config().token_min_issuance_fee();
-        let coins_value = (tf.genesis().utxos()[0].value().coin_amount().unwrap()
+        let coins_value = (tf.genesis().utxos()[0].value().unwrap().coin_amount().unwrap()
             - token_min_issuance_fee)
             .unwrap();
         let genesis_outpoint_id = tf.genesis().get_id().into();
@@ -1696,11 +1696,11 @@ fn tokens_reorgs_and_cleanup_data(#[case] seed: Seed) {
         );
         // Check issuance storage in the chain and in the storage
         assert_eq!(
-            issuance_tx.transaction().outputs()[0].value(),
+            issuance_tx.transaction().outputs()[0].value().unwrap(),
             issuance_value.clone().into()
         );
         assert_eq!(
-            token_aux_data.issuance_tx().outputs()[0].value(),
+            token_aux_data.issuance_tx().outputs()[0].value().unwrap(),
             issuance_value.into()
         );
 

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -19,7 +19,7 @@ use chainstate::{
     BlockError, BlockSource, ChainstateError, CheckBlockError, CheckBlockTransactionsError,
     ConnectTransactionError, TokensError,
 };
-use chainstate_test_framework::{TestFramework, TransactionBuilder};
+use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::chain::tokens::{Metadata, NftIssuance, TokenIssuance, TokenTransfer};
 use common::primitives::{id, Id};
 use common::{
@@ -39,8 +39,6 @@ use test_utils::{
     random::{make_seedable_rng, Seed},
     random_string,
 };
-
-use super::helpers::get_output_value;
 
 #[rstest]
 #[trace]

--- a/chainstate/test-suite/src/tests/helpers/mod.rs
+++ b/chainstate/test-suite/src/tests/helpers/mod.rs
@@ -75,3 +75,14 @@ pub fn new_pub_key_destination(rng: &mut (impl Rng + CryptoRng)) -> Destination 
     let (_, pub_key) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
     Destination::PublicKey(pub_key)
 }
+
+pub fn get_output_value(output: &TxOutput) -> Option<OutputValue> {
+    match output {
+        TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
+            Some(v.clone())
+        }
+        TxOutput::StakePool(_)
+        | TxOutput::ProduceBlockFromStake(_, _)
+        | TxOutput::DecommissionPool(_, _, _, _) => unimplemented!(),
+    }
+}

--- a/chainstate/test-suite/src/tests/helpers/mod.rs
+++ b/chainstate/test-suite/src/tests/helpers/mod.rs
@@ -75,14 +75,3 @@ pub fn new_pub_key_destination(rng: &mut (impl Rng + CryptoRng)) -> Destination 
     let (_, pub_key) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
     Destination::PublicKey(pub_key)
 }
-
-pub fn get_output_value(output: &TxOutput) -> Option<OutputValue> {
-    match output {
-        TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
-            Some(v.clone())
-        }
-        TxOutput::StakePool(_)
-        | TxOutput::ProduceBlockFromStake(_, _)
-        | TxOutput::DecommissionPool(_, _, _, _) => unimplemented!(),
-    }
-}

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -17,7 +17,7 @@ use chainstate::{
     is_rfc3986_valid_symbol, BlockError, ChainstateError, CheckBlockError,
     CheckBlockTransactionsError, TokensError,
 };
-use chainstate_test_framework::{TestFramework, TransactionBuilder};
+use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::chain::tokens::OutputValue;
 use common::chain::tokens::TokenData;
 use common::chain::Block;
@@ -37,8 +37,6 @@ use test_utils::{
     random::{make_seedable_rng, Seed},
     random_string,
 };
-
-use super::helpers::get_output_value;
 
 #[rstest]
 #[trace]

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -688,7 +688,7 @@ fn nft_icon_uri_empty(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(issuance_output.value(), output_value);
+        assert_eq!(issuance_output.value().unwrap(), output_value);
     })
 }
 
@@ -876,7 +876,7 @@ fn nft_metadata_uri_empty(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(issuance_output.value(), output_value);
+        assert_eq!(issuance_output.value().unwrap(), output_value);
     })
 }
 
@@ -1066,7 +1066,7 @@ fn nft_media_uri_empty(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(issuance_output.value(), output_value);
+        assert_eq!(issuance_output.value().unwrap(), output_value);
     })
 }
 
@@ -1284,7 +1284,7 @@ fn nft_media_hash_valid(#[case] seed: Seed) {
                 tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
             let issuance_output = &outputs[0];
 
-            match issuance_output.value().token_data().unwrap() {
+            match issuance_output.value().unwrap().token_data().unwrap() {
                 TokenData::NftIssuance(nft) => {
                     assert_eq!(nft.metadata.media_hash(), &media_hash);
                 }
@@ -1353,6 +1353,6 @@ fn nft_valid_case(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(issuance_output.value(), output_value.into());
+        assert_eq!(issuance_output.value().unwrap(), output_value.into());
     })
 }

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -38,6 +38,8 @@ use test_utils::{
     random_string,
 };
 
+use super::helpers::get_output_value;
+
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -688,7 +690,7 @@ fn nft_icon_uri_empty(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(issuance_output.value().unwrap(), output_value);
+        assert_eq!(get_output_value(issuance_output).unwrap(), output_value);
     })
 }
 
@@ -876,7 +878,7 @@ fn nft_metadata_uri_empty(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(issuance_output.value().unwrap(), output_value);
+        assert_eq!(get_output_value(issuance_output).unwrap(), output_value);
     })
 }
 
@@ -1066,7 +1068,7 @@ fn nft_media_uri_empty(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(issuance_output.value().unwrap(), output_value);
+        assert_eq!(get_output_value(issuance_output).unwrap(), output_value);
     })
 }
 
@@ -1284,7 +1286,7 @@ fn nft_media_hash_valid(#[case] seed: Seed) {
                 tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
             let issuance_output = &outputs[0];
 
-            match issuance_output.value().unwrap().token_data().unwrap() {
+            match get_output_value(issuance_output).unwrap().token_data().unwrap() {
                 TokenData::NftIssuance(nft) => {
                     assert_eq!(nft.metadata.media_hash(), &media_hash);
                 }
@@ -1353,6 +1355,9 @@ fn nft_valid_case(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(issuance_output.value().unwrap(), output_value.into());
+        assert_eq!(
+            get_output_value(issuance_output).unwrap(),
+            output_value.into()
+        );
     })
 }

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -31,6 +31,8 @@ use test_utils::{
     random_string,
 };
 
+use super::helpers::get_output_value;
+
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -415,11 +417,11 @@ fn nft_reorgs_and_cleanup_data(#[case] seed: Seed) {
         );
         // Check issuance storage in the chain and in the storage
         assert_eq!(
-            issuance_tx.outputs()[0].value().unwrap(),
+            get_output_value(&issuance_tx.outputs()[0]).unwrap(),
             issuance_value.clone().into()
         );
         assert_eq!(
-            token_aux_data.issuance_tx().outputs()[0].value().unwrap(),
+            get_output_value(&token_aux_data.issuance_tx().outputs()[0]).unwrap(),
             issuance_value.into()
         );
 

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use chainstate::{BlockError, BlockSource, ChainstateError, ConnectTransactionError};
-use chainstate_test_framework::{TestFramework, TransactionBuilder};
+use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::{
     chain::{
         signature::inputsig::InputWitness,
@@ -30,8 +30,6 @@ use test_utils::{
     random::{make_seedable_rng, Seed},
     random_string,
 };
-
-use super::helpers::get_output_value;
 
 #[rstest]
 #[trace]

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -415,11 +415,11 @@ fn nft_reorgs_and_cleanup_data(#[case] seed: Seed) {
         );
         // Check issuance storage in the chain and in the storage
         assert_eq!(
-            issuance_tx.outputs()[0].value(),
+            issuance_tx.outputs()[0].value().unwrap(),
             issuance_value.clone().into()
         );
         assert_eq!(
-            token_aux_data.issuance_tx().outputs()[0].value(),
+            token_aux_data.issuance_tx().outputs()[0].value().unwrap(),
             issuance_value.into()
         );
 

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -17,7 +17,7 @@ use chainstate::{
     BlockError, ChainstateError, CheckBlockError, CheckBlockTransactionsError,
     ConnectTransactionError, TokensError,
 };
-use chainstate_test_framework::{TestFramework, TransactionBuilder};
+use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::primitives::Idable;
 use common::{
     chain::{
@@ -35,8 +35,6 @@ use test_utils::{
     random::{make_seedable_rng, Seed},
     random_string,
 };
-
-use super::helpers::get_output_value;
 
 #[rstest]
 #[trace]

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -85,7 +85,7 @@ fn nft_transfer_wrong_id(#[case] seed: Seed) {
             .unwrap();
         let block = tf.block(*block_index.block_id());
         assert_eq!(
-            block.transactions()[0].outputs()[0].value(),
+            block.transactions()[0].outputs()[0].value().unwrap(),
             output_value.into()
         );
         assert!(tf
@@ -172,7 +172,7 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
         assert_eq!(block.transactions()[0], tx);
-        assert_eq!(tx.outputs()[0].value(), output_value.into());
+        assert_eq!(tx.outputs()[0].value().unwrap(), output_value.into());
 
         // Try to transfer 0 NFT
         let result = tf
@@ -433,7 +433,7 @@ fn nft_valid_transfer(#[case] seed: Seed) {
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
         assert_eq!(
-            block.transactions()[0].outputs()[0].value(),
+            block.transactions()[0].outputs()[0].value().unwrap(),
             output_value.into()
         );
 
@@ -467,6 +467,6 @@ fn nft_valid_transfer(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let transfer_output = &outputs[0];
 
-        assert_eq!(transfer_output.value(), transfer_value.into());
+        assert_eq!(transfer_output.value().unwrap(), transfer_value.into());
     })
 }

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -36,6 +36,8 @@ use test_utils::{
     random_string,
 };
 
+use super::helpers::get_output_value;
+
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -85,7 +87,7 @@ fn nft_transfer_wrong_id(#[case] seed: Seed) {
             .unwrap();
         let block = tf.block(*block_index.block_id());
         assert_eq!(
-            block.transactions()[0].outputs()[0].value().unwrap(),
+            get_output_value(&block.transactions()[0].outputs()[0]).unwrap(),
             output_value.into()
         );
         assert!(tf
@@ -172,7 +174,10 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
         assert_eq!(block.transactions()[0], tx);
-        assert_eq!(tx.outputs()[0].value().unwrap(), output_value.into());
+        assert_eq!(
+            get_output_value(&tx.outputs()[0]).unwrap(),
+            output_value.into()
+        );
 
         // Try to transfer 0 NFT
         let result = tf
@@ -433,7 +438,7 @@ fn nft_valid_transfer(#[case] seed: Seed) {
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
         assert_eq!(
-            block.transactions()[0].outputs()[0].value().unwrap(),
+            get_output_value(&block.transactions()[0].outputs()[0]).unwrap(),
             output_value.into()
         );
 
@@ -467,6 +472,9 @@ fn nft_valid_transfer(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let transfer_output = &outputs[0];
 
-        assert_eq!(transfer_output.value().unwrap(), transfer_value.into());
+        assert_eq!(
+            get_output_value(transfer_output).unwrap(),
+            transfer_value.into()
+        );
     })
 }

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -272,8 +272,7 @@ fn pos_basic(#[case] seed: Seed) {
     let initially_staked = Amount::from_atoms(1);
     let total_reward = (subsidy + initially_staked).unwrap();
 
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(total_reward, anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_consensus_data(consensus_data)
         .with_timestamp(block_timestamp)
@@ -501,11 +500,7 @@ fn pos_invalid_vrf(#[case] seed: Seed) {
     {
         // valid case
         let consensus_data = ConsensusData::PoS(Box::new(valid_pos_data));
-        let reward_output = TxOutput::ProduceBlockFromStake(
-            Amount::from_atoms(1),
-            anyonecanspend_address(),
-            pool_id,
-        );
+        let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
         tf.make_block_builder()
             .with_consensus_data(consensus_data)
             .with_reward(vec![reward_output])
@@ -572,8 +567,7 @@ fn pos_invalid_pool_id(#[case] seed: Seed) {
     );
 
     // test valid case
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(valid_pos_data)))
         .with_reward(vec![reward_output])
@@ -687,8 +681,7 @@ fn spend_stake_pool_in_block_reward(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
         .with_reward(vec![reward_output])
@@ -716,8 +709,7 @@ fn spend_stake_pool_in_block_reward(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
         .with_reward(vec![reward_output])
@@ -752,8 +744,7 @@ fn spend_stake_pool_in_block_reward(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
         .with_reward(vec![reward_output])
@@ -807,8 +798,7 @@ fn mismatched_pools_in_kernel_and_reward(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id2);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id2);
     let res = tf
         .make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
@@ -889,8 +879,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
         .with_reward(vec![reward_output])
@@ -917,8 +906,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     let block_c_index = tf
         .make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
@@ -955,8 +943,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
         .with_reward(vec![reward_output])
@@ -1013,8 +1000,7 @@ fn decommission_from_produce_block(#[case] seed: Seed) {
     let initially_staked = Amount::from_atoms(1);
     let total_reward = (subsidy + initially_staked).unwrap();
 
-    let produce_block_output =
-        TxOutput::ProduceBlockFromStake(total_reward, anyonecanspend_address(), pool_id1);
+    let produce_block_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id1);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
         .with_reward(vec![produce_block_output])
@@ -1053,8 +1039,7 @@ fn decommission_from_produce_block(#[case] seed: Seed) {
         ))
         .build();
 
-    let produce_block_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id2);
+    let produce_block_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id2);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
         .with_reward(vec![produce_block_output])
@@ -1150,8 +1135,7 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
     let initially_staked = Amount::from_atoms(1);
     let total_reward = (subsidy + initially_staked).unwrap();
 
-    let produce_block_output =
-        TxOutput::ProduceBlockFromStake(total_reward, anyonecanspend_address(), pool_id1);
+    let produce_block_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id1);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data.clone())))
         .with_reward(vec![produce_block_output])
@@ -1169,8 +1153,7 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
         ))
         .build();
 
-    let produce_block_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id1);
+    let produce_block_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id1);
     tf.make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
         .with_reward(vec![produce_block_output])

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -148,11 +148,7 @@ fn stable_block_time(#[case] seed: Seed) {
         )
         .expect("should be able to mine");
 
-        let reward_output = TxOutput::ProduceBlockFromStake(
-            Amount::from_atoms(1),
-            anyonecanspend_address(),
-            pool_id,
-        );
+        let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
         tf.make_block_builder()
             .with_consensus_data(ConsensusData::PoS(Box::new(pos_data.clone())))
             .with_timestamp(valid_block_timestamp)
@@ -189,8 +185,7 @@ fn invalid_target(#[case] seed: Seed) {
         invalid_target,
     );
 
-    let reward_output =
-        TxOutput::ProduceBlockFromStake(Amount::from_atoms(1), anyonecanspend_address(), pool_id);
+    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     let res = tf
         .make_block_builder()
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -16,7 +16,7 @@
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use super::helpers::{get_output_value, new_pub_key_destination};
+use super::helpers::new_pub_key_destination;
 
 use chainstate::chainstate_interface::ChainstateInterface;
 use chainstate::{
@@ -25,7 +25,8 @@ use chainstate::{
     OrphanCheckError,
 };
 use chainstate_test_framework::{
-    anyonecanspend_address, empty_witness, TestFramework, TestStore, TransactionBuilder,
+    anyonecanspend_address, empty_witness, get_output_value, TestFramework, TestStore,
+    TransactionBuilder,
 };
 use chainstate_types::{GenBlockIndex, GetAncestorError, PropertyQueryError};
 use common::chain::{

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -379,7 +379,10 @@ fn transaction_processing_order(#[case] seed: Seed) {
             Transaction::new(
                 0,
                 vec![TxInput::new(tf.genesis().get_id().into(), 0)],
-                vec![TxOutput::Transfer(tf.genesis().utxos()[0].value(), anyonecanspend_address())],
+                vec![TxOutput::Transfer(
+                    tf.genesis().utxos()[0].value().unwrap(),
+                    anyonecanspend_address(),
+                )],
                 0,
             )
             .unwrap(),
@@ -393,7 +396,7 @@ fn transaction_processing_order(#[case] seed: Seed) {
                 0,
                 vec![TxInput::new(tx1.transaction().get_id().into(), 0)],
                 vec![TxOutput::Transfer(
-                    tx1.transaction().outputs()[0].value(),
+                    tx1.transaction().outputs()[0].value().unwrap(),
                     anyonecanspend_address(),
                 )],
                 0,

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -16,7 +16,7 @@
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use super::helpers::new_pub_key_destination;
+use super::helpers::{get_output_value, new_pub_key_destination};
 
 use chainstate::chainstate_interface::ChainstateInterface;
 use chainstate::{
@@ -380,7 +380,7 @@ fn transaction_processing_order(#[case] seed: Seed) {
                 0,
                 vec![TxInput::new(tf.genesis().get_id().into(), 0)],
                 vec![TxOutput::Transfer(
-                    tf.genesis().utxos()[0].value().unwrap(),
+                    get_output_value(&tf.genesis().utxos()[0]).unwrap(),
                     anyonecanspend_address(),
                 )],
                 0,
@@ -396,7 +396,7 @@ fn transaction_processing_order(#[case] seed: Seed) {
                 0,
                 vec![TxInput::new(tx1.transaction().get_id().into(), 0)],
                 vec![TxOutput::Transfer(
-                    tx1.transaction().outputs()[0].value().unwrap(),
+                    get_output_value(&tx1.transaction().outputs()[0]).unwrap(),
                     anyonecanspend_address(),
                 )],
                 0,

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -274,7 +274,7 @@ fn stake_pool_overspend(#[case] seed: Seed) {
             let genesis_tx_output =
                 genesis_outputs.get(&OutPointSourceId::BlockReward(genesis_id)).unwrap();
             assert_eq!(genesis_tx_output.len(), 1);
-            genesis_tx_output.get(0).unwrap().value().coin_amount().unwrap()
+            genesis_tx_output.get(0).unwrap().value().unwrap().coin_amount().unwrap()
         };
         let genesis_overspend_amount = (genesis_output_amount + Amount::from_atoms(1)).unwrap();
 

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -274,7 +274,10 @@ fn stake_pool_overspend(#[case] seed: Seed) {
             let genesis_tx_output =
                 genesis_outputs.get(&OutPointSourceId::BlockReward(genesis_id)).unwrap();
             assert_eq!(genesis_tx_output.len(), 1);
-            genesis_tx_output.get(0).unwrap().value().unwrap().coin_amount().unwrap()
+            super::helpers::get_output_value(&genesis_tx_output[0])
+                .unwrap()
+                .coin_amount()
+                .unwrap()
         };
         let genesis_overspend_amount = (genesis_output_amount + Amount::from_atoms(1)).unwrap();
 

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -19,7 +19,7 @@ use chainstate::BlockSource;
 use chainstate::{BlockError, ChainstateError, ConnectTransactionError};
 use chainstate_storage::TipStorageTag;
 use chainstate_test_framework::{
-    anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
+    anyonecanspend_address, empty_witness, get_output_value, TestFramework, TransactionBuilder,
 };
 use common::{
     chain::{
@@ -274,10 +274,7 @@ fn stake_pool_overspend(#[case] seed: Seed) {
             let genesis_tx_output =
                 genesis_outputs.get(&OutPointSourceId::BlockReward(genesis_id)).unwrap();
             assert_eq!(genesis_tx_output.len(), 1);
-            super::helpers::get_output_value(&genesis_tx_output[0])
-                .unwrap()
-                .coin_amount()
-                .unwrap()
+            get_output_value(&genesis_tx_output[0]).unwrap().coin_amount().unwrap()
         };
         let genesis_overspend_amount = (genesis_output_amount + Amount::from_atoms(1)).unwrap();
 

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -105,6 +105,8 @@ pub enum ConnectTransactionError {
     InvalidInputTypeInReward,
     #[error("Attempted to use a invalid output type in block reward")]
     InvalidOutputTypeInReward,
+    #[error("Balance of pool {0} not found")]
+    PoolBalanceNotFound(PoolId),
     #[error("Data of pool {0} not found")]
     PoolDataNotFound(PoolId),
 

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
@@ -52,7 +52,7 @@ pub fn check_reward_inputs_outputs_purposes(
                     | TxOutput::DecommissionPool(_, _, _, _) => {
                         Err(ConnectTransactionError::InvalidInputTypeInReward)
                     }
-                    TxOutput::StakePool(_) | TxOutput::ProduceBlockFromStake(_, _, _) => {
+                    TxOutput::StakePool(_) | TxOutput::ProduceBlockFromStake(_, _) => {
                         let outputs =
                             reward.outputs().ok_or(ConnectTransactionError::SpendStakeError(
                                 SpendStakeError::NoBlockRewardOutputs,
@@ -69,7 +69,7 @@ pub fn check_reward_inputs_outputs_purposes(
                                 | TxOutput::DecommissionPool(_, _, _, _) => {
                                     Err(ConnectTransactionError::InvalidOutputTypeInReward)
                                 }
-                                TxOutput::ProduceBlockFromStake(_, _, _) => Ok(()),
+                                TxOutput::ProduceBlockFromStake(_, _) => Ok(()),
                             },
                             _ => Err(ConnectTransactionError::SpendStakeError(
                                 SpendStakeError::MultipleBlockRewardOutputs,
@@ -96,7 +96,7 @@ pub fn check_reward_inputs_outputs_purposes(
                     TxOutput::Transfer(_, _)
                     | TxOutput::Burn(_)
                     | TxOutput::StakePool(_)
-                    | TxOutput::ProduceBlockFromStake(_, _, _)
+                    | TxOutput::ProduceBlockFromStake(_, _)
                     | TxOutput::DecommissionPool(_, _, _, _) => false,
                 });
             ensure!(
@@ -163,36 +163,32 @@ fn is_valid_one_to_one_combination(input_utxo: &TxOutput, output: &TxOutput) -> 
         | (TxOutput::Transfer(_, _), TxOutput::LockThenTransfer(_, _, _))
         | (TxOutput::Transfer(_, _), TxOutput::Burn(_))
         | (TxOutput::Transfer(_, _), TxOutput::StakePool(_)) => true,
-        | (TxOutput::Transfer(_, _), TxOutput::ProduceBlockFromStake(_, _, _))
+        | (TxOutput::Transfer(_, _), TxOutput::ProduceBlockFromStake(_, _))
         | (TxOutput::Transfer(_, _), TxOutput::DecommissionPool(_, _, _, _)) => false,
         | (TxOutput::LockThenTransfer(_, _, _), TxOutput::Transfer(_, _))
         | (TxOutput::LockThenTransfer(_, _, _), TxOutput::LockThenTransfer(_, _, _))
         | (TxOutput::LockThenTransfer(_, _, _), TxOutput::Burn(_))
         | (TxOutput::LockThenTransfer(_, _, _), TxOutput::StakePool(_)) => true,
-        | (TxOutput::LockThenTransfer(_, _, _), TxOutput::ProduceBlockFromStake(_, _, _))
+        | (TxOutput::LockThenTransfer(_, _, _), TxOutput::ProduceBlockFromStake(_, _))
         | (TxOutput::LockThenTransfer(_, _, _), TxOutput::DecommissionPool(_, _, _, _)) => false,
         | (TxOutput::Burn(_), _) => false,
         | (TxOutput::StakePool(_), TxOutput::Transfer(_, _))
         | (TxOutput::StakePool(_), TxOutput::LockThenTransfer(_, _, _))
         | (TxOutput::StakePool(_), TxOutput::Burn(_))
         | (TxOutput::StakePool(_), TxOutput::StakePool(_))
-        | (TxOutput::StakePool(_), TxOutput::ProduceBlockFromStake(_, _, _)) => false,
+        | (TxOutput::StakePool(_), TxOutput::ProduceBlockFromStake(_, _)) => false,
         | (TxOutput::StakePool(_), TxOutput::DecommissionPool(_, _, _, _)) => true,
-        | (TxOutput::ProduceBlockFromStake(_, _, _), TxOutput::Transfer(_, _))
-        | (TxOutput::ProduceBlockFromStake(_, _, _), TxOutput::LockThenTransfer(_, _, _))
-        | (TxOutput::ProduceBlockFromStake(_, _, _), TxOutput::Burn(_))
-        | (TxOutput::ProduceBlockFromStake(_, _, _), TxOutput::StakePool(_))
-        | (TxOutput::ProduceBlockFromStake(_, _, _), TxOutput::ProduceBlockFromStake(_, _, _)) => {
-            false
-        }
-        | (TxOutput::ProduceBlockFromStake(_, _, _), TxOutput::DecommissionPool(_, _, _, _)) => {
-            true
-        }
+        | (TxOutput::ProduceBlockFromStake(_, _), TxOutput::Transfer(_, _))
+        | (TxOutput::ProduceBlockFromStake(_, _), TxOutput::LockThenTransfer(_, _, _))
+        | (TxOutput::ProduceBlockFromStake(_, _), TxOutput::Burn(_))
+        | (TxOutput::ProduceBlockFromStake(_, _), TxOutput::StakePool(_))
+        | (TxOutput::ProduceBlockFromStake(_, _), TxOutput::ProduceBlockFromStake(_, _)) => false,
+        | (TxOutput::ProduceBlockFromStake(_, _), TxOutput::DecommissionPool(_, _, _, _)) => true,
         | (TxOutput::DecommissionPool(_, _, _, _), TxOutput::Transfer(_, _))
         | (TxOutput::DecommissionPool(_, _, _, _), TxOutput::LockThenTransfer(_, _, _))
         | (TxOutput::DecommissionPool(_, _, _, _), TxOutput::Burn(_))
         | (TxOutput::DecommissionPool(_, _, _, _), TxOutput::StakePool(_)) => true,
-        | (TxOutput::DecommissionPool(_, _, _, _), TxOutput::ProduceBlockFromStake(_, _, _))
+        | (TxOutput::DecommissionPool(_, _, _, _), TxOutput::ProduceBlockFromStake(_, _))
         | (TxOutput::DecommissionPool(_, _, _, _), TxOutput::DecommissionPool(_, _, _, _)) => false,
     }
 }
@@ -216,9 +212,7 @@ fn are_inputs_valid_for_tx(inputs_utxos: &[TxOutput]) -> bool {
         TxOutput::Transfer(_, _)
         | TxOutput::LockThenTransfer(_, _, _)
         | TxOutput::DecommissionPool(_, _, _, _) => true,
-        TxOutput::Burn(_) | TxOutput::StakePool(_) | TxOutput::ProduceBlockFromStake(_, _, _) => {
-            false
-        }
+        TxOutput::Burn(_) | TxOutput::StakePool(_) | TxOutput::ProduceBlockFromStake(_, _) => false,
     })
 }
 
@@ -228,7 +222,7 @@ fn are_outputs_valid_for_tx(outputs: &[TxOutput]) -> bool {
         | TxOutput::LockThenTransfer(_, _, _)
         | TxOutput::Burn(_)
         | TxOutput::StakePool(_) => true,
-        TxOutput::ProduceBlockFromStake(_, _, _) | TxOutput::DecommissionPool(_, _, _, _) => false,
+        TxOutput::ProduceBlockFromStake(_, _) | TxOutput::DecommissionPool(_, _, _, _) => false,
     });
 
     let is_stake_pool_unique = outputs
@@ -237,7 +231,7 @@ fn are_outputs_valid_for_tx(outputs: &[TxOutput]) -> bool {
             TxOutput::Transfer(_, _)
             | TxOutput::LockThenTransfer(_, _, _)
             | TxOutput::Burn(_)
-            | TxOutput::ProduceBlockFromStake(_, _, _)
+            | TxOutput::ProduceBlockFromStake(_, _)
             | TxOutput::DecommissionPool(_, _, _, _) => false,
             TxOutput::StakePool(_) => true,
         })
@@ -335,11 +329,7 @@ mod tests {
     }
 
     fn produce_block() -> TxOutput {
-        TxOutput::ProduceBlockFromStake(
-            Amount::ZERO,
-            Destination::AnyoneCanSpend,
-            PoolId::new(H256::zero()),
-        )
+        TxOutput::ProduceBlockFromStake(Destination::AnyoneCanSpend, PoolId::new(H256::zero()))
     }
 
     fn decommission_pool() -> TxOutput {

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -209,7 +209,7 @@ where
             .outputs()
             .iter()
             .filter(|o| matches!(*o, TxOutput::Burn(_)))
-            .filter_map(|o| o.value().map(|v| v.coin_amount()).flatten())
+            .filter_map(|o| o.value().and_then(|v| v.coin_amount()))
             .try_fold(Amount::ZERO, |so_far, v| {
                 (so_far + v).ok_or_else(|| ConnectTransactionError::BurnAmountSumError(tx.get_id()))
             })?;
@@ -297,6 +297,7 @@ where
 
         check_transferred_amount_in_reward(
             &self.utxo_cache,
+            &self.accounting_delta_adapter.accounting_delta(),
             &block.block_reward_transactable(),
             block.get_id(),
             total_fees,
@@ -405,6 +406,7 @@ where
         // check for attempted money printing
         let fee = check_transferred_amounts_and_get_fee(
             &self.utxo_cache,
+            &self.accounting_delta_adapter.accounting_delta(),
             tx.transaction(),
             issuance_token_id_getter,
         )?;

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -209,7 +209,7 @@ where
             .outputs()
             .iter()
             .filter(|o| matches!(*o, TxOutput::Burn(_)))
-            .filter_map(|o| o.value().coin_amount())
+            .filter_map(|o| o.value().map(|v| v.coin_amount()).flatten())
             .try_fold(Amount::ZERO, |so_far, v| {
                 (so_far + v).ok_or_else(|| ConnectTransactionError::BurnAmountSumError(tx.get_id()))
             })?;
@@ -235,7 +235,7 @@ where
                 Err(ConnectTransactionError::InvalidOutputTypeInReward)
             }
             TxOutput::StakePool(d) => Ok(d.as_ref().clone().into()),
-            TxOutput::ProduceBlockFromStake(_, _, pool_id)
+            TxOutput::ProduceBlockFromStake(_, pool_id)
             | TxOutput::DecommissionPool(_, _, pool_id, _) => self
                 .accounting_delta_adapter
                 .accounting_delta()
@@ -333,7 +333,7 @@ where
                 TxOutput::Transfer(_, _)
                 | TxOutput::LockThenTransfer(_, _, _)
                 | TxOutput::Burn(_)
-                | TxOutput::ProduceBlockFromStake(_, _, _) => None,
+                | TxOutput::ProduceBlockFromStake(_, _) => None,
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -371,7 +371,7 @@ where
             TxOutput::Transfer(_, _)
             | TxOutput::LockThenTransfer(_, _, _)
             | TxOutput::Burn(_)
-            | TxOutput::ProduceBlockFromStake(_, _, _) => Ok(()),
+            | TxOutput::ProduceBlockFromStake(_, _) => Ok(()),
         })
     }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -42,7 +42,7 @@ fn check_timelock(
         TxOutput::Transfer(_, _)
         | TxOutput::Burn(_)
         | TxOutput::StakePool(_)
-        | TxOutput::ProduceBlockFromStake(_, _, _) => return Ok(()),
+        | TxOutput::ProduceBlockFromStake(_, _) => return Ok(()),
         TxOutput::LockThenTransfer(_, _, tl) | TxOutput::DecommissionPool(_, _, _, tl) => tl,
     };
 

--- a/chainstate/tx-verifier/src/transaction_verifier/token_issuance_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/token_issuance_cache.rs
@@ -74,8 +74,11 @@ impl TokenIssuanceCache {
         block_id: Option<Id<Block>>,
         tx: &Transaction,
     ) -> Result<(), TokensError> {
-        let was_token_issued =
-            tx.outputs().iter().any(|output| is_tokens_issuance(&output.value()));
+        let was_token_issued = tx
+            .outputs()
+            .iter()
+            .any(|output| output.value().map_or(false, |v| is_tokens_issuance(&v)));
+
         if was_token_issued {
             self.write_issuance(&block_id.unwrap_or_else(|| H256::zero().into()), tx)?;
         }
@@ -83,8 +86,10 @@ impl TokenIssuanceCache {
     }
 
     pub fn unregister(&mut self, tx: &Transaction) -> Result<(), TokensError> {
-        let was_tokens_issued =
-            tx.outputs().iter().any(|output| is_tokens_issuance(&output.value()));
+        let was_tokens_issued = tx
+            .outputs()
+            .iter()
+            .any(|output| output.value().map_or(false, |v| is_tokens_issuance(&v)));
 
         if was_tokens_issued {
             self.write_undo_issuance(tx)?;
@@ -146,8 +151,11 @@ impl TokenIssuanceCache {
     where
         ConnectTransactionError: From<E>,
     {
-        let has_token_issuance =
-            tx.outputs().iter().any(|output| is_tokens_issuance(&output.value()));
+        let has_token_issuance = tx
+            .outputs()
+            .iter()
+            .any(|output| output.value().map_or(false, |v| is_tokens_issuance(&v)));
+
         if has_token_issuance {
             let token_id = token_id(tx).ok_or(TokensError::TokenIdCantBeCalculated)?;
             match self.data.entry(token_id) {

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -16,7 +16,7 @@
 use thiserror::Error;
 
 use common::{
-    chain::{Block, GenBlock},
+    chain::{Block, GenBlock, PoolId},
     primitives::{BlockHeight, Id},
 };
 
@@ -50,6 +50,8 @@ pub enum PropertyQueryError {
     GenesisHeaderRequested,
     #[error("Tried getting value of a token outpoint")]
     ExpectedCoinOutpointAndFoundToken,
+    #[error("Balance of pool {0} not found")]
+    PoolBalanceNotFound(PoolId),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/common/src/chain/tokens/tokens_utils.rs
+++ b/common/src/chain/tokens/tokens_utils.rs
@@ -36,6 +36,13 @@ pub fn is_tokens_issuance(output_value: &OutputValue) -> bool {
 pub fn get_tokens_issuance_count(outputs: &[TxOutput]) -> usize {
     outputs
         .iter()
-        .filter(|&output| output.value().map_or(false, |v| is_tokens_issuance(&v)))
+        .filter(|&output| match output {
+            TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
+                is_tokens_issuance(v)
+            }
+            TxOutput::StakePool(_)
+            | TxOutput::ProduceBlockFromStake(_, _)
+            | TxOutput::DecommissionPool(_, _, _, _) => false,
+        })
         .count()
 }

--- a/common/src/chain/tokens/tokens_utils.rs
+++ b/common/src/chain/tokens/tokens_utils.rs
@@ -34,5 +34,8 @@ pub fn is_tokens_issuance(output_value: &OutputValue) -> bool {
 }
 
 pub fn get_tokens_issuance_count(outputs: &[TxOutput]) -> usize {
-    outputs.iter().filter(|&output| is_tokens_issuance(&output.value())).count()
+    outputs
+        .iter()
+        .filter(|&output| output.value().map_or(false, |v| is_tokens_issuance(&v)))
+        .count()
 }

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -55,7 +55,7 @@ pub enum TxOutput {
     /// Output type that represents spending of a stake pool output in a block reward
     /// in order to produce a block
     #[codec(index = 4)]
-    ProduceBlockFromStake(Amount, Destination, PoolId),
+    ProduceBlockFromStake(Destination, PoolId),
     #[codec(index = 5)]
     DecommissionPool(Amount, Destination, PoolId, OutputTimeLock),
 }
@@ -68,7 +68,7 @@ impl TxOutput {
             TxOutput::LockThenTransfer(_, d, _) => Some(d),
             TxOutput::Burn(_) => None,
             TxOutput::StakePool(d) => Some(d.staker()),
-            TxOutput::ProduceBlockFromStake(_, d, _) => Some(d),
+            TxOutput::ProduceBlockFromStake(d, _) => Some(d),
             TxOutput::DecommissionPool(_, d, _, _) => Some(d),
         }
     }
@@ -79,21 +79,21 @@ impl TxOutput {
             | TxOutput::LockThenTransfer(_, _, _)
             | TxOutput::StakePool(_)
             | TxOutput::DecommissionPool(_, _, _, _)
-            | TxOutput::ProduceBlockFromStake(_, _, _) => false,
+            | TxOutput::ProduceBlockFromStake(_, _) => false,
             TxOutput::Burn(_) => true,
         }
     }
 }
 
 impl TxOutput {
-    pub fn value(&self) -> OutputValue {
+    pub fn value(&self) -> Option<OutputValue> {
         match self {
-            TxOutput::Transfer(v, _) => v.clone(),
-            TxOutput::LockThenTransfer(v, _, _) => v.clone(),
-            TxOutput::Burn(v) => v.clone(),
-            TxOutput::StakePool(d) => OutputValue::Coin(d.value()),
-            TxOutput::ProduceBlockFromStake(v, _, _) => OutputValue::Coin(*v),
-            TxOutput::DecommissionPool(v, _, _, _) => OutputValue::Coin(*v),
+            TxOutput::Transfer(v, _) => Some(v.clone()),
+            TxOutput::LockThenTransfer(v, _, _) => Some(v.clone()),
+            TxOutput::Burn(v) => Some(v.clone()),
+            TxOutput::StakePool(d) => Some(OutputValue::Coin(d.value())),
+            TxOutput::ProduceBlockFromStake(_, _) => None,
+            TxOutput::DecommissionPool(v, _, _, _) => Some(OutputValue::Coin(*v)),
         }
     }
 
@@ -102,7 +102,7 @@ impl TxOutput {
             TxOutput::Transfer(_, _)
             | TxOutput::Burn(_)
             | TxOutput::StakePool(_)
-            | TxOutput::ProduceBlockFromStake(_, _, _) => false,
+            | TxOutput::ProduceBlockFromStake(_, _) => false,
             TxOutput::DecommissionPool(_, _, _, _) | TxOutput::LockThenTransfer(_, _, _) => true,
         }
     }

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -83,19 +83,6 @@ impl TxOutput {
             TxOutput::Burn(_) => true,
         }
     }
-}
-
-impl TxOutput {
-    pub fn value(&self) -> Option<OutputValue> {
-        match self {
-            TxOutput::Transfer(v, _) => Some(v.clone()),
-            TxOutput::LockThenTransfer(v, _, _) => Some(v.clone()),
-            TxOutput::Burn(v) => Some(v.clone()),
-            TxOutput::StakePool(d) => Some(OutputValue::Coin(d.value())),
-            TxOutput::ProduceBlockFromStake(_, _) => None,
-            TxOutput::DecommissionPool(v, _, _, _) => Some(OutputValue::Coin(*v)),
-        }
-    }
 
     pub fn has_timelock(&self) -> bool {
         match self {

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -739,7 +739,7 @@ fn check_mutate_output(
         TxOutput::LockThenTransfer(v, d, l) => TxOutput::LockThenTransfer(add_value(v), d, l),
         TxOutput::Burn(v) => TxOutput::Burn(add_value(v)),
         TxOutput::StakePool(_) => unreachable!(), // TODO: come back to this later
-        TxOutput::ProduceBlockFromStake(_, _, _) => unreachable!(), // TODO: come back to this later
+        TxOutput::ProduceBlockFromStake(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::DecommissionPool(_, _, _, _) => unreachable!(), // TODO: come back to this later
     };
 

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -1085,7 +1085,7 @@ fn mutate_output(_rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedT
         TxOutput::LockThenTransfer(v, d, l) => TxOutput::LockThenTransfer(add_value(v), d, l),
         TxOutput::Burn(v) => TxOutput::Burn(add_value(v)),
         TxOutput::StakePool(_) => unreachable!(), // TODO: come back to this later
-        TxOutput::ProduceBlockFromStake(_, _, _) => unreachable!(), // TODO: come back to this later
+        TxOutput::ProduceBlockFromStake(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::DecommissionPool(_, _, _, _) => unreachable!(), // TODO: come back to this later
     };
     SignedTransactionWithUtxo {

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -143,7 +143,7 @@ where
             ));
         }
         TxOutput::StakePool(d) => d.as_ref().vrf_public_key().clone(),
-        TxOutput::ProduceBlockFromStake(_, _, pool_id) => {
+        TxOutput::ProduceBlockFromStake(_, pool_id) => {
             let pool_data = pos_accounting_view
                 .get_pool_data(pool_id)?
                 .ok_or(ConsensusPoSError::PoolDataNotFound(pool_id))?;

--- a/mempool/src/error.rs
+++ b/mempool/src/error.rs
@@ -108,4 +108,6 @@ pub enum TxValidationError {
     InternalError,
     #[error("Tip moved while trying to process transaction")]
     TipMoved,
+    #[error("Produce block output in transaction {0}")]
+    ProduceBlockOutputInTx(Id<Transaction>),
 }

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -97,7 +97,7 @@ pub struct MempoolStore {
     pub spender_txs: BTreeMap<OutPoint, Id<Transaction>>,
 
     // Track transactions by internal unique sequence number. This is used to recover the order in
-    // which the transacitons have been inserted into the mempool, so they can be re-inserted in
+    // which the transactions have been inserted into the mempool, so they can be re-inserted in
     // the same order after a reorg. We keep both mapping from transactions to sequence numbers and
     // the mapping from sequence number back to transaction. The sequence number to be allocated to
     // the next incoming transaction is kept separately.

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -162,13 +162,10 @@ impl MempoolStore {
                     .ok_or_else(make_err)
             })
             .map(|output| {
-                output
-                    .value()
-                    .map(|value| match value {
-                        OutputValue::Coin(coin) => coin,
-                        OutputValue::Token(_) => Amount::ZERO,
-                    })
-                    .unwrap_or(Amount::ZERO)
+                output.value().map_or(Amount::ZERO, |value| match value {
+                    OutputValue::Coin(coin) => coin,
+                    OutputValue::Token(_) => Amount::ZERO,
+                })
             })
     }
 

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -161,9 +161,14 @@ impl MempoolStore {
                     .get(outpoint.output_index() as usize)
                     .ok_or_else(make_err)
             })
-            .map(|output| match output.value() {
-                OutputValue::Coin(coin) => coin,
-                OutputValue::Token(_) => Amount::from_atoms(0),
+            .map(|output| {
+                output
+                    .value()
+                    .map(|value| match value {
+                        OutputValue::Coin(coin) => coin,
+                        OutputValue::Token(_) => Amount::ZERO,
+                    })
+                    .unwrap_or(Amount::ZERO)
             })
     }
 

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -461,11 +461,7 @@ async fn tx_spend_several_inputs<M: GetMemoryUsage + Send + Sync>(
         let outpoint = input.outpoint().clone();
         let chainstate_outpoint_value = mempool
             .chainstate_handle
-            .call(move |this| {
-                this.get_inputs_outpoints_values(
-                    &Transaction::new(0, vec![input], vec![], 0).unwrap(),
-                )
-            })
+            .call(move |this| this.get_inputs_outpoints_coin_amount(&[input]))
             .await??;
         let input_value = match chainstate_outpoint_value.first().unwrap() {
             Some(input_value) => *input_value,

--- a/mempool/src/pool/try_get_fee.rs
+++ b/mempool/src/pool/try_get_fee.rs
@@ -66,9 +66,11 @@ where
             .transaction()
             .outputs()
             .iter()
-            .filter_map(|output| match output.value() {
-                OutputValue::Coin(coin) => Some(coin),
-                OutputValue::Token(_) => None,
+            .filter_map(|output| {
+                output.value().and_then(|value| match value {
+                    OutputValue::Coin(coin) => Some(coin),
+                    OutputValue::Token(_) => None,
+                })
             })
             .sum::<Option<_>>()
             .ok_or(TxValidationError::OutputValuesOverflow)?;

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -23,6 +23,7 @@ use common::chain::PoolId;
 use common::chain::Transaction;
 use common::chain::TxInput;
 use common::chain::TxMainChainIndex;
+use common::chain::TxOutput;
 use common::primitives::Amount;
 use common::{
     chain::{
@@ -121,9 +122,13 @@ mockall::mock! {
             tx_id: &Id<common::chain::Transaction>,
         ) -> Result<Option<TokenId>, ChainstateError>;
         fn available_inputs(&self, tx: &Transaction) -> Result<Vec<Option<TxInput>>, ChainstateError>;
-        fn get_inputs_outpoints_values(
+        fn get_inputs_outpoints_coin_amount(
             &self,
-            tx: &Transaction,
+            inputs: &[TxInput],
+        ) -> Result<Vec<Option<Amount>>, ChainstateError>;
+        fn get_outputs_coin_amount(
+            &self,
+            outputs: &[TxOutput],
         ) -> Result<Vec<Option<Amount>>, ChainstateError>;
         fn get_mainchain_blocks_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
         fn get_block_id_tree_as_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;


### PR DESCRIPTION
The high-level motivation for this PR is to move staked coins arithmetics from utxo model to accounting. Basically once staked the manipulations like reward distribution to staker and delegators can be performed inside accounting only. 