### PR TITLE
Transaction inputs from accounts

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -156,10 +156,13 @@ impl BanScore for SignatureDestinationGetterError {
     fn ban_score(&self) -> u32 {
         match self {
             SignatureDestinationGetterError::SpendingOutputInBlockReward => 100,
+            SignatureDestinationGetterError::SpendingFromAccountInBlockReward => 100,
             SignatureDestinationGetterError::SigVerifyOfBurnedOutput => 100,
             SignatureDestinationGetterError::PoolDataNotFound(_) => 100,
             SignatureDestinationGetterError::DelegationDataNotFound(_) => 100,
             SignatureDestinationGetterError::SigVerifyPoSAccountingError(_) => 100,
+            SignatureDestinationGetterError::UtxoOutputNotFound(_) => 100,
+            SignatureDestinationGetterError::UtxoViewError(_) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -140,6 +140,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::NonceIsNotIncremental(_) => 100,
             ConnectTransactionError::AttemptToCreateStakePoolFromAccounts => 100,
             ConnectTransactionError::AttemptToCreateDelegationFromAccounts => 100,
+            ConnectTransactionError::MissingTransactionNonce(_) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -141,6 +141,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::AttemptToCreateStakePoolFromAccounts => 100,
             ConnectTransactionError::AttemptToCreateDelegationFromAccounts => 100,
             ConnectTransactionError::MissingTransactionNonce(_) => 100,
+            ConnectTransactionError::FailedToIncrementAccountNonce => 0,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -133,6 +133,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::BlockRewardInputOutputMismatch(_, _) => 100,
             ConnectTransactionError::TotalDelegationBalanceZero(_) => 0,
             ConnectTransactionError::DelegationDataNotFound(_) => 0,
+            ConnectTransactionError::DelegationBalanceNotFound(_) => 0,
             ConnectTransactionError::DestinationRetrievalError(err) => err.ban_score(),
             ConnectTransactionError::OutputTimelockError(err) => err.ban_score(),
             ConnectTransactionError::NotEnoughPledgeToCreateStakePool(_, _, _) => 100,

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -401,6 +401,7 @@ impl BanScore for utxo::Error {
             utxo::Error::NoBlockchainHeightFound => 0,
             utxo::Error::MissingBlockRewardUndo(_) => 0,
             utxo::Error::InvalidBlockRewardOutputType(_) => 100,
+            utxo::Error::TxInputAndUndoMismatch(_) => 100,
             utxo::Error::ViewRead => 0,
             utxo::Error::StorageWrite => 0,
         }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -137,6 +137,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::DestinationRetrievalError(err) => err.ban_score(),
             ConnectTransactionError::OutputTimelockError(err) => err.ban_score(),
             ConnectTransactionError::NotEnoughPledgeToCreateStakePool(_, _, _) => 100,
+            ConnectTransactionError::NonceIsNotIncremental(_) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -138,6 +138,8 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::OutputTimelockError(err) => err.ban_score(),
             ConnectTransactionError::NotEnoughPledgeToCreateStakePool(_, _, _) => 100,
             ConnectTransactionError::NonceIsNotIncremental(_) => 100,
+            ConnectTransactionError::AttemptToCreateStakePoolFromAccounts => 100,
+            ConnectTransactionError::AttemptToCreateDelegationFromAccounts => 100,
         }
     }
 }

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -31,8 +31,8 @@ use common::{
         config::EpochIndex,
         tokens::TokenAuxiliaryData,
         tokens::{get_tokens_issuance_count, TokenId},
-        AccountType, Block, ChainConfig, GenBlock, GenBlockId, OutPoint, OutPointSourceId,
-        Transaction, TxOutput,
+        AccountType, Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId, Transaction,
+        TxOutput, UtxoOutPoint,
     },
     primitives::{id::WithId, BlockHeight, Id, Idable},
     time_getter::TimeGetter,
@@ -483,7 +483,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                 match block.consensus_data() {
                     ConsensusData::None | ConsensusData::PoW(_) => match output {
                         TxOutput::LockThenTransfer(_, _, tl) => {
-                            let outpoint = OutPoint::new(block.get_id().into(), index as u32);
+                            let outpoint = UtxoOutPoint::new(block.get_id().into(), index as u32);
                             let required =
                                 block.consensus_data().reward_maturity_distance(self.chain_config);
                             tx_verifier::timelock_check::check_output_maturity_setting(

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -660,7 +660,6 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         self.check_duplicate_inputs(block).log_err()?;
         self.check_tokens_txs(block).log_err()?;
         self.check_no_signature_size(block).log_err()?;
-        // FIXME: check nonce
         Ok(())
     }
 

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -31,8 +31,8 @@ use common::{
         config::EpochIndex,
         tokens::TokenAuxiliaryData,
         tokens::{get_tokens_issuance_count, TokenId},
-        Block, ChainConfig, GenBlock, GenBlockId, OutPoint, OutPointSourceId, Transaction,
-        TxOutput,
+        AccountType, Block, ChainConfig, GenBlock, GenBlockId, OutPoint, OutPointSourceId,
+        Transaction, TxOutput,
     },
     primitives::{id::WithId, BlockHeight, Id, Idable},
     time_getter::TimeGetter,
@@ -333,6 +333,13 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         epoch_index: EpochIndex,
     ) -> Result<Option<EpochData>, PropertyQueryError> {
         self.db_tx.get_epoch_data(epoch_index).map_err(PropertyQueryError::from)
+    }
+
+    pub fn get_account_nonce_count(
+        &self,
+        account: AccountType,
+    ) -> Result<Option<u128>, PropertyQueryError> {
+        self.db_tx.get_account_nonce_count(account).map_err(PropertyQueryError::from)
     }
 
     pub fn get_block_height_in_main_chain(

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -660,6 +660,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         self.check_duplicate_inputs(block).log_err()?;
         self.check_tokens_txs(block).log_err()?;
         self.check_no_signature_size(block).log_err()?;
+        // FIXME: check nonce
         Ok(())
     }
 

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -577,14 +577,14 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             let mut tx_inputs = BTreeSet::new();
             for input in tx.inputs() {
                 ensure!(
-                    tx_inputs.insert(input.outpoint()),
+                    tx_inputs.insert(input),
                     CheckBlockTransactionsError::DuplicateInputInTransaction(
                         tx.transaction().get_id(),
                         block.get_id()
                     )
                 );
                 ensure!(
-                    block_inputs.insert(input.outpoint()),
+                    block_inputs.insert(input),
                     CheckBlockTransactionsError::DuplicateInputInBlock(block.get_id())
                 );
             }

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -31,8 +31,8 @@ use common::{
         config::EpochIndex,
         tokens::TokenAuxiliaryData,
         tokens::{get_tokens_issuance_count, TokenId},
-        AccountType, Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId, Transaction,
-        TxOutput, UtxoOutPoint,
+        AccountNonce, AccountType, Block, ChainConfig, GenBlock, GenBlockId, OutPointSourceId,
+        Transaction, TxOutput, UtxoOutPoint,
     },
     primitives::{id::WithId, BlockHeight, Id, Idable},
     time_getter::TimeGetter,
@@ -338,7 +338,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     pub fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, PropertyQueryError> {
+    ) -> Result<Option<AccountNonce>, PropertyQueryError> {
         self.db_tx.get_account_nonce_count(account).map_err(PropertyQueryError::from)
     }
 

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -28,8 +28,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, ChainConfig, DelegationId, GenBlock, GenBlockId, OutPointSourceId, PoolId,
-        Transaction,
+        AccountType, Block, ChainConfig, DelegationId, GenBlock, GenBlockId, OutPointSourceId,
+        PoolId, Transaction,
     },
     primitives::{Amount, Id},
 };
@@ -83,6 +83,15 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Transacti
     ) -> Result<Option<AccountingBlockUndo>, TransactionVerifierStorageError> {
         self.db_tx
             .get_accounting_undo(id)
+            .map_err(TransactionVerifierStorageError::from)
+    }
+
+    fn get_account_nonce_count(
+        &self,
+        account: AccountType,
+    ) -> Result<Option<u128>, TransactionVerifierStorageError> {
+        self.db_tx
+            .get_account_nonce_count(account)
             .map_err(TransactionVerifierStorageError::from)
     }
 }
@@ -293,6 +302,25 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
                 panic!("Flushing mempool info into the storage is forbidden")
             }
         }
+    }
+
+    fn set_account_nonce_count(
+        &mut self,
+        account: AccountType,
+        nonce: u128,
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
+        self.db_tx
+            .set_account_nonce_count(account, nonce)
+            .map_err(TransactionVerifierStorageError::from)
+    }
+
+    fn del_account_nonce_count(
+        &mut self,
+        account: AccountType,
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
+        self.db_tx
+            .del_account_nonce_count(account)
+            .map_err(TransactionVerifierStorageError::from)
     }
 }
 

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -28,8 +28,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, ChainConfig, DelegationId, GenBlock, GenBlockId, OutPointSourceId,
-        PoolId, Transaction,
+        AccountNonce, AccountType, Block, ChainConfig, DelegationId, GenBlock, GenBlockId,
+        OutPointSourceId, PoolId, Transaction,
     },
     primitives::{Amount, Id},
 };
@@ -89,7 +89,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Transacti
     fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, TransactionVerifierStorageError> {
+    ) -> Result<Option<AccountNonce>, TransactionVerifierStorageError> {
         self.db_tx
             .get_account_nonce_count(account)
             .map_err(TransactionVerifierStorageError::from)
@@ -307,7 +307,7 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
     fn set_account_nonce_count(
         &mut self,
         account: AccountType,
-        nonce: u128,
+        nonce: AccountNonce,
     ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.db_tx
             .set_account_nonce_count(account, nonce)

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -118,7 +118,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> UtxosStor
 
     fn get_utxo(
         &self,
-        outpoint: &common::chain::OutPoint,
+        outpoint: &common::chain::UtxoOutPoint,
     ) -> Result<Option<utxo::Utxo>, storage_result::Error> {
         self.db_tx.get_utxo(outpoint)
     }

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -22,7 +22,7 @@ use crate::{ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent};
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex, Locator};
 
 use common::chain::block::signed_block_header::SignedBlockHeader;
-use common::chain::AccountType;
+use common::chain::{AccountNonce, AccountType};
 use common::{
     chain::{
         block::{timestamp::BlockTimestamp, Block, BlockReward, GenBlock},
@@ -230,5 +230,5 @@ pub trait ChainstateInterface: Send {
     fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, ChainstateError>;
+    ) -> Result<Option<AccountNonce>, ChainstateError>;
 }

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -27,8 +27,8 @@ use common::{
     chain::{
         block::{timestamp::BlockTimestamp, Block, BlockReward, GenBlock},
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
-        ChainConfig, DelegationId, OutPoint, OutPointSourceId, PoolId, Transaction, TxInput,
-        TxMainChainIndex,
+        ChainConfig, DelegationId, OutPointSourceId, PoolId, Transaction, TxInput,
+        TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -180,7 +180,7 @@ pub trait ChainstateInterface: Send {
     ) -> Result<(), ChainstateError>;
 
     /// Returns the UTXO for a specified OutPoint
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, ChainstateError>;
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, ChainstateError>;
 
     /// Returns true if the initial block download isn't finished yet.
     fn is_initial_block_download(&self) -> Result<bool, ChainstateError>;

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -22,6 +22,7 @@ use crate::{ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent};
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex, Locator};
 
 use common::chain::block::signed_block_header::SignedBlockHeader;
+use common::chain::AccountType;
 use common::{
     chain::{
         block::{timestamp::BlockTimestamp, Block, BlockReward, GenBlock},
@@ -224,4 +225,10 @@ pub trait ChainstateInterface: Send {
 
     /// Returns information about the chain.
     fn info(&self) -> Result<ChainInfo, ChainstateError>;
+
+    /// Returns account nonce for the account
+    fn get_account_nonce_count(
+        &self,
+        account: AccountType,
+    ) -> Result<Option<u128>, ChainstateError>;
 }

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -394,7 +394,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
                         None => Ok(None),
                     }
                 }
-                TxInput::Account(_, _) => Ok(None),
+                TxInput::Account(_) => Ok(None),
             })
             .collect::<Result<Vec<_>, _>>()
     }

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -394,7 +394,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
                         None => Ok(None),
                     }
                 }
-                TxInput::Account(_) => Ok(None),
+                TxInput::Account(_, _) => Ok(None),
             })
             .collect::<Result<Vec<_>, _>>()
     }

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -32,8 +32,8 @@ use common::{
         block::{signed_block_header::SignedBlockHeader, Block, BlockReward, GenBlock},
         config::ChainConfig,
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
-        AccountType, DelegationId, OutPoint, OutPointSourceId, PoolId, Transaction, TxInput,
-        TxMainChainIndex, TxOutput,
+        AccountType, DelegationId, OutPointSourceId, PoolId, Transaction, TxInput,
+        TxMainChainIndex, TxOutput, UtxoOutPoint,
     },
     primitives::{id::WithId, Amount, BlockHeight, Id},
 };
@@ -455,7 +455,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
         Ok(())
     }
 
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, ChainstateError> {
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, ChainstateError> {
         let chainstate_ref = self
             .chainstate
             .make_db_tx_ro()

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -32,7 +32,7 @@ use common::{
         block::{signed_block_header::SignedBlockHeader, Block, BlockReward, GenBlock},
         config::ChainConfig,
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
-        AccountType, DelegationId, OutPointSourceId, PoolId, Transaction, TxInput,
+        AccountNonce, AccountType, DelegationId, OutPointSourceId, PoolId, Transaction, TxInput,
         TxMainChainIndex, TxOutput, UtxoOutPoint,
     },
     primitives::{id::WithId, Amount, BlockHeight, Id},
@@ -561,7 +561,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
     fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, ChainstateError> {
+    ) -> Result<Option<AccountNonce>, ChainstateError> {
         self.chainstate
             .make_db_tx_ro()
             .map_err(|e| ChainstateError::FailedToReadProperty(e.into()))?

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -382,11 +382,12 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
         let utxo_view = chainstate_ref.make_utxo_view();
         let pos_accounting_view = chainstate_ref.make_pos_accounting_view();
 
+        // FIXME: reconsider
         inputs
             .iter()
             .map(|input| {
                 let utxo = utxo_view
-                    .utxo(input.outpoint())
+                    .utxo(input.outpoint().unwrap())
                     .map_err(|e| ChainstateError::FailedToReadProperty(e.into()))?;
                 match utxo {
                     Some(utxo) => get_output_coin_amount(&pos_accounting_view, utxo.output()),

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -32,8 +32,8 @@ use common::{
         block::{signed_block_header::SignedBlockHeader, Block, BlockReward, GenBlock},
         config::ChainConfig,
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
-        DelegationId, OutPoint, OutPointSourceId, PoolId, Transaction, TxInput, TxMainChainIndex,
-        TxOutput,
+        AccountType, DelegationId, OutPoint, OutPointSourceId, PoolId, Transaction, TxInput,
+        TxMainChainIndex, TxOutput,
     },
     primitives::{id::WithId, Amount, BlockHeight, Id},
 };
@@ -556,6 +556,17 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
             median_time,
             is_initial_block_download,
         })
+    }
+
+    fn get_account_nonce_count(
+        &self,
+        account: AccountType,
+    ) -> Result<Option<u128>, ChainstateError> {
+        self.chainstate
+            .make_db_tx_ro()
+            .map_err(|e| ChainstateError::FailedToReadProperty(e.into()))?
+            .get_account_nonce_count(account)
+            .map_err(ChainstateError::FailedToReadProperty)
     }
 }
 

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -25,7 +25,7 @@ use common::chain::{
     block::{signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp, BlockReward},
     config::ChainConfig,
     tokens::TokenAuxiliaryData,
-    AccountType, OutPointSourceId, TxMainChainIndex,
+    AccountNonce, AccountType, OutPointSourceId, TxMainChainIndex,
 };
 use common::chain::{Transaction, UtxoOutPoint};
 use common::{
@@ -331,7 +331,7 @@ where
     fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, ChainstateError> {
+    ) -> Result<Option<AccountNonce>, ChainstateError> {
         self.deref().get_account_nonce_count(account)
     }
 }

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -27,7 +27,7 @@ use common::chain::{
     tokens::TokenAuxiliaryData,
     AccountType, OutPointSourceId, TxMainChainIndex,
 };
-use common::chain::{OutPoint, Transaction};
+use common::chain::{Transaction, UtxoOutPoint};
 use common::{
     chain::{
         tokens::{RPCTokenInfo, TokenId},
@@ -268,7 +268,7 @@ where
         self.deref().export_bootstrap_stream(writer, include_orphans)
     }
 
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, ChainstateError> {
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, ChainstateError> {
         self.deref().utxo(outpoint)
     }
 

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -25,7 +25,7 @@ use common::chain::{
     block::{signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp, BlockReward},
     config::ChainConfig,
     tokens::TokenAuxiliaryData,
-    OutPointSourceId, TxMainChainIndex,
+    AccountType, OutPointSourceId, TxMainChainIndex,
 };
 use common::chain::{OutPoint, Transaction};
 use common::{
@@ -326,6 +326,13 @@ where
         block_id: Id<Block>,
     ) -> Result<Option<SignedBlockHeader>, ChainstateError> {
         self.deref().get_block_header(block_id)
+    }
+
+    fn get_account_nonce_count(
+        &self,
+        account: AccountType,
+    ) -> Result<Option<u128>, ChainstateError> {
+        self.deref().get_account_nonce_count(account)
     }
 }
 

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -22,7 +22,7 @@ use common::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
-        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
+        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -248,6 +248,8 @@ impl<B: storage::Backend> BlockchainStorageRead for Store<B> {
         ) -> crate::Result<Option<DeltaMergeUndo>>;
 
         fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
+
+        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
     }
 }
 
@@ -399,6 +401,9 @@ impl<B: storage::Backend> BlockchainStorageWrite for Store<B> {
 
         fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
         fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
+
+        fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> crate::Result<()>;
+        fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
     }
 }
 

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -22,7 +22,7 @@ use common::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
-        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
+        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -58,7 +58,7 @@ impl<B: storage::Backend> Store<B> {
     }
 
     /// Collect and return all utxos from the storage
-    pub fn read_utxo_set(&self) -> crate::Result<BTreeMap<OutPoint, Utxo>> {
+    pub fn read_utxo_set(&self) -> crate::Result<BTreeMap<UtxoOutPoint, Utxo>> {
         let db = self.transaction_ro()?;
         db.0.get::<db::DBUtxo, _>()
             .prefix_iter_decoded(&())
@@ -256,7 +256,7 @@ impl<B: storage::Backend> BlockchainStorageRead for Store<B> {
 impl<B: storage::Backend> UtxosStorageRead for Store<B> {
     type Error = crate::Error;
     delegate_to_transaction! {
-        fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
+        fn get_utxo(&self, outpoint: &UtxoOutPoint) -> crate::Result<Option<Utxo>>;
         fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
     }
@@ -409,8 +409,8 @@ impl<B: storage::Backend> BlockchainStorageWrite for Store<B> {
 
 impl<B: storage::Backend> UtxosStorageWrite for Store<B> {
     delegate_to_transaction! {
-        fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> crate::Result<()>;
-        fn del_utxo(&mut self, outpoint: &OutPoint) -> crate::Result<()>;
+        fn set_utxo(&mut self, outpoint: &UtxoOutPoint, entry: Utxo) -> crate::Result<()>;
+        fn del_utxo(&mut self, outpoint: &UtxoOutPoint) -> crate::Result<()>;
         fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> crate::Result<()>;
         fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> crate::Result<()>;
         fn del_undo_data(&mut self, id: Id<Block>) -> crate::Result<()>;

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -22,7 +22,8 @@ use common::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
-        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, UtxoOutPoint,
+        AccountNonce, AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId,
+        UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -249,7 +250,7 @@ impl<B: storage::Backend> BlockchainStorageRead for Store<B> {
 
         fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
 
-        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
+        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
     }
 }
 
@@ -402,7 +403,7 @@ impl<B: storage::Backend> BlockchainStorageWrite for Store<B> {
         fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
         fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
 
-        fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> crate::Result<()>;
+        fn set_account_nonce_count(&mut self, account: AccountType, nonce: AccountNonce) -> crate::Result<()>;
         fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
     }
 }

--- a/chainstate/storage/src/internal/store_tx.rs
+++ b/chainstate/storage/src/internal/store_tx.rs
@@ -21,7 +21,8 @@ use common::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
-        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, UtxoOutPoint,
+        AccountNonce, AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId,
+        UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id, Idable, H256},
 };
@@ -208,7 +209,10 @@ macro_rules! impl_read_ops {
                 self.read::<db::DBAccountingEpochDeltaUndo, _, _>(epoch_index)
             }
 
-            fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>> {
+            fn get_account_nonce_count(
+                &self,
+                account: AccountType,
+            ) -> crate::Result<Option<AccountNonce>> {
                 self.read::<db::DBAccountNonceCount, _, _>(account)
             }
         }
@@ -500,7 +504,11 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
         self.0.get_mut::<db::DBEpochData, _>().del(epoch_index).map_err(Into::into)
     }
 
-    fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> crate::Result<()> {
+    fn set_account_nonce_count(
+        &mut self,
+        account: AccountType,
+        nonce: AccountNonce,
+    ) -> crate::Result<()> {
         self.write::<db::DBAccountNonceCount, _, _, _>(account, nonce)
     }
 

--- a/chainstate/storage/src/internal/store_tx.rs
+++ b/chainstate/storage/src/internal/store_tx.rs
@@ -21,7 +21,7 @@ use common::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
-        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
+        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id, Idable, H256},
 };
@@ -216,7 +216,7 @@ macro_rules! impl_read_ops {
         impl<'st, B: storage::Backend> UtxosStorageRead for $TxType<'st, B> {
             type Error = crate::Error;
 
-            fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>> {
+            fn get_utxo(&self, outpoint: &UtxoOutPoint) -> crate::Result<Option<Utxo>> {
                 self.read::<db::DBUtxo, _, _>(outpoint)
             }
 
@@ -510,11 +510,11 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 }
 
 impl<'st, B: storage::Backend> UtxosStorageWrite for StoreTxRw<'st, B> {
-    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> crate::Result<()> {
+    fn set_utxo(&mut self, outpoint: &UtxoOutPoint, entry: Utxo) -> crate::Result<()> {
         self.write::<db::DBUtxo, _, _, _>(outpoint, entry)
     }
 
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> crate::Result<()> {
+    fn del_utxo(&mut self, outpoint: &UtxoOutPoint) -> crate::Result<()> {
         self.0.get_mut::<db::DBUtxo, _>().del(outpoint).map_err(Into::into)
     }
 

--- a/chainstate/storage/src/internal/store_tx.rs
+++ b/chainstate/storage/src/internal/store_tx.rs
@@ -21,7 +21,7 @@ use common::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::{Transaction, TxMainChainIndex, TxMainChainPosition},
-        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
+        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
     },
     primitives::{Amount, BlockHeight, Id, Idable, H256},
 };
@@ -206,6 +206,10 @@ macro_rules! impl_read_ops {
                 epoch_index: EpochIndex,
             ) -> crate::Result<Option<DeltaMergeUndo>> {
                 self.read::<db::DBAccountingEpochDeltaUndo, _, _>(epoch_index)
+            }
+
+            fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>> {
+                self.read::<db::DBAccountNonceCount, _, _>(account)
             }
         }
 
@@ -494,6 +498,14 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()> {
         self.0.get_mut::<db::DBEpochData, _>().del(epoch_index).map_err(Into::into)
+    }
+
+    fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> crate::Result<()> {
+        self.write::<db::DBAccountNonceCount, _, _, _>(account, nonce)
+    }
+
+    fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()> {
+        self.0.get_mut::<db::DBAccountNonceCount, _>().del(account).map_err(Into::into)
     }
 }
 

--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -248,7 +248,7 @@ fn test_storage_transactions_with_result_check() {
 }
 
 /// returns a tuple of utxo and outpoint, for testing.
-fn create_rand_utxo(rng: &mut (impl Rng + CryptoRng), block_height: u64) -> (Utxo, OutPoint) {
+fn create_rand_utxo(rng: &mut (impl Rng + CryptoRng), block_height: u64) -> (Utxo, UtxoOutPoint) {
     // just a random value generated, and also a random `is_block_reward` value.
     let random_value = rng.gen_range(0..(u128::MAX - 1));
     let (_, pub_key) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
@@ -259,7 +259,7 @@ fn create_rand_utxo(rng: &mut (impl Rng + CryptoRng), block_height: u64) -> (Utx
 
     // generate utxo
     let utxo = Utxo::new_for_blockchain(output, BlockHeight::new(block_height));
-    let outpoint = OutPoint::new(
+    let outpoint = UtxoOutPoint::new(
         OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))),
         0,
     );

--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -290,7 +290,7 @@ pub fn create_rand_block_undo(
         let utxo_rng = rng.gen_range(1..max_lim_of_utxos);
         let tx_utxos = (0..utxo_rng)
             .enumerate()
-            .map(|(i, _)| create_rand_utxo(rng, i as u64).0)
+            .map(|(i, _)| rng.gen::<bool>().then(|| create_rand_utxo(rng, i as u64).0))
             .collect();
 
         tx_undo.push(UtxosTxUndoWithSources::new(tx_utxos, vec![]));

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -31,7 +31,7 @@ use common::chain::block::BlockReward;
 use common::chain::config::EpochIndex;
 use common::chain::tokens::{TokenAuxiliaryData, TokenId};
 use common::chain::transaction::{Transaction, TxMainChainIndex, TxMainChainPosition};
-use common::chain::{Block, GenBlock, OutPointSourceId};
+use common::chain::{AccountType, Block, GenBlock, OutPointSourceId};
 use common::primitives::{BlockHeight, Id};
 use pos_accounting::{
     AccountingBlockUndo, DeltaMergeUndo, PoSAccountingDeltaData, PoSAccountingStorageRead,
@@ -117,6 +117,9 @@ pub trait BlockchainStorageRead:
         &self,
         epoch_index: EpochIndex,
     ) -> crate::Result<Option<DeltaMergeUndo>>;
+
+    /// Get nonce value for specific account
+    fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
 }
 
 /// Modifying operations on persistent blockchain data
@@ -208,6 +211,9 @@ pub trait BlockchainStorageWrite:
 
     // Remove accounting block undo data for specific block
     fn del_accounting_epoch_undo_delta(&mut self, epoch_index: EpochIndex) -> Result<()>;
+
+    fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> Result<()>;
+    fn del_account_nonce_count(&mut self, account: AccountType) -> Result<()>;
 }
 
 /// Marker trait for types where read/write operations are run in a transaction

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -31,7 +31,7 @@ use common::chain::block::BlockReward;
 use common::chain::config::EpochIndex;
 use common::chain::tokens::{TokenAuxiliaryData, TokenId};
 use common::chain::transaction::{Transaction, TxMainChainIndex, TxMainChainPosition};
-use common::chain::{AccountType, Block, GenBlock, OutPointSourceId};
+use common::chain::{AccountNonce, AccountType, Block, GenBlock, OutPointSourceId};
 use common::primitives::{BlockHeight, Id};
 use pos_accounting::{
     AccountingBlockUndo, DeltaMergeUndo, PoSAccountingDeltaData, PoSAccountingStorageRead,
@@ -119,7 +119,7 @@ pub trait BlockchainStorageRead:
     ) -> crate::Result<Option<DeltaMergeUndo>>;
 
     /// Get nonce value for specific account
-    fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
+    fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
 }
 
 /// Modifying operations on persistent blockchain data
@@ -212,7 +212,7 @@ pub trait BlockchainStorageWrite:
     // Remove accounting block undo data for specific block
     fn del_accounting_epoch_undo_delta(&mut self, epoch_index: EpochIndex) -> Result<()>;
 
-    fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> Result<()>;
+    fn set_account_nonce_count(&mut self, account: AccountType, nonce: AccountNonce) -> Result<()>;
     fn del_account_nonce_count(&mut self, account: AccountType) -> Result<()>;
 }
 

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -25,7 +25,7 @@ use common::{
         block::BlockReward,
         config::EpochIndex,
         transaction::{OutPointSourceId, Transaction, TxMainChainIndex, TxMainChainPosition},
-        Block, DelegationId, GenBlock, OutPoint, PoolId,
+        AccountType, Block, DelegationId, GenBlock, OutPoint, PoolId,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -89,6 +89,8 @@ mockall::mock! {
         ) -> crate::Result<Option<DeltaMergeUndo>>;
 
         fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
+
+        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
     }
 
     impl UtxosStorageRead for Store {
@@ -188,6 +190,9 @@ mockall::mock! {
 
         fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
         fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
+
+        fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> crate::Result<()>;
+        fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
     }
 
     impl UtxosStorageWrite for Store {
@@ -329,6 +334,8 @@ mockall::mock! {
         ) -> crate::Result<Option<DeltaMergeUndo>>;
 
         fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
+
+        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
     }
 
     impl crate::UtxosStorageRead for StoreTxRo {
@@ -437,6 +444,8 @@ mockall::mock! {
         ) -> crate::Result<Option<DeltaMergeUndo>>;
 
         fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
+
+       fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
     }
 
     impl UtxosStorageRead for StoreTxRw {
@@ -537,6 +546,9 @@ mockall::mock! {
 
         fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
         fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
+
+        fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> crate::Result<()>;
+        fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
     }
 
     impl UtxosStorageWrite for StoreTxRw {

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -25,7 +25,7 @@ use common::{
         block::BlockReward,
         config::EpochIndex,
         transaction::{OutPointSourceId, Transaction, TxMainChainIndex, TxMainChainPosition},
-        AccountType, Block, DelegationId, GenBlock, OutPoint, PoolId,
+        AccountType, Block, DelegationId, GenBlock, PoolId, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -95,7 +95,7 @@ mockall::mock! {
 
     impl UtxosStorageRead for Store {
         type Error = crate::Error;
-        fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
+        fn get_utxo(&self, outpoint: &UtxoOutPoint) -> crate::Result<Option<Utxo>>;
         fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
     }
@@ -196,8 +196,8 @@ mockall::mock! {
     }
 
     impl UtxosStorageWrite for Store {
-        fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> crate::Result<()>;
-        fn del_utxo(&mut self, outpoint: &OutPoint) -> crate::Result<()>;
+        fn set_utxo(&mut self, outpoint: &UtxoOutPoint, entry: Utxo) -> crate::Result<()>;
+        fn del_utxo(&mut self, outpoint: &UtxoOutPoint) -> crate::Result<()>;
 
         fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> crate::Result<()>;
 
@@ -340,7 +340,7 @@ mockall::mock! {
 
     impl crate::UtxosStorageRead for StoreTxRo {
         type Error = crate::Error;
-        fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
+        fn get_utxo(&self, outpoint: &UtxoOutPoint) -> crate::Result<Option<Utxo>>;
         fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
     }
@@ -450,7 +450,7 @@ mockall::mock! {
 
     impl UtxosStorageRead for StoreTxRw {
         type Error = crate::Error;
-        fn get_utxo(&self, outpoint: &OutPoint) -> crate::Result<Option<Utxo>>;
+        fn get_utxo(&self, outpoint: &UtxoOutPoint) -> crate::Result<Option<Utxo>>;
         fn get_best_block_for_utxos(&self) -> crate::Result<Id<GenBlock>>;
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
     }
@@ -552,8 +552,8 @@ mockall::mock! {
     }
 
     impl UtxosStorageWrite for StoreTxRw {
-        fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> crate::Result<()>;
-        fn del_utxo(&mut self, outpoint: &OutPoint) -> crate::Result<()>;
+        fn set_utxo(&mut self, outpoint: &UtxoOutPoint, entry: Utxo) -> crate::Result<()>;
+        fn del_utxo(&mut self, outpoint: &UtxoOutPoint) -> crate::Result<()>;
 
         fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> crate::Result<()>;
 

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -25,7 +25,7 @@ use common::{
         block::BlockReward,
         config::EpochIndex,
         transaction::{OutPointSourceId, Transaction, TxMainChainIndex, TxMainChainPosition},
-        AccountType, Block, DelegationId, GenBlock, PoolId, UtxoOutPoint,
+        AccountNonce, AccountType, Block, DelegationId, GenBlock, PoolId, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -90,7 +90,7 @@ mockall::mock! {
 
         fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
 
-        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
+        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
     }
 
     impl UtxosStorageRead for Store {
@@ -191,7 +191,7 @@ mockall::mock! {
         fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
         fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
 
-        fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> crate::Result<()>;
+        fn set_account_nonce_count(&mut self, account: AccountType, nonce: AccountNonce) -> crate::Result<()>;
         fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
     }
 
@@ -335,7 +335,7 @@ mockall::mock! {
 
         fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
 
-        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
+        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
     }
 
     impl crate::UtxosStorageRead for StoreTxRo {
@@ -445,7 +445,7 @@ mockall::mock! {
 
         fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
 
-       fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<u128>>;
+       fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
     }
 
     impl UtxosStorageRead for StoreTxRw {
@@ -547,7 +547,7 @@ mockall::mock! {
         fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
         fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
 
-        fn set_account_nonce_count(&mut self, account: AccountType, nonce: u128) -> crate::Result<()>;
+        fn set_account_nonce_count(&mut self, account: AccountType, nonce: AccountNonce) -> crate::Result<()>;
         fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
     }
 

--- a/chainstate/storage/src/schema.rs
+++ b/chainstate/storage/src/schema.rs
@@ -20,8 +20,8 @@ use common::{
     chain::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
-        Transaction, TxMainChainIndex,
+        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, Transaction,
+        TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -44,7 +44,7 @@ storage::decl_schema! {
         /// Storage for block IDs indexed by block height.
         pub DBBlockByHeight: Map<BlockHeight, Id<GenBlock>>,
         /// Store for Utxo Entries
-        pub DBUtxo: Map<OutPoint, Utxo>,
+        pub DBUtxo: Map<UtxoOutPoint, Utxo>,
         /// Store for utxo BlockUndo
         pub DBUtxosBlockUndo: Map<Id<Block>, UtxosBlockUndo>,
         /// Store for EpochData

--- a/chainstate/storage/src/schema.rs
+++ b/chainstate/storage/src/schema.rs
@@ -20,7 +20,7 @@ use common::{
     chain::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId, Transaction,
+        Account, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId, Transaction,
         TxMainChainIndex,
     },
     primitives::{Amount, BlockHeight, Id},
@@ -53,6 +53,8 @@ storage::decl_schema! {
         pub DBTokensAuxData: Map<TokenId, TokenAuxiliaryData>,
         /// Store of issuance tx id vs token id
         pub DBIssuanceTxVsTokenId: Map<Id<Transaction>, TokenId>,
+        /// Store the number of transactions per account
+        pub DBTransactionCounts: Map<Account, u128>,
 
         /// Store for accounting BlockUndo
         pub DBAccountingBlockUndo: Map<Id<Block>, AccountingBlockUndo>,

--- a/chainstate/storage/src/schema.rs
+++ b/chainstate/storage/src/schema.rs
@@ -20,8 +20,8 @@ use common::{
     chain::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, Transaction,
-        TxMainChainIndex, UtxoOutPoint,
+        AccountNonce, AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId,
+        Transaction, TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -54,7 +54,7 @@ storage::decl_schema! {
         /// Store of issuance tx id vs token id
         pub DBIssuanceTxVsTokenId: Map<Id<Transaction>, TokenId>,
         /// Store the number of transactions per account
-        pub DBAccountNonceCount: Map<AccountType, u128>,
+        pub DBAccountNonceCount: Map<AccountType, AccountNonce>,
 
         /// Store for accounting BlockUndo
         pub DBAccountingBlockUndo: Map<Id<Block>, AccountingBlockUndo>,

--- a/chainstate/storage/src/schema.rs
+++ b/chainstate/storage/src/schema.rs
@@ -20,8 +20,8 @@ use common::{
     chain::{
         config::EpochIndex,
         tokens::{TokenAuxiliaryData, TokenId},
-        Account, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId, Transaction,
-        TxMainChainIndex,
+        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
+        Transaction, TxMainChainIndex,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -54,7 +54,7 @@ storage::decl_schema! {
         /// Store of issuance tx id vs token id
         pub DBIssuanceTxVsTokenId: Map<Id<Transaction>, TokenId>,
         /// Store the number of transactions per account
-        pub DBTransactionCounts: Map<Account, u128>,
+        pub DBAccountNonceCount: Map<AccountType, u128>,
 
         /// Store for accounting BlockUndo
         pub DBAccountingBlockUndo: Map<Id<Block>, AccountingBlockUndo>,

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -23,7 +23,7 @@ use chainstate_types::BlockIndex;
 use common::chain::block::block_body::BlockBody;
 use common::chain::block::signed_block_header::{BlockHeaderSignature, BlockHeaderSignatureData};
 use common::chain::block::BlockHeader;
-use common::chain::{OutPoint, OutPointSourceId};
+use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::{
     chain::{
         block::{timestamp::BlockTimestamp, BlockReward, ConsensusData},
@@ -47,7 +47,7 @@ pub struct BlockBuilder<'f> {
     consensus_data: ConsensusData,
     reward: BlockReward,
     block_source: BlockSource,
-    used_utxo: BTreeSet<OutPoint>,
+    used_utxo: BTreeSet<UtxoOutPoint>,
     block_signing_key: Option<PrivateKey>,
 }
 
@@ -176,7 +176,10 @@ impl<'f> BlockBuilder<'f> {
         let (mut witnesses, mut inputs, outputs) =
             self.make_test_inputs_outputs(parent_outputs, rng);
         let spend_from = self.framework.outputs_from_genblock(spend_from.into());
-        inputs.push(TxInput::new(spend_from.keys().next().unwrap().clone(), 0));
+        inputs.push(TxInput::from_utxo(
+            spend_from.keys().next().unwrap().clone(),
+            0,
+        ));
         witnesses.push(InputWitness::NoSignature(None));
         self.transactions.push(
             SignedTransaction::new(Transaction::new(0, inputs, outputs).unwrap(), witnesses)

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -248,7 +248,7 @@ fn process_block(#[case] seed: test_utils::random::Seed) {
         .add_transaction(
             TransactionBuilder::new()
                 .add_input(
-                    TxInput::new(
+                    TxInput::from_utxo(
                         OutPointSourceId::BlockReward(<Id<GenBlock>>::from(gen_block_id)),
                         0,
                     ),

--- a/chainstate/test-framework/src/transaction_builder.rs
+++ b/chainstate/test-framework/src/transaction_builder.rs
@@ -101,7 +101,7 @@ fn build_transaction(#[case] seed: test_utils::random::Seed) {
 
     let flags = 1;
     let witness = InputWitness::NoSignature(None);
-    let input = TxInput::new(
+    let input = TxInput::from_utxo(
         OutPointSourceId::Transaction(Id::new(H256::random_using(&mut rng))),
         0,
     );

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -92,7 +92,7 @@ pub fn create_utxo_data(
 
     Some((
         empty_witness(rng),
-        TxInput::new(outsrc, index as u32),
+        TxInput::from_utxo(outsrc, index as u32),
         new_output,
     ))
 }
@@ -219,7 +219,7 @@ pub fn create_multiple_utxo_data(
 
     Some((
         empty_witness(rng),
-        TxInput::new(outsrc, index as u32),
+        TxInput::from_utxo(outsrc, index as u32),
         new_outputs,
     ))
 }

--- a/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
@@ -27,7 +27,7 @@ use chainstate_test_framework::{
 use common::{
     chain::{
         config::Builder as ConfigBuilder, stakelock::StakePoolData, tokens::OutputValue,
-        Destination, OutPoint, OutPointSourceId, PoolId, SignedTransaction, TxInput, TxOutput,
+        Destination, OutPointSourceId, PoolId, SignedTransaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, Idable},
 };
@@ -62,11 +62,11 @@ fn make_tx_with_stake_pool_from_genesis(
     tf: &mut TestFramework,
     amount_to_stake: Amount,
     amount_to_transfer: Amount,
-) -> (SignedTransaction, PoolId, PoolData, OutPoint) {
+) -> (SignedTransaction, PoolId, PoolData, UtxoOutPoint) {
     let outpoint_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
     make_tx_with_stake_pool(
         rng,
-        OutPoint::new(outpoint_id, 0),
+        UtxoOutPoint::new(outpoint_id, 0),
         amount_to_stake,
         amount_to_transfer,
     )
@@ -74,10 +74,10 @@ fn make_tx_with_stake_pool_from_genesis(
 
 fn make_tx_with_stake_pool(
     rng: &mut (impl Rng + CryptoRng),
-    input0_outpoint: OutPoint,
+    input0_outpoint: UtxoOutPoint,
     amount_to_stake: Amount,
     amount_to_transfer: Amount,
-) -> (SignedTransaction, PoolId, PoolData, OutPoint) {
+) -> (SignedTransaction, PoolId, PoolData, UtxoOutPoint) {
     let destination = new_pub_key_destination(rng);
     let pool_id = pos_accounting::make_pool_id(&input0_outpoint);
     let pool_data = create_pool_data(rng, destination, amount_to_stake);
@@ -114,7 +114,7 @@ fn make_tx_with_stake_pool(
             1,
         )
     };
-    let transfer_outpoint = OutPoint::new(
+    let transfer_outpoint = UtxoOutPoint::new(
         OutPointSourceId::Transaction(tx.transaction().get_id()),
         transfer_output_idx,
     );
@@ -668,7 +668,7 @@ fn accounting_storage_no_accounting_data(#[case] seed: Seed) {
 
         let tx1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -101,10 +101,10 @@ fn store_coin(#[case] seed: Seed) {
 
         let expected_undo_utxo_data: BTreeMap<Id<Transaction>, UtxosTxUndo> = [(
             tx_id,
-            UtxosTxUndo::new(vec![Utxo::new_for_blockchain(
+            UtxosTxUndo::new(vec![Some(Utxo::new_for_blockchain(
                 tf.genesis().utxos().first().unwrap().clone(),
                 BlockHeight::zero(),
-            )]),
+            ))]),
         )]
         .into();
 

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -23,8 +23,8 @@ use chainstate_test_framework::{
 use common::chain::{AccountOutPoint, AccountSpending, AccountType, DelegationId, PoolId};
 use common::{
     chain::{
-        timelock::OutputTimeLock, tokens::OutputValue, Destination, OutPointSourceId, TxInput,
-        TxOutput, UtxoOutPoint,
+        timelock::OutputTimeLock, tokens::OutputValue, AccountNonce, Destination, OutPointSourceId,
+        TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Idable, H256},
 };
@@ -339,7 +339,7 @@ fn delegate_staking(#[case] seed: Seed) {
         let tx = TransactionBuilder::new()
             .add_input(
                 TxInput::Account(AccountOutPoint::new(
-                    0,
+                    AccountNonce::new(0),
                     AccountSpending::Delegation(delegation_id, (amount_to_spend * 2).unwrap()),
                 )),
                 empty_witness(&mut rng),
@@ -370,7 +370,7 @@ fn delegate_staking(#[case] seed: Seed) {
             let tx = TransactionBuilder::new()
                 .add_input(
                     TxInput::Account(AccountOutPoint::new(
-                        0,
+                        AccountNonce::new(0),
                         AccountSpending::Delegation(delegation_id, spend_change),
                     )),
                     empty_witness(&mut rng),
@@ -396,7 +396,7 @@ fn delegate_staking(#[case] seed: Seed) {
         let tx = TransactionBuilder::new()
             .add_input(
                 TxInput::Account(AccountOutPoint::new(
-                    1,
+                    AccountNonce::new(1),
                     AccountSpending::Delegation(delegation_id, spend_change),
                 )),
                 empty_witness(&mut rng),
@@ -497,7 +497,7 @@ fn decommission_then_spend_share_then_cleanup_delegations(#[case] seed: Seed) {
         let tx = TransactionBuilder::new()
             .add_input(
                 TxInput::Account(AccountOutPoint::new(
-                    0,
+                    AccountNonce::new(0),
                     AccountSpending::Delegation(delegation_id, (amount_to_spend * 2).unwrap()),
                 )),
                 empty_witness(&mut rng),
@@ -527,7 +527,7 @@ fn decommission_then_spend_share_then_cleanup_delegations(#[case] seed: Seed) {
         let tx = TransactionBuilder::new()
             .add_input(
                 TxInput::Account(AccountOutPoint::new(
-                    1,
+                    AccountNonce::new(1),
                     AccountSpending::Delegation(delegation_id, spend_change),
                 )),
                 empty_witness(&mut rng),

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -338,11 +338,10 @@ fn delegate_staking(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(AccountOutPoint::new(
-                    0,
-                    AccountType::Delegation(delegation_id),
+                TxInput::Account(
+                    AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
                     (amount_to_spend * 2).unwrap(),
-                )),
+                ),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -370,11 +369,10 @@ fn delegate_staking(#[case] seed: Seed) {
             // try spend delegation without increasing nonce
             let tx = TransactionBuilder::new()
                 .add_input(
-                    TxInput::Account(AccountOutPoint::new(
-                        0,
-                        AccountType::Delegation(delegation_id),
+                    TxInput::Account(
+                        AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
                         spend_change,
-                    )),
+                    ),
                     empty_witness(&mut rng),
                 )
                 .add_output(TxOutput::LockThenTransfer(
@@ -397,11 +395,10 @@ fn delegate_staking(#[case] seed: Seed) {
         // Spend all delegation balance
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(AccountOutPoint::new(
-                    1,
-                    AccountType::Delegation(delegation_id),
+                TxInput::Account(
+                    AccountOutPoint::new(1, AccountType::Delegation(delegation_id)),
                     spend_change,
-                )),
+                ),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -499,11 +496,10 @@ fn decommission_then_spend_share_then_cleanup_delegations(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(AccountOutPoint::new(
-                    0,
-                    AccountType::Delegation(delegation_id),
+                TxInput::Account(
+                    AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
                     (amount_to_spend * 2).unwrap(),
-                )),
+                ),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -530,11 +526,10 @@ fn decommission_then_spend_share_then_cleanup_delegations(#[case] seed: Seed) {
         // Spend all delegation balance
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(AccountOutPoint::new(
-                    1,
-                    AccountType::Delegation(delegation_id),
+                TxInput::Account(
+                    AccountOutPoint::new(1, AccountType::Delegation(delegation_id)),
                     spend_change,
-                )),
+                ),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -20,7 +20,7 @@ use chainstate_storage::TipStorageTag;
 use chainstate_test_framework::{
     empty_witness, get_output_value, TestFramework, TestStore, TransactionBuilder,
 };
-use common::chain::{AccountOutPoint, AccountType, DelegationId, PoolId};
+use common::chain::{AccountOutPoint, AccountSpending, AccountType, DelegationId, PoolId};
 use common::{
     chain::{
         timelock::OutputTimeLock, tokens::OutputValue, Destination, OutPointSourceId, TxInput,
@@ -338,10 +338,10 @@ fn delegate_staking(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(
-                    AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
-                    (amount_to_spend * 2).unwrap(),
-                ),
+                TxInput::Account(AccountOutPoint::new(
+                    0,
+                    AccountSpending::Delegation(delegation_id, (amount_to_spend * 2).unwrap()),
+                )),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -369,10 +369,10 @@ fn delegate_staking(#[case] seed: Seed) {
             // try spend delegation without increasing nonce
             let tx = TransactionBuilder::new()
                 .add_input(
-                    TxInput::Account(
-                        AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
-                        spend_change,
-                    ),
+                    TxInput::Account(AccountOutPoint::new(
+                        0,
+                        AccountSpending::Delegation(delegation_id, spend_change),
+                    )),
                     empty_witness(&mut rng),
                 )
                 .add_output(TxOutput::LockThenTransfer(
@@ -395,10 +395,10 @@ fn delegate_staking(#[case] seed: Seed) {
         // Spend all delegation balance
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(
-                    AccountOutPoint::new(1, AccountType::Delegation(delegation_id)),
-                    spend_change,
-                ),
+                TxInput::Account(AccountOutPoint::new(
+                    1,
+                    AccountSpending::Delegation(delegation_id, spend_change),
+                )),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -496,10 +496,10 @@ fn decommission_then_spend_share_then_cleanup_delegations(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(
-                    AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
-                    (amount_to_spend * 2).unwrap(),
-                ),
+                TxInput::Account(AccountOutPoint::new(
+                    0,
+                    AccountSpending::Delegation(delegation_id, (amount_to_spend * 2).unwrap()),
+                )),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -526,10 +526,10 @@ fn decommission_then_spend_share_then_cleanup_delegations(#[case] seed: Seed) {
         // Spend all delegation balance
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(
-                    AccountOutPoint::new(1, AccountType::Delegation(delegation_id)),
-                    spend_change,
-                ),
+                TxInput::Account(AccountOutPoint::new(
+                    1,
+                    AccountSpending::Delegation(delegation_id, spend_change),
+                )),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -646,5 +646,3 @@ fn spend_share_then_decommission_then_cleanup_delegations(#[case] seed: Seed) {
         assert!(delegation_data.is_none());
     });
 }
-
-// FIXME: add tests that spends delegation with reward

--- a/chainstate/test-suite/src/tests/double_spend_tests.rs
+++ b/chainstate/test-suite/src/tests/double_spend_tests.rs
@@ -254,7 +254,7 @@ fn overspend_multiple_outputs(#[case] seed: Seed) {
         );
         let tx2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(tx1.transaction().get_id().into(), 0),
+                TxInput::from_utxo(tx1.transaction().get_id().into(), 0),
                 InputWitness::NoSignature(None),
             )
             .with_outputs(vec![tx2_output.clone(), tx2_output])
@@ -301,7 +301,7 @@ fn duplicate_input_in_the_same_tx(#[case] seed: Seed) {
         let first_tx = tx_from_genesis(&tf.genesis(), &mut rng, tx1_output_value);
 
         let witness = InputWitness::NoSignature(None);
-        let input = TxInput::new(first_tx.transaction().get_id().into(), 0);
+        let input = TxInput::from_utxo(first_tx.transaction().get_id().into(), 0);
         let second_tx = TransactionBuilder::new()
             .add_input(input.clone(), witness.clone())
             .add_input(input, witness)
@@ -354,9 +354,9 @@ fn same_input_diff_sig_in_the_same_tx(#[case] seed: Seed) {
         let first_tx = tx_from_genesis(&tf.genesis(), &mut rng, tx1_output_value);
 
         let witness1 = InputWitness::NoSignature(Some(vec![0, 1, 2]));
-        let input1 = TxInput::new(first_tx.transaction().get_id().into(), 0);
+        let input1 = TxInput::from_utxo(first_tx.transaction().get_id().into(), 0);
         let witness2 = InputWitness::NoSignature(Some(vec![0, 1, 2, 3]));
-        let input2 = TxInput::new(first_tx.transaction().get_id().into(), 0);
+        let input2 = TxInput::from_utxo(first_tx.transaction().get_id().into(), 0);
         let second_tx = TransactionBuilder::new()
             .add_input(input1, witness1)
             .add_input(input2, witness2)
@@ -471,7 +471,7 @@ fn try_spend_burned_output_same_block(#[case] seed: Seed) {
 
         let first_tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),
@@ -505,7 +505,7 @@ fn try_spend_burned_output_different_blocks(#[case] seed: Seed) {
 
         let first_tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),
@@ -533,7 +533,7 @@ fn try_spend_burned_output_different_blocks(#[case] seed: Seed) {
 fn tx_from_genesis(genesis: &Genesis, rng: &mut impl Rng, output_value: u128) -> SignedTransaction {
     TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(rng),
         )
         .add_output(TxOutput::Transfer(
@@ -545,7 +545,7 @@ fn tx_from_genesis(genesis: &Genesis, rng: &mut impl Rng, output_value: u128) ->
 
 // Creates a transaction with an input based on the specified transaction id.
 fn tx_from_tx(tx: &SignedTransaction, output_value: u128) -> SignedTransaction {
-    let input = TxInput::new(tx.transaction().get_id().into(), 0);
+    let input = TxInput::from_utxo(tx.transaction().get_id().into(), 0);
     let output = TxOutput::Transfer(
         OutputValue::Coin(Amount::from_atoms(output_value)),
         anyonecanspend_address(),

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -57,7 +57,7 @@ fn token_issue_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id.clone(), 0),
+                        TxInput::from_utxo(outpoint_source_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -94,7 +94,7 @@ fn token_issue_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id.clone(), 0),
+                        TxInput::from_utxo(outpoint_source_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -143,7 +143,7 @@ fn token_issue_test(#[case] seed: Seed) {
                     .add_transaction(
                         TransactionBuilder::new()
                             .add_input(
-                                TxInput::new(outpoint_source_id.clone(), 0),
+                                TxInput::from_utxo(outpoint_source_id.clone(), 0),
                                 InputWitness::NoSignature(None),
                             )
                             .add_output(TxOutput::Transfer(
@@ -184,7 +184,7 @@ fn token_issue_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id.clone(), 0),
+                        TxInput::from_utxo(outpoint_source_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -220,7 +220,7 @@ fn token_issue_test(#[case] seed: Seed) {
                 .add_transaction(
                     TransactionBuilder::new()
                         .add_input(
-                            TxInput::new(outpoint_source_id.clone(), 0),
+                            TxInput::from_utxo(outpoint_source_id.clone(), 0),
                             InputWitness::NoSignature(None),
                         )
                         .add_output(TxOutput::Transfer(
@@ -260,7 +260,7 @@ fn token_issue_test(#[case] seed: Seed) {
                 .add_transaction(
                     TransactionBuilder::new()
                         .add_input(
-                            TxInput::new(outpoint_source_id.clone(), 0),
+                            TxInput::from_utxo(outpoint_source_id.clone(), 0),
                             InputWitness::NoSignature(None),
                         )
                         .add_output(TxOutput::Transfer(
@@ -298,7 +298,7 @@ fn token_issue_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id.clone(), 0),
+                        TxInput::from_utxo(outpoint_source_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -339,7 +339,7 @@ fn token_issue_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -387,7 +387,7 @@ fn token_transfer_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(genesis_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -416,7 +416,7 @@ fn token_transfer_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -439,7 +439,7 @@ fn token_transfer_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -467,7 +467,7 @@ fn token_transfer_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -495,7 +495,7 @@ fn token_transfer_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -525,7 +525,7 @@ fn token_transfer_test(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -569,7 +569,7 @@ fn multiple_token_issuance_in_one_tx(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(genesis_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -600,7 +600,7 @@ fn multiple_token_issuance_in_one_tx(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -651,7 +651,7 @@ fn token_issuance_with_insufficient_fee(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -688,7 +688,7 @@ fn token_issuance_with_insufficient_fee(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -730,7 +730,7 @@ fn transfer_split_and_combine_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -754,7 +754,7 @@ fn transfer_split_and_combine_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     // One piece of tokens in the first output, other piece of tokens in the second output
@@ -787,11 +787,11 @@ fn transfer_split_and_combine_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(split_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(split_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(split_outpoint_id, 1),
+                        TxInput::from_utxo(split_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -839,7 +839,7 @@ fn burn_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -864,7 +864,7 @@ fn burn_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -891,7 +891,7 @@ fn burn_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -924,7 +924,7 @@ fn burn_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(first_burn_outpoint_id, 1),
+                        TxInput::from_utxo(first_burn_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -957,7 +957,7 @@ fn burn_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(second_burn_outpoint_id.clone(), 1),
+                        TxInput::from_utxo(second_burn_outpoint_id.clone(), 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -981,7 +981,7 @@ fn burn_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(second_burn_outpoint_id, 0),
+                        TxInput::from_utxo(second_burn_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1040,7 +1040,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1069,11 +1069,11 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 1),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -1102,7 +1102,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(b1_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(b1_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1135,7 +1135,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(b1_outpoint_id, 1),
+                        TxInput::from_utxo(b1_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1156,7 +1156,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(c1_outpoint_id, 0),
+                        TxInput::from_utxo(c1_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1178,7 +1178,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1210,11 +1210,11 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(b2_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(b2_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(b2_outpoint_id, 1),
+                        TxInput::from_utxo(b2_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -1245,11 +1245,11 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(c2_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(c2_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(c2_outpoint_id, 1),
+                        TxInput::from_utxo(c2_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -1279,11 +1279,11 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(d2_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(d2_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(d2_outpoint_id, 1),
+                        TxInput::from_utxo(d2_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1329,7 +1329,7 @@ fn attempt_to_print_tokens_one_output(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1354,7 +1354,7 @@ fn attempt_to_print_tokens_one_output(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1382,7 +1382,7 @@ fn attempt_to_print_tokens_one_output(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1427,7 +1427,7 @@ fn attempt_to_print_tokens_two_outputs(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1452,7 +1452,7 @@ fn attempt_to_print_tokens_two_outputs(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1488,7 +1488,7 @@ fn attempt_to_print_tokens_two_outputs(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1531,7 +1531,7 @@ fn spend_different_token_than_one_in_input(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1560,11 +1560,11 @@ fn spend_different_token_than_one_in_input(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(first_issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(first_issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(first_issuance_outpoint_id, 1),
+                        TxInput::from_utxo(first_issuance_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1609,15 +1609,15 @@ fn spend_different_token_than_one_in_input(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(second_issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(second_issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(second_issuance_outpoint_id.clone(), 1),
+                        TxInput::from_utxo(second_issuance_outpoint_id.clone(), 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(second_issuance_outpoint_id, 2),
+                        TxInput::from_utxo(second_issuance_outpoint_id, 2),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1670,7 +1670,7 @@ fn tokens_reorgs_and_cleanup_data(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1884,7 +1884,7 @@ fn issue_and_transfer_in_the_same_block(#[case] seed: Seed) {
 
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),
@@ -1905,7 +1905,7 @@ fn issue_and_transfer_in_the_same_block(#[case] seed: Seed) {
 
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::Transaction(tx_1.transaction().get_id()),
                     0,
                 ),

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -23,8 +23,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, ChainConfig, DelegationId, GenBlock, GenBlockId, OutPointSourceId, PoolId,
-        Transaction, TxMainChainIndex,
+        AccountType, Block, ChainConfig, DelegationId, GenBlock, GenBlockId, OutPointSourceId,
+        PoolId, Transaction, TxMainChainIndex,
     },
     primitives::{Amount, Id},
 };
@@ -93,6 +93,15 @@ impl TransactionVerifierStorageRef for InMemoryStorageWrapper {
     ) -> Result<Option<pos_accounting::AccountingBlockUndo>, TransactionVerifierStorageError> {
         self.storage
             .get_accounting_undo(id)
+            .map_err(TransactionVerifierStorageError::from)
+    }
+
+    fn get_account_nonce_count(
+        &self,
+        account: AccountType,
+    ) -> Result<Option<u128>, TransactionVerifierStorageError> {
+        self.storage
+            .get_account_nonce_count(account)
             .map_err(TransactionVerifierStorageError::from)
     }
 }

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -111,7 +111,7 @@ impl UtxosStorageRead for InMemoryStorageWrapper {
 
     fn get_utxo(
         &self,
-        outpoint: &common::chain::OutPoint,
+        outpoint: &common::chain::UtxoOutPoint,
     ) -> Result<Option<utxo::Utxo>, storage_result::Error> {
         self.storage.get_utxo(outpoint)
     }

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -23,8 +23,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, ChainConfig, DelegationId, GenBlock, GenBlockId, OutPointSourceId,
-        PoolId, Transaction, TxMainChainIndex,
+        AccountNonce, AccountType, Block, ChainConfig, DelegationId, GenBlock, GenBlockId,
+        OutPointSourceId, PoolId, Transaction, TxMainChainIndex,
     },
     primitives::{Amount, Id},
 };
@@ -99,7 +99,7 @@ impl TransactionVerifierStorageRef for InMemoryStorageWrapper {
     fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, TransactionVerifierStorageError> {
+    ) -> Result<Option<AccountNonce>, TransactionVerifierStorageError> {
         self.storage
             .get_account_nonce_count(account)
             .map_err(TransactionVerifierStorageError::from)

--- a/chainstate/test-suite/src/tests/helpers/mod.rs
+++ b/chainstate/test-suite/src/tests/helpers/mod.rs
@@ -42,7 +42,7 @@ pub fn add_block_with_locked_output(
 
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::new(prev_block_outputs.keys().next().unwrap().clone(), 0),
+            TxInput::from_utxo(prev_block_outputs.keys().next().unwrap().clone(), 0),
             InputWitness::NoSignature(None),
         )
         .add_anyone_can_spend_output(10000)
@@ -66,7 +66,7 @@ pub fn add_block_with_locked_output(
     assert!(block_outputs.contains_key(&tx_id.into()));
     (
         InputWitness::NoSignature(None),
-        TxInput::new(tx_id.into(), 1),
+        TxInput::from_utxo(tx_id.into(), 1),
         tx_id,
     )
 }

--- a/chainstate/test-suite/src/tests/helpers/pos.rs
+++ b/chainstate/test-suite/src/tests/helpers/pos.rs
@@ -22,7 +22,7 @@ use common::{
         config::EpochIndex,
         signature::inputsig::InputWitness,
         stakelock::StakePoolData,
-        Destination, OutPoint, PoolId, RequiredConsensus,
+        Destination, PoolId, RequiredConsensus, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Compact},
 };
@@ -38,7 +38,7 @@ use super::block_index_handle_impl::TestBlockIndexHandle;
 #[allow(clippy::too_many_arguments)]
 pub fn pos_mine(
     initial_timestamp: BlockTimestamp,
-    kernel_outpoint: OutPoint,
+    kernel_outpoint: UtxoOutPoint,
     kernel_witness: InputWitness,
     vrf_sk: &VRFPrivateKey,
     sealed_epoch_randomness: PoSRandomness,

--- a/chainstate/test-suite/src/tests/homomorphism.rs
+++ b/chainstate/test-suite/src/tests/homomorphism.rs
@@ -55,7 +55,7 @@ fn coins_homomorphism(#[case] seed: Seed) {
 
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),
@@ -69,7 +69,7 @@ fn coins_homomorphism(#[case] seed: Seed) {
 
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::Transaction(tx_1.transaction().get_id()),
                     0,
                 ),
@@ -83,7 +83,7 @@ fn coins_homomorphism(#[case] seed: Seed) {
 
         let tx_3 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::Transaction(tx_2.transaction().get_id()),
                     0,
                 ),
@@ -140,7 +140,7 @@ fn tokens_homomorphism(#[case] seed: Seed) {
 
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),
@@ -164,7 +164,7 @@ fn tokens_homomorphism(#[case] seed: Seed) {
 
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::Transaction(tx_1.transaction().get_id()),
                     0,
                 ),

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -48,7 +48,7 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
         // Issuance
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(genesis_outpoint_id, 0),
+                TxInput::from_utxo(genesis_outpoint_id, 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -74,7 +74,7 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -101,7 +101,7 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -142,7 +142,7 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
         // Issuance
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(genesis_outpoint_id, 0),
+                TxInput::from_utxo(genesis_outpoint_id, 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -165,7 +165,7 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
         // Burn
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(issuance_outpoint_id, 0),
+                TxInput::from_utxo(issuance_outpoint_id, 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Burn(
@@ -194,7 +194,7 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(first_burn_outpoint_id, 0),
+                        TxInput::from_utxo(first_burn_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -56,7 +56,7 @@ fn nft_name_too_long(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -113,7 +113,7 @@ fn nft_empty_name(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -177,7 +177,7 @@ fn nft_invalid_name(#[case] seed: Seed) {
                 .add_transaction(
                     TransactionBuilder::new()
                         .add_input(
-                            TxInput::new(outpoint_source_id.clone(), 0),
+                            TxInput::from_utxo(outpoint_source_id.clone(), 0),
                             InputWitness::NoSignature(None),
                         )
                         .add_output(TxOutput::Transfer(
@@ -234,7 +234,7 @@ fn nft_ticker_too_long(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -292,7 +292,7 @@ fn nft_empty_ticker(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -356,7 +356,7 @@ fn nft_invalid_ticker(#[case] seed: Seed) {
                 .add_transaction(
                     TransactionBuilder::new()
                         .add_input(
-                            TxInput::new(outpoint_source_id.clone(), 0),
+                            TxInput::from_utxo(outpoint_source_id.clone(), 0),
                             InputWitness::NoSignature(None),
                         )
                         .add_output(TxOutput::Transfer(
@@ -413,7 +413,7 @@ fn nft_description_too_long(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -471,7 +471,7 @@ fn nft_empty_description(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -535,7 +535,7 @@ fn nft_invalid_description(#[case] seed: Seed) {
                 .add_transaction(
                     TransactionBuilder::new()
                         .add_input(
-                            TxInput::new(outpoint_source_id.clone(), 0),
+                            TxInput::from_utxo(outpoint_source_id.clone(), 0),
                             InputWitness::NoSignature(None),
                         )
                         .add_output(TxOutput::Transfer(
@@ -591,7 +591,7 @@ fn nft_icon_uri_too_long(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -664,7 +664,7 @@ fn nft_icon_uri_empty(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -722,7 +722,7 @@ fn nft_icon_uri_invalid(#[case] seed: Seed) {
                 .add_transaction(
                     TransactionBuilder::new()
                         .add_input(
-                            TxInput::new(outpoint_source_id.clone(), 0),
+                            TxInput::from_utxo(outpoint_source_id.clone(), 0),
                             InputWitness::NoSignature(None),
                         )
                         .add_output(TxOutput::Transfer(
@@ -780,7 +780,7 @@ fn nft_metadata_uri_too_long(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -852,7 +852,7 @@ fn nft_metadata_uri_empty(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -910,7 +910,7 @@ fn nft_metadata_uri_invalid(#[case] seed: Seed) {
                 .add_transaction(
                     TransactionBuilder::new()
                         .add_input(
-                            TxInput::new(outpoint_source_id.clone(), 0),
+                            TxInput::from_utxo(outpoint_source_id.clone(), 0),
                             InputWitness::NoSignature(None),
                         )
                         .add_output(TxOutput::Transfer(
@@ -968,7 +968,7 @@ fn nft_media_uri_too_long(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1042,7 +1042,7 @@ fn nft_media_uri_empty(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -1100,7 +1100,7 @@ fn nft_media_uri_invalid(#[case] seed: Seed) {
                 .add_transaction(
                     TransactionBuilder::new()
                         .add_input(
-                            TxInput::new(outpoint_source_id.clone(), 0),
+                            TxInput::from_utxo(outpoint_source_id.clone(), 0),
                             InputWitness::NoSignature(None),
                         )
                         .add_output(TxOutput::Transfer(
@@ -1158,7 +1158,7 @@ fn new_block_with_media_hash(
         .add_transaction(
             TransactionBuilder::new()
                 .add_input(
-                    TxInput::new(input_source_id.clone(), 0),
+                    TxInput::from_utxo(input_source_id.clone(), 0),
                     InputWitness::NoSignature(None),
                 )
                 .add_output(TxOutput::Transfer(
@@ -1329,7 +1329,7 @@ fn nft_valid_case(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(outpoint_source_id, 0),
+                        TxInput::from_utxo(outpoint_source_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -78,7 +78,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -111,11 +111,11 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 1),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
@@ -148,7 +148,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(b1_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(b1_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -181,7 +181,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(b1_outpoint_id, 1),
+                        TxInput::from_utxo(b1_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -206,7 +206,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(c1_outpoint_id, 0),
+                        TxInput::from_utxo(c1_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -229,7 +229,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
         // Second chain - B2
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(issuance_outpoint_id, 0),
+                TxInput::from_utxo(issuance_outpoint_id, 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -259,11 +259,11 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
         // C2 - burn NFT in a second chain
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(b2_outpoint_id.clone(), 0),
+                TxInput::from_utxo(b2_outpoint_id.clone(), 0),
                 InputWitness::NoSignature(None),
             )
             .add_input(
-                TxInput::new(b2_outpoint_id, 1),
+                TxInput::from_utxo(b2_outpoint_id, 1),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Burn(
@@ -292,11 +292,11 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
         // Now D2 trying to spend NFT from mainchain
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(c2_outpoint_id.clone(), 0),
+                TxInput::from_utxo(c2_outpoint_id.clone(), 0),
                 InputWitness::NoSignature(None),
             )
             .add_input(
-                TxInput::new(c2_outpoint_id, 1),
+                TxInput::from_utxo(c2_outpoint_id, 1),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Burn(
@@ -328,11 +328,11 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(d2_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(d2_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(d2_outpoint_id, 1),
+                        TxInput::from_utxo(d2_outpoint_id, 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -387,7 +387,7 @@ fn nft_reorgs_and_cleanup_data(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(genesis_outpoint_id, 0),
+                        TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -67,7 +67,7 @@ fn nft_transfer_wrong_id(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(genesis_outpoint_id, 0),
+                TxInput::from_utxo(genesis_outpoint_id, 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -98,7 +98,7 @@ fn nft_transfer_wrong_id(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -153,7 +153,7 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(genesis_outpoint_id, 0),
+                TxInput::from_utxo(genesis_outpoint_id, 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -183,7 +183,7 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -213,7 +213,7 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -267,7 +267,7 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
         let token_min_issuance_fee = tf.chainstate.get_chain_config().token_min_issuance_fee();
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(genesis_outpoint_id, 0),
+                TxInput::from_utxo(genesis_outpoint_id, 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -294,11 +294,11 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
         let token_min_issuance_fee = tf.chainstate.get_chain_config().token_min_issuance_fee();
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(first_issuance_outpoint_id.clone(), 0),
+                TxInput::from_utxo(first_issuance_outpoint_id.clone(), 0),
                 InputWitness::NoSignature(None),
             )
             .add_input(
-                TxInput::new(first_issuance_outpoint_id, 1),
+                TxInput::from_utxo(first_issuance_outpoint_id, 1),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -350,15 +350,15 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(second_issuance_outpoint_id.clone(), 0),
+                        TxInput::from_utxo(second_issuance_outpoint_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(second_issuance_outpoint_id.clone(), 1),
+                        TxInput::from_utxo(second_issuance_outpoint_id.clone(), 1),
                         InputWitness::NoSignature(None),
                     )
                     .add_input(
-                        TxInput::new(second_issuance_outpoint_id, 2),
+                        TxInput::from_utxo(second_issuance_outpoint_id, 2),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
@@ -417,7 +417,7 @@ fn nft_valid_transfer(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(genesis_outpoint_id, 0),
+                TxInput::from_utxo(genesis_outpoint_id, 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -450,7 +450,7 @@ fn nft_valid_transfer(#[case] seed: Seed) {
             .add_transaction(
                 TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(issuance_outpoint_id, 0),
+                        TxInput::from_utxo(issuance_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(

--- a/chainstate/test-suite/src/tests/output_timelock.rs
+++ b/chainstate/test-suite/src/tests/output_timelock.rs
@@ -72,7 +72,9 @@ fn output_lock_until_height(#[case] seed: Seed) {
                 .build_and_process()
                 .unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::TimeLockViolation(locked_input.outpoint().clone())
+                ConnectTransactionError::TimeLockViolation(
+                    locked_input.outpoint().unwrap().clone()
+                )
             ))
         );
         assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(1));
@@ -113,7 +115,9 @@ fn output_lock_until_height(#[case] seed: Seed) {
                     .build_and_process()
                     .unwrap_err(),
                 ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                    ConnectTransactionError::TimeLockViolation(locked_input.outpoint().clone())
+                    ConnectTransactionError::TimeLockViolation(
+                        locked_input.outpoint().unwrap().clone()
+                    )
                 ))
             );
             assert_eq!(
@@ -231,7 +235,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
                 .build_and_process()
                 .unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::TimeLockViolation(input.outpoint().clone())
+                ConnectTransactionError::TimeLockViolation(input.outpoint().unwrap().clone())
             ))
         );
         assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(1));
@@ -272,7 +276,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
                     .build_and_process()
                     .unwrap_err(),
                 ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                    ConnectTransactionError::TimeLockViolation(input.outpoint().clone())
+                    ConnectTransactionError::TimeLockViolation(input.outpoint().unwrap().clone())
                 ))
             );
             assert_eq!(
@@ -447,7 +451,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
                     .build_and_process()
                     .unwrap_err(),
                 ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                    ConnectTransactionError::TimeLockViolation(input.outpoint().clone())
+                    ConnectTransactionError::TimeLockViolation(input.outpoint().unwrap().clone())
                 ))
             );
             assert_eq!(
@@ -595,7 +599,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
                     .build_and_process()
                     .unwrap_err(),
                 ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                    ConnectTransactionError::TimeLockViolation(input.outpoint().clone())
+                    ConnectTransactionError::TimeLockViolation(input.outpoint().unwrap().clone())
                 ))
             );
             assert_eq!(

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -27,7 +27,7 @@ use chainstate_test_framework::{
 use common::{
     chain::{
         config::Builder as ConfigBuilder, stakelock::StakePoolData, tokens::OutputValue, GenBlock,
-        OutPoint, OutPointSourceId, TxInput, TxOutput,
+        OutPointSourceId, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, Id, Idable},
 };
@@ -82,7 +82,7 @@ fn stake_pool_reorg(#[case] seed: Seed) {
             // prepare tx_a
             let destination_a = new_pub_key_destination(&mut rng);
             let (_, vrf_pub_key_a) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
-            let genesis_outpoint = OutPoint::new(
+            let genesis_outpoint = UtxoOutPoint::new(
                 OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                 0,
             );
@@ -105,7 +105,7 @@ fn stake_pool_reorg(#[case] seed: Seed) {
             // prepare tx_b
             let tx_b = TransactionBuilder::new()
                 .add_input(
-                    TxInput::new(OutPointSourceId::BlockReward(genesis_id.into()), 0),
+                    TxInput::from_utxo(OutPointSourceId::BlockReward(genesis_id.into()), 0),
                     empty_witness(&mut rng),
                 )
                 .add_output(TxOutput::Transfer(
@@ -117,7 +117,7 @@ fn stake_pool_reorg(#[case] seed: Seed) {
             // prepare tx_c
             let destination_c = new_pub_key_destination(&mut rng);
             let (_, vrf_pub_key_c) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
-            let tx_b_outpoint0 = OutPoint::new(
+            let tx_b_outpoint0 = UtxoOutPoint::new(
                 OutPointSourceId::Transaction(tx_b.transaction().get_id()),
                 0,
             );

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -46,9 +46,9 @@ use common::{
         stakelock::StakePoolData,
         timelock::OutputTimeLock,
         tokens::OutputValue,
-        AccountOutPoint, AccountSpending, Block, ConsensusUpgrade, Destination, GenBlock, Genesis,
-        NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId, SignedTransaction, TxInput,
-        TxOutput, UpgradeVersion, UtxoOutPoint,
+        AccountNonce, AccountOutPoint, AccountSpending, Block, ConsensusUpgrade, Destination,
+        GenBlock, Genesis, NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId,
+        SignedTransaction, TxInput, TxOutput, UpgradeVersion, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Id, Idable, H256},
     Uint256,
@@ -2098,7 +2098,7 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
 
     let amount_to_withdraw = Amount::from_atoms(rng.gen_range(1..amount_to_delegate.into_atoms()));
     let tx_input_spend_from_delegation = AccountOutPoint::new(
-        0,
+        AccountNonce::new(0),
         AccountSpending::Delegation(delegation_id, amount_to_withdraw),
     );
     let tx = TransactionBuilder::new()
@@ -2162,7 +2162,7 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     {
         let delegation_balance_overspend = (delegation_balance + Amount::from_atoms(1)).unwrap();
         let tx_input_spend_from_delegation = AccountOutPoint::new(
-            1,
+            AccountNonce::new(1),
             AccountSpending::Delegation(delegation_id, delegation_balance_overspend),
         );
         let tx = TransactionBuilder::new()
@@ -2198,7 +2198,7 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     }
 
     let tx_input_spend_from_delegation = AccountOutPoint::new(
-        1,
+        AccountNonce::new(1),
         AccountSpending::Delegation(delegation_id, delegation_balance),
     );
     let tx = TransactionBuilder::new()

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -318,7 +318,7 @@ fn produce_kernel_signature(
         SigHashType::default(),
         staking_destination,
         &block_reward_tx,
-        std::iter::once(utxo).collect::<Vec<_>>().as_slice(),
+        std::iter::once(Some(utxo)).collect::<Vec<_>>().as_slice(),
         0,
     )
     .unwrap()

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -46,7 +46,7 @@ use common::{
         stakelock::StakePoolData,
         timelock::OutputTimeLock,
         tokens::OutputValue,
-        AccountOutPoint, AccountType, Block, ConsensusUpgrade, Destination, GenBlock, Genesis,
+        AccountOutPoint, AccountSpending, Block, ConsensusUpgrade, Destination, GenBlock, Genesis,
         NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId, SignedTransaction, TxInput,
         TxOutput, UpgradeVersion, UtxoOutPoint,
     },
@@ -2097,11 +2097,13 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     .expect("should be able to mine");
 
     let amount_to_withdraw = Amount::from_atoms(rng.gen_range(1..amount_to_delegate.into_atoms()));
-    let tx_input_spend_from_delegation =
-        AccountOutPoint::new(0, AccountType::Delegation(delegation_id));
+    let tx_input_spend_from_delegation = AccountOutPoint::new(
+        0,
+        AccountSpending::Delegation(delegation_id, amount_to_withdraw),
+    );
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::Account(tx_input_spend_from_delegation, amount_to_withdraw),
+            TxInput::Account(tx_input_spend_from_delegation),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::LockThenTransfer(
@@ -2159,11 +2161,13 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     // try overspend
     {
         let delegation_balance_overspend = (delegation_balance + Amount::from_atoms(1)).unwrap();
-        let tx_input_spend_from_delegation =
-            AccountOutPoint::new(1, AccountType::Delegation(delegation_id));
+        let tx_input_spend_from_delegation = AccountOutPoint::new(
+            1,
+            AccountSpending::Delegation(delegation_id, delegation_balance_overspend),
+        );
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(tx_input_spend_from_delegation, delegation_balance_overspend),
+                TxInput::Account(tx_input_spend_from_delegation),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -2193,11 +2197,13 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
         );
     }
 
-    let tx_input_spend_from_delegation =
-        AccountOutPoint::new(1, AccountType::Delegation(delegation_id));
+    let tx_input_spend_from_delegation = AccountOutPoint::new(
+        1,
+        AccountSpending::Delegation(delegation_id, delegation_balance),
+    );
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::Account(tx_input_spend_from_delegation, delegation_balance),
+            TxInput::Account(tx_input_spend_from_delegation),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::LockThenTransfer(

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -2097,14 +2097,11 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     .expect("should be able to mine");
 
     let amount_to_withdraw = Amount::from_atoms(rng.gen_range(1..amount_to_delegate.into_atoms()));
-    let tx_input_spend_from_delegation = AccountOutPoint::new(
-        0,
-        AccountType::Delegation(delegation_id),
-        amount_to_withdraw,
-    );
+    let tx_input_spend_from_delegation =
+        AccountOutPoint::new(0, AccountType::Delegation(delegation_id));
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::Account(tx_input_spend_from_delegation),
+            TxInput::Account(tx_input_spend_from_delegation, amount_to_withdraw),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::LockThenTransfer(
@@ -2162,14 +2159,11 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     // try overspend
     {
         let delegation_balance_overspend = (delegation_balance + Amount::from_atoms(1)).unwrap();
-        let tx_input_spend_from_delegation = AccountOutPoint::new(
-            1,
-            AccountType::Delegation(delegation_id),
-            delegation_balance_overspend,
-        );
+        let tx_input_spend_from_delegation =
+            AccountOutPoint::new(1, AccountType::Delegation(delegation_id));
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::Account(tx_input_spend_from_delegation),
+                TxInput::Account(tx_input_spend_from_delegation, delegation_balance_overspend),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -2199,14 +2193,11 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
         );
     }
 
-    let tx_input_spend_from_delegation = AccountOutPoint::new(
-        1,
-        AccountType::Delegation(delegation_id),
-        delegation_balance,
-    );
+    let tx_input_spend_from_delegation =
+        AccountOutPoint::new(1, AccountType::Delegation(delegation_id));
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::Account(tx_input_spend_from_delegation),
+            TxInput::Account(tx_input_spend_from_delegation, delegation_balance),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::LockThenTransfer(

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -2024,7 +2024,7 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
         .unwrap();
     tf.progress_time_seconds_since_epoch(target_block_time);
 
-    // Process block_2 and distibute reward
+    // Process block_2 and distribute reward
     let stake_pool_outpoint = UtxoOutPoint::new(tx1_id.into(), 1);
     let staking_destination = Destination::PublicKey(PublicKey::from_private_key(&staking_sk));
     let reward_outputs =

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -146,6 +146,7 @@ fn stable_block_time(#[case] seed: Seed) {
         // produce kernel signature
         let (best_block_source_id, best_block_utxos) =
             tf.outputs_from_genblock(tf.best_block_id()).into_iter().next().unwrap();
+        let inputs_utxos = best_block_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let reward_outputs =
             vec![TxOutput::ProduceBlockFromStake(staking_destination.clone(), pool_id)];
@@ -161,7 +162,7 @@ fn stable_block_time(#[case] seed: Seed) {
             Default::default(),
             staking_destination.clone(),
             &block_reward_tx,
-            &best_block_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             0,
         )
         .unwrap();

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -352,7 +352,7 @@ fn spend_inputs_simple(#[case] seed: Seed) {
             let tx_id = tx.transaction().get_id();
             // All inputs must spend a corresponding output
             for tx_in in tx.transaction().inputs() {
-                let outpoint = tx_in.outpoint();
+                let outpoint = tx_in.outpoint().unwrap();
                 if *tf.chainstate.get_chainstate_config().tx_index_enabled {
                     let prev_out_tx_index =
                         tf.chainstate.get_mainchain_tx_index(&outpoint.tx_id()).unwrap().unwrap();

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -30,7 +30,7 @@ use chainstate_test_framework::{
 };
 use chainstate_types::{GenBlockIndex, GetAncestorError, PropertyQueryError};
 use common::chain::{
-    signed_transaction::SignedTransaction, stakelock::StakePoolData, OutPoint, Transaction,
+    signed_transaction::SignedTransaction, stakelock::StakePoolData, Transaction, UtxoOutPoint,
 };
 use common::primitives::BlockDistance;
 use common::{
@@ -99,7 +99,7 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
-        let outpoint = OutPoint::new(block_id.into(), 0);
+        let outpoint = UtxoOutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
@@ -121,7 +121,7 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
-        let outpoint = OutPoint::new(block_id.into(), 0);
+        let outpoint = UtxoOutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
@@ -143,7 +143,7 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
-        let outpoint = OutPoint::new(block_id.into(), 0);
+        let outpoint = UtxoOutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
@@ -165,7 +165,7 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
-        let outpoint = OutPoint::new(block_id.into(), 0);
+        let outpoint = UtxoOutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
@@ -193,7 +193,7 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
             .build();
 
         let block_id = block.get_id();
-        let outpoint = OutPoint::new(block_id.into(), 0);
+        let outpoint = UtxoOutPoint::new(block_id.into(), 0);
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
@@ -326,7 +326,8 @@ fn spend_inputs_simple(#[case] seed: Seed) {
         let genesis_id = tf.genesis().get_id();
         for (idx, txo) in tf.genesis().utxos().iter().enumerate() {
             let idx = idx as u32;
-            let utxo = tf.chainstate.utxo(&OutPoint::new(genesis_id.into(), idx)).unwrap().unwrap();
+            let utxo =
+                tf.chainstate.utxo(&UtxoOutPoint::new(genesis_id.into(), idx)).unwrap().unwrap();
             assert_eq!(utxo.output(), txo);
             assert_eq!(utxo.source(), &UtxoSource::Blockchain(BlockHeight::new(0)));
         }
@@ -352,7 +353,7 @@ fn spend_inputs_simple(#[case] seed: Seed) {
             let tx_id = tx.transaction().get_id();
             // All inputs must spend a corresponding output
             for tx_in in tx.transaction().inputs() {
-                let outpoint = tx_in.outpoint().unwrap();
+                let outpoint = tx_in.utxo_outpoint().unwrap();
                 if *tf.chainstate.get_chainstate_config().tx_index_enabled {
                     let prev_out_tx_index =
                         tf.chainstate.get_mainchain_tx_index(&outpoint.tx_id()).unwrap().unwrap();
@@ -374,7 +375,7 @@ fn spend_inputs_simple(#[case] seed: Seed) {
                         OutputSpentState::Unspent
                     );
                     let utxo =
-                        tf.chainstate.utxo(&OutPoint::new(tx_id.into(), idx)).unwrap().unwrap();
+                        tf.chainstate.utxo(&UtxoOutPoint::new(tx_id.into(), idx)).unwrap().unwrap();
                     assert_eq!(utxo.output(), txo);
                     assert_eq!(utxo.source(), &UtxoSource::Blockchain(BlockHeight::new(1)));
                 }
@@ -397,7 +398,7 @@ fn transaction_processing_order(#[case] seed: Seed) {
         let tx1 = SignedTransaction::new(
             Transaction::new(
                 0,
-                vec![TxInput::new(tf.genesis().get_id().into(), 0)],
+                vec![TxInput::from_utxo(tf.genesis().get_id().into(), 0)],
                 vec![TxOutput::Transfer(
                     get_output_value(&tf.genesis().utxos()[0]).unwrap(),
                     anyonecanspend_address(),
@@ -412,7 +413,7 @@ fn transaction_processing_order(#[case] seed: Seed) {
         let tx2 = SignedTransaction::new(
             Transaction::new(
                 0,
-                vec![TxInput::new(tx1.transaction().get_id().into(), 0)],
+                vec![TxInput::from_utxo(tx1.transaction().get_id().into(), 0)],
                 vec![TxOutput::Transfer(
                     get_output_value(&tx1.transaction().outputs()[0]).unwrap(),
                     anyonecanspend_address(),
@@ -1225,7 +1226,7 @@ fn burn_inputs_in_tx(#[case] seed: Seed) {
 
         let first_tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -53,7 +53,7 @@ fn signed_tx(#[case] seed: Seed) {
         // genesis block.
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(
                         tf.chainstate.get_chain_config().genesis_block_id(),
                     ),
@@ -69,7 +69,7 @@ fn signed_tx(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::Transaction(tx_1.transaction().get_id()),
                     0,
                 ),
@@ -141,7 +141,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
         // genesis block.
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(chain_config.genesis_block_id()),
                     0,
                 ),
@@ -155,7 +155,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::Transaction(tx_1.transaction().get_id()),
                     0,
                 ),
@@ -246,7 +246,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
         // genesis block.
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(chain_config.genesis_block_id()),
                     0,
                 ),
@@ -260,7 +260,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::Transaction(tx_1.transaction().get_id()),
                     0,
                 ),
@@ -371,7 +371,7 @@ fn too_large_no_sig_data(#[case] seed: Seed) {
 
             let tx = TransactionBuilder::new()
                 .add_input(
-                    TxInput::new(
+                    TxInput::from_utxo(
                         OutPointSourceId::BlockReward(chain_config.genesis_block_id()),
                         0,
                     ),
@@ -395,7 +395,7 @@ fn too_large_no_sig_data(#[case] seed: Seed) {
 
             let tx = TransactionBuilder::new()
                 .add_input(
-                    TxInput::new(
+                    TxInput::from_utxo(
                         OutPointSourceId::BlockReward(chain_config.genesis_block_id()),
                         0,
                     ),

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -90,7 +90,7 @@ fn signed_tx(#[case] seed: Seed) {
                 SigHashType::try_from(SigHashType::ALL).unwrap(),
                 Destination::PublicKey(public_key),
                 &tx,
-                &[&tx_1.transaction().outputs()[0]],
+                &[Some(&tx_1.transaction().outputs()[0])],
                 0,
             )
             .unwrap();
@@ -175,7 +175,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
             let sighash = signature_hash(
                 SigHashType::try_from(SigHashType::ALL).unwrap(),
                 &tx,
-                &[&tx_1.transaction().outputs()[0]],
+                &[Some(&tx_1.transaction().outputs()[0])],
                 0,
             )
             .unwrap();
@@ -197,7 +197,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
                     &authorization,
                     SigHashType::try_from(SigHashType::ALL).unwrap(),
                     &tx,
-                    &[&tx_1.transaction().outputs()[0]],
+                    &[Some(&tx_1.transaction().outputs()[0])],
                     0,
                 )
                 .unwrap();
@@ -285,7 +285,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
         let sighash = signature_hash(
             SigHashType::try_from(SigHashType::ALL).unwrap(),
             &tx,
-            &[&tx_1.transaction().outputs()[0]],
+            &[Some(&tx_1.transaction().outputs()[0])],
             0,
         )
         .unwrap();
@@ -306,7 +306,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
                         &authorization,
                         SigHashType::try_from(SigHashType::ALL).unwrap(),
                         &tx,
-                        &[&tx_1.transaction().outputs()[0]],
+                        &[Some(&tx_1.transaction().outputs()[0])],
                         0,
                     )
                     .unwrap();

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -592,6 +592,7 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
 
         let (best_block_source_id, best_block_utxos) =
             tf.outputs_from_genblock(tf.best_block_id()).into_iter().next().unwrap();
+        let inputs_utxos = best_block_utxos.iter().map(Some).collect::<Vec<_>>();
 
         {
             // sign with staking key
@@ -615,7 +616,7 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
                     Default::default(),
                     Destination::PublicKey(staking_pk),
                     &tx,
-                    &best_block_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos,
                     0,
                 )
                 .unwrap();
@@ -656,7 +657,7 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
                 Default::default(),
                 Destination::PublicKey(decommission_pk),
                 &tx,
-                &best_block_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 0,
             )
             .unwrap();

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -30,7 +30,8 @@ use common::{
         stakelock::StakePoolData,
         timelock::OutputTimeLock,
         tokens::{OutputValue, TokenData, TokenTransfer},
-        Destination, GenBlock, OutPoint, OutPointSourceId, SignedTransaction, TxInput, TxOutput,
+        Destination, GenBlock, OutPointSourceId, SignedTransaction, TxInput, TxOutput,
+        UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, Id, Idable},
 };
@@ -62,7 +63,7 @@ fn stake_pool_basic(#[case] seed: Seed) {
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
 
-        let stake_pool_outpoint = OutPoint::new(
+        let stake_pool_outpoint = UtxoOutPoint::new(
             OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
             0,
         );
@@ -105,7 +106,7 @@ fn stake_pool_and_spend_coin_same_tx(#[case] seed: Seed) {
             Amount::from_atoms(rng.gen_range(min_stake_pool_pledge..(min_stake_pool_pledge * 10)));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
-        let genesis_outpoint = OutPoint::new(
+        let genesis_outpoint = UtxoOutPoint::new(
             OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
             0,
         );
@@ -146,7 +147,7 @@ fn stake_pool_and_issue_tokens_same_tx(#[case] seed: Seed) {
             Amount::from_atoms(rng.gen_range(min_stake_pool_pledge..(min_stake_pool_pledge * 10)));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
-        let genesis_outpoint = OutPoint::new(
+        let genesis_outpoint = UtxoOutPoint::new(
             OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
             0,
         );
@@ -193,7 +194,7 @@ fn stake_pool_and_transfer_tokens_same_tx(#[case] seed: Seed) {
             Amount::from_atoms(rng.gen_range(min_stake_pool_pledge..(min_stake_pool_pledge * 10)));
         let tx0 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),
@@ -217,17 +218,17 @@ fn stake_pool_and_transfer_tokens_same_tx(#[case] seed: Seed) {
         let (_, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
-        let outpoint0 = OutPoint::new(OutPointSourceId::Transaction(tx0_id), 0);
+        let outpoint0 = UtxoOutPoint::new(OutPointSourceId::Transaction(tx0_id), 0);
         let pool_id = pos_accounting::make_pool_id(&outpoint0);
 
         // stake pool with coin input and transfer tokens with token input
         let tx1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(OutPointSourceId::Transaction(tx0_id), 0),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx0_id), 0),
                 empty_witness(&mut rng),
             )
             .add_input(
-                TxInput::new(OutPointSourceId::Transaction(tx0_id), 1),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx0_id), 1),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(
@@ -273,7 +274,7 @@ fn stake_pool_twice(#[case] seed: Seed) {
             Amount::from_atoms(rng.gen_range(min_stake_pool_pledge..(min_stake_pool_pledge * 10)));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
-        let genesis_outpoint = OutPoint::new(
+        let genesis_outpoint = UtxoOutPoint::new(
             OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
             0,
         );
@@ -327,7 +328,7 @@ fn stake_pool_overspend(#[case] seed: Seed) {
             genesis_overspend_amount,
             vrf_pk,
         );
-        let genesis_outpoint = OutPoint::new(OutPointSourceId::BlockReward(genesis_id), 0);
+        let genesis_outpoint = UtxoOutPoint::new(OutPointSourceId::BlockReward(genesis_id), 0);
         let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let tx = TransactionBuilder::new()
@@ -362,7 +363,7 @@ fn stake_pool_not_enough_pledge(#[case] seed: Seed) {
         let genesis_id = tf.genesis().get_id().into();
         let (_, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
 
-        let genesis_outpoint = OutPoint::new(OutPointSourceId::BlockReward(genesis_id), 0);
+        let genesis_outpoint = UtxoOutPoint::new(OutPointSourceId::BlockReward(genesis_id), 0);
         let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let min_pledge = tf.chainstate.get_chain_config().min_stake_pool_pledge();
@@ -427,7 +428,7 @@ fn decommission_from_stake_pool(#[case] seed: Seed) {
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
 
-        let stake_pool_outpoint = OutPoint::new(
+        let stake_pool_outpoint = UtxoOutPoint::new(
             OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
             0,
         );
@@ -449,7 +450,7 @@ fn decommission_from_stake_pool(#[case] seed: Seed) {
             let overspend_amount = (amount_to_stake + Amount::from_atoms(1)).unwrap();
             let tx2 = TransactionBuilder::new()
                 .add_input(
-                    TxInput::new(OutPointSourceId::Transaction(stake_pool_tx_id), 0),
+                    TxInput::from_utxo(OutPointSourceId::Transaction(stake_pool_tx_id), 0),
                     empty_witness(&mut rng),
                 )
                 .add_output(TxOutput::LockThenTransfer(
@@ -472,7 +473,7 @@ fn decommission_from_stake_pool(#[case] seed: Seed) {
 
         let tx2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(OutPointSourceId::Transaction(stake_pool_tx_id), 0),
+                TxInput::from_utxo(OutPointSourceId::Transaction(stake_pool_tx_id), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -507,7 +508,7 @@ fn decommission_from_stake_pool_same_block(#[case] seed: Seed) {
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
 
-        let stake_pool_outpoint = OutPoint::new(
+        let stake_pool_outpoint = UtxoOutPoint::new(
             OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
             0,
         );
@@ -526,7 +527,7 @@ fn decommission_from_stake_pool_same_block(#[case] seed: Seed) {
 
         let tx2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(OutPointSourceId::Transaction(stake_pool_tx_id), 0),
+                TxInput::from_utxo(OutPointSourceId::Transaction(stake_pool_tx_id), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::LockThenTransfer(
@@ -574,7 +575,7 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
             Amount::ZERO,
         );
 
-        let stake_pool_outpoint = OutPoint::new(
+        let stake_pool_outpoint = UtxoOutPoint::new(
             OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
             0,
         );
@@ -599,7 +600,7 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
             let tx2 = {
                 let tx = TransactionBuilder::new()
                     .add_input(
-                        TxInput::new(best_block_source_id.clone(), 0),
+                        TxInput::from_utxo(best_block_source_id.clone(), 0),
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::LockThenTransfer(
@@ -640,7 +641,7 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
         let tx2 = {
             let tx = TransactionBuilder::new()
                 .add_input(
-                    TxInput::new(best_block_source_id, 0),
+                    TxInput::from_utxo(best_block_source_id, 0),
                     InputWitness::NoSignature(None),
                 )
                 .add_output(TxOutput::LockThenTransfer(

--- a/chainstate/test-suite/src/tests/tx_verifier_among_threads.rs
+++ b/chainstate/test-suite/src/tests/tx_verifier_among_threads.rs
@@ -16,7 +16,7 @@
 use chainstate_test_framework::{TestFramework, TestStore};
 use common::chain::config::Builder as ConfigBuilder;
 use common::{
-    chain::{DelegationId, OutPoint, PoolId},
+    chain::{DelegationId, PoolId, UtxoOutPoint},
     primitives::{Id, H256},
 };
 use pos_accounting::PoSAccountingView;
@@ -32,11 +32,11 @@ struct EmptyUtxosView;
 impl UtxosView for EmptyUtxosView {
     type Error = std::convert::Infallible;
 
-    fn utxo(&self, _outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
+    fn utxo(&self, _outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Self::Error> {
         Ok(None)
     }
 
-    fn has_utxo(&self, _outpoint: &OutPoint) -> Result<bool, Self::Error> {
+    fn has_utxo(&self, _outpoint: &UtxoOutPoint) -> Result<bool, Self::Error> {
         Ok(false)
     }
 

--- a/chainstate/test-suite/src/tests/tx_verifier_disconnect.rs
+++ b/chainstate/test-suite/src/tests/tx_verifier_disconnect.rs
@@ -112,7 +112,7 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
         // create a block with a single tx based on genesis
         let tx0 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
                     0,
                 ),
@@ -144,7 +144,7 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
         // create and connect a tx from mempool based on best block
         let tx1 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(OutPointSourceId::Transaction(tx0_id), 0),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx0_id), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(
@@ -160,7 +160,7 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
         // create and connect a tx from mempool based on previous tx from mempool
         let tx2 = TransactionBuilder::new()
             .add_input(
-                TxInput::new(OutPointSourceId::Transaction(tx1.transaction().get_id()), 0),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx1.transaction().get_id()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(

--- a/chainstate/tx-verifier/src/transaction_verifier/accounting_delta_adapter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/accounting_delta_adapter.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use super::{storage::TransactionVerifierStorageError, TransactionSource};
 
 use common::{
-    chain::{OutPoint, PoolId},
+    chain::{PoolId, UtxoOutPoint},
     primitives::Amount,
 };
 use pos_accounting::{
@@ -151,7 +151,7 @@ impl<'a, P: PoSAccountingView> PoSAccountingOperations for PoSAccountingOperatio
         &mut self,
         target_pool: PoolId,
         spend_key: common::chain::Destination,
-        input0_outpoint: &OutPoint,
+        input0_outpoint: &UtxoOutPoint,
     ) -> Result<(common::chain::DelegationId, PoSAccountingUndo), pos_accounting::Error> {
         let mut delta = PoSAccountingDelta::new(&self.adapter.accounting_delta);
 

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -19,8 +19,8 @@ use common::{
         block::{Block, GenBlock},
         signature::TransactionSigError,
         tokens::TokenId,
-        AccountType, DelegationId, OutPoint, OutPointSourceId, PoolId, SpendError, Spender,
-        Transaction, TxMainChainIndexError,
+        AccountType, DelegationId, OutPointSourceId, PoolId, SpendError, Spender, Transaction,
+        TxMainChainIndexError, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -80,7 +80,7 @@ pub enum ConnectTransactionError {
     #[error("Block reward addition error for block {0}")]
     RewardAdditionError(Id<Block>),
     #[error("Timelock rules violated in output {0:?}")]
-    TimeLockViolation(OutPoint),
+    TimeLockViolation(UtxoOutPoint),
     #[error("Utxo error: {0}")]
     UtxoError(#[from] utxo::Error),
     #[error("Tokens error: {0}")]

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -147,6 +147,8 @@ pub enum ConnectTransactionError {
     OutputTimelockError(#[from] timelock_check::OutputMaturityError),
     #[error("Nonce is not incremental: {0:?}")]
     NonceIsNotIncremental(AccountType),
+    #[error("Nonce is not found: {0:?}")]
+    MissingTransactionNonce(AccountType),
     #[error(
         "Transaction {0} has not enough pledge to create a stake pool: giver {1:?}, required {2:?}"
     )]

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -157,6 +157,8 @@ pub enum ConnectTransactionError {
     AttemptToCreateStakePoolFromAccounts,
     #[error("Attempt to create delegation from accounting inputs")]
     AttemptToCreateDelegationFromAccounts,
+    #[error("Failed to increment account nonce")]
+    FailedToIncrementAccountNonce,
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -151,6 +151,10 @@ pub enum ConnectTransactionError {
         "Transaction {0} has not enough pledge to create a stake pool: giver {1:?}, required {2:?}"
     )]
     NotEnoughPledgeToCreateStakePool(Id<Transaction>, Amount, Amount),
+    #[error("Attemp to create stake pool from accounting inputs")]
+    AttemptToCreateStakePoolFromAccounts,
+    #[error("Attemp to create delegation from accounting inputs")]
+    AttemptToCreateDelegationFromAccounts,
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -19,8 +19,8 @@ use common::{
         block::{Block, GenBlock},
         signature::TransactionSigError,
         tokens::TokenId,
-        DelegationId, OutPoint, OutPointSourceId, PoolId, SpendError, Spender, Transaction,
-        TxMainChainIndexError,
+        AccountType, DelegationId, OutPoint, OutPointSourceId, PoolId, SpendError, Spender,
+        Transaction, TxMainChainIndexError,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -145,6 +145,8 @@ pub enum ConnectTransactionError {
     DestinationRetrievalError(#[from] SignatureDestinationGetterError),
     #[error("Output timelock error: {0}")]
     OutputTimelockError(#[from] timelock_check::OutputMaturityError),
+    #[error("Nonce is not incremental: {0:?}")]
+    NonceIsNotIncremental(AccountType),
     #[error(
         "Transaction {0} has not enough pledge to create a stake pool: giver {1:?}, required {2:?}"
     )]

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -153,9 +153,9 @@ pub enum ConnectTransactionError {
         "Transaction {0} has not enough pledge to create a stake pool: giver {1:?}, required {2:?}"
     )]
     NotEnoughPledgeToCreateStakePool(Id<Transaction>, Amount, Amount),
-    #[error("Attemp to create stake pool from accounting inputs")]
+    #[error("Attempt to create stake pool from accounting inputs")]
     AttemptToCreateStakePoolFromAccounts,
-    #[error("Attemp to create delegation from accounting inputs")]
+    #[error("Attempt to create delegation from accounting inputs")]
     AttemptToCreateDelegationFromAccounts,
 }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -129,8 +129,10 @@ pub enum ConnectTransactionError {
     DistributedDelegationsRewardExceedTotal(PoolId, Id<Block>, Amount, Amount),
     #[error("Total balance of delegations in pool {0} is zero")]
     TotalDelegationBalanceZero(PoolId),
-    #[error("Delegation {0} not found")]
+    #[error("Data for delegation {0} not found")]
     DelegationDataNotFound(DelegationId),
+    #[error("Balance for delegation {0} not found")]
+    DelegationBalanceNotFound(DelegationId),
 
     // TODO The following should contain more granular inner error information
     //      https://github.com/mintlayer/mintlayer-core/issues/811

--- a/chainstate/tx-verifier/src/transaction_verifier/flush.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/flush.rs
@@ -16,7 +16,7 @@
 use super::{
     storage::{TransactionVerifierStorageMut, TransactionVerifierStorageRef},
     token_issuance_cache::{CachedAuxDataOp, CachedTokenIndexOp, ConsumedTokenIssuanceCache},
-    CachedInputsOperation, TransactionVerifierDelta,
+    CachedInputsOperation, CachedOperation, TransactionVerifierDelta,
 };
 use common::chain::OutPointSourceId;
 
@@ -120,11 +120,12 @@ where
     }
 
     // flush nonce values
-    for (account, nonce) in consumed.account_nonce {
-        match nonce {
-            Some(nonce) => storage.set_account_nonce_count(account, nonce),
-            None => storage.del_account_nonce_count(account),
-        }?;
+    for (account, op) in consumed.account_nonce {
+        match op {
+            CachedOperation::Write(nonce) => storage.set_account_nonce_count(account, nonce)?,
+            CachedOperation::Read(_) => (),
+            CachedOperation::Erase => storage.del_account_nonce_count(account)?,
+        };
     }
 
     Ok(())

--- a/chainstate/tx-verifier/src/transaction_verifier/flush.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/flush.rs
@@ -119,5 +119,13 @@ where
         }
     }
 
+    // flush nonce values
+    for (account, nonce) in consumed.account_nonce {
+        match nonce {
+            Some(nonce) => storage.set_account_nonce_count(account, nonce),
+            None => storage.del_account_nonce_count(account),
+        }?;
+    }
+
     Ok(())
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -28,8 +28,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, Transaction,
-        TxMainChainIndex, UtxoOutPoint,
+        AccountNonce, AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId,
+        Transaction, TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, Id},
 };
@@ -111,7 +111,7 @@ where
     fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, <Self as TransactionVerifierStorageRef>::Error> {
+    ) -> Result<Option<AccountNonce>, <Self as TransactionVerifierStorageRef>::Error> {
         match self.account_nonce.get(&account) {
             Some(op) => match *op {
                 CachedOperation::Write(nonce) => Ok(Some(nonce)),
@@ -267,7 +267,7 @@ where
     fn set_account_nonce_count(
         &mut self,
         account: AccountType,
-        nonce: u128,
+        nonce: AccountNonce,
     ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
         self.account_nonce.insert(account, CachedOperation::Write(nonce));
         Ok(())
@@ -277,7 +277,7 @@ where
         &mut self,
         account: AccountType,
     ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
-        self.account_nonce.insert(account, CachedOperation::<u128>::Erase);
+        self.account_nonce.insert(account, CachedOperation::<AccountNonce>::Erase);
         Ok(())
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -28,8 +28,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
-        Transaction, TxMainChainIndex,
+        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, Transaction,
+        TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, Id},
 };
@@ -126,7 +126,7 @@ where
 {
     type Error = <S as utxo::UtxosStorageRead>::Error;
 
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<utxo::Utxo>, Self::Error> {
+    fn get_utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<utxo::Utxo>, Self::Error> {
         self.utxo_cache.utxo(outpoint).map_err(|e| e.into())
     }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
@@ -31,7 +31,7 @@ fn get_inputs_utxos(
         .iter()
         .filter_map(|input| match input {
             TxInput::Utxo(outpoint) => Some(outpoint),
-            TxInput::Account(_, _) => None,
+            TxInput::Account(_) => None,
         })
         .map(|outpoint| {
             utxo_view
@@ -170,8 +170,8 @@ fn is_valid_tx_with_accounting_input(tx: &Transaction) -> Result<(), ConnectTran
         .iter()
         .filter(|input| match input {
             TxInput::Utxo(_) => false,
-            TxInput::Account(account, _) => match account.account() {
-                common::chain::AccountType::Delegation(_) => true,
+            TxInput::Account(account) => match account.account() {
+                common::chain::AccountSpending::Delegation(_, _) => true,
             },
         })
         .exactly_one()

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
@@ -31,7 +31,7 @@ fn get_inputs_utxos(
         .iter()
         .filter_map(|input| match input {
             TxInput::Utxo(outpoint) => Some(outpoint),
-            TxInput::Account(_) => None,
+            TxInput::Account(_, _) => None,
         })
         .map(|outpoint| {
             utxo_view
@@ -170,7 +170,7 @@ fn is_valid_tx_with_accounting_input(tx: &Transaction) -> Result<(), ConnectTran
         .iter()
         .filter(|input| match input {
             TxInput::Utxo(_) => false,
-            TxInput::Account(account) => match account.account() {
+            TxInput::Account(account, _) => match account.account() {
                 common::chain::AccountType::Delegation(_) => true,
             },
         })

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
@@ -29,9 +29,13 @@ fn get_inputs_utxos(
 ) -> Result<Vec<TxOutput>, ConnectTransactionError> {
     inputs
         .iter()
-        .map(|input| {
+        .filter_map(|input| match input {
+            TxInput::Utxo(outpoint) => Some(outpoint),
+            TxInput::Accounting(_) => None,
+        })
+        .map(|outpoint| {
             utxo_view
-                .utxo(input.outpoint())
+                .utxo(outpoint)
                 .map_err(|_| utxo::Error::ViewRead)?
                 .map(|u| u.output().clone())
                 .ok_or(ConnectTransactionError::MissingOutputOrSpent)
@@ -132,7 +136,7 @@ pub fn check_tx_inputs_outputs_purposes(
 
     match inputs_utxos.as_slice() {
         // no inputs
-        [] => return Err(ConnectTransactionError::MissingTxInputs),
+        [] => todo!("handle accounting inputs"),
         // single input
         [input_utxo] => match tx.outputs() {
             // no outputs

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
@@ -31,7 +31,7 @@ fn get_inputs_utxos(
         .iter()
         .filter_map(|input| match input {
             TxInput::Utxo(outpoint) => Some(outpoint),
-            TxInput::Accounting(_) => None,
+            TxInput::Account(_) => None,
         })
         .map(|outpoint| {
             utxo_view

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
@@ -319,11 +319,13 @@ fn tx_one_to_many(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn tx_spend_delegation(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
-    let inputs = vec![TxInput::Account(AccountOutPoint::new(
-        0,
-        AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng))),
+    let inputs = vec![TxInput::Account(
+        AccountOutPoint::new(
+            0,
+            AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng))),
+        ),
         Amount::ZERO,
-    ))];
+    )];
 
     let number_of_outputs = rng.gen_range(2..10);
     let source_outputs = [lock_then_transfer()];

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
@@ -21,8 +21,8 @@ use common::{
         stakelock::StakePoolData,
         timelock::OutputTimeLock,
         tokens::OutputValue,
-        AccountInput, AccountType, Block, DelegationId, Destination, GenBlock, OutPoint,
-        OutPointSourceId, PoolId, TxInput,
+        AccountOutPoint, AccountType, Block, DelegationId, Destination, GenBlock, OutPointSourceId,
+        PoolId, TxInput, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, Compact, Id, H256},
 };
@@ -135,7 +135,7 @@ fn prepare_utxos_and_tx(
         .enumerate()
         .map(|(i, output)| {
             (
-                OutPoint::new(
+                UtxoOutPoint::new(
                     OutPointSourceId::Transaction(Id::new(H256::random_using(rng))),
                     i as u32,
                 ),
@@ -235,7 +235,7 @@ fn tx_one_to_one(
     #[case] output: TxOutput,
     #[case] result: Result<(), ConnectTransactionError>,
 ) {
-    let outpoint = OutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
+    let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
 
     let utxo_db = UtxosDBInMemoryImpl::new(
         Id::<GenBlock>::new(H256::zero()),
@@ -319,7 +319,7 @@ fn tx_one_to_many(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn tx_spend_delegation(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
-    let inputs = vec![TxInput::Account(AccountInput::new(
+    let inputs = vec![TxInput::Account(AccountOutPoint::new(
         0,
         AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng))),
         Amount::ZERO,
@@ -635,7 +635,7 @@ fn reward_one_to_one(
     #[case] output: TxOutput,
     #[case] result: Result<(), ConnectTransactionError>,
 ) {
-    let outpoint = OutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
+    let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
     let utxo_db = UtxosDBInMemoryImpl::new(
         Id::<GenBlock>::new(H256::zero()),
         BTreeMap::from_iter([(
@@ -661,7 +661,7 @@ fn reward_one_to_none(#[case] seed: Seed) {
         .into_iter()
         .next()
         .unwrap();
-    let outpoint = OutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
+    let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
 
     let best_block_id: Id<GenBlock> = Id::new(H256::random_using(&mut rng));
     let utxo_db = UtxosDBInMemoryImpl::new(
@@ -743,7 +743,7 @@ fn reward_many_to_none(#[case] seed: Seed) {
         .enumerate()
         .map(|(i, output)| {
             (
-                OutPoint::new(
+                UtxoOutPoint::new(
                     OutPointSourceId::BlockReward(Id::new(H256::zero())),
                     i as u32,
                 ),

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
@@ -21,8 +21,8 @@ use common::{
         stakelock::StakePoolData,
         timelock::OutputTimeLock,
         tokens::OutputValue,
-        AccountOutPoint, AccountType, Block, DelegationId, Destination, GenBlock, OutPointSourceId,
-        PoolId, TxInput, UtxoOutPoint,
+        AccountOutPoint, AccountSpending, Block, DelegationId, Destination, GenBlock,
+        OutPointSourceId, PoolId, TxInput, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, Compact, Id, H256},
 };
@@ -319,13 +319,13 @@ fn tx_one_to_many(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn tx_spend_delegation(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
-    let inputs = vec![TxInput::Account(
-        AccountOutPoint::new(
-            0,
-            AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng))),
+    let inputs = vec![TxInput::Account(AccountOutPoint::new(
+        0,
+        AccountSpending::Delegation(
+            DelegationId::new(H256::random_using(&mut rng)),
+            Amount::ZERO,
         ),
-        Amount::ZERO,
-    )];
+    ))];
 
     let number_of_outputs = rng.gen_range(2..10);
     let source_outputs = [lock_then_transfer()];

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
@@ -322,6 +322,7 @@ fn tx_spend_delegation(#[case] seed: Seed) {
     let inputs = vec![TxInput::Account(AccountInput::new(
         0,
         AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng))),
+        Amount::ZERO,
     ))];
 
     let number_of_outputs = rng.gen_range(2..10);

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
@@ -21,7 +21,7 @@ use common::{
         stakelock::StakePoolData,
         timelock::OutputTimeLock,
         tokens::OutputValue,
-        AccountOutPoint, AccountSpending, Block, DelegationId, Destination, GenBlock,
+        AccountNonce, AccountOutPoint, AccountSpending, Block, DelegationId, Destination, GenBlock,
         OutPointSourceId, PoolId, TxInput, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, Compact, Id, H256},
@@ -320,7 +320,7 @@ fn tx_one_to_many(#[case] seed: Seed) {
 fn tx_spend_delegation(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let inputs = vec![TxInput::Account(AccountOutPoint::new(
-        0,
+        AccountNonce::new(0),
         AccountSpending::Delegation(
             DelegationId::new(H256::random_using(&mut rng)),
             Amount::ZERO,

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -66,8 +66,8 @@ use common::{
         signature::Signable,
         signed_transaction::SignedTransaction,
         tokens::{get_tokens_issuance_count, TokenId},
-        AccountInput, AccountType, Block, ChainConfig, DelegationId, GenBlock, OutPoint,
-        OutPointSourceId, PoolId, Transaction, TxInput, TxMainChainIndex, TxOutput,
+        AccountOutPoint, AccountType, Block, ChainConfig, DelegationId, GenBlock, OutPointSourceId,
+        PoolId, Transaction, TxInput, TxMainChainIndex, TxOutput, UtxoOutPoint,
     },
     primitives::{id::WithId, Amount, Id, Idable, H256},
 };
@@ -350,7 +350,7 @@ where
     fn spend_input_from_account(
         &mut self,
         tx_source: TransactionSource,
-        account_input: &AccountInput,
+        account_input: &AccountOutPoint,
     ) -> Result<PoSAccountingUndo, ConnectTransactionError> {
         let account = *account_input.account();
         // Check that account nonce increments previous value
@@ -380,7 +380,7 @@ where
     fn spend_input_from_utxo(
         &mut self,
         tx_source: TransactionSource,
-        input_outpoint: &OutPoint,
+        input_outpoint: &UtxoOutPoint,
     ) -> Result<Option<PoSAccountingUndo>, ConnectTransactionError> {
         let input_utxo = self
             .utxo_cache
@@ -435,7 +435,7 @@ where
             .collect::<Result<Vec<_>, _>>()?;
 
         // Process tx outputs in terms of pos accounting.
-        let input_utxo_outpoint = tx.inputs().iter().find_map(|input| input.outpoint());
+        let input_utxo_outpoint = tx.inputs().iter().find_map(|input| input.utxo_outpoint());
         let outputs_undos = tx
             .outputs()
             .iter()

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -354,10 +354,10 @@ where
     ) -> Result<PoSAccountingUndo, ConnectTransactionError> {
         let account = *account_input.account();
         // Check that account nonce increments previous value
-        let current_nonce = self
+        let expected_nonce = self
             .get_account_nonce_count(account)
-            .map_err(|_| ConnectTransactionError::TxVerifierStorage)?;
-        let expected_nonce = current_nonce.map_or(0, |nonce| nonce + 1);
+            .map_err(|_| ConnectTransactionError::TxVerifierStorage)?
+            .map_or(0, |nonce| nonce + 1);
         ensure!(
             expected_nonce == account_input.nonce(),
             ConnectTransactionError::NonceIsNotIncremental(account)

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -650,7 +650,10 @@ where
             self.chain_config.as_ref(),
             &self.utxo_cache,
             tx,
-            SignatureDestinationGetter::new_for_transaction(&self.accounting_delta_adapter),
+            SignatureDestinationGetter::new_for_transaction(
+                &self.accounting_delta_adapter.accounting_delta(),
+                &self.utxo_cache,
+            ),
         )?;
 
         self.connect_pos_accounting_outputs(tx_source.into(), tx.transaction())?;
@@ -716,7 +719,7 @@ where
                 self.chain_config.as_ref(),
                 &self.utxo_cache,
                 &reward_transactable,
-                SignatureDestinationGetter::new_for_block_reward(),
+                SignatureDestinationGetter::new_for_block_reward(&self.utxo_cache),
             )?;
         }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
@@ -15,7 +15,7 @@
 
 use common::chain::{
     signature::{verify_signature, Transactable},
-    ChainConfig,
+    ChainConfig, TxInput,
 };
 use utxo::UtxosView;
 
@@ -40,13 +40,13 @@ where
 
     let inputs_utxos = inputs
         .iter()
-        .map(|input| match input.outpoint() {
-            Some(outpoint) => utxo_view
+        .map(|input| match input {
+            TxInput::Utxo(outpoint) => utxo_view
                 .utxo(outpoint)
                 .map_err(|_| utxo::Error::ViewRead)?
                 .ok_or(ConnectTransactionError::MissingOutputOrSpent)
                 .map(|utxo| Some(utxo.take_output())),
-            None => Ok(None),
+            TxInput::Account(_) => Ok(None),
         })
         .collect::<Result<Vec<_>, ConnectTransactionError>>()?;
     let inputs_utxos = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
@@ -46,7 +46,7 @@ where
                 .map_err(|_| utxo::Error::ViewRead)?
                 .ok_or(ConnectTransactionError::MissingOutputOrSpent)
                 .map(|utxo| Some(utxo.take_output())),
-            TxInput::Account(_) => Ok(None),
+            TxInput::Account(_, _) => Ok(None),
         })
         .collect::<Result<Vec<_>, ConnectTransactionError>>()?;
     let inputs_utxos = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
@@ -41,7 +41,7 @@ where
     let inputs_utxos = inputs
         .iter()
         .map(|input| {
-            let outpoint = input.outpoint();
+            let outpoint = input.outpoint().unwrap(); // FIXME: impl
             utxo_view
                 .utxo(outpoint)
                 .map_err(|_| utxo::Error::ViewRead)?

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
@@ -46,7 +46,7 @@ where
                 .map_err(|_| utxo::Error::ViewRead)?
                 .ok_or(ConnectTransactionError::MissingOutputOrSpent)
                 .map(|utxo| Some(utxo.take_output())),
-            TxInput::Account(_, _) => Ok(None),
+            TxInput::Account(_) => Ok(None),
         })
         .collect::<Result<Vec<_>, ConnectTransactionError>>()?;
     let inputs_utxos = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::chain::{DelegationId, Destination, OutPoint, PoolId, TxInput, TxOutput};
+use common::chain::{DelegationId, Destination, PoolId, TxInput, TxOutput, UtxoOutPoint};
 use pos_accounting::PoSAccountingView;
 use utxo::UtxosView;
 
@@ -33,7 +33,7 @@ pub enum SignatureDestinationGetterError {
     #[error("Delegation data not found for signature verification {0}")]
     DelegationDataNotFound(DelegationId),
     #[error("Utxo for the outpoint not fount: {0:?}")]
-    UtxoOutputNotFound(OutPoint),
+    UtxoOutputNotFound(UtxoOutPoint),
     #[error("Error accessing utxo set")]
     UtxoViewError(utxo::Error),
     #[error("During destination getting for signature verification: PoS accounting error {0}")]

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
@@ -120,7 +120,7 @@ impl<'a> SignatureDestinationGetter<'a> {
                             }
                         }
                     }
-                    TxInput::Account(account_input) => match account_input.account() {
+                    TxInput::Account(account_input, _) => match account_input.account() {
                         common::chain::AccountType::Delegation(delegation_id) => {
                             Ok(accounting_view
                                 .get_delegation_data(*delegation_id)?
@@ -179,7 +179,7 @@ impl<'a> SignatureDestinationGetter<'a> {
                             }
                         }
                     }
-                    TxInput::Account(_) => {
+                    TxInput::Account(_, _) => {
                         Err(SignatureDestinationGetterError::SpendingFromAccountInBlockReward)
                     }
                 }

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
@@ -120,8 +120,8 @@ impl<'a> SignatureDestinationGetter<'a> {
                             }
                         }
                     }
-                    TxInput::Account(account_input, _) => match account_input.account() {
-                        common::chain::AccountType::Delegation(delegation_id) => {
+                    TxInput::Account(account_input) => match account_input.account() {
+                        common::chain::AccountSpending::Delegation(delegation_id, _) => {
                             Ok(accounting_view
                                 .get_delegation_data(*delegation_id)?
                                 .ok_or(SignatureDestinationGetterError::DelegationDataNotFound(
@@ -179,7 +179,7 @@ impl<'a> SignatureDestinationGetter<'a> {
                             }
                         }
                     }
-                    TxInput::Account(_, _) => {
+                    TxInput::Account(_) => {
                         Err(SignatureDestinationGetterError::SpendingFromAccountInBlockReward)
                     }
                 }

--- a/chainstate/tx-verifier/src/transaction_verifier/storage.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/storage.rs
@@ -19,7 +19,7 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, GenBlock, OutPointSourceId, Transaction, TxMainChainIndex,
+        AccountType, Block, GenBlock, OutPointSourceId, Transaction, TxMainChainIndex,
     },
     primitives::Id,
 };
@@ -107,6 +107,11 @@ where
         &self,
         id: Id<Block>,
     ) -> Result<Option<AccountingBlockUndo>, <Self as TransactionVerifierStorageRef>::Error>;
+
+    fn get_account_nonce_count(
+        &self,
+        account: AccountType,
+    ) -> Result<Option<u128>, <Self as TransactionVerifierStorageRef>::Error>;
 }
 
 pub trait TransactionVerifierStorageMut:
@@ -172,6 +177,16 @@ pub trait TransactionVerifierStorageMut:
         tx_source: TransactionSource,
         delta: &PoSAccountingDeltaData,
     ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
+
+    fn set_account_nonce_count(
+        &mut self,
+        account: AccountType,
+        nonce: u128,
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
+    fn del_account_nonce_count(
+        &mut self,
+        account: AccountType,
+    ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
 }
 
 impl<T: Deref> TransactionVerifierStorageRef for T
@@ -213,5 +228,12 @@ where
         id: Id<Block>,
     ) -> Result<Option<AccountingBlockUndo>, <Self as TransactionVerifierStorageRef>::Error> {
         self.deref().get_accounting_undo(id)
+    }
+
+    fn get_account_nonce_count(
+        &self,
+        account: AccountType,
+    ) -> Result<Option<u128>, <Self as TransactionVerifierStorageRef>::Error> {
+        self.deref().get_account_nonce_count(account)
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/storage.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/storage.rs
@@ -19,7 +19,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, GenBlock, OutPointSourceId, Transaction, TxMainChainIndex,
+        AccountNonce, AccountType, Block, GenBlock, OutPointSourceId, Transaction,
+        TxMainChainIndex,
     },
     primitives::Id,
 };
@@ -111,7 +112,7 @@ where
     fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, <Self as TransactionVerifierStorageRef>::Error>;
+    ) -> Result<Option<AccountNonce>, <Self as TransactionVerifierStorageRef>::Error>;
 }
 
 pub trait TransactionVerifierStorageMut:
@@ -181,7 +182,7 @@ pub trait TransactionVerifierStorageMut:
     fn set_account_nonce_count(
         &mut self,
         account: AccountType,
-        nonce: u128,
+        nonce: AccountNonce,
     ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error>;
     fn del_account_nonce_count(
         &mut self,
@@ -233,7 +234,7 @@ where
     fn get_account_nonce_count(
         &self,
         account: AccountType,
-    ) -> Result<Option<u128>, <Self as TransactionVerifierStorageRef>::Error> {
+    ) -> Result<Option<AccountNonce>, <Self as TransactionVerifierStorageRef>::Error> {
         self.deref().get_account_nonce_count(account)
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
@@ -658,13 +658,13 @@ fn hierarchy_test_nonce(#[case] seed: Seed) {
 
     let chain_config = ConfigBuilder::test_chain().build();
 
-    let nonce0 = rng.gen::<u128>();
+    let nonce0 = AccountNonce::new(rng.gen());
     let account0 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
 
-    let nonce1 = rng.gen::<u128>();
+    let nonce1 = AccountNonce::new(rng.gen());
     let account1 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
 
-    let nonce2 = rng.gen::<u128>();
+    let nonce2 = AccountNonce::new(rng.gen());
     let account2 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
 
     let mut store = mock::MockStore::new();

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
@@ -117,7 +117,7 @@ fn hierarchy_test_undo_from_chain(#[case] seed: Seed) {
         None,
         BTreeMap::from([(
             H256::random_using(&mut rng).into(),
-            UtxosTxUndoWithSources::new(vec![utxo0_undo], vec![]),
+            UtxosTxUndoWithSources::new(vec![Some(utxo0_undo)], vec![]),
         )]),
     )
     .unwrap();
@@ -128,7 +128,7 @@ fn hierarchy_test_undo_from_chain(#[case] seed: Seed) {
         None,
         BTreeMap::from([(
             H256::random_using(&mut rng).into(),
-            UtxosTxUndoWithSources::new(vec![utxo1_undo], vec![]),
+            UtxosTxUndoWithSources::new(vec![Some(utxo1_undo)], vec![]),
         )]),
     )
     .unwrap();
@@ -139,7 +139,7 @@ fn hierarchy_test_undo_from_chain(#[case] seed: Seed) {
         None,
         BTreeMap::from([(
             H256::random_using(&mut rng).into(),
-            UtxosTxUndoWithSources::new(vec![utxo2_undo], vec![]),
+            UtxosTxUndoWithSources::new(vec![Some(utxo2_undo)], vec![]),
         )]),
     )
     .unwrap();

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -53,7 +53,7 @@ fn utxo_set_from_chain_hierarchy(#[case] seed: Seed) {
         None,
         BTreeMap::from([(
             tx_1_id,
-            UtxosTxUndoWithSources::new(vec![create_utxo(&mut rng, 100).1], vec![]),
+            UtxosTxUndoWithSources::new(vec![Some(create_utxo(&mut rng, 100).1)], vec![]),
         )]),
     )
     .unwrap();
@@ -65,7 +65,7 @@ fn utxo_set_from_chain_hierarchy(#[case] seed: Seed) {
         None,
         BTreeMap::from([(
             tx_2_id,
-            UtxosTxUndoWithSources::new(vec![create_utxo(&mut rng, 100).1], vec![]),
+            UtxosTxUndoWithSources::new(vec![Some(create_utxo(&mut rng, 100).1)], vec![]),
         )]),
     )
     .unwrap();
@@ -549,7 +549,7 @@ fn block_undo_from_chain_conflict_hierarchy(#[case] seed: Seed) {
         Some(UtxosBlockRewardUndo::new(vec![utxo1.clone()])),
         BTreeMap::from([(
             tx_1_id,
-            UtxosTxUndoWithSources::new(vec![utxo2.clone()], vec![]),
+            UtxosTxUndoWithSources::new(vec![Some(utxo2.clone())], vec![]),
         )]),
     )
     .unwrap();
@@ -558,15 +558,21 @@ fn block_undo_from_chain_conflict_hierarchy(#[case] seed: Seed) {
         Some(UtxosBlockRewardUndo::new(vec![utxo3.clone()])),
         BTreeMap::from([(
             tx_2_id,
-            UtxosTxUndoWithSources::new(vec![utxo4.clone()], vec![]),
+            UtxosTxUndoWithSources::new(vec![Some(utxo4.clone())], vec![]),
         )]),
     )
     .unwrap();
     let expected_block_undo = UtxosBlockUndo::new(
         Some(UtxosBlockRewardUndo::new(vec![utxo1, utxo3])),
         BTreeMap::from([
-            (tx_1_id, UtxosTxUndoWithSources::new(vec![utxo2], vec![])),
-            (tx_2_id, UtxosTxUndoWithSources::new(vec![utxo4], vec![])),
+            (
+                tx_1_id,
+                UtxosTxUndoWithSources::new(vec![Some(utxo2)], vec![]),
+            ),
+            (
+                tx_2_id,
+                UtxosTxUndoWithSources::new(vec![Some(utxo4)], vec![]),
+            ),
         ]),
     )
     .unwrap();

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -999,3 +999,112 @@ fn pos_accounting_stake_pool_undo_del_hierarchy(#[case] seed: Seed) {
     let consumed_verifier1 = verifier1.consume().unwrap();
     flush::flush_to_storage(&mut store, consumed_verifier1).unwrap();
 }
+
+// Create the following hierarchy:
+//
+// TransactionVerifier -> TransactionVerifier -> MockStore
+// nonce2                 nonce1
+//
+// Check that data from TransactionVerifiers are flushed from one TransactionVerifier to another
+// and then to the store
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn nonce_set_hierarchy(#[case] seed: Seed) {
+    let mut rng = test_utils::random::make_seedable_rng(seed);
+
+    let chain_config = ConfigBuilder::test_chain().build();
+
+    let nonce1 = rng.gen::<u128>();
+    let account1 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
+
+    let nonce2 = rng.gen::<u128>();
+    let account2 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
+
+    let mut store = mock::MockStore::new();
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
+    store.expect_batch_write().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
+    store
+        .expect_set_account_nonce_count()
+        .with(eq(account1), eq(nonce1))
+        .times(1)
+        .return_const(Ok(()));
+    store
+        .expect_set_account_nonce_count()
+        .with(eq(account2), eq(nonce2))
+        .times(1)
+        .return_const(Ok(()));
+
+    let mut verifier1 =
+        TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
+    verifier1.account_nonce = BTreeMap::from([(account1, CachedOperation::Write(nonce1))]);
+
+    let verifier2 = {
+        let mut verifier = verifier1.derive_child();
+        verifier.account_nonce = BTreeMap::from([(account2, CachedOperation::Write(nonce2))]);
+        verifier
+    };
+
+    let consumed_verifier2 = verifier2.consume().unwrap();
+    flush::flush_to_storage(&mut verifier1, consumed_verifier2).unwrap();
+
+    let consumed_verifier1 = verifier1.consume().unwrap();
+    flush::flush_to_storage(&mut store, consumed_verifier1).unwrap();
+}
+
+// Create the following hierarchy:
+//
+// TransactionVerifier -> TransactionVerifier -> MockStore
+//                                               nonce0; nonce1
+//
+// Erase nonce0 in TransactionVerifier2 and nonce1 in TransactionVerifier1.
+// Flush and check that the data was deleted from the store
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn nonce_del_hierarchy(#[case] seed: Seed) {
+    let mut rng = test_utils::random::make_seedable_rng(seed);
+
+    let chain_config = ConfigBuilder::test_chain().build();
+
+    let account0 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
+    let account1 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
+
+    let mut store = mock::MockStore::new();
+    store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
+    store.expect_batch_write().times(1).return_const(Ok(()));
+    store
+        .expect_batch_write_delta()
+        .times(1)
+        .return_const(Ok(DeltaMergeUndo::new()));
+    store
+        .expect_del_account_nonce_count()
+        .with(eq(account0))
+        .times(1)
+        .return_const(Ok(()));
+    store
+        .expect_del_account_nonce_count()
+        .with(eq(account1))
+        .times(1)
+        .return_const(Ok(()));
+
+    let mut verifier1 =
+        TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
+    verifier1.account_nonce = BTreeMap::from([(account1, CachedOperation::Erase)]);
+
+    let verifier2 = {
+        let mut verifier = verifier1.derive_child();
+        verifier.account_nonce = BTreeMap::from([(account0, CachedOperation::Erase)]);
+        verifier
+    };
+
+    let consumed_verifier2 = verifier2.consume().unwrap();
+    flush::flush_to_storage(&mut verifier1, consumed_verifier2).unwrap();
+
+    let consumed_verifier1 = verifier1.consume().unwrap();
+    flush::flush_to_storage(&mut store, consumed_verifier1).unwrap();
+}

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -1015,10 +1015,10 @@ fn nonce_set_hierarchy(#[case] seed: Seed) {
 
     let chain_config = ConfigBuilder::test_chain().build();
 
-    let nonce1 = rng.gen::<u128>();
+    let nonce1 = AccountNonce::new(rng.gen());
     let account1 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
 
-    let nonce2 = rng.gen::<u128>();
+    let nonce2 = AccountNonce::new(rng.gen());
     let account2 = AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng)));
 
     let mut store = mock::MockStore::new();

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -24,8 +24,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, Transaction,
-        TxMainChainIndex, UtxoOutPoint,
+        AccountNonce, AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId,
+        Transaction, TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, Id},
 };
@@ -69,7 +69,7 @@ mockall::mock! {
         fn get_account_nonce_count(
             &self,
             account: AccountType,
-        ) -> Result<Option<u128>, TransactionVerifierStorageError>;
+        ) -> Result<Option<AccountNonce>, TransactionVerifierStorageError>;
     }
 
     impl TransactionVerifierStorageMut for Store {
@@ -129,7 +129,7 @@ mockall::mock! {
         fn set_account_nonce_count(
             &mut self,
             account: AccountType,
-            nonce: u128,
+            nonce: AccountNonce,
         ) -> Result<(), TransactionVerifierStorageError>;
         fn del_account_nonce_count(
             &mut self,

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -24,8 +24,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId, Transaction,
-        TxMainChainIndex,
+        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
+        Transaction, TxMainChainIndex,
     },
     primitives::{Amount, Id},
 };
@@ -65,6 +65,11 @@ mockall::mock! {
             &self,
             id: Id<Block>,
         ) -> Result<Option<pos_accounting::AccountingBlockUndo>, TransactionVerifierStorageError>;
+
+        fn get_account_nonce_count(
+            &self,
+            account: AccountType,
+        ) -> Result<Option<u128>, TransactionVerifierStorageError>;
     }
 
     impl TransactionVerifierStorageMut for Store {
@@ -119,6 +124,16 @@ mockall::mock! {
             &mut self,
             tx_source: TransactionSource,
             delta: &PoSAccountingDeltaData,
+        ) -> Result<(), TransactionVerifierStorageError>;
+
+        fn set_account_nonce_count(
+            &mut self,
+            account: AccountType,
+            nonce: u128,
+        ) -> Result<(), TransactionVerifierStorageError>;
+        fn del_account_nonce_count(
+            &mut self,
+            account: AccountType,
         ) -> Result<(), TransactionVerifierStorageError>;
     }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -24,8 +24,8 @@ use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
-        Transaction, TxMainChainIndex,
+        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, Transaction,
+        TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, Id},
 };
@@ -139,7 +139,7 @@ mockall::mock! {
 
     impl UtxosStorageRead for Store {
         type Error = storage_result::Error;
-        fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, storage_result::Error>;
+        fn get_utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, storage_result::Error>;
         fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, storage_result::Error>;
         fn get_undo_data(&self, id: Id<Block>) -> Result<Option<utxo::UtxosBlockUndo>, storage_result::Error>;
     }

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
@@ -19,7 +19,7 @@ mod mock;
 
 use super::*;
 use common::{
-    chain::{stakelock::StakePoolData, tokens::OutputValue, Destination, OutPoint},
+    chain::{stakelock::StakePoolData, tokens::OutputValue, Destination, UtxoOutPoint},
     primitives::{amount::UnsignedIntType, per_thousand::PerThousand, BlockHeight, H256},
 };
 use crypto::{
@@ -29,8 +29,8 @@ use crypto::{
 };
 use utxo::Utxo;
 
-fn create_utxo(rng: &mut (impl Rng + CryptoRng), value: UnsignedIntType) -> (OutPoint, Utxo) {
-    let outpoint = OutPoint::new(
+fn create_utxo(rng: &mut (impl Rng + CryptoRng), value: UnsignedIntType) -> (UtxoOutPoint, Utxo) {
+    let outpoint = UtxoOutPoint::new(
         OutPointSourceId::Transaction(Id::new(H256::random_using(rng))),
         0,
     );

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -126,7 +126,6 @@ where
     };
 
     // check if utxos can already be spent
-    //input_utxos.iter().filter_map(|utxo|utxo.map(|(outpoint, utxo)| (outpoint, utxo))).try_for_each(| (outpoint, utxo)| -> Result<(), ConnectTransactionError>{
     input_utxos.iter().filter_map(|utxo| utxo.as_ref()).try_for_each(| (outpoint, utxo)| -> Result<(), ConnectTransactionError>{
         if let Some(timelock) = utxo.output().timelock() {
             let height = match utxo.source() {

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -113,7 +113,7 @@ where
                     .ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
                 Ok(Some((outpoint.clone(), utxo)))
             }
-            TxInput::Account(_) => Ok(None),
+            TxInput::Account(_, _) => Ok(None),
         })
         .collect::<Result<Vec<_>, ConnectTransactionError>>()?;
     debug_assert_eq!(inputs.len(), input_utxos.len());
@@ -184,7 +184,7 @@ where
                         }
                     }
                 }
-                TxInput::Account(account_input) => match account_input.account() {
+                TxInput::Account(account_input, _) => match account_input.account() {
                     AccountType::Delegation(_) => {
                         Some(OutputTimelockCheckRequired::DelegationSpendMaturity)
                     }

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -17,7 +17,7 @@ use chainstate_types::{block_index_ancestor_getter, GenBlockIndex};
 use common::{
     chain::{
         block::timestamp::BlockTimestamp, signature::Transactable, timelock::OutputTimeLock,
-        AccountType, ChainConfig, GenBlock, OutPointSourceId, TxInput, TxOutput, UtxoOutPoint,
+        AccountSpending, ChainConfig, GenBlock, OutPointSourceId, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{BlockDistance, BlockHeight, Id},
 };
@@ -113,7 +113,7 @@ where
                     .ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
                 Ok(Some((outpoint.clone(), utxo)))
             }
-            TxInput::Account(_, _) => Ok(None),
+            TxInput::Account(_) => Ok(None),
         })
         .collect::<Result<Vec<_>, ConnectTransactionError>>()?;
     debug_assert_eq!(inputs.len(), input_utxos.len());
@@ -184,8 +184,8 @@ where
                         }
                     }
                 }
-                TxInput::Account(account_input, _) => match account_input.account() {
-                    AccountType::Delegation(_) => {
+                TxInput::Account(account_input) => match account_input.account() {
+                    AccountSpending::Delegation(_, _) => {
                         Some(OutputTimelockCheckRequired::DelegationSpendMaturity)
                     }
                 },

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -133,18 +133,15 @@ where
         Fn(&Id<Transaction>) -> Result<Option<TokenId>, ConnectTransactionError>,
 {
     let iter = inputs.iter().map(|input| {
+        let outpoint = input.outpoint().unwrap(); // FIXME: impl
         let utxo = utxo_view
-            .utxo(input.outpoint())
+            .utxo(outpoint)
             .map_err(|_| utxo::Error::ViewRead)?
             .ok_or(ConnectTransactionError::MissingOutputOrSpent)?;
 
         let output_value = get_output_value(pos_accounting_view, utxo.output())?;
 
-        amount_from_outpoint(
-            input.outpoint().tx_id(),
-            &output_value,
-            &issuance_token_id_getter,
-        )
+        amount_from_outpoint(outpoint.tx_id(), &output_value, &issuance_token_id_getter)
     });
 
     let iter = fallible_iterator::convert(iter);

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -21,7 +21,7 @@ use common::{
         block::{BlockRewardTransactable, ConsensusData},
         signature::Signable,
         tokens::{get_tokens_issuance_count, token_id, OutputValue, TokenData, TokenId},
-        AccountType, Block, OutPointSourceId, Transaction, TxInput, TxOutput,
+        AccountSpending, Block, OutPointSourceId, Transaction, TxInput, TxOutput,
     },
     primitives::{Amount, Id},
 };
@@ -159,8 +159,8 @@ where
 
             amount_from_outpoint(outpoint.tx_id(), &output_value, &issuance_token_id_getter)
         }
-        TxInput::Account(account_input, withdraw_amount) => match account_input.account() {
-            AccountType::Delegation(delegation_id) => {
+        TxInput::Account(account_input) => match account_input.account() {
+            AccountSpending::Delegation(delegation_id, withdraw_amount) => {
                 let total_balance = pos_accounting_view
                     .get_delegation_balance(*delegation_id)
                     .map_err(|_| pos_accounting::Error::ViewFail)?
@@ -603,10 +603,10 @@ mod tests {
 
         // try overspend balance
         {
-            let input = TxInput::Account(
-                AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
-                overspend_amount,
-            );
+            let input = TxInput::Account(AccountOutPoint::new(
+                0,
+                AccountSpending::Delegation(delegation_id, overspend_amount),
+            ));
 
             let output = TxOutput::Transfer(
                 OutputValue::Coin(overspend_amount),
@@ -627,10 +627,10 @@ mod tests {
 
         // try overspend input
         {
-            let input = TxInput::Account(
-                AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
-                withdraw_amount,
-            );
+            let input = TxInput::Account(AccountOutPoint::new(
+                0,
+                AccountSpending::Delegation(delegation_id, withdraw_amount),
+            ));
 
             let output = TxOutput::Transfer(
                 OutputValue::Coin(overspend_amount),
@@ -649,10 +649,10 @@ mod tests {
             );
         }
 
-        let input = TxInput::Account(
-            AccountOutPoint::new(0, AccountType::Delegation(delegation_id)),
-            withdraw_amount,
-        );
+        let input = TxInput::Account(AccountOutPoint::new(
+            0,
+            AccountSpending::Delegation(delegation_id, withdraw_amount),
+        ));
         let output = TxOutput::Transfer(
             OutputValue::Coin(withdraw_amount),
             Destination::AnyoneCanSpend,

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -350,7 +350,7 @@ mod tests {
             block::consensus_data::{PoSData, PoWData},
             stakelock::StakePoolData,
             timelock::OutputTimeLock,
-            AccountInput, DelegationId, Destination, GenBlock, OutPoint, PoolId,
+            AccountOutPoint, DelegationId, Destination, GenBlock, PoolId, UtxoOutPoint,
         },
         primitives::{per_thousand::PerThousand, Compact, H256},
     };
@@ -367,7 +367,7 @@ mod tests {
     fn check_block_reward_pow(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
 
-        let outpoint = OutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
+        let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
         let input_amount = Amount::from_atoms(rng.gen_range(0..100_000));
         let input_utxo =
             TxOutput::Transfer(OutputValue::Coin(input_amount), Destination::AnyoneCanSpend);
@@ -450,7 +450,7 @@ mod tests {
         let mut rng = make_seedable_rng(seed);
 
         let pool_id = PoolId::new(H256::zero());
-        let outpoint = OutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
+        let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
         let pledge_amount = Amount::from_atoms(rng.gen_range(0..100_000));
         let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
         let vrf_data = vrf_sk.produce_vrf_data(TranscriptAssembler::new(b"abc").finalize().into());
@@ -512,7 +512,7 @@ mod tests {
         let pool_id_1 = PoolId::new(H256::random_using(&mut rng));
         let pool_id_2 = PoolId::new(H256::random_using(&mut rng));
 
-        let outpoint = OutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
+        let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
         let pledge_amount_1 = Amount::from_atoms(rng.gen_range(0..100_000));
         let pledge_amount_2 = Amount::from_atoms(rng.gen_range(100_000..200_000));
         let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
@@ -606,7 +606,7 @@ mod tests {
 
         // try overspend balance
         {
-            let input = TxInput::Account(AccountInput::new(
+            let input = TxInput::Account(AccountOutPoint::new(
                 0,
                 AccountType::Delegation(delegation_id),
                 overspend_amount,
@@ -631,7 +631,7 @@ mod tests {
 
         // try overspend input
         {
-            let input = TxInput::Account(AccountInput::new(
+            let input = TxInput::Account(AccountOutPoint::new(
                 0,
                 AccountType::Delegation(delegation_id),
                 withdraw_amount,
@@ -654,7 +654,7 @@ mod tests {
             );
         }
 
-        let input = TxInput::Account(AccountInput::new(
+        let input = TxInput::Account(AccountOutPoint::new(
             0,
             AccountType::Delegation(delegation_id),
             withdraw_amount,

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -347,7 +347,8 @@ mod tests {
             block::consensus_data::{PoSData, PoWData},
             stakelock::StakePoolData,
             timelock::OutputTimeLock,
-            AccountOutPoint, DelegationId, Destination, GenBlock, PoolId, UtxoOutPoint,
+            AccountNonce, AccountOutPoint, DelegationId, Destination, GenBlock, PoolId,
+            UtxoOutPoint,
         },
         primitives::{per_thousand::PerThousand, Compact, H256},
     };
@@ -604,7 +605,7 @@ mod tests {
         // try overspend balance
         {
             let input = TxInput::Account(AccountOutPoint::new(
-                0,
+                AccountNonce::new(0),
                 AccountSpending::Delegation(delegation_id, overspend_amount),
             ));
 
@@ -628,7 +629,7 @@ mod tests {
         // try overspend input
         {
             let input = TxInput::Account(AccountOutPoint::new(
-                0,
+                AccountNonce::new(0),
                 AccountSpending::Delegation(delegation_id, withdraw_amount),
             ));
 
@@ -650,7 +651,7 @@ mod tests {
         }
 
         let input = TxInput::Account(AccountOutPoint::new(
-            0,
+            AccountNonce::new(0),
             AccountSpending::Delegation(delegation_id, withdraw_amount),
         ));
         let output = TxOutput::Transfer(

--- a/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
@@ -108,7 +108,7 @@ impl TxIndexCache {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => Some(outpoint),
-                TxInput::Account(_, _) => None,
+                TxInput::Account(_) => None,
             })
             .try_for_each(|outpoint| {
                 let prev_tx_index_op = self.get_from_cached_mut(&outpoint.tx_id())?;
@@ -123,7 +123,7 @@ impl TxIndexCache {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => Some(outpoint),
-                TxInput::Account(_, _) => None,
+                TxInput::Account(_) => None,
             })
             .try_for_each(|outpoint| {
                 let prev_tx_index_op = self.get_from_cached_mut(&outpoint.tx_id())?;
@@ -144,7 +144,7 @@ impl TxIndexCache {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => Some(outpoint),
-                TxInput::Account(_, _) => None,
+                TxInput::Account(_) => None,
             })
             .try_for_each(|outpoint| {
                 match self.data.entry(outpoint.tx_id()) {

--- a/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
@@ -108,7 +108,7 @@ impl TxIndexCache {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => Some(outpoint),
-                TxInput::Account(_) => None,
+                TxInput::Account(_, _) => None,
             })
             .try_for_each(|outpoint| {
                 let prev_tx_index_op = self.get_from_cached_mut(&outpoint.tx_id())?;
@@ -123,7 +123,7 @@ impl TxIndexCache {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => Some(outpoint),
-                TxInput::Account(_) => None,
+                TxInput::Account(_, _) => None,
             })
             .try_for_each(|outpoint| {
                 let prev_tx_index_op = self.get_from_cached_mut(&outpoint.tx_id())?;
@@ -144,7 +144,7 @@ impl TxIndexCache {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => Some(outpoint),
-                TxInput::Account(_) => None,
+                TxInput::Account(_, _) => None,
             })
             .try_for_each(|outpoint| {
                 match self.data.entry(outpoint.tx_id()) {

--- a/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
@@ -105,7 +105,7 @@ impl TxIndexCache {
         spender: Spender,
     ) -> Result<(), TxIndexError> {
         for input in inputs {
-            let outpoint = input.outpoint();
+            let outpoint = input.outpoint().unwrap(); // FIXME: impl
             let prev_tx_index_op = self.get_from_cached_mut(&outpoint.tx_id())?;
             prev_tx_index_op
                 .spend(outpoint.output_index(), spender.clone())
@@ -117,7 +117,7 @@ impl TxIndexCache {
 
     pub fn unspend_tx_index_inputs(&mut self, inputs: &[TxInput]) -> Result<(), TxIndexError> {
         for input in inputs {
-            let outpoint = input.outpoint();
+            let outpoint = input.outpoint().unwrap(); // FIXME: impl
             let prev_tx_index_op = self.get_from_cached_mut(&outpoint.tx_id())?;
             prev_tx_index_op.unspend(outpoint.output_index()).map_err(TxIndexError::from)?;
         }
@@ -135,7 +135,7 @@ impl TxIndexCache {
         ConnectTransactionError: From<E>,
     {
         inputs.iter().try_for_each(|input| {
-            let outpoint = input.outpoint();
+            let outpoint = input.outpoint().unwrap(); // FIXME: impl
             match self.data.entry(outpoint.tx_id()) {
                 Entry::Occupied(_) => (),
                 Entry::Vacant(entry) => {

--- a/common/src/chain/block/block_body/mod.rs
+++ b/common/src/chain/block/block_body/mod.rs
@@ -122,7 +122,7 @@ mod tests {
             OutPointSourceId::BlockReward(Id::new(generate_random_h256(rng)))
         };
 
-        TxInput::new(outpoint, rng.next_u32())
+        TxInput::from_utxo(outpoint, rng.next_u32())
     }
 
     fn generate_random_invalid_output(rng: &mut (impl Rng + CryptoRng)) -> TxOutput {

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -386,7 +386,7 @@ mod tests {
     #[case(Seed::from_entropy())]
     fn tx_with_witness_always_different_merkle_witness_root(#[case] seed: Seed) {
         let mut rng = test_utils::random::make_seedable_rng(seed);
-        let inputs = vec![TxInput::new(
+        let inputs = vec![TxInput::from_utxo(
             OutPointSourceId::Transaction(H256::random_using(&mut rng).into()),
             0,
         )];

--- a/common/src/chain/transaction/account_nonce.rs
+++ b/common/src/chain/transaction/account_nonce.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serialization::{Decode, Encode};
+
+/// An incremental value that represents sequential number of spending from an account.
+/// It's equivalent to the nonce in Ethereum and helps preserving order of transactions and
+/// avoid transaction replay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+pub struct AccountNonce(#[codec(compact)] u64);
+
+impl AccountNonce {
+    pub fn new(nonce: u64) -> Self {
+        Self(nonce)
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+
+    pub fn increment(self) -> Option<Self> {
+        (self.0 < u64::MAX).then(|| AccountNonce::new(self.0 + 1))
+    }
+
+    pub fn decrement(self) -> Option<Self> {
+        (self.0 > 0).then(|| AccountNonce::new(self.0 - 1))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crypto::random::Rng;
+    use rstest::rstest;
+    use test_utils::random::Seed;
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn test_nonce_increment(#[case] seed: Seed) {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
+
+        assert_eq!(AccountNonce::new(u64::MAX).increment(), None);
+
+        let v = rng.gen_range(0..u64::MAX - 1);
+        assert_eq!(
+            AccountNonce::new(v).increment(),
+            Some(AccountNonce::new(v + 1))
+        );
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn test_nonce_decrement(#[case] seed: Seed) {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
+
+        assert_eq!(AccountNonce::new(0).decrement(), None);
+
+        let v = rng.gen_range(1..u64::MAX);
+        assert_eq!(
+            AccountNonce::new(v).decrement(),
+            Some(AccountNonce::new(v - 1))
+        );
+    }
+}

--- a/common/src/chain/transaction/account_nonce.rs
+++ b/common/src/chain/transaction/account_nonce.rs
@@ -31,11 +31,11 @@ impl AccountNonce {
     }
 
     pub fn increment(self) -> Option<Self> {
-        (self.0 < u64::MAX).then(|| AccountNonce::new(self.0 + 1))
+        self.0.checked_add(1).map(AccountNonce::new)
     }
 
     pub fn decrement(self) -> Option<Self> {
-        (self.0 > 0).then(|| AccountNonce::new(self.0 - 1))
+        self.0.checked_sub(1).map(AccountNonce::new)
     }
 }
 #[cfg(test)]

--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{chain::DelegationId, primitives::Amount};
+use crate::{
+    chain::{AccountNonce, DelegationId},
+    primitives::Amount,
+};
 use serialization::{Decode, Encode};
 
 // Type of an account that can be used to identify series of spending from an account
@@ -42,21 +45,16 @@ pub enum AccountSpending {
 /// Type of OutPoint that represents spending from an account
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub struct AccountOutPoint {
-    /// An incremental value that represents sequential number of spending from an account.
-    /// It's equivalent to the nonce in Ethereum and helps preserving order of transactions and
-    /// avoid transaction replay.
-    #[codec(compact)]
-    nonce: u128,
-    /// Type of account to spend from.
+    nonce: AccountNonce,
     account: AccountSpending,
 }
 
 impl AccountOutPoint {
-    pub fn new(nonce: u128, account: AccountSpending) -> Self {
+    pub fn new(nonce: AccountNonce, account: AccountSpending) -> Self {
         Self { nonce, account }
     }
 
-    pub fn nonce(&self) -> u128 {
+    pub fn nonce(&self) -> AccountNonce {
         self.nonce
     }
 

--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -22,11 +22,17 @@ pub enum AccountType {
     Delegation(DelegationId),
 }
 
+/// Type of OutPoint that represents spending from an account
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub struct AccountOutPoint {
+    /// An incremental value that represents sequential number of spending from an account.
+    /// It's equivalent to the nonce in Ethereum and helps preserving order of transactions and avoid double-spends.
     #[codec(compact)]
     nonce: u128,
+    /// Type of account to spend from.
     account: AccountType,
+    /// The amount to withdraw from account. This field helps solving 2 problems: calculating fees and
+    /// providing ability to sign input balance with the witness.
     withdraw_amount: Amount,
 }
 

--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 use crate::chain::DelegationId;
-use crate::primitives::Amount;
 use serialization::{Decode, Encode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
@@ -33,18 +32,11 @@ pub struct AccountOutPoint {
     nonce: u128,
     /// Type of account to spend from.
     account: AccountType,
-    /// The amount to withdraw from account. This field helps solving 2 problems: calculating fees and
-    /// providing ability to sign input balance with the witness.
-    withdraw_amount: Amount,
 }
 
 impl AccountOutPoint {
-    pub fn new(nonce: u128, account: AccountType, withdraw_amount: Amount) -> Self {
-        Self {
-            nonce,
-            account,
-            withdraw_amount,
-        }
+    pub fn new(nonce: u128, account: AccountType) -> Self {
+        Self { nonce, account }
     }
 
     pub fn nonce(&self) -> u128 {
@@ -53,9 +45,5 @@ impl AccountOutPoint {
 
     pub fn account(&self) -> &AccountType {
         &self.account
-    }
-
-    pub fn withdraw_amount(&self) -> &Amount {
-        &self.withdraw_amount
     }
 }

--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -19,6 +19,7 @@ use serialization::{Decode, Encode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub enum AccountType {
+    #[codec(index = 0)]
     Delegation(DelegationId),
 }
 
@@ -26,7 +27,8 @@ pub enum AccountType {
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub struct AccountOutPoint {
     /// An incremental value that represents sequential number of spending from an account.
-    /// It's equivalent to the nonce in Ethereum and helps preserving order of transactions and avoid double-spends.
+    /// It's equivalent to the nonce in Ethereum and helps preserving order of transactions and
+    /// avoid transaction replay.
     #[codec(compact)]
     nonce: u128,
     /// Type of account to spend from.

--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::chain::DelegationId;
+use crate::primitives::Amount;
+use serialization::{Decode, Encode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+pub enum AccountType {
+    Delegation(DelegationId),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+pub struct AccountOutPoint {
+    #[codec(compact)]
+    nonce: u128,
+    account: AccountType,
+    withdraw_amount: Amount,
+}
+
+impl AccountOutPoint {
+    pub fn new(nonce: u128, account: AccountType, withdraw_amount: Amount) -> Self {
+        Self {
+            nonce,
+            account,
+            withdraw_amount,
+        }
+    }
+
+    pub fn nonce(&self) -> u128 {
+        self.nonce
+    }
+
+    pub fn account(&self) -> &AccountType {
+        &self.account
+    }
+
+    pub fn withdraw_amount(&self) -> &Amount {
+        &self.withdraw_amount
+    }
+}

--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -35,7 +35,8 @@ impl From<AccountSpending> for AccountType {
 }
 
 /// The type represents the amount to withdraw from a particular account.
-/// It helps solving 2 problems: calculating fees and providing ability to sign input balance with the witness.
+/// Otherwise it's unclear how much should be deducted from an account balance.
+/// It also helps solving 2 additional problems: calculating fees and providing ability to sign input balance with the witness.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub enum AccountSpending {
     #[codec(index = 0)]

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -168,6 +168,10 @@ impl TxInput {
         TxInput::Utxo(OutPoint::new(outpoint_source_id, output_index))
     }
 
+    pub fn new_account(nonce: u128, account: AccountType, withdraw_amount: Amount) -> Self {
+        TxInput::Account(AccountInput::new(nonce, account, withdraw_amount))
+    }
+
     pub fn outpoint(&self) -> Option<&OutPoint> {
         match self {
             TxInput::Utxo(outpoint) => Some(outpoint),

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -123,15 +123,21 @@ impl OutPoint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
-pub enum AccountType {
+pub enum Account {
     Pool(PoolId),
     Delegation(DelegationId),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+pub struct AccountOutPoint {
+    nonce: u128,
+    account: Account,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub enum TxInput {
     Utxo(OutPoint),
-    Accounting(AccountType),
+    Accounting(AccountOutPoint),
 }
 
 impl TxInput {

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -21,7 +21,9 @@ use super::{AccountOutPoint, AccountType, OutPointSourceId, UtxoOutPoint};
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub enum TxInput {
     Utxo(UtxoOutPoint),
-    Account(AccountOutPoint),
+    /// `Amount` type represents the amount to withdraw from account.
+    /// It helps solving 2 problems: calculating fees and providing ability to sign input balance with the witness.
+    Account(AccountOutPoint, Amount),
 }
 
 impl TxInput {
@@ -30,13 +32,13 @@ impl TxInput {
     }
 
     pub fn from_account(nonce: u128, account: AccountType, withdraw_amount: Amount) -> Self {
-        TxInput::Account(AccountOutPoint::new(nonce, account, withdraw_amount))
+        TxInput::Account(AccountOutPoint::new(nonce, account), withdraw_amount)
     }
 
     pub fn utxo_outpoint(&self) -> Option<&UtxoOutPoint> {
         match self {
             TxInput::Utxo(outpoint) => Some(outpoint),
-            TxInput::Account(_) => None,
+            TxInput::Account(_, _) => None,
         }
     }
 }

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -15,6 +15,8 @@
 
 use serialization::{Decode, Encode};
 
+use crate::chain::AccountNonce;
+
 use super::{AccountOutPoint, AccountSpending, OutPointSourceId, UtxoOutPoint};
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
@@ -28,7 +30,7 @@ impl TxInput {
         TxInput::Utxo(UtxoOutPoint::new(outpoint_source_id, output_index))
     }
 
-    pub fn from_account(nonce: u128, account: AccountSpending) -> Self {
+    pub fn from_account(nonce: AccountNonce, account: AccountSpending) -> Self {
         TxInput::Account(AccountOutPoint::new(nonce, account))
     }
 

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -134,6 +134,16 @@ pub struct AccountInput {
     account: AccountType,
 }
 
+impl AccountInput {
+    pub fn new(nonce: u128, account: AccountType) -> Self {
+        Self { nonce, account }
+    }
+
+    pub fn account(&self) -> &AccountType {
+        &self.account
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub enum TxInput {
     Utxo(OutPoint),

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -13,17 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::primitives::Amount;
 use serialization::{Decode, Encode};
 
-use super::{AccountOutPoint, AccountType, OutPointSourceId, UtxoOutPoint};
+use super::{AccountOutPoint, AccountSpending, OutPointSourceId, UtxoOutPoint};
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub enum TxInput {
     Utxo(UtxoOutPoint),
-    /// `Amount` type represents the amount to withdraw from account.
-    /// It helps solving 2 problems: calculating fees and providing ability to sign input balance with the witness.
-    Account(AccountOutPoint, Amount),
+    Account(AccountOutPoint),
 }
 
 impl TxInput {
@@ -31,14 +28,14 @@ impl TxInput {
         TxInput::Utxo(UtxoOutPoint::new(outpoint_source_id, output_index))
     }
 
-    pub fn from_account(nonce: u128, account: AccountType, withdraw_amount: Amount) -> Self {
-        TxInput::Account(AccountOutPoint::new(nonce, account), withdraw_amount)
+    pub fn from_account(nonce: u128, account: AccountSpending) -> Self {
+        TxInput::Account(AccountOutPoint::new(nonce, account))
     }
 
     pub fn utxo_outpoint(&self) -> Option<&UtxoOutPoint> {
         match self {
             TxInput::Utxo(outpoint) => Some(outpoint),
-            TxInput::Account(_, _) => None,
+            TxInput::Account(_) => None,
         }
     }
 }

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::chain::DelegationId;
 use crate::chain::{transaction::Transaction, Block, GenBlock, Genesis};
-use crate::chain::{DelegationId, PoolId};
 use crate::primitives::{Id, H256};
 use serialization::{Decode, Encode};
 
@@ -123,21 +123,21 @@ impl OutPoint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
-pub enum Account {
-    Pool(PoolId),
+pub enum AccountType {
     Delegation(DelegationId),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
-pub struct AccountOutPoint {
+pub struct AccountInput {
+    #[codec(compact)]
     nonce: u128,
-    account: Account,
+    account: AccountType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub enum TxInput {
     Utxo(OutPoint),
-    Accounting(AccountOutPoint),
+    Account(AccountInput),
 }
 
 impl TxInput {
@@ -148,7 +148,7 @@ impl TxInput {
     pub fn outpoint(&self) -> Option<&OutPoint> {
         match self {
             TxInput::Utxo(outpoint) => Some(outpoint),
-            TxInput::Accounting(_) => None,
+            TxInput::Account(_) => None,
         }
     }
 }

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use crate::chain::{transaction::Transaction, Block, GenBlock, Genesis};
+use crate::chain::{DelegationId, PoolId};
 use crate::primitives::{Id, H256};
 use serialization::{Decode, Encode};
 
@@ -122,25 +123,33 @@ impl OutPoint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
-pub struct TxInput {
-    outpoint: OutPoint,
+pub enum AccountType {
+    Pool(PoolId),
+    Delegation(DelegationId),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+pub enum TxInput {
+    Utxo(OutPoint),
+    Accounting(AccountType),
 }
 
 impl TxInput {
     pub fn new(outpoint_source_id: OutPointSourceId, output_index: u32) -> Self {
-        TxInput {
-            outpoint: OutPoint::new(outpoint_source_id, output_index),
-        }
+        TxInput::Utxo(OutPoint::new(outpoint_source_id, output_index))
     }
 
-    pub fn outpoint(&self) -> &OutPoint {
-        &self.outpoint
+    pub fn outpoint(&self) -> Option<&OutPoint> {
+        match self {
+            TxInput::Utxo(outpoint) => Some(outpoint),
+            TxInput::Accounting(_) => None,
+        }
     }
 }
 
 impl From<OutPoint> for TxInput {
     fn from(outpoint: OutPoint) -> TxInput {
-        TxInput { outpoint }
+        TxInput::Utxo(outpoint)
     }
 }
 

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -122,7 +122,7 @@ impl OutPoint {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
 pub enum AccountType {
     Delegation(DelegationId),
 }
@@ -142,6 +142,10 @@ impl AccountInput {
             account,
             withdraw_amount,
         }
+    }
+
+    pub fn nonce(&self) -> u128 {
+        self.nonce
     }
 
     pub fn account(&self) -> &AccountType {

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -15,7 +15,7 @@
 
 use crate::chain::DelegationId;
 use crate::chain::{transaction::Transaction, Block, GenBlock, Genesis};
-use crate::primitives::{Id, H256};
+use crate::primitives::{Amount, Id, H256};
 use serialization::{Decode, Encode};
 
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
@@ -132,15 +132,24 @@ pub struct AccountInput {
     #[codec(compact)]
     nonce: u128,
     account: AccountType,
+    withdraw_amount: Amount,
 }
 
 impl AccountInput {
-    pub fn new(nonce: u128, account: AccountType) -> Self {
-        Self { nonce, account }
+    pub fn new(nonce: u128, account: AccountType, withdraw_amount: Amount) -> Self {
+        Self {
+            nonce,
+            account,
+            withdraw_amount,
+        }
     }
 
     pub fn account(&self) -> &AccountType {
         &self.account
+    }
+
+    pub fn withdraw_amount(&self) -> &Amount {
+        &self.withdraw_amount
     }
 }
 

--- a/common/src/chain/transaction/mod.rs
+++ b/common/src/chain/transaction/mod.rs
@@ -26,6 +26,9 @@ pub use input::*;
 pub mod account_outpoint;
 pub use account_outpoint::*;
 
+pub mod account_nonce;
+pub use account_nonce::*;
+
 pub mod utxo_outpoint;
 pub use utxo_outpoint::*;
 

--- a/common/src/chain/transaction/mod.rs
+++ b/common/src/chain/transaction/mod.rs
@@ -23,6 +23,12 @@ use crate::primitives::{id::WithId, Id, Idable, H256};
 pub mod input;
 pub use input::*;
 
+pub mod account_outpoint;
+pub use account_outpoint::*;
+
+pub mod utxo_outpoint;
+pub use utxo_outpoint::*;
+
 pub mod signed_transaction;
 
 pub mod output;

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
@@ -97,9 +97,9 @@ mod test {
         let destination = Destination::PublicKey(public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, 2).unwrap();
 
         for sighash_type in sig_hash_types() {
             let res = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -107,7 +107,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 1,
             );
             assert_eq!(res, Err(TransactionSigError::InvalidInputIndex(1, 1)));
@@ -126,9 +126,9 @@ mod test {
         let destination = Destination::Address(PublicKeyHash::from(&public_key));
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -136,7 +136,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -160,9 +160,9 @@ mod test {
         let destination = Destination::PublicKey(public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -170,7 +170,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 rng.gen_range(0..INPUTS),
             )
             .unwrap();
@@ -200,9 +200,9 @@ mod test {
         let destination = Destination::PublicKey(public_key.clone());
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let input = rng.gen_range(0..inputs_utxos.len());
@@ -211,14 +211,14 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 input,
             )
             .unwrap();
             let spender_signature =
                 AuthorizedPublicKeySpend::from_data(witness.raw_signature()).unwrap();
             let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos_refs, input).unwrap();
             verify_public_key_spending(&public_key, &spender_signature, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
         }
@@ -235,9 +235,9 @@ mod test {
         let destination = Destination::PublicKey(public_key.clone());
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let input = rng.gen_range(0..inputs_utxos.len());
@@ -246,12 +246,12 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 input,
             )
             .unwrap();
             let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos_refs, input).unwrap();
             sign_pubkey_spending(&private_key, &public_key, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
         }

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
@@ -97,6 +97,7 @@ mod test {
         let destination = Destination::PublicKey(public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
 
@@ -106,7 +107,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 1,
             );
             assert_eq!(res, Err(TransactionSigError::InvalidInputIndex(1, 1)));
@@ -125,6 +126,7 @@ mod test {
         let destination = Destination::Address(PublicKeyHash::from(&public_key));
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
@@ -134,7 +136,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -158,6 +160,7 @@ mod test {
         let destination = Destination::PublicKey(public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
@@ -167,7 +170,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 rng.gen_range(0..INPUTS),
             )
             .unwrap();
@@ -197,6 +200,7 @@ mod test {
         let destination = Destination::PublicKey(public_key.clone());
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
@@ -207,19 +211,14 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 input,
             )
             .unwrap();
             let spender_signature =
                 AuthorizedPublicKeySpend::from_data(witness.raw_signature()).unwrap();
-            let sighash = signature_hash(
-                witness.sighash_type(),
-                &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                input,
-            )
-            .unwrap();
+            let sighash =
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
             verify_public_key_spending(&public_key, &spender_signature, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
         }
@@ -236,6 +235,7 @@ mod test {
         let destination = Destination::PublicKey(public_key.clone());
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
@@ -246,17 +246,12 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 input,
             )
             .unwrap();
-            let sighash = signature_hash(
-                witness.sighash_type(),
-                &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                input,
-            )
-            .unwrap();
+            let sighash =
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
             sign_pubkey_spending(&private_key, &public_key, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
         }

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
@@ -105,9 +105,9 @@ mod test {
         let destination = Destination::Address(pubkey_hash);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, 2).unwrap();
 
         for sighash_type in sig_hash_types() {
             let res = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -115,7 +115,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 1,
             );
             assert_eq!(res, Err(TransactionSigError::InvalidInputIndex(1, 1)));
@@ -134,9 +134,9 @@ mod test {
         let destination = Destination::PublicKey(public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -144,7 +144,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -170,9 +170,9 @@ mod test {
         let destination = Destination::Address(pubkey_hash);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
@@ -180,7 +180,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -213,9 +213,9 @@ mod test {
         let destination = Destination::Address(pubkey_hash);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let input = rng.gen_range(0..INPUTS);
@@ -224,14 +224,14 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 input,
             )
             .unwrap();
             let spender_signature =
                 AuthorizedPublicKeyHashSpend::from_data(witness.raw_signature()).unwrap();
             let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos_refs, input).unwrap();
 
             verify_address_spending(&pubkey_hash, &spender_signature, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
@@ -250,9 +250,9 @@ mod test {
         let pubkey_hash = PublicKeyHash::from(&public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, OUTPUTS).unwrap();
 
         for sighash_type in sig_hash_types() {
             let input = rng.gen_range(0..inputs_utxos.len());
@@ -261,12 +261,12 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 input,
             )
             .unwrap();
             let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos_refs, input).unwrap();
 
             sign_address_spending(&private_key, &pubkey_hash, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
@@ -105,6 +105,7 @@ mod test {
         let destination = Destination::Address(pubkey_hash);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
 
@@ -114,7 +115,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 1,
             );
             assert_eq!(res, Err(TransactionSigError::InvalidInputIndex(1, 1)));
@@ -133,6 +134,7 @@ mod test {
         let destination = Destination::PublicKey(public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
@@ -142,7 +144,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -168,6 +170,7 @@ mod test {
         let destination = Destination::Address(pubkey_hash);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
@@ -177,7 +180,7 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 rng.gen_range(0..inputs_utxos.len()),
             )
             .unwrap();
@@ -210,6 +213,7 @@ mod test {
         let destination = Destination::Address(pubkey_hash);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
@@ -220,19 +224,14 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 input,
             )
             .unwrap();
             let spender_signature =
                 AuthorizedPublicKeyHashSpend::from_data(witness.raw_signature()).unwrap();
-            let sighash = signature_hash(
-                witness.sighash_type(),
-                &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                input,
-            )
-            .unwrap();
+            let sighash =
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
 
             verify_address_spending(&pubkey_hash, &spender_signature, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));
@@ -251,6 +250,7 @@ mod test {
         let pubkey_hash = PublicKeyHash::from(&public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), OUTPUTS).unwrap();
 
@@ -261,17 +261,12 @@ mod test {
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 input,
             )
             .unwrap();
-            let sighash = signature_hash(
-                witness.sighash_type(),
-                &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                input,
-            )
-            .unwrap();
+            let sighash =
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, input).unwrap();
 
             sign_address_spending(&private_key, &pubkey_hash, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?}"));

--- a/common/src/chain/transaction/signature/inputsig/standard_signature.rs
+++ b/common/src/chain/transaction/signature/inputsig/standard_signature.rs
@@ -236,9 +236,9 @@ mod test {
         let destination = Destination::Address(PublicKeyHash::from(&public_key));
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, 2).unwrap();
 
         for sighash_type in sig_hash_types() {
             assert_eq!(
@@ -248,7 +248,7 @@ mod test {
                     sighash_type,
                     destination.clone(),
                     &tx,
-                    &inputs_utxos,
+                    &inputs_utxos_refs,
                     INPUT_NUM,
                 ),
                 "{sighash_type:X?}"
@@ -267,9 +267,9 @@ mod test {
         let destination = Destination::PublicKey(public_key);
 
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, 2).unwrap();
 
         for sighash_type in sig_hash_types() {
             assert_eq!(
@@ -279,7 +279,7 @@ mod test {
                     sighash_type,
                     destination.clone(),
                     &tx,
-                    &inputs_utxos,
+                    &inputs_utxos_refs,
                     INPUT_NUM,
                 ),
                 "{sighash_type:X?}"
@@ -305,20 +305,22 @@ mod test {
         for (sighash_type, destination) in sig_hash_types().cartesian_product(outpoints.into_iter())
         {
             let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 1);
-            let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
-            let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 2).unwrap();
+            let inputs_utxos_refs =
+                inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
+
+            let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, 2).unwrap();
             let witness = StandardInputSignature::produce_uniparty_signature_for_input(
                 &private_key,
                 sighash_type,
                 destination.clone(),
                 &tx,
-                &inputs_utxos,
+                &inputs_utxos_refs,
                 INPUT_NUM,
             )
             .unwrap();
 
             let sighash =
-                signature_hash(witness.sighash_type(), &tx, &inputs_utxos, INPUT_NUM).unwrap();
+                signature_hash(witness.sighash_type(), &tx, &inputs_utxos_refs, INPUT_NUM).unwrap();
             witness
                 .verify_signature(&chain_config, &destination, &sighash)
                 .unwrap_or_else(|_| panic!("{sighash_type:X?} {destination:?}"));

--- a/common/src/chain/transaction/signature/mod.rs
+++ b/common/src/chain/transaction/signature/mod.rs
@@ -151,7 +151,7 @@ pub fn verify_signature<T: Transactable>(
     chain_config: &ChainConfig,
     outpoint_destination: &Destination,
     tx: &T,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     input_num: usize,
 ) -> Result<(), TransactionSigError> {
     let inputs = tx.inputs().ok_or(TransactionSigError::SignatureVerificationWithoutInputs)?;
@@ -188,7 +188,7 @@ fn verify_standard_input_signature<T: Transactable>(
     outpoint_destination: &Destination,
     witness: &StandardInputSignature,
     tx: &T,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     input_num: usize,
 ) -> Result<(), TransactionSigError> {
     let sighash = signature_hash(witness.sighash_type(), tx, inputs_utxos, input_num)?;

--- a/common/src/chain/transaction/signature/sighash/hashable.rs
+++ b/common/src/chain/transaction/signature/sighash/hashable.rs
@@ -157,7 +157,7 @@ mod tests {
             OutPointSourceId::BlockReward(Id::new(H256::random_using(rng)))
         };
 
-        TxInput::new(outpoint, rng.next_u32())
+        TxInput::from_utxo(outpoint, rng.next_u32())
     }
 
     fn generate_random_invalid_output(rng: &mut (impl Rng + CryptoRng)) -> TxOutput {

--- a/common/src/chain/transaction/signature/sighash/hashable.rs
+++ b/common/src/chain/transaction/signature/sighash/hashable.rs
@@ -59,13 +59,14 @@ impl SignatureHashableElement for &[TxOutput] {
 pub struct SignatureHashableInputs<'a> {
     inputs: &'a [TxInput],
     /// Include utxos of the inputs to make it possible to verify the inputs scripts and amounts without downloading the full transactions
-    inputs_utxos: &'a [&'a TxOutput],
+    /// It can be None which means that input spend from account not utxo
+    inputs_utxos: &'a [Option<&'a TxOutput>],
 }
 
 impl<'a> SignatureHashableInputs<'a> {
     pub fn new(
         inputs: &'a [TxInput],
-        inputs_utxos: &'a [&'a TxOutput],
+        inputs_utxos: &'a [Option<&'a TxOutput>],
     ) -> Result<Self, TransactionSigError> {
         if inputs.len() != inputs_utxos.len() {
             return Err(TransactionSigError::InvalidUtxoCountVsInputs(
@@ -180,7 +181,7 @@ mod tests {
             .map(|_| generate_random_invalid_output(rng))
             .collect::<Vec<_>>();
 
-        let inputs_utxos = inputs_utxos.iter().collect::<Vec<_>>();
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
 
         let hashable_inputs_result = SignatureHashableInputs::new(&inputs, &inputs_utxos);
 

--- a/common/src/chain/transaction/signature/sighash/hashable.rs
+++ b/common/src/chain/transaction/signature/sighash/hashable.rs
@@ -106,7 +106,7 @@ impl SignatureHashableElement for SignatureHashableInputs<'_> {
                     let inputs = self.inputs;
                     hash_encoded_to(&(inputs.len() as u32), stream);
                     for input in inputs {
-                        hash_encoded_to(&input.outpoint(), stream);
+                        hash_encoded_to(&input, stream);
                     }
                 }
 
@@ -121,7 +121,7 @@ impl SignatureHashableElement for SignatureHashableInputs<'_> {
             }
             sighashtype::InputsMode::AnyoneCanPay => {
                 // Commit the input being signed (target input)
-                hash_encoded_to(&target_input.outpoint(), stream);
+                hash_encoded_to(&target_input, stream);
                 // Commit the utxo of the input being signed (target input)
                 hash_encoded_to(&self.inputs_utxos[target_input_num], stream);
             }

--- a/common/src/chain/transaction/signature/sighash/hashable.rs
+++ b/common/src/chain/transaction/signature/sighash/hashable.rs
@@ -59,7 +59,7 @@ impl SignatureHashableElement for &[TxOutput] {
 pub struct SignatureHashableInputs<'a> {
     inputs: &'a [TxInput],
     /// Include utxos of the inputs to make it possible to verify the inputs scripts and amounts without downloading the full transactions
-    /// It can be None which means that input spend from account not utxo
+    /// It can be None which means that input spends from an account not utxo
     inputs_utxos: &'a [Option<&'a TxOutput>],
 }
 

--- a/common/src/chain/transaction/signature/sighash/mod.rs
+++ b/common/src/chain/transaction/signature/sighash/mod.rs
@@ -40,7 +40,7 @@ fn hash_encoded_if_some<T: Encode>(val: &Option<T>, stream: &mut DefaultHashAlgo
 
 fn stream_signature_hash<T: Signable>(
     tx: &T,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     stream: &mut DefaultHashAlgoStream,
     mode: sighashtype::SigHashType,
     target_input_num: usize,
@@ -71,7 +71,7 @@ fn stream_signature_hash<T: Signable>(
 pub fn signature_hash<T: Signable>(
     mode: sighashtype::SigHashType,
     tx: &T,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     input_num: usize,
 ) -> Result<H256, TransactionSigError> {
     let mut stream = DefaultHashAlgoStream::new();

--- a/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
+++ b/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
@@ -47,6 +47,7 @@ fn mixed_sighash_types(#[case] seed: Seed) {
         sig_hash_types()
     ) {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 6);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_unsigned_tx(&mut rng, &destination, 6, 6).unwrap();
 
         let sigs = [
@@ -63,7 +64,7 @@ fn mixed_sighash_types(#[case] seed: Seed) {
             InputWitness::Standard(
                 make_signature(
                     &tx,
-                    &inputs_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos,
                     input,
                     &private_key,
                     sighash_type,
@@ -76,12 +77,7 @@ fn mixed_sighash_types(#[case] seed: Seed) {
 
         let signed_tx = tx.with_signatures(sigs).unwrap();
 
-        verify_signed_tx(
-            &chain_config,
-            &signed_tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &destination,
-        )
-        .expect("Signature verification failed")
+        verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
+            .expect("Signature verification failed")
     }
 }

--- a/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
+++ b/common/src/chain/transaction/signature/tests/mixed_sighash_types.rs
@@ -47,8 +47,8 @@ fn mixed_sighash_types(#[case] seed: Seed) {
         sig_hash_types()
     ) {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 6);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
-        let tx = generate_unsigned_tx(&mut rng, &destination, 6, 6).unwrap();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, 6).unwrap();
 
         let sigs = [
             sighash_types.0,
@@ -64,7 +64,7 @@ fn mixed_sighash_types(#[case] seed: Seed) {
             InputWitness::Standard(
                 make_signature(
                     &tx,
-                    &inputs_utxos,
+                    &inputs_utxos_refs,
                     input,
                     &private_key,
                     sighash_type,
@@ -77,7 +77,7 @@ fn mixed_sighash_types(#[case] seed: Seed) {
 
         let signed_tx = tx.with_signatures(sigs).unwrap();
 
-        verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
+        verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos_refs, &destination)
             .expect("Signature verification failed")
     }
 }

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -646,7 +646,7 @@ fn check_insert_input(
     let mut inputs_utxos = inputs_utxos.to_vec();
     inputs_utxos.push(Some(&inputs_utxo));
 
-    tx_updater.inputs.push(TxInput::new(outpoint_source_id, 1));
+    tx_updater.inputs.push(TxInput::from_utxo(outpoint_source_id, 1));
     tx_updater.witness.push(InputWitness::NoSignature(Some(vec![1, 2, 3])));
     let tx = tx_updater.generate_tx().unwrap();
     let res = verify_signature(chain_config, destination, &tx, &inputs_utxos, 0);
@@ -752,7 +752,7 @@ fn check_mutate_input(
 ) {
     // Should failed due to change in output value
     let mut tx_updater = MutableTransaction::from(original_tx);
-    tx_updater.inputs[0] = TxInput::new(
+    tx_updater.inputs[0] = TxInput::from_utxo(
         OutPointSourceId::Transaction(Id::<Transaction>::from(H256::random_using(rng))),
         9999,
     );

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -41,7 +41,8 @@ use crypto::{
 use test_utils::random::Seed;
 
 mod mixed_sighash_types;
-mod sign_and_mutate;
+// FIXME: uncomment and fix
+// mod sign_and_mutate;
 mod sign_and_verify;
 
 pub mod utils;
@@ -59,23 +60,19 @@ fn sign_and_verify_different_sighash_types(#[case] seed: Seed) {
 
     for sighash_type in sig_hash_types() {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_and_sign_tx(
             &chain_config,
             &mut rng,
             &destination,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             3,
             &private_key,
             sighash_type,
         )
         .unwrap();
         assert_eq!(
-            verify_signed_tx(
-                &chain_config,
-                &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                &destination
-            ),
+            verify_signed_tx(&chain_config, &tx, &inputs_utxos, &destination),
             Ok(()),
             "{sighash_type:?}"
         );
@@ -97,19 +94,14 @@ fn verify_no_signature(#[case] seed: Seed) {
         destinations(&mut rng, public_key).filter(|d| d != &Destination::AnyoneCanSpend)
     {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 3).unwrap();
         let witnesses = (0..tx.inputs().len())
             .map(|_| InputWitness::NoSignature(Some(vec![1, 2, 3, 4, 5, 6, 7, 8, 9])))
             .collect_vec();
         let signed_tx = tx.with_signatures(witnesses).unwrap();
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &signed_tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                0
-            ),
+            verify_signature(&chain_config, &destination, &signed_tx, &inputs_utxos, 0),
             Err(TransactionSigError::SignatureNotFound),
             "{destination:?}"
         );
@@ -134,6 +126,7 @@ fn verify_invalid_signature(#[case] seed: Seed) {
         sig_hash_types().cartesian_product([empty_signature, invalid_signature])
     {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs_utxos.len(), 3).unwrap();
         let witnesses = (0..tx.inputs().len())
             .map(|_| {
@@ -146,13 +139,7 @@ fn verify_invalid_signature(#[case] seed: Seed) {
         let signed_tx = tx.with_signatures(witnesses).unwrap();
 
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &signed_tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                0
-            ),
+            verify_signature(&chain_config, &destination, &signed_tx, &inputs_utxos, 0),
             Err(TransactionSigError::InvalidSignatureEncoding),
             "{sighash_type:?}, signature = {raw_signature:?}"
         );
@@ -174,11 +161,12 @@ fn verify_signature_invalid_signature_index(#[case] seed: Seed) {
 
     for sighash_type in sig_hash_types() {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_and_sign_tx(
             &chain_config,
             &mut rng,
             &destination,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             3,
             &private_key,
             sighash_type,
@@ -189,7 +177,7 @@ fn verify_signature_invalid_signature_index(#[case] seed: Seed) {
                 &chain_config,
                 &destination,
                 &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos,
                 INVALID_SIGNATURE_INDEX
             ),
             Err(TransactionSigError::InvalidSignatureIndex(
@@ -217,24 +205,19 @@ fn verify_signature_wrong_destination(#[case] seed: Seed) {
 
     for sighash_type in sig_hash_types() {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_and_sign_tx(
             &chain_config,
             &mut rng,
             &outpoint,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             3,
             &private_key,
             sighash_type,
         )
         .unwrap();
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &different_outpoint,
-                &tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                0
-            ),
+            verify_signature(&chain_config, &different_outpoint, &tx, &inputs_utxos, 0),
             Err(TransactionSigError::SignatureVerificationFailed),
             "{sighash_type:?}"
         );
@@ -254,10 +237,11 @@ fn mutate_all(#[case] seed: Seed) {
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+    let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -267,7 +251,7 @@ fn mutate_all(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -275,7 +259,7 @@ fn mutate_all(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -283,14 +267,14 @@ fn mutate_all(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -309,10 +293,11 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+    let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -322,7 +307,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
@@ -330,7 +315,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -338,14 +323,14 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -364,10 +349,11 @@ fn mutate_none(#[case] seed: Seed) {
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::NONE).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+    let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -377,7 +363,7 @@ fn mutate_none(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -385,7 +371,7 @@ fn mutate_none(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -393,14 +379,14 @@ fn mutate_none(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
@@ -420,10 +406,11 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
     let sighash_type =
         SigHashType::try_from(SigHashType::NONE | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+    let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -433,7 +420,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
@@ -441,7 +428,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -449,14 +436,14 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
@@ -475,10 +462,11 @@ fn mutate_single(#[case] seed: Seed) {
     let outpoint_dest = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::SINGLE).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+    let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -488,7 +476,7 @@ fn mutate_single(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -496,7 +484,7 @@ fn mutate_single(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -504,14 +492,14 @@ fn mutate_single(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -531,10 +519,11 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
     let sighash_type =
         SigHashType::try_from(SigHashType::SINGLE | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+    let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let original_tx = sign_mutate_then_verify(
         &chain_config,
         &mut rng,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &private_key,
         sighash_type,
         &outpoint_dest,
@@ -544,7 +533,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
@@ -552,7 +541,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -560,14 +549,14 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         &chain_config,
         &mut rng,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         false,
     );
     check_mutate_output(
         &chain_config,
         &original_tx,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         &outpoint_dest,
         true,
     );
@@ -576,7 +565,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
 fn sign_mutate_then_verify(
     chain_config: &ChainConfig,
     rng: &mut (impl Rng + CryptoRng),
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     private_key: &PrivateKey,
     sighash_type: SigHashType,
     destination: &Destination,
@@ -606,7 +595,7 @@ fn sign_mutate_then_verify(
 fn check_change_flags(
     chain_config: &ChainConfig,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     destination: &Destination,
 ) {
     let mut tx_updater = MutableTransaction::from(original_tx);
@@ -624,7 +613,7 @@ fn check_insert_input(
     chain_config: &ChainConfig,
     rng: &mut (impl Rng + CryptoRng),
     original_tx: &SignedTransaction,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     destination: &Destination,
     should_fail: bool,
 ) {
@@ -637,7 +626,7 @@ fn check_insert_input(
         Destination::AnyoneCanSpend,
     );
     let mut inputs_utxos = inputs_utxos.to_vec();
-    inputs_utxos.push(&inputs_utxo);
+    inputs_utxos.push(Some(&inputs_utxo));
 
     tx_updater.inputs.push(TxInput::new(outpoint_source_id, 1));
     tx_updater.witness.push(InputWitness::NoSignature(Some(vec![1, 2, 3])));
@@ -654,7 +643,7 @@ fn check_insert_input(
 fn check_mutate_witness(
     chain_config: &ChainConfig,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     outpoint_dest: &Destination,
 ) {
     let mut tx_updater = MutableTransaction::from(original_tx);
@@ -681,7 +670,7 @@ fn check_insert_output(
     chain_config: &ChainConfig,
     rng: &mut (impl Rng + CryptoRng),
     original_tx: &SignedTransaction,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     destination: &Destination,
     should_fail: bool,
 ) {
@@ -710,7 +699,7 @@ fn add_value(output_value: OutputValue) -> OutputValue {
 fn check_mutate_output(
     chain_config: &ChainConfig,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     destination: &Destination,
     should_fail: bool,
 ) {
@@ -739,7 +728,7 @@ fn check_mutate_input(
     chain_config: &ChainConfig,
     rng: &mut impl Rng,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     destination: &Destination,
     should_fail: bool,
 ) {
@@ -762,7 +751,7 @@ fn check_mutate_input(
 fn check_mutate_inputs_utxos(
     chain_config: &ChainConfig,
     original_tx: &SignedTransaction,
-    inputs_utxos: &[&TxOutput],
+    inputs_utxos: &[Option<&TxOutput>],
     outpoint_dest: &Destination,
 ) {
     for input in 0..inputs_utxos.len() {
@@ -771,7 +760,7 @@ fn check_mutate_inputs_utxos(
             Destination::AnyoneCanSpend,
         );
         let mut inputs_utxos = inputs_utxos.to_owned();
-        inputs_utxos[input] = &inputs_utxo;
+        inputs_utxos[input] = Some(&inputs_utxo);
 
         assert!(matches!(
             verify_signature(

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -75,24 +75,14 @@ fn test_mutate_tx_internal_data(#[case] seed: Seed) {
             .cartesian_product(test_data)
     {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
-        match sign_whole_tx(
-            tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &private_key,
-            sighash_type,
-            &destination,
-        ) {
+        match sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination) {
             Ok(signed_tx) => {
                 // Test flags change.
                 let updated_tx = change_flags(&mut rng, &signed_tx, 1234567890);
                 assert_eq!(
-                    verify_signed_tx(
-                        &chain_config,
-                        &updated_tx,
-                        &inputs_utxos.iter().collect::<Vec<_>>(),
-                        &destination
-                    ),
+                    verify_signed_tx(&chain_config, &updated_tx, &inputs_utxos, &destination),
                     expected
                 );
             }
@@ -125,10 +115,11 @@ fn modify_and_verify(#[case] seed: Seed) {
     {
         let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &private_key,
             sighash_type,
             &destination,
@@ -137,7 +128,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -145,7 +136,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -153,27 +144,22 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
-        check_mutate_output(
-            &chain_config,
-            &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &destination,
-            true,
-        );
+        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
     }
 
     {
         let sighash_type =
             SigHashType::try_from(SigHashType::ALL | SigHashType::ANYONECANPAY).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &private_key,
             sighash_type,
             &destination,
@@ -182,7 +168,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             false,
         );
@@ -190,7 +176,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -198,26 +184,21 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
-        check_mutate_output(
-            &chain_config,
-            &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &destination,
-            true,
-        );
+        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
     }
 
     {
         let sighash_type = SigHashType::try_from(SigHashType::NONE).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &private_key,
             sighash_type,
             &destination,
@@ -226,7 +207,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -234,7 +215,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -242,27 +223,22 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             false,
         );
-        check_mutate_output(
-            &chain_config,
-            &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &destination,
-            false,
-        );
+        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, false);
     }
 
     {
         let sighash_type =
             SigHashType::try_from(SigHashType::NONE | SigHashType::ANYONECANPAY).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &private_key,
             sighash_type,
             &destination,
@@ -271,7 +247,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             false,
         );
@@ -279,7 +255,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -287,26 +263,21 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             false,
         );
-        check_mutate_output(
-            &chain_config,
-            &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &destination,
-            false,
-        );
+        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, false);
     }
 
     {
         let sighash_type = SigHashType::try_from(SigHashType::SINGLE).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &private_key,
             sighash_type,
             &destination,
@@ -315,7 +286,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -323,7 +294,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -331,27 +302,22 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             false,
         );
-        check_mutate_output(
-            &chain_config,
-            &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &destination,
-            true,
-        );
+        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
     }
 
     {
         let sighash_type =
             SigHashType::try_from(SigHashType::SINGLE | SigHashType::ANYONECANPAY).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &private_key,
             sighash_type,
             &destination,
@@ -360,7 +326,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             false,
         );
@@ -368,7 +334,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             true,
         );
@@ -376,17 +342,11 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
+            &inputs_utxos,
             &destination,
             false,
         );
-        check_mutate_output(
-            &chain_config,
-            &tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &destination,
-            true,
-        );
+        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
     }
 }
 
@@ -404,11 +364,12 @@ fn mutate_all(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos_refs,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -451,11 +412,12 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos_refs,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -486,13 +448,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
         };
         let tx = mutate_input(&mut rng, &tx);
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                0
-            ),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, 0),
             Err(TransactionSigError::SignatureVerificationFailed),
         );
     }
@@ -521,11 +477,12 @@ fn mutate_none(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::NONE).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos_refs,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -580,11 +537,12 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
     let sighash_type =
         SigHashType::try_from(SigHashType::NONE | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos_refs,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -600,13 +558,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         let inputs = tx.tx.inputs().len();
 
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                0
-            ),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, 0),
             Err(TransactionSigError::SignatureVerificationFailed),
         );
         for input in 1..inputs {
@@ -615,7 +567,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
                     &chain_config,
                     &destination,
                     &tx.tx,
-                    &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos_refs,
                     input
                 ),
                 Ok(())
@@ -668,11 +620,12 @@ fn mutate_single(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::SINGLE).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos_refs,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -703,7 +656,7 @@ fn mutate_single(#[case] seed: Seed) {
                     &chain_config,
                     &destination,
                     &tx.tx,
-                    &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos_refs,
                     input
                 ),
                 Err(TransactionSigError::SignatureVerificationFailed)
@@ -714,7 +667,7 @@ fn mutate_single(#[case] seed: Seed) {
                 &chain_config,
                 &destination,
                 &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos_refs,
                 inputs
             ),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
@@ -734,7 +687,7 @@ fn mutate_single(#[case] seed: Seed) {
                     &chain_config,
                     &destination,
                     &tx.tx,
-                    &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos_refs,
                     input
                 ),
                 Ok(())
@@ -745,7 +698,7 @@ fn mutate_single(#[case] seed: Seed) {
                 &chain_config,
                 &destination,
                 &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos_refs,
                 inputs
             ),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
@@ -805,11 +758,12 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
     let sighash_type =
         SigHashType::try_from(SigHashType::SINGLE | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
+    let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos.iter().collect::<Vec<_>>(),
+        &inputs_utxos,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -977,7 +931,7 @@ fn check_mutations<M, R>(
 
 struct SignedTransactionWithUtxo {
     tx: SignedTransaction,
-    inputs_utxos: Vec<TxOutput>,
+    inputs_utxos: Vec<Option<TxOutput>>,
 }
 
 fn add_input(_rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedTransactionWithUtxo {

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -75,14 +75,21 @@ fn test_mutate_tx_internal_data(#[case] seed: Seed) {
             .cartesian_product(test_data)
     {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
-        match sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination) {
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, outputs).unwrap();
+        match sign_whole_tx(
+            tx,
+            &inputs_utxos_refs,
+            &private_key,
+            sighash_type,
+            &destination,
+        ) {
             Ok(signed_tx) => {
                 // Test flags change.
                 let updated_tx = change_flags(&mut rng, &signed_tx, 1234567890);
                 assert_eq!(
-                    verify_signed_tx(&chain_config, &updated_tx, &inputs_utxos, &destination),
+                    verify_signed_tx(&chain_config, &updated_tx, &inputs_utxos_refs, &destination),
                     expected
                 );
             }
@@ -115,7 +122,7 @@ fn modify_and_verify(#[case] seed: Seed) {
     {
         let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
@@ -128,7 +135,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -136,7 +143,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -144,18 +151,18 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
+        check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, true);
     }
 
     {
         let sighash_type =
             SigHashType::try_from(SigHashType::ALL | SigHashType::ANYONECANPAY).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
@@ -168,7 +175,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             false,
         );
@@ -176,7 +183,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -184,17 +191,17 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
+        check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, true);
     }
 
     {
         let sighash_type = SigHashType::try_from(SigHashType::NONE).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
@@ -207,7 +214,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -215,7 +222,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -223,18 +230,18 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             false,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, false);
+        check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, false);
     }
 
     {
         let sighash_type =
             SigHashType::try_from(SigHashType::NONE | SigHashType::ANYONECANPAY).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
@@ -247,7 +254,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             false,
         );
@@ -255,7 +262,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -263,17 +270,17 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             false,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, false);
+        check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, false);
     }
 
     {
         let sighash_type = SigHashType::try_from(SigHashType::SINGLE).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
@@ -286,7 +293,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -294,7 +301,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -302,18 +309,18 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             false,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
+        check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, true);
     }
 
     {
         let sighash_type =
             SigHashType::try_from(SigHashType::SINGLE | SigHashType::ANYONECANPAY).unwrap();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
             &chain_config,
             &mut rng,
@@ -326,7 +333,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             false,
         );
@@ -334,7 +341,7 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             true,
         );
@@ -342,11 +349,11 @@ fn modify_and_verify(#[case] seed: Seed) {
             &chain_config,
             &mut rng,
             &tx,
-            &inputs_utxos,
+            &inputs_utxos_refs,
             &destination,
             false,
         );
-        check_mutate_output(&chain_config, &tx, &inputs_utxos, &destination, true);
+        check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, true);
     }
 }
 
@@ -364,12 +371,11 @@ fn mutate_all(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos_refs,
+        &inputs_utxos,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -412,12 +418,12 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::ALL | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+    let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos_refs,
+        &inputs_utxos,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -477,12 +483,12 @@ fn mutate_none(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::NONE).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos_refs,
+        &inputs_utxos,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -537,12 +543,12 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
     let sighash_type =
         SigHashType::try_from(SigHashType::NONE | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+    let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos_refs,
+        &inputs_utxos,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -620,12 +626,12 @@ fn mutate_single(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
     let sighash_type = SigHashType::try_from(SigHashType::SINGLE).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-    let inputs_utxos_refs = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
+    let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
         &destination,
-        &inputs_utxos_refs,
+        &inputs_utxos,
         OUTPUTS,
         &private_key,
         sighash_type,
@@ -646,11 +652,13 @@ fn mutate_single(#[case] seed: Seed) {
     };
     for mutate in mutations.into_iter() {
         let tx = mutate(&mut rng, &tx);
-        let inputs = tx.tx.inputs().len();
+        let total_inputs = tx.tx.inputs().len();
+        let inputs_utxos_refs =
+            tx.inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         // Mutations make the last input number invalid, so verifying the signature for it should
         // result in the different error.
-        for input in 0..inputs - 1 {
+        for input in 0..total_inputs - 1 {
             assert_eq!(
                 verify_signature(
                     &chain_config,
@@ -668,9 +676,12 @@ fn mutate_single(#[case] seed: Seed) {
                 &destination,
                 &tx.tx,
                 &inputs_utxos_refs,
-                inputs
+                total_inputs
             ),
-            Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
+            Err(TransactionSigError::InvalidSignatureIndex(
+                total_inputs,
+                total_inputs
+            )),
         );
     }
 
@@ -707,26 +718,22 @@ fn mutate_single(#[case] seed: Seed) {
 
     {
         let tx = mutate_output(&mut rng, &tx);
-        let inputs = tx.tx.inputs().len();
+        let total_inputs = tx.tx.inputs().len();
+        let inputs_utxos_refs =
+            tx.inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         // Mutation of the first output makes signature invalid.
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                0
-            ),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, 0),
             Err(TransactionSigError::SignatureVerificationFailed),
         );
-        for input in 1..inputs - 1 {
+        for input in 1..total_inputs - 1 {
             assert_eq!(
                 verify_signature(
                     &chain_config,
                     &destination,
                     &tx.tx,
-                    &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos_refs,
                     input
                 ),
                 Ok(())
@@ -737,10 +744,13 @@ fn mutate_single(#[case] seed: Seed) {
                 &chain_config,
                 &destination,
                 &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                inputs
+                &inputs_utxos_refs,
+                total_inputs
             ),
-            Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
+            Err(TransactionSigError::InvalidSignatureIndex(
+                total_inputs,
+                total_inputs
+            )),
         );
     }
 }
@@ -758,7 +768,6 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
     let sighash_type =
         SigHashType::try_from(SigHashType::SINGLE | SigHashType::ANYONECANPAY).unwrap();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
-    let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
     let tx = generate_and_sign_tx(
         &chain_config,
         &mut rng,
@@ -777,17 +786,19 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
     };
     for mutate in mutations.into_iter() {
         let tx = mutate(&mut rng, &tx);
-        let inputs = tx.tx.inputs().len();
+        let total_inputs = tx.tx.inputs().len();
+        let inputs_utxos_refs =
+            tx.inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         // Mutations make the last input number invalid, so verifying the signature for it should
         // result in the `InvalidInputIndex` error.
-        for input in 0..inputs - 1 {
+        for input in 0..total_inputs - 1 {
             assert_eq!(
                 verify_signature(
                     &chain_config,
                     &destination,
                     &tx.tx,
-                    &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos_refs,
                     input
                 ),
                 Ok(()),
@@ -799,35 +810,34 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
                 &chain_config,
                 &destination,
                 &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                inputs
+                &inputs_utxos_refs,
+                total_inputs
             ),
-            Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs))
+            Err(TransactionSigError::InvalidSignatureIndex(
+                total_inputs,
+                total_inputs
+            ))
         );
     }
 
     let mutations = [mutate_input, mutate_output];
     for mutate in mutations.into_iter() {
         let tx = mutate(&mut rng, &tx);
-        let inputs = tx.tx.inputs().len();
+        let total_inputs = tx.tx.inputs().len();
+        let inputs_utxos_refs =
+            tx.inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                0
-            ),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, 0),
             Err(TransactionSigError::SignatureVerificationFailed),
         );
-        for input in 1..inputs - 1 {
+        for input in 1..total_inputs - 1 {
             assert_eq!(
                 verify_signature(
                     &chain_config,
                     &destination,
                     &tx.tx,
-                    &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos_refs,
                     input
                 ),
                 Ok(()),
@@ -839,27 +849,32 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
                 &chain_config,
                 &destination,
                 &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                inputs
+                &inputs_utxos_refs,
+                total_inputs
             ),
-            Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
+            Err(TransactionSigError::InvalidSignatureIndex(
+                total_inputs,
+                total_inputs
+            )),
         );
     }
 
     let mutations = [remove_first_input, remove_first_output];
     for mutate in mutations.into_iter() {
         let tx = mutate(&mut rng, &tx);
-        let inputs = tx.tx.inputs().len();
+        let total_inputs = tx.tx.inputs().len();
+        let inputs_utxos_refs =
+            tx.inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         // Mutations make the last input number invalid, so verifying the signature for it should
         // result in the `InvalidInputIndex` error.
-        for input in 0..inputs - 1 {
+        for input in 0..total_inputs - 1 {
             assert_eq!(
                 verify_signature(
                     &chain_config,
                     &destination,
                     &tx.tx,
-                    &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                    &inputs_utxos_refs,
                     input
                 ),
                 Err(TransactionSigError::SignatureVerificationFailed),
@@ -871,10 +886,13 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
                 &chain_config,
                 &destination,
                 &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                inputs
+                &inputs_utxos_refs,
+                total_inputs
             ),
-            Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
+            Err(TransactionSigError::InvalidSignatureIndex(
+                total_inputs,
+                total_inputs
+            )),
         );
     }
 }
@@ -884,7 +902,7 @@ fn check_mutations<M, R>(
     chain_config: &ChainConfig,
     rng: &mut R,
     tx: &SignedTransaction,
-    inputs_utxos: &[TxOutput],
+    inputs_utxos: &[Option<TxOutput>],
     destination: &Destination,
     mutations: M,
     expected: Result<(), TransactionSigError>,
@@ -900,13 +918,15 @@ fn check_mutations<M, R>(
         let tx = mutate(rng, &tx);
         // The number of inputs can be changed by the `mutate` function.
         let inputs = tx.tx.inputs().len();
+        let inputs_utxos_refs =
+            tx.inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         assert_eq!(
             verify_signature(
                 chain_config,
                 destination,
                 &tx.tx,
-                &tx.inputs_utxos.iter().collect::<Vec<_>>(),
+                &inputs_utxos_refs,
                 INVALID_INPUT
             ),
             Err(TransactionSigError::InvalidSignatureIndex(
@@ -916,13 +936,7 @@ fn check_mutations<M, R>(
         );
         for input in 0..inputs {
             assert_eq!(
-                verify_signature(
-                    chain_config,
-                    destination,
-                    &tx.tx,
-                    &tx.inputs_utxos.iter().collect::<Vec<_>>(),
-                    input
-                ),
+                verify_signature(chain_config, destination, &tx.tx, &inputs_utxos_refs, input),
                 expected
             );
         }

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -962,7 +962,7 @@ fn add_input(_rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedTrans
 
 fn mutate_input(rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedTransactionWithUtxo {
     let mut updater = MutableTransaction::from(&tx.tx);
-    updater.inputs[0] = TxInput::new(
+    updater.inputs[0] = TxInput::from_utxo(
         OutPointSourceId::Transaction(Id::<Transaction>::from(H256::random_using(rng))),
         9999,
     );

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -31,8 +31,8 @@ use crate::{
         },
         signed_transaction::SignedTransaction,
         tokens::OutputValue,
-        AccountNonce, AccountOutPoint, AccountSpending, ChainConfig, DelegationId, Destination,
-        OutPointSourceId, Transaction, TxInput, TxOutput, UtxoOutPoint,
+        AccountOutPoint, AccountSpending, ChainConfig, DelegationId, Destination, OutPointSourceId,
+        Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Id, H256},
 };
@@ -988,10 +988,11 @@ fn mutate_first_input(
                     ),
                 ))
             } else {
-                TxInput::Account(AccountOutPoint::new(
-                    AccountNonce::new(rng.gen()),
-                    *outpoint.account(),
-                ))
+                let new_nonce = outpoint
+                    .nonce()
+                    .increment()
+                    .unwrap_or_else(|| outpoint.nonce().decrement().unwrap());
+                TxInput::Account(AccountOutPoint::new(new_nonce, *outpoint.account()))
             }
         }
     };

--- a/common/src/chain/transaction/signature/tests/sign_and_verify.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_verify.rs
@@ -53,14 +53,9 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
         .cartesian_product(test_data)
     {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
-        let signed_tx = sign_whole_tx(
-            tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &private_key,
-            sighash_type,
-            &destination,
-        );
+        let signed_tx = sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination);
         // `sign_whole_tx` does nothing if there no inputs.
         if destination == Destination::AnyoneCanSpend && inputs > 0 {
             assert_eq!(
@@ -72,13 +67,8 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
             assert_eq!(signed_tx, Err(TransactionSigError::Unsupported));
         } else {
             let signed_tx = signed_tx.expect("{sighash_type:?} {destination:?}");
-            verify_signed_tx(
-                &chain_config,
-                &signed_tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                &destination,
-            )
-            .expect("{sighash_type:?} {destination:?}")
+            verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
+                .expect("{sighash_type:?} {destination:?}")
         }
     }
 }
@@ -249,21 +239,13 @@ fn sign_and_verify_single(#[case] seed: Seed) {
 
     for (destination, sighash_type, inputs, outputs, expected) in test_data.into_iter() {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
+        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
         let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
-        match sign_whole_tx(
-            tx,
-            &inputs_utxos.iter().collect::<Vec<_>>(),
-            &private_key,
-            sighash_type,
-            &destination,
-        ) {
-            Ok(signed_tx) => verify_signed_tx(
-                &chain_config,
-                &signed_tx,
-                &inputs_utxos.iter().collect::<Vec<_>>(),
-                &destination,
-            )
-            .expect("{sighash_type:X?}, {destination:?}"),
+        match sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination) {
+            Ok(signed_tx) => {
+                verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
+                    .expect("{sighash_type:X?}, {destination:?}")
+            }
             Err(err) => assert_eq!(Err(err), expected, "{sighash_type:X?}, {destination:?}"),
         }
     }

--- a/common/src/chain/transaction/signature/tests/sign_and_verify.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_verify.rs
@@ -53,9 +53,16 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
         .cartesian_product(test_data)
     {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
-        let signed_tx = sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination);
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, outputs).unwrap();
+        let signed_tx = sign_whole_tx(
+            tx,
+            &inputs_utxos_refs,
+            &private_key,
+            sighash_type,
+            &destination,
+        );
         // `sign_whole_tx` does nothing if there no inputs.
         if destination == Destination::AnyoneCanSpend && inputs > 0 {
             assert_eq!(
@@ -67,7 +74,7 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
             assert_eq!(signed_tx, Err(TransactionSigError::Unsupported));
         } else {
             let signed_tx = signed_tx.expect("{sighash_type:?} {destination:?}");
-            verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
+            verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos_refs, &destination)
                 .expect("{sighash_type:?} {destination:?}")
         }
     }
@@ -239,11 +246,18 @@ fn sign_and_verify_single(#[case] seed: Seed) {
 
     for (destination, sighash_type, inputs, outputs, expected) in test_data.into_iter() {
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, inputs);
-        let inputs_utxos = inputs_utxos.iter().map(Some).collect::<Vec<_>>();
-        let tx = generate_unsigned_tx(&mut rng, &destination, inputs, outputs).unwrap();
-        match sign_whole_tx(tx, &inputs_utxos, &private_key, sighash_type, &destination) {
+        let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
+
+        let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, outputs).unwrap();
+        match sign_whole_tx(
+            tx,
+            &inputs_utxos_refs,
+            &private_key,
+            sighash_type,
+            &destination,
+        ) {
             Ok(signed_tx) => {
-                verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos, &destination)
+                verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos_refs, &destination)
                     .expect("{sighash_type:X?}, {destination:?}")
             }
             Err(err) => assert_eq!(Err(err), expected, "{sighash_type:X?}, {destination:?}"),

--- a/common/src/chain/transaction/signature/tests/utils.rs
+++ b/common/src/chain/transaction/signature/tests/utils.rs
@@ -31,8 +31,8 @@ use crate::{
         },
         signed_transaction::SignedTransaction,
         tokens::OutputValue,
-        AccountType, ChainConfig, DelegationId, Destination, Transaction, TransactionCreationError,
-        TxInput, TxOutput,
+        AccountSpending, ChainConfig, DelegationId, Destination, Transaction,
+        TransactionCreationError, TxInput, TxOutput,
     },
     primitives::{amount::UnsignedIntType, Amount, Id, H256},
 };
@@ -105,8 +105,10 @@ pub fn generate_unsigned_tx(
             ),
             None => TxInput::from_account(
                 rng.gen(),
-                AccountType::Delegation(DelegationId::new(H256::random_using(rng))),
-                Amount::from_atoms(rng.gen()),
+                AccountSpending::Delegation(
+                    DelegationId::new(H256::random_using(rng)),
+                    Amount::from_atoms(rng.gen()),
+                ),
             ),
         })
         .collect();

--- a/common/src/chain/transaction/signature/tests/utils.rs
+++ b/common/src/chain/transaction/signature/tests/utils.rs
@@ -99,11 +99,11 @@ pub fn generate_unsigned_tx(
     let inputs = inputs_utxos
         .iter()
         .map(|utxo| match utxo {
-            Some(_) => TxInput::new(
+            Some(_) => TxInput::from_utxo(
                 Id::<Transaction>::new(H256::random_using(rng)).into(),
                 rng.gen(),
             ),
-            None => TxInput::new_account(
+            None => TxInput::from_account(
                 rng.gen(),
                 AccountType::Delegation(DelegationId::new(H256::random_using(rng))),
                 Amount::from_atoms(rng.gen()),

--- a/common/src/chain/transaction/signature/tests/utils.rs
+++ b/common/src/chain/transaction/signature/tests/utils.rs
@@ -31,7 +31,7 @@ use crate::{
         },
         signed_transaction::SignedTransaction,
         tokens::OutputValue,
-        AccountSpending, ChainConfig, DelegationId, Destination, Transaction,
+        AccountNonce, AccountSpending, ChainConfig, DelegationId, Destination, Transaction,
         TransactionCreationError, TxInput, TxOutput,
     },
     primitives::{amount::UnsignedIntType, Amount, Id, H256},
@@ -104,7 +104,7 @@ pub fn generate_unsigned_tx(
                 rng.gen(),
             ),
             None => TxInput::from_account(
-                rng.gen(),
+                AccountNonce::new(rng.gen()),
                 AccountSpending::Delegation(
                     DelegationId::new(H256::random_using(rng)),
                     Amount::from_atoms(rng.gen()),

--- a/common/src/chain/transaction/signed_transaction.rs
+++ b/common/src/chain/transaction/signed_transaction.rs
@@ -126,10 +126,11 @@ mod tests {
         let hash1 = H256([0x51; 32]);
         let hash2 = H256([0x52; 32]);
 
-        let ins0: Vec<TxInput> = [TxInput::new(Id::<Transaction>::new(hash0).into(), 5)].to_vec();
+        let ins0: Vec<TxInput> =
+            [TxInput::from_utxo(Id::<Transaction>::new(hash0).into(), 5)].to_vec();
         let ins1: Vec<TxInput> = [
-            TxInput::new(Id::<Transaction>::new(hash1).into(), 3),
-            TxInput::new(Id::<Transaction>::new(hash2).into(), 0),
+            TxInput::from_utxo(Id::<Transaction>::new(hash1).into(), 3),
+            TxInput::from_utxo(Id::<Transaction>::new(hash2).into(), 0),
         ]
         .to_vec();
 
@@ -185,7 +186,7 @@ mod tests {
         let input_count = 1 + rng.gen::<usize>() % 10;
         let inputs = (0..input_count)
             .map(|_| {
-                TxInput::new(
+                TxInput::from_utxo(
                     Id::<Transaction>::new(H256::random_using(&mut rng)).into(),
                     rng.gen::<u32>() % 10,
                 )

--- a/common/src/chain/transaction/transaction_index/tests.rs
+++ b/common/src/chain/transaction/transaction_index/tests.rs
@@ -239,7 +239,7 @@ fn generate_random_invalid_input(rng: &mut impl Rng) -> TxInput {
         OutPointSourceId::BlockReward(Id::new(generate_random_h256(rng)))
     };
 
-    TxInput::new(outpoint, rng.next_u32())
+    TxInput::from_utxo(outpoint, rng.next_u32())
 }
 
 fn generate_random_invalid_output(rng: &mut (impl Rng + CryptoRng)) -> TxOutput {

--- a/common/src/chain/transaction/utxo_outpoint.rs
+++ b/common/src/chain/transaction/utxo_outpoint.rs
@@ -14,10 +14,10 @@
 // limitations under the License.
 
 use crate::chain::{transaction::Transaction, Block, GenBlock, Genesis};
-use crate::primitives::{Id, H256};
+use crate::primitives::Id;
 use serialization::{Decode, Encode};
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Ord, PartialOrd)]
 pub enum OutPointSourceId {
     #[codec(index = 0)]
     Transaction(Id<Transaction>),
@@ -58,50 +58,10 @@ impl OutPointSourceId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, Ord, PartialOrd)]
 pub struct UtxoOutPoint {
     id: OutPointSourceId,
     index: u32,
-}
-
-impl OutPointSourceId {
-    fn outpoint_source_id_as_monolithic_tuple(&self) -> (u8, H256) {
-        const TX_OUT_INDEX: u8 = 0;
-        const BLK_REWARD_INDEX: u8 = 1;
-        match self {
-            OutPointSourceId::Transaction(h) => (TX_OUT_INDEX, h.get()),
-            OutPointSourceId::BlockReward(h) => (BLK_REWARD_INDEX, h.get()),
-        }
-    }
-}
-
-impl PartialOrd for OutPointSourceId {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for OutPointSourceId {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let id = self.outpoint_source_id_as_monolithic_tuple();
-        let other_id = other.outpoint_source_id_as_monolithic_tuple();
-        id.cmp(&other_id)
-    }
-}
-
-impl PartialOrd for UtxoOutPoint {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for UtxoOutPoint {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let id = self.id.outpoint_source_id_as_monolithic_tuple();
-        let other_id = other.id.outpoint_source_id_as_monolithic_tuple();
-
-        (id, self.index).cmp(&(other_id, other.index))
-    }
 }
 
 impl UtxoOutPoint {
@@ -123,6 +83,8 @@ impl UtxoOutPoint {
 
 #[cfg(test)]
 mod test {
+    use crate::primitives::H256;
+
     use rstest::rstest;
     use test_utils::random::Seed;
 

--- a/common/src/chain/transaction/utxo_outpoint.rs
+++ b/common/src/chain/transaction/utxo_outpoint.rs
@@ -1,0 +1,213 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::chain::{transaction::Transaction, Block, GenBlock, Genesis};
+use crate::primitives::{Id, H256};
+use serialization::{Decode, Encode};
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub enum OutPointSourceId {
+    #[codec(index = 0)]
+    Transaction(Id<Transaction>),
+    #[codec(index = 1)]
+    BlockReward(Id<GenBlock>),
+}
+
+impl From<Id<Transaction>> for OutPointSourceId {
+    fn from(id: Id<Transaction>) -> OutPointSourceId {
+        OutPointSourceId::Transaction(id)
+    }
+}
+
+impl From<Id<GenBlock>> for OutPointSourceId {
+    fn from(id: Id<GenBlock>) -> OutPointSourceId {
+        OutPointSourceId::BlockReward(id)
+    }
+}
+
+impl From<Id<Block>> for OutPointSourceId {
+    fn from(id: Id<Block>) -> OutPointSourceId {
+        OutPointSourceId::BlockReward(id.into())
+    }
+}
+
+impl From<Id<Genesis>> for OutPointSourceId {
+    fn from(id: Id<Genesis>) -> OutPointSourceId {
+        OutPointSourceId::BlockReward(id.into())
+    }
+}
+
+impl OutPointSourceId {
+    pub fn get_tx_id(&self) -> Option<&Id<Transaction>> {
+        match self {
+            OutPointSourceId::Transaction(id) => Some(id),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct UtxoOutPoint {
+    id: OutPointSourceId,
+    index: u32,
+}
+
+impl OutPointSourceId {
+    fn outpoint_source_id_as_monolithic_tuple(&self) -> (u8, H256) {
+        const TX_OUT_INDEX: u8 = 0;
+        const BLK_REWARD_INDEX: u8 = 1;
+        match self {
+            OutPointSourceId::Transaction(h) => (TX_OUT_INDEX, h.get()),
+            OutPointSourceId::BlockReward(h) => (BLK_REWARD_INDEX, h.get()),
+        }
+    }
+}
+
+impl PartialOrd for OutPointSourceId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OutPointSourceId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let id = self.outpoint_source_id_as_monolithic_tuple();
+        let other_id = other.outpoint_source_id_as_monolithic_tuple();
+        id.cmp(&other_id)
+    }
+}
+
+impl PartialOrd for UtxoOutPoint {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for UtxoOutPoint {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let id = self.id.outpoint_source_id_as_monolithic_tuple();
+        let other_id = other.id.outpoint_source_id_as_monolithic_tuple();
+
+        (id, self.index).cmp(&(other_id, other.index))
+    }
+}
+
+impl UtxoOutPoint {
+    pub fn new(outpoint_source_id: OutPointSourceId, output_index: u32) -> Self {
+        UtxoOutPoint {
+            id: outpoint_source_id,
+            index: output_index,
+        }
+    }
+
+    pub fn tx_id(&self) -> OutPointSourceId {
+        self.id.clone()
+    }
+
+    pub fn output_index(&self) -> u32 {
+        self.index
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+    use test_utils::random::Seed;
+
+    use super::*;
+
+    // The hash value doesn't matter because we first compare the enum arm
+    fn compare_test(block_reward_hash: &H256, tx_hash: &H256) {
+        let br = OutPointSourceId::BlockReward(Id::new(*block_reward_hash));
+        let bro0 = UtxoOutPoint::new(br.clone(), 0);
+        let bro1 = UtxoOutPoint::new(br.clone(), 1);
+        let bro2 = UtxoOutPoint::new(br, 2);
+
+        let tx = OutPointSourceId::Transaction(Id::new(*tx_hash));
+        let txo0 = UtxoOutPoint::new(tx.clone(), 0);
+        let txo1 = UtxoOutPoint::new(tx.clone(), 1);
+        let txo2 = UtxoOutPoint::new(tx, 2);
+
+        assert_eq!(bro0.cmp(&bro1), std::cmp::Ordering::Less);
+        assert_eq!(bro0.cmp(&bro2), std::cmp::Ordering::Less);
+        assert_eq!(bro1.cmp(&bro2), std::cmp::Ordering::Less);
+        assert_eq!(bro0.cmp(&bro0), std::cmp::Ordering::Equal);
+        assert_eq!(bro1.cmp(&bro1), std::cmp::Ordering::Equal);
+        assert_eq!(bro2.cmp(&bro2), std::cmp::Ordering::Equal);
+        assert_eq!(bro1.cmp(&bro0), std::cmp::Ordering::Greater);
+        assert_eq!(bro2.cmp(&bro1), std::cmp::Ordering::Greater);
+        assert_eq!(bro2.cmp(&bro0), std::cmp::Ordering::Greater);
+
+        assert_eq!(txo0.cmp(&txo1), std::cmp::Ordering::Less);
+        assert_eq!(txo0.cmp(&txo2), std::cmp::Ordering::Less);
+        assert_eq!(txo1.cmp(&txo2), std::cmp::Ordering::Less);
+        assert_eq!(txo0.cmp(&txo0), std::cmp::Ordering::Equal);
+        assert_eq!(txo1.cmp(&txo1), std::cmp::Ordering::Equal);
+        assert_eq!(txo2.cmp(&txo2), std::cmp::Ordering::Equal);
+        assert_eq!(txo1.cmp(&txo0), std::cmp::Ordering::Greater);
+        assert_eq!(txo2.cmp(&txo1), std::cmp::Ordering::Greater);
+        assert_eq!(txo2.cmp(&txo0), std::cmp::Ordering::Greater);
+
+        assert_eq!(bro0.cmp(&txo0), std::cmp::Ordering::Greater);
+        assert_eq!(bro0.cmp(&txo1), std::cmp::Ordering::Greater);
+        assert_eq!(bro0.cmp(&txo2), std::cmp::Ordering::Greater);
+
+        assert_eq!(txo0.cmp(&bro0), std::cmp::Ordering::Less);
+        assert_eq!(txo1.cmp(&bro0), std::cmp::Ordering::Less);
+        assert_eq!(txo2.cmp(&bro0), std::cmp::Ordering::Less);
+
+        assert_eq!(txo0.cmp(&bro1), std::cmp::Ordering::Less);
+        assert_eq!(txo1.cmp(&bro1), std::cmp::Ordering::Less);
+        assert_eq!(txo2.cmp(&bro1), std::cmp::Ordering::Less);
+
+        assert_eq!(txo0.cmp(&bro2), std::cmp::Ordering::Less);
+        assert_eq!(txo1.cmp(&bro2), std::cmp::Ordering::Less);
+        assert_eq!(txo2.cmp(&bro2), std::cmp::Ordering::Less);
+
+        assert_eq!(bro1.cmp(&txo1), std::cmp::Ordering::Greater);
+        assert_eq!(txo1.cmp(&bro1), std::cmp::Ordering::Less);
+
+        assert_eq!(bro2.cmp(&txo2), std::cmp::Ordering::Greater);
+        assert_eq!(txo2.cmp(&bro2), std::cmp::Ordering::Less);
+    }
+
+    #[test]
+    fn ord_and_equality_less() {
+        let hash_br = H256::from_low_u64_le(10);
+        let hash_tx = H256::from_low_u64_le(20);
+
+        compare_test(&hash_br, &hash_tx);
+    }
+
+    #[test]
+    fn ord_and_equality_greater() {
+        let hash_br = H256::from_low_u64_le(20);
+        let hash_tx = H256::from_low_u64_le(10);
+
+        compare_test(&hash_br, &hash_tx);
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn ord_and_equality_random(#[case] seed: Seed) {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
+
+        let hash_br = H256::random_using(&mut rng);
+        let hash_tx = H256::random_using(&mut rng);
+
+        compare_test(&hash_br, &hash_tx);
+    }
+}

--- a/common/tests/transaction.rs
+++ b/common/tests/transaction.rs
@@ -15,6 +15,7 @@
 
 use common::chain::signature::inputsig::InputWitness;
 use common::chain::signed_transaction::SignedTransaction;
+use common::chain::DelegationId;
 use common::chain::{tokens::OutputValue, transaction::*};
 use common::primitives::{Amount, Id, Idable, H256};
 use expect_test::expect;
@@ -30,13 +31,34 @@ fn transaction_id_snapshots() {
         Destination::ScriptHash(Id::new(hash0)),
     )]
     .to_vec();
-    let ins0: Vec<TxInput> = [TxInput::new(Id::<Transaction>::new(hash0).into(), 5)].to_vec();
-    let ins1: Vec<TxInput> = [
+    let utxo_ins0: Vec<TxInput> = [TxInput::new(Id::<Transaction>::new(hash0).into(), 5)].to_vec();
+    let utxo_ins1: Vec<TxInput> = [
         TxInput::new(Id::<Transaction>::new(hash1).into(), 3),
         TxInput::new(Id::<Transaction>::new(hash2).into(), 0),
     ]
     .to_vec();
 
+    let account_ins0: Vec<TxInput> = [TxInput::new_account(
+        0,
+        AccountType::Delegation(DelegationId::new(hash0)),
+        Amount::from_atoms(15),
+    )]
+    .to_vec();
+    let account_ins1: Vec<TxInput> = [
+        TxInput::new_account(
+            1,
+            AccountType::Delegation(DelegationId::new(hash1)),
+            Amount::from_atoms(35),
+        ),
+        TxInput::new_account(
+            2,
+            AccountType::Delegation(DelegationId::new(hash2)),
+            Amount::from_atoms(55),
+        ),
+    ]
+    .to_vec();
+
+    // empty inputs/outputs
     let tx = Transaction::new(0x00, vec![], vec![]).unwrap();
     let signed_tx = SignedTransaction::new(tx, vec![]).unwrap();
     expect![[r#"
@@ -44,21 +66,16 @@ fn transaction_id_snapshots() {
     "#]]
     .assert_debug_eq(&signed_tx.transaction().get_id().get());
 
-    let tx = Transaction::new(0x00, vec![], vec![]).unwrap();
-    let signed_tx = SignedTransaction::new(tx, vec![]).unwrap();
-    expect![[r#"
-        0x3db1faf0caf4f929459d5709c7f5e88c83b0c172ffc995a89035055ffadf7e2d
-    "#]]
-    .assert_debug_eq(&signed_tx.transaction().get_id().get());
-
-    let tx = Transaction::new(0x00, ins0.clone(), vec![]).unwrap();
+    // single utxo input / empty outputs
+    let tx = Transaction::new(0x00, utxo_ins0.clone(), vec![]).unwrap();
     let signed_tx = SignedTransaction::new(tx, vec![InputWitness::NoSignature(None)]).unwrap();
     expect![[r#"
-        0xbfda14833ab08e9819fdf0b899adf0dc38655255619538a015c2b1dcc74bcc34
+        0xbcd223a8ae03b116d255db0d7e2cc5a0570cde789813dd4d6ecd5f6f4d8585b5
     "#]]
     .assert_debug_eq(&signed_tx.transaction().get_id().get());
 
-    let tx = Transaction::new(0x00, ins1.clone(), vec![]).unwrap();
+    // two utxo inputs / empty outputs
+    let tx = Transaction::new(0x00, utxo_ins1.clone(), vec![]).unwrap();
     let signed_tx = SignedTransaction::new(
         tx,
         vec![
@@ -68,18 +85,20 @@ fn transaction_id_snapshots() {
     )
     .unwrap();
     expect![[r#"
-        0x679ac36cd1dd5c6f53aa532d01f96c61f4ff37eb1e71219ee38a2af19198e64a
+        0x1e2a16bdf1f663e8065e6c541d1d45196001471be9c94d1d87ebf84b4f1206a4
     "#]]
     .assert_debug_eq(&signed_tx.transaction().get_id().get());
 
-    let tx = Transaction::new(0x00, ins0, outs0.clone()).unwrap();
+    // single utxo inputs / single output
+    let tx = Transaction::new(0x00, utxo_ins0, outs0.clone()).unwrap();
     let signed_tx = SignedTransaction::new(tx, vec![InputWitness::NoSignature(None)]).unwrap();
     expect![[r#"
-        0x4ef0c69971c04aeb22c95c657c0dc92477ec8944edac0a4cc7642d944ecd815c
+        0x8ade05e1e0c8b77a86a8848f8a3c236e5b4666c71f01fc6a48174b553fc9e92f
     "#]]
     .assert_debug_eq(&signed_tx.transaction().get_id().get());
 
-    let tx = Transaction::new(0x00, ins1, outs0).unwrap();
+    // two utxo inputs / single output
+    let tx = Transaction::new(0x00, utxo_ins1, outs0.clone()).unwrap();
     let signed_tx = SignedTransaction::new(
         tx,
         vec![
@@ -89,7 +108,38 @@ fn transaction_id_snapshots() {
     )
     .unwrap();
     expect![[r#"
-        0x566a068e9f4a13b6ce758a1f9ca2262d87db71e6bd82a102303fd1b5ac860f22
+        0xe576d18773468bfbd828eb181106cc417e83a7852b659ffd5943351388b73559
+    "#]]
+    .assert_debug_eq(&signed_tx.transaction().get_id().get());
+
+    // single account input / empty outputs
+    let tx = Transaction::new(0x00, account_ins0.clone(), vec![]).unwrap();
+    let signed_tx = SignedTransaction::new(tx, vec![InputWitness::NoSignature(None)]).unwrap();
+    expect![[r#"
+        0x74e8d5d826597b52493fc7488fcc63f3f2f44a6c457abf8713f1cc5d353872c7
+    "#]]
+    .assert_debug_eq(&signed_tx.transaction().get_id().get());
+
+    // single account input / single output
+    let tx = Transaction::new(0x00, account_ins0, outs0.clone()).unwrap();
+    let signed_tx = SignedTransaction::new(tx, vec![InputWitness::NoSignature(None)]).unwrap();
+    expect![[r#"
+        0x093479a8a5b7e276db9d9fb205f0cfb7c826567a5fd412e91a1c6f10b5528e82
+    "#]]
+    .assert_debug_eq(&signed_tx.transaction().get_id().get());
+
+    // two account inputs / single output
+    let tx = Transaction::new(0x00, account_ins1, outs0).unwrap();
+    let signed_tx = SignedTransaction::new(
+        tx,
+        vec![
+            InputWitness::NoSignature(Some(vec![0x01, 0x05, 0x09])),
+            InputWitness::NoSignature(Some(vec![0x91, 0x55, 0x19, 0x00])),
+        ],
+    )
+    .unwrap();
+    expect![[r#"
+        0xa17efbc0f7ec4ac790bae3c235328535f403da62f80d4a8b282a817daf55bdfd
     "#]]
     .assert_debug_eq(&signed_tx.transaction().get_id().get());
 }

--- a/common/tests/transaction.rs
+++ b/common/tests/transaction.rs
@@ -31,26 +31,27 @@ fn transaction_id_snapshots() {
         Destination::ScriptHash(Id::new(hash0)),
     )]
     .to_vec();
-    let utxo_ins0: Vec<TxInput> = [TxInput::new(Id::<Transaction>::new(hash0).into(), 5)].to_vec();
+    let utxo_ins0: Vec<TxInput> =
+        [TxInput::from_utxo(Id::<Transaction>::new(hash0).into(), 5)].to_vec();
     let utxo_ins1: Vec<TxInput> = [
-        TxInput::new(Id::<Transaction>::new(hash1).into(), 3),
-        TxInput::new(Id::<Transaction>::new(hash2).into(), 0),
+        TxInput::from_utxo(Id::<Transaction>::new(hash1).into(), 3),
+        TxInput::from_utxo(Id::<Transaction>::new(hash2).into(), 0),
     ]
     .to_vec();
 
-    let account_ins0: Vec<TxInput> = [TxInput::new_account(
+    let account_ins0: Vec<TxInput> = [TxInput::from_account(
         0,
         AccountType::Delegation(DelegationId::new(hash0)),
         Amount::from_atoms(15),
     )]
     .to_vec();
     let account_ins1: Vec<TxInput> = [
-        TxInput::new_account(
+        TxInput::from_account(
             1,
             AccountType::Delegation(DelegationId::new(hash1)),
             Amount::from_atoms(35),
         ),
-        TxInput::new_account(
+        TxInput::from_account(
             2,
             AccountType::Delegation(DelegationId::new(hash2)),
             Amount::from_atoms(55),

--- a/common/tests/transaction.rs
+++ b/common/tests/transaction.rs
@@ -40,17 +40,17 @@ fn transaction_id_snapshots() {
     .to_vec();
 
     let account_ins0: Vec<TxInput> = [TxInput::from_account(
-        0,
+        AccountNonce::new(0),
         AccountSpending::Delegation(DelegationId::new(hash0), Amount::from_atoms(15)),
     )]
     .to_vec();
     let account_ins1: Vec<TxInput> = [
         TxInput::from_account(
-            1,
+            AccountNonce::new(1),
             AccountSpending::Delegation(DelegationId::new(hash1), Amount::from_atoms(35)),
         ),
         TxInput::from_account(
-            2,
+            AccountNonce::new(2),
             AccountSpending::Delegation(DelegationId::new(hash2), Amount::from_atoms(55)),
         ),
     ]

--- a/common/tests/transaction.rs
+++ b/common/tests/transaction.rs
@@ -41,20 +41,17 @@ fn transaction_id_snapshots() {
 
     let account_ins0: Vec<TxInput> = [TxInput::from_account(
         0,
-        AccountType::Delegation(DelegationId::new(hash0)),
-        Amount::from_atoms(15),
+        AccountSpending::Delegation(DelegationId::new(hash0), Amount::from_atoms(15)),
     )]
     .to_vec();
     let account_ins1: Vec<TxInput> = [
         TxInput::from_account(
             1,
-            AccountType::Delegation(DelegationId::new(hash1)),
-            Amount::from_atoms(35),
+            AccountSpending::Delegation(DelegationId::new(hash1), Amount::from_atoms(35)),
         ),
         TxInput::from_account(
             2,
-            AccountType::Delegation(DelegationId::new(hash2)),
-            Amount::from_atoms(55),
+            AccountSpending::Delegation(DelegationId::new(hash2), Amount::from_atoms(55)),
         ),
     ]
     .to_vec();

--- a/consensus/src/pos/input_data.rs
+++ b/consensus/src/pos/input_data.rs
@@ -216,7 +216,7 @@ where
     let sighash = signature_hash(
         SigHashType::default(),
         &block_reward_transactable,
-        &pos_input_data.kernel_input_utxos().iter().collect::<Vec<_>>(),
+        &pos_input_data.kernel_input_utxos().iter().map(Some).collect::<Vec<_>>(),
         0,
     )
     .map_err(|_| ConsensusPoSError::FailedToSignKernel)?;

--- a/consensus/src/pos/kernel.rs
+++ b/consensus/src/pos/kernel.rs
@@ -25,7 +25,7 @@ pub fn get_kernel_output<U: UtxosView>(
     match kernel_inputs {
         [] => Err(ConsensusPoSError::NoKernel),
         [kernel_input] => {
-            let kernel_outpoint = kernel_input.outpoint();
+            let kernel_outpoint = kernel_input.outpoint().ok_or(ConsensusPoSError::NoKernel)?;
             let kernel_output = utxos_view
                 .utxo(kernel_outpoint)
                 .map_err(|_| ConsensusPoSError::FailedToFetchUtxo)?

--- a/consensus/src/pos/kernel.rs
+++ b/consensus/src/pos/kernel.rs
@@ -25,7 +25,8 @@ pub fn get_kernel_output<U: UtxosView>(
     match kernel_inputs {
         [] => Err(ConsensusPoSError::NoKernel),
         [kernel_input] => {
-            let kernel_outpoint = kernel_input.outpoint().ok_or(ConsensusPoSError::NoKernel)?;
+            let kernel_outpoint =
+                kernel_input.utxo_outpoint().ok_or(ConsensusPoSError::NoKernel)?;
             let kernel_output = utxos_view
                 .utxo(kernel_outpoint)
                 .map_err(|_| ConsensusPoSError::FailedToFetchUtxo)?

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -185,6 +185,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::DelegationBalanceNotFound(_) => 0,
             ConnectTransactionError::MissingTransactionNonce(_) => 0,
             ConnectTransactionError::DestinationRetrievalError(err) => err.mempool_ban_score(),
+            ConnectTransactionError::FailedToIncrementAccountNonce => 0,
         }
     }
 }

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -276,6 +276,7 @@ impl MempoolBanScore for utxo::Error {
             utxo::Error::MissingBlockRewardUndo(_) => 0,
             utxo::Error::ViewRead => 0,
             utxo::Error::StorageWrite => 0,
+            utxo::Error::TxInputAndUndoMismatch(_) => 0,
         }
     }
 }

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -122,6 +122,7 @@ impl MempoolBanScore for ConnectTransactionError {
             // it is the transaction or the current tip that's wrong, we don't punish the peer.
             ConnectTransactionError::MissingOutputOrSpent => 0,
             ConnectTransactionError::TimeLockViolation(_) => 0,
+            ConnectTransactionError::NonceIsNotIncremental(_) => 0,
 
             // These are delegated to the inner error
             ConnectTransactionError::UtxoError(err) => err.mempool_ban_score(),

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -179,6 +179,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::BlockRewardInputOutputMismatch(_, _) => 0,
             ConnectTransactionError::TotalDelegationBalanceZero(_) => 0,
             ConnectTransactionError::DelegationDataNotFound(_) => 0,
+            ConnectTransactionError::DelegationBalanceNotFound(_) => 0,
             ConnectTransactionError::DestinationRetrievalError(err) => err.mempool_ban_score(),
         }
     }

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -147,6 +147,8 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::PoolOwnerRewardCalculationFailed(_, _) => 100,
             ConnectTransactionError::PoolOwnerRewardCannotExceedTotalReward(_, _, _, _) => 100,
             ConnectTransactionError::NotEnoughPledgeToCreateStakePool(_, _, _) => 100,
+            ConnectTransactionError::AttemptToCreateStakePoolFromAccounts => 100,
+            ConnectTransactionError::AttemptToCreateDelegationFromAccounts => 100,
             ConnectTransactionError::OutputTimelockError(err) => err.ban_score(),
 
             // Should not happen when processing standalone transactions

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -183,6 +183,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::TotalDelegationBalanceZero(_) => 0,
             ConnectTransactionError::DelegationDataNotFound(_) => 0,
             ConnectTransactionError::DelegationBalanceNotFound(_) => 0,
+            ConnectTransactionError::MissingTransactionNonce(_) => 0,
             ConnectTransactionError::DestinationRetrievalError(err) => err.mempool_ban_score(),
         }
     }

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -190,10 +190,13 @@ impl MempoolBanScore for SignatureDestinationGetterError {
     fn mempool_ban_score(&self) -> u32 {
         match self {
             SignatureDestinationGetterError::SpendingOutputInBlockReward => 100,
+            SignatureDestinationGetterError::SpendingFromAccountInBlockReward => 100,
             SignatureDestinationGetterError::SigVerifyOfBurnedOutput => 100,
             SignatureDestinationGetterError::PoolDataNotFound(_) => 0,
             SignatureDestinationGetterError::DelegationDataNotFound(_) => 0,
             SignatureDestinationGetterError::SigVerifyPoSAccountingError(_) => 100,
+            SignatureDestinationGetterError::UtxoOutputNotFound(_) => 0,
+            SignatureDestinationGetterError::UtxoViewError(_) => 0,
         }
     }
 }

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -224,7 +224,7 @@ impl<M> Mempool<M> {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => outpoint.tx_id().get_tx_id().cloned(),
-                TxInput::Account(_) => None,
+                TxInput::Account(_, _) => None,
             })
             .filter(|id| self.store.txs_by_id.contains_key(id))
             .collect::<BTreeSet<_>>();

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -224,7 +224,7 @@ impl<M> Mempool<M> {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => outpoint.tx_id().get_tx_id().cloned(),
-                TxInput::Account(_, _) => None,
+                TxInput::Account(_) => None,
             })
             .filter(|id| self.store.txs_by_id.contains_key(id))
             .collect::<BTreeSet<_>>();

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -23,7 +23,7 @@ use chainstate::{
 use common::{
     chain::{
         block::timestamp::BlockTimestamp, Block, ChainConfig, GenBlock, SignedTransaction,
-        Transaction,
+        Transaction, TxInput,
     },
     primitives::{amount::Amount, BlockHeight, Id, Idable},
     time_getter::TimeGetter,
@@ -222,7 +222,10 @@ impl<M> Mempool<M> {
             .transaction()
             .inputs()
             .iter()
-            .filter_map(|input| input.outpoint().unwrap().tx_id().get_tx_id().cloned()) // FIXME: impl
+            .filter_map(|input| match input {
+                TxInput::Utxo(outpoint) => outpoint.tx_id().get_tx_id().cloned(),
+                TxInput::Account(_) => None,
+            })
             .filter(|id| self.store.txs_by_id.contains_key(id))
             .collect::<BTreeSet<_>>();
         let ancestor_ids =
@@ -414,8 +417,7 @@ impl<M: GetMemoryUsage> Mempool<M> {
         tx.transaction()
             .inputs()
             .iter()
-            .filter_map(|input| self.store.find_conflicting_tx(input.outpoint().unwrap()))
-        // FIXME: impl
+            .filter_map(|input| self.store.find_conflicting_tx(input))
     }
 }
 
@@ -515,11 +517,9 @@ impl<M: GetMemoryUsage> Mempool<M> {
         tx: &TxEntryWithFee,
         conflicts: &[&TxMempoolEntry],
     ) -> Result<(), MempoolPolicyError> {
-        let outpoints_spent_by_conflicts = conflicts
+        let inputs_spent_by_conflicts = conflicts
             .iter()
-            .flat_map(|conflict| {
-                conflict.transaction().inputs().iter().map(|input| input.outpoint())
-            })
+            .flat_map(|conflict| conflict.transaction().inputs().iter())
             .collect::<BTreeSet<_>>();
 
         tx.transaction()
@@ -529,7 +529,7 @@ impl<M: GetMemoryUsage> Mempool<M> {
                 // input spends an unconfirmed output
                 input.spends_unconfirmed(self) &&
                 // this unconfirmed output is not spent by one of the conflicts
-                !outpoints_spent_by_conflicts.contains(&input.outpoint())
+                !inputs_spent_by_conflicts.contains(input)
             })
             .map_or(Ok(()), |_| {
                 Err(MempoolPolicyError::SpendsNewUnconfirmedOutput)

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -222,7 +222,7 @@ impl<M> Mempool<M> {
             .transaction()
             .inputs()
             .iter()
-            .filter_map(|input| input.outpoint().tx_id().get_tx_id().cloned())
+            .filter_map(|input| input.outpoint().unwrap().tx_id().get_tx_id().cloned()) // FIXME: impl
             .filter(|id| self.store.txs_by_id.contains_key(id))
             .collect::<BTreeSet<_>>();
         let ancestor_ids =
@@ -414,7 +414,8 @@ impl<M: GetMemoryUsage> Mempool<M> {
         tx.transaction()
             .inputs()
             .iter()
-            .filter_map(|input| self.store.find_conflicting_tx(input.outpoint()))
+            .filter_map(|input| self.store.find_conflicting_tx(input.outpoint().unwrap()))
+        // FIXME: impl
     }
 }
 

--- a/mempool/src/pool/spends_unconfirmed.rs
+++ b/mempool/src/pool/spends_unconfirmed.rs
@@ -34,7 +34,7 @@ impl<M: GetMemoryUsage> SpendsUnconfirmed<M> for TxInput {
                 .tx_id()
                 .get_tx_id()
                 .map_or(false, |tx_id| mempool.contains_transaction(tx_id)),
-            TxInput::Account(_) => false,
+            TxInput::Account(_, _) => false,
         }
     }
 }

--- a/mempool/src/pool/spends_unconfirmed.rs
+++ b/mempool/src/pool/spends_unconfirmed.rs
@@ -28,10 +28,13 @@ where
 
 impl<M: GetMemoryUsage> SpendsUnconfirmed<M> for TxInput {
     fn spends_unconfirmed(&self, mempool: &Mempool<M>) -> bool {
-        self.outpoint()
-            .unwrap() // FIXME: impl
-            .tx_id()
-            .get_tx_id()
-            .map_or(false, |tx_id| mempool.contains_transaction(tx_id))
+        // TODO: if TxInput spends from an account there is no way to know tx_id
+        match self {
+            TxInput::Utxo(outpoint) => outpoint
+                .tx_id()
+                .get_tx_id()
+                .map_or(false, |tx_id| mempool.contains_transaction(tx_id)),
+            TxInput::Account(_) => false,
+        }
     }
 }

--- a/mempool/src/pool/spends_unconfirmed.rs
+++ b/mempool/src/pool/spends_unconfirmed.rs
@@ -34,7 +34,7 @@ impl<M: GetMemoryUsage> SpendsUnconfirmed<M> for TxInput {
                 .tx_id()
                 .get_tx_id()
                 .map_or(false, |tx_id| mempool.contains_transaction(tx_id)),
-            TxInput::Account(_, _) => false,
+            TxInput::Account(_) => false,
         }
     }
 }

--- a/mempool/src/pool/spends_unconfirmed.rs
+++ b/mempool/src/pool/spends_unconfirmed.rs
@@ -29,6 +29,7 @@ where
 impl<M: GetMemoryUsage> SpendsUnconfirmed<M> for TxInput {
     fn spends_unconfirmed(&self, mempool: &Mempool<M>) -> bool {
         self.outpoint()
+            .unwrap() // FIXME: impl
             .tx_id()
             .get_tx_id()
             .map_or(false, |tx_id| mempool.contains_transaction(tx_id))

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use common::{
-    chain::{OutPoint, SignedTransaction, Transaction},
+    chain::{SignedTransaction, Transaction, TxInput},
     primitives::Id,
 };
 use logging::log;
@@ -91,9 +91,9 @@ pub struct MempoolStore {
     // TODO add txs_by_ancestor_score index, which will be used by the block production subsystem
     // to select the best transactions for the next block
     //
-    // We keep the information of which outpoints are spent by entries currently in the mempool.
+    // We keep the information of which inputs are spent by entries currently in the mempool.
     // This allows us to recognize conflicts (double-spends) and handle them
-    pub spender_txs: BTreeMap<OutPoint, Id<Transaction>>,
+    pub spender_txs: BTreeMap<TxInput, Id<Transaction>>,
 
     // Track transactions by internal unique sequence number. This is used to recover the order in
     // which the transactions have been inserted into the mempool, so they can be re-inserted in
@@ -219,8 +219,8 @@ impl MempoolStore {
 
     fn mark_outpoints_as_spent(&mut self, entry: &TxMempoolEntry) {
         let id = entry.tx_id();
-        for outpoint in entry.entry.transaction().inputs().iter().map(|input| input.outpoint()) {
-            self.spender_txs.insert(outpoint.unwrap().clone(), id); // FIXME: impl
+        for input in entry.entry.transaction().inputs().iter() {
+            self.spender_txs.insert(input.clone(), id);
         }
     }
 
@@ -420,8 +420,8 @@ impl MempoolStore {
         }
     }
 
-    pub fn find_conflicting_tx(&self, outpoint: &OutPoint) -> Option<Id<Transaction>> {
-        self.spender_txs.get(outpoint).cloned()
+    pub fn find_conflicting_tx(&self, input: &TxInput) -> Option<Id<Transaction>> {
+        self.spender_txs.get(input).cloned()
     }
 
     /// Take all the transactions from the store in the original order of insertion

--- a/mempool/src/pool/store.rs
+++ b/mempool/src/pool/store.rs
@@ -220,7 +220,7 @@ impl MempoolStore {
     fn mark_outpoints_as_spent(&mut self, entry: &TxMempoolEntry) {
         let id = entry.tx_id();
         for outpoint in entry.entry.transaction().inputs().iter().map(|input| input.outpoint()) {
-            self.spender_txs.insert(outpoint.clone(), id);
+            self.spender_txs.insert(outpoint.unwrap().clone(), id); // FIXME: impl
         }
     }
 

--- a/mempool/src/pool/tests/expiry.rs
+++ b/mempool/src/pool/tests/expiry.rs
@@ -33,7 +33,7 @@ async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let parent = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::Transfer(
@@ -61,7 +61,7 @@ async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
     let outpoint_source_id = OutPointSourceId::Transaction(parent_id);
     let child = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id, 0),
+        TxInput::from_utxo(outpoint_source_id, 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         None,
         flags,
@@ -91,7 +91,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
     let genesis = tf.genesis();
     let num_outputs = 2;
     let mut tx_builder = TransactionBuilder::new().add_input(
-        TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+        TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
         empty_witness(&mut rng),
     );
 
@@ -123,7 +123,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
     let outpoint_source_id = OutPointSourceId::Transaction(parent_id);
     let child_0 = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id.clone(), 0),
+        TxInput::from_utxo(outpoint_source_id.clone(), 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         None,
         flags,
@@ -132,7 +132,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
 
     let child_1 = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id, 1),
+        TxInput::from_utxo(outpoint_source_id, 1),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         None,
         flags,

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -977,7 +977,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
             )?)
         .unwrap()
     );
-    assert_eq!(rolling_fee, FeeRate::new(Amount::from_atoms(3625)));
+    assert_eq!(rolling_fee, FeeRate::new(Amount::from_atoms(3629)));
     log::debug!(
         "minimum rolling fee after child_0's eviction {:?}",
         rolling_fee

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -435,7 +435,7 @@ async fn tx_spend_several_inputs<M: GetMemoryUsage + Send + Sync>(
     let mut input_values = Vec::new();
     let inputs = inputs.to_owned();
     for input in inputs.clone() {
-        let outpoint = input.outpoint().clone();
+        let outpoint = input.outpoint().unwrap().clone();
         let chainstate_outpoint_value = mempool
             .chainstate_handle
             .call(move |this| this.get_inputs_outpoints_coin_amount(&[input]))

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -28,7 +28,7 @@ use common::{
         signature::inputsig::InputWitness,
         tokens::OutputValue,
         transaction::{Destination, TxInput, TxOutput},
-        OutPoint, OutPointSourceId, Transaction,
+        OutPointSourceId, Transaction, UtxoOutPoint,
     },
     primitives::{Id, H256},
 };
@@ -63,7 +63,7 @@ fn real_size(#[case] seed: Seed) -> anyhow::Result<()> {
     let tf = TestFramework::builder(&mut rng).build();
     let genesis = tf.genesis();
     let mut tx_builder = TransactionBuilder::new().add_input(
-        TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+        TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
         empty_witness(&mut rng),
     );
 
@@ -99,7 +99,7 @@ async fn add_single_tx() -> anyhow::Result<()> {
     let outpoint_source_id = mempool.chain_config.genesis_block_id().into();
 
     let flags = 0;
-    let input = TxInput::new(outpoint_source_id, 0);
+    let input = TxInput::from_utxo(outpoint_source_id, 0);
     let relay_fee: Fee = Amount::from_atoms(get_relay_fee_from_tx_size(TX_SPEND_INPUT_SIZE)).into();
     let tx = tx_spend_input(
         &mempool,
@@ -136,7 +136,7 @@ async fn txs_sorted(#[case] seed: Seed) -> anyhow::Result<()> {
     let target_txs = 10;
 
     let mut tx_builder = TransactionBuilder::new().add_input(
-        TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+        TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
         empty_witness(&mut rng),
     );
     for i in 0..target_txs {
@@ -151,7 +151,7 @@ async fn txs_sorted(#[case] seed: Seed) -> anyhow::Result<()> {
     for i in 0..target_txs {
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(OutPointSourceId::Transaction(initial_tx_id), i as u32),
+                TxInput::from_utxo(OutPointSourceId::Transaction(initial_tx_id), i as u32),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(
@@ -250,7 +250,7 @@ async fn tx_no_outputs(#[case] seed: Seed) -> anyhow::Result<()> {
     let genesis = tf.genesis();
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .build();
@@ -268,9 +268,9 @@ async fn tx_duplicate_inputs() -> anyhow::Result<()> {
     let mut mempool = setup().await;
 
     let outpoint_source_id = OutPointSourceId::from(mempool.chain_config.genesis_block_id());
-    let input = TxInput::new(outpoint_source_id.clone(), 0);
+    let input = TxInput::from_utxo(outpoint_source_id.clone(), 0);
     let witness = b"attempted_double_spend".to_vec();
-    let duplicate_input = TxInput::new(outpoint_source_id, 0);
+    let duplicate_input = TxInput::from_utxo(outpoint_source_id, 0);
     let flags = 0;
     let outputs = tx_spend_input(
         &mempool,
@@ -306,7 +306,7 @@ async fn tx_already_in_mempool() -> anyhow::Result<()> {
     let mut mempool = setup().await;
 
     let outpoint_source_id = OutPointSourceId::from(mempool.chain_config.genesis_block_id());
-    let input = TxInput::new(outpoint_source_id, 0);
+    let input = TxInput::from_utxo(outpoint_source_id, 0);
 
     let flags = 0;
     let tx = tx_spend_input(
@@ -339,7 +339,7 @@ async fn outpoint_not_found(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let outpoint_source_id = OutPointSourceId::from(mempool.chain_config.genesis_block_id());
 
-    let good_input = TxInput::new(outpoint_source_id.clone(), 0);
+    let good_input = TxInput::from_utxo(outpoint_source_id.clone(), 0);
     let flags = 0;
     let outputs = tx_spend_input(
         &mempool,
@@ -354,7 +354,7 @@ async fn outpoint_not_found(#[case] seed: Seed) -> anyhow::Result<()> {
     .to_owned();
 
     let bad_outpoint_index = 1;
-    let bad_input = TxInput::new(outpoint_source_id, bad_outpoint_index);
+    let bad_input = TxInput::from_utxo(outpoint_source_id, bad_outpoint_index);
 
     let inputs = vec![bad_input];
     let tx = SignedTransaction::new(
@@ -388,7 +388,7 @@ async fn tx_too_big(#[case] seed: Seed) -> anyhow::Result<()> {
     .encoded_size();
     let too_many_outputs = MAX_BLOCK_SIZE_BYTES / single_output_size;
     let mut tx_builder = TransactionBuilder::new().add_input(
-        TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+        TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
         empty_witness(&mut rng),
     );
     for _ in 0..too_many_outputs {
@@ -435,7 +435,7 @@ async fn tx_spend_several_inputs<M: GetMemoryUsage + Send + Sync>(
     let mut input_values = Vec::new();
     let inputs = inputs.to_owned();
     for input in inputs.clone() {
-        let outpoint = input.outpoint().unwrap().clone();
+        let outpoint = input.utxo_outpoint().unwrap().clone();
         let chainstate_outpoint_value = mempool
             .chainstate_handle
             .call(move |this| this.get_inputs_outpoints_coin_amount(&[input]))
@@ -489,7 +489,7 @@ async fn one_ancestor_replaceability_signal_is_enough(#[case] seed: Seed) -> any
     let tf = TestFramework::builder(&mut rng).build();
     let genesis = tf.genesis();
     let mut tx_builder = TransactionBuilder::new().add_input(
-        TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+        TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
         empty_witness(&mut rng),
     );
     let num_outputs = 2;
@@ -511,7 +511,7 @@ async fn one_ancestor_replaceability_signal_is_enough(#[case] seed: Seed) -> any
     let outpoint_source_id = OutPointSourceId::Transaction(tx.transaction().get_id());
     let ancestor_with_signal = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id.clone(), 0),
+        TxInput::from_utxo(outpoint_source_id.clone(), 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         None,
         flags_replaceable,
@@ -520,7 +520,7 @@ async fn one_ancestor_replaceability_signal_is_enough(#[case] seed: Seed) -> any
 
     let ancestor_without_signal = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id, 1),
+        TxInput::from_utxo(outpoint_source_id, 1),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         None,
         flags_irreplaceable,
@@ -530,12 +530,12 @@ async fn one_ancestor_replaceability_signal_is_enough(#[case] seed: Seed) -> any
     mempool.add_transaction(ancestor_with_signal.clone())?;
     mempool.add_transaction(ancestor_without_signal.clone())?;
 
-    let input_with_replaceable_parent = TxInput::new(
+    let input_with_replaceable_parent = TxInput::from_utxo(
         OutPointSourceId::Transaction(ancestor_with_signal.transaction().get_id()),
         0,
     );
 
-    let input_with_irreplaceable_parent = TxInput::new(
+    let input_with_irreplaceable_parent = TxInput::from_utxo(
         OutPointSourceId::Transaction(ancestor_without_signal.transaction().get_id()),
         0,
     );
@@ -721,7 +721,7 @@ async fn test_bip125_max_replacements(
     let genesis = tf.genesis();
     let mut tx_builder = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .with_flags(1);
@@ -744,7 +744,7 @@ async fn test_bip125_max_replacements(
     let outpoint_source_id = OutPointSourceId::Transaction(tx_id);
     let fee = 2_000;
     for (index, _) in outputs.iter().enumerate() {
-        let input = TxInput::new(outpoint_source_id.clone(), index.try_into().unwrap());
+        let input = TxInput::from_utxo(outpoint_source_id.clone(), index.try_into().unwrap());
         let tx = tx_spend_input(
             &mempool,
             input,
@@ -812,7 +812,7 @@ async fn spends_new_unconfirmed(#[case] seed: Seed) -> anyhow::Result<()> {
     let genesis = tf.genesis();
     let mut tx_builder = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .with_flags(1);
@@ -829,8 +829,8 @@ async fn spends_new_unconfirmed(#[case] seed: Seed) -> anyhow::Result<()> {
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
     mempool.add_transaction(tx)?;
 
-    let input1 = TxInput::new(outpoint_source_id.clone(), 0);
-    let input2 = TxInput::new(outpoint_source_id, 1);
+    let input1 = TxInput::from_utxo(outpoint_source_id.clone(), 0);
+    let input2 = TxInput::from_utxo(outpoint_source_id, 1);
 
     let flags = 0;
     let original_fee: Fee = Amount::from_atoms(100).into();
@@ -894,7 +894,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     let genesis = tf.genesis();
     let mut tx_builder = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .with_flags(1);
@@ -934,7 +934,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     // child_0 has the lower fee so it will be evicted when memory usage is too high
     let child_0 = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id.clone(), 0),
+        TxInput::from_utxo(outpoint_source_id.clone(), 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         None,
         flags,
@@ -949,7 +949,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     .into();
     let child_1 = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id.clone(), 1),
+        TxInput::from_utxo(outpoint_source_id.clone(), 1),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         big_fee,
         flags,
@@ -995,7 +995,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     // validation
     let child_2 = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id.clone(), 2),
+        TxInput::from_utxo(outpoint_source_id.clone(), 2),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         None,
         flags,
@@ -1019,7 +1019,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     // We provide a sufficient fee for the tx to pass the minimum rolling fee requirement
     let child_2_high_fee = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id, 2),
+        TxInput::from_utxo(outpoint_source_id, 2),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         mempool.get_minimum_rolling_fee().compute_fee(estimate_tx_size(1, 1)).unwrap(),
         flags,
@@ -1027,7 +1027,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     .await?;
     let child_2_high_fee_id = child_2_high_fee.transaction().get_id();
     let child_2_high_fee_outpt =
-        OutPoint::new(OutPointSourceId::Transaction(child_2_high_fee_id), 0);
+        UtxoOutPoint::new(OutPointSourceId::Transaction(child_2_high_fee_id), 0);
     log::debug!("before child2_high_fee");
     mempool.add_transaction(child_2_high_fee.clone())?;
 
@@ -1081,7 +1081,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     );
     let dummy_tx = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::Transaction(child_2_high_fee_id), 0),
+            TxInput::from_utxo(OutPointSourceId::Transaction(child_2_high_fee_id), 0),
             InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         )
         .add_output(TxOutput::Transfer(
@@ -1138,7 +1138,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let another_dummy = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::Transaction(child_1_id), 0),
+            TxInput::from_utxo(OutPointSourceId::Transaction(child_1_id), 0),
             InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         )
         .add_output(TxOutput::Transfer(
@@ -1169,7 +1169,7 @@ async fn different_size_txs(#[case] seed: Seed) -> anyhow::Result<()> {
     let genesis = tf.genesis();
 
     let mut tx_builder = TransactionBuilder::new().add_input(
-        TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+        TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
         empty_witness(&mut rng),
     );
     for _ in 0..10_000 {
@@ -1192,7 +1192,7 @@ async fn different_size_txs(#[case] seed: Seed) -> anyhow::Result<()> {
         let mut tx_builder = TransactionBuilder::new();
         for j in 0..num_inputs {
             tx_builder = tx_builder.add_input(
-                TxInput::new(
+                TxInput::from_utxo(
                     OutPointSourceId::Transaction(initial_tx.transaction().get_id()),
                     100 * i + j,
                 ),
@@ -1243,7 +1243,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::Transfer(
@@ -1270,7 +1270,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_c_fee: Fee = (tx_a_fee + Amount::from_atoms(1000).into()).unwrap();
     let tx_a = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id.clone(), 0),
+        TxInput::from_utxo(outpoint_source_id.clone(), 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         tx_a_fee,
         flags,
@@ -1284,7 +1284,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let tx_b = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id, 1),
+        TxInput::from_utxo(outpoint_source_id, 1),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         tx_b_fee,
         flags,
@@ -1297,7 +1297,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let tx_c = tx_spend_input(
         &mempool,
-        TxInput::new(OutPointSourceId::Transaction(tx_b_id), 0),
+        TxInput::from_utxo(OutPointSourceId::Transaction(tx_b_id), 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         tx_c_fee,
         flags,
@@ -1394,7 +1394,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::Transfer(
@@ -1421,7 +1421,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_c_fee = (tx_a_fee + Amount::from_atoms(1000).into()).unwrap();
     let tx_a = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id.clone(), 0),
+        TxInput::from_utxo(outpoint_source_id.clone(), 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         tx_a_fee,
         flags,
@@ -1434,7 +1434,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let tx_b = tx_spend_input(
         &mempool,
-        TxInput::new(outpoint_source_id, 1),
+        TxInput::from_utxo(outpoint_source_id, 1),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         tx_b_fee,
         flags,
@@ -1447,7 +1447,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let tx_c = tx_spend_input(
         &mempool,
-        TxInput::new(OutPointSourceId::Transaction(tx_b_id), 0),
+        TxInput::from_utxo(OutPointSourceId::Transaction(tx_b_id), 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         tx_c_fee,
         flags,
@@ -1527,7 +1527,7 @@ async fn mempool_full(#[case] seed: Seed) -> anyhow::Result<()> {
 
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::Transfer(
@@ -1554,7 +1554,7 @@ async fn no_empty_bags_in_indices(#[case] seed: Seed) -> anyhow::Result<()> {
     let tf = TestFramework::builder(&mut rng).build();
     let genesis = tf.genesis();
     let mut tx_builder = TransactionBuilder::new().add_input(
-        TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+        TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
         empty_witness(&mut rng),
     );
 
@@ -1580,7 +1580,7 @@ async fn no_empty_bags_in_indices(#[case] seed: Seed) -> anyhow::Result<()> {
         txs.push(
             tx_spend_input(
                 &mempool,
-                TxInput::new(outpoint_source_id.clone(), u32::try_from(i).unwrap()),
+                TxInput::from_utxo(outpoint_source_id.clone(), u32::try_from(i).unwrap()),
                 empty_witness(&mut rng),
                 Fee::new(Amount::from_atoms(fee + u128::try_from(i).unwrap())),
                 flags,
@@ -1624,7 +1624,7 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
     let target_txs = 10;
 
     let mut tx_builder = TransactionBuilder::new().add_input(
-        TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+        TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
         empty_witness(&mut rng),
     );
     for i in 0..target_txs {
@@ -1639,7 +1639,7 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
     for i in 0..target_txs {
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::new(OutPointSourceId::Transaction(initial_tx_id), i as u32),
+                TxInput::from_utxo(OutPointSourceId::Transaction(initial_tx_id), i as u32),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(

--- a/mempool/src/pool/tests/reorg.rs
+++ b/mempool/src/pool/tests/reorg.rs
@@ -42,7 +42,7 @@ async fn basic_reorg(#[case] seed: Seed) {
     // Add the first transaction
     let tx1 = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .add_anyone_can_spend_output(10_000_000)
@@ -53,7 +53,7 @@ async fn basic_reorg(#[case] seed: Seed) {
     // Add another transaction
     let tx2 = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::Transaction(tx1_id), 0),
+            TxInput::from_utxo(OutPointSourceId::Transaction(tx1_id), 0),
             empty_witness(&mut rng),
         )
         .add_anyone_can_spend_output(9_000_000)
@@ -127,7 +127,7 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
     // Add the first transaction
     let tx1 = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .add_anyone_can_spend_output(10_000_000)
@@ -138,7 +138,7 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
     // Add another transaction
     let tx2 = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::Transaction(tx1_id), 0),
+            TxInput::from_utxo(OutPointSourceId::Transaction(tx1_id), 0),
             empty_witness(&mut rng),
         )
         .add_anyone_can_spend_output(9_000_000)

--- a/mempool/src/pool/tests/replacement.rs
+++ b/mempool/src/pool/tests/replacement.rs
@@ -33,7 +33,7 @@ async fn test_replace_tx(
 
     let outpoint_source_id = OutPointSourceId::BlockReward(genesis.get_id().into());
 
-    let input = TxInput::new(outpoint_source_id, 0);
+    let input = TxInput::from_utxo(outpoint_source_id, 0);
     let flags = 1;
 
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
@@ -85,7 +85,7 @@ async fn try_replace_irreplaceable(#[case] seed: Seed) -> anyhow::Result<()> {
     let genesis = tf.genesis();
     let outpoint_source_id = OutPointSourceId::BlockReward(genesis.get_id().into());
 
-    let input = TxInput::new(outpoint_source_id, 0);
+    let input = TxInput::from_utxo(outpoint_source_id, 0);
     let flags = 0;
     let original_fee: Fee =
         Amount::from_atoms(get_relay_fee_from_tx_size(TX_SPEND_INPUT_SIZE)).into();
@@ -180,7 +180,7 @@ async fn tx_replace_child(#[case] seed: Seed) -> anyhow::Result<()> {
     let genesis = tf.genesis();
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::Transfer(
@@ -193,7 +193,7 @@ async fn tx_replace_child(#[case] seed: Seed) -> anyhow::Result<()> {
     mempool.add_transaction(tx.clone())?;
 
     let outpoint_source_id = OutPointSourceId::Transaction(tx.transaction().get_id());
-    let child_tx_input = TxInput::new(outpoint_source_id, 0);
+    let child_tx_input = TxInput::from_utxo(outpoint_source_id, 0);
     // We want to test that even though child_tx doesn't signal replaceability directly, it is replaceable because its parent signalled replaceability
     // replaced
     let flags = 0;
@@ -233,7 +233,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     let genesis = tf.genesis();
     let tx = TransactionBuilder::new()
         .add_input(
-            TxInput::new(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
+            TxInput::from_utxo(OutPointSourceId::BlockReward(genesis.get_id().into()), 0),
             empty_witness(&mut rng),
         )
         .add_output(TxOutput::Transfer(
@@ -247,7 +247,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     mempool.add_transaction(tx)?;
 
     let outpoint_source_id = OutPointSourceId::Transaction(tx_id);
-    let input = TxInput::new(outpoint_source_id, 0);
+    let input = TxInput::from_utxo(outpoint_source_id, 0);
 
     let rbf = 1;
     let no_rbf = 0;
@@ -272,7 +272,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     let descendant1_fee: Fee = Amount::from_atoms(100).into();
     let descendant1 = tx_spend_input(
         &mempool,
-        TxInput::new(descendant_outpoint_source_id.clone(), 0),
+        TxInput::from_utxo(descendant_outpoint_source_id.clone(), 0),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         descendant1_fee,
         no_rbf,
@@ -284,7 +284,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     let descendant2_fee: Fee = Amount::from_atoms(100).into();
     let descendant2 = tx_spend_input(
         &mempool,
-        TxInput::new(descendant_outpoint_source_id, 1),
+        TxInput::from_utxo(descendant_outpoint_source_id, 1),
         InputWitness::NoSignature(Some(DUMMY_WITNESS_MSG.to_vec())),
         descendant2_fee,
         no_rbf,

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::chain::tokens::OutputValue;
-use common::chain::OutPoint;
+use common::chain::UtxoOutPoint;
 use common::primitives::H256;
 
 // Re-export various testing utils from other crates
@@ -32,7 +32,7 @@ use super::*;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ValuedOutPoint {
-    pub outpoint: OutPoint,
+    pub outpoint: UtxoOutPoint,
     pub value: Amount,
 }
 
@@ -56,7 +56,7 @@ fn dummy_witness() -> InputWitness {
 fn dummy_input() -> TxInput {
     let outpoint_source_id = OutPointSourceId::Transaction(Id::new(H256::zero()));
     let output_index = 0;
-    TxInput::new(outpoint_source_id, output_index)
+    TxInput::from_utxo(outpoint_source_id, output_index)
 }
 
 fn dummy_output() -> TxOutput {
@@ -105,7 +105,7 @@ pub async fn try_get_fee<M: GetMemoryUsage>(mempool: &Mempool<M>, tx: &SignedTra
         } else {
             let value = get_unconfirmed_outpoint_value(
                 &mempool.store,
-                tx.transaction().inputs().get(i).expect("index").outpoint().unwrap(),
+                tx.transaction().inputs().get(i).expect("index").utxo_outpoint().unwrap(),
             );
             input_values.push(value);
         }
@@ -124,7 +124,7 @@ pub async fn try_get_fee<M: GetMemoryUsage>(mempool: &Mempool<M>, tx: &SignedTra
 }
 
 // unconfirmed means: The outpoint comes from a transaction in the mempool
-pub fn get_unconfirmed_outpoint_value(store: &MempoolStore, outpoint: &OutPoint) -> Amount {
+pub fn get_unconfirmed_outpoint_value(store: &MempoolStore, outpoint: &UtxoOutPoint) -> Amount {
     let tx_id = *outpoint.tx_id().get_tx_id().expect("Not a transaction");
     let entry = store.txs_by_id.get(&tx_id).expect("Entry not found");
     let tx = entry.transaction().transaction();

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -105,7 +105,7 @@ pub async fn try_get_fee<M: GetMemoryUsage>(mempool: &Mempool<M>, tx: &SignedTra
         } else {
             let value = get_unconfirmed_outpoint_value(
                 &mempool.store,
-                tx.transaction().inputs().get(i).expect("index").outpoint(),
+                tx.transaction().inputs().get(i).expect("index").outpoint().unwrap(),
             );
             input_values.push(value);
         }

--- a/mempool/src/pool/tx_verifier/chainstate_handle.rs
+++ b/mempool/src/pool/tx_verifier/chainstate_handle.rs
@@ -226,8 +226,8 @@ impl TransactionVerifierStorageRef for ChainstateHandle {
         panic!("Mempool should not undo stuff in chainstate")
     }
 
-    fn get_account_nonce_count(&self, _account: AccountType) -> Result<Option<u128>, Error> {
-        todo!("implement")
+    fn get_account_nonce_count(&self, account: AccountType) -> Result<Option<u128>, Error> {
+        self.call(move |c| c.get_account_nonce_count(account))
     }
 }
 

--- a/mempool/src/pool/tx_verifier/chainstate_handle.rs
+++ b/mempool/src/pool/tx_verifier/chainstate_handle.rs
@@ -26,8 +26,8 @@ use chainstate_types::storage_result;
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, Transaction,
-        TxMainChainIndex, UtxoOutPoint,
+        AccountNonce, AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId,
+        Transaction, TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, Id},
 };
@@ -226,7 +226,7 @@ impl TransactionVerifierStorageRef for ChainstateHandle {
         panic!("Mempool should not undo stuff in chainstate")
     }
 
-    fn get_account_nonce_count(&self, account: AccountType) -> Result<Option<u128>, Error> {
+    fn get_account_nonce_count(&self, account: AccountType) -> Result<Option<AccountNonce>, Error> {
         self.call(move |c| c.get_account_nonce_count(account))
     }
 }

--- a/mempool/src/pool/tx_verifier/chainstate_handle.rs
+++ b/mempool/src/pool/tx_verifier/chainstate_handle.rs
@@ -26,8 +26,8 @@ use chainstate_types::storage_result;
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
-        Transaction, TxMainChainIndex,
+        AccountType, Block, DelegationId, GenBlock, OutPointSourceId, PoolId, Transaction,
+        TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, Id},
 };
@@ -121,7 +121,7 @@ impl utils::shallow_clone::ShallowClone for ChainstateHandle {
 impl UtxosStorageRead for ChainstateHandle {
     type Error = Error;
 
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Error> {
+    fn get_utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Error> {
         let outpoint = outpoint.clone();
         self.call(move |c| c.utxo(&outpoint))
     }
@@ -234,12 +234,12 @@ impl TransactionVerifierStorageRef for ChainstateHandle {
 impl UtxosView for ChainstateHandle {
     type Error = Error;
 
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Error> {
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Error> {
         let outpoint = outpoint.clone();
         self.call(move |c| c.utxo(&outpoint))
     }
 
-    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Error> {
+    fn has_utxo(&self, outpoint: &UtxoOutPoint) -> Result<bool, Error> {
         self.utxo(outpoint).map(|outpt| outpt.is_some())
     }
 

--- a/mempool/src/pool/tx_verifier/chainstate_handle.rs
+++ b/mempool/src/pool/tx_verifier/chainstate_handle.rs
@@ -26,8 +26,8 @@ use chainstate_types::storage_result;
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
-        Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId, Transaction,
-        TxMainChainIndex,
+        AccountType, Block, DelegationId, GenBlock, OutPoint, OutPointSourceId, PoolId,
+        Transaction, TxMainChainIndex,
     },
     primitives::{Amount, Id},
 };
@@ -224,6 +224,10 @@ impl TransactionVerifierStorageRef for ChainstateHandle {
 
     fn get_accounting_undo(&self, _id: Id<Block>) -> Result<Option<AccountingBlockUndo>, Error> {
         panic!("Mempool should not undo stuff in chainstate")
+    }
+
+    fn get_account_nonce_count(&self, _account: AccountType) -> Result<Option<u128>, Error> {
+        todo!("implement")
     }
 }
 

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -26,7 +26,8 @@ use common::{
             GenBlock,
         },
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
-        ChainConfig, DelegationId, OutPoint, OutPointSourceId, PoolId, TxInput, TxMainChainIndex,
+        AccountType, ChainConfig, DelegationId, OutPoint, OutPointSourceId, PoolId, TxInput,
+        TxMainChainIndex,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -156,6 +157,10 @@ mockall::mock! {
             delegation_id: DelegationId,
         ) -> Result<Option<Amount>, ChainstateError>;
         fn info(&self) -> Result<ChainInfo, ChainstateError>;
+        fn get_account_nonce_count(
+            &self,
+            account: AccountType,
+        ) -> Result<Option<u128>, ChainstateError>;
     }
 }
 

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -26,8 +26,8 @@ use common::{
             GenBlock,
         },
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
-        AccountType, ChainConfig, DelegationId, OutPoint, OutPointSourceId, PoolId, TxInput,
-        TxMainChainIndex,
+        AccountType, ChainConfig, DelegationId, OutPointSourceId, PoolId, TxInput,
+        TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
 };
@@ -134,7 +134,7 @@ mockall::mock! {
             writer: std::io::BufWriter<Box<dyn std::io::Write + Send + 'a>>,
             include_orphans: bool,
         ) -> Result<(), ChainstateError>;
-        fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, ChainstateError>;
+        fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, ChainstateError>;
         fn is_initial_block_download(&self) -> Result<bool, ChainstateError>;
         fn stake_pool_exists(&self, pool_id: PoolId) -> Result<bool, ChainstateError>;
         fn get_stake_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, ChainstateError>;

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -26,7 +26,7 @@ use common::{
             GenBlock,
         },
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
-        AccountType, ChainConfig, DelegationId, OutPointSourceId, PoolId, TxInput,
+        AccountNonce, AccountType, ChainConfig, DelegationId, OutPointSourceId, PoolId, TxInput,
         TxMainChainIndex, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Id},
@@ -160,7 +160,7 @@ mockall::mock! {
         fn get_account_nonce_count(
             &self,
             account: AccountType,
-        ) -> Result<Option<u128>, ChainstateError>;
+        ) -> Result<Option<AccountNonce>, ChainstateError>;
     }
 }
 

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -541,7 +541,7 @@ pub fn new_block(
         }
     };
 
-    let input = TxInput::new(input, 0);
+    let input = TxInput::from_utxo(input, 0);
     let output = TxOutput::Transfer(
         OutputValue::Coin(Amount::from_atoms(100000)),
         Destination::AnyoneCanSpend,

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -351,7 +351,7 @@ async fn valid_transaction(#[case] seed: Seed) {
 fn transaction(out_point: Id<GenBlock>) -> SignedTransaction {
     let tx = Transaction::new(
         0x00,
-        vec![TxInput::new(OutPointSourceId::from(out_point), 0)],
+        vec![TxInput::from_utxo(OutPointSourceId::from(out_point), 0)],
         vec![TxOutput::Burn(OutputValue::Coin(Amount::from_atoms(1)))],
     )
     .unwrap();

--- a/pos_accounting/src/pool/delta/operator_impls.rs
+++ b/pos_accounting/src/pool/delta/operator_impls.rs
@@ -15,7 +15,7 @@
 
 use accounting::DataDelta;
 use common::{
-    chain::{DelegationId, Destination, OutPoint, PoolId},
+    chain::{DelegationId, Destination, PoolId, UtxoOutPoint},
     primitives::Amount,
 };
 
@@ -126,7 +126,7 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
         &mut self,
         target_pool: PoolId,
         spend_key: Destination,
-        input0_outpoint: &OutPoint,
+        input0_outpoint: &UtxoOutPoint,
     ) -> Result<(DelegationId, PoSAccountingUndo), Error> {
         if !self.pool_exists(target_pool)? {
             return Err(Error::DelegationCreationFailedPoolDoesNotExist);

--- a/pos_accounting/src/pool/helpers.rs
+++ b/pos_accounting/src/pool/helpers.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{DelegationId, OutPoint, PoolId},
+    chain::{DelegationId, PoolId, UtxoOutPoint},
     primitives::id::{hash_encoded_to, DefaultHashAlgoStream},
 };
 use crypto::hash::StreamHasher;
@@ -29,7 +29,7 @@ pub fn delegation_id_preimage_suffix() -> u32 {
     1
 }
 
-pub fn make_pool_id(input0_outpoint: &OutPoint) -> PoolId {
+pub fn make_pool_id(input0_outpoint: &UtxoOutPoint) -> PoolId {
     let mut hasher = DefaultHashAlgoStream::new();
     hash_encoded_to(&input0_outpoint, &mut hasher);
     // 0 is arbitrary here, we use this as prefix to use this information again
@@ -37,7 +37,7 @@ pub fn make_pool_id(input0_outpoint: &OutPoint) -> PoolId {
     PoolId::new(hasher.finalize().into())
 }
 
-pub fn make_delegation_id(input0_outpoint: &OutPoint) -> DelegationId {
+pub fn make_delegation_id(input0_outpoint: &UtxoOutPoint) -> DelegationId {
     let mut hasher = DefaultHashAlgoStream::new();
     hash_encoded_to(&input0_outpoint, &mut hasher);
     // 1 is arbitrary here, we use this as prefix to use this information again

--- a/pos_accounting/src/pool/operations.rs
+++ b/pos_accounting/src/pool/operations.rs
@@ -15,7 +15,7 @@
 
 use accounting::DataDeltaUndo;
 use common::{
-    chain::{DelegationId, Destination, OutPoint, PoolId},
+    chain::{DelegationId, Destination, PoolId, UtxoOutPoint},
     primitives::Amount,
 };
 use serialization::{Decode, Encode};
@@ -113,7 +113,7 @@ pub trait PoSAccountingOperations {
         &mut self,
         target_pool: PoolId,
         spend_key: Destination,
-        input0_outpoint: &OutPoint,
+        input0_outpoint: &UtxoOutPoint,
     ) -> Result<(DelegationId, PoSAccountingUndo), Error>;
 
     fn delete_delegation_id(

--- a/pos_accounting/src/pool/storage/operator_impls.rs
+++ b/pos_accounting/src/pool/storage/operator_impls.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{DelegationId, Destination, OutPoint, PoolId},
+    chain::{DelegationId, Destination, PoolId, UtxoOutPoint},
     primitives::Amount,
 };
 
@@ -117,7 +117,7 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingOperations
         &mut self,
         target_pool: PoolId,
         spend_key: Destination,
-        input0_outpoint: &OutPoint,
+        input0_outpoint: &UtxoOutPoint,
     ) -> Result<(DelegationId, PoSAccountingUndo), Error> {
         if !self.pool_exists(target_pool)? {
             return Err(Error::DelegationCreationFailedPoolDoesNotExist);

--- a/pos_accounting/src/pool/tests/mod.rs
+++ b/pos_accounting/src/pool/tests/mod.rs
@@ -16,7 +16,7 @@
 use std::collections::BTreeMap;
 
 use common::{
-    chain::{DelegationId, Destination, OutPoint, OutPointSourceId, PoolId},
+    chain::{DelegationId, Destination, OutPointSourceId, PoolId, UtxoOutPoint},
     primitives::{per_thousand::PerThousand, Amount, Id, H256},
 };
 use crypto::{
@@ -71,7 +71,7 @@ fn create_pool(
     pledged_amount: Amount,
 ) -> Result<(PoolId, PoolData, PoSAccountingUndo), Error> {
     let destination = new_pub_key_destination(rng);
-    let outpoint = OutPoint::new(
+    let outpoint = UtxoOutPoint::new(
         OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))),
         0,
     );
@@ -87,7 +87,7 @@ fn create_delegation_id(
     target_pool: PoolId,
 ) -> Result<(DelegationId, Destination, PoSAccountingUndo), Error> {
     let destination = new_pub_key_destination(rng);
-    let outpoint = OutPoint::new(
+    let outpoint = UtxoOutPoint::new(
         OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))),
         0,
     );

--- a/pos_accounting/src/pool/tests/operations_tests.rs
+++ b/pos_accounting/src/pool/tests/operations_tests.rs
@@ -16,7 +16,7 @@
 use std::collections::BTreeMap;
 
 use common::{
-    chain::{OutPoint, OutPointSourceId},
+    chain::{OutPointSourceId, UtxoOutPoint},
     primitives::{Amount, Id, H256},
 };
 use crypto::random::RngCore;
@@ -43,7 +43,7 @@ fn create_pool_twice(#[case] seed: Seed) {
     let mut storage = InMemoryPoSAccounting::new();
 
     let pledge_amount = Amount::from_atoms(100);
-    let outpoint = OutPoint::new(
+    let outpoint = UtxoOutPoint::new(
         OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))),
         0,
     );
@@ -191,7 +191,7 @@ fn create_delegation_twice(#[case] seed: Seed) {
     let pledge_amount = Amount::from_atoms(100);
     let (pool_id, _, mut storage) = create_storage_with_pool(&mut rng, pledge_amount);
 
-    let outpoint = OutPoint::new(
+    let outpoint = UtxoOutPoint::new(
         OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))),
         0,
     );
@@ -228,7 +228,7 @@ fn create_delegation_id_unknown_pool(#[case] seed: Seed) {
     let mut storage = InMemoryPoSAccounting::new();
 
     let destination = new_pub_key_destination(&mut rng);
-    let outpoint = OutPoint::new(
+    let outpoint = UtxoOutPoint::new(
         OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))),
         0,
     );

--- a/pos_accounting/src/pool/tests/simulation_tests.rs
+++ b/pos_accounting/src/pool/tests/simulation_tests.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{DelegationId, Destination, OutPoint, OutPointSourceId, PoolId},
+    chain::{DelegationId, Destination, OutPointSourceId, PoolId, UtxoOutPoint},
     primitives::{Amount, Id, H256},
 };
 use crypto::random::{CryptoRng, Rng};
@@ -31,9 +31,9 @@ use crate::{
     PoSAccountingView,
 };
 
-fn random_outpoint0(rng: &mut impl Rng) -> OutPoint {
+fn random_outpoint0(rng: &mut impl Rng) -> UtxoOutPoint {
     let source_id = OutPointSourceId::Transaction(Id::new(H256::random_using(rng)));
-    OutPoint::new(source_id, 0)
+    UtxoOutPoint::new(source_id, 0)
 }
 
 fn get_random_pool_id(rng: &mut impl Rng, storage: &InMemoryPoSAccounting) -> Option<PoolId> {

--- a/test/functional/mempool_basic_reorg.py
+++ b/test/functional/mempool_basic_reorg.py
@@ -22,15 +22,17 @@ def hash_object(obj, data):
     return scalecodec.ScaleBytes(mintlayer_hash(obj.encode(data).data)).to_hex()[2:]
 
 def reward_input(block_id, index = 0):
-    return {
-        'id': { 'BlockReward': '0x{}'.format(block_id) },
-        'index': index,
+    return { 'Utxo' : {
+           'id': { 'BlockReward': '0x{}'.format(block_id) },
+           'index': index,
+        }
     }
 
 def tx_input(tx_id, index = 0):
-    return {
-        'id': { 'Transaction': '0x{}'.format(tx_id) },
-        'index': index,
+    return { 'Utxo' : {
+           'id': { 'Transaction': '0x{}'.format(tx_id) },
+           'index': index,
+        }
     }
 
 def make_tx(inputs, output_amounts, flags = 0):

--- a/test/functional/mempool_submit_tx.py
+++ b/test/functional/mempool_submit_tx.py
@@ -58,9 +58,10 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
 
         # Submit a valid transaction
 
-        input = {
-            'id': { 'BlockReward': '0x{}'.format(tip_id) },
-            'index': 0,
+        input = { 'Utxo': {
+                'id': { 'BlockReward': '0x{}'.format(tip_id) },
+                'index': 0,
+            }
         }
         output = {
             'Transfer': [ { 'Coin': 1_000_000 }, { 'AnyoneCanSpend': None } ],

--- a/test/functional/p2p_relay_transactions.py
+++ b/test/functional/p2p_relay_transactions.py
@@ -51,9 +51,10 @@ class RelayTransactions(BitcoinTestFramework):
 
         # Submit a valid transaction.
         genesis = self.nodes[0].chainstate_block_id_at_height(0)
-        input = {
-            'id': { 'BlockReward': '0x{}'.format(genesis) },
-            'index': 0,
+        input = { 'Utxo': {
+                'id': { 'BlockReward': '0x{}'.format(genesis) },
+                'index': 0,
+            }
         }
         output = {
             'Transfer': [ { 'Coin': 1_000_000 }, { 'AnyoneCanSpend': None } ],

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -58,11 +58,19 @@ def init_mintlayer_types():
                 ]
             },
 
-            "TxInput": {
+            "OutPoint": {
                 "type": "struct",
                 "type_mapping": [
                     ["id", "OutPointSourceId"],
                     ["index", "u32"],
+                ]
+            },
+
+            "TxInput": {
+                "type": "enum",
+                "type_mapping": [
+                    ["Utxo", "OutPoint"],
+                    # TODO account
                 ]
             },
 

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -252,7 +252,7 @@ def init_mintlayer_types():
             "GenerateBlockInputData": {
                 "type": "enum",
                 "type_mapping": [
-                    ["Nono", "()"],
+                    ["None", "()"],
                     ["PoW", "Box<PoWGenerateBlockInputData>"],
                     ["PoS", "()"]
                     # TODO PoS

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -195,8 +195,8 @@ impl<P: UtxosView> UtxosCache<P> {
                 let utxos = inputs
                     .iter()
                     .filter_map(|tx_in| tx_in.outpoint().map(|outpoint| self.spend_utxo(outpoint)))
-                    .collect::<Result<Vec<Utxo>, Error>>()?;
-                utxos.is_empty().then(|| UtxosBlockRewardUndo::new(utxos))
+                    .collect::<Result<Vec<_>, _>>()?;
+                (!utxos.is_empty()).then(|| UtxosBlockRewardUndo::new(utxos))
             }
             None => None,
         };
@@ -467,9 +467,10 @@ fn can_be_spent(output: &TxOutput) -> bool {
         TxOutput::Transfer(..)
         | TxOutput::LockThenTransfer(..)
         | TxOutput::CreateStakePool(..)
-        | TxOutput::ProduceBlockFromStake(..)
-        | TxOutput::DelegateStaking(..) => true,
-        TxOutput::CreateDelegationId(..) | TxOutput::Burn(..) => false,
+        | TxOutput::ProduceBlockFromStake(..) => true,
+        TxOutput::CreateDelegationId(..) | TxOutput::DelegateStaking(..) | TxOutput::Burn(..) => {
+            false
+        }
     }
 }
 

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -177,7 +177,7 @@ impl<P: UtxosView> UtxosCache<P> {
             .zip(tx_undo.into_inner().into_iter())
             .try_for_each(|(tx_in, utxo)| match tx_in {
                 TxInput::Utxo(outpoint) => self.add_utxo(outpoint, utxo, false),
-                TxInput::Accounting(_) => Ok(()),
+                TxInput::Account(_) => Ok(()),
             })
     }
 
@@ -234,7 +234,7 @@ impl<P: UtxosView> UtxosCache<P> {
             inputs.iter().zip(block_undo.into_inner().into_iter()).try_for_each(
                 |(tx_in, utxo)| match tx_in {
                     TxInput::Utxo(outpoint) => self.add_utxo(outpoint, utxo, false),
-                    TxInput::Accounting(_) => Ok(()),
+                    TxInput::Account(_) => Ok(()),
                 },
             )?;
         }

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -22,7 +22,7 @@ use common::{
     chain::{
         block::{BlockReward, BlockRewardTransactable},
         signature::Signable,
-        GenBlock, OutPoint, OutPointSourceId, Transaction, TxInput, TxOutput,
+        GenBlock, OutPointSourceId, Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{BlockHeight, Id, Idable},
 };
@@ -33,7 +33,7 @@ use std::{
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ConsumedUtxoCache {
-    pub(crate) container: BTreeMap<OutPoint, UtxoEntry>,
+    pub(crate) container: BTreeMap<UtxoOutPoint, UtxoEntry>,
     pub(crate) best_block: Id<GenBlock>,
 }
 
@@ -41,7 +41,7 @@ pub struct UtxosCache<P> {
     parent: P,
     current_block_hash: Id<GenBlock>,
     // pub(crate) visibility is required for tests that are in a different mod
-    pub(crate) utxos: BTreeMap<OutPoint, UtxoEntry>,
+    pub(crate) utxos: BTreeMap<UtxoOutPoint, UtxoEntry>,
     // TODO: calculate memory usage (mintlayer/mintlayer-core#354)
     #[allow(dead_code)]
     memory_usage: usize,
@@ -51,7 +51,7 @@ impl<P: UtxosView> UtxosCache<P> {
     /// Returns a UtxoEntry, given the outpoint.
     // the reason why it's not a `&UtxoEntry`, is because the flags are bound to change esp.
     // when the utxo was actually retrieved from the parent.
-    fn fetch_utxo_entry(&mut self, outpoint: &OutPoint) -> Result<Option<UtxoEntry>, Error> {
+    fn fetch_utxo_entry(&mut self, outpoint: &UtxoOutPoint) -> Result<Option<UtxoEntry>, Error> {
         if let Some(res) = self.utxos.get(outpoint) {
             return Ok(Some(res.clone()));
         }
@@ -94,7 +94,7 @@ impl<P: UtxosView> UtxosCache<P> {
         check_for_overwrite: bool,
     ) -> Result<(), Error> {
         for (idx, output) in reward.outputs().iter().enumerate() {
-            let outpoint = OutPoint::new(OutPointSourceId::BlockReward(*block_id), idx as u32);
+            let outpoint = UtxoOutPoint::new(OutPointSourceId::BlockReward(*block_id), idx as u32);
             // block reward transactions can always be overwritten
             let overwrite = if check_for_overwrite {
                 self.has_utxo(&outpoint).map_err(|_| Error::ViewRead)?
@@ -123,7 +123,7 @@ impl<P: UtxosView> UtxosCache<P> {
             // outputs that cannot be spent should not be included into utxo set
             .filter(|(_, output)| can_be_spent(output))
             .try_for_each(|(idx, output)| {
-                let outpoint = OutPoint::new(id.clone(), idx as u32);
+                let outpoint = UtxoOutPoint::new(id.clone(), idx as u32);
                 // by default no overwrite allowed.
                 let has_utxo = self.has_utxo(&outpoint).map_err(|_| Error::ViewRead)?;
                 let overwrite = check_for_overwrite && has_utxo;
@@ -165,7 +165,7 @@ impl<P: UtxosView> UtxosCache<P> {
         tx_undo: UtxosTxUndo,
     ) -> Result<(), Error> {
         for (i, output) in tx.outputs().iter().enumerate() {
-            let tx_outpoint = OutPoint::new(OutPointSourceId::from(tx.get_id()), i as u32);
+            let tx_outpoint = UtxoOutPoint::new(OutPointSourceId::from(tx.get_id()), i as u32);
 
             if can_be_spent(output) {
                 self.spend_utxo(&tx_outpoint)?;
@@ -212,7 +212,7 @@ impl<P: UtxosView> UtxosCache<P> {
                 if !can_be_spent(output) {
                     return Err(Error::InvalidBlockRewardOutputType(*block_id));
                 }
-                let outpoint = OutPoint::new(source_id.clone(), idx as u32);
+                let outpoint = UtxoOutPoint::new(source_id.clone(), idx as u32);
                 let utxo = Utxo::new(output.clone(), UtxoSource::Blockchain(height));
                 self.add_utxo(&outpoint, utxo, false)?;
             }
@@ -229,7 +229,7 @@ impl<P: UtxosView> UtxosCache<P> {
     ) -> Result<(), Error> {
         if let Some(outputs) = reward_transactable.outputs() {
             for (i, _) in outputs.iter().enumerate() {
-                let tx_outpoint = OutPoint::new(OutPointSourceId::from(*block_id), i as u32);
+                let tx_outpoint = UtxoOutPoint::new(OutPointSourceId::from(*block_id), i as u32);
                 self.spend_utxo(&tx_outpoint)?;
             }
         }
@@ -251,7 +251,7 @@ impl<P: UtxosView> UtxosCache<P> {
     /// Adds an utxo entry to the cache
     pub fn add_utxo(
         &mut self,
-        outpoint: &OutPoint,
+        outpoint: &UtxoOutPoint,
         utxo: Utxo,
         possible_overwrite: bool, // TODO: change this to an enum that explains what happens
     ) -> Result<(), Error> {
@@ -301,7 +301,7 @@ impl<P: UtxosView> UtxosCache<P> {
 
     /// Flags the utxo as "spent", given an outpoint.
     /// Returns the Utxo if an update was performed.
-    pub fn spend_utxo(&mut self, outpoint: &OutPoint) -> Result<Utxo, Error> {
+    pub fn spend_utxo(&mut self, outpoint: &UtxoOutPoint) -> Result<Utxo, Error> {
         let entry = self.fetch_utxo_entry(outpoint)?.ok_or(Error::NoUtxoFound)?;
         // TODO: update the memory usage
         // self.memory_usage must be deducted from this entry's size
@@ -320,12 +320,12 @@ impl<P: UtxosView> UtxosCache<P> {
     }
 
     /// Checks whether utxo exists in the cache
-    pub fn has_utxo_in_cache(&self, outpoint: &OutPoint) -> bool {
+    pub fn has_utxo_in_cache(&self, outpoint: &UtxoOutPoint) -> bool {
         self.utxos.contains_key(outpoint)
     }
 
     /// Returns a mutable reference of the utxo, given the outpoint.
-    pub fn get_mut_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<&mut Utxo>, Error> {
+    pub fn get_mut_utxo(&mut self, outpoint: &UtxoOutPoint) -> Result<Option<&mut Utxo>, Error> {
         let entry = match self.fetch_utxo_entry(outpoint)? {
             Some(entry) => entry,
             None => return Ok(None),
@@ -348,7 +348,7 @@ impl<P: UtxosView> UtxosCache<P> {
     }
 
     /// Removes the utxo from the cache if it's not modified
-    pub fn uncache(&mut self, outpoint: &OutPoint) -> Result<(), Error> {
+    pub fn uncache(&mut self, outpoint: &UtxoOutPoint) -> Result<(), Error> {
         let key = outpoint;
         if let Some(entry) = self.utxos.get(key) {
             // see bitcoin's Uncache.
@@ -382,7 +382,7 @@ impl<P> Debug for UtxosCache<P> {
 impl<P: UtxosView> UtxosView for UtxosCache<P> {
     type Error = P::Error;
 
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Self::Error> {
         let key = outpoint;
         if let Some(res) = self.utxos.get(key) {
             return Ok(res.utxo().cloned());
@@ -392,7 +392,7 @@ impl<P: UtxosView> UtxosView for UtxosCache<P> {
         self.parent.utxo(outpoint)
     }
 
-    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Self::Error> {
+    fn has_utxo(&self, outpoint: &UtxoOutPoint) -> Result<bool, Self::Error> {
         self.utxo(outpoint).map(|u| u.is_some())
     }
 

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -145,7 +145,7 @@ impl<P: UtxosView> UtxosCache<P> {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => Some(outpoint.tx_id()),
-                TxInput::Account(_, _) => None,
+                TxInput::Account(_) => None,
             })
             .collect();
 
@@ -154,7 +154,7 @@ impl<P: UtxosView> UtxosCache<P> {
             .iter()
             .map(|input| match input {
                 TxInput::Utxo(outpoint) => self.spend_utxo(outpoint).map(Some),
-                TxInput::Account(_, _) => Ok(None),
+                TxInput::Account(_) => Ok(None),
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
@@ -185,7 +185,7 @@ impl<P: UtxosView> UtxosCache<P> {
             .filter_map(|(input, undo)| match undo {
                 Some(utxo) => match input {
                     TxInput::Utxo(outpoint) => Some(Ok((outpoint, utxo))),
-                    TxInput::Account(_, _) => Some(Err(Error::TxInputAndUndoMismatch(tx.get_id()))),
+                    TxInput::Account(_) => Some(Err(Error::TxInputAndUndoMismatch(tx.get_id()))),
                 },
                 None => None,
             })
@@ -210,7 +210,7 @@ impl<P: UtxosView> UtxosCache<P> {
                     .iter()
                     .filter_map(|input| match input {
                         TxInput::Utxo(outpoint) => Some(self.spend_utxo(outpoint)),
-                        TxInput::Account(_, _) => None,
+                        TxInput::Account(_) => None,
                     })
                     .collect::<Result<Vec<_>, _>>()?;
                 (!utxos.is_empty()).then(|| UtxosBlockRewardUndo::new(utxos))
@@ -253,7 +253,7 @@ impl<P: UtxosView> UtxosCache<P> {
                 .zip(block_undo.into_inner().into_iter())
                 .filter_map(|(tx_in, utxo)| match tx_in {
                     TxInput::Utxo(outpoint) => Some((outpoint, utxo)),
-                    TxInput::Account(_, _) => None,
+                    TxInput::Account(_) => None,
                 })
                 .try_for_each(|(outpoint, utxo)| self.add_utxo(outpoint, utxo, false))?;
         }

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -145,7 +145,7 @@ impl<P: UtxosView> UtxosCache<P> {
             .iter()
             .filter_map(|input| match input {
                 TxInput::Utxo(outpoint) => Some(outpoint.tx_id()),
-                TxInput::Account(_) => None,
+                TxInput::Account(_, _) => None,
             })
             .collect();
 
@@ -154,7 +154,7 @@ impl<P: UtxosView> UtxosCache<P> {
             .iter()
             .map(|input| match input {
                 TxInput::Utxo(outpoint) => self.spend_utxo(outpoint).map(Some),
-                TxInput::Account(_) => Ok(None),
+                TxInput::Account(_, _) => Ok(None),
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
@@ -185,7 +185,7 @@ impl<P: UtxosView> UtxosCache<P> {
             .filter_map(|(input, undo)| match undo {
                 Some(utxo) => match input {
                     TxInput::Utxo(outpoint) => Some(Ok((outpoint, utxo))),
-                    TxInput::Account(_) => Some(Err(Error::TxInputAndUndoMismatch(tx.get_id()))),
+                    TxInput::Account(_, _) => Some(Err(Error::TxInputAndUndoMismatch(tx.get_id()))),
                 },
                 None => None,
             })
@@ -210,7 +210,7 @@ impl<P: UtxosView> UtxosCache<P> {
                     .iter()
                     .filter_map(|input| match input {
                         TxInput::Utxo(outpoint) => Some(self.spend_utxo(outpoint)),
-                        TxInput::Account(_) => None,
+                        TxInput::Account(_, _) => None,
                     })
                     .collect::<Result<Vec<_>, _>>()?;
                 (!utxos.is_empty()).then(|| UtxosBlockRewardUndo::new(utxos))
@@ -253,7 +253,7 @@ impl<P: UtxosView> UtxosCache<P> {
                 .zip(block_undo.into_inner().into_iter())
                 .filter_map(|(tx_in, utxo)| match tx_in {
                     TxInput::Utxo(outpoint) => Some((outpoint, utxo)),
-                    TxInput::Account(_) => None,
+                    TxInput::Account(_, _) => None,
                 })
                 .try_for_each(|(outpoint, utxo)| self.add_utxo(outpoint, utxo, false))?;
         }

--- a/utxo/src/error.rs
+++ b/utxo/src/error.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{block::GenBlock, OutPointSourceId},
+    chain::{block::GenBlock, OutPointSourceId, Transaction},
     primitives::Id,
 };
 use thiserror::Error;
@@ -37,6 +37,8 @@ pub enum Error {
     MissingBlockRewardUndo(Id<GenBlock>),
     #[error("Block reward type is invalid `{0}`")]
     InvalidBlockRewardOutputType(Id<GenBlock>),
+    #[error("Undo for transaction `{0}` doesn't match inputs")]
+    TxInputAndUndoMismatch(Id<Transaction>),
 
     // TODO This is a temporary solution. It does not provide much information, the exact utxo
     //      view error is lost. The concrete error type depends on the UtxoView used. The error

--- a/utxo/src/storage/in_memory.rs
+++ b/utxo/src/storage/in_memory.rs
@@ -17,20 +17,20 @@ use super::{UtxosStorageRead, UtxosStorageWrite};
 use crate::{Utxo, UtxosBlockUndo, UtxosView};
 use chainstate_types::storage_result::{self, Error};
 use common::{
-    chain::{Block, GenBlock, OutPoint},
+    chain::{Block, GenBlock, UtxoOutPoint},
     primitives::Id,
 };
 use std::collections::BTreeMap;
 
 #[derive(Clone)]
 pub struct UtxosDBInMemoryImpl {
-    store: BTreeMap<OutPoint, Utxo>,
+    store: BTreeMap<UtxoOutPoint, Utxo>,
     undo_store: BTreeMap<Id<Block>, UtxosBlockUndo>,
     best_block_id: Id<GenBlock>,
 }
 
 impl UtxosDBInMemoryImpl {
-    pub fn new(best_block: Id<GenBlock>, initial_utxos: BTreeMap<OutPoint, Utxo>) -> Self {
+    pub fn new(best_block: Id<GenBlock>, initial_utxos: BTreeMap<UtxoOutPoint, Utxo>) -> Self {
         Self {
             store: initial_utxos,
             undo_store: BTreeMap::new(),
@@ -42,7 +42,7 @@ impl UtxosDBInMemoryImpl {
 impl UtxosStorageRead for UtxosDBInMemoryImpl {
     type Error = storage_result::Error;
 
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Error> {
+    fn get_utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Error> {
         let res = self.store.get(outpoint);
         Ok(res.cloned())
     }
@@ -58,11 +58,11 @@ impl UtxosStorageRead for UtxosDBInMemoryImpl {
 }
 
 impl UtxosStorageWrite for UtxosDBInMemoryImpl {
-    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), Error> {
+    fn set_utxo(&mut self, outpoint: &UtxoOutPoint, entry: Utxo) -> Result<(), Error> {
         self.store.insert(outpoint.clone(), entry);
         Ok(())
     }
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), Error> {
+    fn del_utxo(&mut self, outpoint: &UtxoOutPoint) -> Result<(), Error> {
         self.store.remove(outpoint);
         Ok(())
     }
@@ -85,11 +85,11 @@ impl UtxosStorageWrite for UtxosDBInMemoryImpl {
 impl UtxosView for UtxosDBInMemoryImpl {
     type Error = std::convert::Infallible;
 
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Self::Error> {
         Ok(self.store.get(outpoint).cloned())
     }
 
-    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Self::Error> {
+    fn has_utxo(&self, outpoint: &UtxoOutPoint) -> Result<bool, Self::Error> {
         Ok(self.store.get(outpoint).is_some())
     }
 

--- a/utxo/src/storage/rw_impls.rs
+++ b/utxo/src/storage/rw_impls.rs
@@ -16,16 +16,16 @@
 use super::{UtxosDB, UtxosStorageRead, UtxosStorageWrite};
 use crate::{Utxo, UtxosBlockUndo};
 use common::{
-    chain::{Block, GenBlock, OutPoint},
+    chain::{Block, GenBlock, UtxoOutPoint},
     primitives::Id,
 };
 
 impl<S: UtxosStorageWrite> UtxosStorageWrite for UtxosDB<S> {
-    fn set_utxo(&mut self, outpoint: &OutPoint, entry: Utxo) -> Result<(), Self::Error> {
+    fn set_utxo(&mut self, outpoint: &UtxoOutPoint, entry: Utxo) -> Result<(), Self::Error> {
         self.0.set_utxo(outpoint, entry)
     }
 
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<(), Self::Error> {
+    fn del_utxo(&mut self, outpoint: &UtxoOutPoint) -> Result<(), Self::Error> {
         self.0.del_utxo(outpoint)
     }
 
@@ -44,7 +44,7 @@ impl<S: UtxosStorageWrite> UtxosStorageWrite for UtxosDB<S> {
 impl<S: UtxosStorageRead> UtxosStorageRead for UtxosDB<S> {
     type Error = S::Error;
 
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
+    fn get_utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Self::Error> {
         self.0.get_utxo(outpoint)
     }
 

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -146,7 +146,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
     let spent_utxos = expected_tx_inputs
         .iter()
         .map(|input| {
-            let outpoint = input.outpoint();
+            let outpoint = input.outpoint().unwrap();
             assert!(db.has_utxo(outpoint).unwrap());
 
             db.utxo(outpoint).expect("utxo should exist.")
@@ -211,7 +211,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
 
     // check that all in tx_inputs do NOT exist
     expected_tx_inputs.iter().for_each(|input| {
-        assert_eq!(db.utxo(input.outpoint()), Ok(None));
+        assert_eq!(db.utxo(input.outpoint().unwrap()), Ok(None));
     });
 
     // save the undo data to the db.
@@ -226,7 +226,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
     {
         block.transactions().iter().for_each(|tx| {
             tx.inputs().iter().for_each(|input| {
-                assert_eq!(db.utxo(input.outpoint()), Ok(None));
+                assert_eq!(db.utxo(input.outpoint().unwrap()), Ok(None));
             });
         });
     }
@@ -260,7 +260,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
             // add the undo utxos back to the view.
             tx.inputs().iter().enumerate().for_each(|(in_idx, input)| {
                 let utxo = undos.get(in_idx).unwrap();
-                cache.add_utxo(input.outpoint(), utxo.clone(), true).unwrap();
+                cache.add_utxo(input.outpoint().unwrap(), utxo.clone(), true).unwrap();
             });
         });
 
@@ -275,7 +275,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
 
     // check that all the expected_tx_inputs exists, and the same utxo is saved.
     expected_tx_inputs.iter().enumerate().for_each(|(idx, input)| {
-        let res = db.utxo(input.outpoint());
+        let res = db.utxo(input.outpoint().unwrap());
 
         let expected_utxo = spent_utxos.get(idx);
         assert_eq!(res.ok().as_ref(), expected_utxo);

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -193,10 +193,7 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
         {
             block_undo.tx_undos().iter().enumerate().for_each(|(b_idx, (_tx_id, tx_undo))| {
                 tx_undo.inner().iter().enumerate().for_each(|(t_idx, utxo)| {
-                    assert_eq!(
-                        Some(Some(utxo)),
-                        spent_utxos.get(b_idx + t_idx).map(|x| x.as_ref())
-                    );
+                    assert_eq!(Some(utxo), spent_utxos.get(b_idx + t_idx));
                 })
             })
         }
@@ -259,8 +256,8 @@ fn utxo_and_undo_test(#[case] seed: Seed) {
 
             // add the undo utxos back to the view.
             tx.inputs().iter().enumerate().for_each(|(in_idx, input)| {
-                let utxo = undos.get(in_idx).unwrap();
-                cache.add_utxo(input.utxo_outpoint().unwrap(), utxo.clone(), true).unwrap();
+                let utxo = undos[in_idx].clone().unwrap();
+                cache.add_utxo(input.utxo_outpoint().unwrap(), utxo, true).unwrap();
             });
         });
 

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -16,18 +16,18 @@
 use super::{UtxosDB, UtxosStorageRead, UtxosStorageWrite};
 use crate::{ConsumedUtxoCache, Error, FlushableUtxoView, Utxo, UtxosView};
 use common::{
-    chain::{GenBlock, OutPoint},
+    chain::{GenBlock, UtxoOutPoint},
     primitives::Id,
 };
 
 impl<S: UtxosStorageRead> UtxosView for UtxosDB<S> {
     type Error = S::Error;
 
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Self::Error> {
         self.get_utxo(outpoint)
     }
 
-    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Self::Error> {
+    fn has_utxo(&self, outpoint: &UtxoOutPoint) -> Result<bool, Self::Error> {
         self.utxo(outpoint).map(|u| u.is_some())
     }
 

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -529,7 +529,7 @@ fn multiple_update_utxos_test(#[case] seed: Seed) {
 
     // check that the spent utxos should not exist in the cache anymore.
     to_spend.iter().for_each(|input| {
-        assert!(cache.utxo(input.outpoint()).unwrap_infallible().is_none());
+        assert!(cache.utxo(input.outpoint().unwrap()).unwrap_infallible().is_none());
     });
 }
 

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -38,8 +38,8 @@ use common::{
         },
         signature::inputsig::InputWitness,
         tokens::OutputValue,
-        AccountSpending, DelegationId, Destination, OutPointSourceId, PoolId, Transaction, TxInput,
-        TxOutput, UtxoOutPoint,
+        AccountNonce, AccountSpending, DelegationId, Destination, OutPointSourceId, PoolId,
+        Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Compact, Id, Idable, H256},
 };
@@ -895,7 +895,7 @@ fn check_tx_spend_undo_spend_from_account(#[case] seed: Seed) {
 
     // spend from an account in a transaction
     let input = TxInput::from_account(
-        rng.gen(),
+        AccountNonce::new(rng.gen()),
         AccountSpending::Delegation(
             DelegationId::new(H256::random_using(&mut rng)),
             Amount::from_atoms(rng.gen()),

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -38,7 +38,7 @@ use common::{
         },
         signature::inputsig::InputWitness,
         tokens::OutputValue,
-        AccountType, DelegationId, Destination, OutPointSourceId, PoolId, Transaction, TxInput,
+        AccountSpending, DelegationId, Destination, OutPointSourceId, PoolId, Transaction, TxInput,
         TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, Compact, Id, Idable, H256},
@@ -896,8 +896,10 @@ fn check_tx_spend_undo_spend_from_account(#[case] seed: Seed) {
     // spend from an account in a transaction
     let input = TxInput::from_account(
         rng.gen(),
-        AccountType::Delegation(DelegationId::new(H256::random_using(&mut rng))),
-        Amount::from_atoms(rng.gen()),
+        AccountSpending::Delegation(
+            DelegationId::new(H256::random_using(&mut rng)),
+            Amount::from_atoms(rng.gen()),
+        ),
     );
     let tx = Transaction::new(0x00, vec![input], create_tx_outputs(&mut rng, 1)).unwrap();
     let new_utxo_outpoint = UtxoOutPoint::new(tx.get_id().into(), 0);

--- a/utxo/src/tests/simulation.rs
+++ b/utxo/src/tests/simulation.rs
@@ -17,7 +17,7 @@ use std::convert::Infallible;
 
 use super::test_helper::{create_utxo, empty_test_utxos_view, UnwrapInfallible};
 use crate::{ConsumedUtxoCache, FlushableUtxoView, UtxosCache, UtxosView};
-use common::chain::OutPoint;
+use common::chain::UtxoOutPoint;
 use crypto::random::{CryptoRng, Rng};
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
@@ -35,7 +35,7 @@ fn cache_simulation_test(
     #[case] iterations_per_cache: usize,
 ) {
     let mut rng = make_seedable_rng(seed);
-    let mut result: Vec<OutPoint> = Vec::new();
+    let mut result: Vec<UtxoOutPoint> = Vec::new();
     let test_view = empty_test_utxos_view(common::primitives::H256::zero().into());
     let mut base = UtxosCache::new(test_view).unwrap_infallible();
 
@@ -69,7 +69,7 @@ fn cache_simulation_test(
 /// 6. Consume the current cache, and return it
 fn simulation_step<P: UtxosView<Error = Infallible>>(
     rng: &mut (impl Rng + CryptoRng),
-    all_outputs: &mut Vec<OutPoint>,
+    all_outputs: &mut Vec<UtxoOutPoint>,
     parent_cache: &UtxosCache<P>,
     iterations_per_cache: usize,
     nested_level: usize,
@@ -111,8 +111,8 @@ fn populate_cache<P: UtxosView<Error = Infallible>>(
     rng: &mut (impl Rng + CryptoRng),
     cache: &mut UtxosCache<P>,
     iterations_count: usize,
-    prev_result: &[OutPoint],
-) -> Vec<OutPoint> {
+    prev_result: &[UtxoOutPoint],
+) -> Vec<UtxoOutPoint> {
     let mut spent_an_entry = false;
     let mut added_an_entry = false;
     let mut removed_an_entry = false;
@@ -120,7 +120,7 @@ fn populate_cache<P: UtxosView<Error = Infallible>>(
     let mut missed_an_entry = false;
     let mut found_an_entry = false;
     // track outpoints
-    let mut result: Vec<OutPoint> = Vec::new();
+    let mut result: Vec<UtxoOutPoint> = Vec::new();
 
     for i in 0..iterations_count {
         //select outpoint and utxo from existing or create new

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -202,7 +202,7 @@ fn populate_cache_with_undo<P: UtxosView<Error = Infallible>>(
                 cache
                     .add_utxo(
                         &undo_info.prev_outpoint,
-                        undo_info.tx_undo.utxos()[0].clone(),
+                        undo_info.tx_undo.utxos()[0].clone().unwrap(),
                         cache.has_utxo(&undo_info.prev_outpoint).unwrap_infallible(),
                     )
                     .unwrap();

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -18,7 +18,7 @@ use crate::{
     ConsumedUtxoCache, FlushableUtxoView, UtxoSource, UtxosCache, UtxosTxUndoWithSources, UtxosView,
 };
 use common::{
-    chain::{block::BlockReward, OutPoint, OutPointSourceId, Transaction, TxInput},
+    chain::{block::BlockReward, OutPointSourceId, Transaction, TxInput, UtxoOutPoint},
     primitives::{BlockHeight, Id, Idable, H256},
 };
 use crypto::random::{CryptoRng, Rng};
@@ -29,12 +29,12 @@ use test_utils::random::{make_seedable_rng, Seed};
 // Structure to store outpoints of current utxo set and info for undo
 #[derive(Default)]
 struct ResultWithUndo {
-    utxo_outpoints: Vec<OutPoint>,
-    outpoints_with_undo: BTreeMap<OutPoint, UndoInfo>,
+    utxo_outpoints: Vec<UtxoOutPoint>,
+    outpoints_with_undo: BTreeMap<UtxoOutPoint, UndoInfo>,
 }
 
 struct UndoInfo {
-    prev_outpoint: OutPoint,
+    prev_outpoint: UtxoOutPoint,
     tx_undo: UtxosTxUndoWithSources,
 }
 
@@ -151,7 +151,9 @@ fn populate_cache_with_undo<P: UtxosView<Error = Infallible>>(
                         false,
                     )
                     .unwrap();
-                result.utxo_outpoints.push(OutPoint::new(OutPointSourceId::from(block_id), 0));
+                result
+                    .utxo_outpoints
+                    .push(UtxoOutPoint::new(OutPointSourceId::from(block_id), 0));
             } else {
                 //spend random utxo in a transaction
 
@@ -169,7 +171,7 @@ fn populate_cache_with_undo<P: UtxosView<Error = Infallible>>(
                 };
 
                 //use this outpoint as input for transaction
-                let input = TxInput::new(outpoint.tx_id(), outpoint.output_index());
+                let input = TxInput::from_utxo(outpoint.tx_id(), outpoint.output_index());
                 let tx = Transaction::new(0x00, vec![input], create_tx_outputs(rng, 1)).unwrap();
 
                 //spent the transaction
@@ -177,7 +179,7 @@ fn populate_cache_with_undo<P: UtxosView<Error = Infallible>>(
                 let undo = cache.connect_transaction(&tx, block_height).unwrap();
 
                 //keep result updated
-                let new_outpoint = OutPoint::new(OutPointSourceId::from(tx.get_id()), 0);
+                let new_outpoint = UtxoOutPoint::new(OutPointSourceId::from(tx.get_id()), 0);
                 result.utxo_outpoints.push(new_outpoint.clone());
                 result.outpoints_with_undo.insert(
                     new_outpoint,

--- a/utxo/src/view.rs
+++ b/utxo/src/view.rs
@@ -17,7 +17,7 @@ use std::ops::Deref;
 
 use crate::{ConsumedUtxoCache, Utxo, UtxosCache};
 use common::{
-    chain::{GenBlock, OutPoint},
+    chain::{GenBlock, UtxoOutPoint},
     primitives::Id,
 };
 
@@ -26,10 +26,10 @@ pub trait UtxosView {
     type Error: std::error::Error;
 
     /// Retrieves utxo.
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error>;
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Self::Error>;
 
     /// Checks whether outpoint is unspent.
-    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Self::Error>;
+    fn has_utxo(&self, outpoint: &UtxoOutPoint) -> Result<bool, Self::Error>;
 
     /// Retrieves the block hash of the best block in this view
     fn best_block_hash(&self) -> Result<Id<GenBlock>, Self::Error>;
@@ -63,11 +63,11 @@ where
 {
     type Error = <T::Target as UtxosView>::Error;
 
-    fn utxo(&self, outpoint: &OutPoint) -> Result<Option<Utxo>, Self::Error> {
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Self::Error> {
         self.deref().utxo(outpoint)
     }
 
-    fn has_utxo(&self, outpoint: &OutPoint) -> Result<bool, Self::Error> {
+    fn has_utxo(&self, outpoint: &UtxoOutPoint) -> Result<bool, Self::Error> {
         self.deref().has_utxo(outpoint)
     }
 

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -27,7 +27,7 @@ use common::chain::signature::sighash::sighashtype::SigHashType;
 use common::chain::signature::TransactionSigError;
 use common::chain::tokens::{OutputValue, TokenData, TokenId};
 use common::chain::{
-    Block, ChainConfig, Destination, GenBlock, OutPoint, SignedTransaction, TxInput, TxOutput,
+    Block, ChainConfig, Destination, GenBlock, SignedTransaction, TxInput, TxOutput, UtxoOutPoint,
 };
 use common::primitives::per_thousand::PerThousand;
 use common::primitives::{Amount, BlockHeight, Id};
@@ -192,7 +192,7 @@ impl Account {
             .get_utxos(UtxoType::Transfer.into())
             .into_iter()
             .map(|(outpoint, txo)| (outpoint, txo.clone()))
-            .collect::<Vec<(OutPoint, TxOutput)>>();
+            .collect::<Vec<(UtxoOutPoint, TxOutput)>>();
 
         let input0 = utxos.get(0).ok_or(WalletError::NoUtxos)?;
         let pool_id = pos_accounting::make_pool_id(&input0.0);
@@ -467,7 +467,7 @@ impl Account {
         Ok(balances)
     }
 
-    pub fn get_utxos(&self, utxo_types: UtxoTypes) -> BTreeMap<OutPoint, &TxOutput> {
+    pub fn get_utxos(&self, utxo_types: UtxoTypes) -> BTreeMap<UtxoOutPoint, &TxOutput> {
         let mut all_outputs = self.output_cache.utxos();
         all_outputs.retain(|_outpoint, txo| {
             self.is_mine_or_watched(txo) && utxo_types.contains(get_utxo_type(txo))

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -511,7 +511,7 @@ impl Account {
         tx: WalletTx,
     ) -> WalletResult<()> {
         let relevant_inputs = tx.inputs().iter().any(|input| match input {
-            TxInput::Utxo(outpoint) => self.output_cache.outpoints().contains(&outpoint),
+            TxInput::Utxo(outpoint) => self.output_cache.outpoints().contains(outpoint),
             TxInput::Account(_) => false,
         });
         let relevant_outputs = self.mark_outputs_as_seen(db_tx, tx.outputs())?;

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -321,7 +321,7 @@ impl Account {
     ) -> WalletResult<SignedTransaction> {
         let (tx, utxos) = req.into_transaction_and_utxos()?;
         let inputs = tx.inputs();
-        let input_utxos = utxos.iter().collect::<Vec<_>>();
+        let input_utxos = utxos.iter().map(Some).collect::<Vec<_>>();
         if utxos.len() != inputs.len() {
             return Err(
                 TransactionSigError::InvalidUtxoCountVsInputs(utxos.len(), inputs.len()).into(),

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -512,7 +512,7 @@ impl Account {
     ) -> WalletResult<()> {
         let relevant_inputs = tx.inputs().iter().any(|input| match input {
             TxInput::Utxo(outpoint) => self.output_cache.outpoints().contains(outpoint),
-            TxInput::Account(_) => false,
+            TxInput::Account(_, _) => false,
         });
         let relevant_outputs = self.mark_outputs_as_seen(db_tx, tx.outputs())?;
         if relevant_inputs || relevant_outputs {

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -512,7 +512,7 @@ impl Account {
     ) -> WalletResult<()> {
         let relevant_inputs = tx.inputs().iter().any(|input| match input {
             TxInput::Utxo(outpoint) => self.output_cache.outpoints().contains(&outpoint),
-            TxInput::Accounting(_) => false,
+            TxInput::Account(_) => false,
         });
         let relevant_outputs = self.mark_outputs_as_seen(db_tx, tx.outputs())?;
         if relevant_inputs || relevant_outputs {

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -512,7 +512,7 @@ impl Account {
     ) -> WalletResult<()> {
         let relevant_inputs = tx.inputs().iter().any(|input| match input {
             TxInput::Utxo(outpoint) => self.output_cache.outpoints().contains(outpoint),
-            TxInput::Account(_, _) => false,
+            TxInput::Account(_) => false,
         });
         let relevant_outputs = self.mark_outputs_as_seen(db_tx, tx.outputs())?;
         if relevant_inputs || relevant_outputs {

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -510,10 +510,10 @@ impl Account {
         db_tx: &mut impl WalletStorageWriteLocked,
         tx: WalletTx,
     ) -> WalletResult<()> {
-        let relevant_inputs = tx
-            .inputs()
-            .iter()
-            .any(|input| self.output_cache.outpoints().contains(input.outpoint()));
+        let relevant_inputs = tx.inputs().iter().any(|input| match input {
+            TxInput::Utxo(outpoint) => self.output_cache.outpoints().contains(&outpoint),
+            TxInput::Accounting(_) => false,
+        });
         let relevant_outputs = self.mark_outputs_as_seen(db_tx, tx.outputs())?;
         if relevant_inputs || relevant_outputs {
             let id = AccountWalletTxId::new(self.get_account_id(), tx.id());

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -64,7 +64,7 @@ impl OutputCache {
                 TxInput::Utxo(outpoint) => {
                     self.consumed.insert(outpoint.clone());
                 }
-                TxInput::Account(_, _) => {
+                TxInput::Account(_) => {
                     unimplemented!()
                 }
             }
@@ -80,7 +80,7 @@ impl OutputCache {
                     TxInput::Utxo(outpoint) => {
                         self.consumed.remove(outpoint);
                     }
-                    TxInput::Account(_, _) => {
+                    TxInput::Account(_) => {
                         unimplemented!()
                     }
                 }

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -15,7 +15,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use common::chain::{OutPoint, TxInput, TxOutput};
+use common::chain::{TxInput, TxOutput, UtxoOutPoint};
 use wallet_types::{AccountWalletTxId, WalletTx};
 
 /// A helper structure for the UTXO search.
@@ -31,7 +31,7 @@ use wallet_types::{AccountWalletTxId, WalletTx};
 /// A similar approach is used by the Bitcoin Core wallet.
 pub struct OutputCache {
     txs: BTreeMap<AccountWalletTxId, WalletTx>,
-    consumed: BTreeSet<OutPoint>,
+    consumed: BTreeSet<UtxoOutPoint>,
 }
 
 impl OutputCache {
@@ -54,7 +54,7 @@ impl OutputCache {
         &self.txs
     }
 
-    pub fn outpoints(&self) -> &BTreeSet<OutPoint> {
+    pub fn outpoints(&self) -> &BTreeSet<UtxoOutPoint> {
         &self.consumed
     }
 
@@ -88,16 +88,16 @@ impl OutputCache {
         }
     }
 
-    fn valid_utxo(&self, outpoint: &OutPoint) -> bool {
+    fn valid_utxo(&self, outpoint: &UtxoOutPoint) -> bool {
         !self.consumed.contains(outpoint)
     }
 
-    pub fn utxos(&self) -> BTreeMap<OutPoint, &TxOutput> {
+    pub fn utxos(&self) -> BTreeMap<UtxoOutPoint, &TxOutput> {
         let mut utxos = BTreeMap::new();
 
         for tx in self.txs.values() {
             for (index, output) in tx.outputs().iter().enumerate() {
-                let outpoint = OutPoint::new(tx.id(), index as u32);
+                let outpoint = UtxoOutPoint::new(tx.id(), index as u32);
                 if self.valid_utxo(&outpoint) {
                     utxos.insert(outpoint, output);
                 }

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -64,7 +64,7 @@ impl OutputCache {
                 TxInput::Utxo(outpoint) => {
                     self.consumed.insert(outpoint.clone());
                 }
-                TxInput::Account(_) => {
+                TxInput::Account(_, _) => {
                     unimplemented!()
                 }
             }
@@ -80,7 +80,7 @@ impl OutputCache {
                     TxInput::Utxo(outpoint) => {
                         self.consumed.remove(outpoint);
                     }
-                    TxInput::Account(_) => {
+                    TxInput::Account(_, _) => {
                         unimplemented!()
                     }
                 }

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -64,7 +64,7 @@ impl OutputCache {
                 TxInput::Utxo(outpoint) => {
                     self.consumed.insert(outpoint.clone());
                 }
-                TxInput::Accounting(_) => {
+                TxInput::Account(_) => {
                     unimplemented!()
                 }
             }
@@ -80,7 +80,7 @@ impl OutputCache {
                     TxInput::Utxo(outpoint) => {
                         self.consumed.remove(outpoint);
                     }
-                    TxInput::Accounting(_) => {
+                    TxInput::Account(_) => {
                         unimplemented!()
                     }
                 }

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -15,7 +15,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use common::chain::{OutPoint, TxOutput};
+use common::chain::{OutPoint, TxInput, TxOutput};
 use wallet_types::{AccountWalletTxId, WalletTx};
 
 /// A helper structure for the UTXO search.
@@ -60,7 +60,14 @@ impl OutputCache {
 
     pub fn add_tx(&mut self, tx_id: AccountWalletTxId, tx: WalletTx) {
         for input in tx.inputs() {
-            self.consumed.insert(input.outpoint().clone());
+            match input {
+                TxInput::Utxo(outpoint) => {
+                    self.consumed.insert(outpoint.clone());
+                }
+                TxInput::Accounting(_) => {
+                    unimplemented!()
+                }
+            }
         }
         self.txs.insert(tx_id, tx);
     }
@@ -69,7 +76,14 @@ impl OutputCache {
         let tx_opt = self.txs.remove(tx_id);
         if let Some(tx) = tx_opt {
             for input in tx.inputs() {
-                self.consumed.remove(input.outpoint());
+                match input {
+                    TxInput::Utxo(outpoint) => {
+                        self.consumed.remove(outpoint);
+                    }
+                    TxInput::Accounting(_) => {
+                        unimplemented!()
+                    }
+                }
             }
         }
     }

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -194,7 +194,6 @@ fn sign_transaction(#[case] seed: Seed) {
 
     let sig_tx = account.sign_transaction(req, &db_tx).unwrap();
 
-    // FIMXE: sign account input
     let utxos_ref = utxos.iter().map(Some).collect::<Vec<_>>();
 
     for i in 0..sig_tx.inputs().len() {

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -153,7 +153,7 @@ fn sign_transaction(#[case] seed: Seed) {
             } else {
                 Id::<GenBlock>::new(H256::random_using(&mut rng)).into()
             };
-            TxInput::new(source_id, rng.next_u32())
+            TxInput::from_utxo(source_id, rng.next_u32())
         })
         .collect();
 

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -194,10 +194,11 @@ fn sign_transaction(#[case] seed: Seed) {
 
     let sig_tx = account.sign_transaction(req, &db_tx).unwrap();
 
-    let utxos_ref = utxos.iter().collect::<Vec<_>>();
+    // FIMXE: sign account input
+    let utxos_ref = utxos.iter().map(Some).collect::<Vec<_>>();
 
     for i in 0..sig_tx.inputs().len() {
-        let destination = Account::get_tx_output_destination(utxos_ref[i]).unwrap();
+        let destination = Account::get_tx_output_destination(utxos_ref[i].unwrap()).unwrap();
         verify_signature(&config, destination, &sig_tx, &utxos_ref, i).unwrap();
     }
 }

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -18,7 +18,7 @@ use common::address::Address;
 use common::chain::stakelock::StakePoolData;
 use common::chain::tokens::OutputValue;
 use common::chain::{
-    Destination, OutPoint, PoolId, Transaction, TransactionCreationError, TxInput, TxOutput,
+    Destination, PoolId, Transaction, TransactionCreationError, TxInput, TxOutput, UtxoOutPoint,
 };
 use common::primitives::per_thousand::PerThousand;
 use common::primitives::Amount;
@@ -104,9 +104,15 @@ impl SendRequest {
         &self.utxos
     }
 
-    pub fn with_inputs(mut self, utxos: impl IntoIterator<Item = (OutPoint, TxOutput)>) -> Self {
+    pub fn with_inputs(
+        mut self,
+        utxos: impl IntoIterator<Item = (UtxoOutPoint, TxOutput)>,
+    ) -> Self {
         for (outpoint, txo) in utxos {
-            self.inputs.push(TxInput::new(outpoint.tx_id(), outpoint.output_index()));
+            self.inputs.push(TxInput::from_utxo(
+                outpoint.tx_id(),
+                outpoint.output_index(),
+            ));
             self.utxos.push(txo);
         }
         self

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -25,8 +25,8 @@ use common::address::Address;
 use common::chain::signature::TransactionSigError;
 use common::chain::tokens::TokenId;
 use common::chain::{
-    Block, ChainConfig, GenBlock, OutPoint, SignedTransaction, Transaction,
-    TransactionCreationError, TxOutput,
+    Block, ChainConfig, GenBlock, SignedTransaction, Transaction, TransactionCreationError,
+    TxOutput, UtxoOutPoint,
 };
 use common::primitives::{Amount, BlockHeight, Id};
 use consensus::PoSGenerateBlockInputData;
@@ -261,7 +261,7 @@ impl<B: storage::Backend> Wallet<B> {
         &self,
         account_index: U31,
         utxo_types: UtxoTypes,
-    ) -> WalletResult<BTreeMap<OutPoint, TxOutput>> {
+    ) -> WalletResult<BTreeMap<UtxoOutPoint, TxOutput>> {
         let account = self
             .accounts
             .get(&account_index)

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -417,7 +417,7 @@ fn wallet_balance_parent_child_transactions() {
 
     let transaction2 = Transaction::new(
         0,
-        vec![TxInput::new(OutPointSourceId::Transaction(transaction_id1), 0)],
+        vec![TxInput::from_utxo(OutPointSourceId::Transaction(transaction_id1), 0)],
         vec![make_address_output(address2, tx_amount2).unwrap()],
     )
     .unwrap();

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -30,7 +30,7 @@ use std::{
 
 use common::{
     address::Address,
-    chain::{tokens::TokenId, Block, ChainConfig, OutPoint, SignedTransaction, TxOutput},
+    chain::{tokens::TokenId, Block, ChainConfig, SignedTransaction, TxOutput, UtxoOutPoint},
     primitives::{Amount, Idable},
 };
 use consensus::GenerateBlockInputData;
@@ -179,7 +179,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
     pub fn get_utxos(
         &self,
         utxo_types: UtxoTypes,
-    ) -> Result<BTreeMap<OutPoint, TxOutput>, ControllerError<T>> {
+    ) -> Result<BTreeMap<UtxoOutPoint, TxOutput>, ControllerError<T>> {
         self.wallet
             .get_utxos(DEFAULT_ACCOUNT_INDEX, utxo_types)
             .map_err(ControllerError::WalletError)


### PR DESCRIPTION
This PR introduces the ability to spend not only from utxos but also from accounts. This is achieved by making `TxInput` an enum of `Utxo` | `Account`.


TODOs:

- [x] verify input/output policy with inputs from accounts;
- [x] check transferred amounts;
- [x] handle transaction fee
- [x] revisit timelock checks;
- [x] handle nonce in chainstate: verify, provide access from db;
- [x] sign tx inputs from accounts; verify signature;
- [x] transaction index
- [x] track double-spends in mempool via txinput nonce;
- [x] revisit tests, add new;

P.S. last commit contains renames in tons of files, I can potentially make it as a separate PR to simplify reviewing process
