### PR TITLE
Add `HexEncoded` wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5158,6 +5158,7 @@ name = "serialization"
 version = "0.1.0"
 dependencies = [
  "hex",
+ "serde",
  "serialization-core",
  "serialization-tagged",
  "thiserror",

--- a/chainstate/src/rpc.rs
+++ b/chainstate/src/rpc.rs
@@ -23,7 +23,7 @@ use common::{
     primitives::{BlockHeight, Id},
 };
 use rpc::Result as RpcResult;
-use serialization::hex::{HexDecode, HexEncode};
+use serialization::hex_encoded::HexEncoded;
 use subsystem::subsystem::CallError;
 
 #[rpc::rpc(server, client, namespace = "chainstate")]
@@ -38,11 +38,11 @@ trait ChainstateRpc {
 
     /// Returns a hex-encoded serialized block with the given id.
     #[method(name = "get_block")]
-    async fn get_block(&self, id: Id<Block>) -> RpcResult<Option<String>>;
+    async fn get_block(&self, id: Id<Block>) -> RpcResult<Option<HexEncoded<Block>>>;
 
     /// Submit a block to be included in the chain
     #[method(name = "submit_block")]
-    async fn submit_block(&self, block_hex: String) -> RpcResult<()>;
+    async fn submit_block(&self, block_hex: HexEncoded<Block>) -> RpcResult<()>;
 
     /// Get block height in main chain
     #[method(name = "block_height_in_main_chain")]
@@ -95,14 +95,15 @@ impl ChainstateRpcServer for super::ChainstateHandle {
         handle_error(self.call(move |this| this.get_block_id_from_height(&height)).await)
     }
 
-    async fn get_block(&self, id: Id<Block>) -> RpcResult<Option<String>> {
+    async fn get_block(&self, id: Id<Block>) -> RpcResult<Option<HexEncoded<Block>>> {
         let block = handle_error(self.call(move |this| this.get_block(id)).await)?;
-        Ok(block.map(|b| b.hex_encode()))
+        Ok(block.map(HexEncoded::new))
     }
 
-    async fn submit_block(&self, block_hex: String) -> RpcResult<()> {
-        let block = Block::hex_decode_all(&block_hex).map_err(rpc::Error::to_call_error)?;
-        let res = self.call_mut(move |this| this.process_block(block, BlockSource::Local)).await;
+    async fn submit_block(&self, block: HexEncoded<Block>) -> RpcResult<()> {
+        let res = self
+            .call_mut(move |this| this.process_block(block.into_inner(), BlockSource::Local))
+            .await;
         // remove the block index from the return value
         let res = res.map(|v| v.map(|_bi| ()));
         handle_error(res)

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::chain::SignedTransaction;
-use serialization::hex::HexDecode;
+use serialization::hex_encoded::HexEncoded;
 
 use crate::{error::P2pError, interface::types::ConnectedPeer, types::peer_id::PeerId};
 use rpc::Result as RpcResult;
@@ -55,7 +55,7 @@ trait P2pRpc {
 
     /// Submits a transaction to mempool, and if it is valid, broadcasts it to the network.
     #[method(name = "submit_transaction")]
-    async fn submit_transaction(&self, tx_hex: String) -> RpcResult<()>;
+    async fn submit_transaction(&self, tx: HexEncoded<SignedTransaction>) -> RpcResult<()>;
 }
 
 #[async_trait::async_trait]
@@ -95,9 +95,8 @@ impl P2pRpcServer for super::P2pHandle {
         handle_error(res)
     }
 
-    async fn submit_transaction(&self, tx_hex: String) -> RpcResult<()> {
-        let tx = SignedTransaction::hex_decode_all(&tx_hex).map_err(rpc::Error::to_call_error)?;
-        handle_error(self.call_async_mut(|s| s.submit_transaction(tx)).await)
+    async fn submit_transaction(&self, tx: HexEncoded<SignedTransaction>) -> RpcResult<()> {
+        handle_error(self.call_async_mut(|s| s.submit_transaction(tx.into_inner())).await)
     }
 }
 

--- a/serialization/Cargo.toml
+++ b/serialization/Cargo.toml
@@ -10,4 +10,5 @@ serialization-core = { path = 'core' }
 serialization-tagged = { path = 'tagged' }
 
 hex.workspace = true
+serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true

--- a/serialization/src/hex_encoded.rs
+++ b/serialization/src/hex_encoded.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str::FromStr;
+
+use crate::hex::{HexDecode, HexEncode, HexError};
+
+/// Wrapper that serializes objects as hex encoded string for `serde`
+#[derive(Debug, Clone)]
+pub struct HexEncoded<T>(T);
+
+impl<T> HexEncoded<T> {
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> AsRef<T> for HexEncoded<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> From<T> for HexEncoded<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: serialization_core::Encode> serde::Serialize for HexEncoded<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let hex = self.0.hex_encode();
+        serializer.serialize_str(&hex)
+    }
+}
+
+impl<'de, T: serialization_core::Decode> serde::Deserialize<'de> for HexEncoded<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let hex = String::deserialize(deserializer)?;
+        let value = T::hex_decode_all(hex).map_err(serde::de::Error::custom)?;
+        Ok(HexEncoded(value))
+    }
+}
+
+impl<T: serialization_core::Decode> FromStr for HexEncoded<T> {
+    type Err = HexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        <T as HexDecode>::hex_decode_all(s).map(Self)
+    }
+}

--- a/serialization/src/lib.rs
+++ b/serialization/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod encoded;
 pub mod extras;
 pub mod hex;
+pub mod hex_encoded;
 
 // Re-export all the constituent parts
 pub use serialization_core::*;

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -33,7 +33,6 @@ pub use node_comm::node_traits::{ConnectedPeer, NodeInterface, PeerId};
 pub use node_comm::{
     handles_client::WalletHandlesClient, make_rpc_client, rpc_client::NodeRpcClient,
 };
-use serialization::hex::HexEncode;
 use wallet::{send_request::make_address_output, DefaultWallet};
 use wallet_types::account_info::DEFAULT_ACCOUNT_INDEX;
 
@@ -147,7 +146,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
             .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![output])
             .map_err(ControllerError::WalletError)?;
         self.rpc_client
