### PR TITLE
utxo: Make best block always available

### DIFF
--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -114,7 +114,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> UtxosStor
         self.db_tx.get_utxo(outpoint)
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, storage_result::Error> {
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, storage_result::Error> {
         self.db_tx.get_best_block_for_utxos()
     }
 

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -254,7 +254,7 @@ impl<B: storage::Backend> UtxosStorageRead for Store<B> {
     type Error = crate::Error;
     delegate_to_transaction! {
         fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
-        fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>>;
+        fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
     }
 }

--- a/chainstate/storage/src/internal/store_tx.rs
+++ b/chainstate/storage/src/internal/store_tx.rs
@@ -210,8 +210,9 @@ macro_rules! impl_read_ops {
                 self.read::<db::DBUtxo, _, _>(outpoint)
             }
 
-            fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>> {
+            fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>> {
                 self.read_value::<well_known::UtxosBestBlockId>()
+                    .map(|id| id.expect("Best block for UTXOs to be present"))
             }
 
             fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>> {

--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -373,13 +373,8 @@ fn utxo_db_impl_test(#[case] seed: Seed) {
     let block_id: Id<Block> = Id::new(H256::random_using(&mut rng));
     assert!(db_interface.set_best_block_for_utxos(&block_id.into()).is_ok());
 
-    let block_id = Id::new(
-        db_interface
-            .get_best_block_for_utxos()
-            .expect("query should not fail")
-            .expect("should return the block id")
-            .get(),
-    );
+    let block_id =
+        Id::new(db_interface.get_best_block_for_utxos().expect("query should not fail").get());
 
     // undo checking
     let undo = create_rand_block_undo(&mut rng, 10, 10);

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -92,7 +92,7 @@ mockall::mock! {
     impl UtxosStorageRead for Store {
         type Error = crate::Error;
         fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
-        fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>>;
+        fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
     }
 
@@ -331,7 +331,7 @@ mockall::mock! {
     impl crate::UtxosStorageRead for StoreTxRo {
         type Error = crate::Error;
         fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
-        fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>>;
+        fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
     }
 
@@ -438,7 +438,7 @@ mockall::mock! {
     impl UtxosStorageRead for StoreTxRw {
         type Error = crate::Error;
         fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
-        fn get_best_block_for_utxos(&self) -> crate::Result<Option<Id<GenBlock>>>;
+        fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
     }
 

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -66,7 +66,7 @@ fn store_coin(#[case] seed: Seed) {
         // best block has changed
         let db_tx = storage.transaction_ro().unwrap();
         assert_eq!(
-            db_tx.get_best_block_for_utxos().expect("ok").expect("some"),
+            db_tx.get_best_block_for_utxos().expect("ok"),
             Id::<GenBlock>::from(block_id)
         );
         assert_eq!(
@@ -147,7 +147,7 @@ fn store_token(#[case] seed: Seed) {
 
         // best block has changed
         assert_eq!(
-            db_tx.get_best_block_for_utxos().expect("ok").expect("some"),
+            db_tx.get_best_block_for_utxos().expect("ok"),
             Id::<GenBlock>::from(block_id)
         );
         assert_eq!(
@@ -264,7 +264,7 @@ fn reorg_store_coin(#[case] seed: Seed) {
         // best block has changed
         let db_tx = storage.transaction_ro().unwrap();
         assert_eq!(
-            db_tx.get_best_block_for_utxos().expect("ok").expect("some"),
+            db_tx.get_best_block_for_utxos().expect("ok"),
             Id::<GenBlock>::from(block_3_id)
         );
         assert_eq!(
@@ -461,7 +461,7 @@ fn reorg_store_token(#[case] seed: Seed) {
         // best block has changed
         let db_tx = storage.transaction_ro().unwrap();
         assert_eq!(
-            db_tx.get_best_block_for_utxos().expect("ok").expect("some"),
+            db_tx.get_best_block_for_utxos().expect("ok"),
             Id::<GenBlock>::from(block_3_id)
         );
         assert_eq!(

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -107,7 +107,7 @@ impl UtxosStorageRead for InMemoryStorageWrapper {
         self.storage.get_utxo(outpoint)
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, storage_result::Error> {
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, storage_result::Error> {
         self.storage.get_best_block_for_utxos()
     }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -120,8 +120,8 @@ where
         self.utxo_cache.utxo(outpoint).map_err(|e| e.into())
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Self::Error> {
-        Ok(Some(self.best_block))
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, Self::Error> {
+        Ok(self.best_block)
     }
 
     fn get_undo_data(&self, id: Id<Block>) -> Result<Option<UtxosBlockUndo>, Self::Error> {

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -119,8 +119,7 @@ impl<C, S: TransactionVerifierStorageRef + ShallowClone> TransactionVerifier<C, 
             .expect("Utxo cache setup failed");
         let best_block = storage
             .get_best_block_for_utxos()
-            .expect("Database error while reading utxos best block")
-            .expect("best block should be some");
+            .expect("Database error while reading utxos best block");
         let tx_index_cache = OptionalTxIndexCache::from_config(&verifier_config);
         Self {
             storage,
@@ -151,8 +150,7 @@ where
     ) -> Self {
         let best_block = storage
             .get_best_block_for_utxos()
-            .expect("Database error while reading utxos best block")
-            .expect("best block should be some");
+            .expect("Database error while reading utxos best block");
         let tx_index_cache = OptionalTxIndexCache::from_config(&verifier_config);
         Self {
             storage,

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
@@ -50,9 +50,7 @@ fn hierarchy_test_utxo(#[case] seed: Seed) {
     let (outpoint2, utxo2) = create_utxo(&mut rng, 2000);
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_get_utxo()
         .with(eq(outpoint0.clone()))
@@ -147,9 +145,7 @@ fn hierarchy_test_undo_from_chain(#[case] seed: Seed) {
     .unwrap();
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_get_undo_data()
         .with(eq(block_undo_id_0))
@@ -236,9 +232,7 @@ fn hierarchy_test_tx_index(#[case] seed: Seed) {
     let tx_index_2 = TxMainChainIndex::new(pos2, 2).unwrap();
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_get_mainchain_tx_index()
         .with(eq(outpoint0.clone()))
@@ -326,9 +320,7 @@ fn hierarchy_test_tokens(#[case] seed: Seed) {
     );
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_get_token_aux_data()
         .with(eq(token_id_0))
@@ -452,9 +444,7 @@ fn hierarchy_test_block_index(#[case] seed: Seed) {
     let block_id: Id<Block> = Id::new(H256::random_using(&mut rng));
     let block_index = GenBlockIndex::Genesis(Arc::clone(chain_config.genesis_block()));
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_get_gen_block_index()
         .with(eq(Id::<GenBlock>::from(block_id)))
@@ -507,9 +497,7 @@ fn hierarchy_test_stake_pool(#[case] seed: Seed) {
     let block_undo_id_2: Id<Block> = Id::new(H256::random_using(&mut rng));
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_get_pool_balance()
         .with(eq(pool_id_0))

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -71,9 +71,7 @@ fn utxo_set_from_chain_hierarchy(#[case] seed: Seed) {
     .unwrap();
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -151,9 +149,7 @@ fn tx_index_set_hierarchy(#[case] seed: Seed) {
     let tx_index_2 = TxMainChainIndex::new(pos2, 2).unwrap();
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -221,9 +217,7 @@ fn tokens_set_hierarchy(#[case] seed: Seed) {
     );
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -303,9 +297,7 @@ fn utxo_del_from_chain_hierarchy(#[case] seed: Seed) {
     let block_2_undo: UtxosBlockUndo = Default::default();
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_get_utxo()
         .with(eq(outpoint1.clone()))
@@ -383,9 +375,7 @@ fn tx_index_del_hierarchy(#[case] seed: Seed) {
     let outpoint2 = OutPointSourceId::Transaction(Id::new(H256::random_using(&mut rng)));
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -446,9 +436,7 @@ fn tokens_del_hierarchy(#[case] seed: Seed) {
     let tx_id_2 = Transaction::new(2, vec![], vec![], 2).unwrap().get_id();
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -509,9 +497,7 @@ fn utxo_conflict_hierarchy(#[case] seed: Seed) {
     let (_, utxo2) = create_utxo(&mut rng, 2000);
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -586,9 +572,7 @@ fn block_undo_from_chain_conflict_hierarchy(#[case] seed: Seed) {
     .unwrap();
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_set_utxo_undo_data()
         .with(
@@ -655,9 +639,7 @@ fn tx_index_conflict_hierarchy(#[case] seed: Seed) {
     let tx_index_2 = TxMainChainIndex::new(pos2, 2).unwrap();
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -719,9 +701,7 @@ fn tokens_conflict_hierarchy(#[case] seed: Seed) {
     );
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -795,9 +775,7 @@ fn pos_accounting_stake_pool_set_hierarchy(#[case] seed: Seed) {
     let pool_id_2 = pos_accounting::make_pool_id(&outpoint2);
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -865,9 +843,7 @@ fn pos_accounting_stake_pool_undo_set_hierarchy(#[case] seed: Seed) {
     let block_undo_id_2: Id<Block> = Id::new(H256::random_using(&mut rng));
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()
@@ -959,9 +935,7 @@ fn pos_accounting_stake_pool_undo_del_hierarchy(#[case] seed: Seed) {
     let block_undo_id_2: Id<Block> = Id::new(H256::random_using(&mut rng));
 
     let mut store = mock::MockStore::new();
-    store
-        .expect_get_best_block_for_utxos()
-        .return_const(Ok(Some(H256::zero().into())));
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
     store
         .expect_batch_write_delta()

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -125,7 +125,7 @@ mockall::mock! {
     impl UtxosStorageRead for Store {
         type Error = storage_result::Error;
         fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, storage_result::Error>;
-        fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>,storage_result::Error>;
+        fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, storage_result::Error>;
         fn get_undo_data(&self, id: Id<Block>) -> Result<Option<utxo::UtxosBlockUndo>, storage_result::Error>;
     }
 

--- a/mempool/src/pool/tx_verifier/chainstate_handle.rs
+++ b/mempool/src/pool/tx_verifier/chainstate_handle.rs
@@ -126,8 +126,8 @@ impl UtxosStorageRead for ChainstateHandle {
         self.call(move |c| c.utxo(&outpoint))
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Error> {
-        self.call(|c| c.get_best_block_id()).map(Some)
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, Error> {
+        self.call(|c| c.get_best_block_id())
     }
 
     fn get_undo_data(&self, _id: Id<Block>) -> Result<Option<UtxosBlockUndo>, Error> {
@@ -240,7 +240,7 @@ impl UtxosView for ChainstateHandle {
     }
 
     fn best_block_hash(&self) -> Result<Id<GenBlock>, Error> {
-        self.get_best_block_for_utxos().map(|id| id.expect("Best block to be set"))
+        self.get_best_block_for_utxos()
     }
 
     fn estimated_size(&self) -> Option<usize> {

--- a/utxo/src/storage/in_memory.rs
+++ b/utxo/src/storage/in_memory.rs
@@ -52,8 +52,8 @@ impl UtxosStorageRead for UtxosDBInMemoryImpl {
         Ok(res.cloned())
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Error> {
-        Ok(Some(self.best_block_id))
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, Error> {
+        Ok(self.best_block_id)
     }
 }
 

--- a/utxo/src/storage/mod.rs
+++ b/utxo/src/storage/mod.rs
@@ -26,7 +26,7 @@ use std::ops::{Deref, DerefMut};
 pub trait UtxosStorageRead {
     type Error: std::error::Error;
     fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error>;
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Self::Error>;
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, Self::Error>;
     fn get_undo_data(&self, id: Id<Block>) -> Result<Option<UtxosBlockUndo>, Self::Error>;
 }
 
@@ -45,15 +45,7 @@ pub struct UtxosDB<S>(S);
 
 impl<S: UtxosStorageRead> UtxosDB<S> {
     pub fn new(store: S) -> Self {
-        let utxos_db = Self(store);
-        debug_assert!(
-            utxos_db
-                .get_best_block_for_utxos()
-                .expect("Database error while reading utxos best block")
-                .is_some(),
-            "Attempted to load an uninitialized utxos db"
-        );
-        utxos_db
+        Self(store)
     }
 }
 
@@ -98,7 +90,7 @@ where
         self.deref().get_utxo(outpoint)
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Self::Error> {
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, Self::Error> {
         self.deref().get_best_block_for_utxos()
     }
 

--- a/utxo/src/storage/rw_impls.rs
+++ b/utxo/src/storage/rw_impls.rs
@@ -48,7 +48,7 @@ impl<S: UtxosStorageRead> UtxosStorageRead for UtxosDB<S> {
         self.0.get_utxo(outpoint)
     }
 
-    fn get_best_block_for_utxos(&self) -> Result<Option<Id<GenBlock>>, Self::Error> {
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, Self::Error> {
         self.0.get_best_block_for_utxos()
     }
 

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -32,7 +32,7 @@ impl<S: UtxosStorageRead> UtxosView for UtxosDB<S> {
     }
 
     fn best_block_hash(&self) -> Result<Id<GenBlock>, Self::Error> {
-        Ok(self.get_best_block_for_utxos()?.expect("Failed to get best block hash"))
+        self.get_best_block_for_utxos()
     }
 
     fn estimated_size(&self) -> Option<usize> {


### PR DESCRIPTION
Getting the best block is integral to the UTXO set manipulations. Make it always available without having to handle the error or (more commonly) unwrap.