### PR TITLE
Fix block reward in block production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6449,6 +6449,7 @@ dependencies = [
  "chainstate-storage",
  "clap 4.3.0",
  "common",
+ "consensus",
  "crossterm",
  "directories",
  "logging",

--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -121,7 +121,7 @@ impl BlockProduction {
 
     async fn pull_consensus_data(
         &self,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
         block_timestamp: BlockTimestamp,
     ) -> Result<
         (
@@ -217,10 +217,10 @@ impl BlockProduction {
         block_height: BlockHeight,
         sealed_epoch_index: Option<EpochIndex>,
         sealed_epoch_randomness: Option<PoSRandomness>,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
     ) -> Result<Option<FinalizeBlockInputData>, ConsensusPoSError> {
         match input_data {
-            Some(GenerateBlockInputData::PoS(pos_input_data)) => {
+            GenerateBlockInputData::PoS(pos_input_data) => {
                 let sealed_epoch_index =
                     sealed_epoch_index.ok_or(ConsensusPoSError::NoEpochData)?;
 
@@ -272,8 +272,8 @@ impl BlockProduction {
                     ),
                 )))
             }
-            Some(GenerateBlockInputData::PoW(_)) => Ok(Some(FinalizeBlockInputData::PoW)),
-            None => Ok(None),
+            GenerateBlockInputData::PoW(_) => Ok(Some(FinalizeBlockInputData::PoW)),
+            GenerateBlockInputData::None => Ok(None),
         }
     }
 
@@ -302,7 +302,7 @@ impl BlockProduction {
     /// remnants in the job manager.
     pub async fn produce_block(
         &self,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
         transactions_source: TransactionsSource,
     ) -> Result<(Block, oneshot::Receiver<usize>), BlockProductionError> {
         self.produce_block_with_custom_id(input_data, transactions_source, None).await
@@ -310,7 +310,7 @@ impl BlockProduction {
 
     async fn produce_block_with_custom_id(
         &self,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
         transactions_source: TransactionsSource,
         custom_id: Option<Vec<u8>>,
     ) -> Result<(Block, oneshot::Receiver<usize>), BlockProductionError> {
@@ -761,7 +761,7 @@ mod tests {
                     let id: Vec<u8> = (0..1024).map(|_| rng.gen::<u8>()).collect();
 
                     block_production.produce_block_with_custom_id(
-                        None,
+                        GenerateBlockInputData::None,
                         TransactionsSource::Provided(vec![]),
                         Some(id),
                     )

--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -34,7 +34,7 @@ use common::{
             timestamp::BlockTimestamp, BlockCreationError, BlockHeader, BlockReward, ConsensusData,
         },
         config::EpochIndex,
-        Block, ChainConfig, Destination, GenBlockId, SignedTransaction,
+        Block, ChainConfig, GenBlockId, SignedTransaction,
     },
     primitives::BlockHeight,
     time_getter::TimeGetter,
@@ -259,7 +259,7 @@ impl BlockProduction {
                     ),
                 )))
             }
-            Some(GenerateBlockInputData::PoW) => Ok(Some(FinalizeBlockInputData::PoW)),
+            Some(GenerateBlockInputData::PoW(_)) => Ok(Some(FinalizeBlockInputData::PoW)),
             None => Ok(None),
         }
     }
