### PR TITLE
mempool: Transactions disconnected during reorg to be put back into mempool

### DIFF
--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -89,8 +89,12 @@ impl BlockV1 {
         self.header.timestamp()
     }
 
-    pub fn transactions(&self) -> &Vec<SignedTransaction> {
+    pub fn transactions(&self) -> &[SignedTransaction] {
         &self.body.transactions
+    }
+
+    pub fn into_transactions(self) -> Vec<SignedTransaction> {
+        self.body.transactions
     }
 
     pub fn prev_block_id(&self) -> &Id<crate::chain::GenBlock> {

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -196,9 +196,15 @@ impl Block {
         }
     }
 
-    pub fn transactions(&self) -> &Vec<SignedTransaction> {
+    pub fn transactions(&self) -> &[SignedTransaction] {
         match self {
             Block::V1(blk) => blk.transactions(),
+        }
+    }
+
+    pub fn into_transactions(self) -> Vec<SignedTransaction> {
+        match self {
+            Block::V1(blk) => blk.into_transactions(),
         }
     }
 

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -126,6 +126,18 @@ impl<M> Mempool<M> {
     ) -> subsystem::blocking::BlockingHandle<Box<dyn ChainstateInterface>> {
         subsystem::blocking::BlockingHandle::new(self.chainstate_handle().shallow_clone())
     }
+
+    // Reset the mempool state, returning the list of transactions previously stored in mempool
+    fn reset(&mut self) -> impl Iterator<Item = SignedTransaction> {
+        // Discard the old tx verifier and replace it with a fresh one
+        self.tx_verifier = tx_verifier::create(
+            self.chain_config.shallow_clone(),
+            self.chainstate_handle.shallow_clone(),
+        );
+
+        // Clear the store, returning the list of transacitons it contained previously
+        std::mem::replace(&mut self.store, MempoolStore::new()).into_transactions()
+    }
 }
 
 // Rolling-fee-related methods

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -49,6 +49,7 @@ use self::fee::Fee;
 
 pub mod fee;
 mod feerate;
+mod reorg;
 mod rolling_fee_rate;
 mod spends_unconfirmed;
 mod store;
@@ -75,28 +76,19 @@ pub struct Mempool<M> {
     tx_verifier: tx_verifier::TransactionVerifier,
 }
 
-impl<M> std::fmt::Debug for Mempool<M>
-where
-    M: GetMemoryUsage + 'static + Send + Sync,
-{
+impl<M> std::fmt::Debug for Mempool<M> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.store)
     }
 }
 
-impl<M> GetMemoryUsage for Mempool<M>
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M: GetMemoryUsage> GetMemoryUsage for Mempool<M> {
     fn get_memory_usage(&self) -> usize {
         self.memory_usage_estimator.get_memory_usage()
     }
 }
 
