### PR TITLE
Fix logs printing in wallet-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1222,16 @@ dependencies = [
  "crossbeam-utils",
  "memoffset 0.8.0",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1244,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",
@@ -4623,11 +4647,12 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9be1b4ddfacccf35ea8b4a8d3f7ec9e494ea22969c4156d4b2a393c1b9cef"
+checksum = "0b8684e0f5d6fb8529156a19c637645dd7fd5018efbdeaa306f53f54e3b404de"
 dependencies = [
  "chrono",
+ "crossbeam",
  "crossterm",
  "fd-lock",
  "itertools",
@@ -5706,9 +5731,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -6455,7 +6480,7 @@ dependencies = [
  "common",
  "dialoguer",
  "directories",
- "logging",
+ "env_logger",
  "reedline",
  "serialization",
  "shlex",

--- a/wallet/wallet-cli/Cargo.toml
+++ b/wallet/wallet-cli/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../../common" }
-logging = { path = "../../logging" }
 serialization = { path = "../../serialization" }
 utils = { path = "../../utils" }
 wallet = { path = ".." }
@@ -17,7 +16,8 @@ wallet-storage = { path = '../storage' }
 clap = { version = "4", features = ["derive"] }
 dialoguer = { version = "0.10", features = ["history", "completion"] }
 directories = "5.0"
-reedline = { version = "0.18" }
+env_logger = "0.10"
+reedline = { version = "0.19", features = ["external_printer"] }
 shlex = "1.0"
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }

--- a/wallet/wallet-cli/src/log.rs
+++ b/wallet/wallet-cli/src/log.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct ReedlineLogWriter {
+    printer: reedline::ExternalPrinter<String>,
+    buf: Vec<u8>,
+}
+
+impl ReedlineLogWriter {
+    fn new(printer: reedline::ExternalPrinter<String>) -> Self {
+        Self {
+            printer,
+            buf: Vec::new(),
+        }
+    }
+}
+
+impl std::io::Write for ReedlineLogWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        if self.buf.ends_with(&[b'\n']) {
+            let mut line = std::mem::take(&mut self.buf);
+            line.pop();
+            let _ = self.printer.print(String::from_utf8_lossy(line.as_slice()).to_string());
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Use [reedline::ExternalPrinter] to print log output without mangling reedline console input
+pub fn init() -> reedline::ExternalPrinter<String> {
+    let external_printer = reedline::ExternalPrinter::default();
+
+    let log_writer = ReedlineLogWriter::new(external_printer.clone());
+
+    env_logger::builder()
+        .target(env_logger::Target::Pipe(Box::new(log_writer)))
+        .init();
+
+    external_printer
+}

--- a/wallet/wallet-cli/src/main.rs
+++ b/wallet/wallet-cli/src/main.rs
@@ -22,6 +22,7 @@ mod config;
 mod console;
 mod errors;
 mod helpers;
+mod log;
 mod repl;
 mod wallet_init;
 
@@ -41,7 +42,7 @@ use wallet_controller::cookie::load_cookie;
 const COOKIE_FILENAME: &str = ".cookie";
 
 async fn run(output: &ConsoleContext) -> Result<(), WalletCliError> {
-    logging::init_logging::<&std::path::Path>(None);
+    let printer = log::init();
 
     let args = config::WalletCliArgs::parse();
 
@@ -123,7 +124,7 @@ async fn run(output: &ConsoleContext) -> Result<(), WalletCliError> {
     let output_copy = output.clone();
     let repl_command = repl::get_repl_command();
     let create_line_editor =
-        repl::create_line_editor(repl_command.clone(), output, &data_dir, vi_mode)?;
+        repl::create_line_editor(printer, repl_command.clone(), output, &data_dir, vi_mode)?;
 
     let repl_handle = std::thread::spawn(move || {
         // Run a blocking loop in a separate thread

--- a/wallet/wallet-cli/src/repl/mod.rs
+++ b/wallet/wallet-cli/src/repl/mod.rs
@@ -85,6 +85,7 @@ fn parse_input(line: &str, repl_command: &Command) -> Result<WalletCommand, Wall
 }
 
 pub fn create_line_editor(
+    printer: reedline::ExternalPrinter<String>,
     repl_command: Command,
     output: &ConsoleContext,
     data_dir: &Path,
@@ -108,6 +109,7 @@ pub fn create_line_editor(
     let completer = Box::new(WalletCompletions::new(commands));
 
     let mut line_editor = Reedline::create()
+        .with_external_printer(printer)
         .with_history(history)
         .with_completer(completer)
         .with_quick_completions(false)


### PR DESCRIPTION
Use `reedline::ExternalPrinter` to print log output without mangling reedline console input.