### PR TITLE
Remove DecommissionPool and SpendShareFromPool output types

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -135,6 +135,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::InvalidDecommissionMaturityType => 100,
             ConnectTransactionError::InvalidDecommissionMaturityDistanceValue(_) => 100,
             ConnectTransactionError::InvalidDecommissionMaturityDistance(_, _) => 100,
+            ConnectTransactionError::PoolIdMismatch(_, _) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -135,7 +135,6 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::InvalidDecommissionMaturityType => 100,
             ConnectTransactionError::InvalidDecommissionMaturityDistanceValue(_) => 100,
             ConnectTransactionError::InvalidDecommissionMaturityDistance(_, _) => 100,
-            ConnectTransactionError::PoolIdMismatch(_, _) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -132,6 +132,9 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::TotalDelegationBalanceZero(_) => 0,
             ConnectTransactionError::DelegationDataNotFound(_) => 0,
             ConnectTransactionError::DestinationRetrievalError(err) => err.ban_score(),
+            ConnectTransactionError::InvalidDecommissionMaturityType => 100,
+            ConnectTransactionError::InvalidDecommissionMaturityDistanceValue(_) => 100,
+            ConnectTransactionError::InvalidDecommissionMaturityDistance(_, _) => 100,
         }
     }
 }
@@ -265,9 +268,6 @@ impl BanScore for CheckBlockTransactionsError {
             CheckBlockTransactionsError::EmptyInputsOutputsInTransactionInBlock(_, _) => 100,
             CheckBlockTransactionsError::TokensError(err) => err.ban_score(),
             CheckBlockTransactionsError::InvalidWitnessCount => 100,
-            CheckBlockTransactionsError::InvalidDecommissionMaturityType(_) => 100,
-            CheckBlockTransactionsError::InvalidDecommissionMaturityDistanceValue(_, _) => 100,
-            CheckBlockTransactionsError::InvalidDecommissionMaturityDistance(_, _, _) => 100,
         }
     }
 }

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -147,8 +147,7 @@ fn create_randomness_from_block<S: BlockchainStorageRead>(
         | TxOutput::Burn(_)
         | TxOutput::DecommissionPool(_, _, _, _)
         | TxOutput::CreateDelegationId(_, _)
-        | TxOutput::DelegateStaking(_, _)
-        | TxOutput::SpendShareFromDelegation(_, _, _, _) => {
+        | TxOutput::DelegateStaking(_, _) => {
             return Err(BlockError::SpendStakeError(
                 SpendStakeError::InvalidBlockRewardOutputType,
             ));

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -145,7 +145,6 @@ fn create_randomness_from_block<S: BlockchainStorageRead>(
         TxOutput::Transfer(_, _)
         | TxOutput::LockThenTransfer(_, _, _)
         | TxOutput::Burn(_)
-        | TxOutput::DecommissionPool(_, _, _, _)
         | TxOutput::CreateDelegationId(_, _)
         | TxOutput::DelegateStaking(_, _) => {
             return Err(BlockError::SpendStakeError(

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -151,7 +151,7 @@ fn create_randomness_from_block<S: BlockchainStorageRead>(
                 SpendStakeError::InvalidBlockRewardOutputType,
             ));
         }
-        TxOutput::CreateStakePool(d) => d.as_ref().vrf_public_key().clone(),
+        TxOutput::CreateStakePool(_, d) => d.as_ref().vrf_public_key().clone(),
         TxOutput::ProduceBlockFromStake(_, pool_id) => {
             let pos_view = PoSAccountingDB::<_, TipStorageTag>::new(db_tx);
             let pool_data = pos_view
@@ -267,7 +267,7 @@ mod tests {
             PerThousand::new(0).unwrap(),
             Amount::ZERO,
         );
-        let reward_output = TxOutput::CreateStakePool(Box::new(stake_pool_data));
+        let reward_output = TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data));
         let pos_data = PoSData::new(vec![], vec![], pool_id, vrf_data, Compact(1));
         Block::new(
             vec![],

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -461,8 +461,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                 | TxOutput::Burn(_)
                 | TxOutput::DecommissionPool(_, _, _, _)
                 | TxOutput::CreateDelegationId(_, _)
-                | TxOutput::DelegateStaking(_, _)
-                | TxOutput::SpendShareFromDelegation(_, _, _, _) => Err(
+                | TxOutput::DelegateStaking(_, _) => Err(
                     CheckBlockError::InvalidBlockRewardOutputType(block.get_id()),
                 ),
             }
@@ -575,8 +574,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                     | TxOutput::ProduceBlockFromStake(_, _)
                     | TxOutput::DecommissionPool(_, _, _, _)
                     | TxOutput::CreateDelegationId(_, _)
-                    | TxOutput::DelegateStaking(_, _)
-                    | TxOutput::SpendShareFromDelegation(_, _, _, _) => None,
+                    | TxOutput::DelegateStaking(_, _) => None,
                 })
                 .try_for_each(|token_data| {
                     check_tokens_data(
@@ -592,74 +590,11 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         Ok(())
     }
 
-    fn check_outputs_timelock(
-        &self,
-        block: &Block,
-        block_height: BlockHeight,
-    ) -> Result<(), CheckBlockTransactionsError> {
-        let check = |timelock: &OutputTimeLock,
-                     required: BlockDistance,
-                     tx_id: Id<Transaction>|
-         -> Result<(), CheckBlockTransactionsError> {
-            match timelock {
-                OutputTimeLock::ForBlockCount(c) => {
-                    let cs: i64 = (*c).try_into().map_err(|_| {
-                        CheckBlockTransactionsError::InvalidDecommissionMaturityDistanceValue(
-                            tx_id, *c,
-                        )
-                    })?;
-                    let given = BlockDistance::new(cs);
-                    ensure!(
-                        given >= required,
-                        CheckBlockTransactionsError::InvalidDecommissionMaturityDistance(
-                            tx_id, given, required
-                        )
-                    );
-                    Ok(())
-                }
-                OutputTimeLock::UntilHeight(_)
-                | OutputTimeLock::UntilTime(_)
-                | OutputTimeLock::ForSeconds(_) => {
-                    Err(CheckBlockTransactionsError::InvalidDecommissionMaturityType(tx_id))
-                }
-            }
-        };
-        for tx in block.transactions() {
-            tx.outputs().iter().try_for_each(|output| match output {
-                TxOutput::Transfer(_, _)
-                | TxOutput::Burn(_)
-                | TxOutput::CreateStakePool(_)
-                | TxOutput::ProduceBlockFromStake(_, _)
-                | TxOutput::LockThenTransfer(_, _, _)
-                | TxOutput::CreateDelegationId(_, _)
-                | TxOutput::DelegateStaking(_, _) => Ok(()),
-                TxOutput::SpendShareFromDelegation(_, _, _, timelock) => {
-                    let required =
-                        self.chain_config.as_ref().spend_share_maturity_distance(block_height);
-                    check(timelock, required, tx.transaction().get_id())
-                }
-                TxOutput::DecommissionPool(_, _, _, timelock) => {
-                    let required = self
-                        .chain_config
-                        .as_ref()
-                        .decommission_pool_maturity_distance(block_height);
-                    check(timelock, required, tx.transaction().get_id())
-                }
-            })?;
-        }
-        Ok(())
-    }
-
-    fn check_transactions(
-        &self,
-        block: &Block,
-        block_height: BlockHeight,
-    ) -> Result<(), CheckBlockTransactionsError> {
+    fn check_transactions(&self, block: &Block) -> Result<(), CheckBlockTransactionsError> {
         // Note: duplicate txs are detected through duplicate inputs
         self.check_witness_count(block).log_err()?;
         self.check_duplicate_inputs(block).log_err()?;
         self.check_tokens_txs(block).log_err()?;
-        self.check_outputs_timelock(block, block_height).log_err()?;
         Ok(())
     }
 
@@ -667,11 +602,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         Ok(self.db_tx.get_block(*block_index.block_id()).log_err()?)
     }
 
-    pub fn check_block(
-        &self,
-        block: &WithId<Block>,
-        block_height: BlockHeight,
-    ) -> Result<(), CheckBlockError> {
+    pub fn check_block(&self, block: &WithId<Block>) -> Result<(), CheckBlockError> {
         self.check_block_header(block.header()).log_err()?;
 
         self.check_block_size(block)
@@ -703,7 +634,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             );
         }
 
-        self.check_transactions(block, block_height)
+        self.check_transactions(block)
             .map_err(CheckBlockError::CheckTransactionFailed)
             .log_err()?;
 

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -457,7 +457,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                     Ok(())
                 }
                 TxOutput::Transfer(_, _)
-                | TxOutput::CreateStakePool(_)
+                | TxOutput::CreateStakePool(_, _)
                 | TxOutput::Burn(_)
                 | TxOutput::CreateDelegationId(_, _)
                 | TxOutput::DelegateStaking(_, _) => Err(
@@ -569,7 +569,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                     TxOutput::Transfer(v, _)
                     | TxOutput::LockThenTransfer(v, _, _)
                     | TxOutput::Burn(v) => v.token_data(),
-                    TxOutput::CreateStakePool(_)
+                    TxOutput::CreateStakePool(_, _)
                     | TxOutput::ProduceBlockFromStake(_, _)
                     | TxOutput::CreateDelegationId(_, _)
                     | TxOutput::DelegateStaking(_, _) => None,

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -459,7 +459,6 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                 TxOutput::Transfer(_, _)
                 | TxOutput::CreateStakePool(_)
                 | TxOutput::Burn(_)
-                | TxOutput::DecommissionPool(_, _, _, _)
                 | TxOutput::CreateDelegationId(_, _)
                 | TxOutput::DelegateStaking(_, _) => Err(
                     CheckBlockError::InvalidBlockRewardOutputType(block.get_id()),
@@ -572,7 +571,6 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                     | TxOutput::Burn(v) => v.token_data(),
                     TxOutput::CreateStakePool(_)
                     | TxOutput::ProduceBlockFromStake(_, _)
-                    | TxOutput::DecommissionPool(_, _, _, _)
                     | TxOutput::CreateDelegationId(_, _)
                     | TxOutput::DelegateStaking(_, _) => None,
                 })

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, convert::TryInto};
+use std::collections::BTreeSet;
 
 use chainstate_storage::{
     BlockchainStorageRead, BlockchainStorageWrite, SealedStorageTag, TipStorageTag, TransactionRw,
@@ -25,12 +25,12 @@ use chainstate_types::{
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp, BlockReward},
-        timelock::OutputTimeLock,
         tokens::TokenAuxiliaryData,
         tokens::{get_tokens_issuance_count, TokenId},
-        Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId, Transaction, TxOutput,
+        Block, ChainConfig, GenBlock, GenBlockId, OutPoint, OutPointSourceId, Transaction,
+        TxOutput,
     },
-    primitives::{id::WithId, BlockDistance, BlockHeight, Id, Idable},
+    primitives::{id::WithId, BlockHeight, Id, Idable},
     time_getter::TimeGetter,
     Uint256,
 };
@@ -415,56 +415,36 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         Ok(())
     }
 
-    fn check_block_reward_timelock(
-        &self,
-        block: &Block,
-        timelock: &OutputTimeLock,
-    ) -> Result<(), CheckBlockError> {
-        match timelock {
-            OutputTimeLock::ForBlockCount(c) => {
-                let cs: i64 = (*c)
-                    .try_into()
-                    .map_err(|_| {
-                        CheckBlockError::InvalidBlockRewardMaturityDistanceValue(block.get_id(), *c)
-                    })
-                    .log_err()?;
-                let given = BlockDistance::new(cs);
-                let required = block.consensus_data().reward_maturity_distance(self.chain_config);
-                ensure!(
-                    given >= required,
-                    CheckBlockError::InvalidBlockRewardMaturityDistance(
-                        block.get_id(),
-                        given,
-                        required
-                    )
-                );
-                Ok(())
-            }
-            OutputTimeLock::UntilHeight(_)
-            | OutputTimeLock::UntilTime(_)
-            | OutputTimeLock::ForSeconds(_) => Err(
-                CheckBlockError::InvalidBlockRewardMaturityTimelockType(block.get_id()),
-            ),
-        }
-    }
-
     fn check_block_reward_maturity_settings(&self, block: &Block) -> Result<(), CheckBlockError> {
-        block.block_reward().outputs().iter().try_for_each(|output| {
-            match output {
-                TxOutput::LockThenTransfer(_, _, tl) => self.check_block_reward_timelock(block, tl),
-                TxOutput::ProduceBlockFromStake(_, _) => {
-                    // The output can be reused in block reward right away
-                    Ok(())
+        block
+            .block_reward()
+            .outputs()
+            .iter()
+            .enumerate()
+            .try_for_each(|(index, output)| {
+                match output {
+                    TxOutput::LockThenTransfer(_, _, tl) => {
+                        let outpoint = OutPoint::new(block.get_id().into(), index as u32);
+                        let required =
+                            block.consensus_data().reward_maturity_distance(self.chain_config);
+                        tx_verifier::timelock_check::check_output_block_distance(
+                            tl, required, outpoint,
+                        )
+                        .map_err(CheckBlockError::BlockRewardMaturityError)
+                    }
+                    TxOutput::ProduceBlockFromStake(_, _) => {
+                        // The output can be reused in block reward right away
+                        Ok(())
+                    }
+                    TxOutput::Transfer(_, _)
+                    | TxOutput::CreateStakePool(_, _)
+                    | TxOutput::Burn(_)
+                    | TxOutput::CreateDelegationId(_, _)
+                    | TxOutput::DelegateStaking(_, _) => Err(
+                        CheckBlockError::InvalidBlockRewardOutputType(block.get_id()),
+                    ),
                 }
-                TxOutput::Transfer(_, _)
-                | TxOutput::CreateStakePool(_, _)
-                | TxOutput::Burn(_)
-                | TxOutput::CreateDelegationId(_, _)
-                | TxOutput::DelegateStaking(_, _) => Err(
-                    CheckBlockError::InvalidBlockRewardOutputType(block.get_id()),
-                ),
-            }
-        })
+            })
     }
 
     fn check_header_size(&self, header: &SignedBlockHeader) -> Result<(), BlockSizeError> {

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -26,7 +26,7 @@ use common::{
         block::{block_body::BlockMerkleTreeError, timestamp::BlockTimestamp},
         Block, GenBlock, PoolId, Transaction,
     },
-    primitives::{BlockDistance, BlockHeight, Id},
+    primitives::{BlockHeight, Id},
 };
 use consensus::ConsensusVerificationError;
 
@@ -110,14 +110,10 @@ pub enum CheckBlockError {
     CheckTransactionFailed(CheckBlockTransactionsError),
     #[error("Check transaction failed: {0}")]
     ConsensusVerificationFailed(ConsensusVerificationError),
-    #[error("Block reward maturity distance too short in block {0}: {1} < {2}")]
-    InvalidBlockRewardMaturityDistance(Id<Block>, BlockDistance, BlockDistance),
-    #[error("Block reward maturity distance invalid in block {0}: {1}")]
-    InvalidBlockRewardMaturityDistanceValue(Id<Block>, u64),
-    #[error("Invalid block reward output timelock type for block {0}")]
-    InvalidBlockRewardMaturityTimelockType(Id<Block>),
     #[error("Invalid block reward output type for block {0}")]
     InvalidBlockRewardOutputType(Id<Block>),
+    #[error("Block reward maturity error: {0}")]
+    BlockRewardMaturityError(#[from] tx_verifier::timelock_check::OutputTimeLockError),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -134,12 +134,6 @@ pub enum CheckBlockTransactionsError {
     EmptyInputsOutputsInTransactionInBlock(Id<Transaction>, Id<Block>),
     #[error("Tokens error: {0}")]
     TokensError(TokensError),
-    #[error("Maturity setting type for the decommission pool output in tx {0} is invalid")]
-    InvalidDecommissionMaturityType(Id<Transaction>),
-    #[error("Maturity setting for the decommission pool output in tx {0} too short: {1} < {2}")]
-    InvalidDecommissionMaturityDistance(Id<Transaction>, BlockDistance, BlockDistance),
-    #[error("Maturity setting value for the decommission pool output in tx {0} is invalid: {1}")]
-    InvalidDecommissionMaturityDistanceValue(Id<Transaction>, u64),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -288,14 +288,8 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
                 .map_err(BlockError::BestBlockLoadError)
                 .log_err()?;
 
-            let prev_block_height = chainstate_ref
-                .get_block_height_in_main_chain(&block.prev_block_id())
-                .map_err(BlockError::BlockLoadError)
-                .log_err()?
-                .ok_or(BlockError::PrevBlockNotFound)?;
-
             chainstate_ref
-                .check_block(&block, prev_block_height.next_height())
+                .check_block(&block)
                 .map_err(BlockError::CheckBlockFailed)
                 .log_err()?;
 
@@ -439,12 +433,8 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
     ) -> Result<WithId<Block>, BlockError> {
         let chainstate_ref = self.make_db_tx_ro().map_err(BlockError::from)?;
 
-        let prev_block_height = chainstate_ref
-            .get_block_height_in_main_chain(&block.prev_block_id())
-            .map_err(BlockError::BlockLoadError)
-            .log_err()?
-            .ok_or(BlockError::PrevBlockNotFound)?;
-        chainstate_ref.check_block(&block, prev_block_height.next_height()).log_err()?;
+        chainstate_ref.check_block(&block).log_err()?;
+
         Ok(block)
     }
 

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -230,7 +230,6 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                 | TxOutput::Burn(v) => v.token_data(),
                 TxOutput::CreateStakePool(_)
                 | TxOutput::ProduceBlockFromStake(_, _)
-                | TxOutput::DecommissionPool(_, _, _, _)
                 | TxOutput::CreateDelegationId(_, _)
                 | TxOutput::DelegateStaking(_, _) => None,
             })

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -232,8 +232,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                 | TxOutput::ProduceBlockFromStake(_, _)
                 | TxOutput::DecommissionPool(_, _, _, _)
                 | TxOutput::CreateDelegationId(_, _)
-                | TxOutput::DelegateStaking(_, _)
-                | TxOutput::SpendShareFromDelegation(_, _, _, _) => None,
+                | TxOutput::DelegateStaking(_, _) => None,
             })
             // Find issuance data and return RPCTokenInfo
             .find_map(|token_data| match token_data {

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -228,7 +228,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                 TxOutput::Transfer(v, _)
                 | TxOutput::LockThenTransfer(v, _, _)
                 | TxOutput::Burn(v) => v.token_data(),
-                TxOutput::CreateStakePool(_)
+                TxOutput::CreateStakePool(_, _)
                 | TxOutput::ProduceBlockFromStake(_, _)
                 | TxOutput::CreateDelegationId(_, _)
                 | TxOutput::DelegateStaking(_, _) => None,

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -586,9 +586,7 @@ fn get_output_coin_amount(
                 .pledge_amount();
             Some(pledge_amount)
         }
-        TxOutput::DecommissionPool(v, _, _, _)
-        | TxOutput::DelegateStaking(v, _)
-        | TxOutput::SpendShareFromDelegation(v, _, _, _) => Some(*v),
+        TxOutput::DecommissionPool(v, _, _, _) | TxOutput::DelegateStaking(v, _) => Some(*v),
         TxOutput::CreateDelegationId(_, _) => None,
     };
 

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -571,7 +571,7 @@ fn get_output_coin_amount(
         TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
             v.coin_amount()
         }
-        TxOutput::CreateStakePool(data) => Some(data.value()),
+        TxOutput::CreateStakePool(_, data) => Some(data.value()),
         TxOutput::ProduceBlockFromStake(_, pool_id) => {
             let pledge_amount = pos_accounting_view
                 .get_pool_data(*pool_id)

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -586,7 +586,7 @@ fn get_output_coin_amount(
                 .pledge_amount();
             Some(pledge_amount)
         }
-        TxOutput::DecommissionPool(v, _, _, _) | TxOutput::DelegateStaking(v, _) => Some(*v),
+        TxOutput::DelegateStaking(v, _) => Some(*v),
         TxOutput::CreateDelegationId(_, _) => None,
     };
 

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -42,7 +42,7 @@ pub fn get_output_value(output: &TxOutput) -> Option<OutputValue> {
         TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
             Some(v.clone())
         }
-        TxOutput::CreateStakePool(_)
+        TxOutput::CreateStakePool(_, _)
         | TxOutput::ProduceBlockFromStake(_, _)
         | TxOutput::CreateDelegationId(_, _)
         | TxOutput::DelegateStaking(_, _) => None,

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -46,8 +46,7 @@ pub fn get_output_value(output: &TxOutput) -> Option<OutputValue> {
         | TxOutput::ProduceBlockFromStake(_, _)
         | TxOutput::DecommissionPool(_, _, _, _)
         | TxOutput::CreateDelegationId(_, _)
-        | TxOutput::DelegateStaking(_, _)
-        | TxOutput::SpendShareFromDelegation(_, _, _, _) => None,
+        | TxOutput::DelegateStaking(_, _) => None,
     }
 }
 

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -44,7 +44,6 @@ pub fn get_output_value(output: &TxOutput) -> Option<OutputValue> {
         }
         TxOutput::CreateStakePool(_)
         | TxOutput::ProduceBlockFromStake(_, _)
