### PR TITLE
Fix GUI shutdown

### DIFF
--- a/subsystem/src/manager.rs
+++ b/subsystem/src/manager.rs
@@ -370,15 +370,14 @@ impl ShutdownTrigger {
     /// Initiate shutdown
     pub fn initiate(&self) {
         use mpsc::error::TrySendError as E;
-        if let Some(sender) = self.0.upgrade() {
-            sender.try_send(()).unwrap_or_else(|err| match err {
-                E::Full(_) => {
-                    log::info!("Shutdown requested but the system is already shutting down")
-                }
-                E::Closed(_) => log::info!("Shutdown requested but the system is already down"),
-            })
-        } else {
-            log::info!("Shutdown requested but the system is already down")
+        match self.0.upgrade().map(|s| s.try_send(())) {
+            None | Some(Err(E::Closed(_))) => {
+                log::info!("Shutdown requested but the system is already down")
+            }
+            Some(Err(E::Full(_))) => {
+                log::info!("Shutdown requested but the system is already shutting down")
+            }
+            Some(Ok(())) => {}
         }
     }
 }

--- a/subsystem/src/manager.rs
+++ b/subsystem/src/manager.rs
@@ -297,7 +297,7 @@ impl Manager {
 
     /// Create a trigger object that can be used to shut down the system
     pub fn make_shutdown_trigger(&self) -> ShutdownTrigger {
-        ShutdownTrigger(self.shutting_down_tx.clone())
+        ShutdownTrigger(self.shutting_down_tx.downgrade())
     }
 
     /// Run the application main task.
@@ -364,16 +364,22 @@ impl Manager {
 
 /// Used to initiate shutdown of manager and subsystems.
 #[derive(Clone)]
-pub struct ShutdownTrigger(mpsc::Sender<()>);
+pub struct ShutdownTrigger(mpsc::WeakSender<()>);
 
 impl ShutdownTrigger {
     /// Initiate shutdown
     pub fn initiate(&self) {
         use mpsc::error::TrySendError as E;
-        self.0.try_send(()).unwrap_or_else(|err| match err {
-            E::Full(_) => log::info!("Shutdown requested but the system is already shutting down"),
-            E::Closed(_) => log::info!("Shutdown requested but the system is already down"),
-        })
+        if let Some(sender) = self.0.upgrade() {
+            sender.try_send(()).unwrap_or_else(|err| match err {
+                E::Full(_) => {
+                    log::info!("Shutdown requested but the system is already shutting down")
+                }
+                E::Closed(_) => log::info!("Shutdown requested but the system is already down"),
+            })
+        } else {
+            log::info!("Shutdown requested but the system is already down")
+        }
     }
 }
 


### PR DESCRIPTION
There is exactly the same problem that @stanislav-tkach had with p2p tests shutdown. Making one more `ShutdownTrigger` prevents proper shutdown detection. As a quick fix I added `WeakShutdownTrigger` which uses `tokio::sync::mpsc::WeakSender` instead of `tokio::sync::mpsc::Sender`.