### PR TITLE
Use in-memory sqlite database in tests

### DIFF
--- a/storage/sqlite/tests/backend.rs
+++ b/storage/sqlite/tests/backend.rs
@@ -28,7 +28,9 @@ fn main() {
                 .as_ref()
                 .to_path_buf()
                 .join("database.sqlite");
-            Sqlite::new(db_file_path)
+            Sqlite::new(db_file_path).with_options(storage_sqlite::Options {
+                disable_fsync: true,
+            })
         }
     };
 


### PR DESCRIPTION
Our tests became much slower after the SQLite backend tests were added. This can be fixed by using in-memory databases. It looks like we don't do anything with the DB files themselves (don't try to reopen them, for example), so this should be acceptable.

Here are my test times when I run `nextest run --all --no-fail-fast`:
Before:
```
Summary [  22.921s] 1773 tests run: 1773 passed, 14 skipped
```
After:
```
Summary [  15.927s] 1773 tests run: 1773 passed, 14 skipped
```
