### PR TITLE
Add block signature to block header

### DIFF
--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -322,7 +322,7 @@ impl BlockProduction {
                         }
                     };
 
-                    let block = Block::new_from_header(block_header, block_body.clone())?;
+                    let block = Block::new_from_header(block_header.with_no_signature(), block_body.clone())?;
                     return Ok((block, end_confirm_receiver));
                 }
             }

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -986,7 +986,7 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> Chainsta
     }
 
     // TODO(PR): rename this to persist block
-    pub fn accept_block(&mut self, block: &WithId<Block>) -> Result<BlockIndex, BlockError> {
+    pub fn persist_block(&mut self, block: &WithId<Block>) -> Result<BlockIndex, BlockError> {
         let block_index = self.add_to_block_index(block).log_err()?;
         if (self.db_tx.get_block(block.get_id()).map_err(BlockError::from).log_err()?).is_some() {
             return Err(BlockError::BlockAlreadyExists(block.get_id()));

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -985,7 +985,6 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> Chainsta
         Ok(block_index)
     }
 
-    // TODO(PR): rename this to persist block
     pub fn persist_block(&mut self, block: &WithId<Block>) -> Result<BlockIndex, BlockError> {
         let block_index = self.add_to_block_index(block).log_err()?;
         if (self.db_tx.get_block(block.get_id()).map_err(BlockError::from).log_err()?).is_some() {

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -204,6 +204,13 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         self.db_tx.get_block(block_id).map_err(PropertyQueryError::from)
     }
 
+    pub fn get_block_header(
+        &self,
+        block_id: Id<Block>,
+    ) -> Result<Option<SignedBlockHeader>, PropertyQueryError> {
+        Ok(self.db_tx.get_block_header(block_id).log_err()?)
+    }
+
     pub fn is_block_in_main_chain(
         &self,
         block_id: &Id<GenBlock>,

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -299,7 +299,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
                 .map_err(BlockError::CheckBlockFailed)
                 .log_err()?;
 
-            let block_index = chainstate_ref.accept_block(&block).log_err()?;
+            let block_index = chainstate_ref.persist_block(&block).log_err()?;
             let result =
                 chainstate_ref.activate_best_chain(block_index, best_block_id).log_err()?;
             let db_commit_result = chainstate_ref.commit_db_tx().log_err();

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -50,7 +50,7 @@ use chainstate_storage::{
 use chainstate_types::{BlockIndex, PropertyQueryError};
 use common::{
     chain::{
-        block::{timestamp::BlockTimestamp, BlockHeader},
+        block::{signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp},
         config::ChainConfig,
         Block,
     },
@@ -448,9 +448,9 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
         Ok(block)
     }
 
-    pub fn preliminary_header_check(&self, block: BlockHeader) -> Result<(), BlockError> {
+    pub fn preliminary_header_check(&self, header: SignedBlockHeader) -> Result<(), BlockError> {
         let chainstate_ref = self.make_db_tx_ro().map_err(BlockError::from)?;
-        chainstate_ref.check_block_header(&block).log_err()?;
+        chainstate_ref.check_block_header(&header).log_err()?;
         Ok(())
     }
 

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -17,7 +17,7 @@ use chainstate_storage::BlockchainStorageRead;
 use chainstate_types::{BlockIndex, GenBlockIndex, Locator, PropertyQueryError};
 use common::{
     chain::{
-        block::{BlockHeader, BlockReward},
+        block::{signed_block_header::SignedBlockHeader, BlockReward},
         tokens::{
             RPCFungibleTokenInfo, RPCNonFungibleTokenInfo, RPCTokenInfo, TokenAuxiliaryData,
             TokenData, TokenId,
@@ -58,7 +58,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     pub fn get_header_from_height(
         &self,
         height: &BlockHeight,
-    ) -> Result<Option<BlockHeader>, PropertyQueryError> {
+    ) -> Result<Option<SignedBlockHeader>, PropertyQueryError> {
         self.chainstate_ref.get_header_from_height(height)
     }
 
@@ -93,7 +93,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         self.chainstate_ref.get_best_block_index()
     }
 
-    pub fn get_best_block_header(&self) -> Result<BlockHeader, PropertyQueryError> {
+    pub fn get_best_block_header(&self) -> Result<SignedBlockHeader, PropertyQueryError> {
         let best_block_index = self
             .chainstate_ref
             .get_best_block_index()?
@@ -136,7 +136,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         &self,
         locator: Locator,
         header_count_limit: usize,
-    ) -> Result<Vec<BlockHeader>, PropertyQueryError> {
+    ) -> Result<Vec<SignedBlockHeader>, PropertyQueryError> {
         let header_count_limit = BlockDistance::new(
             header_count_limit.try_into().expect("Unreasonable header count limit"),
         );
@@ -173,8 +173,8 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
 
     pub fn filter_already_existing_blocks(
         &self,
-        headers: Vec<BlockHeader>,
-    ) -> Result<Vec<BlockHeader>, PropertyQueryError> {
+        headers: Vec<SignedBlockHeader>,
+    ) -> Result<Vec<SignedBlockHeader>, PropertyQueryError> {
         let first_block = headers.get(0).ok_or(PropertyQueryError::InvalidInputEmpty)?;
         let config = &self.chainstate_ref.chain_config();
         // verify that the first block attaches to our chain

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -62,6 +62,13 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         self.chainstate_ref.get_header_from_height(height)
     }
 
+    pub fn get_block_header(
+        &self,
+        id: Id<Block>,
+    ) -> Result<Option<SignedBlockHeader>, PropertyQueryError> {
+        self.chainstate_ref.get_block_header(id)
+    }
+
     pub fn get_block_id_from_height(
         &self,
         height: &BlockHeight,

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -57,6 +57,10 @@ pub trait ChainstateInterface: Send {
         height: &BlockHeight,
     ) -> Result<Option<Id<GenBlock>>, ChainstateError>;
     fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, ChainstateError>;
+    fn get_block_header(
+        &self,
+        block_id: Id<Block>,
+    ) -> Result<Option<SignedBlockHeader>, ChainstateError>;
 
     /// Returns a list of block headers whose heights distances increase exponentially starting
     /// from the current tip.

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -20,9 +20,10 @@ use crate::detail::BlockSource;
 use crate::{ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent};
 
 use chainstate_types::{BlockIndex, GenBlockIndex, Locator};
+use common::chain::block::signed_block_header::SignedBlockHeader;
 use common::{
     chain::{
-        block::{timestamp::BlockTimestamp, Block, BlockHeader, BlockReward, GenBlock},
+        block::{timestamp::BlockTimestamp, Block, BlockReward, GenBlock},
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
         ChainConfig, DelegationId, OutPoint, OutPointSourceId, PoolId, Transaction, TxInput,
         TxMainChainIndex,
@@ -42,7 +43,7 @@ pub trait ChainstateInterface: Send {
         source: BlockSource,
     ) -> Result<Option<BlockIndex>, ChainstateError>;
     fn preliminary_block_check(&self, block: Block) -> Result<Block, ChainstateError>;
-    fn preliminary_header_check(&self, header: BlockHeader) -> Result<(), ChainstateError>;
+    fn preliminary_header_check(&self, header: SignedBlockHeader) -> Result<(), ChainstateError>;
     fn get_best_block_id(&self) -> Result<Id<GenBlock>, ChainstateError>;
     fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError>;
     fn get_block_height_in_main_chain(
@@ -50,7 +51,7 @@ pub trait ChainstateInterface: Send {
         block_id: &Id<GenBlock>,
     ) -> Result<Option<BlockHeight>, ChainstateError>;
     fn get_best_block_height(&self) -> Result<BlockHeight, ChainstateError>;
-    fn get_best_block_header(&self) -> Result<BlockHeader, ChainstateError>;
+    fn get_best_block_header(&self) -> Result<SignedBlockHeader, ChainstateError>;
     fn get_block_id_from_height(
         &self,
         height: &BlockHeight,
@@ -76,13 +77,13 @@ pub trait ChainstateInterface: Send {
         &self,
         locator: Locator,
         header_count_limit: usize,
-    ) -> Result<Vec<BlockHeader>, ChainstateError>;
+    ) -> Result<Vec<SignedBlockHeader>, ChainstateError>;
 
     /// Removes all headers that are already known to the chain from the given vector.
     fn filter_already_existing_blocks(
         &self,
-        headers: Vec<BlockHeader>,
-    ) -> Result<Vec<BlockHeader>, ChainstateError>;
+        headers: Vec<SignedBlockHeader>,
+    ) -> Result<Vec<SignedBlockHeader>, ChainstateError>;
 
     fn get_block_index(&self, id: &Id<Block>) -> Result<Option<BlockIndex>, ChainstateError>;
     fn get_gen_block_index(

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -129,6 +129,17 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
             .map_err(ChainstateError::FailedToReadProperty)
     }
 
+    fn get_block_header(
+        &self,
+        block_id: Id<Block>,
+    ) -> Result<Option<SignedBlockHeader>, ChainstateError> {
+        self.chainstate
+            .query()
+            .map_err(ChainstateError::from)?
+            .get_block_header(block_id)
+            .map_err(ChainstateError::FailedToReadProperty)
+    }
+
     fn get_locator(&self) -> Result<Locator, ChainstateError> {
         self.chainstate
             .query()

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -27,10 +27,10 @@ use crate::{
 };
 use chainstate_storage::BlockchainStorage;
 use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
-use common::chain::TxOutput;
+use common::chain::{block::signed_block_header::SignedBlockHeader, TxOutput};
 use common::{
     chain::{
-        block::{Block, BlockHeader, BlockReward, GenBlock},
+        block::{Block, BlockReward, GenBlock},
         config::ChainConfig,
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
         DelegationId, OutPoint, OutPointSourceId, PoolId, Transaction, TxInput, TxMainChainIndex,
@@ -68,7 +68,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
             .map_err(ChainstateError::ProcessBlockError)
     }
 
-    fn preliminary_header_check(&self, header: BlockHeader) -> Result<(), ChainstateError> {
+    fn preliminary_header_check(&self, header: SignedBlockHeader) -> Result<(), ChainstateError> {
         self.chainstate
             .preliminary_header_check(header)
             .map_err(ChainstateError::ProcessBlockError)
@@ -149,7 +149,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
         &self,
         locator: Locator,
         header_count_limit: usize,
-    ) -> Result<Vec<BlockHeader>, ChainstateError> {
+    ) -> Result<Vec<SignedBlockHeader>, ChainstateError> {
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
@@ -159,8 +159,8 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
 
     fn filter_already_existing_blocks(
         &self,
-        headers: Vec<BlockHeader>,
-    ) -> Result<Vec<BlockHeader>, ChainstateError> {
+        headers: Vec<SignedBlockHeader>,
+    ) -> Result<Vec<SignedBlockHeader>, ChainstateError> {
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
@@ -179,7 +179,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
         Ok(best_block_index.block_height())
     }
 
-    fn get_best_block_header(&self) -> Result<BlockHeader, ChainstateError> {
+    fn get_best_block_header(&self) -> Result<SignedBlockHeader, ChainstateError> {
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -320,6 +320,13 @@ where
     fn info(&self) -> Result<ChainInfo, ChainstateError> {
         self.deref().info()
     }
+
+    fn get_block_header(
+        &self,
+        block_id: Id<Block>,
+    ) -> Result<Option<SignedBlockHeader>, ChainstateError> {
+        self.deref().get_block_header(block_id)
+    }
 }
 
 #[cfg(test)]

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -22,7 +22,7 @@ use std::{
 use chainstate_types::Locator;
 use chainstate_types::{BlockIndex, GenBlockIndex};
 use common::chain::{
-    block::{timestamp::BlockTimestamp, BlockReward},
+    block::{signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp, BlockReward},
     config::ChainConfig,
     tokens::TokenAuxiliaryData,
     OutPointSourceId, TxMainChainIndex,
@@ -30,7 +30,6 @@ use common::chain::{
 use common::chain::{OutPoint, Transaction};
 use common::{
     chain::{
-        block::BlockHeader,
         tokens::{RPCTokenInfo, TokenId},
         Block, GenBlock,
     },
@@ -69,7 +68,7 @@ where
         self.deref().preliminary_block_check(block)
     }
 
-    fn preliminary_header_check(&self, header: BlockHeader) -> Result<(), ChainstateError> {
+    fn preliminary_header_check(&self, header: SignedBlockHeader) -> Result<(), ChainstateError> {
         self.deref().preliminary_header_check(header)
     }
 
@@ -92,7 +91,7 @@ where
         self.deref().get_best_block_height()
     }
 
-    fn get_best_block_header(&self) -> Result<BlockHeader, ChainstateError> {
+    fn get_best_block_header(&self) -> Result<SignedBlockHeader, ChainstateError> {
         self.deref().get_best_block_header()
     }
 
@@ -119,14 +118,14 @@ where
         &self,
         locator: Locator,
         header_count_limit: usize,
-    ) -> Result<Vec<BlockHeader>, ChainstateError> {
+    ) -> Result<Vec<SignedBlockHeader>, ChainstateError> {
         self.deref().get_headers(locator, header_count_limit)
     }
 
     fn filter_already_existing_blocks(
         &self,
-        headers: Vec<BlockHeader>,
-    ) -> Result<Vec<BlockHeader>, ChainstateError> {
+        headers: Vec<SignedBlockHeader>,
+    ) -> Result<Vec<SignedBlockHeader>, ChainstateError> {
         self.deref().filter_already_existing_blocks(headers)
     }
 

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use chainstate_types::{BlockIndex, EpochData};
 use common::{
     chain::{
-        block::BlockReward,
+        block::{signed_block_header::SignedBlockHeader, BlockReward},
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
@@ -205,6 +205,7 @@ impl<B: storage::Backend> BlockchainStorageRead for Store<B> {
         fn get_best_block_id(&self) -> crate::Result<Option<Id<GenBlock>>>;
         fn get_block_index(&self, id: &Id<Block>) -> crate::Result<Option<BlockIndex>>;
         fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
+        fn get_block_header(&self, id: Id<Block>) -> crate::Result<Option<SignedBlockHeader>>;
         fn get_block_reward(&self, block_index: &BlockIndex) -> crate::Result<Option<BlockReward>>;
 
         fn get_is_mainchain_tx_index_enabled(&self) -> crate::Result<Option<bool>>;

--- a/chainstate/storage/src/internal/store_tx.rs
+++ b/chainstate/storage/src/internal/store_tx.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use chainstate_types::{BlockIndex, EpochData};
+use common::chain::block::signed_block_header::SignedBlockHeader;
 use common::{
     chain::{
         block::BlockReward,
@@ -90,6 +91,11 @@ macro_rules! impl_read_ops {
 
             fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>> {
                 self.read::<db::DBBlock, _, _>(id)
+            }
+
+            fn get_block_header(&self, id: Id<Block>) -> crate::Result<Option<SignedBlockHeader>> {
+                let block_index = self.read::<db::DBBlockIndex, _, _>(id)?;
+                Ok(block_index.map(|block_index| block_index.into_block_header()))
             }
 
             fn get_block_reward(

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -23,6 +23,7 @@ pub mod schema;
 
 use std::collections::BTreeMap;
 
+use common::chain::block::signed_block_header::SignedBlockHeader;
 pub use internal::Store;
 
 use chainstate_types::{BlockIndex, EpochData};
@@ -70,6 +71,8 @@ pub trait BlockchainStorageRead:
 
     /// Get block by its hash
     fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
+
+    fn get_block_header(&self, id: Id<Block>) -> crate::Result<Option<SignedBlockHeader>>;
 
     fn get_is_mainchain_tx_index_enabled(&self) -> crate::Result<Option<bool>>;
 

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -18,6 +18,7 @@
 use std::collections::BTreeMap;
 
 use chainstate_types::{BlockIndex, EpochData};
+use common::chain::block::signed_block_header::SignedBlockHeader;
 use common::chain::tokens::{TokenAuxiliaryData, TokenId};
 use common::{
     chain::{
@@ -48,6 +49,7 @@ mockall::mock! {
         fn get_block_index(&self, id: &Id<Block>) -> crate::Result<Option<BlockIndex>>;
         fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
         fn get_block_reward(&self, block_index: &BlockIndex) -> crate::Result<Option<BlockReward>>;
+        fn get_block_header(&self, id: Id<Block>) -> crate::Result<Option<SignedBlockHeader>>;
 
         fn get_is_mainchain_tx_index_enabled(&self) -> crate::Result<Option<bool>>;
         fn get_mainchain_tx_index(
@@ -290,6 +292,7 @@ mockall::mock! {
         fn get_block_index(&self, id: &Id<Block>) -> crate::Result<Option<BlockIndex>>;
         fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
         fn get_block_reward(&self, block_index: &BlockIndex) -> crate::Result<Option<BlockReward>>;
+        fn get_block_header(&self, id: Id<Block>) -> crate::Result<Option<SignedBlockHeader>>;
 
         fn get_is_mainchain_tx_index_enabled(&self) -> crate::Result<Option<bool>>;
         fn get_mainchain_tx_index(
@@ -396,6 +399,7 @@ mockall::mock! {
         fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
         fn get_block_index(&self, id: &Id<Block>) -> crate::Result<Option<BlockIndex>>;
         fn get_block_reward(&self, block_index: &BlockIndex) -> crate::Result<Option<BlockReward>>;
+        fn get_block_header(&self, id: Id<Block>) -> crate::Result<Option<SignedBlockHeader>>;
 
         fn get_is_mainchain_tx_index_enabled(&self) -> crate::Result<Option<bool>>;
 

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -769,8 +769,13 @@ fn consensus_type(#[case] seed: Seed) {
         let mut block_header = mined_block.header().clone();
         let bits = min_difficulty.into();
         assert_eq!(
-            consensus::mine(&mut block_header, u128::MAX, bits, Arc::new(false.into()))
-                .expect("Unexpected conversion error"),
+            consensus::mine(
+                block_header.header_mut(),
+                u128::MAX,
+                bits,
+                Arc::new(false.into())
+            )
+            .expect("Unexpected conversion error"),
             consensus::MiningResult::Success
         );
         let mined_block = Block::new_from_header(block_header, mined_block.body().clone()).unwrap();
@@ -788,8 +793,13 @@ fn consensus_type(#[case] seed: Seed) {
     let bits = min_difficulty.into();
     let mut block_header = mined_block.header().clone();
     assert_eq!(
-        consensus::mine(&mut block_header, u128::MAX, bits, Arc::new(false.into()))
-            .expect("Unexpected conversion error"),
+        consensus::mine(
+            block_header.header_mut(),
+            u128::MAX,
+            bits,
+            Arc::new(false.into())
+        )
+        .expect("Unexpected conversion error"),
         consensus::MiningResult::Success
     );
     let mined_block = Block::new_from_header(block_header, mined_block.body().clone()).unwrap();
@@ -846,8 +856,13 @@ fn consensus_type(#[case] seed: Seed) {
         let bits = min_difficulty.into();
         let mut block_header = mined_block.header().clone();
         assert_eq!(
-            consensus::mine(&mut block_header, u128::MAX, bits, Arc::new(false.into()))
-                .expect("Unexpected conversion error"),
+            consensus::mine(
+                block_header.header_mut(),
+                u128::MAX,
+                bits,
+                Arc::new(false.into())
+            )
+            .expect("Unexpected conversion error"),
             consensus::MiningResult::Success
         );
         let mined_block = Block::new_from_header(block_header, mined_block.body().clone()).unwrap();
@@ -921,8 +936,13 @@ fn pow(#[case] seed: Seed) {
     let bits = difficulty.into();
     let mut block_header = valid_block.header().clone();
     assert_eq!(
-        consensus::mine(&mut block_header, u128::MAX, bits, Arc::new(false.into()))
-            .expect("Unexpected conversion error"),
+        consensus::mine(
+            block_header.header_mut(),
+            u128::MAX,
+            bits,
+            Arc::new(false.into())
+        )
+        .expect("Unexpected conversion error"),
         consensus::MiningResult::Success
     );
     let valid_block = Block::new_from_header(block_header, valid_block.body().clone()).unwrap();
@@ -994,8 +1014,13 @@ fn read_block_reward_from_storage(#[case] seed: Seed) {
         let bits = difficulty.into();
         let mut block_header = valid_block.header().clone();
         assert_eq!(
-            consensus::mine(&mut block_header, u128::MAX, bits, Arc::new(false.into()))
-                .expect("Unexpected conversion error"),
+            consensus::mine(
+                block_header.header_mut(),
+                u128::MAX,
+                bits,
+                Arc::new(false.into())
+            )
+            .expect("Unexpected conversion error"),
             consensus::MiningResult::Success
         );
         let valid_block = Block::new_from_header(block_header, valid_block.body().clone()).unwrap();

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -770,7 +770,7 @@ fn consensus_type(#[case] seed: Seed) {
         let bits = min_difficulty.into();
         assert_eq!(
             consensus::mine(
-                block_header.header_mut(),
+                block_header.header_mut().unwrap(),
                 u128::MAX,
                 bits,
                 Arc::new(false.into())
@@ -794,7 +794,7 @@ fn consensus_type(#[case] seed: Seed) {
     let mut block_header = mined_block.header().clone();
     assert_eq!(
         consensus::mine(
-            block_header.header_mut(),
+            block_header.header_mut().unwrap(),
             u128::MAX,
             bits,
             Arc::new(false.into())
@@ -857,7 +857,7 @@ fn consensus_type(#[case] seed: Seed) {
         let mut block_header = mined_block.header().clone();
         assert_eq!(
             consensus::mine(
-                block_header.header_mut(),
+                block_header.header_mut().unwrap(),
                 u128::MAX,
                 bits,
                 Arc::new(false.into())
@@ -937,7 +937,7 @@ fn pow(#[case] seed: Seed) {
     let mut block_header = valid_block.header().clone();
     assert_eq!(
         consensus::mine(
-            block_header.header_mut(),
+            block_header.header_mut().unwrap(),
             u128::MAX,
             bits,
             Arc::new(false.into())
@@ -1015,7 +1015,7 @@ fn read_block_reward_from_storage(#[case] seed: Seed) {
         let mut block_header = valid_block.header().clone();
         assert_eq!(
             consensus::mine(
-                block_header.header_mut(),
+                block_header.header_mut().unwrap(),
                 u128::MAX,
                 bits,
                 Arc::new(false.into())
@@ -1243,7 +1243,11 @@ fn make_invalid_pow_block(
     let mut data = PoWData::new(bits, 0);
     for nonce in 0..max_nonce {
         data.update_nonce(nonce);
-        block.update_consensus_data(ConsensusData::PoW(data.clone()));
+        block
+            .header_mut()
+            .header_mut()
+            .unwrap()
+            .update_consensus_data(ConsensusData::PoW(data.clone()));
 
         if !consensus::check_proof_of_work(block.get_id().get(), bits)? {
             return Ok(true);

--- a/chainstate/types/src/block_index.rs
+++ b/chainstate/types/src/block_index.rs
@@ -32,8 +32,6 @@ pub struct BlockIndex {
     time_max: BlockTimestamp,
 }
 
-// TODO(PR): there's a get_block() call for ChainstateInterface in p2p that fetches a whole block just for the header. Fix it.
-
 impl BlockIndex {
     pub fn new(
         block: &Block,

--- a/chainstate/types/src/block_index.rs
+++ b/chainstate/types/src/block_index.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::chain::block::block_header::BlockHeader;
+use common::chain::block::signed_block_header::SignedBlockHeader;
 use common::chain::block::timestamp::BlockTimestamp;
 use common::chain::{Block, GenBlock};
 use common::primitives::{BlockHeight, Id, Idable, H256};
@@ -25,12 +25,14 @@ use crate::GenBlockIndex;
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct BlockIndex {
     block_id: Id<Block>,
-    block_header: BlockHeader,
+    block_header: SignedBlockHeader,
     some_ancestor: Id<GenBlock>,
     chain_trust: H256,
     height: BlockHeight,
     time_max: BlockTimestamp,
 }
+
+// TODO(PR): there's a get_block() call for ChainstateInterface in p2p that fetches a whole block just for the header. Fix it.
 
 impl BlockIndex {
     pub fn new(
@@ -56,11 +58,11 @@ impl BlockIndex {
     }
 
     pub fn prev_block_id(&self) -> &Id<GenBlock> {
-        self.block_header.prev_block_id()
+        self.block_header.header().prev_block_id()
     }
 
     pub fn block_timestamp(&self) -> BlockTimestamp {
-        self.block_header.timestamp()
+        self.block_header.header().timestamp()
     }
 
     pub fn chain_timestamps_max(&self) -> BlockTimestamp {
@@ -75,7 +77,7 @@ impl BlockIndex {
         self.chain_trust.into()
     }
 
-    pub fn block_header(&self) -> &BlockHeader {
+    pub fn block_header(&self) -> &SignedBlockHeader {
         &self.block_header
     }
 
@@ -83,7 +85,7 @@ impl BlockIndex {
         &self.some_ancestor
     }
 
-    pub fn into_block_header(self) -> BlockHeader {
+    pub fn into_block_header(self) -> SignedBlockHeader {
         self.block_header
     }
 

--- a/common/src/chain/block/block_header.rs
+++ b/common/src/chain/block/block_header.rs
@@ -15,6 +15,7 @@
 
 use serialization::{Decode, Encode};
 
+use super::signed_block_header::{BlockHeaderSignature, SignedBlockHeader};
 use super::timestamp::BlockTimestamp;
 use crate::chain::{block::ConsensusData, Block, GenBlock};
 use crate::primitives::id::{Id, Idable, H256};
@@ -64,12 +65,16 @@ impl BlockHeader {
         self.timestamp
     }
 
-    pub fn header_size(&self) -> usize {
-        self.encoded_size()
-    }
-
     pub fn update_consensus_data(&mut self, consensus_data: ConsensusData) {
         self.consensus_data = consensus_data;
+    }
+
+    pub fn with_signature(self, signature: BlockHeaderSignature) -> SignedBlockHeader {
+        SignedBlockHeader::new(signature, self)
+    }
+
+    pub fn with_no_signature(self) -> SignedBlockHeader {
+        SignedBlockHeader::new(BlockHeaderSignature::None, self)
     }
 }
 

--- a/common/src/chain/block/block_v1.rs
+++ b/common/src/chain/block/block_v1.rs
@@ -74,8 +74,8 @@ impl BlockV1 {
         &self.header
     }
 
-    pub fn update_consensus_data(&mut self, consensus_data: ConsensusData) {
-        self.header.header_mut().consensus_data = consensus_data;
+    pub fn header_mut(&mut self) -> &mut SignedBlockHeader {
+        &mut self.header
     }
 
     pub fn consensus_data(&self) -> &ConsensusData {

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -165,12 +165,6 @@ impl Block {
         Ok(block)
     }
 
-    pub fn update_consensus_data(&mut self, consensus_data: ConsensusData) {
-        match self {
-            Block::V1(blk) => blk.update_consensus_data(consensus_data),
-        }
-    }
-
     pub fn consensus_data(&self) -> &ConsensusData {
         match self {
             Block::V1(blk) => blk.consensus_data(),
@@ -192,6 +186,12 @@ impl Block {
     pub fn header(&self) -> &SignedBlockHeader {
         match self {
             Block::V1(blk) => blk.header(),
+        }
+    }
+
+    pub fn header_mut(&mut self) -> &mut SignedBlockHeader {
+        match self {
+            Block::V1(blk) => blk.header_mut(),
         }
     }
 

--- a/common/src/chain/block/signed_block_header.rs
+++ b/common/src/chain/block/signed_block_header.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crypto::key::Signature;
 use serialization::{Decode, Encode};
 use typename::TypeName;
 
@@ -28,15 +27,33 @@ pub enum SignedHeaderError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeName)]
+pub struct BlockHeaderSignatureData {
+    // TODO: determine the proper types for these fields.
+    //       So far, the plan is to make the public key match
+    //       the kernel input destination and hence it should
+    //       be able to verify it too.
+    public_key: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+impl BlockHeaderSignatureData {
+    pub fn new(public_key: Vec<u8>, signature: Vec<u8>) -> Self {
+        Self {
+            public_key,
+            signature,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeName)]
 pub enum BlockHeaderSignature {
     None,
-    PoSBlock(Signature),
+    PoSBlock(BlockHeaderSignatureData),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeName, serialization::Tagged)]
 pub struct SignedBlockHeader {
     block_header: BlockHeader,
-    // TODO: Do we want to include the public key to make it possible to cross-check with the spent kernel?
     signature: BlockHeaderSignature,
 }
 

--- a/common/src/chain/block/signed_block_header.rs
+++ b/common/src/chain/block/signed_block_header.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crypto::key::Signature;
+use serialization::{Decode, Encode};
+use typename::TypeName;
+
+use crate::primitives::id::{Id, Idable};
+
+use super::{timestamp::BlockTimestamp, Block, BlockHeader, ConsensusData, GenBlock};
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeName)]
+pub enum BlockHeaderSignature {
+    None,
+    PoSBlock(Signature),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeName, serialization::Tagged)]
+pub struct SignedBlockHeader {
+    block_header: BlockHeader,
+    // TODO(PR): Do we want to include the public key to make it possible to cross-check with the spent kernel?
+    signature: BlockHeaderSignature,
+}
+
+impl SignedBlockHeader {
+    pub fn new(signature: BlockHeaderSignature, block_header: BlockHeader) -> Self {
+        Self {
+            signature,
+            block_header,
+        }
+    }
+
+    pub fn signature(&self) -> &BlockHeaderSignature {
+        &self.signature
+    }
+
+    pub fn header(&self) -> &BlockHeader {
+        &self.block_header
+    }
+
+    pub fn header_mut(&mut self) -> &mut BlockHeader {
+        &mut self.block_header
+    }
+
+    pub fn take_block_header(self) -> BlockHeader {
+        self.block_header
+    }
+
+    pub fn consensus_data(&self) -> &ConsensusData {
+        &self.header().consensus_data
+    }
+
+    pub fn block_id(&self) -> Id<Block> {
+        self.header().get_id()
+    }
+
+    pub fn prev_block_id(&self) -> &Id<GenBlock> {
+        &self.header().prev_block_id
+    }
+
+    pub fn timestamp(&self) -> BlockTimestamp {
+        self.header().timestamp
+    }
+
+    pub fn header_size(&self) -> usize {
+        self.encoded_size()
+    }
+}
+
+impl Idable for SignedBlockHeader {
+    type Tag = Block;
+
+    fn get_id(&self) -> Id<Self::Tag> {
+        self.header().get_id()
+    }
+}

--- a/common/src/chain/block/signed_block_header.rs
+++ b/common/src/chain/block/signed_block_header.rs
@@ -30,7 +30,7 @@ pub enum BlockHeaderSignature {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeName, serialization::Tagged)]
 pub struct SignedBlockHeader {
     block_header: BlockHeader,
-    // TODO(PR): Do we want to include the public key to make it possible to cross-check with the spent kernel?
+    // TODO: Do we want to include the public key to make it possible to cross-check with the spent kernel?
     signature: BlockHeaderSignature,
 }
 

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -21,7 +21,10 @@ use chainstate::{
 use chainstate_types::{BlockIndex, GenBlockIndex};
 use common::{
     chain::{
-        block::{timestamp::BlockTimestamp, Block, BlockHeader, BlockReward, GenBlock},
+        block::{
+            signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp, Block, BlockReward,
+            GenBlock,
+        },
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
         ChainConfig, DelegationId, OutPoint, OutPointSourceId, PoolId, Transaction, TxInput,
         TxMainChainIndex,
@@ -41,10 +44,10 @@ mockall::mock! {
         fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(ChainstateEvent) + Send + Sync>);
         fn process_block(&mut self, block: Block, source: BlockSource) -> Result<Option<BlockIndex>, ChainstateError>;
         fn preliminary_block_check(&self, block: Block) -> Result<Block, ChainstateError>;
-        fn preliminary_header_check(&self, header: BlockHeader) -> Result<(), ChainstateError>;
+        fn preliminary_header_check(&self, header: SignedBlockHeader) -> Result<(), ChainstateError>;
         fn get_best_block_id(&self) -> Result<Id<GenBlock>, ChainstateError>;
         fn get_best_block_height(&self) -> Result<BlockHeight, ChainstateError>;
-        fn get_best_block_header(&self) -> Result<BlockHeader, ChainstateError>;
+        fn get_best_block_header(&self) -> Result<SignedBlockHeader, ChainstateError>;
         fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError>;
         fn get_block_height_in_main_chain(
             &self,
@@ -61,11 +64,11 @@ mockall::mock! {
             &self,
             locator: Locator,
             header_count_limit: usize,
-        ) -> Result<Vec<BlockHeader>, ChainstateError>;
+        ) -> Result<Vec<SignedBlockHeader>, ChainstateError>;
         fn filter_already_existing_blocks(
             &self,
-            headers: Vec<BlockHeader>,
-        ) -> Result<Vec<BlockHeader>, ChainstateError>;
+            headers: Vec<SignedBlockHeader>,
+        ) -> Result<Vec<SignedBlockHeader>, ChainstateError>;
         fn get_block_index(
             &self,
             id: &Id<Block>

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -58,6 +58,7 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> Result<Option<Id<GenBlock>>, ChainstateError>;
         fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, ChainstateError>;
+        fn get_block_header(&self, block_id: Id<Block>) -> Result<Option<SignedBlockHeader>, ChainstateError>;
         fn get_locator(&self) -> Result<Locator, ChainstateError>;
         fn get_locator_from_height(&self, height: BlockHeight) -> Result<Locator, ChainstateError>;
         fn get_headers(

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -16,7 +16,7 @@
 use chainstate::Locator;
 use common::{
     chain::{
-        block::{Block, BlockHeader},
+        block::{signed_block_header::SignedBlockHeader, Block},
         SignedTransaction, Transaction,
     },
     primitives::Id,
@@ -102,19 +102,19 @@ pub struct PingRequest {
 /// announcement.
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct HeaderList {
-    headers: Vec<BlockHeader>,
+    headers: Vec<SignedBlockHeader>,
 }
 
 impl HeaderList {
-    pub fn new(headers: Vec<BlockHeader>) -> Self {
+    pub fn new(headers: Vec<SignedBlockHeader>) -> Self {
         Self { headers }
     }
 
-    pub fn headers(&self) -> &[BlockHeader] {
+    pub fn headers(&self) -> &[SignedBlockHeader] {
         &self.headers
     }
 
-    pub fn into_headers(self) -> Vec<BlockHeader> {
+    pub fn into_headers(self) -> Vec<SignedBlockHeader> {
         self.headers
     }
 }

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -218,11 +218,10 @@ where
 
         let header = self
             .chainstate_handle
-            .call(move |c| c.get_block(block_id))
+            .call(move |c| c.get_block_header(block_id))
             .await??
             // This should never happen because this block has just been produced by chainstate.
             .expect("A new tip block unavailable")
-            .header()
             .clone();
         self.messaging_handle
             .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![header])))

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -221,8 +221,8 @@ where
             .call(move |c| c.get_block_header(block_id))
             .await??
             // This should never happen because this block has just been produced by chainstate.
-            .expect("A new tip block unavailable")
-            .clone();
+            .expect("A new tip block unavailable");
+
         self.messaging_handle
             .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![header])))
     }

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -33,7 +33,7 @@ use void::Void;
 use chainstate::chainstate_interface::ChainstateInterface;
 use chainstate::{ban_score::BanScore, BlockError, BlockSource, ChainstateError, Locator};
 use common::{
-    chain::{block::BlockHeader, Block, Transaction},
+    chain::{block::signed_block_header::SignedBlockHeader, Block, Transaction},
     primitives::{BlockHeight, Id, Idable},
     time_getter::TimeGetter,
 };
@@ -76,7 +76,7 @@ pub struct Peer<T: NetworkingService> {
     is_initial_block_download: Arc<AtomicBool>,
     /// A list of headers received via the `HeaderListResponse` message that we haven't yet
     /// requested the blocks for.
-    known_headers: Vec<BlockHeader>,
+    known_headers: Vec<SignedBlockHeader>,
     /// A list of blocks that we requested from this peer.
     requested_blocks: BTreeSet<Id<Block>>,
     /// A queue of the blocks requested this peer.
@@ -272,7 +272,7 @@ where
         Ok(())
     }
 
-    async fn handle_header_list(&mut self, headers: Vec<BlockHeader>) -> Result<()> {
+    async fn handle_header_list(&mut self, headers: Vec<SignedBlockHeader>) -> Result<()> {
         log::debug!("Headers list from peer {}", self.id());
         self.last_activity = Some(self.time_getter.get_time());
 
@@ -557,7 +557,7 @@ where
     ///
     /// The number of headers sent equals to `P2pConfig::requested_blocks_limit`, the remaining
     /// headers are stored in the peer context.
-    fn request_blocks(&mut self, mut headers: Vec<BlockHeader>) -> Result<()> {
+    fn request_blocks(&mut self, mut headers: Vec<SignedBlockHeader>) -> Result<()> {
         debug_assert!(self.known_headers.is_empty());
 
         // Remove already requested blocks.


### PR DESCRIPTION
As a first step, we add the signature field of the block.

The processing comes with proof of stake. It's not done yet. An issue will be opened for that.

#875