### PR TITLE
Simplify TransportListener trait by using associated types instead

### DIFF
--- a/p2p/src/net/default_backend/transport/impls/channel.rs
+++ b/p2p/src/net/default_backend/transport/impls/channel.rs
@@ -159,7 +159,10 @@ pub struct ChannelListener {
 }
 
 #[async_trait]
-impl TransportListener<ChannelStream, SocketAddr> for ChannelListener {
+impl TransportListener for ChannelListener {
+    type Stream = ChannelStream;
+    type Address = SocketAddr;
+
     async fn accept(&mut self) -> Result<(ChannelStream, SocketAddr)> {
         let (remote_address, response_sender) =
             self.receiver.recv().await.ok_or(P2pError::ChannelClosed)?;

--- a/p2p/src/net/default_backend/transport/impls/socks5.rs
+++ b/p2p/src/net/default_backend/transport/impls/socks5.rs
@@ -87,7 +87,10 @@ impl Socks5TransportListener {
 }
 
 #[async_trait]
-impl TransportListener<Socks5TransportStream, SocketAddr> for Socks5TransportListener {
+impl TransportListener for Socks5TransportListener {
+    type Stream = Socks5TransportStream;
+    type Address = SocketAddr;
+
     async fn accept(&mut self) -> Result<(Socks5TransportStream, SocketAddr)> {
         std::future::pending().await
     }

--- a/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/tests.rs
+++ b/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/tests.rs
@@ -160,12 +160,10 @@ impl TransportSocket for TestTransport {
 }
 
 #[async_trait]
-impl
-    TransportListener<
-        <MpscChannelTransport as TransportSocket>::Stream,
-        <MpscChannelTransport as TransportSocket>::Address,
-    > for TestListener
-{
+impl TransportListener for TestListener {
+    type Stream = <MpscChannelTransport as TransportSocket>::Stream;
+    type Address = <MpscChannelTransport as TransportSocket>::Address;
+
     async fn accept(
         &mut self,
     ) -> crate::Result<(

--- a/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/wrapped_listener.rs
+++ b/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/wrapped_listener.rs
@@ -53,9 +53,10 @@ impl<S: StreamAdapter<T::Stream>, T: TransportSocket> AdaptedListener<S, T> {
 }
 
 #[async_trait]
-impl<S: StreamAdapter<T::Stream>, T: TransportSocket> TransportListener<S::Stream, T::Address>
-    for AdaptedListener<S, T>
-{
+impl<S: StreamAdapter<T::Stream>, T: TransportSocket> TransportListener for AdaptedListener<S, T> {
+    type Stream = S::Stream;
+    type Address = T::Address;
+
     async fn accept(&mut self) -> Result<(S::Stream, T::Address)> {
         loop {
             let accept_new = self.handshakes.len() < MAX_CONCURRENT_HANDSHAKES;

--- a/p2p/src/net/default_backend/transport/impls/tcp.rs
+++ b/p2p/src/net/default_backend/transport/impls/tcp.rs
@@ -131,7 +131,10 @@ impl TcpTransportListener {
 }
 
 #[async_trait]
-impl TransportListener<TcpTransportStream, SocketAddr> for TcpTransportListener {
+impl TransportListener for TcpTransportListener {
+    type Stream = TcpTransportStream;
+    type Address = SocketAddr;
+
     async fn accept(&mut self) -> Result<(TcpTransportStream, SocketAddr)> {
         // select_next_some will panic if polled while empty
         if self.listeners.is_empty() {

--- a/p2p/src/net/default_backend/transport/traits/listener.rs
+++ b/p2p/src/net/default_backend/transport/traits/listener.rs
@@ -18,12 +18,14 @@ use async_trait::async_trait;
 use crate::Result;
 
 /// An abstraction layer over a potential inbound network connection (acceptor in boost terminology).
-// TODO: Replace Stream and Address trait parameters with associated types?
 #[async_trait]
-pub trait TransportListener<Stream, Address>: Send {
+pub trait TransportListener: Send {
+    type Stream;
+    type Address;
+
     /// Accepts a new inbound connection.
-    async fn accept(&mut self) -> Result<(Stream, Address)>;
+    async fn accept(&mut self) -> Result<(Self::Stream, Self::Address)>;
 
     /// Returns the local address of the listener.
-    fn local_addresses(&self) -> Result<Vec<Address>>;
+    fn local_addresses(&self) -> Result<Vec<Self::Address>>;
 }

--- a/p2p/src/net/default_backend/transport/traits/socket.rs
+++ b/p2p/src/net/default_backend/transport/traits/socket.rs
@@ -45,7 +45,7 @@ pub trait TransportSocket: Send + Sync + 'static {
     type BannableAddress: Debug + Eq + Ord + Send + ToString + FromStr;
 
     /// A listener type (or acceptor as per boost terminology).
-    type Listener: TransportListener<Self::Stream, Self::Address>;
+    type Listener: TransportListener<Stream = Self::Stream, Address = Self::Address>;
 
     /// A messages stream.
     type Stream: PeerStream;


### PR DESCRIPTION
Replaces generic parameters in favor of associated types for simplicity.