@@ -290,17 +290,15 @@ impl BlockProduction {
     pub async fn produce_block(
         &self,
         input_data: Option<GenerateBlockInputData>,
-        reward_destination: Destination,
         transactions_source: TransactionsSource,
     ) -> Result<(Block, oneshot::Receiver<usize>), BlockProductionError> {
-        self.produce_block_with_custom_id(input_data, reward_destination, transactions_source, None)
+        self.produce_block_with_custom_id(input_data, transactions_source, None)
             .await
     }
 
     async fn produce_block_with_custom_id(
         &self,
         input_data: Option<GenerateBlockInputData>,
-        _reward_destination: Destination,
         transactions_source: TransactionsSource,
         custom_id: Option<Vec<u8>>,
     ) -> Result<(Block, oneshot::Receiver<usize>), BlockProductionError> {
@@ -756,7 +754,6 @@ mod tests {
 
                     block_production.produce_block_with_custom_id(
                         None,
-                        Destination::AnyoneCanSpend,
                         TransactionsSource::Provided(vec![]),
                         Some(id),
                     )

--- a/blockprod/src/interface/blockprod_interface.rs
+++ b/blockprod/src/interface/blockprod_interface.rs
@@ -32,7 +32,7 @@ pub trait BlockProductionInterface: Send {
     /// generated with available transactions in the mempool
     async fn generate_block(
         &mut self,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, BlockProductionError>;
 }

--- a/blockprod/src/interface/blockprod_interface.rs
+++ b/blockprod/src/interface/blockprod_interface.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::chain::{Block, Destination, SignedTransaction};
+use common::chain::{Block, SignedTransaction};
 use consensus::GenerateBlockInputData;
 
 use crate::{detail::job_manager::JobKey, BlockProductionError};
@@ -33,7 +33,6 @@ pub trait BlockProductionInterface: Send {
     async fn generate_block(
         &mut self,
         input_data: Option<GenerateBlockInputData>,
-        reward_destination: Destination,
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, BlockProductionError>;
 }

--- a/blockprod/src/interface/blockprod_interface_impl.rs
+++ b/blockprod/src/interface/blockprod_interface_impl.rs
@@ -43,8 +43,7 @@ impl BlockProductionInterface for BlockProduction {
             None => crate::detail::TransactionsSource::Mempool,
         };
 
-        let (block, end_receiver) =
-            self.produce_block(input_data, transactions).await?;
+        let (block, end_receiver) = self.produce_block(input_data, transactions).await?;
 
         // The only error that can happen is if the channel is closed. We don't care about that here.
         let _finished = end_receiver.await;

--- a/blockprod/src/interface/blockprod_interface_impl.rs
+++ b/blockprod/src/interface/blockprod_interface_impl.rs
@@ -35,7 +35,7 @@ impl BlockProductionInterface for BlockProduction {
 
     async fn generate_block(
         &mut self,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, BlockProductionError> {
         let transactions = match transactions {

--- a/blockprod/src/interface/blockprod_interface_impl.rs
+++ b/blockprod/src/interface/blockprod_interface_impl.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::chain::{Block, Destination, SignedTransaction};
+use common::chain::{Block, SignedTransaction};
 use consensus::GenerateBlockInputData;
 
 use crate::{
@@ -36,7 +36,6 @@ impl BlockProductionInterface for BlockProduction {
     async fn generate_block(
         &mut self,
         input_data: Option<GenerateBlockInputData>,
-        reward_destination: Destination,
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, BlockProductionError> {
         let transactions = match transactions {
@@ -45,7 +44,7 @@ impl BlockProductionInterface for BlockProduction {
         };
 
         let (block, end_receiver) =
-            self.produce_block(input_data, reward_destination, transactions).await?;
+            self.produce_block(input_data, transactions).await?;
 
         // The only error that can happen is if the channel is closed. We don't care about that here.
         let _finished = end_receiver.await;

--- a/blockprod/src/rpc.rs
+++ b/blockprod/src/rpc.rs
@@ -15,10 +15,7 @@
 
 //! Block production subsystem RPC handler
 
-use common::{
-    chain::Block,
-    chain::SignedTransaction,
-};
+use common::{chain::Block, chain::SignedTransaction};
 use consensus::GenerateBlockInputData;
 use rpc::Result as RpcResult;
 use serialization::hex_encoded::HexEncoded;
@@ -79,10 +76,7 @@ impl BlockProductionRpcServer for super::BlockProductionHandle {
 
         let block = handle_error(
             self.call_async_mut(move |this| {
-                this.generate_block(
-                    input_data.map(HexEncoded::take),
-                    transactions,
-                )
+                this.generate_block(input_data.map(HexEncoded::take), transactions)
             })
             .await,
         )?;

--- a/blockprod/src/rpc.rs
+++ b/blockprod/src/rpc.rs
@@ -42,7 +42,7 @@ trait BlockProductionRpc {
     #[method(name = "generate_block")]
     async fn generate_block(
         &self,
-        input_data: Option<HexEncoded<GenerateBlockInputData>>,
+        input_data: HexEncoded<GenerateBlockInputData>,
         transactions: Option<Vec<HexEncoded<SignedTransaction>>>,
     ) -> RpcResult<HexEncoded<Block>>;
 }
@@ -68,17 +68,15 @@ impl BlockProductionRpcServer for super::BlockProductionHandle {
 
     async fn generate_block(
         &self,
-        input_data: Option<HexEncoded<GenerateBlockInputData>>,
+        input_data: HexEncoded<GenerateBlockInputData>,
         transactions: Option<Vec<HexEncoded<SignedTransaction>>>,
     ) -> rpc::Result<HexEncoded<Block>> {
         let transactions =
             transactions.map(|txs| txs.into_iter().map(HexEncoded::take).collect::<Vec<_>>());
 
         let block = handle_error(
-            self.call_async_mut(move |this| {
-                this.generate_block(input_data.map(HexEncoded::take), transactions)
-            })
-            .await,
+            self.call_async_mut(move |this| this.generate_block(input_data.take(), transactions))
+                .await,
         )?;
 
         Ok(block.into())

--- a/blockprod/src/rpc.rs
+++ b/blockprod/src/rpc.rs
@@ -17,7 +17,7 @@
 
 use common::{
     chain::Block,
-    chain::{Destination, SignedTransaction},
+    chain::SignedTransaction,
 };
 use consensus::GenerateBlockInputData;
 use rpc::Result as RpcResult;
@@ -38,14 +38,14 @@ trait BlockProductionRpc {
     #[method(name = "stop_job")]
     async fn stop_job(&self, job_id: HexEncoded<JobKey>) -> RpcResult<bool>;
 
-    /// Generate a block with the given transactions to the specified
-    /// reward destination. If transactions are None, the block will be
-    /// generated with available transactions in the mempool
+    /// Generate a block with the given transactions
+    ///
+    /// If `transactions` is `None`, the block will be generated with
+    /// available transactions in the mempool
     #[method(name = "generate_block")]
     async fn generate_block(
         &self,
         input_data: Option<HexEncoded<GenerateBlockInputData>>,
-        reward_destination: HexEncoded<Destination>,
         transactions: Option<Vec<HexEncoded<SignedTransaction>>>,
     ) -> RpcResult<HexEncoded<Block>>;
 }
@@ -72,7 +72,6 @@ impl BlockProductionRpcServer for super::BlockProductionHandle {
     async fn generate_block(
         &self,
         input_data: Option<HexEncoded<GenerateBlockInputData>>,
-        reward_destination: HexEncoded<Destination>,
         transactions: Option<Vec<HexEncoded<SignedTransaction>>>,
     ) -> rpc::Result<HexEncoded<Block>> {
         let transactions =
@@ -82,7 +81,6 @@ impl BlockProductionRpcServer for super::BlockProductionHandle {
             self.call_async_mut(move |this| {
                 this.generate_block(
                     input_data.map(HexEncoded::take),
-                    reward_destination.take(),
                     transactions,
                 )
             })

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -298,6 +298,7 @@ impl BanScore for ConsensusPoWError {
             ConsensusPoWError::PreviousBitsDecodingFailed(_) => 0,
             ConsensusPoWError::InvalidTargetBits(_, _) => 100,
             ConsensusPoWError::GenesisCannotHaveOngoingDifficulty => 100,
+            ConsensusPoWError::InvalidBlockRewardMaturityDistance(_) => 0,
         }
     }
 }

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -722,7 +722,7 @@ fn consensus_type(#[case] seed: Seed) {
     assert!(matches!(
         tf.make_block_builder()
             .add_test_transaction_from_best_block(&mut rng)
-            .with_consensus_data(ConsensusData::PoW(PoWData::new(Compact(0), 0)))
+            .with_consensus_data(ConsensusData::PoW(Box::new(PoWData::new(Compact(0), 0))))
             .build_and_process()
             .unwrap_err(),
         ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
@@ -1238,7 +1238,7 @@ fn make_invalid_pow_block(
     max_nonce: u128,
     bits: Compact,
 ) -> Result<bool, ConsensusPoWError> {
-    let mut data = PoWData::new(bits, 0);
+    let mut data = Box::new(PoWData::new(bits, 0));
     for nonce in 0..max_nonce {
         data.update_nonce(nonce);
         block

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -362,7 +362,7 @@ mod tests {
                 &pos_accounting_db,
                 &block_reward,
                 Id::<Block>::new(H256::zero()),
-                &ConsensusData::PoW(PoWData::new(Compact(1), 1)),
+                &ConsensusData::PoW(Box::new(PoWData::new(Compact(1), 1))),
                 fee,
                 subsidy,
             )

--- a/common/src/chain/block/consensus_data.rs
+++ b/common/src/chain/block/consensus_data.rs
@@ -29,7 +29,7 @@ pub enum ConsensusData {
     #[codec(index = 0)]
     None,
     #[codec(index = 1)]
-    PoW(PoWData),
+    PoW(Box<PoWData>),
     #[codec(index = 2)]
     PoS(Box<PoSData>),
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -27,17 +27,17 @@ use chainstate_types::{
 };
 use common::{
     chain::block::{
-        consensus_data::PoWData,
         signed_block_header::{BlockHeaderSignature, BlockHeaderSignatureData, SignedBlockHeader},
         timestamp::BlockTimestamp,
-        BlockHeader, ConsensusData,
+        BlockHeader, BlockReward, ConsensusData,
     },
-    chain::{ChainConfig, RequiredConsensus},
+    chain::{timelock::OutputTimeLock, ChainConfig, Destination, RequiredConsensus, TxOutput, tokens::OutputValue},
     primitives::BlockHeight,
 };
 use serialization::{Decode, Encode};
 
-use crate::pos::input_data::generate_pos_consensus_data;
+use crate::pos::input_data::generate_pos_consensus_data_and_reward;
+use crate::pow::input_data::generate_pow_consensus_data_and_reward;
 
 pub use crate::{
     error::ConsensusVerificationError,
@@ -52,7 +52,10 @@ pub use crate::{
         target::calculate_target_required_from_block_index,
         StakeResult,
     },
-    pow::{calculate_work_required, check_proof_of_work, mine, ConsensusPoWError, MiningResult},
+    pow::{
+        calculate_work_required, check_proof_of_work, input_data::PoWGenerateBlockInputData, mine,
+        ConsensusPoWError, MiningResult,
+    },
     validator::validate_consensus,
 };
 
@@ -86,7 +89,7 @@ pub enum FinalizeBlockInputData {
     PoS(PoSFinalizeBlockInputData),
 }
 
-pub fn generate_consensus_data<G>(
+pub fn generate_consensus_data_and_reward<G>(
     chain_config: &ChainConfig,
     prev_block_index: &GenBlockIndex,
     sealed_epoch_randomness: Option<PoSRandomness>,
@@ -94,14 +97,38 @@ pub fn generate_consensus_data<G>(
     block_timestamp: BlockTimestamp,
     block_height: BlockHeight,
     get_ancestor: G,
-) -> Result<ConsensusData, ConsensusCreationError>
+) -> Result<(ConsensusData, BlockReward), ConsensusCreationError>
 where
     G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
 {
     match chain_config.net_upgrade().consensus_status(block_height) {
-        RequiredConsensus::IgnoreConsensus => Ok(ConsensusData::None),
+        RequiredConsensus::IgnoreConsensus => {
+            let consensus_data = ConsensusData::None;
+
+            let time_lock = {
+                let block_distance = consensus_data.reward_maturity_distance(chain_config);
+
+                let reward_maturity_distance_i64: i64 = block_distance
+                    .try_into()
+                    .map_err(|_| ConsensusPoWError::InvalidBlockRewardMaturityDistance(block_distance))?;
+
+                let reward_maturity_distance_u64: u64 = reward_maturity_distance_i64
+                    .try_into()
+                    .map_err(|_| ConsensusPoWError::InvalidBlockRewardMaturityDistance(block_distance))?;
+
+                OutputTimeLock::ForBlockCount(reward_maturity_distance_u64)
+            };
+
+            let block_reward = BlockReward::new(vec![TxOutput::LockThenTransfer(
+                OutputValue::Coin(chain_config.block_subsidy_at_height(&block_height)),
+                Destination::AnyoneCanSpend,
+                time_lock,
+            )]);
+
+            Ok((consensus_data, block_reward))
+        },
         RequiredConsensus::PoS(pos_status) => match input_data {
-            Some(GenerateBlockInputData::PoS(pos_input_data)) => generate_pos_consensus_data(
+            Some(GenerateBlockInputData::PoS(pos_input_data)) => generate_pos_consensus_data_and_reward(
                 chain_config,
                 prev_block_index,
                 *pos_input_data,
@@ -111,19 +138,21 @@ where
                 block_height,
                 get_ancestor,
             ),
-            Some(GenerateBlockInputData::PoW) => Err(ConsensusPoSError::PoWInputDataProvided)?,
+            Some(GenerateBlockInputData::PoW(_)) => Err(ConsensusPoSError::PoWInputDataProvided)?,
             None => Err(ConsensusPoSError::NoInputDataProvided)?,
         },
-        RequiredConsensus::PoW(pow_status) => {
-            let work_required = calculate_work_required(
+        RequiredConsensus::PoW(pow_status) => match input_data {
+            Some(GenerateBlockInputData::PoW(pow_input_data)) => generate_pow_consensus_data_and_reward(
                 chain_config,
                 prev_block_index,
                 block_timestamp,
                 &pow_status,
                 get_ancestor,
-            )?;
-
-            Ok(ConsensusData::PoW(PoWData::new(work_required, 0)))
+                *pow_input_data,
+                block_height,
+            ).map_err(ConsensusCreationError::MiningError),
+            Some(GenerateBlockInputData::PoS(_)) => Err(ConsensusCreationError::MiningError(ConsensusPoWError::PoSInputDataProvided)),
+            None => Err(ConsensusCreationError::MiningError(ConsensusPoWError::NoInputDataProvided)),
         }
     }
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -75,7 +75,7 @@ pub enum ConsensusCreationError {
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub enum GenerateBlockInputData {
     #[codec(index = 0)]
-    PoW,
+    PoW(Box<PoWGenerateBlockInputData>),
     #[codec(index = 1)]
     PoS(Box<PoSGenerateBlockInputData>),
 }

--- a/consensus/src/pos/input_data.rs
+++ b/consensus/src/pos/input_data.rs
@@ -209,7 +209,7 @@ where
         pos_input_data.stake_private_key(),
         SigHashType::default(),
         reward_destination,
-        &block_reward,
+        &block_reward_transactable,
         &kernel_input_utxos.iter().collect::<Vec<_>>(),
         0,
     )

--- a/consensus/src/pos/input_data.rs
+++ b/consensus/src/pos/input_data.rs
@@ -23,7 +23,8 @@ use chainstate_types::{
 };
 use common::{
     chain::block::{
-        consensus_data::PoSData, timestamp::BlockTimestamp, BlockRewardTransactable, ConsensusData,
+        consensus_data::PoSData, timestamp::BlockTimestamp, BlockReward, BlockRewardTransactable,
+        ConsensusData,
     },
     chain::{
         config::EpochIndex,
@@ -177,7 +178,7 @@ impl PoSFinalizeBlockInputData {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn generate_pos_consensus_data<G>(
+pub fn generate_pos_consensus_data_and_reward<G>(
     chain_config: &ChainConfig,
     prev_block_index: &GenBlockIndex,
     pos_input_data: PoSGenerateBlockInputData,
@@ -186,7 +187,7 @@ pub fn generate_pos_consensus_data<G>(
     block_timestamp: BlockTimestamp,
     block_height: BlockHeight,
     get_ancestor: G,
-) -> Result<ConsensusData, ConsensusCreationError>
+) -> Result<(ConsensusData, BlockReward), ConsensusCreationError>
 where
     G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
 {
@@ -197,7 +198,7 @@ where
         pos_input_data.pool_id(),
     )];
 
-    let block_reward = BlockRewardTransactable::new(
+    let block_reward_transactable = BlockRewardTransactable::new(
         Some(pos_input_data.kernel_inputs()),
         Some(&kernel_output),
         None,
@@ -240,11 +241,15 @@ where
         get_ancestor,
     )?;
 
-    Ok(ConsensusData::PoS(Box::new(PoSData::new(
+    let consensus_data = ConsensusData::PoS(Box::new(PoSData::new(
         pos_input_data.kernel_inputs().clone(),
         vec![input_witness],
         pos_input_data.pool_id(),
         vrf_data,
         target_required,
-    ))))
+    )));
+
+    let block_reward = BlockReward::new(kernel_output);
+
+    Ok((consensus_data, block_reward))
 }

--- a/consensus/src/pow/error.rs
+++ b/consensus/src/pow/error.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use chainstate_types::PropertyQueryError;
 use common::{
     chain::block::Block,
-    primitives::{BlockHeight, Compact, Id, BlockDistance},
+    primitives::{BlockDistance, BlockHeight, Compact, Id},
 };
 
 /// A proof of work consensus error.

--- a/consensus/src/pow/error.rs
+++ b/consensus/src/pow/error.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use chainstate_types::PropertyQueryError;
 use common::{
     chain::block::Block,
-    primitives::{BlockHeight, Compact, Id},
+    primitives::{BlockHeight, Compact, Id, BlockDistance},
 };
 
 /// A proof of work consensus error.
@@ -46,4 +46,6 @@ pub enum ConsensusPoWError {
     NoInputDataProvided,
     #[error("Genesis block cannot have an ongoing difficulty")]
     GenesisCannotHaveOngoingDifficulty,
+    #[error("Block reward maturity value {0} is invalid")]
+    InvalidBlockRewardMaturityDistance(BlockDistance),
 }

--- a/consensus/src/pow/input_data.rs
+++ b/consensus/src/pow/input_data.rs
@@ -20,8 +20,8 @@ use common::{
         consensus_data::PoWData, timestamp::BlockTimestamp, BlockReward, ConsensusData,
     },
     chain::{
-        timelock::OutputTimeLock, tokens::OutputValue, ChainConfig, Destination,
-        PoWStatus, TxOutput,
+        timelock::OutputTimeLock, tokens::OutputValue, ChainConfig, Destination, PoWStatus,
+        TxOutput,
     },
     primitives::BlockHeight,
 };
@@ -55,7 +55,7 @@ where
         chain_config,
         prev_gen_block_index,
         block_timestamp,
-        &pow_status,
+        pow_status,
         get_ancestor,
     )?;
 

--- a/consensus/src/pow/input_data.rs
+++ b/consensus/src/pow/input_data.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::pow::{calculate_work_required, error::ConsensusPoWError};
+use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
+use common::{
+    chain::block::{
+        consensus_data::PoWData, timestamp::BlockTimestamp, BlockReward, ConsensusData,
+    },
+    chain::{
+        timelock::OutputTimeLock, tokens::OutputValue, ChainConfig, Destination,
+        PoWStatus, TxOutput,
+    },
+    primitives::BlockHeight,
+};
+use serialization::{Decode, Encode};
+
+// TODO see PoS equivalent
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct PoWGenerateBlockInputData {
+    reward_destination: Destination,
+}
+
+impl PoWGenerateBlockInputData {
+    pub fn reward_destination(&self) -> &Destination {
+        &self.reward_destination
+    }
+}
+
+pub fn generate_pow_consensus_data_and_reward<G>(
+    chain_config: &ChainConfig,
+    prev_gen_block_index: &GenBlockIndex,
+    block_timestamp: BlockTimestamp,
+    pow_status: &PoWStatus,
+    get_ancestor: G,
+    pow_input_data: PoWGenerateBlockInputData,
+    block_height: BlockHeight,
+) -> Result<(ConsensusData, BlockReward), ConsensusPoWError>
+where
+    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+{
+    let work_required = calculate_work_required(
+        chain_config,
+        prev_gen_block_index,
+        block_timestamp,
+        &pow_status,
+        get_ancestor,
+    )?;
+
+    let consensus_data = ConsensusData::PoW(Box::new(PoWData::new(work_required, 0)));
+
+    let time_lock = {
+        let block_distance = consensus_data.reward_maturity_distance(chain_config);
+
+        let reward_maturity_distance_i64: i64 = block_distance
+            .try_into()
+            .map_err(|_| ConsensusPoWError::InvalidBlockRewardMaturityDistance(block_distance))?;
+
+        let reward_maturity_distance_u64: u64 = reward_maturity_distance_i64
+            .try_into()
+            .map_err(|_| ConsensusPoWError::InvalidBlockRewardMaturityDistance(block_distance))?;
+
+        OutputTimeLock::ForBlockCount(reward_maturity_distance_u64)
+    };
+
+    let block_reward = BlockReward::new(vec![TxOutput::LockThenTransfer(
+        OutputValue::Coin(chain_config.block_subsidy_at_height(&block_height)),
+        pow_input_data.reward_destination().clone(),
+        time_lock,
+    )]);
+
+    Ok((consensus_data, block_reward))
+}

--- a/consensus/src/pow/mod.rs
+++ b/consensus/src/pow/mod.rs
@@ -20,6 +20,7 @@ pub use self::{
 
 mod error;
 mod helpers;
+pub mod input_data;
 mod work;
 
 use std::time::Duration;

--- a/consensus/src/pow/work.rs
+++ b/consensus/src/pow/work.rs
@@ -242,7 +242,7 @@ pub fn mine(
     bits: Compact,
     stop_flag: Arc<AtomicBool>,
 ) -> Result<MiningResult, ConsensusPoWError> {
-    let mut data = PoWData::new(bits, 0);
+    let mut data = Box::new(PoWData::new(bits, 0));
     for nonce in 0..max_nonce {
         //TODO: optimize this: https://github.com/mintlayer/mintlayer-core/pull/99#discussion_r809713922
         data.update_nonce(nonce);

--- a/test/functional/feature_lmdb_backend_test.py
+++ b/test/functional/feature_lmdb_backend_test.py
@@ -9,6 +9,10 @@ from test_framework.util import (
     assert_equal,
 )
 
+import scalecodec
+
+block_input_data_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('GenerateBlockInputData')
+
 class ExampleTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -39,11 +43,19 @@ class ExampleTest(BitcoinTestFramework):
         # get current tip hash
         assert_equal(self.block_height(), 0)
 
+        block_input_data = block_input_data_obj.encode(
+            {
+                "PoW": {
+                    "reward_destination": "AnyoneCanSpend",
+                }
+            }
+        ).to_hex()[2:]
+
         # add two blocks
-        block = self.nodes[0].blockprod_generate_block(None, "00", [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
         blocks.append(block)
         node.chainstate_submit_block(blocks[0])
-        block = self.nodes[0].blockprod_generate_block(None, "00", [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
         blocks.append(block)
         node.chainstate_submit_block(blocks[1])
         assert_equal(self.block_height(), 2)
@@ -58,7 +70,7 @@ class ExampleTest(BitcoinTestFramework):
 
         # Add three more blocks
         for i in range(2, 5):
-            block = self.nodes[0].blockprod_generate_block(None, "00", [])
+            block = self.nodes[0].blockprod_generate_block(block_input_data, [])
             blocks.append(block)
             node.chainstate_submit_block(blocks[i])
         assert_equal(self.block_height(), 5)

--- a/test/functional/p2p_syncing_test.py
+++ b/test/functional/p2p_syncing_test.py
@@ -9,6 +9,10 @@ from test_framework.util import (
     assert_equal,
 )
 
+import scalecodec
+
+block_input_data_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('GenerateBlockInputData')
+
 class SyncingTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -41,8 +45,16 @@ class SyncingTest(BitcoinTestFramework):
 
         blocks = []
 
+        block_input_data = block_input_data_obj.encode(
+            {
+                "PoW": {
+                    "reward_destination": "AnyoneCanSpend",
+                }
+            }
+        ).to_hex()[2:]
+
         # add first block
-        block = self.nodes[0].blockprod_generate_block(None, "00", [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
         blocks.append(block)
         self.nodes[0].chainstate_submit_block(blocks[0])
         assert_equal(self.block_height(0), 1)
@@ -50,7 +62,7 @@ class SyncingTest(BitcoinTestFramework):
         self.assert_tip(0, blocks[0])
 
         # add second block
-        block = self.nodes[0].blockprod_generate_block(None, "00", [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
         blocks.append(block)
         self.nodes[0].chainstate_submit_block(blocks[1])
         assert_equal(self.block_height(0), 2)
@@ -73,14 +85,14 @@ class SyncingTest(BitcoinTestFramework):
         self.assert_tip(1, blocks[1])
 
         # submit third block
-        block = self.nodes[0].blockprod_generate_block(None, "00", [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
         blocks.append(block)
         self.nodes[0].chainstate_submit_block(blocks[2])
         assert_equal(self.block_height(0), 3)
         self.assert_tip(0, blocks[2])
 
         # submit final block
-        block = self.nodes[0].blockprod_generate_block(None, "00", [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
         blocks.append(block)
         self.nodes[0].chainstate_submit_block(blocks[3])
         assert_equal(self.block_height(0), 4)

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -239,7 +239,23 @@ def init_mintlayer_types():
                     ["announcement", "Announcement"],
                     ["header_list_request", "HeaderListRequest"],
                 ]
-            }
+            },
+
+            "GenerateBlockInputData": {
+                "type": "enum",
+                "type_mapping": [
+                    ["PoW", "Box<PoWGenerateBlockInputData>"],
+                    ["PoS", "()"]
+                    # TODO PoS
+                ]
+            },
+
+            "PoWGenerateBlockInputData": {
+                "type": "struct",
+                "type_mapping": [
+                    ["reward_destination", "Destination"],
+                ]
+            },
         }
     }
 

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -244,6 +244,7 @@ def init_mintlayer_types():
             "GenerateBlockInputData": {
                 "type": "enum",
                 "type_mapping": [
+                    ["Nono", "()"],
                     ["PoW", "Box<PoWGenerateBlockInputData>"],
                     ["PoS", "()"]
                     # TODO PoS

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -708,7 +708,7 @@ fn check_pow_reward_spend_undo_spend(#[case] seed: Seed) {
         vec![],
         Id::new(H256::random_using(&mut rng)),
         BlockTimestamp::from_int_seconds(1),
-        ConsensusData::PoW(PoWData::new(Compact(1), 1)),
+        ConsensusData::PoW(Box::new(PoWData::new(Compact(1), 1))),
         BlockReward::new(create_tx_outputs(&mut rng, 1)),
     )
     .unwrap();

--- a/wallet/wallet-cli-lib/Cargo.toml
+++ b/wallet/wallet-cli-lib/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../../common" }
+consensus = { path = "../../consensus" }
 logging = { path = "../../logging" }
 node-comm = { path = "../wallet-node-client" }
 serialization = { path = "../../serialization" }

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -21,6 +21,7 @@ use common::{
     chain::{Block, ChainConfig, Destination, SignedTransaction},
     primitives::{Amount, BlockHeight, H256},
 };
+use consensus::GenerateBlockInputData;
 use serialization::{hex::HexEncode, hex_encoded::HexEncoded};
 use wallet_controller::{NodeInterface, NodeRpcClient, PeerId, RpcController};
 
@@ -301,7 +302,7 @@ pub async fn handle_wallet_command(
             let transactions =
                 transactions.map(|txs| txs.into_iter().map(HexEncoded::take).collect());
             let block = rpc_client
-                .generate_block(None, transactions)
+                .generate_block(GenerateBlockInputData::None, transactions)
                 .await
                 .map_err(WalletCliError::RpcError)?;
             rpc_client.submit_block(block).await.map_err(WalletCliError::RpcError)?;

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -295,13 +295,13 @@ pub async fn handle_wallet_command(
         }
 
         WalletCommand::GenerateBlock {
-            reward_destination,
+            reward_destination: _,
             transactions,
         } => {
             let transactions =
                 transactions.map(|txs| txs.into_iter().map(HexEncoded::take).collect());
             let block = rpc_client
-                .generate_block(None, reward_destination.take(), transactions)
+                .generate_block(None, transactions)
                 .await
                 .map_err(WalletCliError::RpcError)?;
             rpc_client.submit_block(block).await.map_err(WalletCliError::RpcError)?;

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -17,7 +17,7 @@ use std::sync::Mutex;
 
 use chainstate::ChainInfo;
 use chainstate_test_framework::TestFramework;
-use common::chain::{Destination, SignedTransaction};
+use common::chain::SignedTransaction;
 use consensus::GenerateBlockInputData;
 use crypto::random::{seq::IteratorRandom, CryptoRng, Rng};
 use node_comm::{
@@ -138,7 +138,6 @@ impl NodeInterface for MockNode {
     async fn generate_block(
         &self,
         _input_data: Option<GenerateBlockInputData>,
-        _reward_destination_hex: Destination,
         _transactions_hex: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error> {
         unreachable!()

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -137,7 +137,7 @@ impl NodeInterface for MockNode {
 
     async fn generate_block(
         &self,
-        _input_data: Option<GenerateBlockInputData>,
+        _input_data: GenerateBlockInputData,
         _transactions_hex: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error> {
         unreachable!()

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -122,7 +122,7 @@ impl NodeInterface for WalletHandlesClient {
 
     async fn generate_block(
         &self,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error> {
         let block = self

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -127,9 +127,7 @@ impl NodeInterface for WalletHandlesClient {
     ) -> Result<Block, Self::Error> {
         let block = self
             .block_prod
-            .call_async_mut(move |this| {
-                this.generate_block(input_data, transactions)
-            })
+            .call_async_mut(move |this| this.generate_block(input_data, transactions))
             .await??;
 
         Ok(block)

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -16,7 +16,7 @@
 use blockprod::{BlockProductionError, BlockProductionHandle};
 use chainstate::{BlockSource, ChainInfo, ChainstateError, ChainstateHandle};
 use common::{
-    chain::{Block, Destination, GenBlock, SignedTransaction},
+    chain::{Block, GenBlock, SignedTransaction},
     primitives::{BlockHeight, Id},
 };
 use consensus::GenerateBlockInputData;
@@ -123,13 +123,12 @@ impl NodeInterface for WalletHandlesClient {
     async fn generate_block(
         &self,
         input_data: Option<GenerateBlockInputData>,
-        reward_destination: Destination,
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error> {
         let block = self
             .block_prod
             .call_async_mut(move |this| {
-                this.generate_block(input_data, reward_destination, transactions)
+                this.generate_block(input_data, transactions)
             })
             .await??;
 

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -41,7 +41,7 @@ pub trait NodeInterface {
     ) -> Result<Option<(Id<GenBlock>, BlockHeight)>, Self::Error>;
     async fn generate_block(
         &self,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
         transactions_hex: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error>;
     async fn submit_block(&self, block: Block) -> Result<(), Self::Error>;

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -15,7 +15,7 @@
 
 use chainstate::ChainInfo;
 use common::{
-    chain::{Block, Destination, GenBlock, SignedTransaction},
+    chain::{Block, GenBlock, SignedTransaction},
     primitives::{BlockHeight, Id},
 };
 
@@ -42,7 +42,6 @@ pub trait NodeInterface {
     async fn generate_block(
         &self,
         input_data: Option<GenerateBlockInputData>,
-        reward_destination: Destination,
         transactions_hex: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error>;
     async fn submit_block(&self, block: Block) -> Result<(), Self::Error>;

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -81,18 +81,14 @@ impl NodeInterface for NodeRpcClient {
 
     async fn generate_block(
         &self,
-        input_data: Option<GenerateBlockInputData>,
+        input_data: GenerateBlockInputData,
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error> {
         let transactions = transactions.map(|txs| txs.into_iter().map(HexEncoded::new).collect());
-        BlockProductionRpcClient::generate_block(
-            &self.http_client,
-            input_data.map(Into::into),
-            transactions,
-        )
-        .await
-        .map(HexEncoded::take)
-        .map_err(NodeRpcError::ResponseError)
+        BlockProductionRpcClient::generate_block(&self.http_client, input_data.into(), transactions)
+            .await
+            .map(HexEncoded::take)
+            .map_err(NodeRpcError::ResponseError)
     }
 
     async fn submit_block(&self, block: Block) -> Result<(), Self::Error> {

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -16,7 +16,7 @@
 use blockprod::rpc::BlockProductionRpcClient;
 use chainstate::{rpc::ChainstateRpcClient, ChainInfo};
 use common::{
-    chain::{Block, Destination, GenBlock, SignedTransaction},
+    chain::{Block, GenBlock, SignedTransaction},
     primitives::{BlockHeight, Id},
 };
 use consensus::GenerateBlockInputData;
@@ -82,14 +82,12 @@ impl NodeInterface for NodeRpcClient {
     async fn generate_block(
         &self,
         input_data: Option<GenerateBlockInputData>,
-        reward_destination: Destination,
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error> {
         let transactions = transactions.map(|txs| txs.into_iter().map(HexEncoded::new).collect());
         BlockProductionRpcClient::generate_block(
             &self.http_client,
             input_data.map(Into::into),
-            reward_destination.into(),
             transactions,
         )
         .await


### PR DESCRIPTION
Before this PR, `Destination` was a parameter to the `generate_block()` RPC call. But as PoS blocks no longer need this parameter, I've move it into the PoW's `input_data` enum.

So from here, since we need to look at `ConsenusData` fields for PoS when generating the block reward, I've moved creating the `BlockReward` into `consensus/src/po[sw]/input_data.rs` for convenience.