-            .submit_transaction(tx.hex_encode())
+            .submit_transaction(tx)
             .await
             .map_err(ControllerError::NodeCallError)
     }

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -17,6 +17,7 @@ use std::sync::Mutex;
 
 use chainstate::ChainInfo;
 use chainstate_test_framework::TestFramework;
+use common::chain::{Destination, SignedTransaction};
 use crypto::random::{seq::IteratorRandom, CryptoRng, Rng};
 use node_comm::{
     node_traits::{ConnectedPeer, PeerId},
@@ -135,15 +136,15 @@ impl NodeInterface for MockNode {
 
     async fn generate_block(
         &self,
-        _reward_destination_hex: String,
-        _transactions_hex: Option<Vec<String>>,
-    ) -> Result<String, Self::Error> {
+        _reward_destination_hex: Destination,
+        _transactions_hex: Option<Vec<SignedTransaction>>,
+    ) -> Result<Block, Self::Error> {
         unreachable!()
     }
-    async fn submit_block(&self, _block_hex: String) -> Result<(), Self::Error> {
+    async fn submit_block(&self, _block: Block) -> Result<(), Self::Error> {
         unreachable!()
     }
-    async fn submit_transaction(&self, _transaction_hex: String) -> Result<(), Self::Error> {
+    async fn submit_transaction(&self, _tx: SignedTransaction) -> Result<(), Self::Error> {
         unreachable!()
     }
 

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -15,7 +15,7 @@
 
 use chainstate::ChainInfo;
 use common::{
-    chain::{Block, GenBlock},
+    chain::{Block, Destination, GenBlock, SignedTransaction},
     primitives::{BlockHeight, Id},
 };
 
@@ -40,11 +40,11 @@ pub trait NodeInterface {
     ) -> Result<Option<(Id<GenBlock>, BlockHeight)>, Self::Error>;
     async fn generate_block(
         &self,
-        reward_destination_hex: String,
-        transactions_hex: Option<Vec<String>>,
-    ) -> Result<String, Self::Error>;
-    async fn submit_block(&self, block_hex: String) -> Result<(), Self::Error>;
-    async fn submit_transaction(&self, transaction_hex: String) -> Result<(), Self::Error>;
+        reward_destination: Destination,
+        transactions_hex: Option<Vec<SignedTransaction>>,
+    ) -> Result<Block, Self::Error>;
+    async fn submit_block(&self, block: Block) -> Result<(), Self::Error>;
+    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error>;
 
     async fn node_shutdown(&self) -> Result<(), Self::Error>;
     async fn node_version(&self) -> Result<String, Self::Error>;


### PR DESCRIPTION
We do a lot of manual hex conversions in RPC interfaces. Most of this could be replaced by a wrapper that implements `serde::Serialize` and `serde::Deserialize` and uses `HexDecode` and `HexEncode` internally.