### PR TITLE
Fix Rust 1.70 clippy errors arising from do_checks.sh script

### DIFF
--- a/blockprod/src/detail/job_manager/mod.rs
+++ b/blockprod/src/detail/job_manager/mod.rs
@@ -282,7 +282,7 @@ impl Drop for JobManager {
             return;
         }
 
-        tokio::spawn(async move { result_receiver.await });
+        tokio::spawn(result_receiver);
     }
 }
 

--- a/common/src/uint/endian.rs
+++ b/common/src/uint/endian.rs
@@ -106,7 +106,7 @@ macro_rules! define_chunk_slice_to_int {
     ($name: ident, $type: ty, $converter: ident) => {
         #[inline]
         pub fn $name(inp: &[u8], outp: &mut [$type]) {
-            assert_eq!(inp.len(), outp.len() * ::core::mem::size_of::<$type>());
+            assert_eq!(inp.len(), ::core::mem::size_of_val(outp));
             for (outp_val, data_bytes) in
                 outp.iter_mut().zip(inp.chunks(::core::mem::size_of::<$type>()))
             {

--- a/crypto/src/util/eq.rs
+++ b/crypto/src/util/eq.rs
@@ -47,6 +47,7 @@ impl SliceEqualityCheckMethod {
 }
 
 #[cfg(test)]
+#[allow(clippy::redundant_clone)]
 pub mod test {
     use rstest::rstest;
 


### PR DESCRIPTION
With stable Rust 1.70 in the `do_checks.sh` file, the command
```sh
cargo clippy --all-features --workspace --all-targets -- -D warnings -A clippy::new_without_default -W clippy::implicit_saturating_sub -W clippy::implicit_clone -W clippy::map_unwrap_or -W clippy::unnested_or_patterns -W clippy::manual_assert -W clippy::unused_async -W clippy::mut_mut -W clippy::todo
```
fails with the following errors:

1.
```
error: manual slice size calculation
   --> common/src/uint/endian.rs:109:35
    |
109 |             assert_eq!(inp.len(), outp.len() * ::core::mem::size_of::<$type>());
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
119 | define_chunk_slice_to_int!(bytes_to_u64_slice_le, u64, slice_to_u64_le);
    | ----------------------------------------------------------------------- in this macro invocation
    |
    = help: consider using std::mem::size_of_value instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_slice_size_calculation
    = note: `-D clippy::manual-slice-size-calculation` implied by `-D warnings`
    = note: this error originates in the macro `define_chunk_slice_to_int` (in Nightly builds, run with -Z macro-backtrace for more info)
```

2.
```
error: this async expression only awaits a single future
   --> blockprod/src/detail/job_manager/mod.rs:285:22
    |
285 |         tokio::spawn(async move { result_receiver.await });
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `result_receiver`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_async_block
    = note: `-D clippy::redundant-async-block` implied by `-D warnings`
```

3.
```
error: redundant clone
  --> crypto/src/util/eq.rs:85:35
   |
85 |         let data2: Vec<u8> = data1.clone();
   |                                   ^^^^^^^^ help: remove this
   |
note: cloned value is neither consumed nor mutated
  --> crypto/src/util/eq.rs:85:30
   |
85 |         let data2: Vec<u8> = data1.clone();
   |                              ^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
   = note: `-D clippy::redundant-clone` implied by `-D warnings`

error: redundant clone
   --> crypto/src/util/eq.rs:115:35
    |
115 |         let data2: Vec<u8> = data1.clone();
    |                                   ^^^^^^^^ help: remove this
    |
note: cloned value is neither consumed nor mutated
   --> crypto/src/util/eq.rs:115:30
    |
115 |         let data2: Vec<u8> = data1.clone();
    |                              ^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
```