-        | TxOutput::DecommissionPool(_, _, _, _)
         | TxOutput::CreateDelegationId(_, _)
         | TxOutput::DelegateStaking(_, _) => None,
     }

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -54,7 +54,10 @@ fn prepare_stake_pool(
 
     let tx = TransactionBuilder::new()
         .add_input(genesis_outpoint.into(), empty_witness(rng))
-        .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+        .add_output(TxOutput::CreateStakePool(
+            pool_id,
+            Box::new(stake_pool_data),
+        ))
         .add_output(TxOutput::Transfer(
             OutputValue::Coin(amount_to_stake),
             Destination::AnyoneCanSpend,
@@ -207,7 +210,10 @@ fn create_delegation_twice(#[case] seed: Seed) {
         // create pool and 2 transfer utxos
         let tx = TransactionBuilder::new()
             .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .add_output(TxOutput::Transfer(
                 OutputValue::Coin(amount_to_stake),
                 Destination::AnyoneCanSpend,

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -321,16 +321,14 @@ fn delegate_staking(#[case] seed: Seed) {
         let tx = TransactionBuilder::new()
             .add_input(delegate_staking_outpoint.into(), empty_witness(&mut rng))
             .add_output(TxOutput::DelegateStaking(spend_change, delegation_id))
-            .add_output(TxOutput::SpendShareFromDelegation(
-                amount_to_spend,
+            .add_output(TxOutput::LockThenTransfer(
+                OutputValue::Coin(amount_to_spend),
                 Destination::AnyoneCanSpend,
-                delegation_id,
                 OutputTimeLock::ForBlockCount(1),
             ))
-            .add_output(TxOutput::SpendShareFromDelegation(
-                amount_to_spend,
+            .add_output(TxOutput::LockThenTransfer(
+                OutputValue::Coin(amount_to_spend),
                 Destination::AnyoneCanSpend,
-                delegation_id,
                 OutputTimeLock::ForBlockCount(1),
             ))
             .build();
@@ -349,10 +347,9 @@ fn delegate_staking(#[case] seed: Seed) {
         // Spend all delegation balance
         let tx = TransactionBuilder::new()
             .add_input(delegate_staking_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::SpendShareFromDelegation(
-                spend_change,
+            .add_output(TxOutput::LockThenTransfer(
+                OutputValue::Coin(spend_change),
                 Destination::AnyoneCanSpend,
-                delegation_id,
                 OutputTimeLock::ForBlockCount(1),
             ))
             .build();
@@ -387,7 +384,7 @@ fn delegation_cleanup(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let (pool_id, stake_outpoint, delegation_id, _, transfer_outpoint) =
+        let (_, stake_outpoint, delegation_id, _, transfer_outpoint) =
             prepare_delegation(&mut rng, &mut tf);
         let amount_to_delegate = get_output_value(
             utxo::UtxosStorageRead::get_utxo(&tf.storage, &transfer_outpoint)
@@ -419,10 +416,9 @@ fn delegation_cleanup(#[case] seed: Seed) {
         // decommission the pool
         let tx = TransactionBuilder::new()
             .add_input(stake_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::DecommissionPool(
-                Amount::from_atoms(1),
+            .add_output(TxOutput::LockThenTransfer(
+                OutputValue::Coin(Amount::from_atoms(1)),
                 Destination::AnyoneCanSpend,
-                pool_id,
                 OutputTimeLock::ForBlockCount(1),
             ))
             .build();
@@ -431,10 +427,9 @@ fn delegation_cleanup(#[case] seed: Seed) {
         // Spend all delegation share
         let tx = TransactionBuilder::new()
             .add_input(delegate_staking_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::SpendShareFromDelegation(
-                amount_to_delegate,
+            .add_output(TxOutput::LockThenTransfer(
+                OutputValue::Coin(amount_to_delegate),
                 Destination::AnyoneCanSpend,
-                delegation_id,
                 OutputTimeLock::ForBlockCount(1),
             ))
             .build();

--- a/chainstate/test-suite/src/tests/mempool_output_timelock.rs
+++ b/chainstate/test-suite/src/tests/mempool_output_timelock.rs
@@ -73,7 +73,7 @@ fn output_lock_until_height(#[case] seed: Seed) {
         for height in 2..block_height_that_unlocks {
             // attempt to spend the locked output
             let best_block_index = tf.best_block_index();
-            assert_eq!(
+            assert!(matches!(
                 verifier.connect_transaction(
                     &TransactionSourceForConnect::Mempool {
                         current_best: &best_block_index,
@@ -82,8 +82,8 @@ fn output_lock_until_height(#[case] seed: Seed) {
                     &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                     None
                 ),
-                Err(ConnectTransactionError::TimeLockViolation)
-            );
+                Err(ConnectTransactionError::TimeLockViolation(_))
+            ));
 
             tf.make_block_builder().build_and_process().unwrap();
             assert_eq!(
@@ -140,7 +140,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
         for height in 2..block_count_that_unlocks + block_height_with_locked_output {
             // attempt to spend the locked output
             let best_block_index = tf.best_block_index();
-            assert_eq!(
+            assert!(matches!(
                 verifier.connect_transaction(
                     &TransactionSourceForConnect::Mempool {
                         current_best: &best_block_index,
@@ -149,8 +149,8 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
                     &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                     None,
                 ),
-                Err(ConnectTransactionError::TimeLockViolation)
-            );
+                Err(ConnectTransactionError::TimeLockViolation(_))
+            ));
 
             // create another block, with no transactions, and get the blockchain to progress
             tf.make_block_builder().build_and_process().unwrap();
@@ -231,7 +231,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
 
             // Check that the output still cannot be spent.
             let best_block_index = tf.best_block_index();
-            assert_eq!(
+            assert!(matches!(
                 verifier.connect_transaction(
                     &TransactionSourceForConnect::Mempool {
                         current_best: &best_block_index,
@@ -240,8 +240,8 @@ fn output_lock_until_time(#[case] seed: Seed) {
                     &mtp,
                     None,
                 ),
-                Err(ConnectTransactionError::TimeLockViolation)
-            );
+                Err(ConnectTransactionError::TimeLockViolation(_))
+            ));
 
             // Create another block, with no transactions, and get the blockchain to progress.
             tf.make_block_builder()
@@ -324,7 +324,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
 
             // Check that the output still cannot be spent.
             let best_block_index = tf.best_block_index();
-            assert_eq!(
+            assert!(matches!(
                 verifier.connect_transaction(
                     &TransactionSourceForConnect::Mempool {
                         current_best: &best_block_index,
@@ -333,8 +333,8 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
                     &mtp,
                     None
                 ),
-                Err(ConnectTransactionError::TimeLockViolation)
-            );
+                Err(ConnectTransactionError::TimeLockViolation(_))
+            ));
 
             assert_eq!(
                 tf.best_block_index().block_height(),

--- a/chainstate/test-suite/src/tests/output_timelock.rs
+++ b/chainstate/test-suite/src/tests/output_timelock.rs
@@ -61,7 +61,7 @@ fn output_lock_until_height(#[case] seed: Seed) {
         );
 
         // attempt to create the next block, and attempt to spend the locked output
-        assert_eq!(
+        assert!(matches!(
             tf.make_block_builder()
                 .add_transaction(
                     TransactionBuilder::new()
@@ -72,9 +72,9 @@ fn output_lock_until_height(#[case] seed: Seed) {
                 .build_and_process()
                 .unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::TimeLockViolation
+                ConnectTransactionError::TimeLockViolation(_)
             ))
-        );
+        ));
         assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(1));
 
         // create another block, and spend the first input from the previous block
@@ -102,7 +102,7 @@ fn output_lock_until_height(#[case] seed: Seed) {
             logging::log::info!("Submitting block of height: {}", height);
 
             // Create another block, and spend the first input from the previous block.
-            assert_eq!(
+            assert!(matches!(
                 tf.make_block_builder()
                     .add_transaction(
                         TransactionBuilder::new()
@@ -113,9 +113,9 @@ fn output_lock_until_height(#[case] seed: Seed) {
                     .build_and_process()
                     .unwrap_err(),
                 ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                    ConnectTransactionError::TimeLockViolation
+                    ConnectTransactionError::TimeLockViolation(_)
                 ))
-            );
+            ));
             assert_eq!(
                 tf.best_block_index().block_height(),
                 BlockHeight::new(height - 1)
@@ -186,15 +186,15 @@ fn output_lock_until_height_but_spend_at_same_block(#[case] seed: Seed) {
             .add_anyone_can_spend_output(5000)
             .build();
 
-        assert_eq!(
+        assert!(matches!(
             tf.make_block_builder()
                 .with_transactions(vec![tx1, tx2])
                 .build_and_process()
                 .unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::TimeLockViolation
+                ConnectTransactionError::TimeLockViolation(_)
             ))
-        );
+        ));
         assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(0));
     });
 }
@@ -219,7 +219,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
         );
 
         // attempt to create the next block, and attempt to spend the locked output
-        assert_eq!(
+        assert!(matches!(
             tf.make_block_builder()
                 .add_transaction(
                     TransactionBuilder::new()
@@ -230,9 +230,9 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
                 .build_and_process()
                 .unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::TimeLockViolation
+                ConnectTransactionError::TimeLockViolation(_)
             ))
-        );
+        ));
         assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(1));
 
         // create another block, and spend the first input from the previous block
@@ -260,7 +260,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
             logging::log::info!("Submitting block of height: {}", height);
 
             // create another block, and spend the first input from the previous block
-            assert_eq!(
+            assert!(matches!(
                 tf.make_block_builder()
                     .add_transaction(
                         TransactionBuilder::new()
@@ -271,9 +271,9 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
                     .build_and_process()
                     .unwrap_err(),
                 ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                    ConnectTransactionError::TimeLockViolation
+                    ConnectTransactionError::TimeLockViolation(_)
                 ))
-            );
+            ));
             assert_eq!(
                 tf.best_block_index().block_height(),
                 BlockHeight::new(height - 1)
@@ -337,15 +337,15 @@ fn output_lock_for_block_count_but_spend_at_same_block(#[case] seed: Seed) {
             )
             .add_anyone_can_spend_output(50000)
             .build();
-        assert_eq!(
+        assert!(matches!(
             tf.make_block_builder()
                 .with_transactions(vec![tx1, tx2])
                 .build_and_process()
                 .unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::TimeLockViolation
+                ConnectTransactionError::TimeLockViolation(_)
             ))
-        );
+        ));
         assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(0));
     });
 }
@@ -432,7 +432,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
             );
 
             // Check that the output still cannot be spent.
-            assert_eq!(
+            assert!(matches!(
                 tf.make_block_builder()
                     .add_transaction(
                         TransactionBuilder::new()
@@ -444,9 +444,9 @@ fn output_lock_until_time(#[case] seed: Seed) {
                     .build_and_process()
                     .unwrap_err(),
                 ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                    ConnectTransactionError::TimeLockViolation
+                    ConnectTransactionError::TimeLockViolation(_)
                 ))
-            );
+            ));
             assert_eq!(
                 tf.best_block_index().block_height(),
                 BlockHeight::new(height as u64),
@@ -520,15 +520,15 @@ fn output_lock_until_time_but_spend_at_same_block(#[case] seed: Seed) {
             .add_anyone_can_spend_output(50000)
             .build();
 
-        assert_eq!(
+        assert!(matches!(
             tf.make_block_builder()
                 .with_transactions(vec![tx1, tx2])
                 .build_and_process()
                 .unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::TimeLockViolation
+                ConnectTransactionError::TimeLockViolation(_)
             ))
-        );
+        ));
         assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(0));
     });
 }
@@ -579,7 +579,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
             );
 
             // Check that the output still cannot be spent.
-            assert_eq!(
+            assert!(matches!(
                 tf.make_block_builder()
                     .add_transaction(
                         TransactionBuilder::new()
@@ -591,9 +591,9 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
                     .build_and_process()
                     .unwrap_err(),
                 ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                    ConnectTransactionError::TimeLockViolation
+                    ConnectTransactionError::TimeLockViolation(_)
                 ))
-            );
+            ));
             assert_eq!(
                 tf.best_block_index().block_height(),
                 BlockHeight::new(height as u64),
@@ -665,15 +665,15 @@ fn output_lock_for_seconds_but_spend_at_same_block(#[case] seed: Seed) {
             .add_anyone_can_spend_output(50000)
             .build();
 
-        assert_eq!(
+        assert!(matches!(
             tf.make_block_builder()
                 .with_transactions(vec![tx1, tx2])
                 .build_and_process()
                 .unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::TimeLockViolation
+                ConnectTransactionError::TimeLockViolation(_)
             ))
-        );
+        ));
         assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(0));
     });
 }

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -1363,10 +1363,9 @@ fn decommission_from_produce_block(#[case] seed: Seed) {
 
     let tx = TransactionBuilder::new()
         .add_input(block_2_reward_outpoint.into(), empty_witness(&mut rng))
-        .add_output(TxOutput::DecommissionPool(
-            total_reward,
+        .add_output(TxOutput::LockThenTransfer(
+            OutputValue::Coin(total_reward),
             anyonecanspend_address(),
-            pool_id1,
             OutputTimeLock::ForBlockCount(2000),
         ))
         .build();
@@ -1481,10 +1480,9 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
 
     let tx = TransactionBuilder::new()
         .add_input(stake_pool_outpoint2.into(), empty_witness(&mut rng))
-        .add_output(TxOutput::DecommissionPool(
-            total_reward,
+        .add_output(TxOutput::LockThenTransfer(
+            OutputValue::Coin(total_reward),
             anyonecanspend_address(),
-            pool_id2,
             OutputTimeLock::ForBlockCount(50),
         ))
         .build();

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -1096,7 +1096,9 @@ fn mismatched_pools_in_kernel_and_reward(#[case] seed: Seed) {
     assert_eq!(
         res,
         ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-            ConnectTransactionError::SpendStakeError(SpendStakeError::StakePoolDataMismatch)
+            ConnectTransactionError::SpendStakeError(SpendStakeError::StakePoolIdMismatch(
+                pool_id1, pool_id2
+            ))
         ))
     );
 }
@@ -1520,5 +1522,3 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
         res_pool_balance
     );
 }
-
-// FIXME: test pool_id mismatch

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -102,7 +102,10 @@ fn setup_test_chain_with_staked_pool(
             TxInput::new(OutPointSourceId::BlockReward(genesis_id.into()), 0),
             empty_witness(rng),
         )
-        .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+        .add_output(TxOutput::CreateStakePool(
+            pool_id,
+            Box::new(stake_pool_data),
+        ))
         .build();
     tf.make_block_builder().add_transaction(tx).build_and_process().unwrap();
 

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -40,9 +40,9 @@ use common::{
         timelock::OutputTimeLock,
         tokens::OutputValue,
         Block, ConsensusUpgrade, Destination, GenBlock, NetUpgrades, OutPointSourceId,
-        OutputSpentState, TxInput, TxOutput, UpgradeVersion,
+        OutputSpentState, PoolId, TxInput, TxOutput, UpgradeVersion,
     },
-    primitives::{per_thousand::PerThousand, Amount, BlockHeight, Compact, Id, Idable},
+    primitives::{per_thousand::PerThousand, Amount, BlockHeight, Compact, Id, Idable, H256},
     Uint256,
 };
 use consensus::{ConsensusPoWError, ConsensusVerificationError};
@@ -194,18 +194,20 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
         // Case 7: reward is a stake lock
         let decommission_destination = new_pub_key_destination(&mut rng);
         let (_, vrf_pub_key) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
+        let pool_id = PoolId::new(H256::random_using(&mut rng));
         let block = tf
             .make_block_builder()
-            .with_reward(vec![TxOutput::CreateStakePool(Box::new(
-                StakePoolData::new(
+            .with_reward(vec![TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(StakePoolData::new(
                     Amount::from_atoms(10),
                     anyonecanspend_address(),
                     vrf_pub_key,
                     decommission_destination,
                     PerThousand::new(0).unwrap(),
                     Amount::ZERO,
-                ),
-            ))])
+                )),
+            )])
             .add_test_transaction_from_best_block(&mut rng)
             .build();
 

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -54,6 +54,7 @@ use crypto::{
 use rstest::rstest;
 use test_utils::mock_time_getter::mocked_time_getter_seconds;
 use test_utils::random::{make_seedable_rng, Seed};
+use tx_verifier::timelock_check::OutputTimeLockError;
 use utxo::UtxoSource;
 
 #[rstest]
@@ -98,10 +99,13 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
+        let outpoint = OutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::InvalidBlockRewardMaturityTimelockType(block_id)
+                CheckBlockError::BlockRewardMaturityError(
+                    OutputTimeLockError::InvalidOutputMaturitySettingType(outpoint)
+                )
             ))
         );
 
@@ -117,10 +121,13 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
+        let outpoint = OutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::InvalidBlockRewardMaturityTimelockType(block_id)
+                CheckBlockError::BlockRewardMaturityError(
+                    OutputTimeLockError::InvalidOutputMaturitySettingType(outpoint)
+                )
             ))
         );
 
@@ -136,10 +143,13 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
+        let outpoint = OutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::InvalidBlockRewardMaturityTimelockType(block_id)
+                CheckBlockError::BlockRewardMaturityError(
+                    OutputTimeLockError::InvalidOutputMaturitySettingType(outpoint)
+                )
             ))
         );
 
