### PR TITLE
Disable initial_download_unexpected_disconnect p2p test

### DIFF
--- a/p2p/src/sync/tests/network_sync.rs
+++ b/p2p/src/sync/tests/network_sync.rs
@@ -126,6 +126,7 @@ async fn basic(#[case] seed: Seed) {
     manager2.join_subsystem_manager().await;
 }
 
+#[ignore = "This test sometimes breaks on CI, disabled until fixed"]
 #[rstest::rstest]
 #[trace]
 #[case(Seed::from_entropy())]


### PR DESCRIPTION
I can't reproduce the problem locally, and I don't want to spend too much time on the test right now.
The test itself is not very important, so let's disable it for now.