### PR TITLE
Activate main event loop in the GUI

### DIFF
--- a/node-gui/src/main_window/main_menu.rs
+++ b/node-gui/src/main_window/main_menu.rs
@@ -64,8 +64,8 @@ impl MainMenu {
         c.into()
     }
 
-    pub fn start() -> Vec<Command<MenuMessage>> {
-        vec![]
+    pub fn start() -> impl IntoIterator<Item = Command<MenuMessage>> {
+        []
     }
 
     pub fn update(&self, msg: MenuMessage) -> Command<MenuMessage> {

--- a/node-gui/src/main_window/main_menu.rs
+++ b/node-gui/src/main_window/main_menu.rs
@@ -24,6 +24,7 @@ use crate::backend_controller::NodeBackendController;
 
 #[derive(Debug, Clone)]
 pub enum MenuMessage {
+    Start,
     NoOp,
     Exit,
 }
@@ -63,8 +64,13 @@ impl MainMenu {
         c.into()
     }
 
+    pub fn start() -> Vec<Command<MenuMessage>> {
+        vec![]
+    }
+
     pub fn update(&self, msg: MenuMessage) -> Command<MenuMessage> {
         match msg {
+            MenuMessage::Start => iced::Command::batch(Self::start()),
             MenuMessage::NoOp => Command::none(),
             MenuMessage::Exit => iced::window::close(),
         }

--- a/node-gui/src/main_window/main_widget/mod.rs
+++ b/node-gui/src/main_window/main_widget/mod.rs
@@ -22,6 +22,7 @@ use crate::backend_controller::NodeBackendController;
 #[derive(Debug, Clone)]
 pub enum MainWidgetMessage {
     NoOp,
+    Start,
     TabsMessage(tabs::TabsMessage),
 }
 
@@ -36,19 +37,26 @@ impl MainWidget {
         }
     }
 
-    pub fn view(
-        &self,
-        backend_controller: &NodeBackendController,
-    ) -> Element<'_, MainWidgetMessage, iced::Renderer> {
-        self.tabs.view(backend_controller).map(MainWidgetMessage::TabsMessage)
+    pub fn start() -> Vec<Command<MainWidgetMessage>> {
+        vec![iced::Command::perform(async {}, |_| {
+            MainWidgetMessage::TabsMessage(tabs::TabsMessage::Start)
+        })]
     }
 
     pub fn update(&mut self, msg: MainWidgetMessage) -> Command<MainWidgetMessage> {
         match msg {
             MainWidgetMessage::NoOp => Command::none(),
+            MainWidgetMessage::Start => iced::Command::batch(Self::start()),
             MainWidgetMessage::TabsMessage(tabs_message) => {
                 self.tabs.update(tabs_message).map(MainWidgetMessage::TabsMessage)
             }
         }
+    }
+
+    pub fn view(
+        &self,
+        backend_controller: &NodeBackendController,
+    ) -> Element<'_, MainWidgetMessage, iced::Renderer> {
+        self.tabs.view(backend_controller).map(MainWidgetMessage::TabsMessage)
     }
 }

--- a/node-gui/src/main_window/main_widget/mod.rs
+++ b/node-gui/src/main_window/main_widget/mod.rs
@@ -36,8 +36,8 @@ impl MainWidget {
         }
     }
 
