### PR TITLE
Support displaying error on failed initialization in GUI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ default-members = [
   "mempool",
   "node-lib",
   "node-daemon",
+  "node-gui",
   "p2p",
   "rpc",
   "script",

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -101,8 +101,7 @@ pub async fn initialize(
             Default::default(),
             peerdb_storage,
         )
-        .await
-        .expect("The p2p subsystem initialization failed"),
+        .await?,
     );
 
     // Block production


### PR DESCRIPTION
Some gymnastics were needed to make this possible. The primary is that the Message type (which is used to drive events in the GUI) must implement Clone trait, so the NodeController must also support the Clone trait, which in turn lead to having to find a way to make the manager join handle support the Clone trait... and it's not nice.
