### PR TITLE
Try to fix p2p tests

### DIFF
--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -220,7 +220,10 @@ impl SyncManagerHandle {
 
     /// Awaits on the sync manager join handle and rethrows the panic.
     pub async fn resume_panic(self) {
-        panic::resume_unwind(self.sync_manager_handle.await.unwrap_err().into_panic());
+        let err = self.sync_manager_handle.await.unwrap_err();
+        self.shutdown_trigger.initiate();
+        self.subsystem_manager_handle.join().await;
+        panic::resume_unwind(err.into_panic());
     }
 
     pub async fn join_subsystem_manager(self) {


### PR DESCRIPTION
Try to fix a shutdown deadlock in p2p tests where mempool is making a blocking call but other subsystems are already stopped.