-    pub fn start() -> Vec<Command<MainWidgetMessage>> {
-        vec![iced::Command::perform(async {}, |_| {
+    pub fn start() -> impl IntoIterator<Item = Command<MainWidgetMessage>> {
+        [iced::Command::perform(async {}, |_| {
             MainWidgetMessage::TabsMessage(tabs::TabsMessage::Start)
         })]
     }

--- a/node-gui/src/main_window/main_widget/mod.rs
+++ b/node-gui/src/main_window/main_widget/mod.rs
@@ -21,7 +21,6 @@ use crate::backend_controller::NodeBackendController;
 
 #[derive(Debug, Clone)]
 pub enum MainWidgetMessage {
-    NoOp,
     Start,
     TabsMessage(tabs::TabsMessage),
 }
@@ -45,7 +44,6 @@ impl MainWidget {
 
     pub fn update(&mut self, msg: MainWidgetMessage) -> Command<MainWidgetMessage> {
         match msg {
-            MainWidgetMessage::NoOp => Command::none(),
             MainWidgetMessage::Start => iced::Command::batch(Self::start()),
             MainWidgetMessage::TabsMessage(tabs_message) => {
                 self.tabs.update(tabs_message).map(MainWidgetMessage::TabsMessage)

--- a/node-gui/src/main_window/main_widget/tabs/mod.rs
+++ b/node-gui/src/main_window/main_widget/tabs/mod.rs
@@ -53,6 +53,7 @@ impl From<Icon> for char {
 
 #[derive(Debug, Clone)]
 pub enum TabsMessage {
+    Start,
     TabSelected(usize),
     Summary(SummaryMessage),
     Settings(SettingsMessage),
@@ -90,8 +91,16 @@ impl TabsWidget {
             .into()
     }
 
+    pub fn start() -> Vec<Command<TabsMessage>> {
+        vec![
+            iced::Command::perform(async {}, |_| TabsMessage::Summary(SummaryMessage::Start)),
+            iced::Command::perform(async {}, |_| TabsMessage::Settings(SettingsMessage::Start)),
+        ]
+    }
+
     pub fn update(&mut self, msg: TabsMessage) -> iced::Command<TabsMessage> {
         match msg {
+            TabsMessage::Start => iced::Command::batch(Self::start()),
             TabsMessage::TabSelected(n) => {
                 self.active_tab = n;
                 Command::none()

--- a/node-gui/src/main_window/main_widget/tabs/mod.rs
+++ b/node-gui/src/main_window/main_widget/tabs/mod.rs
@@ -91,8 +91,8 @@ impl TabsWidget {
             .into()
     }
 
-    pub fn start() -> Vec<Command<TabsMessage>> {
-        vec![
+    pub fn start() -> impl IntoIterator<Item = Command<TabsMessage>> {
+        [
             iced::Command::perform(async {}, |_| TabsMessage::Summary(SummaryMessage::Start)),
             iced::Command::perform(async {}, |_| TabsMessage::Settings(SettingsMessage::Start)),
         ]

--- a/node-gui/src/main_window/main_widget/tabs/settings.rs
+++ b/node-gui/src/main_window/main_widget/tabs/settings.rs
@@ -73,8 +73,8 @@ impl SettingsTab {
         &self.settings
     }
 
-    pub fn start() -> Vec<Command<SettingsMessage>> {
-        vec![]
+    pub fn start() -> impl IntoIterator<Item = Command<SettingsMessage>> {
+        []
     }
 
     pub fn update(&mut self, message: SettingsMessage) -> Command<SettingsMessage> {

--- a/node-gui/src/main_window/main_widget/tabs/settings.rs
+++ b/node-gui/src/main_window/main_widget/tabs/settings.rs
@@ -54,6 +54,7 @@ impl TabSettings {
 
 #[derive(Debug, Clone)]
 pub enum SettingsMessage {
+    Start,
     PositionSelected(TabBarPosition),
 }
 
@@ -72,8 +73,13 @@ impl SettingsTab {
         &self.settings
     }
 
+    pub fn start() -> Vec<Command<SettingsMessage>> {
+        vec![]
+    }
+
     pub fn update(&mut self, message: SettingsMessage) -> Command<SettingsMessage> {
         match message {
+            SettingsMessage::Start => iced::Command::batch(Self::start()),
             SettingsMessage::PositionSelected(position) => {
                 self.settings.tab_bar_position = Some(position);
                 Command::none()

--- a/node-gui/src/main_window/main_widget/tabs/summary.rs
+++ b/node-gui/src/main_window/main_widget/tabs/summary.rs
@@ -71,12 +71,10 @@ pub struct SummaryTab {
 
 impl SummaryTab {
     pub fn new(controller: NodeBackendController) -> Self {
-        let summary_tab = SummaryTab {
+        SummaryTab {
             controller,
             current_tip: None,
-        };
-        // let _ = summary_tab.update(SummaryMessage::Starting);
-        summary_tab
+        }
     }
 
     pub fn start(

--- a/node-gui/src/main_window/main_widget/tabs/summary.rs
+++ b/node-gui/src/main_window/main_widget/tabs/summary.rs
@@ -176,10 +176,9 @@ impl Tab for SummaryTab {
     }
 
     fn content(&self) -> Element<'_, Self::Message> {
-        let (best_id, best_height) = self.current_tip.unwrap_or((
-            self.controller.chain_config().genesis_block_id(),
-            1000.into(),
-        ));
+        let (best_id, best_height) = self
+            .current_tip
+            .unwrap_or((self.controller.chain_config().genesis_block_id(), 0.into()));
 
         let grid = Grid::with_columns(2);
         let grid = grid.push(Text::new("Best block id ")).push(Text::new(best_id.to_string()));

--- a/node-gui/src/main_window/main_widget/tabs/summary.rs
+++ b/node-gui/src/main_window/main_widget/tabs/summary.rs
@@ -79,8 +79,10 @@ impl SummaryTab {
         summary_tab
     }
 
-    pub fn start(controller: NodeBackendController) -> Vec<Command<SummaryMessage>> {
-        vec![Command::perform(
+    pub fn start(
+        controller: NodeBackendController,
+    ) -> impl IntoIterator<Item = Command<SummaryMessage>> {
+        [Command::perform(
             Self::initialize_subscriptions(controller.node().chainstate.clone()),
             SummaryMessage::Ready,
         )]

--- a/node-gui/src/main_window/main_widget/tabs/summary.rs
+++ b/node-gui/src/main_window/main_widget/tabs/summary.rs
@@ -40,11 +40,11 @@ use super::{Icon, Tab, TabsMessage};
 pub enum SummaryMessage {
     Start,
     Ready(RegisteredSubscriptions),
-    UpdateState((RegisteredSubscriptions, WidgetDataUpdate)),
+    UpdateState((RegisteredSubscriptions, SummaryWidgetDataUpdate)),
 }
 
 #[derive(Debug, Clone)]
-pub enum WidgetDataUpdate {
+pub enum SummaryWidgetDataUpdate {
     TipUpdated((Id<GenBlock>, BlockHeight)),
     NoOp,
 }
@@ -95,8 +95,8 @@ impl SummaryTab {
             ),
             SummaryMessage::UpdateState((subs, new_data)) => {
                 match new_data {
-                    WidgetDataUpdate::TipUpdated(tip) => self.current_tip = Some(tip),
-                    WidgetDataUpdate::NoOp => (),
+                    SummaryWidgetDataUpdate::TipUpdated(tip) => self.current_tip = Some(tip),
+                    SummaryWidgetDataUpdate::NoOp => (),
                 }
                 Command::perform(
                     Self::event_loop_single_iteration(subs),
@@ -144,7 +144,7 @@ impl SummaryTab {
 
     async fn event_loop_single_iteration(
         subs: RegisteredSubscriptions,
-    ) -> (RegisteredSubscriptions, WidgetDataUpdate) {
+    ) -> (RegisteredSubscriptions, SummaryWidgetDataUpdate) {
         let mut chainstate_event_receiver = subs.chainstate_event_receiver.lock().await;
         tokio::select! {
             event = (*chainstate_event_receiver).recv() => {
@@ -152,9 +152,9 @@ impl SummaryTab {
                 if let Some((block_id, block_height)) = event {
                     std::thread::sleep(std::time::Duration::from_millis(3000));
                     println!("Updating state: new tip: {:?} at height {:?}", block_id, block_height);
-                    (subs, WidgetDataUpdate::TipUpdated((block_id, block_height)))
+                    (subs, SummaryWidgetDataUpdate::TipUpdated((block_id, block_height)))
                 } else {
-                    (subs, WidgetDataUpdate::NoOp)
+                    (subs, SummaryWidgetDataUpdate::NoOp)
                 }
             }
         }

--- a/node-gui/src/main_window/mod.rs
+++ b/node-gui/src/main_window/mod.rs
@@ -13,16 +13,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use iced::Element;
+use iced::{Command, Element};
 
-use crate::{backend_controller::NodeBackendController, Message};
+use crate::{
+    backend_controller::NodeBackendController,
+    main_window::{main_menu::MenuMessage, main_widget::MainWidgetMessage},
+};
 
-pub mod main_menu;
-pub mod main_widget;
+mod main_menu;
+mod main_widget;
 
 pub struct MainWindow {
     pub main_menu: main_menu::MainMenu,
     pub main_widget: main_widget::MainWidget,
+}
+
+#[derive(Debug, Clone)]
+pub enum MainWindowMessage {
+    Start,
+    MenuMessage(main_menu::MenuMessage),
+    MainWidgetMessage(main_widget::MainWidgetMessage),
 }
 
 impl MainWindow {
@@ -33,16 +43,43 @@ impl MainWindow {
         }
     }
 
+    pub fn start() -> Vec<Command<MainWindowMessage>> {
+        vec![
+            iced::Command::perform(async {}, |_| {
+                MainWindowMessage::MainWidgetMessage(MainWidgetMessage::Start)
+            }),
+            iced::Command::perform(async {}, |_| {
+                MainWindowMessage::MenuMessage(MenuMessage::Start)
+            }),
+        ]
+    }
+
+    pub fn update(&mut self, msg: MainWindowMessage) -> iced::Command<MainWindowMessage> {
+        match msg {
+            MainWindowMessage::Start => iced::Command::batch(Self::start()),
+            MainWindowMessage::MenuMessage(menu_message) => {
+                self.main_menu.update(menu_message).map(MainWindowMessage::MenuMessage)
+            }
+            MainWindowMessage::MainWidgetMessage(main_widget_message) => self
+                .main_widget
+                .update(main_widget_message)
+                .map(MainWindowMessage::MainWidgetMessage),
+        }
+    }
+
     pub fn view(
         &self,
         backend_controller: &NodeBackendController,
-    ) -> Element<'_, Message, iced::Renderer> {
+    ) -> Element<'_, MainWindowMessage, iced::Renderer> {
         let c = iced::widget::column![
-            iced::widget::row!(self.main_menu.view(backend_controller).map(Message::MenuMessage)),
+            iced::widget::row!(self
+                .main_menu
+                .view(backend_controller)
+                .map(MainWindowMessage::MenuMessage)),
             iced::widget::row!(self
                 .main_widget
                 .view(backend_controller)
-                .map(Message::MainWidgetMessage))
+                .map(MainWindowMessage::MainWidgetMessage))
         ];
 
         c.into()

--- a/node-gui/src/main_window/mod.rs
+++ b/node-gui/src/main_window/mod.rs
@@ -43,8 +43,8 @@ impl MainWindow {
         }
     }
 
-    pub fn start() -> Vec<Command<MainWindowMessage>> {
-        vec![
+    pub fn start() -> impl IntoIterator<Item = Command<MainWindowMessage>> {
+        [
             iced::Command::perform(async {}, |_| {
                 MainWindowMessage::MainWidgetMessage(MainWidgetMessage::Start)
             }),


### PR DESCRIPTION
In the previous PR, the main event loop wasn't working. Here it's working when the node starts in a cascade started from the main event loop. So, an event from chainstate will update the GUI.

Unfortunately, the only way to test this is by running the GUI in debug mode, where we can see that the chainstate subscription function is called, and that an event loop iteration is done. We still can't hook the node to anything so far to see those update actively. 