### PR TITLE
rpc: Ergonomic way of handling errors

### DIFF
--- a/chainstate/src/rpc.rs
+++ b/chainstate/src/rpc.rs
@@ -17,14 +17,13 @@
 
 use std::io::{Read, Write};
 
-use crate::{Block, BlockSource, ChainInfo, ChainstateError, GenBlock};
+use crate::{Block, BlockSource, ChainInfo, GenBlock};
 use common::{
     chain::tokens::{RPCTokenInfo, TokenId},
     primitives::{BlockHeight, Id},
 };
 use rpc::Result as RpcResult;
 use serialization::hex_encoded::HexEncoded;
-use subsystem::subsystem::CallError;
 
 #[rpc::rpc(server, client, namespace = "chainstate")]
 trait ChainstateRpc {
@@ -88,15 +87,16 @@ trait ChainstateRpc {
 #[async_trait::async_trait]
 impl ChainstateRpcServer for super::ChainstateHandle {
     async fn best_block_id(&self) -> RpcResult<Id<GenBlock>> {
-        handle_error(self.call(|this| this.get_best_block_id()).await)
+        rpc::handle_result(self.call(|this| this.get_best_block_id()).await)
     }
 
     async fn block_id_at_height(&self, height: BlockHeight) -> RpcResult<Option<Id<GenBlock>>> {
-        handle_error(self.call(move |this| this.get_block_id_from_height(&height)).await)
+        rpc::handle_result(self.call(move |this| this.get_block_id_from_height(&height)).await)
     }
 
     async fn get_block(&self, id: Id<Block>) -> RpcResult<Option<HexEncoded<Block>>> {
-        let block = handle_error(self.call(move |this| this.get_block(id)).await)?;
+        let block: Option<Block> =
+            rpc::handle_result(self.call(move |this| this.get_block(id)).await)?;
         Ok(block.map(HexEncoded::new))
     }
 
@@ -106,18 +106,20 @@ impl ChainstateRpcServer for super::ChainstateHandle {
             .await;
         // remove the block index from the return value
         let res = res.map(|v| v.map(|_bi| ()));
-        handle_error(res)
+        rpc::handle_result(res)
     }
 
     async fn block_height_in_main_chain(
         &self,
         block_id: Id<GenBlock>,
     ) -> RpcResult<Option<BlockHeight>> {
-        handle_error(self.call(move |this| this.get_block_height_in_main_chain(&block_id)).await)
+        rpc::handle_result(
+            self.call(move |this| this.get_block_height_in_main_chain(&block_id)).await,
+        )
     }
 
     async fn best_block_height(&self) -> RpcResult<BlockHeight> {
-        handle_error(self.call(move |this| this.get_best_block_height()).await)
+        rpc::handle_result(self.call(move |this| this.get_best_block_height()).await)
     }
 
     async fn last_common_ancestor_by_id(
@@ -125,14 +127,14 @@ impl ChainstateRpcServer for super::ChainstateHandle {
         first_block: Id<GenBlock>,
         second_block: Id<GenBlock>,
     ) -> RpcResult<Option<(Id<GenBlock>, BlockHeight)>> {
-        handle_error(
+        rpc::handle_result(
             self.call(move |this| this.last_common_ancestor_by_id(&first_block, &second_block))
                 .await,
         )
     }
 
     async fn token_info(&self, token_id: TokenId) -> RpcResult<Option<RPCTokenInfo>> {
-        handle_error(self.call(move |this| this.get_token_info_for_rpc(token_id)).await)
+        rpc::handle_result(self.call(move |this| this.get_token_info_for_rpc(token_id)).await)
     }
 
     async fn export_bootstrap_file(
@@ -145,12 +147,10 @@ impl ChainstateRpcServer for super::ChainstateHandle {
         let writer: std::io::BufWriter<Box<dyn Write + Send>> =
             std::io::BufWriter::new(Box::new(file_obj));
 
-        handle_error(
+        rpc::handle_result(
             self.call(move |this| this.export_bootstrap_stream(writer, include_orphans))
                 .await,
-        )?;
-
-        Ok(())
+        )
     }
 
     async fn import_bootstrap_file(&self, file_path: &std::path::Path) -> RpcResult<()> {
@@ -159,18 +159,12 @@ impl ChainstateRpcServer for super::ChainstateHandle {
         let reader: std::io::BufReader<Box<dyn Read + Send>> =
             std::io::BufReader::new(Box::new(file_obj));
 
-        handle_error(self.call_mut(move |this| this.import_bootstrap_stream(reader)).await)?;
-
-        Ok(())
+        rpc::handle_result(self.call_mut(move |this| this.import_bootstrap_stream(reader)).await)
     }
 
     async fn info(&self) -> RpcResult<ChainInfo> {
-        handle_error(self.call(move |this| this.info()).await)
+        rpc::handle_result(self.call(move |this| this.info()).await)
     }
-}
-
-fn handle_error<T>(e: Result<Result<T, ChainstateError>, CallError>) -> RpcResult<T> {
-    e.map_err(rpc::Error::to_call_error)?.map_err(rpc::Error::to_call_error)
 }
 
 #[cfg(test)]

--- a/chainstate/src/rpc.rs
+++ b/chainstate/src/rpc.rs
@@ -143,7 +143,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
         include_orphans: bool,
     ) -> RpcResult<()> {
         // TODO: test this function in functional tests
-        let file_obj = std::fs::File::create(file_path).map_err(rpc::Error::to_call_error)?;
+        let file_obj: std::fs::File = rpc::handle_result(std::fs::File::create(file_path))?;
         let writer: std::io::BufWriter<Box<dyn Write + Send>> =
             std::io::BufWriter::new(Box::new(file_obj));
 
@@ -155,7 +155,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
 
     async fn import_bootstrap_file(&self, file_path: &std::path::Path) -> RpcResult<()> {
         // TODO: test this function in functional tests
-        let file_obj = std::fs::File::open(file_path).map_err(rpc::Error::to_call_error)?;
+        let file_obj: std::fs::File = rpc::handle_result(std::fs::File::create(file_path))?;
         let reader: std::io::BufReader<Box<dyn Read + Send>> =
             std::io::BufReader::new(Box::new(file_obj));
 

--- a/mempool/src/rpc.rs
+++ b/mempool/src/rpc.rs
@@ -37,21 +37,14 @@ trait MempoolRpc {
 #[async_trait::async_trait]
 impl MempoolRpcServer for super::MempoolHandle {
     async fn contains_tx(&self, tx_id: Id<Transaction>) -> rpc::Result<bool> {
-        self.call(move |this| this.contains_transaction(&tx_id))
-            .await
-            .map_err(rpc::Error::to_call_error)?
-            .map_err(rpc::Error::to_call_error)
+        rpc::handle_result(self.call(move |this| this.contains_transaction(&tx_id)).await)
     }
 
     async fn submit_transaction(&self, tx: HexEncoded<SignedTransaction>) -> rpc::Result<()> {
-        self.call_mut(|this| this.add_transaction(tx.take()))
-            .await
-            .log_err()
-            .map_err(rpc::Error::to_call_error)?
-            .map_err(rpc::Error::to_call_error)
+        rpc::handle_result(self.call_mut(|this| this.add_transaction(tx.take())).await.log_err())
     }
 
     async fn local_best_block_id(&self) -> rpc::Result<Id<GenBlock>> {
-        self.call(|this| this.best_block_id()).await.map_err(rpc::Error::to_call_error)
+        rpc::handle_result(self.call(|this| this.best_block_id()).await)
     }
 }

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -16,9 +16,8 @@
 use common::chain::SignedTransaction;
 use serialization::hex_encoded::HexEncoded;
 
-use crate::{error::P2pError, interface::types::ConnectedPeer, types::peer_id::PeerId};
+use crate::{interface::types::ConnectedPeer, types::peer_id::PeerId};
 use rpc::Result as RpcResult;
-use subsystem::subsystem::CallError;
 
 #[rpc::rpc(server, client, namespace = "p2p")]
 trait P2pRpc {
@@ -62,45 +61,40 @@ trait P2pRpc {
 impl P2pRpcServer for super::P2pHandle {
     async fn connect(&self, addr: String) -> RpcResult<()> {
         let res = self.call_async_mut(|this| this.connect(addr)).await;
-        handle_error(res)
+        rpc::handle_result(res)
     }
 
     async fn disconnect(&self, peer_id: PeerId) -> RpcResult<()> {
         let res = self.call_async_mut(move |this| this.disconnect(peer_id)).await;
-        handle_error(res)
+        rpc::handle_result(res)
     }
 
     async fn get_peer_count(&self) -> RpcResult<usize> {
         let res = self.call_async(|this| this.get_peer_count()).await;
-        handle_error(res)
+        rpc::handle_result(res)
     }
 
     async fn get_bind_addresses(&self) -> RpcResult<Vec<String>> {
         let res = self.call_async(|this| this.get_bind_addresses()).await;
-        handle_error(res)
+        rpc::handle_result(res)
     }
 
     async fn get_connected_peers(&self) -> RpcResult<Vec<ConnectedPeer>> {
         let res = self.call_async(|this| this.get_connected_peers()).await;
-        handle_error(res)
+        rpc::handle_result(res)
     }
 
     async fn add_reserved_node(&self, addr: String) -> RpcResult<()> {
         let res = self.call_async_mut(|this| this.add_reserved_node(addr)).await;
-        handle_error(res)
+        rpc::handle_result(res)
     }
 
     async fn remove_reserved_node(&self, addr: String) -> RpcResult<()> {
         let res = self.call_async_mut(move |this| this.remove_reserved_node(addr)).await;
-        handle_error(res)
+        rpc::handle_result(res)
     }
 
     async fn submit_transaction(&self, tx: HexEncoded<SignedTransaction>) -> RpcResult<()> {
-        handle_error(self.call_async_mut(|s| s.submit_transaction(tx.take())).await)
+        rpc::handle_result(self.call_async_mut(|s| s.submit_transaction(tx.take())).await)
     }
-}
-
-fn handle_error<T>(e: Result<Result<T, P2pError>, CallError>) -> RpcResult<T> {
-    e.map_err(rpc::Error::to_call_error)
-        .and_then(|r| r.map_err(rpc::Error::to_call_error))
 }

--- a/rpc/examples/simple_server.rs
+++ b/rpc/examples/simple_server.rs
@@ -67,7 +67,7 @@ impl SomeSubsystemRpcServer for SomeSubsystemHandle {
     }
 
     async fn bump(&self) -> rpc::Result<u64> {
-        self.call_mut(SomeSubsystem::bump).await.map_err(rpc::Error::to_call_error)
+        rpc::handle_result(self.call_mut(SomeSubsystem::bump).await)
     }
 }
 

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error handling machinery for RPC
+
+/// RPC error
+pub use jsonrpsee::core::Error;
+
+/// The Result type with RPC-specific error.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Handle RPC result
+///
+/// This is a generic way of converting the likes of:
+/// * `R`
+/// * `Result<R, E0>`
+/// * `Result<Result<R, E0>, E1>`
+/// * etc...
+///
+/// to `rpc::Result<R>`.
+///
+/// Works provided the errors satisfy the required bounds which are [std::error::Error], [Send],
+/// [Sync], and `'static` lifetime. Type annotations for the `R` parameter may be required at times
+/// but most of the time type inference will figure it out. In general, nailing down the `R` type
+/// is sufficient for the compiler to infer the rest of the generic arguments.
+///
+/// In particular, using `?` often requires a type annotation:
+/// ```ignore
+///     let foo: MyFooType = rpc::handle_result(blah)?;
+/// ```
+///
+/// TODO: Maybe this could be generalized to also handle `anyhow::Error` and moved elsewhere?
+pub fn handle_result<T: HandleResult<R, I>, R, I>(res: T) -> self::Result<R> {
+    res.handle_result()
+}
+
+pub trait HandleResult<R, I> {
+    fn handle_result(self) -> self::Result<R>;
+}
+
+impl<R> HandleResult<R, ()> for R {
+    fn handle_result(self) -> self::Result<R> {
+        Ok(self)
+    }
+}
+
+impl<R, T, E, I> HandleResult<R, (I,)> for std::result::Result<T, E>
+where
+    T: HandleResult<R, I>,
+    E: 'static + Sync + Send + std::error::Error,
+{
+    fn handle_result(self) -> self::Result<R> {
+        self.map_err(Error::to_call_error).and_then(T::handle_result)
+    }
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2022-2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 mod config;
+mod error;
 mod rpc_auth;
 pub mod rpc_creds;
 
@@ -25,15 +26,12 @@ use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use logging::log;
 
 pub use config::RpcConfig;
-pub use jsonrpsee::core::server::Methods;
-pub use jsonrpsee::core::Error;
-pub use jsonrpsee::proc_macros::rpc;
+pub use error::{handle_result, Error, Result};
+
+pub use jsonrpsee::{core::server::Methods, proc_macros::rpc};
 use rpc_auth::RpcAuth;
 use rpc_creds::RpcCreds;
 use tower_http::validate_request::ValidateRequestHeaderLayer;
-
-/// The Result type with RPC-specific error.
-pub type Result<T> = core::result::Result<T, Error>;
 
 #[rpc(server, namespace = "example_server")]
 trait RpcInfo {

--- a/test-rpc-functions/src/rpc.rs
+++ b/test-rpc-functions/src/rpc.rs
@@ -85,8 +85,8 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
     }
 
     async fn public_key_from_private_key(&self, private_key_hex: String) -> rpc::Result<String> {
-        let private_key = crypto::key::PrivateKey::hex_decode_all(private_key_hex)
-            .map_err(rpc::Error::to_call_error)?;
+        let private_key =
+            rpc::handle_result(crypto::key::PrivateKey::hex_decode_all(private_key_hex))?;
 
         let public_key = crypto::key::PublicKey::from_private_key(&private_key);
 
@@ -98,10 +98,10 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         private_key_hex: String,
         message_hex: String,
     ) -> rpc::Result<String> {
-        let private_key = crypto::key::PrivateKey::hex_decode_all(private_key_hex)
-            .map_err(rpc::Error::to_call_error)?;
+        let private_key: crypto::key::PrivateKey =
+            rpc::handle_result(crypto::key::PrivateKey::hex_decode_all(private_key_hex))?;
 
-        let message = Vec::<u8>::hex_decode_all(message_hex).map_err(rpc::Error::to_call_error)?;
+        let message: Vec<u8> = rpc::handle_result(Vec::<u8>::hex_decode_all(message_hex))?;
 
         let signature = private_key.sign_message(&message).map_err(RpcTestFunctionsError::from);
         let signature: Signature = rpc::handle_result(signature)?;
@@ -115,12 +115,11 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         message_hex: String,
         signature_hex: String,
     ) -> rpc::Result<bool> {
-        let public_key = crypto::key::PublicKey::hex_decode_all(public_key_hex)
-            .map_err(rpc::Error::to_call_error)?;
+        let public_key: crypto::key::PublicKey =
+            rpc::handle_result(crypto::key::PublicKey::hex_decode_all(public_key_hex))?;
 
-        let message = Vec::<u8>::hex_decode_all(message_hex).map_err(rpc::Error::to_call_error)?;
-        let signature =
-            Signature::hex_decode_all(signature_hex).map_err(rpc::Error::to_call_error)?;
+        let message: Vec<u8> = rpc::handle_result(Vec::<u8>::hex_decode_all(message_hex))?;
+        let signature = rpc::handle_result(Signature::hex_decode_all(signature_hex))?;
 
         let verify_result = public_key.verify_message(&signature, &message);
 
@@ -138,8 +137,8 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         &self,
         private_key_hex: String,
     ) -> rpc::Result<String> {
-        let private_key = crypto::vrf::VRFPrivateKey::hex_decode_all(private_key_hex)
-            .map_err(rpc::Error::to_call_error)?;
+        let private_key =
+            rpc::handle_result(crypto::vrf::VRFPrivateKey::hex_decode_all(private_key_hex))?;
 
         let public_key = crypto::vrf::VRFPublicKey::from_private_key(&private_key);
 
@@ -153,16 +152,15 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         random_seed: String,
         block_timestamp: u64,
     ) -> rpc::Result<String> {
-        let random_seed: H256 =
-            H256::hex_decode_all(random_seed).map_err(rpc::Error::to_call_error)?;
+        let random_seed: H256 = rpc::handle_result(H256::hex_decode_all(random_seed))?;
 
         let transcript = construct_transcript(
             epoch_index,
             &random_seed,
             BlockTimestamp::from_int_seconds(block_timestamp),
         );
-        let private_key = crypto::vrf::VRFPrivateKey::hex_decode_all(private_key_hex)
-            .map_err(rpc::Error::to_call_error)?;
+        let private_key: crypto::vrf::VRFPrivateKey =
+            rpc::handle_result(crypto::vrf::VRFPrivateKey::hex_decode_all(private_key_hex))?;
 
         let signature = private_key.produce_vrf_data(transcript.into());
 
@@ -177,11 +175,10 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         vrf_public_key: String,
         block_timestamp: BlockTimestamp,
     ) -> rpc::Result<String> {
-        let vrf_data =
-            crypto::vrf::VRFReturn::hex_decode_all(vrf_data).map_err(rpc::Error::to_call_error)?;
-        let vrf_public_key = crypto::vrf::VRFPublicKey::hex_decode_all(vrf_public_key)
-            .map_err(rpc::Error::to_call_error)?;
-        let random_seed = H256::hex_decode_all(random_seed).map_err(rpc::Error::to_call_error)?;
+        let vrf_data = rpc::handle_result(crypto::vrf::VRFReturn::hex_decode_all(vrf_data))?;
+        let vrf_public_key =
+            rpc::handle_result(crypto::vrf::VRFPublicKey::hex_decode_all(vrf_public_key))?;
+        let random_seed = rpc::handle_result(H256::hex_decode_all(random_seed))?;
 
         let vrf_output = verify_vrf_and_get_vrf_output(
             epoch_index,

--- a/test-rpc-functions/src/rpc.rs
+++ b/test-rpc-functions/src/rpc.rs
@@ -104,7 +104,7 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         let message = Vec::<u8>::hex_decode_all(message_hex).map_err(rpc::Error::to_call_error)?;
 
         let signature = private_key.sign_message(&message).map_err(RpcTestFunctionsError::from);
-        let signature = handle_error(signature)?;
+        let signature: Signature = rpc::handle_result(signature)?;
 
         Ok(signature.hex_encode())
     }
@@ -192,12 +192,8 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         )
         .map_err(RpcTestFunctionsError::from);
 
-        let vrf_output = handle_error(vrf_output)?;
+        let vrf_output: H256 = rpc::handle_result(vrf_output)?;
 
         Ok(vrf_output.hex_encode())
     }
-}
-
-fn handle_error<T>(e: Result<T, RpcTestFunctionsError>) -> rpc::Result<T> {
-    e.map_err(rpc::Error::to_call_error)
 }


### PR DESCRIPTION
Replace the ad-hoc way RPC implementations in various subsystems handle nested errors with a generic one provided by the `rpc` crate.