-impl<M> Mempool<M>
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M> Mempool<M> {
     pub fn new(
         chain_config: Arc<ChainConfig>,
         chainstate_handle: subsystem::Handle<Box<dyn ChainstateInterface>>,
@@ -128,13 +120,16 @@ where
     pub fn chainstate_handle(&self) -> &subsystem::Handle<Box<dyn ChainstateInterface>> {
         &self.chainstate_handle
     }
+
+    pub fn blocking_chainstate_handle(
+        &self,
+    ) -> subsystem::blocking::BlockingHandle<Box<dyn ChainstateInterface>> {
+        subsystem::blocking::BlockingHandle::new(self.chainstate_handle().shallow_clone())
+    }
 }
 
 // Rolling-fee-related methods
-impl<M> Mempool<M>
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M: GetMemoryUsage> Mempool<M> {
     fn rolling_fee_halflife(&self) -> Time {
         let mem_usage = self.get_memory_usage();
         if mem_usage < self.max_size / 4 {
@@ -200,10 +195,7 @@ where
 }
 
 // Entry Creation
-impl<M> Mempool<M>
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M> Mempool<M> {
     fn create_entry(&self, tx: TxWithFee) -> Result<TxMempoolEntry, MempoolPolicyError> {
         let (tx, fee) = tx.into_tx_and_fee();
 
@@ -229,10 +221,7 @@ where
 }
 
 // Transaction Validation
-impl<M> Mempool<M>
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M: GetMemoryUsage> Mempool<M> {
     fn validate_transaction(
         &self,
         tx: SignedTransaction,
@@ -285,8 +274,7 @@ where
         &self,
         tx: SignedTransaction,
     ) -> Result<(TxWithFee, TransactionVerifierDelta), TxValidationError> {
-        let chainstate_handle =
-            subsystem::blocking::BlockingHandle::new(self.chainstate_handle().shallow_clone());
+        let chainstate_handle = self.blocking_chainstate_handle();
 
         for _ in 0..MAX_TX_ADDITION_ATTEMPTS {
             let (tip, current_best) = chainstate_handle.call(|chainstate| {
@@ -413,10 +401,7 @@ where
 }
 
 // RBF checks
-impl<M> Mempool<M>
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M: GetMemoryUsage> Mempool<M> {
     fn rbf_checks(&self, tx: &TxWithFee) -> Result<Conflicts, MempoolPolicyError> {
         let conflicts = self
             .conflicting_tx_ids(tx.tx())
@@ -574,10 +559,7 @@ where
 }
 
 // Transaction Finalization
-impl<M> Mempool<M>
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M: GetMemoryUsage> Mempool<M> {
     fn finalize_tx(&mut self, tx: TxWithFee) -> Result<(), Error> {
         let entry = self.create_entry(tx)?;
         let id = entry.tx_id();
@@ -671,10 +653,7 @@ where
 }
 
 // Mempool Interface and Event Reactions
-impl<M> Mempool<M>
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M: GetMemoryUsage> Mempool<M> {
     pub fn add_transaction(&mut self, tx: SignedTransaction) -> Result<(), Error> {
         log::debug!("Adding transaction {:?}", tx.transaction().get_id());
         log::trace!("Adding transaction {tx:?}");
@@ -752,29 +731,10 @@ where
     }
 
     pub fn new_tip_set(&mut self, block_id: Id<Block>, block_height: BlockHeight) {
+        log::info!("new tip: block {block_id:?} height {block_height:?}");
+        reorg::handle_new_tip(self, block_id)
         // TODO: turn on mempool new tip broadcasts when ready
         // self.events_controller.broadcast(MempoolEvent::NewTip(block_id, block_height));
-
-        log::info!("new tip with block_id {block_id:?} and block_height {block_height:?}");
-
-        self.rolling_fee_rate.write().set_block_since_last_rolling_fee_bump(true);
-
-        // Take all the mempool previous transactions
-        let old_store = std::mem::replace(&mut self.store, MempoolStore::new());
-
-        // Discard the old tx verifier and replace it with a fresh one
-        self.tx_verifier = tx_verifier::create(
-            self.chain_config.shallow_clone(),
-            self.chainstate_handle.shallow_clone(),
-        );
-
-        // Re-populate the verifier with transactions
-        for tx in old_store.into_transactions() {
-            let tx_id = tx.transaction().get_id();
-            if let Err(e) = self.add_transaction(tx) {
-                log::trace!("Evicting {tx_id} from mempool: {e:?}")
-            }
-        }
     }
 }
 

--- a/mempool/src/pool/reorg.rs
+++ b/mempool/src/pool/reorg.rs
@@ -92,7 +92,7 @@ fn find_disconnected_txs(
         return Ok(Vec::new());
     }
 
-    // Collect IDs of trancsactions included in the newly connected chain
+    // Collect IDs of transactions included in the newly connected chain
     let mut connected_txs = BTreeSet::new();
     for_each_block(chainstate, new_tip_id, common_id, |block| {
         connected_txs.extend(block.transactions().iter().map(|t| t.transaction().get_id()))
@@ -102,9 +102,9 @@ fn find_disconnected_txs(
     let mut disconnected_txs = Vec::new();
     for_each_block(chainstate, old_tip_id, common_id, |block| {
         // We iterate blocks in the reverse order, so for consistent transaction input/output
-        // dependencies, take transacitons in reverse too,
+        // dependencies, take transactions in reverse too,
         let txns = block.transactions().iter().rev();
-        // We disregerd transactions that are re-added on the newly connected chain
+        // We disregard transactions that are re-added on the newly connected chain
         let txns = txns.filter(|txn| !connected_txs.contains(&txn.transaction().get_id()));
         disconnected_txs.extend(txns.cloned())
     })?;

--- a/mempool/src/pool/reorg.rs
+++ b/mempool/src/pool/reorg.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Support for updating the mempool upon a reorg
+
+use std::{collections::BTreeSet, mem};
+
+use chainstate::chainstate_interface::ChainstateInterface;
+use common::{
+    chain::{Block, GenBlock, SignedTransaction},
+    primitives::{Id, Idable},
+};
+use logging::log;
+use utils::{shallow_clone::ShallowClone, tap_error_log::LogError};
+use utxo::UtxosStorageRead;
+
+use crate::{
+    get_memory_usage::GetMemoryUsage,
+    pool::{tx_verifier, Mempool, MempoolStore},
+};
+
+/// An error that can happen in mempool on chain reorg
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ReorgError {
+    #[error(transparent)]
+    Chainstate(#[from] chainstate::ChainstateError),
+    #[error("Could not find the previous tip")]
+    OldTip,
+    #[error("Could not find the previous tip index")]
+    OldTipIndex,
+    #[error("Could not find the new tip index")]
+    NewTipIndex,
+    #[error("Block {0:?} not found while traversing history")]
+    BlockNotFound(Id<Block>),
+    #[error("Chainstate call: {0}")]
+    ChainstateCall(#[from] subsystem::subsystem::CallError),
+}
+
+/// Iterate over blocks following the parent link. Apply given function to each block.
+fn for_each_block(
+    chainstate: &dyn ChainstateInterface,
+    mut curr_id: Id<Block>,
+    stop_id: Id<GenBlock>,
+    mut func: impl FnMut(Block),
+) -> Result<(), ReorgError> {
+    let chain_config = chainstate.get_chain_config();
+    while curr_id != stop_id {
+        let block = chainstate
+            .get_block(curr_id)?
+            .ok_or_else(|| ReorgError::BlockNotFound(curr_id))?;
+        curr_id = match block.prev_block_id().classify(chain_config) {
+            common::chain::GenBlockId::Genesis(_) => break,
+            common::chain::GenBlockId::Block(block_id) => block_id,
+        };
+        func(block);
+    }
+    Ok(())
+}
+
+fn find_disconnected_txs(
+    chainstate: &dyn ChainstateInterface,
+    old_tip_id: Id<GenBlock>,
+    new_tip_id: Id<Block>,
+) -> Result<Vec<SignedTransaction>, ReorgError> {
+    let chain_config = chainstate.get_chain_config();
+    let old_tip_id = match old_tip_id.classify(chain_config) {
+        common::chain::GenBlockId::Genesis(_) => return Ok(Vec::new()),
+        common::chain::GenBlockId::Block(id) => id,
+    };
+
+    let common_id = {
+        let old_index = chainstate.get_block_index(&old_tip_id)?.ok_or(ReorgError::OldTipIndex)?;
+        let new_index = chainstate.get_block_index(&new_tip_id)?.ok_or(ReorgError::NewTipIndex)?;
+        let common_index = chainstate.last_common_ancestor(&old_index.into(), &new_index.into())?;
+        common_index.block_id()
+    };
+
+    // Short circuit the expensive processing below if no blocks are being disconnected
+    if old_tip_id == common_id {
+        return Ok(Vec::new());
+    }
+
+    // Collect IDs of trancsactions included in the newly connected chain
+    let mut connected_txs = BTreeSet::new();
+    for_each_block(chainstate, new_tip_id, common_id, |block| {
+        connected_txs.extend(block.transactions().iter().map(|t| t.transaction().get_id()))
+    })?;
+
+    // Collect txns that have been removed from the blockchain and not added on the new fork
+    let mut disconnected_txs = Vec::new();
+    for_each_block(chainstate, old_tip_id, common_id, |block| {
+        // We iterate blocks in the reverse order, so for consistent transaction input/output
+        // dependencies, take transacitons in reverse too,
+        let txns = block.transactions().iter().rev();
+        // We disregerd transactions that are re-added on the newly connected chain
+        let txns = txns.filter(|txn| !connected_txs.contains(&txn.transaction().get_id()));
+        disconnected_txs.extend(txns.cloned())
+    })?;
+
+    Ok(disconnected_txs)
+}
+
+fn fetch_disconnected_txs<M>(
+    mempool: &Mempool<M>,
+    new_tip: Id<Block>,
+) -> Result<Vec<SignedTransaction>, ReorgError> {
+    let chainstate = mempool.blocking_chainstate_handle();
+
+    let old_tip = mempool.tx_verifier.get_best_block_for_utxos().map_err(|_| ReorgError::OldTip)?;
+    if old_tip == new_tip {
+        return Ok(Vec::new());
+    }
+
+    chainstate.call(move |c| find_disconnected_txs(c.as_ref(), old_tip, new_tip))?
+}
+
+pub fn handle_new_tip<M: GetMemoryUsage>(mempool: &mut Mempool<M>, new_tip: Id<Block>) {
+    mempool.rolling_fee_rate.get_mut().set_block_since_last_rolling_fee_bump(true);
+
+    let mut disconnected_txs = fetch_disconnected_txs(mempool, new_tip)
+        .log_err_pfx("Fetching disconnected transactions on a reorg")
+        .unwrap_or_default();
+
+    // Take all the mempool previous transactions
+    let old_store = mem::replace(&mut mempool.store, MempoolStore::new());
+
+    // Discard the old tx verifier and replace it with a fresh one
+    mempool.tx_verifier = tx_verifier::create(
+        mempool.chain_config.shallow_clone(),
+        mempool.chainstate_handle.shallow_clone(),
+    );
+
+    // Re-populate the verifier with transactions from disconnected chain.
+    // The transactions are returned in the order of them being disconnected which is the opposite
+    // of what we want, so we need to reverse the iterator here.
+    while let Some(tx) = disconnected_txs.pop() {
+        let tx_id = tx.transaction().get_id();
+        if let Err(e) = mempool.add_transaction(tx) {
+            log::debug!("Disconnected transaction {tx_id:?} no longer validates: {e:?}")
+        }
+    }
+
+    // Re-populate the verifier with transactions from mempool
+    for tx in old_store.into_transactions() {
+        let tx_id = tx.transaction().get_id();
+        if let Err(e) = mempool.add_transaction(tx) {
+            log::debug!("Evicting {tx_id:?} from mempool: {e:?}")
+        }
+    }
+}

--- a/mempool/src/pool/spends_unconfirmed.rs
+++ b/mempool/src/pool/spends_unconfirmed.rs
@@ -21,15 +21,12 @@ use super::Mempool;
 
 pub trait SpendsUnconfirmed<M>
 where
-    M: GetMemoryUsage + Send + Sync,
+    M: GetMemoryUsage,
 {
     fn spends_unconfirmed(&self, mempool: &Mempool<M>) -> bool;
 }
 
-impl<M> SpendsUnconfirmed<M> for TxInput
-where
-    M: GetMemoryUsage + Send + Sync,
-{
+impl<M: GetMemoryUsage> SpendsUnconfirmed<M> for TxInput {
     fn spends_unconfirmed(&self, mempool: &Mempool<M>) -> bool {
         let outpoint_id = self.outpoint().tx_id().get_tx_id().cloned();
         outpoint_id.is_some()

--- a/mempool/src/pool/tests/expiry.rs
+++ b/mempool/src/pool/tests/expiry.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 use common::chain::tokens::OutputValue;
-use test_utils::mock_time_getter::mocked_time_getter_seconds;
 
 use super::*;
 use crate::SystemUsageEstimator;

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -21,9 +21,6 @@ use crate::{
 use chainstate::{
     make_chainstate, BlockSource, ChainstateConfig, DefaultTransactionVerificationStrategy,
 };
-use chainstate_test_framework::{
-    anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
-};
 use common::{
     chain::{
         block::{timestamp::BlockTimestamp, Block, BlockReward, ConsensusData},
@@ -35,17 +32,13 @@ use common::{
     },
     primitives::{Id, H256},
 };
-use rstest::rstest;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
-use test_utils::{
-    mock_time_getter::mocked_time_getter_seconds,
-    random::{make_seedable_rng, Seed},
-};
 
 mod expiry;
+mod reorg;
 mod replacement;
 mod utils;
 

--- a/mempool/src/pool/tests/reorg.rs
+++ b/mempool/src/pool/tests/reorg.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::chain::GenBlock;
+
+use super::*;
+
+fn make_test_block(txs: Vec<SignedTransaction>, parent: impl Into<Id<GenBlock>>) -> Block {
+    Block::new(
+        txs,
+        parent.into(),
+        BlockTimestamp::from_int_seconds(1639975461),
+        ConsensusData::None,
+        BlockReward::new(vec![]),
+    )
+    .unwrap()
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn basic_reorg(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let tf = TestFramework::builder(&mut rng).build();
+    let genesis = tf.genesis();
+    let mut mempool = setup_with_chainstate(tf.chainstate()).await;
+    let chainstate = mempool.chainstate_handle().shallow_clone();
+
+    // Add the first transaction
+    let tx1 = TransactionBuilder::new()
+        .add_input(
+            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            empty_witness(&mut rng),
+        )
+        .add_anyone_can_spend_output(10_000_000)
+        .build();
+    let tx1_id = tx1.transaction().get_id();
+    mempool.add_transaction(tx1.clone()).expect("adding tx1");
+
+    // Add another transaction
+    let tx2 = TransactionBuilder::new()
+        .add_input(
+            TxInput::new(OutPointSourceId::Transaction(tx1_id), 0),
+            empty_witness(&mut rng),
+        )
+        .add_anyone_can_spend_output(9_000_000)
+        .build();
+    let tx2_id = tx2.transaction().get_id();
+    mempool.add_transaction(tx2.clone()).expect("adding tx2");
+
+    // Check the transactions are there
+    assert!(mempool.contains_transaction(&tx1_id));
+    assert!(mempool.contains_transaction(&tx2_id));
+
+    // Submit a block with tx1 and check the corresponding tx has been removed from mempool
+    let block1 = make_test_block(vec![tx1], genesis.get_id());
+    let block1_id = block1.get_id();
+    chainstate
+        .call_mut(move |c| c.process_block(block1, BlockSource::Local))
+        .await
+        .unwrap()
+        .expect("block1");
+    mempool.new_tip_set(block1_id, BlockHeight::new(1));
+    assert!(!mempool.contains_transaction(&tx1_id));
+    assert!(mempool.contains_transaction(&tx2_id));
+
+    // Submit a block wit tx2 and check transactions are no longer in mempool
+    let block2 = make_test_block(vec![tx2], block1_id);
+    let block2_id = block2.get_id();
+    chainstate
+        .call_mut(move |c| c.process_block(block2, BlockSource::Local))
+        .await
+        .unwrap()
+        .expect("block2");
+    mempool.new_tip_set(block2_id, BlockHeight::new(2));
+    assert!(!mempool.contains_transaction(&tx1_id));
+    assert!(!mempool.contains_transaction(&tx2_id));
+
+    // Submit two blocks on top of block1 and reorg out block2, causing tx2 to reappear in mempool
+    let block3 = make_test_block(Vec::new(), block1_id);
+    let block4 = make_test_block(Vec::new(), block3.get_id());
+    let block4_id = block4.get_id();
+    for (block, name) in [(block3, "block3"), (block4, "block4")] {
+        chainstate
+            .call_mut(move |c| c.process_block(block, BlockSource::Local))
+            .await
+            .unwrap()
+            .expect(name);
+    }
+    mempool.new_tip_set(block4_id, BlockHeight::new(3));
+    assert!(!mempool.contains_transaction(&tx1_id));
+    assert!(mempool.contains_transaction(&tx2_id));
+}

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -17,6 +17,17 @@ use common::chain::tokens::OutputValue;
 use common::chain::OutPoint;
 use common::primitives::H256;
 
+// Re-export various testing utils from other crates
+pub use chainstate_test_framework::{
+    anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
+};
+pub use logging::log;
+pub use rstest::rstest;
+pub use test_utils::{
+    mock_time_getter::mocked_time_getter_seconds,
+    random::{make_seedable_rng, Seed},
+};
+
 use super::*;
 
 #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Transactions that are disconnected during a reorg and are not present in the new fork are flushed back into the mempool so they have a chance to be added back into the chain later.

TODO: Need to properly wire up chainstate event subscription which apparently has not yet been done.