### PR TITLE
Add password encryption to wallet for root keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6514,6 +6514,7 @@ dependencies = [
  "storage",
  "storage-sqlite",
  "test-utils",
+ "thiserror",
  "utils",
  "utxo",
  "wallet-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,13 +6303,16 @@ dependencies = [
  "logging",
  "loom",
  "num-traits",
+ "parity-scale-codec",
  "probabilistic-collections",
  "qrcodegen",
  "rstest",
+ "serialization",
  "slave-pool",
  "static_assertions",
  "test-utils",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ serde = "1.0"
 static_assertions = "1.1"
 thiserror = "1.0"
 tokio = { version = "1.27", default-features = false }
+zeroize = "1.5"
 
 rstest = "0.17"
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -27,11 +27,11 @@ chacha20poly1305 = "0.10"
 schnorrkel = "0.10"
 merlin = { version = "3.0", default-features = false }
 argon2 = { version = "0.5", features = ["std"] }
-zeroize = "1.5"
 
 generic-array.workspace = true
 parity-scale-codec.workspace = true
 thiserror.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/crypto/src/symkey/chacha20poly1305/mod.rs
+++ b/crypto/src/symkey/chacha20poly1305/mod.rs
@@ -18,12 +18,13 @@ use crate::symkey::Error;
 use chacha20poly1305::aead::{AeadInPlace, KeyInit};
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use serialization::{Decode, Encode};
+use zeroize::ZeroizeOnDrop;
 
 pub const NONCE_LEN: usize = 24;
 pub const KEY_LEN: usize = 32;
 
 #[must_use]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, ZeroizeOnDrop)]
 pub struct Chacha20poly1305Key {
     key_data: chacha20poly1305::Key,
 }

--- a/crypto/src/symkey/mod.rs
+++ b/crypto/src/symkey/mod.rs
@@ -122,7 +122,7 @@ mod test {
     }
 
     #[test]
-    fn constryct_key_from_slice_random_size() {
+    fn construct_key_from_slice_random_size() {
         let mut rng = make_true_rng();
         let bytes: Vec<u8> = (0..rng.gen_range(0..100)).map(|_| rng.gen::<u8>()).collect();
         let result =

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [dependencies]
 logging = {path = '../logging'}
 crypto = { path = "../crypto/" }
+serialization = { path = "../serialization" }
 
 atomic-traits = "0.3"
 directories = "5.0"
@@ -15,8 +16,10 @@ num-traits = "0.2"
 probabilistic-collections = "0.7"
 qrcodegen = "1.8"
 slave-pool = "0.2"
+zeroize = "1.5"
 
 thiserror.workspace = true
+parity-scale-codec.workspace = true
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -16,10 +16,10 @@ num-traits = "0.2"
 probabilistic-collections = "0.7"
 qrcodegen = "1.8"
 slave-pool = "0.2"
-zeroize = "1.5"
 
 thiserror.workspace = true
 parity-scale-codec.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -23,6 +23,7 @@ pub mod default_data_dir;
 pub mod ensure;
 pub mod eventhandler;
 pub mod exp_rand;
+pub mod maybe_encrypted;
 pub mod newtype;
 pub mod once_destructor;
 pub mod qrcode;

--- a/utils/src/maybe_encrypted.rs
+++ b/utils/src/maybe_encrypted.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::marker::PhantomData;
+
+use crypto::{random::make_true_rng, symkey::SymmetricKey};
+use serialization::{Decode, DecodeAll, Encode};
+use zeroize::Zeroizing;
+
+/// A generic type that stores a value as a vector of bytes that are optionally encrypted
+#[derive(Encode, Decode)]
+pub struct MaybeEncrypted<T: Encode + Decode + DecodeAll> {
+    value: Vec<u8>,
+    _phantom: PhantomData<fn() -> T>,
+}
+
+impl<T: Decode + Encode + DecodeAll> MaybeEncrypted<T> {
+    /// Creates a new `MaybeEncrypted` instance with the given value and encryption key.
+    ///
+    /// If the encryption key is `Some`, the value will be encrypted using the key.
+    /// If the encryption key is `None`, the value will be stored as plain bytes.
+    pub fn new(value: &T, encryption_key: &Option<SymmetricKey>) -> Self {
+        match encryption_key {
+            Some(key) => Self::new_encrypted(value, key),
+            None => Self::new_plain(value),
+        }
+    }
+
+    fn new_plain(value: &T) -> Self {
+        Self {
+            value: value.encode(),
+            _phantom: Default::default(),
+        }
+    }
+
+    fn new_encrypted(value: &T, encryption_key: &SymmetricKey) -> Self {
+        Self {
+            value: encryption_key
+                .encrypt(
+                    Zeroizing::new(value.encode()).as_slice(),
+                    &mut make_true_rng(),
+                    None,
+                )
+                .expect("should not fail"),
+            _phantom: Default::default(),
+        }
+    }
+
+    /// Attempts to take the value from the `MaybeEncrypted` instance.
+    ///
+    /// If the encryption key is `Some`, the value will be decrypted using the key.
+    /// If the encryption key is `None`, the value is assumed to be plain bytes and decoded as is.
+    pub fn try_take(
+        self,
+        encryption_key: &Option<SymmetricKey>,
+    ) -> Result<T, crypto::symkey::Error> {
+        match encryption_key {
+            Some(key) => self.try_take_decrypt(key),
+            None => self.try_take_plain(),
+        }
+    }
+
+    fn try_take_plain(self) -> Result<T, crypto::symkey::Error> {
+        T::decode_all(&mut self.value.as_slice()).map_err(|_| {
+            crypto::symkey::Error::DecryptionError(
+                "Could not decode plain content probably it is encrypted".into(),
+            )
+        })
+    }
+
+    pub fn try_take_decrypt(
+        self,
+        encryption_key: &SymmetricKey,
+    ) -> Result<T, crypto::symkey::Error> {
+        encryption_key.decrypt(self.value.as_slice(), None).map(|decrypted_bytes| {
+            T::decode_all(&mut Zeroizing::new(decrypted_bytes).as_slice())
+                .expect("should have been correctly encoded")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto::random::Rng;
+    use crypto::symkey::SymmetricKeyKind;
+    use rstest::rstest;
+    use test_utils::random::{make_seedable_rng, Seed};
+
+    use super::*;
+
+    #[test]
+    fn test_new_plain_and_back() {
+        let value = 42;
+        let maybe_encrypted = MaybeEncrypted::new(&value, &None);
+
+        assert_eq!(maybe_encrypted.try_take(&None).unwrap(), value);
+    }
+
+    #[test]
+    fn test_new_plain_and_back_plain() {
+        let value = 42;
+        let maybe_encrypted = MaybeEncrypted::new(&value, &None);
+
+        assert_eq!(maybe_encrypted.try_take_plain().unwrap(), value);
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn test_new_plain_and_back_decrypted_error(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let value = rng.gen::<u32>();
+        let maybe_encrypted = MaybeEncrypted::new(&value, &None);
+
+        let key = SymmetricKey::new(SymmetricKeyKind::XChacha20Poly1305, &mut rng);
+        let key = Some(key);
+
+        assert!(maybe_encrypted.try_take(&key).is_err());
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn test_new_encrypted_and_back(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let value = rng.gen::<u32>();
+        let key = SymmetricKey::new(SymmetricKeyKind::XChacha20Poly1305, &mut rng);
+        let key = Some(key);
+        let maybe_encrypted = MaybeEncrypted::new(&value, &key);
+
+        assert_eq!(maybe_encrypted.try_take(&key).unwrap(), value);
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn test_new_encrypted_and_back_no_key_error(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let value = rng.gen::<u32>();
+        let key = SymmetricKey::new(SymmetricKeyKind::XChacha20Poly1305, &mut rng);
+        let key = Some(key);
+        let maybe_encrypted = MaybeEncrypted::new(&value, &key);
+
+        assert!(maybe_encrypted.try_take(&None).is_err());
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn test_new_encrypted_and_back_different_key_error(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let value = rng.gen::<u32>();
+        let key = SymmetricKey::new(SymmetricKeyKind::XChacha20Poly1305, &mut rng);
+        let key = Some(key);
+        let maybe_encrypted = MaybeEncrypted::new(&value, &key);
+
+        let mut different_key = SymmetricKey::new(SymmetricKeyKind::XChacha20Poly1305, &mut rng);
+        while &different_key == key.as_ref().unwrap() {
+            different_key = SymmetricKey::new(SymmetricKeyKind::XChacha20Poly1305, &mut rng);
+        }
+        let different_key = Some(different_key);
+
+        assert!(maybe_encrypted.try_take(&different_key).is_err());
+    }
+}

--- a/utils/src/maybe_encrypted.rs
+++ b/utils/src/maybe_encrypted.rs
@@ -30,7 +30,7 @@ pub enum MaybeEncryptedError {
     DecodingError(#[from] serialization::Error),
 }
 
-/// A generic helper type that is used to encode/decode and optionaly encrypt/decrypt a type T
+/// A generic helper type that is used to encode/decode and optionally encrypt/decrypt a type T
 #[derive(Encode, Decode)]
 pub struct MaybeEncrypted<T> {
     value: Vec<u8>,

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -24,7 +24,7 @@ bip39 = { version = "2.0", default-features = false, features = ["std", "zeroize
 itertools.workspace = true
 parity-scale-codec.workspace = true
 thiserror.workspace = true
-zeroize = "1.5"
+zeroize.workspace = true
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -168,8 +168,8 @@ impl Account {
         Ok(vrf_from_private_key(&private_key))
     }
 
-    pub fn get_vrf_public_key(&self) -> WalletResult<VRFPublicKey> {
-        let vrf_keys = self.get_vrf_key()?;
+    pub fn get_vrf_public_key(&self, db_tx: &impl WalletStorageRead) -> WalletResult<VRFPublicKey> {
+        let vrf_keys = self.get_vrf_key(db_tx)?;
         Ok(vrf_keys.1)
     }
 

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -29,7 +29,7 @@ use crypto::random::{Rng, RngCore};
 use rstest::rstest;
 use std::ops::{Div, Mul, Sub};
 use test_utils::random::{make_seedable_rng, Seed};
-use wallet_storage::{DefaultBackend, Store, TransactionRw, Transactional};
+use wallet_storage::{DefaultBackend, Store, TransactionRwUnlocked, Transactional};
 use wallet_types::account_info::DEFAULT_ACCOUNT_INDEX;
 use wallet_types::KeyPurpose::{Change, ReceiveFunds};
 
@@ -40,7 +40,7 @@ const MNEMONIC: &str =
 fn account_addresses() {
     let config = Arc::new(create_regtest());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
-    let mut db_tx = db.transaction_rw(None).unwrap();
+    let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();
@@ -69,7 +69,7 @@ fn account_addresses() {
 fn account_addresses_lookahead() {
     let config = Arc::new(create_regtest());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
-    let mut db_tx = db.transaction_rw(None).unwrap();
+    let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();
@@ -110,7 +110,7 @@ fn sign_transaction(#[case] seed: Seed) {
 
     let config = Arc::new(create_regtest());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
-    let mut db_tx = db.transaction_rw(None).unwrap();
+    let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -192,7 +192,7 @@ fn sign_transaction(#[case] seed: Seed) {
 
     let req = SendRequest::from_transaction(tx, utxos.clone());
 
-    let sig_tx = account.sign_transaction(req).unwrap();
+    let sig_tx = account.sign_transaction(req, &db_tx).unwrap();
 
     let utxos_ref = utxos.iter().collect::<Vec<_>>();
 

--- a/wallet/src/key_chain/account_key_chain/tests.rs
+++ b/wallet/src/key_chain/account_key_chain/tests.rs
@@ -18,7 +18,7 @@ use crate::key_chain::MasterKeyChain;
 use common::chain::config::create_unit_test_config;
 use crypto::key::secp256k1::Secp256k1PublicKey;
 use rstest::rstest;
-use wallet_storage::{DefaultBackend, Store, TransactionRw, Transactional};
+use wallet_storage::{DefaultBackend, Store, TransactionRwUnlocked, Transactional};
 use wallet_types::account_info::DEFAULT_ACCOUNT_INDEX;
 
 // TODO: More tests
@@ -33,7 +33,7 @@ const MNEMONIC: &str =
 fn check_mine_methods(#[case] public: &str) {
     let chain_config = Arc::new(create_unit_test_config());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
-    let mut db_tx = db.transaction_rw(None).unwrap();
+    let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(chain_config, &mut db_tx, MNEMONIC, None).unwrap();

--- a/wallet/src/key_chain/leaf_key_chain/mod.rs
+++ b/wallet/src/key_chain/leaf_key_chain/mod.rs
@@ -316,7 +316,7 @@ impl LeafKeySoftChain {
 
     /// Get the last derived key index
     pub fn get_last_derived_index(&self) -> Option<ChildNumber> {
-        self.derived_public_keys.last_key_value().map(|(k, _)| *k)
+        self.derived_public_keys.keys().last().copied()
     }
 
     /// Derive up `lookahead_size` keys starting from the last used index. If the gap from the last
@@ -382,12 +382,12 @@ impl LeafKeySoftChain {
 
     /// Get the extended public key provided a public key or None if no key found
     pub fn get_child_num_from_public_key(&self, pub_key: &PublicKey) -> Option<ChildNumber> {
-        self.public_key_to_index.get(pub_key).cloned()
+        self.public_key_to_index.get(pub_key).copied()
     }
 
     /// Get the extended public key provided a public key hash or None if no key found
     pub fn get_child_num_from_public_key_hash(&self, pkh: &PublicKeyHash) -> Option<ChildNumber> {
-        self.public_key_hash_to_index.get(pkh).cloned()
+        self.public_key_hash_to_index.get(pkh).copied()
     }
 
     /// Mark a specific key as used in the key pool. This will update the last used key index if

--- a/wallet/src/key_chain/master_key_chain/mod.rs
+++ b/wallet/src/key_chain/master_key_chain/mod.rs
@@ -21,16 +21,14 @@ use crypto::key::hdkd::derivable::Derivable;
 use crypto::key::hdkd::u31::U31;
 use itertools::Itertools;
 use std::sync::Arc;
-use wallet_storage::{StoreTxRo, StoreTxRw, WalletStorageRead, WalletStorageWrite};
+use utils::ensure;
+use wallet_storage::{StoreTxRw, WalletStorageRead, WalletStorageWrite};
 use wallet_types::{RootKeyContent, RootKeyId};
 use zeroize::Zeroize;
 
 pub struct MasterKeyChain {
     /// The specific chain this KeyChain is based on, this will affect the address format
     chain_config: Arc<ChainConfig>,
-    /// The master key of this key chain from where all the keys are derived from
-    // TODO implement encryption
-    root_key: ExtendedPrivateKey,
 }
 
 impl MasterKeyChain {
@@ -74,31 +72,31 @@ impl MasterKeyChain {
 
         db_tx.set_root_key(&key_id, &key_content)?;
 
-        let root_key = key_content.into_key();
-
-        Ok(MasterKeyChain {
-            chain_config,
-            root_key,
-        })
+        Ok(MasterKeyChain { chain_config })
     }
 
-    /// Load the Master key chain from database and all the account key chains it derives
-    pub fn load_from_database<B: storage::Backend>(
-        chain_config: Arc<ChainConfig>,
-        db_tx: &StoreTxRo<B>,
-    ) -> KeyChainResult<Self> {
-        // The current format supports a single root key
-        let root_key = db_tx
+    pub fn load_root_key(db_tx: &impl WalletStorageRead) -> KeyChainResult<ExtendedPrivateKey> {
+        let key = db_tx
             .get_all_root_keys()?
             .into_values()
             .exactly_one()
             .map_err(|_| KeyChainError::OnlyOneRootKeyIsSupported)?
             .into_key();
 
-        Ok(MasterKeyChain {
-            chain_config,
-            root_key,
-        })
+        Ok(key)
+    }
+
+    /// Creates a Master key chain, checks the database for an existing one
+    pub fn existing_from_database(
+        chain_config: Arc<ChainConfig>,
+        db_tx: &impl WalletStorageRead,
+    ) -> KeyChainResult<Self> {
+        ensure!(
+            db_tx.exactly_one_root_key()?,
+            KeyChainError::OnlyOneRootKeyIsSupported
+        );
+        // The current format supports a single root key
+        Ok(MasterKeyChain { chain_config })
     }
 
     pub fn create_account_key_chain<B: storage::Backend>(
@@ -106,17 +104,14 @@ impl MasterKeyChain {
         db_tx: &mut StoreTxRw<B>,
         account_index: U31,
     ) -> KeyChainResult<AccountKeyChain> {
+        let root_key = Self::load_root_key(db_tx)?;
         AccountKeyChain::new_from_root_key(
             self.chain_config.clone(),
             db_tx,
-            &self.root_key,
+            root_key,
             account_index,
             LOOKAHEAD_SIZE,
         )
-    }
-
-    pub fn root_private_key(&self) -> &ExtendedPrivateKey {
-        &self.root_key
     }
 }
 

--- a/wallet/src/key_chain/master_key_chain/mod.rs
+++ b/wallet/src/key_chain/master_key_chain/mod.rs
@@ -87,7 +87,7 @@ impl MasterKeyChain {
     }
 
     /// Creates a Master key chain, checks the database for an existing one
-    pub fn existing_from_database(
+    pub fn new_from_existing_database(
         chain_config: Arc<ChainConfig>,
         db_tx: &impl WalletStorageRead,
     ) -> KeyChainResult<Self> {

--- a/wallet/src/key_chain/tests.rs
+++ b/wallet/src/key_chain/tests.rs
@@ -100,7 +100,7 @@ fn key_chain_creation(
         key_chain.issue_key(&mut db_tx, purpose).unwrap()
     };
     assert_eq!(pk.get_derivation_path().to_string(), path_str.to_string());
-    let sk = AccountKeyChain::get_private_key(master_key_chain.root_private_key(), &pk).unwrap();
+    let sk = key_chain.derive_private_key(&pk, &db_tx).unwrap();
     let pk2 = ExtendedPublicKey::from_private_key(&sk);
     assert_eq!(pk2.get_derivation_path().to_string(), path_str.to_string());
     assert_eq!(pk, pk2);
@@ -161,7 +161,6 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
         Arc::clone(&chain_config),
         &db.transaction_ro().unwrap(),
         &id,
-        master_key_chain.root_private_key(),
         &account_info,
     )
     .unwrap();
@@ -225,7 +224,6 @@ fn top_up_and_lookahead(#[case] purpose: KeyPurpose) {
         chain_config,
         &db.transaction_ro().unwrap(),
         &id,
-        master_key_chain.root_private_key(),
         &account_info,
     )
     .unwrap();

--- a/wallet/src/key_chain/tests.rs
+++ b/wallet/src/key_chain/tests.rs
@@ -25,7 +25,9 @@ use rstest::rstest;
 use std::str::FromStr;
 use std::sync::Arc;
 use test_utils::assert_encoded_eq;
-use wallet_storage::{DefaultBackend, Store, TransactionRw, Transactional};
+use wallet_storage::{
+    DefaultBackend, Store, TransactionRwLocked, TransactionRwUnlocked, Transactional,
+};
 use wallet_types::{account_info::DEFAULT_ACCOUNT_INDEX, AccountInfo};
 
 const MNEMONIC: &str =
@@ -66,7 +68,7 @@ fn key_chain_creation(
 ) {
     let chain_config = Arc::new(create_unit_test_config());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
-    let mut db_tx = db.transaction_rw(None).unwrap();
+    let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(chain_config, &mut db_tx, MNEMONIC, None).unwrap();
 
@@ -86,7 +88,7 @@ fn key_chain_creation(
     let pkh = PublicKeyHash::zero();
     assert!(!key_chain.is_public_key_hash_mine(&pkh));
 
-    let mut db_tx = db.transaction_rw(None).unwrap();
+    let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
     let path = DerivationPath::from_str(path_str).unwrap();
     // Derive expected key
     let pk = {
@@ -123,7 +125,7 @@ fn key_chain_creation(
 fn key_lookahead(#[case] purpose: KeyPurpose) {
     let chain_config = Arc::new(create_unit_test_config());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
-    let mut db_tx = db.transaction_rw(None).unwrap();
+    let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(chain_config.clone(), &mut db_tx, MNEMONIC, None)
             .unwrap();
@@ -201,7 +203,7 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
 fn top_up_and_lookahead(#[case] purpose: KeyPurpose) {
     let chain_config = Arc::new(create_unit_test_config());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
-    let mut db_tx = db.transaction_rw(None).unwrap();
+    let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(Arc::clone(&chain_config), &mut db_tx, MNEMONIC, None)
             .unwrap();

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -142,7 +142,7 @@ impl<B: storage::Backend> Wallet<B> {
             return Err(WalletError::WalletNotInitialized);
         }
 
-        let key_chain = MasterKeyChain::existing_from_database(chain_config.clone(), &db_tx)?;
+        let key_chain = MasterKeyChain::new_from_existing_database(chain_config.clone(), &db_tx)?;
 
         let accounts_info = db_tx.get_accounts_info()?;
 
@@ -170,11 +170,11 @@ impl<B: storage::Backend> Wallet<B> {
         self.db.encrypt_private_keys(password).map_err(WalletError::from)
     }
 
-    pub fn lock_wallet(&mut self) {
-        self.db.lock_private_keys()
+    pub fn lock_wallet(&mut self) -> WalletResult<()> {
+        self.db.lock_private_keys().map_err(WalletError::from)
     }
 
-    pub fn unlock_wallet(&mut self, password: &Option<String>) -> WalletResult<()> {
+    pub fn unlock_wallet(&mut self, password: &String) -> WalletResult<()> {
         self.db.unlock_private_keys(password).map_err(WalletError::from)
     }
 

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -265,10 +265,11 @@ impl<B: storage::Backend> Wallet<B> {
     }
 
     pub fn get_vrf_public_key(&mut self, account_index: U31) -> WalletResult<VRFPublicKey> {
+        let db_tx = self.db.transaction_ro()?;
         self.accounts
             .get(&account_index)
             .ok_or(WalletError::NoAccountFoundWithIndex(account_index))?
-            .get_vrf_public_key()
+            .get_vrf_public_key(&db_tx)
     }
 
     pub fn create_transaction_to_addresses(

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -142,20 +142,14 @@ impl<B: storage::Backend> Wallet<B> {
             return Err(WalletError::WalletNotInitialized);
         }
 
-        //TODO: if wallet is locked load into read only mode
-        let key_chain = MasterKeyChain::load_from_database(Arc::clone(&chain_config), &db_tx)?;
+        let key_chain = MasterKeyChain::existing_from_database(chain_config.clone(), &db_tx)?;
 
         let accounts_info = db_tx.get_accounts_info()?;
 
         let accounts = accounts_info
             .keys()
             .map(|account_id| {
-                Account::load_from_database(
-                    Arc::clone(&chain_config),
-                    &db_tx,
-                    account_id,
-                    key_chain.root_private_key(),
-                )
+                Account::load_from_database(Arc::clone(&chain_config), &db_tx, account_id)
             })
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
@@ -302,11 +296,12 @@ impl<B: storage::Backend> Wallet<B> {
         &mut self,
         account_index: U31,
     ) -> WalletResult<PoSGenerateBlockInputData> {
+        let db_tx = self.db.transaction_ro()?;
         let account = self
             .accounts
             .get(&account_index)
             .ok_or(WalletError::NoAccountFoundWithIndex(account_index))?;
-        account.get_pos_gen_block_data()
+        account.get_pos_gen_block_data(&db_tx)
     }
 
     /// Returns the last scanned block hash and height.

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -183,6 +183,9 @@ impl<B: storage::Backend> Wallet<B> {
         self.accounts.keys()
     }
 
+    // TODO: this should not be public, as specified by BIP44 accounts must be created sequentially
+    // and a new next account should be rejected if the previously created one has no transactions
+    // associated with it
     pub fn create_account(&mut self, account_index: U31) -> WalletResult<()> {
         ensure!(
             !self.accounts.contains_key(&account_index),

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -497,9 +497,9 @@ fn locked_wallet_accounts_creation_fail(#[case] seed: Seed) {
     let err = wallet.create_account(rng.gen_range(0..1 << 31).try_into().unwrap());
     assert_eq!(
         err,
-        Err(WalletError::KeyChainError(KeyChainError::DatabaseError(
+        Err(WalletError::DatabaseError(
             wallet_storage::Error::WalletLocked
-        )))
+        ))
     );
 
     // success after unlock
@@ -567,9 +567,9 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
 
     assert_eq!(
         wallet.create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output.clone()]),
-        Err(WalletError::KeyChainError(KeyChainError::DatabaseError(
+        Err(WalletError::DatabaseError(
             wallet_storage::Error::WalletLocked
-        )))
+        ))
     );
 
     // success after unlock
@@ -577,4 +577,19 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
     wallet
         .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
         .unwrap();
+}
+
+#[test]
+fn lock_wallet_fail_empty_password() {
+    let chain_config = Arc::new(create_mainnet());
+
+    let db = create_wallet_in_memory().unwrap();
+    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let empty_password = Some(String::new());
+    assert_eq!(
+        wallet.encrypt_wallet(&empty_password),
+        Err(WalletError::DatabaseError(
+            wallet_storage::Error::WalletEmptyPassword
+        ))
+    );
 }

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -66,7 +66,6 @@ fn get_address(
 fn verify_wallet_balance(
     chain_config: &Arc<ChainConfig>,
     wallet: &DefaultWallet,
-    db: &Arc<Store<DefaultBackend>>,
     expected_balance: Amount,
 ) {
     let (coin_balance, _) = wallet
@@ -78,7 +77,8 @@ fn verify_wallet_balance(
     assert_eq!(coin_balance, expected_balance);
 
     // Loading a copy of the wallet from the same DB should be safe because loading is an R/O operation
-    let wallet = Wallet::load_wallet(Arc::clone(chain_config), Arc::clone(db)).unwrap();
+    let db_copy = wallet.db.clone();
+    let wallet = Wallet::load_wallet(Arc::clone(chain_config), db_copy).unwrap();
     let (coin_balance, _) = wallet
         .get_balance(
             DEFAULT_ACCOUNT_INDEX,
@@ -104,28 +104,30 @@ fn test_balance_from_genesis(
 
     let db = create_wallet_in_memory().unwrap();
 
-    let mut wallet =
-        Wallet::new_wallet(Arc::clone(&chain_config), Arc::clone(&db), MNEMONIC, None).unwrap();
+    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
     wallet.create_account(DEFAULT_ACCOUNT_INDEX).unwrap();
 
-    verify_wallet_balance(&chain_config, &wallet, &db, expected_balance);
+    verify_wallet_balance(&chain_config, &wallet, expected_balance);
 }
 
 #[test]
 fn wallet_creation_in_memory() {
     let chain_config = Arc::new(create_regtest());
-    let db = create_wallet_in_memory().unwrap();
+    let empty_db = create_wallet_in_memory().unwrap();
 
-    match Wallet::load_wallet(Arc::clone(&chain_config), Arc::clone(&db)) {
+    // fail to load an empty wallet
+    match Wallet::load_wallet(Arc::clone(&chain_config), empty_db) {
         Ok(_) => panic!("Wallet loading should fail"),
         Err(err) => assert_eq!(err, WalletError::WalletNotInitialized),
     }
 
-    let wallet =
-        Wallet::new_wallet(Arc::clone(&chain_config), Arc::clone(&db), MNEMONIC, None).unwrap();
-    drop(wallet);
+    let empty_db = create_wallet_in_memory().unwrap();
+    // initialize a new wallet with mnemonic
+    let wallet = Wallet::new_wallet(Arc::clone(&chain_config), empty_db, MNEMONIC, None).unwrap();
+    let initialized_db = wallet.db;
 
-    let _wallet = Wallet::load_wallet(chain_config, db).unwrap();
+    // successfully load a wallet from initialized db
+    let _wallet = Wallet::load_wallet(chain_config, initialized_db).unwrap();
 }
 
 #[test]
@@ -183,8 +185,7 @@ fn wallet_balance_block_reward() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet =
-        Wallet::new_wallet(Arc::clone(&chain_config), Arc::clone(&db), MNEMONIC, None).unwrap();
+    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
     wallet.create_account(DEFAULT_ACCOUNT_INDEX).unwrap();
 
     let (coin_balance, _) = wallet
@@ -223,7 +224,7 @@ fn wallet_balance_block_reward() {
     let (best_block_id, best_block_height) = wallet.get_best_block().unwrap();
     assert_eq!(best_block_id, block1_id);
     assert_eq!(best_block_height, BlockHeight::new(1));
-    verify_wallet_balance(&chain_config, &wallet, &db, block1_amount);
+    verify_wallet_balance(&chain_config, &wallet, block1_amount);
 
     // Create the second block that sends the reward to the wallet
     let block2_amount = Amount::from_atoms(20000);
@@ -252,7 +253,6 @@ fn wallet_balance_block_reward() {
     verify_wallet_balance(
         &chain_config,
         &wallet,
-        &db,
         (block1_amount + block2_amount).unwrap(),
     );
 
@@ -285,7 +285,6 @@ fn wallet_balance_block_reward() {
     verify_wallet_balance(
         &chain_config,
         &wallet,
-        &db,
         (block1_amount + block2_amount_new).unwrap(),
     );
 }
@@ -295,8 +294,7 @@ fn wallet_balance_block_transactions() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet =
-        Wallet::new_wallet(Arc::clone(&chain_config), Arc::clone(&db), MNEMONIC, None).unwrap();
+    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
     wallet.create_account(DEFAULT_ACCOUNT_INDEX).unwrap();
 
     let tx_amount1 = Amount::from_atoms(10000);
@@ -326,7 +324,7 @@ fn wallet_balance_block_transactions() {
 
     wallet.scan_new_blocks(BlockHeight::new(0), vec![block1]).unwrap();
 
-    verify_wallet_balance(&chain_config, &wallet, &db, tx_amount1);
+    verify_wallet_balance(&chain_config, &wallet, tx_amount1);
 }
 
 #[test]
@@ -335,8 +333,7 @@ fn wallet_balance_parent_child_transactions() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet =
-        Wallet::new_wallet(Arc::clone(&chain_config), Arc::clone(&db), MNEMONIC, None).unwrap();
+    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
     wallet.create_account(DEFAULT_ACCOUNT_INDEX).unwrap();
 
     let tx_amount1 = Amount::from_atoms(20000);
@@ -386,20 +383,20 @@ fn wallet_balance_parent_child_transactions() {
 
     wallet.scan_new_blocks(BlockHeight::new(0), vec![block1]).unwrap();
 
-    verify_wallet_balance(&chain_config, &wallet, &db, tx_amount2);
+    verify_wallet_balance(&chain_config, &wallet, tx_amount2);
 }
 
 #[track_caller]
 fn test_wallet_accounts(
     chain_config: &Arc<ChainConfig>,
     wallet: &DefaultWallet,
-    db: &Arc<Store<DefaultBackend>>,
     expected_accounts: Vec<U31>,
 ) {
     let accounts = wallet.account_indexes().cloned().collect::<Vec<_>>();
     assert_eq!(accounts, expected_accounts);
 
-    let mut wallet = Wallet::load_wallet(Arc::clone(chain_config), Arc::clone(db)).unwrap();
+    let db_copy = wallet.db.clone();
+    let mut wallet = Wallet::load_wallet(Arc::clone(chain_config), db_copy).unwrap();
     let accounts = wallet.account_indexes().cloned().collect::<Vec<_>>();
     assert_eq!(accounts, expected_accounts);
 
@@ -413,24 +410,21 @@ fn wallet_accounts_creation() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet =
-        Wallet::new_wallet(Arc::clone(&chain_config), Arc::clone(&db), MNEMONIC, None).unwrap();
-    test_wallet_accounts(&chain_config, &wallet, &db, vec![]);
+    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    test_wallet_accounts(&chain_config, &wallet, vec![]);
 
     wallet.create_account(DEFAULT_ACCOUNT_INDEX).unwrap();
-    test_wallet_accounts(&chain_config, &wallet, &db, vec![DEFAULT_ACCOUNT_INDEX]);
+    test_wallet_accounts(&chain_config, &wallet, vec![DEFAULT_ACCOUNT_INDEX]);
 
     wallet.create_account(1.try_into().unwrap()).unwrap();
     test_wallet_accounts(
         &chain_config,
         &wallet,
-        &db,
         vec![DEFAULT_ACCOUNT_INDEX, 1.try_into().unwrap()],
     );
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet =
-        Wallet::new_wallet(Arc::clone(&chain_config), Arc::clone(&db), MNEMONIC, None).unwrap();
+    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
     wallet.create_account(123.try_into().unwrap()).unwrap();
-    test_wallet_accounts(&chain_config, &wallet, &db, vec![123.try_into().unwrap()]);
+    test_wallet_accounts(&chain_config, &wallet, vec![123.try_into().unwrap()]);
 }

--- a/wallet/storage/Cargo.toml
+++ b/wallet/storage/Cargo.toml
@@ -17,7 +17,6 @@ utxo = { path = '../../utxo' }
 wallet-types = { path = '../types' }
 utils = { path = '../../utils' }
 
-# External dependencies
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/wallet/storage/Cargo.toml
+++ b/wallet/storage/Cargo.toml
@@ -15,9 +15,12 @@ storage = { path = '../../storage', features = ['inmemory'] }
 storage-sqlite = { path = "../../storage/sqlite" }
 utxo = { path = '../../utxo' }
 wallet-types = { path = '../types' }
+utils = { path = '../../utils' }
+
+# External dependencies
+thiserror.workspace = true
 
 [dev-dependencies]
 test-utils = {path = '../../test-utils'}
-utils = { path = '../../utils' }
 
 rstest.workspace = true

--- a/wallet/storage/src/internal/mod.rs
+++ b/wallet/storage/src/internal/mod.rs
@@ -237,6 +237,7 @@ impl<B: storage::Backend> WalletStorageRead for Store<B> {
         fn get_addresses(&self, account_id: &AccountId) -> crate::Result<BTreeMap<AccountDerivationPathId, Address>>;
         fn get_root_key(&self, id: &RootKeyId) -> crate::Result<Option<RootKeyContent >>;
         fn get_all_root_keys(&self) -> crate::Result<BTreeMap<RootKeyId, RootKeyContent >>;
+        fn exactly_one_root_key(&self) -> crate::Result<bool>;
         fn check_can_decrypt_all_root_keys(&self, encryption_key: &SymmetricKey) -> crate::Result<()>;
         fn get_keychain_usage_state(&self, id: &AccountKeyPurposeId) -> crate::Result<Option<KeychainUsageState>>;
         fn get_keychain_usage_states(&self, account_id: &AccountId) -> crate::Result<BTreeMap<AccountKeyPurposeId, KeychainUsageState>>;

--- a/wallet/storage/src/internal/password.rs
+++ b/wallet/storage/src/internal/password.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::num::NonZeroUsize;
+
+use crypto::{
+    kdf::{
+        argon2::Argon2Config, hash_from_challenge, hash_password, KdfChallenge, KdfConfig,
+        KdfResult,
+    },
+    random::make_true_rng,
+    symkey::{key_size, SymmetricKey, SymmetricKeyKind},
+};
+
+/// Converts a password into a symmetric encryption key and generates a KDF challenge.
+///
+/// # Arguments
+///
+/// * `password` - A `String` representing the password to convert into a symmetric encryption key.
+///
+/// # Returns
+///
+/// This function returns a tuple `(SymmetricKey, KdfChallenge)`, where `SymmetricKey` is the derived
+/// encryption key and `KdfChallenge` is the generated challenge value.
+///
+pub fn password_to_sym_key(password: &String) -> crate::Result<(SymmetricKey, KdfChallenge)> {
+    if password.is_empty() {
+        return Err(crate::Error::WalletEmptyPassword);
+    }
+
+    let mut rng = make_true_rng();
+    let config = KdfConfig::Argon2id {
+        // TODO: hardcoded values
+        config: Argon2Config::new(700, 16, 2),
+        hash_length: NonZeroUsize::new(key_size(SymmetricKeyKind::XChacha20Poly1305))
+            .expect("not 0"),
+        salt_length: NonZeroUsize::new(32).expect("not 0"),
+    };
+    let kdf_result = hash_password(&mut rng, config, password.as_bytes())
+        .map_err(|_| crate::Error::WalletInvalidPassword)?;
+    let KdfResult::Argon2id {
+        hashed_password,
+        config: _,
+        salt: _,
+    } = &kdf_result;
+
+    let sym_key = SymmetricKey::from_raw_key(
+        SymmetricKeyKind::XChacha20Poly1305,
+        hashed_password.as_slice(),
+    )
+    .expect("must be correct size");
+
+    let challenge = kdf_result.into_challenge();
+
+    Ok((sym_key, challenge))
+}
+
+/// Derives a symmetric encryption key from a password and a KDF challenge.
+///
+/// This function takes a password and a KDF challenge as input and derives a symmetric encryption key
+/// using a key derivation function (KDF). The KDF challenge is used to authenticate the derived key
+/// during decryption.
+///
+/// # Arguments
+///
+/// * `password` - A `String` representing the password to derive the symmetric encryption key.
+/// * `kdf_challenge` - A `KdfChallenge` representing the challenge used for key derivation.
+///
+/// # Returns
+///
+/// This function returns a `SymmetricKey`, which is the derived encryption key.
+/// Returns an WalletInvalidPassword error if the password did not pass the challenge
+///
+pub fn challenge_to_sym_key(
+    password: &String,
+    kdf_challenge: KdfChallenge,
+) -> crate::Result<SymmetricKey> {
+    let KdfResult::Argon2id {
+        hashed_password,
+        salt: _,
+        config: _,
+    } = hash_from_challenge(kdf_challenge, password.as_bytes())
+        .map_err(|_| crate::Error::WalletInvalidPassword)?;
+
+    let sym_key = SymmetricKey::from_raw_key(
+        SymmetricKeyKind::XChacha20Poly1305,
+        hashed_password.as_slice(),
+    )
+    .expect("must be correct size");
+
+    Ok(sym_key)
+}
+
+#[cfg(test)]
+mod test {
+    use crypto::random::Rng;
+    use rstest::rstest;
+    use test_utils::random::{make_seedable_rng, Seed};
+
+    use super::{challenge_to_sym_key, password_to_sym_key};
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn test_password_to_challenge_and_back(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+
+        let password: String = (0..rng.gen_range(1..100)).map(|_| rng.gen::<char>()).collect();
+        let (original_key, kdf_challenge) = password_to_sym_key(&password).unwrap();
+
+        let reconstructed_key = challenge_to_sym_key(&password, kdf_challenge).unwrap();
+
+        assert_eq!(original_key, reconstructed_key);
+    }
+
+    #[test]
+    fn test_empty_password_error() {
+        let password = String::new();
+        let result = password_to_sym_key(&password);
+
+        assert_eq!(result, Err(crate::Error::WalletEmptyPassword));
+    }
+}

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -177,6 +177,15 @@ macro_rules! impl_read_ops {
                     .map(Iterator::collect)
             }
 
+            fn exactly_one_root_key(&self) -> crate::Result<bool> {
+                self.storage
+                    .get::<db::DBRootKeys, _>()
+                    .prefix_iter_decoded(&())
+                    .map_err(crate::Error::from)
+                    .map(Iterator::count)
+                    .map(|count| count == 1)
+            }
+
             /// Check if the provided encryption_key can decrypt all of the root keys
             fn check_can_decrypt_all_root_keys(
                 &self,

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -16,7 +16,10 @@
 use std::collections::BTreeMap;
 
 use common::address::Address;
-use crypto::key::extended::ExtendedPublicKey;
+use crypto::{
+    kdf::KdfChallenge, key::extended::ExtendedPublicKey, random::make_true_rng,
+    symkey::SymmetricKey,
+};
 use serialization::{Codec, DecodeAll, Encode, EncodeLike};
 use storage::schema;
 use wallet_types::{
@@ -30,6 +33,8 @@ use crate::{
 };
 
 mod well_known {
+    use crypto::kdf::KdfChallenge;
+
     use super::Codec;
 
     /// Pre-defined database keys
@@ -51,13 +56,50 @@ mod well_known {
     }
 
     declare_entry!(StoreVersion: u32);
+    declare_entry!(EncryptionKeyKdfChallenge: KdfChallenge);
 }
 
 /// Read-only chainstate storage transaction
-pub struct StoreTxRo<'st, B: storage::Backend>(pub(super) storage::TransactionRo<'st, B, Schema>);
+pub struct StoreTxRo<'st, B: storage::Backend> {
+    pub(super) storage: storage::TransactionRo<'st, B, Schema>,
+    encryption_key: &'st Option<SymmetricKey>,
+    locked: bool,
+}
 
 /// Read-write chainstate storage transaction
-pub struct StoreTxRw<'st, B: storage::Backend>(pub(super) storage::TransactionRw<'st, B, Schema>);
+pub struct StoreTxRw<'st, B: storage::Backend> {
+    pub(super) storage: storage::TransactionRw<'st, B, Schema>,
+    encryption_key: &'st Option<SymmetricKey>,
+    locked: bool,
+}
+
+impl<'st, B: storage::Backend> StoreTxRo<'st, B> {
+    pub fn new(
+        storage: storage::TransactionRo<'st, B, Schema>,
+        encryption_key: &'st Option<SymmetricKey>,
+        locked: bool,
+    ) -> Self {
+        Self {
+            storage,
+            encryption_key,
+            locked,
+        }
+    }
+}
+
+impl<'st, B: storage::Backend> StoreTxRw<'st, B> {
+    pub fn new(
+        storage: storage::TransactionRw<'st, B, Schema>,
+        encryption_key: &'st Option<SymmetricKey>,
+        locked: bool,
+    ) -> Self {
+        Self {
+            storage,
+            encryption_key,
+            locked,
+        }
+    }
+}
 
 macro_rules! impl_read_ops {
     ($TxType:ident) => {
@@ -72,7 +114,7 @@ macro_rules! impl_read_ops {
             }
 
             fn get_accounts_info(&self) -> crate::Result<BTreeMap<AccountId, AccountInfo>> {
-                Ok(self.0.get::<db::DBAccounts, _>().prefix_iter_decoded(&())?.collect())
+                Ok(self.storage.get::<db::DBAccounts, _>().prefix_iter_decoded(&())?.collect())
             }
 
             fn get_address(&self, id: &AccountDerivationPathId) -> crate::Result<Option<Address>> {
@@ -83,22 +125,78 @@ macro_rules! impl_read_ops {
                 &self,
                 account_id: &AccountId,
             ) -> crate::Result<BTreeMap<AccountDerivationPathId, Address>> {
-                self.0
+                self.storage
                     .get::<db::DBAddresses, _>()
                     .prefix_iter_decoded(account_id)
+                    .map_err(crate::Error::from)
                     .map(Iterator::collect)
             }
 
+            fn get_encryption_key_kdf_challenge(&self) -> crate::Result<Option<KdfChallenge>> {
+                self.read_value::<well_known::EncryptionKeyKdfChallenge>()
+            }
+
             fn get_root_key(&self, id: &RootKeyId) -> crate::Result<Option<RootKeyContent>> {
-                self.read::<db::DBRootKeys, _, _>(id)
+                utils::ensure!(!self.locked, crate::Error::WalletLocked());
+                Ok(self
+                    .read::<db::DBRootKeys, _, _>(id)?
+                    .map(|v| match self.encryption_key.as_ref() {
+                        Some(key) => {
+                            (key.decrypt(v.as_slice(), None)
+                                .expect("key has been checked in unlock_private_keys"))
+                        }
+                        None => (v),
+                    })
+                    .map(|v| RootKeyContent::decode_all(&mut v.as_slice()).expect("valid decode")))
             }
 
             /// Collect and return all keys from the storage
             fn get_all_root_keys(&self) -> crate::Result<BTreeMap<RootKeyId, RootKeyContent>> {
-                self.0
+                utils::ensure!(!self.locked, crate::Error::WalletLocked());
+                self.storage
                     .get::<db::DBRootKeys, _>()
                     .prefix_iter_decoded(&())
+                    .map_err(crate::Error::from)
+                    .map(|item| {
+                        item.map(|(k, v)| match self.encryption_key.as_ref() {
+                            Some(key) => (
+                                k,
+                                key.decrypt(v.as_slice(), None)
+                                    .expect("key has been checked in unlock_private_keys"),
+                            ),
+                            None => (k, v),
+                        })
+                        .map(|(k, v)| {
+                            (
+                                k,
+                                RootKeyContent::decode_all(&mut v.as_slice())
+                                    .expect("valid decode"),
+                            )
+                        })
+                    })
                     .map(Iterator::collect)
+            }
+
+            /// Check if the provided encryption_key can decrypt all of the root keys
+            fn check_can_decrypt_all_root_keys(
+                &self,
+                encryption_key: &SymmetricKey,
+            ) -> crate::Result<()> {
+                self.storage
+                    .get::<db::DBRootKeys, _>()
+                    .prefix_iter_decoded(&())
+                    .map_err(crate::Error::from)
+                    .map(|mut item| {
+                        item.try_for_each(|(_, v)| {
+                            let decrypted_value = encryption_key
+                                .decrypt(v.as_slice(), None)
+                                .map_err(|_| crate::Error::WalletInvalidPassword())?;
+
+                            RootKeyContent::decode_all(&mut decrypted_value.as_slice())
+                                .map_err(|_| crate::Error::WalletInvalidPassword())?;
+                            Ok(())
+                        })
+                    })?
             }
 
             /// Collect and return all transactions from the storage
@@ -106,9 +204,10 @@ macro_rules! impl_read_ops {
                 &self,
                 account_id: &AccountId,
             ) -> crate::Result<BTreeMap<AccountWalletTxId, WalletTx>> {
-                self.0
+                self.storage
                     .get::<db::DBTxs, _>()
                     .prefix_iter_decoded(account_id)
+                    .map_err(crate::Error::from)
                     .map(Iterator::collect)
             }
 
@@ -123,9 +222,10 @@ macro_rules! impl_read_ops {
                 &self,
                 account_id: &AccountId,
             ) -> crate::Result<BTreeMap<AccountKeyPurposeId, KeychainUsageState>> {
-                self.0
+                self.storage
                     .get::<db::DBKeychainUsageStates, _>()
                     .prefix_iter_decoded(account_id)
+                    .map_err(crate::Error::from)
                     .map(Iterator::collect)
             }
 
@@ -140,9 +240,10 @@ macro_rules! impl_read_ops {
                 &self,
                 account_id: &AccountId,
             ) -> crate::Result<BTreeMap<AccountDerivationPathId, ExtendedPublicKey>> {
-                self.0
+                self.storage
                     .get::<db::DBPubKeys, _>()
                     .prefix_iter_decoded(account_id)
+                    .map_err(crate::Error::from)
                     .map(Iterator::collect)
             }
         }
@@ -155,7 +256,7 @@ macro_rules! impl_read_ops {
                 Schema: schema::HasDbMap<DbMap, I>,
                 K: EncodeLike<DbMap::Key>,
             {
-                let map = self.0.get::<DbMap, I>();
+                let map = self.storage.get::<DbMap, I>();
                 map.get(key).map_err(crate::Error::from).map(|x| x.map(|x| x.decode()))
             }
 
@@ -185,7 +286,7 @@ impl<'st, B: storage::Backend> WalletStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn del_transaction(&mut self, id: &AccountWalletTxId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBTxs, _>().del(id).map_err(Into::into)
+        self.storage.get_mut::<db::DBTxs, _>().del(id).map_err(Into::into)
     }
 
     fn set_account(&mut self, id: &AccountId, tx: &AccountInfo) -> crate::Result<()> {
@@ -193,7 +294,7 @@ impl<'st, B: storage::Backend> WalletStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn del_account(&mut self, id: &AccountId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBAccounts, _>().del(id).map_err(Into::into)
+        self.storage.get_mut::<db::DBAccounts, _>().del(id).map_err(Into::into)
     }
 
     fn set_address(
@@ -205,15 +306,62 @@ impl<'st, B: storage::Backend> WalletStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn del_address(&mut self, id: &AccountDerivationPathId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBAddresses, _>().del(id).map_err(Into::into)
+        self.storage.get_mut::<db::DBAddresses, _>().del(id).map_err(Into::into)
     }
 
     fn set_root_key(&mut self, id: &RootKeyId, tx: &RootKeyContent) -> crate::Result<()> {
-        self.write::<db::DBRootKeys, _, _, _>(id, tx)
+        utils::ensure!(!self.locked, crate::Error::WalletLocked());
+        let encoded_value = match self.encryption_key.as_ref() {
+            Some(key) => key
+                .encrypt(tx.encode().as_slice(), &mut make_true_rng(), None)
+                .expect("should not fail"),
+            None => tx.encode(),
+        };
+        self.write::<db::DBRootKeys, _, _, _>(id, encoded_value)
     }
 
     fn del_root_key(&mut self, id: &RootKeyId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBRootKeys, _>().del(id).map_err(Into::into)
+        utils::ensure!(!self.locked, crate::Error::WalletLocked());
+        self.storage.get_mut::<db::DBRootKeys, _>().del(id).map_err(Into::into)
+    }
+
+    fn encrypt_root_keys(
+        &mut self,
+        new_encryption_key: &Option<SymmetricKey>,
+    ) -> crate::Result<()> {
+        utils::ensure!(!self.locked, crate::Error::WalletLocked());
+
+        let changed_root_keys: Vec<_> = self
+            .storage
+            .get::<db::DBRootKeys, _>()
+            .prefix_iter_decoded(&())
+            .map_err(crate::Error::from)
+            .map(|item| {
+                item.map(|(k, v)| match self.encryption_key.as_ref() {
+                    Some(key) => (
+                        k,
+                        key.decrypt(v.as_slice(), None)
+                            .expect("key has been checked in unlock_private_keys"),
+                    ),
+                    None => (k, v),
+                })
+                .map(|(k, v)| {
+                    (
+                        k,
+                        match new_encryption_key.as_ref() {
+                            Some(key) => key
+                                .encrypt(v.as_slice(), &mut make_true_rng(), None)
+                                .expect("should not fail"),
+                            None => v,
+                        },
+                    )
+                })
+            })?
+            .collect();
+
+        changed_root_keys
+            .into_iter()
+            .try_for_each(|(k, v)| self.write::<db::DBRootKeys, _, _, _>(k, v))
     }
 
     fn set_keychain_usage_state(
@@ -225,7 +373,10 @@ impl<'st, B: storage::Backend> WalletStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn del_keychain_usage_state(&mut self, id: &AccountKeyPurposeId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBKeychainUsageStates, _>().del(id).map_err(Into::into)
+        self.storage
+            .get_mut::<db::DBKeychainUsageStates, _>()
+            .del(id)
+            .map_err(Into::into)
     }
 
     fn set_public_key(
@@ -236,7 +387,12 @@ impl<'st, B: storage::Backend> WalletStorageWrite for StoreTxRw<'st, B> {
         self.write::<db::DBPubKeys, _, _, _>(id, pub_key)
     }
     fn det_public_key(&mut self, id: &AccountDerivationPathId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBPubKeys, _>().del(id).map_err(Into::into)
+        self.storage.get_mut::<db::DBPubKeys, _>().del(id).map_err(Into::into)
+    }
+
+    fn set_encryption_kdf_challenge(&mut self, salt: &KdfChallenge) -> crate::Result<()> {
+        self.write_value::<well_known::EncryptionKeyKdfChallenge>(salt)
+            .map_err(Into::into)
     }
 }
 
@@ -249,7 +405,7 @@ impl<'st, B: storage::Backend> StoreTxRw<'st, B> {
         K: EncodeLike<<DbMap as schema::DbMap>::Key>,
         V: EncodeLike<<DbMap as schema::DbMap>::Value>,
     {
-        self.0.get_mut::<DbMap, I>().put(key, value).map_err(Into::into)
+        self.storage.get_mut::<DbMap, I>().put(key, value).map_err(Into::into)
     }
 
     // Write a value for a well-known entry
@@ -260,17 +416,17 @@ impl<'st, B: storage::Backend> StoreTxRw<'st, B> {
 
 impl<'st, B: storage::Backend> crate::TransactionRo for StoreTxRo<'st, B> {
     fn close(self) {
-        self.0.close()
+        self.storage.close()
     }
 }
 
 impl<'st, B: storage::Backend> crate::TransactionRw for StoreTxRw<'st, B> {
     fn commit(self) -> crate::Result<()> {
-        self.0.commit().map_err(Into::into)
+        self.storage.commit().map_err(Into::into)
     }
 
     fn abort(self) {
-        self.0.abort()
+        self.storage.abort()
     }
 }
 

--- a/wallet/storage/src/internal/test.rs
+++ b/wallet/storage/src/internal/test.rs
@@ -16,6 +16,11 @@
 use super::*;
 use crate::DefaultBackend;
 
+use crypto::key::extended::{ExtendedKeyKind, ExtendedPrivateKey};
+use crypto::random::{CryptoRng, Rng};
+use rstest::rstest;
+use test_utils::random::{make_seedable_rng, Seed};
+
 #[test]
 fn storage_get_default_version_in_tx() {
     utils::concurrency::model(|| {
@@ -26,4 +31,67 @@ fn storage_get_default_version_in_tx() {
         assert_eq!(vtx, 1, "Default storage version wrong");
         assert_eq!(vtx, vst, "Transaction and non-transaction inconsistency");
     })
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn compare_encrypt_and_decrypt_root_key(#[case] seed: Seed) {
+    utils::concurrency::model(move || {
+        let mut rng = make_seedable_rng(seed);
+        let mut store = Store::new(DefaultBackend::new_in_memory()).unwrap();
+        let (xpriv_key, xpub_key) =
+            ExtendedPrivateKey::new_from_rng(&mut rng, ExtendedKeyKind::Secp256k1Schnorr);
+        let key_id = RootKeyId::from(xpub_key);
+        let key_content = RootKeyContent::from(xpriv_key);
+        store.set_root_key(&key_id, &key_content).unwrap();
+
+        // check it was writen correctly
+        assert_eq!(store.get_root_key(&key_id).unwrap().unwrap(), key_content);
+
+        // now encrypt the keys with a new password
+
+        let new_password = gen_random_password(&mut rng);
+        store.encrypt_private_keys(&new_password).unwrap();
+
+        // check it can decrypt it correctly
+        assert_eq!(store.get_root_key(&key_id).unwrap().unwrap(), key_content);
+
+        // after locking the store can't operate on the root keys
+        store.lock_private_keys();
+
+        let error = store.get_root_key(&key_id);
+        assert_eq!(error, Err(crate::Error::WalletLocked()));
+        let error = store.get_all_root_keys();
+        assert_eq!(error, Err(crate::Error::WalletLocked()));
+        let error = store.set_root_key(&key_id, &key_content);
+        assert_eq!(error, Err(crate::Error::WalletLocked()));
+        let error = store.del_root_key(&key_id);
+        assert_eq!(error, Err(crate::Error::WalletLocked()));
+
+        // fail to unlock with the wrong password
+        let mut wrong_password = gen_random_password(&mut rng);
+        while wrong_password == new_password {
+            wrong_password = gen_random_password(&mut rng);
+        }
+        assert_ne!(new_password, wrong_password);
+
+        let error = store.unlock_private_keys(&wrong_password);
+        assert_eq!(error, Err(crate::Error::WalletInvalidPassword()));
+
+        // after unlocking with the right key we can get the root keys again
+        store.unlock_private_keys(&new_password).unwrap();
+
+        // check it can decrypt it correctly
+        assert_eq!(store.get_root_key(&key_id).unwrap().unwrap(), key_content);
+    })
+}
+
+fn gen_random_password(rng: &mut (impl Rng + CryptoRng)) -> Option<String> {
+    let new_password: String = (0..rng.gen_range(0..100)).map(|_| rng.gen::<char>()).collect();
+    if new_password.is_empty() {
+        Some(new_password)
+    } else {
+        None
+    }
 }

--- a/wallet/storage/src/internal/test.rs
+++ b/wallet/storage/src/internal/test.rs
@@ -21,6 +21,10 @@ use crypto::random::{CryptoRng, Rng};
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
 
+fn gen_random_password(rng: &mut (impl Rng + CryptoRng)) -> String {
+    (0..rng.gen_range(1..100)).map(|_| rng.gen::<char>()).collect()
+}
+
 #[test]
 fn storage_get_default_version_in_tx() {
     utils::concurrency::model(|| {
@@ -46,28 +50,28 @@ fn compare_encrypt_and_decrypt_root_key(#[case] seed: Seed) {
         let key_content = RootKeyContent::from(xpriv_key);
         store.set_root_key(&key_id, &key_content).unwrap();
 
-        // check it was writen correctly
+        // check it was written correctly
         assert_eq!(store.get_root_key(&key_id).unwrap().unwrap(), key_content);
 
         // now encrypt the keys with a new password
 
         let new_password = gen_random_password(&mut rng);
-        store.encrypt_private_keys(&new_password).unwrap();
+        store.encrypt_private_keys(&Some(new_password.clone())).unwrap();
 
         // check it can decrypt it correctly
         assert_eq!(store.get_root_key(&key_id).unwrap().unwrap(), key_content);
 
         // after locking the store can't operate on the root keys
-        store.lock_private_keys();
+        store.lock_private_keys().unwrap();
 
         let error = store.get_root_key(&key_id);
-        assert_eq!(error, Err(crate::Error::WalletLocked()));
+        assert_eq!(error, Err(crate::Error::WalletLocked));
         let error = store.get_all_root_keys();
-        assert_eq!(error, Err(crate::Error::WalletLocked()));
+        assert_eq!(error, Err(crate::Error::WalletLocked));
         let error = store.set_root_key(&key_id, &key_content);
-        assert_eq!(error, Err(crate::Error::WalletLocked()));
+        assert_eq!(error, Err(crate::Error::WalletLocked));
         let error = store.del_root_key(&key_id);
-        assert_eq!(error, Err(crate::Error::WalletLocked()));
+        assert_eq!(error, Err(crate::Error::WalletLocked));
 
         // fail to unlock with the wrong password
         let mut wrong_password = gen_random_password(&mut rng);
@@ -77,7 +81,7 @@ fn compare_encrypt_and_decrypt_root_key(#[case] seed: Seed) {
         assert_ne!(new_password, wrong_password);
 
         let error = store.unlock_private_keys(&wrong_password);
-        assert_eq!(error, Err(crate::Error::WalletInvalidPassword()));
+        assert_eq!(error, Err(crate::Error::WalletInvalidPassword));
 
         // after unlocking with the right key we can get the root keys again
         store.unlock_private_keys(&new_password).unwrap();
@@ -85,13 +89,4 @@ fn compare_encrypt_and_decrypt_root_key(#[case] seed: Seed) {
         // check it can decrypt it correctly
         assert_eq!(store.get_root_key(&key_id).unwrap().unwrap(), key_content);
     })
-}
-
-fn gen_random_password(rng: &mut (impl Rng + CryptoRng)) -> Option<String> {
-    let new_password: String = (0..rng.gen_range(0..100)).map(|_| rng.gen::<char>()).collect();
-    if new_password.is_empty() {
-        Some(new_password)
-    } else {
-        None
-    }
 }

--- a/wallet/storage/src/is_transaction_seal.rs
+++ b/wallet/storage/src/is_transaction_seal.rs
@@ -18,3 +18,5 @@ pub trait Seal {}
 
 impl<'st, B: storage::Backend> Seal for crate::internal::StoreTxRo<'st, B> {}
 impl<'st, B: storage::Backend> Seal for crate::internal::StoreTxRw<'st, B> {}
+impl<'st, B: storage::Backend> Seal for crate::internal::StoreTxRoUnlocked<'st, B> {}
+impl<'st, B: storage::Backend> Seal for crate::internal::StoreTxRwUnlocked<'st, B> {}

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -35,9 +35,15 @@ pub enum Error {
     #[error("{0}")]
     StorageError(#[from] storage::Error),
     #[error("The wallet is locked")]
-    WalletLocked(),
+    WalletLocked,
+    #[error("Cannot encrypt the wallet with an empty password")]
+    WalletEmptyPassword,
     #[error("Invalid wallet password")]
-    WalletInvalidPassword(),
+    WalletInvalidPassword,
+    #[error("The wallet is already unlocked")]
+    WalletAlreadyUnlocked,
+    #[error("Cannot lock the wallet without setting a password")]
+    WalletLockedWithoutAPassword,
 }
 
 /// Possibly failing result of wallet storage query

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -60,6 +60,7 @@ pub trait WalletStorageRead {
     ) -> Result<BTreeMap<AccountDerivationPathId, Address>>;
     fn get_root_key(&self, id: &RootKeyId) -> Result<Option<RootKeyContent>>;
     fn get_all_root_keys(&self) -> Result<BTreeMap<RootKeyId, RootKeyContent>>;
+    fn exactly_one_root_key(&self) -> Result<bool>;
     fn check_can_decrypt_all_root_keys(&self, encryption_key: &SymmetricKey) -> crate::Result<()>;
     fn get_keychain_usage_state(
         &self,

--- a/wallet/storage/src/schema.rs
+++ b/wallet/storage/src/schema.rs
@@ -15,8 +15,10 @@
 
 //! Wallet database schema
 
+use crate::RootKeyContent;
 use common::address::Address;
 use crypto::key::extended::ExtendedPublicKey;
+use utils::maybe_encrypted::MaybeEncrypted;
 use wallet_types::{
     AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletTxId,
     KeychainUsageState, RootKeyId, WalletTx,
@@ -32,7 +34,7 @@ storage::decl_schema! {
         /// Store keychain usage states
         pub DBKeychainUsageStates: Map<AccountKeyPurposeId, KeychainUsageState>,
         /// Store for all the private keys in this wallet
-        pub DBRootKeys: Map<RootKeyId, Vec<u8>>,
+        pub DBRootKeys: Map<RootKeyId, MaybeEncrypted<RootKeyContent>>,
         /// Store for all the public keys in this wallet
         pub DBPubKeys: Map<AccountDerivationPathId, ExtendedPublicKey>,
         /// Store for all the addresses that belong to an account

--- a/wallet/storage/src/schema.rs
+++ b/wallet/storage/src/schema.rs
@@ -19,7 +19,7 @@ use common::address::Address;
 use crypto::key::extended::ExtendedPublicKey;
 use wallet_types::{
     AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletTxId,
-    KeychainUsageState, RootKeyContent, RootKeyId, WalletTx,
+    KeychainUsageState, RootKeyId, WalletTx,
 };
 
 storage::decl_schema! {
@@ -32,7 +32,7 @@ storage::decl_schema! {
         /// Store keychain usage states
         pub DBKeychainUsageStates: Map<AccountKeyPurposeId, KeychainUsageState>,
         /// Store for all the private keys in this wallet
-        pub DBRootKeys: Map<RootKeyId, RootKeyContent>,
+        pub DBRootKeys: Map<RootKeyId, Vec<u8>>,
         /// Store for all the public keys in this wallet
         pub DBPubKeys: Map<AccountDerivationPathId, ExtendedPublicKey>,
         /// Store for all the addresses that belong to an account

--- a/wallet/types/Cargo.toml
+++ b/wallet/types/Cargo.toml
@@ -14,7 +14,7 @@ serialization = { path = "../../serialization" }
 storage = { path = '../../storage', features = ['inmemory'] }
 
 bip39 = { version = "2.0", default-features = false, features = ["std", "zeroize"] }
-zeroize = "1.5"
+zeroize.workspace = true
 thiserror.workspace = true
 parity-scale-codec.workspace = true
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -33,7 +33,7 @@ use self::helper_types::CliUtxoTypes;
 #[derive(Debug, Parser)]
 #[clap(rename_all = "lower")]
 pub enum WalletCommand {
-    // TODO: Add optional password
+    // TODO: Add Encrypt/Unlock/Lock wallet commands
     /// Create new wallet
     CreateWallet {
         /// File path

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -59,8 +59,8 @@ pub enum WalletCommand {
 
     // Unlocks the private keys for usage.
     UnlockPrivateKeys {
-        // Optional existing password if there is any.
-        password: Option<String>,
+        // The existing password.
+        password: String,
     },
 
     // Locks the private keys so they can't be used until they are unlocked again
@@ -329,7 +329,7 @@ pub async fn handle_wallet_command(
                     return Err(WalletCliError::NoWallet);
                 }
                 Some(controller) => {
-                    controller.lock_wallet();
+                    controller.lock_wallet().map_err(WalletCliError::Controller)?;
                 }
             }
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -33,7 +33,6 @@ use self::helper_types::CliUtxoTypes;
 #[derive(Debug, Parser)]
 #[clap(rename_all = "lower")]
 pub enum WalletCommand {
-    // TODO: Add Encrypt/Unlock/Lock wallet commands
     /// Create new wallet
     CreateWallet {
         /// File path

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -52,6 +52,21 @@ pub enum WalletCommand {
     /// Close wallet file
     CloseWallet,
 
+    /// Encrypts the private keys with a new password, expects the wallet to be unlocked
+    EncryptPrivateKeys {
+        // Optional new password, if not specified will remove any existing encryption.
+        password: Option<String>,
+    },
+
+    // Unlocks the private keys for usage.
+    UnlockPrivateKeys {
+        // Optional existing password if there is any.
+        password: Option<String>,
+    },
+
+    // Locks the private keys so they can't be used until they are unlocked again
+    LockPrivateKeys,
+
     /// Returns the node chainstate
     ChainstateInfo,
 
@@ -279,6 +294,45 @@ pub async fn handle_wallet_command(
             utils::ensure!(controller_opt.is_some(), WalletCliError::NoWallet);
 
             *controller_opt = None;
+
+            Ok(ConsoleCommand::Print("Success".to_owned()))
+        }
+
+        WalletCommand::EncryptPrivateKeys { password } => {
+            match controller_opt.as_mut() {
+                None => {
+                    return Err(WalletCliError::NoWallet);
+                }
+                Some(controller) => {
+                    controller.encrypt_wallet(&password).map_err(WalletCliError::Controller)?;
+                }
+            }
+
+            Ok(ConsoleCommand::Print("Success".to_owned()))
+        }
+
+        WalletCommand::UnlockPrivateKeys { password } => {
+            match controller_opt.as_mut() {
+                None => {
+                    return Err(WalletCliError::NoWallet);
+                }
+                Some(controller) => {
+                    controller.unlock_wallet(&password).map_err(WalletCliError::Controller)?;
+                }
+            }
+
+            Ok(ConsoleCommand::Print("Success".to_owned()))
+        }
+
+        WalletCommand::LockPrivateKeys => {
+            match controller_opt.as_mut() {
+                None => {
+                    return Err(WalletCliError::NoWallet);
+                }
+                Some(controller) => {
+                    controller.lock_wallet();
+                }
+            }
 
             Ok(ConsoleCommand::Print("Success".to_owned()))
         }

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -53,9 +53,12 @@ pub enum WalletCommand {
 
     /// Encrypts the private keys with a new password, expects the wallet to be unlocked
     EncryptPrivateKeys {
-        // Optional new password, if not specified will remove any existing encryption.
-        password: Option<String>,
+        // The new password
+        password: String,
     },
+
+    /// Remove any existing encryption, expects the wallet to be unlocked
+    RemovePrivateKeysEncryption,
 
     // Unlocks the private keys for usage.
     UnlockPrivateKeys {
@@ -303,7 +306,22 @@ pub async fn handle_wallet_command(
                     return Err(WalletCliError::NoWallet);
                 }
                 Some(controller) => {
-                    controller.encrypt_wallet(&password).map_err(WalletCliError::Controller)?;
+                    controller
+                        .encrypt_wallet(&Some(password))
+                        .map_err(WalletCliError::Controller)?;
+                }
+            }
+
+            Ok(ConsoleCommand::Print("Success".to_owned()))
+        }
+
+        WalletCommand::RemovePrivateKeysEncryption => {
+            match controller_opt.as_mut() {
+                None => {
+                    return Err(WalletCliError::NoWallet);
+                }
+                Some(controller) => {
+                    controller.encrypt_wallet(&None).map_err(WalletCliError::Controller)?;
                 }
             }
 

--- a/wallet/wallet-controller/Cargo.toml
+++ b/wallet/wallet-controller/Cargo.toml
@@ -22,7 +22,7 @@ async-trait.workspace = true
 bip39 = { version = "2.0", default-features = false, features = ["std", "zeroize"] }
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }
-zeroize = "1.5"
+zeroize.workspace = true
 
 [dev-dependencies]
 chainstate-test-framework = { path = "../../chainstate/test-framework" }

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -132,6 +132,18 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         Ok(wallet)
     }
 
+    pub fn encrypt_wallet(&mut self, password: &Option<String>) -> Result<(), ControllerError<T>> {
+        self.wallet.encrypt_wallet(password).map_err(ControllerError::WalletError)
+    }
+
+    pub fn unlock_wallet(&mut self, password: &Option<String>) -> Result<(), ControllerError<T>> {
+        self.wallet.unlock_wallet(password).map_err(ControllerError::WalletError)
+    }
+
+    pub fn lock_wallet(&mut self) {
+        self.wallet.lock_wallet()
+    }
+
     pub fn get_balance(&self) -> Result<(Amount, BTreeMap<TokenId, Amount>), ControllerError<T>> {
         self.wallet
             .get_balance(

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -132,16 +132,39 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         Ok(wallet)
     }
 
+    /// Encrypts the wallet using the specified `password`, or removes the existing encryption if `password` is `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `password` - An optional `String` representing the new password for encrypting the wallet.
+    ///
+    /// # Returns
+    ///
+    /// This method returns an error if the wallet is locked
     pub fn encrypt_wallet(&mut self, password: &Option<String>) -> Result<(), ControllerError<T>> {
         self.wallet.encrypt_wallet(password).map_err(ControllerError::WalletError)
     }
 
-    pub fn unlock_wallet(&mut self, password: &Option<String>) -> Result<(), ControllerError<T>> {
+    /// Unlocks the wallet using the specified password.
+    ///
+    /// # Arguments
+    ///
+    /// * `password` - A `String` representing the password that was used to encrypt the wallet.
+    ///
+    /// # Returns
+    ///
+    /// This method returns an error if the password is incorrect
+    pub fn unlock_wallet(&mut self, password: &String) -> Result<(), ControllerError<T>> {
         self.wallet.unlock_wallet(password).map_err(ControllerError::WalletError)
     }
 
-    pub fn lock_wallet(&mut self) {
-        self.wallet.lock_wallet()
+    /// Locks the wallet by making the encrypted private keys inaccessible.
+    ///
+    /// # Returns
+    ///
+    /// This method returns an error if the wallet is not encrypted.
+    pub fn lock_wallet(&mut self) -> Result<(), ControllerError<T>> {
+        self.wallet.lock_wallet().map_err(ControllerError::WalletError)
     }
 
     pub fn get_balance(&self) -> Result<(Amount, BTreeMap<TokenId, Amount>), ControllerError<T>> {


### PR DESCRIPTION
- new optional Symmetric key is stored in the Wallet Store
- transactions are now split in 4 types ReadLocked, ReadUnlocked, WriteLocked and WriteUnlocked
where the Unlocked variants have access to the encrypted data in this case the root keys, and the Locked variants do not.
- each get/set operation of the root keys is now encrypted/decrypted according to the set symmetric key
- new util struct `MaybeEncrypted<T>` to help with encode+encrypt a T to bytes and decryption+decode_all from bytes back to T.
- new commands for the Wallet CLI for encrypting/unlocking/locking the private keys

TODO: 
- Argon2Config hardcoded values

Closes #799.