### PR TITLE
Fix `p2p_syncing_test.py` test failure

### DIFF
--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -161,7 +161,7 @@ where
                 )
             }
             Err(err) => {
-                log::error!("Failed to establish connection: {err}");
+                log::error!("Failed to establish connection to {address:?}: {err}");
 
                 self.conn_tx
                     .send(ConnectivityEvent::ConnectionError {

--- a/p2p/src/peer_manager/peerdb/address_data/tests.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/tests.rs
@@ -29,7 +29,7 @@ fn randomized(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let started_at = Duration::ZERO;
 
-    let weights = [100, 100, 100, 10, 10];
+    let weights = [100, 100, 100, 100, 10, 10];
     assert_eq!(weights.len(), ALL_TRANSITIONS.len());
     let weights = WeightedIndex::new(weights).unwrap();
 
@@ -45,6 +45,7 @@ fn randomized(#[case] seed: Seed) {
             let is_valid_transition = match transition {
                 AddressStateTransitionTo::Connected => !address_data.is_connected(),
                 AddressStateTransitionTo::Disconnected => address_data.is_connected(),
+                AddressStateTransitionTo::DisconnectedByUser => address_data.is_connected(),
                 AddressStateTransitionTo::ConnectionFailed => !address_data.is_connected(),
                 AddressStateTransitionTo::SetReserved => true,
                 AddressStateTransitionTo::UnsetReserved => true,
@@ -86,4 +87,28 @@ fn reachable_reconnects(#[case] seed: Seed) {
         time_until_removed >= 2 * week && time_until_removed <= 6 * week,
         "invalid time until removed: {time_until_removed:?}"
     );
+}
+
+#[rstest]
+#[trace]
+#[case(
+    Seed::from_entropy(),
+    AddressStateTransitionTo::DisconnectedByUser,
+    false
+)]
+#[case(Seed::from_entropy(), AddressStateTransitionTo::Disconnected, true)]
+fn no_reconnects_after_manual_disconnect(
+    #[case] seed: Seed,
+    #[case] reason: AddressStateTransitionTo,
+    #[case] expected_reconnect: bool,
+) {
+    let mut rng = make_seedable_rng(seed);
+    let now = Duration::from_secs(1600000000);
+
+    let mut address = AddressData::new(true, false, now);
+    address.transition_to(AddressStateTransitionTo::Connected, now, &mut rng);
+    address.transition_to(reason, now, &mut rng);
+    let reconnect = address.connect_now(now + Duration::from_secs(100 * 24 * 3600));
+    // Test that there are no reconnection attempts to peers that were disconnected by RPC
+    assert_eq!(reconnect, expected_reconnect);
 }

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -253,11 +253,14 @@ where
         self.change_address_state(address, AddressStateTransitionTo::Connected);
     }
 
-    /// Handle peer disconnection event
-    ///
-    /// Close the connection to an active peer.
+    /// Handle peer disconnect event with unspecified reason
     pub fn outbound_peer_disconnected(&mut self, address: A) {
         self.change_address_state(address, AddressStateTransitionTo::Disconnected);
+    }
+
+    /// Handle peer disconnect event after RPC command
+    pub fn outbound_peer_disconnected_by_user(&mut self, address: A) {
+        self.change_address_state(address, AddressStateTransitionTo::DisconnectedByUser);
     }
 
     pub fn change_address_state(&mut self, address: A, transition: AddressStateTransitionTo) {


### PR DESCRIPTION
Do not reconnect to peers that have been manually disconnected (from RPC commands).