@@ -155,10 +165,13 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
+        let outpoint = OutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::InvalidBlockRewardMaturityDistanceValue(block_id, u64::MAX)
+                CheckBlockError::BlockRewardMaturityError(
+                    OutputTimeLockError::InvalidOutputMaturityDistanceValue(outpoint, u64::MAX)
+                )
             ))
         );
 
@@ -180,14 +193,17 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
+        let outpoint = OutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::InvalidBlockRewardMaturityDistance(
-                    block_id,
-                    BlockDistance::new(reward_lock_distance - 1),
-                    BlockDistance::new(reward_lock_distance)
-                ),
+                CheckBlockError::BlockRewardMaturityError(
+                    OutputTimeLockError::InvalidOutputMaturityDistance(
+                        outpoint,
+                        BlockDistance::new(reward_lock_distance - 1),
+                        BlockDistance::new(reward_lock_distance)
+                    )
+                )
             ))
         );
 

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -67,7 +67,10 @@ fn stake_pool_basic(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(stake_pool_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .build();
 
         let block = tf.make_block_builder().add_transaction(tx).build();
@@ -96,16 +99,18 @@ fn stake_pool_and_spend_coin_same_tx(#[case] seed: Seed) {
         let amount_to_stake = Amount::from_atoms(rng.gen_range(100_000..200_000));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
+        let genesis_outpoint = OutPoint::new(
+            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+            0,
+        );
+        let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::new(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
-                empty_witness(&mut rng),
-            )
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .add_output(TxOutput::Transfer(
                 OutputValue::Coin(Amount::from_atoms(rng.gen_range(100_000..200_000))),
                 anyonecanspend_address(),
@@ -132,16 +137,18 @@ fn stake_pool_and_issue_tokens_same_tx(#[case] seed: Seed) {
         let amount_to_stake = Amount::from_atoms(rng.gen_range(100_000..200_000));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
+        let genesis_outpoint = OutPoint::new(
+            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+            0,
+        );
+        let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::new(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
-                empty_witness(&mut rng),
-            )
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .add_output(TxOutput::Transfer(
                 random_token_issuance(tf.chainstate.get_chain_config().clone(), &mut rng).into(),
                 anyonecanspend_address(),
@@ -198,6 +205,8 @@ fn stake_pool_and_transfer_tokens_same_tx(#[case] seed: Seed) {
         let amount_to_stake = Amount::from_atoms(rng.gen_range(100..100_000));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
+        let outpoint0 = OutPoint::new(OutPointSourceId::Transaction(tx0_id), 0);
+        let pool_id = pos_accounting::make_pool_id(&outpoint0);
 
         // stake pool with coin input and transfer tokens with token input
         let tx1 = TransactionBuilder::new()
@@ -217,7 +226,10 @@ fn stake_pool_and_transfer_tokens_same_tx(#[case] seed: Seed) {
                 .into(),
                 anyonecanspend_address(),
             ))
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .build();
 
         let best_block_index = tf
@@ -246,17 +258,22 @@ fn stake_pool_twice(#[case] seed: Seed) {
         let amount_to_stake = Amount::from_atoms(rng.gen_range(100_000..200_000));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
+        let genesis_outpoint = OutPoint::new(
+            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+            0,
+        );
+        let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::new(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
-                empty_witness(&mut rng),
-            )
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data.clone())))
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data.clone()),
+            ))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .build();
 
         let result = tf.make_block_builder().add_transaction(tx).build_and_process();
@@ -295,13 +312,15 @@ fn stake_pool_overspend(#[case] seed: Seed) {
             genesis_overspend_amount,
             vrf_pk,
         );
+        let genesis_outpoint = OutPoint::new(OutPointSourceId::BlockReward(genesis_id), 0);
+        let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::new(OutPointSourceId::BlockReward(genesis_id), 0),
-                empty_witness(&mut rng),
-            )
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .build();
 
         let result = tf.make_block_builder().add_transaction(tx).build_and_process();
@@ -339,7 +358,10 @@ fn decommission_from_stake_pool(#[case] seed: Seed) {
 
         let tx1 = TransactionBuilder::new()
             .add_input(stake_pool_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .build();
         let stake_pool_tx_id = tx1.transaction().get_id();
 
@@ -413,7 +435,10 @@ fn decommission_from_stake_pool_same_block(#[case] seed: Seed) {
 
         let tx1 = TransactionBuilder::new()
             .add_input(stake_pool_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .build();
         let stake_pool_tx_id = tx1.transaction().get_id();
 
@@ -474,7 +499,10 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
 
         let tx1 = TransactionBuilder::new()
             .add_input(stake_pool_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(Box::new(stake_pool_data)))
+            .add_output(TxOutput::CreateStakePool(
+                pool_id,
+                Box::new(stake_pool_data),
+            ))
             .build();
 
         tf.make_block_builder().add_transaction(tx1).build_and_process().unwrap();

--- a/chainstate/tx-verifier/src/lib.rs
+++ b/chainstate/tx-verifier/src/lib.rs
@@ -23,5 +23,5 @@ pub use transaction_verifier::{
         TransactionVerifierStorageError, TransactionVerifierStorageMut,
         TransactionVerifierStorageRef,
     },
-    Fee, TransactionSource, TransactionVerifier,
+    timelock_check, Fee, TransactionSource, TransactionVerifier,
 };

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -22,7 +22,7 @@ use common::{
         DelegationId, OutPointSourceId, PoolId, SpendError, Spender, Transaction,
         TxMainChainIndexError,
     },
-    primitives::{Amount, BlockHeight, Id},
+    primitives::{Amount, BlockDistance, BlockHeight, Id},
 };
 use thiserror::Error;
 
@@ -139,6 +139,12 @@ pub enum ConnectTransactionError {
 
     #[error("Destination retrieval error for signature verification {0}")]
     DestinationRetrievalError(#[from] SignatureDestinationGetterError),
+    #[error("Maturity setting type for the decommission pool output is invalid")]
+    InvalidDecommissionMaturityType,
+    #[error("Maturity setting for the decommission pool output is too short: {0} < {1}")]
+    InvalidDecommissionMaturityDistance(BlockDistance, BlockDistance),
+    #[error("Maturity setting value for the decommission pool output is invalid: {0}")]
+    InvalidDecommissionMaturityDistanceValue(u64),
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -145,6 +145,8 @@ pub enum ConnectTransactionError {
     InvalidDecommissionMaturityDistance(BlockDistance, BlockDistance),
     #[error("Maturity setting value for the decommission pool output is invalid: {0}")]
     InvalidDecommissionMaturityDistanceValue(u64),
+    #[error("Pool ids should be equal: {0}, {1}")]
+    PoolIdMismatch(PoolId, PoolId),
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -145,8 +145,6 @@ pub enum ConnectTransactionError {
     InvalidDecommissionMaturityDistance(BlockDistance, BlockDistance),
     #[error("Maturity setting value for the decommission pool output is invalid: {0}")]
     InvalidDecommissionMaturityDistanceValue(u64),
-    #[error("Pool ids should be equal: {0}, {1}")]
-    PoolIdMismatch(PoolId, PoolId),
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {
@@ -268,6 +266,8 @@ pub enum SpendStakeError {
     InvalidBlockRewardOutputType,
     #[error("Stake pool data in kernel doesn't match data in block reward output")]
     StakePoolDataMismatch,
+    #[error("Pool id in kernel {0} doesn't match id in block reward output {1}")]
+    StakePoolIdMismatch(PoolId, PoolId),
     #[error("Consensus PoS error")]
     ConsensusPoSError(#[from] consensus::ConsensusPoSError),
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
@@ -49,7 +49,6 @@ pub fn check_reward_inputs_outputs_purposes(
                     TxOutput::Transfer(..)
                     | TxOutput::LockThenTransfer(..)
                     | TxOutput::Burn(..)
-                    | TxOutput::DecommissionPool(..)
                     | TxOutput::CreateDelegationId(..)
                     | TxOutput::DelegateStaking(..) => {
                         Err(ConnectTransactionError::InvalidInputTypeInReward)
@@ -68,7 +67,6 @@ pub fn check_reward_inputs_outputs_purposes(
                                 | TxOutput::LockThenTransfer(..)
                                 | TxOutput::Burn(..)
                                 | TxOutput::CreateStakePool(..)
-                                | TxOutput::DecommissionPool(..)
                                 | TxOutput::CreateDelegationId(..)
                                 | TxOutput::DelegateStaking(..) => {
                                     Err(ConnectTransactionError::InvalidOutputTypeInReward)
@@ -101,7 +99,6 @@ pub fn check_reward_inputs_outputs_purposes(
                     | TxOutput::Burn(..)
                     | TxOutput::CreateStakePool(..)
                     | TxOutput::ProduceBlockFromStake(..)
-                    | TxOutput::DecommissionPool(..)
                     | TxOutput::CreateDelegationId(..)
                     | TxOutput::DelegateStaking(..) => false,
                 });
@@ -168,49 +165,36 @@ fn is_valid_one_to_one_combination(input_utxo: &TxOutput, output: &TxOutput) -> 
         | (TxOutput::Transfer(..), TxOutput::CreateStakePool(..))
         | (TxOutput::Transfer(..), TxOutput::CreateDelegationId(..))
         | (TxOutput::Transfer(..), TxOutput::DelegateStaking(..)) => true,
-        | (TxOutput::Transfer(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::Transfer(..), TxOutput::DecommissionPool(..)) => false,
+        | (TxOutput::Transfer(..), TxOutput::ProduceBlockFromStake(..)) => false,
         | (TxOutput::LockThenTransfer(..), TxOutput::Transfer(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::LockThenTransfer(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::Burn(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::CreateStakePool(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::CreateDelegationId(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::DelegateStaking(..)) => true,
-        | (TxOutput::LockThenTransfer(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::LockThenTransfer(..), TxOutput::DecommissionPool(..)) => false,
+        | (TxOutput::LockThenTransfer(..), TxOutput::ProduceBlockFromStake(..)) => false,
         | (TxOutput::Burn(..), _) => false,
         | (TxOutput::CreateStakePool(..), TxOutput::Transfer(..))
-        | (TxOutput::CreateStakePool(..), TxOutput::LockThenTransfer(..))
         | (TxOutput::CreateStakePool(..), TxOutput::Burn(..))
         | (TxOutput::CreateStakePool(..), TxOutput::CreateStakePool(..))
         | (TxOutput::CreateStakePool(..), TxOutput::ProduceBlockFromStake(..))
         | (TxOutput::CreateStakePool(..), TxOutput::CreateDelegationId(..))
         | (TxOutput::CreateStakePool(..), TxOutput::DelegateStaking(..)) => false,
-        | (TxOutput::CreateStakePool(..), TxOutput::DecommissionPool(..)) => true,
+        | (TxOutput::CreateStakePool(..), TxOutput::LockThenTransfer(..)) => true,
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::Transfer(..))
-        | (TxOutput::ProduceBlockFromStake(..), TxOutput::LockThenTransfer(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::Burn(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::CreateStakePool(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::ProduceBlockFromStake(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::CreateDelegationId(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::DelegateStaking(..)) => false,
-        | (TxOutput::ProduceBlockFromStake(..), TxOutput::DecommissionPool(..)) => true,
-        | (TxOutput::DecommissionPool(..), TxOutput::Transfer(..))
-        | (TxOutput::DecommissionPool(..), TxOutput::LockThenTransfer(..))
-        | (TxOutput::DecommissionPool(..), TxOutput::Burn(..))
-        | (TxOutput::DecommissionPool(..), TxOutput::CreateStakePool(..))
-        | (TxOutput::DecommissionPool(..), TxOutput::CreateDelegationId(..))
-        | (TxOutput::DecommissionPool(..), TxOutput::DelegateStaking(..)) => true,
-        | (TxOutput::DecommissionPool(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::DecommissionPool(..), TxOutput::DecommissionPool(..)) => false,
+        | (TxOutput::ProduceBlockFromStake(..), TxOutput::LockThenTransfer(..)) => true,
         | (TxOutput::CreateDelegationId(..), _) => false,
         | (TxOutput::DelegateStaking(..), TxOutput::Transfer(..))
-        | (TxOutput::DelegateStaking(..), TxOutput::LockThenTransfer(..))
         | (TxOutput::DelegateStaking(..), TxOutput::Burn(..))
         | (TxOutput::DelegateStaking(..), TxOutput::CreateStakePool(..))
         | (TxOutput::DelegateStaking(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::DelegateStaking(..), TxOutput::DecommissionPool(..))
         | (TxOutput::DelegateStaking(..), TxOutput::CreateDelegationId(..)) => false,
+        | (TxOutput::DelegateStaking(..), TxOutput::LockThenTransfer(..))
         | (TxOutput::DelegateStaking(..), TxOutput::DelegateStaking(..)) => true,
     }
 }
@@ -239,7 +223,6 @@ fn is_delegation_spending(input_utxo: &TxOutput, outputs: &[TxOutput]) -> bool {
         | TxOutput::Burn(..)
         | TxOutput::CreateStakePool(..)
         | TxOutput::ProduceBlockFromStake(..)
-        | TxOutput::DecommissionPool(..)
         | TxOutput::CreateDelegationId(..) => false,
         TxOutput::DelegateStaking(..) => true,
     };
@@ -252,7 +235,6 @@ fn is_delegation_spending(input_utxo: &TxOutput, outputs: &[TxOutput]) -> bool {
             | TxOutput::Burn(..)
             | TxOutput::CreateStakePool(..)
             | TxOutput::ProduceBlockFromStake(..)
-            | TxOutput::DecommissionPool(..)
             | TxOutput::CreateDelegationId(..) => false,
             TxOutput::DelegateStaking(..) => true,
         })
@@ -265,7 +247,6 @@ fn is_delegation_spending(input_utxo: &TxOutput, outputs: &[TxOutput]) -> bool {
             | TxOutput::Burn(..)
             | TxOutput::CreateStakePool(..)
             | TxOutput::ProduceBlockFromStake(..)
-            | TxOutput::DecommissionPool(..)
             | TxOutput::CreateDelegationId(..)
             | TxOutput::DelegateStaking(..) => false,
             TxOutput::LockThenTransfer(..) => true,
@@ -293,9 +274,7 @@ fn is_valid_any_to_any_combination_for_tx(
 
 fn are_inputs_valid_for_tx(inputs_utxos: &[TxOutput]) -> bool {
     inputs_utxos.iter().all(|input_utxo| match input_utxo {
-        TxOutput::Transfer(..)
-        | TxOutput::LockThenTransfer(..)
-        | TxOutput::DecommissionPool(..) => true,
+        TxOutput::Transfer(..) | TxOutput::LockThenTransfer(..) => true,
         TxOutput::Burn(..)
         | TxOutput::CreateStakePool(..)
         | TxOutput::ProduceBlockFromStake(..)
@@ -312,7 +291,7 @@ fn are_outputs_valid_for_tx(outputs: &[TxOutput]) -> bool {
         | TxOutput::CreateStakePool(..)
         | TxOutput::CreateDelegationId(..)
         | TxOutput::DelegateStaking(..) => true,
-        TxOutput::ProduceBlockFromStake(..) | TxOutput::DecommissionPool(..) => false,
+        TxOutput::ProduceBlockFromStake(..) => false,
     });
 
     let is_stake_pool_unique = outputs
@@ -322,7 +301,6 @@ fn are_outputs_valid_for_tx(outputs: &[TxOutput]) -> bool {
             | TxOutput::LockThenTransfer(..)
             | TxOutput::Burn(..)
             | TxOutput::ProduceBlockFromStake(..)
-            | TxOutput::DecommissionPool(..)
             | TxOutput::CreateDelegationId(..)
             | TxOutput::DelegateStaking(..) => false,
             TxOutput::CreateStakePool(..) => true,
@@ -338,7 +316,6 @@ fn are_outputs_valid_for_tx(outputs: &[TxOutput]) -> bool {
             | TxOutput::Burn(..)
             | TxOutput::CreateStakePool(..)
             | TxOutput::ProduceBlockFromStake(..)
-            | TxOutput::DecommissionPool(..)
             | TxOutput::DelegateStaking(..) => false,
             TxOutput::CreateDelegationId(..) => true,
         })
@@ -406,15 +383,6 @@ mod tests {
 
     fn produce_block() -> TxOutput {
         TxOutput::ProduceBlockFromStake(Destination::AnyoneCanSpend, PoolId::new(H256::zero()))
-    }
-
-    fn decommission_pool() -> TxOutput {
-        TxOutput::DecommissionPool(
-            Amount::ZERO,
-            Destination::AnyoneCanSpend,
-            PoolId::new(H256::zero()),
-            OutputTimeLock::ForBlockCount(1),
-        )
     }
 
     fn create_delegation() -> TxOutput {
@@ -525,7 +493,6 @@ mod tests {
     #[case(transfer(), lock_then_transfer(), Ok(()))]
     #[case(transfer(), stake_pool(),         Ok(()))]
     #[case(transfer(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(transfer(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(transfer(), create_delegation(),  Ok(()))]
     #[case(transfer(), delegate_staking(),   Ok(()))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -534,7 +501,6 @@ mod tests {
     #[case(burn(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(burn(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(burn(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(burn(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(burn(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(burn(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -543,7 +509,6 @@ mod tests {
     #[case(lock_then_transfer(), lock_then_transfer(), Ok(()))]
     #[case(lock_then_transfer(), stake_pool(),         Ok(()))]
     #[case(lock_then_transfer(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(lock_then_transfer(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(lock_then_transfer(), create_delegation(),  Ok(()))]
     #[case(lock_then_transfer(), delegate_staking(),   Ok(()))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -552,7 +517,6 @@ mod tests {
     #[case(stake_pool(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(stake_pool(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(stake_pool(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(stake_pool(), decommission_pool(),  Ok(()))]
     #[case(stake_pool(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(stake_pool(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -561,25 +525,14 @@ mod tests {
     #[case(produce_block(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(produce_block(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(produce_block(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(produce_block(), decommission_pool(),  Ok(()))]
     #[case(produce_block(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(produce_block(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    /*-----------------------------------------------------------------------------------------------*/
-    #[case(decommission_pool(), transfer(),           Ok(()))]
-    #[case(decommission_pool(), burn(),               Ok(()))]
-    #[case(decommission_pool(), lock_then_transfer(), Ok(()))]
-    #[case(decommission_pool(), stake_pool(),         Ok(()))]
-    #[case(decommission_pool(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(decommission_pool(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(decommission_pool(), create_delegation(),  Ok(()))]
-    #[case(decommission_pool(), delegate_staking(),   Ok(()))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(create_delegation(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(create_delegation(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -588,7 +541,6 @@ mod tests {
     #[case(delegate_staking(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(delegate_staking(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), delegate_staking(),   Ok(()))]
     fn tx_one_to_one(
@@ -644,7 +596,7 @@ mod tests {
 
         // valid cases
         {
-            let valid_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
+            let valid_inputs = [lock_then_transfer(), transfer()];
             let valid_outputs = [lock_then_transfer(), transfer(), burn()];
             check(&valid_inputs, &valid_outputs, Ok(()));
         }
@@ -691,9 +643,9 @@ mod tests {
     #[trace]
     #[case(Seed::from_entropy())]
     fn tx_one_to_any_invalid_outputs(#[case] seed: Seed) {
-        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
+        let source_inputs = [lock_then_transfer(), transfer()];
         let source_valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
-        let source_invalid_outputs = [produce_block(), decommission_pool()];
+        let source_invalid_outputs = [produce_block()];
 
         let mut rng = make_seedable_rng(seed);
         let inputs = get_random_outputs_combination(&mut rng, &source_inputs, 1);
@@ -724,7 +676,7 @@ mod tests {
     fn tx_one_to_any_stake_multiple_pools(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
 
-        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
+        let source_inputs = [lock_then_transfer(), transfer()];
         let source_valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
         let source_invalid_outputs = [stake_pool()];
 
@@ -760,7 +712,7 @@ mod tests {
     fn tx_one_to_any_create_multiple_delegations(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
 
-        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
+        let source_inputs = [lock_then_transfer(), transfer()];
         let source_valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
         let source_invalid_outputs = [create_delegation()];
 
@@ -812,7 +764,7 @@ mod tests {
         };
 
         // valid cases
-        let valid_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
+        let valid_inputs = [lock_then_transfer(), transfer()];
         let valid_outputs = [
             lock_then_transfer(),
             transfer(),
@@ -824,7 +776,7 @@ mod tests {
         check(&valid_inputs, &valid_outputs, Ok(()));
 
         // invalid outputs
-        let invalid_outputs = [produce_block(), decommission_pool()];
+        let invalid_outputs = [produce_block()];
         check(
             &valid_inputs,
             &invalid_outputs,
@@ -856,14 +808,13 @@ mod tests {
         };
 
         // valid cases
-        let valid_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
+        let valid_inputs = [lock_then_transfer(), transfer()];
         let valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
         check(&valid_inputs, &valid_outputs, Ok(()));
 
         // invalid cases
         let invalid_inputs = [burn(), stake_pool(), produce_block(), create_delegation()];
-        let invalid_outputs =
-            [stake_pool(), produce_block(), decommission_pool(), create_delegation()];
+        let invalid_outputs = [stake_pool(), produce_block(), create_delegation()];
         check(
             &invalid_inputs,
             &valid_outputs,
@@ -883,7 +834,6 @@ mod tests {
     #[case(transfer(), lock_then_transfer(), Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(transfer(), stake_pool(),         Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(transfer(), produce_block(),      Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(transfer(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(transfer(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(transfer(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -892,7 +842,6 @@ mod tests {
     #[case(burn(), lock_then_transfer(), Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(burn(), stake_pool(),         Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(burn(), produce_block(),      Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(burn(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(burn(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(burn(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -901,7 +850,6 @@ mod tests {
     #[case(lock_then_transfer(), lock_then_transfer(), Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(lock_then_transfer(), stake_pool(),         Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(lock_then_transfer(), produce_block(),      Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(lock_then_transfer(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(lock_then_transfer(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(lock_then_transfer(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -910,7 +858,6 @@ mod tests {
     #[case(stake_pool(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(stake_pool(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(stake_pool(), produce_block(),      Ok(()))]
-    #[case(stake_pool(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(stake_pool(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(stake_pool(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -919,25 +866,14 @@ mod tests {
     #[case(produce_block(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(produce_block(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(produce_block(), produce_block(),      Ok(()))]
-    #[case(produce_block(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(produce_block(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(produce_block(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInReward))]
-    /*-----------------------------------------------------------------------------------------------*/
-    #[case(decommission_pool(), transfer(),           Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(decommission_pool(), burn(),               Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(decommission_pool(), lock_then_transfer(), Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(decommission_pool(), stake_pool(),         Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(decommission_pool(), produce_block(),      Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(decommission_pool(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(decommission_pool(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(decommission_pool(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(create_delegation(), transfer(),           Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), burn(),               Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), lock_then_transfer(), Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), stake_pool(),         Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), produce_block(),      Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(create_delegation(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
@@ -946,7 +882,6 @@ mod tests {
     #[case(delegate_staking(), lock_then_transfer(), Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(delegate_staking(), stake_pool(),         Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(delegate_staking(), produce_block(),      Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(delegate_staking(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(delegate_staking(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(delegate_staking(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
     fn reward_one_to_one(
@@ -1027,7 +962,6 @@ mod tests {
                 burn(),
                 stake_pool(),
                 produce_block(),
-                decommission_pool(),
                 create_delegation(),
                 delegate_staking(),
             ];
@@ -1056,7 +990,6 @@ mod tests {
             burn(),
             stake_pool(),
             produce_block(),
-            decommission_pool(),
             create_delegation(),
             delegate_staking(),
         ];

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
@@ -371,14 +371,17 @@ mod tests {
 
     fn stake_pool() -> TxOutput {
         let (_, vrf_pub_key) = VRFPrivateKey::new_from_entropy(VRFKeyKind::Schnorrkel);
-        TxOutput::CreateStakePool(Box::new(StakePoolData::new(
-            Amount::ZERO,
-            Destination::AnyoneCanSpend,
-            vrf_pub_key,
-            Destination::AnyoneCanSpend,
-            PerThousand::new(0).unwrap(),
-            Amount::ZERO,
-        )))
+        TxOutput::CreateStakePool(
+            PoolId::new(H256::zero()),
+            Box::new(StakePoolData::new(
+                Amount::ZERO,
+                Destination::AnyoneCanSpend,
+                vrf_pub_key,
+                Destination::AnyoneCanSpend,
+                PerThousand::new(0).unwrap(),
+                Amount::ZERO,
+            )),
+        )
     }
 
     fn produce_block() -> TxOutput {
@@ -514,7 +517,7 @@ mod tests {
     /*-----------------------------------------------------------------------------------------------*/
     #[case(stake_pool(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(stake_pool(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(stake_pool(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInTx))]
+    #[case(stake_pool(), lock_then_transfer(), Ok(()))]
     #[case(stake_pool(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(stake_pool(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(stake_pool(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
@@ -522,7 +525,7 @@ mod tests {
     /*-----------------------------------------------------------------------------------------------*/
     #[case(produce_block(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(produce_block(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(produce_block(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInTx))]
+    #[case(produce_block(), lock_then_transfer(), Ok(()))]
     #[case(produce_block(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(produce_block(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(produce_block(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
@@ -538,7 +541,7 @@ mod tests {
     /*-----------------------------------------------------------------------------------------------*/
     #[case(delegate_staking(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(delegate_staking(), lock_then_transfer(), Err(ConnectTransactionError::InvalidOutputTypeInTx))]
+    #[case(delegate_staking(), lock_then_transfer(), Ok(()))]
     #[case(delegate_staking(), stake_pool(),         Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy.rs
@@ -51,8 +51,7 @@ pub fn check_reward_inputs_outputs_purposes(
                     | TxOutput::Burn(..)
                     | TxOutput::DecommissionPool(..)
                     | TxOutput::CreateDelegationId(..)
-                    | TxOutput::DelegateStaking(..)
-                    | TxOutput::SpendShareFromDelegation(..) => {
+                    | TxOutput::DelegateStaking(..) => {
                         Err(ConnectTransactionError::InvalidInputTypeInReward)
                     }
                     TxOutput::CreateStakePool(..) | TxOutput::ProduceBlockFromStake(..) => {
@@ -71,8 +70,7 @@ pub fn check_reward_inputs_outputs_purposes(
                                 | TxOutput::CreateStakePool(..)
                                 | TxOutput::DecommissionPool(..)
                                 | TxOutput::CreateDelegationId(..)
-                                | TxOutput::DelegateStaking(..)
-                                | TxOutput::SpendShareFromDelegation(..) => {
+                                | TxOutput::DelegateStaking(..) => {
                                     Err(ConnectTransactionError::InvalidOutputTypeInReward)
                                 }
                                 TxOutput::ProduceBlockFromStake(..) => Ok(()),
@@ -105,8 +103,7 @@ pub fn check_reward_inputs_outputs_purposes(
                     | TxOutput::ProduceBlockFromStake(..)
                     | TxOutput::DecommissionPool(..)
                     | TxOutput::CreateDelegationId(..)
-                    | TxOutput::DelegateStaking(..)
-                    | TxOutput::SpendShareFromDelegation(..) => false,
+                    | TxOutput::DelegateStaking(..) => false,
                 });
             ensure!(
                 all_lock_then_transfer,
@@ -172,8 +169,7 @@ fn is_valid_one_to_one_combination(input_utxo: &TxOutput, output: &TxOutput) -> 
         | (TxOutput::Transfer(..), TxOutput::CreateDelegationId(..))
         | (TxOutput::Transfer(..), TxOutput::DelegateStaking(..)) => true,
         | (TxOutput::Transfer(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::Transfer(..), TxOutput::DecommissionPool(..))
-        | (TxOutput::Transfer(..), TxOutput::SpendShareFromDelegation(..)) => false,
+        | (TxOutput::Transfer(..), TxOutput::DecommissionPool(..)) => false,
         | (TxOutput::LockThenTransfer(..), TxOutput::Transfer(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::LockThenTransfer(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::Burn(..))
@@ -181,7 +177,6 @@ fn is_valid_one_to_one_combination(input_utxo: &TxOutput, output: &TxOutput) -> 
         | (TxOutput::LockThenTransfer(..), TxOutput::CreateDelegationId(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::DelegateStaking(..)) => true,
         | (TxOutput::LockThenTransfer(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::LockThenTransfer(..), TxOutput::SpendShareFromDelegation(..))
         | (TxOutput::LockThenTransfer(..), TxOutput::DecommissionPool(..)) => false,
         | (TxOutput::Burn(..), _) => false,
         | (TxOutput::CreateStakePool(..), TxOutput::Transfer(..))
@@ -190,15 +185,13 @@ fn is_valid_one_to_one_combination(input_utxo: &TxOutput, output: &TxOutput) -> 
         | (TxOutput::CreateStakePool(..), TxOutput::CreateStakePool(..))
         | (TxOutput::CreateStakePool(..), TxOutput::ProduceBlockFromStake(..))
         | (TxOutput::CreateStakePool(..), TxOutput::CreateDelegationId(..))
-        | (TxOutput::CreateStakePool(..), TxOutput::DelegateStaking(..))
-        | (TxOutput::CreateStakePool(..), TxOutput::SpendShareFromDelegation(..)) => false,
+        | (TxOutput::CreateStakePool(..), TxOutput::DelegateStaking(..)) => false,
         | (TxOutput::CreateStakePool(..), TxOutput::DecommissionPool(..)) => true,
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::Transfer(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::LockThenTransfer(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::Burn(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::CreateStakePool(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::ProduceBlockFromStake(..), TxOutput::SpendShareFromDelegation(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::CreateDelegationId(..))
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::DelegateStaking(..)) => false,
         | (TxOutput::ProduceBlockFromStake(..), TxOutput::DecommissionPool(..)) => true,
@@ -209,7 +202,6 @@ fn is_valid_one_to_one_combination(input_utxo: &TxOutput, output: &TxOutput) -> 
         | (TxOutput::DecommissionPool(..), TxOutput::CreateDelegationId(..))
         | (TxOutput::DecommissionPool(..), TxOutput::DelegateStaking(..)) => true,
         | (TxOutput::DecommissionPool(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::DecommissionPool(..), TxOutput::SpendShareFromDelegation(..))
         | (TxOutput::DecommissionPool(..), TxOutput::DecommissionPool(..)) => false,
         | (TxOutput::CreateDelegationId(..), _) => false,
         | (TxOutput::DelegateStaking(..), TxOutput::Transfer(..))
@@ -219,17 +211,7 @@ fn is_valid_one_to_one_combination(input_utxo: &TxOutput, output: &TxOutput) -> 
         | (TxOutput::DelegateStaking(..), TxOutput::ProduceBlockFromStake(..))
         | (TxOutput::DelegateStaking(..), TxOutput::DecommissionPool(..))
         | (TxOutput::DelegateStaking(..), TxOutput::CreateDelegationId(..)) => false,
-        | (TxOutput::DelegateStaking(..), TxOutput::DelegateStaking(..))
-        | (TxOutput::DelegateStaking(..), TxOutput::SpendShareFromDelegation(..)) => true,
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::Transfer(..))
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::LockThenTransfer(..))
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::Burn(..))
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::CreateStakePool(..))
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::CreateDelegationId(..))
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::DelegateStaking(..)) => true,
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::ProduceBlockFromStake(..))
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::DecommissionPool(..))
-        | (TxOutput::SpendShareFromDelegation(..), TxOutput::SpendShareFromDelegation(..)) => false,
+        | (TxOutput::DelegateStaking(..), TxOutput::DelegateStaking(..)) => true,
     }
 }
 
@@ -258,8 +240,7 @@ fn is_delegation_spending(input_utxo: &TxOutput, outputs: &[TxOutput]) -> bool {
         | TxOutput::CreateStakePool(..)
         | TxOutput::ProduceBlockFromStake(..)
         | TxOutput::DecommissionPool(..)
-        | TxOutput::CreateDelegationId(..)
-        | TxOutput::SpendShareFromDelegation(..) => false,
+        | TxOutput::CreateDelegationId(..) => false,
         TxOutput::DelegateStaking(..) => true,
     };
 
@@ -272,8 +253,7 @@ fn is_delegation_spending(input_utxo: &TxOutput, outputs: &[TxOutput]) -> bool {
             | TxOutput::CreateStakePool(..)
             | TxOutput::ProduceBlockFromStake(..)
             | TxOutput::DecommissionPool(..)
-            | TxOutput::CreateDelegationId(..)
-            | TxOutput::SpendShareFromDelegation(..) => false,
+            | TxOutput::CreateDelegationId(..) => false,
             TxOutput::DelegateStaking(..) => true,
         })
         .count();
@@ -282,14 +262,13 @@ fn is_delegation_spending(input_utxo: &TxOutput, outputs: &[TxOutput]) -> bool {
         .iter()
         .filter(|output| match output {
             TxOutput::Transfer(..)
-            | TxOutput::LockThenTransfer(..)
             | TxOutput::Burn(..)
             | TxOutput::CreateStakePool(..)
             | TxOutput::ProduceBlockFromStake(..)
             | TxOutput::DecommissionPool(..)
             | TxOutput::CreateDelegationId(..)
             | TxOutput::DelegateStaking(..) => false,
-            TxOutput::SpendShareFromDelegation(..) => true,
+            TxOutput::LockThenTransfer(..) => true,
         })
         .count();
 
@@ -316,8 +295,7 @@ fn are_inputs_valid_for_tx(inputs_utxos: &[TxOutput]) -> bool {
     inputs_utxos.iter().all(|input_utxo| match input_utxo {
         TxOutput::Transfer(..)
         | TxOutput::LockThenTransfer(..)
-        | TxOutput::DecommissionPool(..)
-        | TxOutput::SpendShareFromDelegation(..) => true,
+        | TxOutput::DecommissionPool(..) => true,
         TxOutput::Burn(..)
         | TxOutput::CreateStakePool(..)
         | TxOutput::ProduceBlockFromStake(..)
@@ -334,9 +312,7 @@ fn are_outputs_valid_for_tx(outputs: &[TxOutput]) -> bool {
         | TxOutput::CreateStakePool(..)
         | TxOutput::CreateDelegationId(..)
         | TxOutput::DelegateStaking(..) => true,
-        TxOutput::ProduceBlockFromStake(..)
-        | TxOutput::DecommissionPool(..)
-        | TxOutput::SpendShareFromDelegation(..) => false,
+        TxOutput::ProduceBlockFromStake(..) | TxOutput::DecommissionPool(..) => false,
     });
 
     let is_stake_pool_unique = outputs
@@ -348,8 +324,7 @@ fn are_outputs_valid_for_tx(outputs: &[TxOutput]) -> bool {
             | TxOutput::ProduceBlockFromStake(..)
             | TxOutput::DecommissionPool(..)
             | TxOutput::CreateDelegationId(..)
-            | TxOutput::DelegateStaking(..)
-            | TxOutput::SpendShareFromDelegation(..) => false,
+            | TxOutput::DelegateStaking(..) => false,
             TxOutput::CreateStakePool(..) => true,
         })
         .count()
@@ -364,8 +339,7 @@ fn are_outputs_valid_for_tx(outputs: &[TxOutput]) -> bool {
             | TxOutput::CreateStakePool(..)
             | TxOutput::ProduceBlockFromStake(..)
             | TxOutput::DecommissionPool(..)
-            | TxOutput::DelegateStaking(..)
-            | TxOutput::SpendShareFromDelegation(..) => false,
+            | TxOutput::DelegateStaking(..) => false,
             TxOutput::CreateDelegationId(..) => true,
         })
         .count()
@@ -449,15 +423,6 @@ mod tests {
 
     fn delegate_staking() -> TxOutput {
         TxOutput::DelegateStaking(Amount::ZERO, DelegationId::new(H256::zero()))
-    }
-
-    fn spend_share() -> TxOutput {
-        TxOutput::SpendShareFromDelegation(
-            Amount::ZERO,
-            Destination::AnyoneCanSpend,
-            DelegationId::new(H256::zero()),
-            OutputTimeLock::ForBlockCount(1),
-        )
     }
 
     fn get_random_outputs_combination(
@@ -563,7 +528,6 @@ mod tests {
     #[case(transfer(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(transfer(), create_delegation(),  Ok(()))]
     #[case(transfer(), delegate_staking(),   Ok(()))]
-    #[case(transfer(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(burn(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(burn(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
@@ -573,7 +537,6 @@ mod tests {
     #[case(burn(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(burn(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(burn(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(burn(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(lock_then_transfer(), transfer(),           Ok(()))]
     #[case(lock_then_transfer(), burn(),               Ok(()))]
@@ -583,7 +546,6 @@ mod tests {
     #[case(lock_then_transfer(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(lock_then_transfer(), create_delegation(),  Ok(()))]
     #[case(lock_then_transfer(), delegate_staking(),   Ok(()))]
-    #[case(lock_then_transfer(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(stake_pool(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(stake_pool(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
@@ -593,7 +555,6 @@ mod tests {
     #[case(stake_pool(), decommission_pool(),  Ok(()))]
     #[case(stake_pool(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(stake_pool(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(stake_pool(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(produce_block(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(produce_block(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
@@ -603,7 +564,6 @@ mod tests {
     #[case(produce_block(), decommission_pool(),  Ok(()))]
     #[case(produce_block(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(produce_block(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(produce_block(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(decommission_pool(), transfer(),           Ok(()))]
     #[case(decommission_pool(), burn(),               Ok(()))]
@@ -613,7 +573,6 @@ mod tests {
     #[case(decommission_pool(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(decommission_pool(), create_delegation(),  Ok(()))]
     #[case(decommission_pool(), delegate_staking(),   Ok(()))]
-    #[case(decommission_pool(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(create_delegation(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
@@ -623,7 +582,6 @@ mod tests {
     #[case(create_delegation(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(create_delegation(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(create_delegation(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(delegate_staking(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInTx))]
@@ -633,17 +591,6 @@ mod tests {
     #[case(delegate_staking(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     #[case(delegate_staking(), delegate_staking(),   Ok(()))]
-    #[case(delegate_staking(), spend_share(),        Ok(()))]
-    /*-----------------------------------------------------------------------------------------------*/
-    #[case(spend_share(), transfer(),           Ok(()))]
-    #[case(spend_share(), burn(),               Ok(()))]
-    #[case(spend_share(), lock_then_transfer(), Ok(()))]
-    #[case(spend_share(), stake_pool(),         Ok(()))]
-    #[case(spend_share(), produce_block(),      Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(spend_share(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInTx))]
-    #[case(spend_share(), create_delegation(),  Ok(()))]
-    #[case(spend_share(), delegate_staking(),   Ok(()))]
-    #[case(spend_share(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInTx))]
     fn tx_one_to_one(
         #[case] input_utxo: TxOutput,
         #[case] output: TxOutput,
@@ -697,8 +644,7 @@ mod tests {
 
         // valid cases
         {
-            let valid_inputs =
-                [lock_then_transfer(), transfer(), decommission_pool(), spend_share()];
+            let valid_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
             let valid_outputs = [lock_then_transfer(), transfer(), burn()];
             check(&valid_inputs, &valid_outputs, Ok(()));
         }
@@ -719,7 +665,7 @@ mod tests {
     #[case(Seed::from_entropy())]
     fn tx_spend_delegation(#[case] seed: Seed) {
         let inputs = [delegate_staking()];
-        let outputs = [spend_share()];
+        let outputs = [lock_then_transfer()];
 
         let mut rng = make_seedable_rng(seed);
         let number_of_outputs = rng.gen_range(2..10);
@@ -745,7 +691,7 @@ mod tests {
     #[trace]
     #[case(Seed::from_entropy())]
     fn tx_one_to_any_invalid_outputs(#[case] seed: Seed) {
-        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool(), spend_share()];
+        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
         let source_valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
         let source_invalid_outputs = [produce_block(), decommission_pool()];
 
@@ -778,7 +724,7 @@ mod tests {
     fn tx_one_to_any_stake_multiple_pools(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
 
-        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool(), spend_share()];
+        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
         let source_valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
         let source_invalid_outputs = [stake_pool()];
 
@@ -814,7 +760,7 @@ mod tests {
     fn tx_one_to_any_create_multiple_delegations(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
 
-        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool(), spend_share()];
+        let source_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
         let source_valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
         let source_invalid_outputs = [create_delegation()];
 
@@ -866,7 +812,7 @@ mod tests {
         };
 
         // valid cases
-        let valid_inputs = [lock_then_transfer(), transfer(), decommission_pool(), spend_share()];
+        let valid_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
         let valid_outputs = [
             lock_then_transfer(),
             transfer(),
@@ -910,7 +856,7 @@ mod tests {
         };
 
         // valid cases
-        let valid_inputs = [lock_then_transfer(), transfer(), decommission_pool(), spend_share()];
+        let valid_inputs = [lock_then_transfer(), transfer(), decommission_pool()];
         let valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
         check(&valid_inputs, &valid_outputs, Ok(()));
 
@@ -940,7 +886,6 @@ mod tests {
     #[case(transfer(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(transfer(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(transfer(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(transfer(), spend_share(),        Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(burn(), transfer(),           Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(burn(), burn(),               Err(ConnectTransactionError::InvalidInputTypeInReward))]
@@ -950,7 +895,6 @@ mod tests {
     #[case(burn(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(burn(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(burn(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(burn(), spend_share(),        Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(lock_then_transfer(), transfer(),           Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(lock_then_transfer(), burn(),               Err(ConnectTransactionError::InvalidInputTypeInReward))]
@@ -960,7 +904,6 @@ mod tests {
     #[case(lock_then_transfer(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(lock_then_transfer(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(lock_then_transfer(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(lock_then_transfer(), spend_share(),        Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(stake_pool(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(stake_pool(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInReward))]
@@ -970,7 +913,6 @@ mod tests {
     #[case(stake_pool(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(stake_pool(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(stake_pool(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInReward))]
-    #[case(stake_pool(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(produce_block(), transfer(),           Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(produce_block(), burn(),               Err(ConnectTransactionError::InvalidOutputTypeInReward))]
@@ -980,7 +922,6 @@ mod tests {
     #[case(produce_block(), decommission_pool(),  Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(produce_block(), create_delegation(),  Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     #[case(produce_block(), delegate_staking(),   Err(ConnectTransactionError::InvalidOutputTypeInReward))]
-    #[case(produce_block(), spend_share(),        Err(ConnectTransactionError::InvalidOutputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(decommission_pool(), transfer(),           Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(decommission_pool(), burn(),               Err(ConnectTransactionError::InvalidInputTypeInReward))]
@@ -990,7 +931,6 @@ mod tests {
     #[case(decommission_pool(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(decommission_pool(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(decommission_pool(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(decommission_pool(), spend_share(),        Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(create_delegation(), transfer(),           Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), burn(),               Err(ConnectTransactionError::InvalidInputTypeInReward))]
@@ -1000,7 +940,6 @@ mod tests {
     #[case(create_delegation(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(create_delegation(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(create_delegation(), spend_share(),        Err(ConnectTransactionError::InvalidInputTypeInReward))]
     /*-----------------------------------------------------------------------------------------------*/
     #[case(delegate_staking(), transfer(),           Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(delegate_staking(), burn(),               Err(ConnectTransactionError::InvalidInputTypeInReward))]
@@ -1010,17 +949,6 @@ mod tests {
     #[case(delegate_staking(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(delegate_staking(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
     #[case(delegate_staking(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(delegate_staking(), spend_share(),        Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    /*-----------------------------------------------------------------------------------------------*/
-    #[case(spend_share(), transfer(),           Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(spend_share(), burn(),               Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(spend_share(), lock_then_transfer(), Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(spend_share(), stake_pool(),         Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(spend_share(), produce_block(),      Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(spend_share(), decommission_pool(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(spend_share(), create_delegation(),  Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(spend_share(), delegate_staking(),   Err(ConnectTransactionError::InvalidInputTypeInReward))]
-    #[case(spend_share(), spend_share(),        Err(ConnectTransactionError::InvalidInputTypeInReward))]
     fn reward_one_to_one(
         #[case] input_utxo: TxOutput,
         #[case] output: TxOutput,
@@ -1102,7 +1030,6 @@ mod tests {
                 decommission_pool(),
                 create_delegation(),
                 delegate_staking(),
-                spend_share(),
             ];
 
             let number_of_outputs = rng.gen_range(1..10);
@@ -1132,7 +1059,6 @@ mod tests {
             decommission_pool(),
             create_delegation(),
             delegate_staking(),
-            spend_share(),
         ];
 
         let number_of_outputs = rng.gen_range(2..10);

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -21,7 +21,6 @@ mod input_output_policy;
 mod optional_tx_index_cache;
 mod reward_distribution;
 mod signature_check;
-mod timelock_check;
 mod token_issuance_cache;
 mod transferred_amount_check;
 mod tx_index_cache;
@@ -33,6 +32,7 @@ pub mod flush;
 pub mod hierarchy;
 pub mod signature_destination_getter;
 pub mod storage;
+pub mod timelock_check;
 
 mod tx_source;
 pub use tx_source::{TransactionSource, TransactionSourceForConnect};
@@ -567,8 +567,9 @@ where
             &self.storage,
             &self.chain_config,
             &self.utxo_cache,
-            tx_source,
             tx,
+            tx_source,
+            tx.transaction().get_id().into(),
             median_time_past,
         )?;
 

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -66,7 +66,7 @@ use common::{
         signature::Signable,
         signed_transaction::SignedTransaction,
         tokens::{get_tokens_issuance_count, TokenId},
-        Block, ChainConfig, DelegationId, GenBlock, OutPointSourceId, Transaction,
+        Block, ChainConfig, DelegationId, GenBlock, OutPoint, OutPointSourceId, Transaction,
         TxMainChainIndex, TxOutput,
     },
     primitives::{id::WithId, Amount, Id, Idable, H256},
@@ -339,13 +339,14 @@ where
                             Some(res)
                         }
                         TxOutput::CreateStakePool(_) => {
-                            todo!("impl");
-                            //let res = self
-                            //    .accounting_delta_adapter
-                            //    .operations(tx_source)
-                            //    .decommission_pool(*pool_id)
-                            //    .map_err(ConnectTransactionError::PoSAccountingError);
-                            //Some(res)
+                            let utxo_input0 = OutPoint::new(input.outpoint().tx_id(), 0);
+                            let pool_id = pos_accounting::make_pool_id(&utxo_input0);
+                            let res = self
+                                .accounting_delta_adapter
+                                .operations(tx_source)
+                                .decommission_pool(pool_id)
+                                .map_err(ConnectTransactionError::PoSAccountingError);
+                            Some(res)
                         }
                         TxOutput::ProduceBlockFromStake(_, pool_id) => {
                             let res = self

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -349,6 +349,8 @@ where
         let input0 = tx.inputs().get(0).ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
         let mut check_for_delegation_cleanup: Option<DelegationId> = None;
 
+        // Spending `CreateStakePool`, `ProduceBlockFromStake` or `DelegateStaking` utxos should result in either
+        // decommissioning a pool of spending share in accounting
         let inputs_undos = tx
             .inputs()
             .iter()
@@ -373,6 +375,8 @@ where
                             Some(res)
                         }
                         TxOutput::ProduceBlockFromStake(_, pool_id) => {
+                            // spending `ProduceBlockFromStake` results in decommissioning in case `CreateStakePool`
+                            // has already been spend while staking blocks
                             let res = self
                                 .accounting_delta_adapter
                                 .operations(tx_source)

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -216,8 +216,7 @@ where
                 | TxOutput::ProduceBlockFromStake(_, _)
                 | TxOutput::DecommissionPool(_, _, _, _)
                 | TxOutput::CreateDelegationId(_, _)
-                | TxOutput::DelegateStaking(_, _)
-                | TxOutput::SpendShareFromDelegation(_, _, _, _) => None,
+                | TxOutput::DelegateStaking(_, _) => None,
             })
             .sum::<Option<Amount>>()
             .ok_or_else(|| ConnectTransactionError::BurnAmountSumError(tx.get_id()))?;
@@ -243,8 +242,7 @@ where
             | TxOutput::LockThenTransfer(_, _, _)
             | TxOutput::Burn(_)
             | TxOutput::CreateDelegationId(_, _)
-            | TxOutput::DelegateStaking(_, _)
-            | TxOutput::SpendShareFromDelegation(_, _, _, _) => {
+            | TxOutput::DelegateStaking(_, _) => {
                 Err(ConnectTransactionError::InvalidOutputTypeInReward)
             }
             TxOutput::CreateStakePool(d) => Ok(d.as_ref().clone().into()),
@@ -345,7 +343,6 @@ where
                         TxOutput::CreateStakePool(_)
                         | TxOutput::DecommissionPool(_, _, _, _)
                         | TxOutput::CreateDelegationId(_, _)
-                        | TxOutput::SpendShareFromDelegation(_, _, _, _)
                         | TxOutput::Transfer(_, _)
                         | TxOutput::LockThenTransfer(_, _, _)
                         | TxOutput::Burn(_)
@@ -400,10 +397,6 @@ where
                         .delegate_staking(*delegation_id, *amount)
                         .map_err(ConnectTransactionError::PoSAccountingError);
                     Some(res)
-                }
-                TxOutput::SpendShareFromDelegation(_, _, _, _) => {
-                    // TODO: check for delegation_id mismatch
-                    None
                 }
                 TxOutput::Transfer(_, _)
                 | TxOutput::LockThenTransfer(_, _, _)
@@ -466,8 +459,7 @@ where
             TxOutput::CreateStakePool(_)
             | TxOutput::DecommissionPool(_, _, _, _)
             | TxOutput::CreateDelegationId(_, _)
-            | TxOutput::DelegateStaking(_, _)
-            | TxOutput::SpendShareFromDelegation(_, _, _, _) => {
+            | TxOutput::DelegateStaking(_, _) => {
                 let block_undo_fetcher = |id: Id<Block>| {
                     self.storage
                         .get_accounting_undo(id)

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
@@ -76,7 +76,7 @@ impl<'a> SignatureDestinationGetter<'a> {
                         ))?
                         .spend_destination()
                         .clone()),
-                    TxOutput::CreateStakePool(pool_data) => {
+                    TxOutput::CreateStakePool(_, pool_data) => {
                         // Spending an output of a pool creation transaction is only allowed in a
                         // context of a transaction (as opposed to block reward) only if this pool
                         // is being decommissioned.
@@ -120,7 +120,7 @@ impl<'a> SignatureDestinationGetter<'a> {
                         // create another block, given that this is a block reward.
                         Ok(d.clone())
                     }
-                    TxOutput::CreateStakePool(pool_data) => {
+                    TxOutput::CreateStakePool(_, pool_data) => {
                         // Spending an output of a pool creation output is only allowed when
                         // creating a block (given it's in a block reward; otherwise it should
                         // be a transaction for decommissioning the pool), hence the staker key

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
@@ -64,7 +64,6 @@ impl<'a> SignatureDestinationGetter<'a> {
                 match output {
                     TxOutput::Transfer(_, d)
                     | TxOutput::LockThenTransfer(_, d, _)
-                    | TxOutput::SpendShareFromDelegation(_, d, _, _)
                     | TxOutput::DecommissionPool(_, d, _, _) => Ok(d.clone()),
                     TxOutput::CreateDelegationId(_, _) | TxOutput::Burn(_) => {
                         // This error is emitted in other places for attempting to make this spend,
@@ -112,7 +111,6 @@ impl<'a> SignatureDestinationGetter<'a> {
                     TxOutput::Transfer(_, _)
                     | TxOutput::LockThenTransfer(_, _, _)
                     | TxOutput::DelegateStaking(_, _)
-                    | TxOutput::SpendShareFromDelegation(_, _, _, _)
                     | TxOutput::DecommissionPool(_, _, _, _) => {
                         Err(SignatureDestinationGetterError::SpendingOutputInBlockReward)
                     }

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
@@ -62,9 +62,7 @@ impl<'a> SignatureDestinationGetter<'a> {
         let destination_getter =
             |output: &TxOutput| -> Result<Destination, SignatureDestinationGetterError> {
                 match output {
-                    TxOutput::Transfer(_, d)
-                    | TxOutput::LockThenTransfer(_, d, _)
-                    | TxOutput::DecommissionPool(_, d, _, _) => Ok(d.clone()),
+                    TxOutput::Transfer(_, d) | TxOutput::LockThenTransfer(_, d, _) => Ok(d.clone()),
                     TxOutput::CreateDelegationId(_, _) | TxOutput::Burn(_) => {
                         // This error is emitted in other places for attempting to make this spend,
                         // but this is just a double-check.
@@ -110,8 +108,7 @@ impl<'a> SignatureDestinationGetter<'a> {
                 match output {
                     TxOutput::Transfer(_, _)
                     | TxOutput::LockThenTransfer(_, _, _)
-                    | TxOutput::DelegateStaking(_, _)
-                    | TxOutput::DecommissionPool(_, _, _, _) => {
+                    | TxOutput::DelegateStaking(_, _) => {
                         Err(SignatureDestinationGetterError::SpendingOutputInBlockReward)
                     }
                     TxOutput::CreateDelegationId(_, _) | TxOutput::Burn(_) => {

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -108,7 +108,7 @@ where
             | TxOutput::LockThenTransfer(_, _, _)
             | TxOutput::Burn(_)
             | TxOutput::CreateDelegationId(_, _) => None,
-            TxOutput::CreateStakePool(_) | TxOutput::ProduceBlockFromStake(_, _) => {
+            TxOutput::CreateStakePool(_, _) | TxOutput::ProduceBlockFromStake(_, _) => {
                 Some(OutputTimelockCheckRequired::DecommissioningMaturity)
             }
             TxOutput::DelegateStaking(_, _) => {
@@ -164,7 +164,7 @@ where
             match output {
                 TxOutput::Transfer(_, _)
                 | TxOutput::Burn(_)
-                | TxOutput::CreateStakePool(_)
+                | TxOutput::CreateStakePool(_, _)
                 | TxOutput::ProduceBlockFromStake(_, _)
                 | TxOutput::CreateDelegationId(_, _)
                 | TxOutput::DelegateStaking(_, _) => Ok(()),

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -107,7 +107,6 @@ where
             TxOutput::Transfer(_, _)
             | TxOutput::LockThenTransfer(_, _, _)
             | TxOutput::Burn(_)
-            | TxOutput::DecommissionPool(_, _, _, _)
             | TxOutput::CreateDelegationId(_, _) => None,
             TxOutput::CreateStakePool(_) | TxOutput::ProduceBlockFromStake(_, _) => {
                 Some(OutputTimelockCheckRequired::DecommissioningMaturity)
@@ -181,11 +180,6 @@ where
                         check_output_timelock(timelock, required)
                     }
                 },
-                TxOutput::DecommissionPool(_, _, _, timelock) => {
-                    let required =
-                        chain_config.as_ref().decommission_pool_maturity_distance(block_height);
-                    check_output_timelock(timelock, required)
-                }
             }?;
         }
     }

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -115,9 +115,9 @@ fn get_output_value<P: PoSAccountingView>(
             OutputValue::Coin(pledge_amount)
         }
         TxOutput::CreateDelegationId(_, _) => OutputValue::Coin(Amount::ZERO),
-        TxOutput::DecommissionPool(v, _, _, _)
-        | TxOutput::DelegateStaking(v, _)
-        | TxOutput::SpendShareFromDelegation(v, _, _, _) => OutputValue::Coin(*v),
+        TxOutput::DecommissionPool(v, _, _, _) | TxOutput::DelegateStaking(v, _) => {
+            OutputValue::Coin(*v)
+        }
     };
     Ok(res)
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -115,9 +115,7 @@ fn get_output_value<P: PoSAccountingView>(
             OutputValue::Coin(pledge_amount)
         }
         TxOutput::CreateDelegationId(_, _) => OutputValue::Coin(Amount::ZERO),
-        TxOutput::DecommissionPool(v, _, _, _) | TxOutput::DelegateStaking(v, _) => {
-            OutputValue::Coin(*v)
-        }
+        TxOutput::DelegateStaking(v, _) => OutputValue::Coin(*v),
     };
     Ok(res)
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -105,7 +105,7 @@ fn get_output_value<P: PoSAccountingView>(
         TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
             v.clone()
         }
-        TxOutput::CreateStakePool(data) => OutputValue::Coin(data.value()),
+        TxOutput::CreateStakePool(_, data) => OutputValue::Coin(data.value()),
         TxOutput::ProduceBlockFromStake(_, pool_id) => {
             let pledge_amount = pos_accounting_view
                 .get_pool_data(*pool_id)
@@ -433,7 +433,7 @@ mod tests {
             PerThousand::new(0).unwrap(),
             Amount::ZERO,
         );
-        let input_utxo = TxOutput::CreateStakePool(Box::new(stake_pool_data.clone()));
+        let input_utxo = TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data.clone()));
         let utxo_db = utxo::UtxosDBInMemoryImpl::new(
             Id::<GenBlock>::new(H256::zero()),
             BTreeMap::from_iter([(
@@ -504,7 +504,7 @@ mod tests {
             PerThousand::new(0).unwrap(),
             Amount::ZERO,
         );
-        let input_utxo = TxOutput::CreateStakePool(Box::new(stake_pool_data_1.clone()));
+        let input_utxo = TxOutput::CreateStakePool(pool_id_1, Box::new(stake_pool_data_1.clone()));
         let utxo_db = utxo::UtxosDBInMemoryImpl::new(
             Id::<GenBlock>::new(H256::zero()),
             BTreeMap::from_iter([(

--- a/common/src/chain/tokens/tokens_utils.rs
+++ b/common/src/chain/tokens/tokens_utils.rs
@@ -44,8 +44,7 @@ pub fn get_tokens_issuance_count(outputs: &[TxOutput]) -> usize {
             | TxOutput::ProduceBlockFromStake(_, _)
             | TxOutput::DecommissionPool(_, _, _, _)
             | TxOutput::CreateDelegationId(_, _)
-            | TxOutput::DelegateStaking(_, _)
-            | TxOutput::SpendShareFromDelegation(_, _, _, _) => false,
+            | TxOutput::DelegateStaking(_, _) => false,
         })
         .count()
 }

--- a/common/src/chain/tokens/tokens_utils.rs
+++ b/common/src/chain/tokens/tokens_utils.rs
@@ -40,7 +40,7 @@ pub fn get_tokens_issuance_count(outputs: &[TxOutput]) -> usize {
             TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) | TxOutput::Burn(v) => {
                 is_tokens_issuance(v)
             }
-            TxOutput::CreateStakePool(_)
+            TxOutput::CreateStakePool(_, _)
             | TxOutput::ProduceBlockFromStake(_, _)
             | TxOutput::CreateDelegationId(_, _)
             | TxOutput::DelegateStaking(_, _) => false,

--- a/common/src/chain/tokens/tokens_utils.rs
+++ b/common/src/chain/tokens/tokens_utils.rs
@@ -42,7 +42,6 @@ pub fn get_tokens_issuance_count(outputs: &[TxOutput]) -> usize {
             }
             TxOutput::CreateStakePool(_)
             | TxOutput::ProduceBlockFromStake(_, _)
-            | TxOutput::DecommissionPool(_, _, _, _)
             | TxOutput::CreateDelegationId(_, _)
             | TxOutput::DelegateStaking(_, _) => false,
         })

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -62,8 +62,6 @@ pub enum TxOutput {
     CreateDelegationId(Destination, PoolId),
     #[codec(index = 7)]
     DelegateStaking(Amount, DelegationId),
-    #[codec(index = 8)]
-    SpendShareFromDelegation(Amount, Destination, DelegationId, OutputTimeLock),
 }
 
 impl TxOutput {
@@ -75,9 +73,9 @@ impl TxOutput {
             | TxOutput::ProduceBlockFromStake(_, _)
             | TxOutput::CreateDelegationId(_, _)
             | TxOutput::DelegateStaking(_, _) => None,
-            TxOutput::LockThenTransfer(_, _, tl)
-            | TxOutput::DecommissionPool(_, _, _, tl)
-            | TxOutput::SpendShareFromDelegation(_, _, _, tl) => Some(tl),
+            TxOutput::LockThenTransfer(_, _, tl) | TxOutput::DecommissionPool(_, _, _, tl) => {
+                Some(tl)
+            }
         }
     }
 }

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -51,7 +51,7 @@ pub enum TxOutput {
     Burn(OutputValue),
     /// Output type that is used to create a stake pool
     #[codec(index = 3)]
-    CreateStakePool(Box<StakePoolData>),
+    CreateStakePool(PoolId, Box<StakePoolData>),
     /// Output type that represents spending of a stake pool output in a block reward
     /// in order to produce a block
     #[codec(index = 4)]
@@ -67,7 +67,7 @@ impl TxOutput {
         match self {
             TxOutput::Transfer(_, _)
             | TxOutput::Burn(_)
-            | TxOutput::CreateStakePool(_)
+            | TxOutput::CreateStakePool(_, _)
             | TxOutput::ProduceBlockFromStake(_, _)
             | TxOutput::CreateDelegationId(_, _)
             | TxOutput::DelegateStaking(_, _) => None,

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -57,10 +57,8 @@ pub enum TxOutput {
     #[codec(index = 4)]
     ProduceBlockFromStake(Destination, PoolId),
     #[codec(index = 5)]
-    DecommissionPool(Amount, Destination, PoolId, OutputTimeLock),
-    #[codec(index = 6)]
     CreateDelegationId(Destination, PoolId),
-    #[codec(index = 7)]
+    #[codec(index = 6)]
     DelegateStaking(Amount, DelegationId),
 }
 
@@ -73,9 +71,7 @@ impl TxOutput {
             | TxOutput::ProduceBlockFromStake(_, _)
             | TxOutput::CreateDelegationId(_, _)
             | TxOutput::DelegateStaking(_, _) => None,
-            TxOutput::LockThenTransfer(_, _, tl) | TxOutput::DecommissionPool(_, _, _, tl) => {
-                Some(tl)
-            }
+            TxOutput::LockThenTransfer(_, _, tl) => Some(tl),
         }
     }
 }

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -738,7 +738,7 @@ fn check_mutate_output(
         TxOutput::Transfer(v, d) => TxOutput::Transfer(add_value(v), d),
         TxOutput::LockThenTransfer(v, d, l) => TxOutput::LockThenTransfer(add_value(v), d, l),
         TxOutput::Burn(v) => TxOutput::Burn(add_value(v)),
-        TxOutput::CreateStakePool(_) => unreachable!(), // TODO: come back to this later
+        TxOutput::CreateStakePool(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::ProduceBlockFromStake(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::CreateDelegationId(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::DelegateStaking(_, _) => unreachable!(), // TODO: come back to this later

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -743,7 +743,6 @@ fn check_mutate_output(
         TxOutput::DecommissionPool(_, _, _, _) => unreachable!(), // TODO: come back to this later
         TxOutput::CreateDelegationId(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::DelegateStaking(_, _) => unreachable!(), // TODO: come back to this later
-        TxOutput::SpendShareFromDelegation(_, _, _, _) => unreachable!(), // TODO: come back to this later
     };
 
     let tx = tx_updater.generate_tx().unwrap();

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -740,7 +740,6 @@ fn check_mutate_output(
         TxOutput::Burn(v) => TxOutput::Burn(add_value(v)),
         TxOutput::CreateStakePool(_) => unreachable!(), // TODO: come back to this later
         TxOutput::ProduceBlockFromStake(_, _) => unreachable!(), // TODO: come back to this later
-        TxOutput::DecommissionPool(_, _, _, _) => unreachable!(), // TODO: come back to this later
         TxOutput::CreateDelegationId(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::DelegateStaking(_, _) => unreachable!(), // TODO: come back to this later
     };

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -1089,7 +1089,6 @@ fn mutate_output(_rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedT
         TxOutput::DecommissionPool(_, _, _, _) => unreachable!(), // TODO: come back to this later
         TxOutput::CreateDelegationId(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::DelegateStaking(_, _) => unreachable!(), // TODO: come back to this later
-        TxOutput::SpendShareFromDelegation(_, _, _, _) => unreachable!(), // TODO: come back to this later
     };
     SignedTransactionWithUtxo {
         tx: updater.generate_tx().unwrap(),

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -1084,7 +1084,7 @@ fn mutate_output(_rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedT
         TxOutput::Transfer(v, d) => TxOutput::Transfer(add_value(v), d),
         TxOutput::LockThenTransfer(v, d, l) => TxOutput::LockThenTransfer(add_value(v), d, l),
         TxOutput::Burn(v) => TxOutput::Burn(add_value(v)),
-        TxOutput::CreateStakePool(_) => unreachable!(), // TODO: come back to this later
+        TxOutput::CreateStakePool(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::ProduceBlockFromStake(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::CreateDelegationId(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::DelegateStaking(_, _) => unreachable!(), // TODO: come back to this later

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -1086,7 +1086,6 @@ fn mutate_output(_rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedT
         TxOutput::Burn(v) => TxOutput::Burn(add_value(v)),
         TxOutput::CreateStakePool(_) => unreachable!(), // TODO: come back to this later
         TxOutput::ProduceBlockFromStake(_, _) => unreachable!(), // TODO: come back to this later
-        TxOutput::DecommissionPool(_, _, _, _) => unreachable!(), // TODO: come back to this later
         TxOutput::CreateDelegationId(_, _) => unreachable!(), // TODO: come back to this later
         TxOutput::DelegateStaking(_, _) => unreachable!(), // TODO: come back to this later
     };

--- a/consensus/src/pos/block_sig.rs
+++ b/consensus/src/pos/block_sig.rs
@@ -47,8 +47,7 @@ fn get_staking_kernel_destination(
         | TxOutput::LockThenTransfer(_, _, _)
         | TxOutput::Burn(_)
         | TxOutput::CreateDelegationId(_, _)
-        | TxOutput::DelegateStaking(_, _)
-        | TxOutput::DecommissionPool(_, _, _, _) => {
+        | TxOutput::DelegateStaking(_, _) => {
             return Err(BlockSignatureError::WrongOutputType(header.get_id()))
         }
         TxOutput::CreateStakePool(stake_pool) => stake_pool.staker(),

--- a/consensus/src/pos/block_sig.rs
+++ b/consensus/src/pos/block_sig.rs
@@ -50,7 +50,7 @@ fn get_staking_kernel_destination(
         | TxOutput::DelegateStaking(_, _) => {
             return Err(BlockSignatureError::WrongOutputType(header.get_id()))
         }
-        TxOutput::CreateStakePool(stake_pool) => stake_pool.staker(),
+        TxOutput::CreateStakePool(_, stake_pool) => stake_pool.staker(),
         TxOutput::ProduceBlockFromStake(dest, _) => dest,
     };
 

--- a/consensus/src/pos/block_sig.rs
+++ b/consensus/src/pos/block_sig.rs
@@ -48,7 +48,6 @@ fn get_staking_kernel_destination(
         | TxOutput::Burn(_)
         | TxOutput::CreateDelegationId(_, _)
         | TxOutput::DelegateStaking(_, _)
-        | TxOutput::SpendShareFromDelegation(_, _, _, _)
         | TxOutput::DecommissionPool(_, _, _, _) => {
             return Err(BlockSignatureError::WrongOutputType(header.get_id()))
         }

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -145,7 +145,6 @@ where
         TxOutput::Transfer(_, _)
         | TxOutput::LockThenTransfer(_, _, _)
         | TxOutput::Burn(_)
-        | TxOutput::DecommissionPool(_, _, _, _)
         | TxOutput::CreateDelegationId(_, _)
         | TxOutput::DelegateStaking(_, _) => {
             // only pool outputs can be staked

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -147,8 +147,7 @@ where
         | TxOutput::Burn(_)
         | TxOutput::DecommissionPool(_, _, _, _)
         | TxOutput::CreateDelegationId(_, _)
-        | TxOutput::DelegateStaking(_, _)
-        | TxOutput::SpendShareFromDelegation(_, _, _, _) => {
+        | TxOutput::DelegateStaking(_, _) => {
             // only pool outputs can be staked
             return Err(ConsensusPoSError::RandomnessError(
                 PoSRandomnessError::InvalidOutputTypeInStakeKernel(header.get_id()),

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -152,7 +152,7 @@ where
                 PoSRandomnessError::InvalidOutputTypeInStakeKernel(header.get_id()),
             ));
         }
-        TxOutput::CreateStakePool(d) => d.as_ref().vrf_public_key().clone(),
+        TxOutput::CreateStakePool(_, d) => d.as_ref().vrf_public_key().clone(),
         TxOutput::ProduceBlockFromStake(_, pool_id) => {
             let pool_data = pos_accounting_view
                 .get_pool_data(pool_id)?

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -146,7 +146,6 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::InvalidDecommissionMaturityDistance(_, _) => 100,
             ConnectTransactionError::InvalidDecommissionMaturityDistanceValue(_) => 100,
             ConnectTransactionError::InvalidDecommissionMaturityType => 100,
-            ConnectTransactionError::PoolIdMismatch(_, _) => 100,
 
             // Should not happen when processing standalone transactions
             ConnectTransactionError::BlockHeightArithmeticError => 0,

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -146,6 +146,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::InvalidDecommissionMaturityDistance(_, _) => 100,
             ConnectTransactionError::InvalidDecommissionMaturityDistanceValue(_) => 100,
             ConnectTransactionError::InvalidDecommissionMaturityType => 100,
+            ConnectTransactionError::PoolIdMismatch(_, _) => 100,
 
             // Should not happen when processing standalone transactions
             ConnectTransactionError::BlockHeightArithmeticError => 0,

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -143,6 +143,9 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::SpendStakeError(_) => 100,
             ConnectTransactionError::PoolOwnerRewardCalculationFailed(_, _) => 100,
             ConnectTransactionError::PoolOwnerRewardCannotExceedTotalReward(_, _, _, _) => 100,
+            ConnectTransactionError::InvalidDecommissionMaturityDistance(_, _) => 100,
+            ConnectTransactionError::InvalidDecommissionMaturityDistanceValue(_) => 100,
+            ConnectTransactionError::InvalidDecommissionMaturityType => 100,
 
             // Should not happen when processing standalone transactions
             ConnectTransactionError::BlockHeightArithmeticError => 0,

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use chainstate::{
+    ban_score::BanScore,
     tx_verifier::transaction_verifier::signature_destination_getter::SignatureDestinationGetterError,
     ChainstateError, ConnectTransactionError, TokensError, TransactionVerifierStorageError,
     TxIndexError,
@@ -119,7 +120,7 @@ impl MempoolBanScore for ConnectTransactionError {
             // These depend on the current chainstate. Since it is not easy to determine whether
             // it is the transaction or the current tip that's wrong, we don't punish the peer.
             ConnectTransactionError::MissingOutputOrSpent => 0,
-            ConnectTransactionError::TimeLockViolation => 0,
+            ConnectTransactionError::TimeLockViolation(_) => 0,
 
             // These are delegated to the inner error
             ConnectTransactionError::UtxoError(err) => err.mempool_ban_score(),
@@ -143,9 +144,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::SpendStakeError(_) => 100,
             ConnectTransactionError::PoolOwnerRewardCalculationFailed(_, _) => 100,
             ConnectTransactionError::PoolOwnerRewardCannotExceedTotalReward(_, _, _, _) => 100,
-            ConnectTransactionError::InvalidDecommissionMaturityDistance(_, _) => 100,
-            ConnectTransactionError::InvalidDecommissionMaturityDistanceValue(_) => 100,
-            ConnectTransactionError::InvalidDecommissionMaturityType => 100,
+            ConnectTransactionError::OutputTimelockError(err) => err.ban_score(),
 
             // Should not happen when processing standalone transactions
             ConnectTransactionError::BlockHeightArithmeticError => 0,

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -456,7 +456,6 @@ fn can_be_spent(output: &TxOutput) -> bool {
         TxOutput::Transfer(_, _)
         | TxOutput::LockThenTransfer(_, _, _)
         | TxOutput::CreateStakePool(_)
-        | TxOutput::DecommissionPool(_, _, _, _)
         | TxOutput::ProduceBlockFromStake(_, _)
         | TxOutput::DelegateStaking(_, _) => true,
         TxOutput::CreateDelegationId(_, _) | TxOutput::Burn(_) => false,

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -458,8 +458,7 @@ fn can_be_spent(output: &TxOutput) -> bool {
         | TxOutput::CreateStakePool(_)
         | TxOutput::DecommissionPool(_, _, _, _)
         | TxOutput::ProduceBlockFromStake(_, _)
-        | TxOutput::DelegateStaking(_, _)
-        | TxOutput::SpendShareFromDelegation(_, _, _, _) => true,
+        | TxOutput::DelegateStaking(_, _) => true,
         TxOutput::CreateDelegationId(_, _) | TxOutput::Burn(_) => false,
     }
 }

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -453,12 +453,12 @@ impl<P> FlushableUtxoView for UtxosCache<P> {
 
 fn can_be_spent(output: &TxOutput) -> bool {
     match output {
-        TxOutput::Transfer(_, _)
-        | TxOutput::LockThenTransfer(_, _, _)
-        | TxOutput::CreateStakePool(_)
-        | TxOutput::ProduceBlockFromStake(_, _)
-        | TxOutput::DelegateStaking(_, _) => true,
-        TxOutput::CreateDelegationId(_, _) | TxOutput::Burn(_) => false,
+        TxOutput::Transfer(..)
+        | TxOutput::LockThenTransfer(..)
+        | TxOutput::CreateStakePool(..)
+        | TxOutput::ProduceBlockFromStake(..)
+        | TxOutput::DelegateStaking(..) => true,
+        TxOutput::CreateDelegationId(..) | TxOutput::Burn(..) => false,
     }
 }
 

--- a/wallet/src/account.rs
+++ b/wallet/src/account.rs
@@ -195,9 +195,7 @@ impl Account {
     fn is_mine_or_watched(&self, txo: &TxOutput) -> bool {
         // TODO: Should we also report `AnyoneCanSpend` as own?
         match txo {
-            TxOutput::Transfer(_, d)
-            | TxOutput::LockThenTransfer(_, d, _)
-            | TxOutput::DecommissionPool(_, d, _, _) => match d {
+            TxOutput::Transfer(_, d) | TxOutput::LockThenTransfer(_, d, _) => match d {
                 Destination::Address(pkh) => self.key_chain.is_public_key_hash_mine(pkh),
                 Destination::PublicKey(pk) => self.key_chain.is_public_key_mine(pk),
                 Destination::AnyoneCanSpend

--- a/wallet/src/account.rs
+++ b/wallet/src/account.rs
@@ -204,7 +204,7 @@ impl Account {
             },
             TxOutput::Burn(_)
             | TxOutput::CreateDelegationId(_, _)
-            | TxOutput::CreateStakePool(_)
+            | TxOutput::CreateStakePool(_, _)
             | TxOutput::ProduceBlockFromStake(_, _) => false,
             TxOutput::DelegateStaking(_, _) => unimplemented!("PoSAccountingView is required"),
         }

--- a/wallet/src/account.rs
+++ b/wallet/src/account.rs
@@ -197,7 +197,6 @@ impl Account {
         match txo {
             TxOutput::Transfer(_, d)
             | TxOutput::LockThenTransfer(_, d, _)
-            | TxOutput::SpendShareFromDelegation(_, d, _, _)
             | TxOutput::DecommissionPool(_, d, _, _) => match d {
                 Destination::Address(pkh) => self.key_chain.is_public_key_hash_mine(pkh),
                 Destination::PublicKey(pk) => self.key_chain.is_public_key_mine(pk),


### PR DESCRIPTION
- Removed `DecommissionPool` and `SpendShareFromPool` from `TxOutput`. From now on `LockThenTransfer` should be used instead. It means that tx `CreateStakePool` -> `LockThenTransfer` will decommission pool and tx `DelegateStaking` -> `LockThenTransfer` will spend share from delegation
- Added `PoolId` to `TxOutput::CreateStakePool` in order to check that block reward cannot misuse pool in StakePool -> ProduceBlockFromStake situation when a staker has 2 pools to stake.
- `check_outputs_timelock` function was moved from ChaninstateRef to TxVerifier because now it requires history to check the lock in txs like `CreateStakePool` -> `LockThenTransfer`

Closes #893 