### PR TITLE
Mempool memory usage tracker

### DIFF
--- a/blockprod/src/lib.rs
+++ b/blockprod/src/lib.rs
@@ -173,7 +173,6 @@ mod tests {
             Arc::clone(&chain_config),
             subsystem::Handle::clone(&chainstate),
             Default::default(),
-            mempool::SystemUsageEstimator {},
         );
         let mempool = manager.add_subsystem_with_custom_eventloop("mempool", {
             move |call, shutdn| mempool.run(call, shutdn)

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -25,7 +25,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 hex.workspace = true
 jsonrpsee = { workspace = true, features = ["macros"] }
-mockall.workspace = true
 parking_lot.workspace = true
 serde.workspace = true
 static_assertions.workspace = true
@@ -38,4 +37,5 @@ chainstate-test-framework = { path = '../chainstate/test-framework' }
 crypto = { path = '../crypto' }
 test-utils = {path = '../test-utils'}
 
+mockall.workspace = true
 rstest.workspace = true

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -24,13 +24,10 @@ pub use interface::{
     mempool_interface_impl::make_mempool,
 };
 
-use crate::{error::Error as MempoolError, get_memory_usage::GetMemoryUsage};
-
-pub use crate::get_memory_usage::SystemUsageEstimator;
+use crate::error::Error as MempoolError;
 
 mod config;
 pub mod error;
-mod get_memory_usage;
 mod interface;
 mod pool;
 pub mod rpc;

--- a/mempool/src/pool/entry.rs
+++ b/mempool/src/pool/entry.rs
@@ -23,10 +23,26 @@ use common::{
 
 use super::{Fee, Time};
 
+/// A dependency of a transaction on a previous account state.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TxAccountDependency {
+    delegation_id: DelegationId,
+    nonce: AccountNonce,
+}
+
+impl TxAccountDependency {
+    pub fn new(delegation_id: DelegationId, nonce: AccountNonce) -> Self {
+        TxAccountDependency {
+            delegation_id,
+            nonce,
+        }
+    }
+}
+
 /// A dependency of a transaction. May be another transaction or a previous account state.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TxDependency {
-    DelegationAccount(DelegationId, AccountNonce),
+    DelegationAccount(TxAccountDependency),
     Transaction(Id<Transaction>),
     // TODO: Block reward?
 }
@@ -39,7 +55,7 @@ impl TxDependency {
     fn from_account(acct: &AccountSpending, nonce: AccountNonce) -> Self {
         match acct {
             AccountSpending::Delegation(delegation_id, _) => {
-                Self::DelegationAccount(*delegation_id, nonce)
+                Self::DelegationAccount(TxAccountDependency::new(*delegation_id, nonce))
             }
         }
     }

--- a/mempool/src/pool/memory_usage_estimator.rs
+++ b/mempool/src/pool/memory_usage_estimator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,19 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use mockall::*;
-pub type MemoryUsage = usize;
+use super::MempoolStore;
 
-#[automock]
-pub trait GetMemoryUsage {
-    fn get_memory_usage(&self) -> MemoryUsage;
+pub trait MemoryUsageEstimator: Send + Sync + 'static {
+    fn estimate_memory_usage(&self, store: &MempoolStore) -> usize;
 }
 
-#[derive(Clone)]
-pub struct SystemUsageEstimator;
-impl GetMemoryUsage for SystemUsageEstimator {
-    fn get_memory_usage(&self) -> MemoryUsage {
-        // TODO implement real usage estimation here
-        0
+/// Estimate memory usage by asking the mempool store
+pub struct StoreMemoryUsageEstimator;
+
+impl MemoryUsageEstimator for StoreMemoryUsageEstimator {
+    fn estimate_memory_usage(&self, store: &MempoolStore) -> usize {
+        store.memory_usage()
     }
 }

--- a/mempool/src/pool/memory_usage_estimator.rs
+++ b/mempool/src/pool/memory_usage_estimator.rs
@@ -23,7 +23,10 @@ pub trait MemoryUsageEstimator: Send + Sync + 'static {
 pub struct StoreMemoryUsageEstimator;
 
 impl MemoryUsageEstimator for StoreMemoryUsageEstimator {
-    fn estimate_memory_usage(&self, store: &MempoolStore) -> usize {
-        store.memory_usage()
+    fn estimate_memory_usage(&self, _store: &MempoolStore) -> usize {
+        // TODO: Just a temporary value to emulate the original behavior. In order for eviction to
+        // work properly, we need to get transaction verifier and mempool to agree on transaction
+        // dependencies.
+        0
     }
 }

--- a/mempool/src/pool/orphans/mod.rs
+++ b/mempool/src/pool/orphans/mod.rs
@@ -156,7 +156,7 @@ impl TxOrphanPool {
         let entry = self.get_at(iid);
         !entry.requires().any(|dep| match dep {
             // Always consider account deps. TODO: can be optimized in the future
-            TxDependency::DelegationAccount(_, _) => false,
+            TxDependency::DelegationAccount(_) => false,
             TxDependency::Transaction(tx_id) => self.maps.by_tx_id.contains_key(&tx_id),
         })
     }

--- a/mempool/src/pool/reorg.rs
+++ b/mempool/src/pool/reorg.rs
@@ -26,7 +26,7 @@ use logging::log;
 use utils::tap_error_log::LogError;
 use utxo::UtxosStorageRead;
 
-use crate::{get_memory_usage::GetMemoryUsage, pool::Mempool};
+use super::{MemoryUsageEstimator, Mempool};
 
 /// An error that can happen in mempool on chain reorg
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -124,7 +124,7 @@ fn fetch_disconnected_txs<M>(
         .map(ReorgData::into_disconnected_transactions)
 }
 
-pub fn handle_new_tip<M: GetMemoryUsage>(mempool: &mut Mempool<M>, new_tip: Id<Block>) {
+pub fn handle_new_tip<M: MemoryUsageEstimator>(mempool: &mut Mempool<M>, new_tip: Id<Block>) {
     mempool.rolling_fee_rate.get_mut().set_block_since_last_rolling_fee_bump(true);
 
     let disconnected_txs = fetch_disconnected_txs(mempool, new_tip)

--- a/mempool/src/pool/spends_unconfirmed.rs
+++ b/mempool/src/pool/spends_unconfirmed.rs
@@ -15,18 +15,13 @@
 
 use common::chain::TxInput;
 
-use crate::get_memory_usage::GetMemoryUsage;
+use super::{MemoryUsageEstimator, Mempool};
 
-use super::Mempool;
-
-pub trait SpendsUnconfirmed<M>
-where
-    M: GetMemoryUsage,
-{
+pub trait SpendsUnconfirmed<M: MemoryUsageEstimator> {
     fn spends_unconfirmed(&self, mempool: &Mempool<M>) -> bool;
 }
 
-impl<M: GetMemoryUsage> SpendsUnconfirmed<M> for TxInput {
+impl<M: MemoryUsageEstimator> SpendsUnconfirmed<M> for TxInput {
     fn spends_unconfirmed(&self, mempool: &Mempool<M>) -> bool {
         // TODO: if TxInput spends from an account there is no way to know tx_id
         match self {

--- a/mempool/src/pool/store/mem_usage.rs
+++ b/mempool/src/pool/store/mem_usage.rs
@@ -1,0 +1,449 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Estimate and track memory usage taken by data structures.
+
+use std::{cmp, mem};
+
+use common::chain::{
+    signature::inputsig::InputWitness, stakelock::StakePoolData, SignedTransaction, TxInput,
+    TxOutput,
+};
+use logging::log;
+
+use super::TxMempoolEntry;
+
+/// Structure that stores the current memory usage and keeps track of its changes
+#[derive(Debug)]
+pub struct MemUsageTracker {
+    current_usage: usize,
+    peak_usage: usize,
+}
+
+impl MemUsageTracker {
+    pub fn new() -> Self {
+        Self {
+            current_usage: 0,
+            peak_usage: 0,
+        }
+    }
+
+    pub fn get_usage(&self) -> usize {
+        self.current_usage
+    }
+
+    fn add(&mut self, amount: usize) {
+        let old = self.current_usage;
+        self.current_usage += amount;
+        self.peak_usage = cmp::max(self.current_usage, self.peak_usage);
+        self.log_change(old);
+    }
+
+    fn sub(&mut self, amount: usize) {
+        let old = self.current_usage;
+        self.current_usage -= amount;
+        self.log_change(old);
+    }
+
+    fn log_change(&self, old: usize) {
+        let new = self.current_usage;
+        log::trace!("Updated memory tracker {self:p}: {old} bytes => {new} bytes");
+    }
+
+    /// Start tracking an object for memory consumption
+    pub fn track<T: MemoryUsage, D: DropPolicy + Default>(&mut self, obj: T) -> Tracked<T, D> {
+        self.add(obj.indirect_memory_usage());
+        let drop_policy = D::default();
+        Tracked { obj, drop_policy }
+    }
+
+    /// Stop tracking memory consumption of an object
+    pub fn release<T: MemoryUsage, D: DropPolicy>(&mut self, tracked: Tracked<T, D>) -> T {
+        self.sub(tracked.indirect_memory_usage());
+        Self::forget(tracked)
+    }
+
+    /// Forget about the object being tracked without updating the tracker.
+    ///
+    /// Useful during tear down when the tracker is no longer in use. If the memory usage
+    /// information is supposed to be updated, use [Self::release].
+    pub fn forget<T, D: DropPolicy>(mut tracked: Tracked<T, D>) -> T {
+        tracked.drop_policy.on_release();
+        tracked.obj
+    }
+
+    /// Modify given object tracked for memory usage
+    ///
+    /// This is the only way to legally modify an object under memory tracking. This method is
+    /// given the object to modify and a closure which performs the modifications. The memory taken
+    /// up by the object is sampled before and after the modifications and the change is recorded
+    /// in the tracker. Closure is also given access to the tracker in case more tracked objects
+    /// need to be created/modified/dropped in the closure body.
+    pub fn modify<T: MemoryUsage, D, R>(
+        &mut self,
+        tracked: &mut Tracked<T, D>,
+        modify_fn: impl for<'a> FnOnce(&'a mut T, &'a mut MemUsageTracker) -> R,
+    ) -> R {
+        let obj = &mut tracked.obj;
+
+        let usage_before = obj.indirect_memory_usage();
+        let result = modify_fn(obj, self);
+        let usage_after = obj.indirect_memory_usage();
+
+        match usage_before.cmp(&usage_after) {
+            cmp::Ordering::Equal => (),
+            cmp::Ordering::Less => self.add(usage_after - usage_before),
+            cmp::Ordering::Greater => self.sub(usage_before - usage_after),
+        }
+
+        result
+    }
+}
+
+/// A data structure which has its memory consumption tracked
+#[derive(Eq, PartialEq, PartialOrd, Ord, Debug)]
+#[must_use = "Memory-tracked object dropped without using Tracked::release"]
+pub struct Tracked<T, D = NoOpDropPolicy> {
+    obj: T,
+    drop_policy: D,
+}
+
+/// We can freely create tracked objects without a tracker provided it does not contribute anything
+/// to the memory consumption accumulator.
+impl<T: ZeroUsageDefault, D: Default> Default for Tracked<T, D> {
+    fn default() -> Self {
+        let obj = T::default();
+        assert_eq!(
+            obj.indirect_memory_usage(),
+            0,
+            "Default not zero-size despite being marked as such"
+        );
+
+        let drop_policy = D::default();
+        Self { obj, drop_policy }
+    }
+}
+
+/// The tracked object can be accessed in an immutable way any time.
+///
+/// This means memory tracking can be circumvented using interior mutability but we ignore the issue
+/// here as the data structures used in mempool do not use interior mutability.
+impl<T, D> std::ops::Deref for Tracked<T, D> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.obj
+    }
+}
+
+/// What to do with a [Tracked] object if it's dropped without being released. The actual handling
+/// of the drop logic is done in the policy type's Drop implementation.
+pub trait DropPolicy {
+    fn on_release(&mut self) {}
+}
+
+/// Trivial drop policy that does nothing
+#[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Default)]
+pub struct NoOpDropPolicy;
+
+impl DropPolicy for NoOpDropPolicy {}
+
+/// Drop policy that asserts if the object has not been properly released
+#[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Default)]
+pub struct AssertDropPolicy {
+    released: bool,
+}
+
+impl DropPolicy for AssertDropPolicy {
+    fn on_release(&mut self) {
+        self.released = true;
+    }
+}
+
+impl Drop for AssertDropPolicy {
+    fn drop(&mut self) {
+        if !self.released {
+            log::error!("A memory-tracked value dropped without being released");
+
+            #[allow(clippy::manual_assert)]
+            if !std::thread::panicking() {
+                panic!("A memory-tracked value dropped without being released");
+            }
+        }
+    }
+}
+
+// Code to estimate size taken up by [std::collections::BTreeSet] or [std::collections::BTreeMap].
+mod btree {
+    // The following structs are laid out in the same way as the real standard library equivalents
+    // to give a reasonably precise estimation of their sizes. It is possible that the library
+    // implementations change in the future. In that case, the estimation becomes less precise
+    // although hopefully will remain good enough for our purposes until the structs below are
+    // updated to reflect the change. It's still just an estimate after all.
+
+    const B: usize = 6; // the B parameter for the B-tree
+    const BF: usize = 2 * B; // branching factor
+    const CAP: usize = BF - 1; // data capacity per node
+
+    struct _LeafNode<K, V> {
+        _parent: *mut (),
+        _parent_idx: u16,
+        _len: u16,
+        _keys: [K; CAP],
+        _vals: [V; CAP],
+    }
+
+    struct _InternalNode<K, V> {
+        _data: _LeafNode<K, V>,
+        _children: [*mut (); BF],
+    }
+
+    /// Estimate the memory usage of the B-tree structure.
+    ///
+    /// This includes the space taken up by the keys and values stored in the tree. It does NOT
+    /// include data pointed to by keys and values indirectly (e.g. via `Box` or `Vec`).
+    pub fn usage<K, V>(num_elems: usize) -> usize {
+        // Use u64 internally to avoid possible overflow issues on 32-bit platforms
+        let num_elems = num_elems as u64;
+
+        // Size of B-tree nodes:
+        let leaf_size = std::mem::size_of::<_LeafNode<K, V>>() as u64;
+        let internal_size = std::mem::size_of::<_InternalNode<K, V>>() as u64;
+
+        // Size of all leaf nodes.
+        let leaves = (leaf_size * num_elems) / CAP as u64;
+
+        // Size of internal nodes. We add extra 10% overhead for all the levels of the tree
+        let elems_per_internal_node = (CAP * BF) as u64;
+        let internals = (internal_size * num_elems * 11) / (elems_per_internal_node * 10);
+
+        // Total size of the B-tree structure. Assuming nodes are on average 75% full,
+        // an additional overhead is added for the unused occupied space.
+        let total = 4 * (leaves + internals) / 3;
+
+        total as usize
+    }
+}
+
+/// Trait for data types capable of reporting their current memory usage
+///
+/// TODO: Make this a derivable trait so the `impl`s react automatically to changes.
+pub trait MemoryUsage {
+    /// Get amount of memory taken by the data owned by `self` (e.g. if it contains `Box` or `Vec`)
+    fn indirect_memory_usage(&self) -> usize;
+}
+
+/// Total memory usage (indirectly by pointers + for the object itself)
+fn total_memory_usage<T: MemoryUsage>(val: &T) -> usize {
+    val.indirect_memory_usage() + mem::size_of::<T>()
+}
+
+macro_rules! impl_no_indirect_memory_usage {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl MemoryUsage for $ty {
+                fn indirect_memory_usage(&self) -> usize { 0 }
+            }
+        )*
+    };
+}
+
+impl_no_indirect_memory_usage!((), bool, usize, u8, u16, u32, u64, u128);
+
+impl<K, V> MemoryUsage for std::collections::BTreeMap<K, V> {
+    /// The mem usage for [BTreeMap].
+    ///
+    /// Includes the nodes and the key and value data stored in the nodes. It does not, however,
+    /// include the memory taken up by data keys and values point to indirectly. Any indirect data
+    /// has to be tracked separately. This is so that the memory usage of the B-tree map/set can be
+    /// calculated from the number of elements alone without any expensive traversals.
+    fn indirect_memory_usage(&self) -> usize {
+        btree::usage::<K, V>(self.len())
+    }
+}
+
+impl<K> MemoryUsage for std::collections::BTreeSet<K> {
+    /// Same limitation as for `BTreeMap` also applies here
+    fn indirect_memory_usage(&self) -> usize {
+        btree::usage::<K, ()>(self.len())
+    }
+}
+
+impl<T: MemoryUsage> MemoryUsage for Option<T> {
+    fn indirect_memory_usage(&self) -> usize {
+        self.as_ref().map_or(0, |x| x.indirect_memory_usage())
+    }
+}
+
+impl<T: MemoryUsage> MemoryUsage for &[T] {
+    fn indirect_memory_usage(&self) -> usize {
+        self.iter().map(T::indirect_memory_usage).sum::<usize>() + mem::size_of_val::<[T]>(*self)
+    }
+}
+
+impl<T: MemoryUsage> MemoryUsage for Vec<T> {
+    fn indirect_memory_usage(&self) -> usize {
+        self.as_slice().indirect_memory_usage()
+    }
+}
+
+impl<T: MemoryUsage> MemoryUsage for Box<T> {
+    fn indirect_memory_usage(&self) -> usize {
+        total_memory_usage::<T>(self.as_ref())
+    }
+}
+
+impl<T: MemoryUsage, D> MemoryUsage for Tracked<T, D> {
+    fn indirect_memory_usage(&self) -> usize {
+        self.obj.indirect_memory_usage()
+    }
+}
+
+impl<T> MemoryUsage for common::primitives::Id<T> {
+    fn indirect_memory_usage(&self) -> usize {
+        0
+    }
+}
+
+impl MemoryUsage for TxMempoolEntry {
+    fn indirect_memory_usage(&self) -> usize {
+        let transaction = self.transaction().indirect_memory_usage();
+        let parents = self.parents.indirect_memory_usage();
+        let children = self.children.indirect_memory_usage();
+        transaction + parents + children
+    }
+}
+
+impl MemoryUsage for SignedTransaction {
+    /// Only data included indirectly (via pointers). The actual object usage is already contained
+    /// in the B-tree map usage.
+    fn indirect_memory_usage(&self) -> usize {
+        let ins = self.inputs().indirect_memory_usage();
+        let outs = self.outputs().indirect_memory_usage();
+        let sigs = self.signatures().indirect_memory_usage();
+        ins + outs + sigs
+    }
+}
+
+impl MemoryUsage for TxOutput {
+    fn indirect_memory_usage(&self) -> usize {
+        match self {
+            TxOutput::Transfer(_, _) => 0,
+            TxOutput::LockThenTransfer(_, _, _) => 0,
+            TxOutput::Burn(_) => 0,
+            TxOutput::CreateStakePool(_, pd) => pd.indirect_memory_usage(),
+            TxOutput::ProduceBlockFromStake(_, _) => 0,
+            TxOutput::CreateDelegationId(_, _) => 0,
+            TxOutput::DelegateStaking(_, _) => 0,
+        }
+    }
+}
+
+impl MemoryUsage for InputWitness {
+    fn indirect_memory_usage(&self) -> usize {
+        match self {
+            InputWitness::NoSignature(data) => data.indirect_memory_usage(),
+            InputWitness::Standard(sig) => sig.raw_signature().indirect_memory_usage(),
+        }
+    }
+}
+
+impl_no_indirect_memory_usage!(TxInput, StakePoolData);
+
+/// Types where the object created by T::default() takes no indirect memory.
+pub trait ZeroUsageDefault: MemoryUsage + Default {}
+
+impl<K, V> ZeroUsageDefault for std::collections::BTreeMap<K, V> {}
+impl<K> ZeroUsageDefault for std::collections::BTreeSet<K> {}
+impl<T: MemoryUsage> ZeroUsageDefault for Vec<T> {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+    use test_utils::random::*;
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn box_size(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+
+        let data: Vec<u8> = (0u32..rng.gen_range(0..=1000)).map(|_| rng.gen()).collect();
+        let box_data = Box::new(data.clone());
+        assert_eq!(total_memory_usage(&data), box_data.indirect_memory_usage());
+    }
+
+    #[allow(unused_allocation)]
+    fn check_indirect_primitive<T: MemoryUsage + Clone>(data: T) {
+        assert_eq!(data.indirect_memory_usage(), 0);
+        assert_eq!(Box::new(data).indirect_memory_usage(), mem::size_of::<T>());
+    }
+
+    #[test]
+    fn primitives() {
+        check_indirect_primitive(());
+        check_indirect_primitive(false);
+        check_indirect_primitive(15u8);
+        check_indirect_primitive(15u16);
+        check_indirect_primitive(15u32);
+        check_indirect_primitive(15u8);
+        check_indirect_primitive(15u16);
+        check_indirect_primitive(15u32);
+        check_indirect_primitive(15u64);
+        check_indirect_primitive(15u128);
+        check_indirect_primitive(15usize);
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn track_vecs(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+
+        let mut tracker = MemUsageTracker::new();
+        let mut data: Tracked<Vec<u8>, NoOpDropPolicy> = Tracked::default();
+
+        let len1 = rng.gen_range(0..=100);
+        tracker.modify(&mut data, |data, _| {
+            data.extend((0..len1).map(|_| rng.gen::<u8>()))
+        });
+        assert_eq!(tracker.get_usage(), len1);
+
+        let len2 = rng.gen_range(0..=300);
+        tracker.modify(&mut data, |data, _| {
+            data.extend((0..len2).map(|_| rng.gen::<u8>()))
+        });
+        assert_eq!(tracker.get_usage(), len1 + len2);
+    }
+
+    #[test]
+    #[should_panic = "dropped without being released"]
+    fn check_assert_drop_policy_works() {
+        let mut tracker = MemUsageTracker::new();
+        let data: Tracked<Box<u32>, AssertDropPolicy> = tracker.track(Box::new(123456u32));
+        assert_eq!(tracker.get_usage(), 4);
+        mem::drop(data);
+    }
+
+    #[test]
+    fn check_assert_drop_policy_works_happy_case() {
+        let mut tracker = MemUsageTracker::new();
+        let data: Tracked<Box<u32>, AssertDropPolicy> = tracker.track(Box::new(123456u32));
+        assert_eq!(tracker.get_usage(), 4);
+        mem::drop(tracker.release(data));
+        assert_eq!(tracker.get_usage(), 0);
+    }
+}

--- a/mempool/src/pool/store/mem_usage.rs
+++ b/mempool/src/pool/store/mem_usage.rs
@@ -23,7 +23,7 @@ use common::chain::{
 };
 use logging::log;
 
-use super::TxMempoolEntry;
+use super::{TxDependency, TxMempoolEntry};
 
 /// Structure that stores the current memory usage and keeps track of its changes
 #[derive(Debug)]
@@ -305,12 +305,6 @@ impl<T: MemoryUsage> MemoryUsage for Box<T> {
     }
 }
 
-impl<T: MemoryUsage, D> MemoryUsage for Tracked<T, D> {
-    fn indirect_memory_usage(&self) -> usize {
-        self.obj.indirect_memory_usage()
-    }
-}
-
 impl<T> MemoryUsage for common::primitives::Id<T> {
     fn indirect_memory_usage(&self) -> usize {
         0
@@ -360,7 +354,7 @@ impl MemoryUsage for InputWitness {
     }
 }
 
-impl_no_indirect_memory_usage!(TxInput, StakePoolData);
+impl_no_indirect_memory_usage!(StakePoolData, TxDependency, TxInput);
 
 /// Types where the object created by T::default() takes no indirect memory.
 pub trait ZeroUsageDefault: MemoryUsage + Default {}

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -164,6 +164,7 @@ impl MempoolStore {
         self.txs_by_id.contains_key(id)
     }
 
+    #[allow(unused)]
     pub fn memory_usage(&self) -> usize {
         self.mem_tracker.get_usage()
     }

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -13,9 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod mem_usage;
+
 use std::{
     cmp::Ordering,
     collections::{btree_map::Entry::Occupied, BTreeMap, BTreeSet},
+    ops::Deref,
 };
 
 use common::{
@@ -27,6 +30,7 @@ use utils::newtype;
 
 use super::{entry::TxEntry, fee::Fee, Time, TxEntryWithFee};
 use crate::error::MempoolPolicyError;
+use mem_usage::Tracked;
 
 newtype! {
     #[derive(Debug)]
@@ -59,11 +63,20 @@ newtype! {
     pub struct AncestorScore(Fee);
 }
 
+#[cfg(test)]
+type StrictDropPolicy = mem_usage::AssertDropPolicy;
+#[cfg(not(test))]
+type StrictDropPolicy = mem_usage::NoOpDropPolicy;
+
+type TrackedMap<K, V> = Tracked<BTreeMap<K, V>>;
+type TrackedSet<K> = Tracked<BTreeSet<K>>;
+type TrackedTxIdMultiMap<K> = TrackedMap<K, TrackedSet<Id<Transaction>>>;
+
 #[derive(Debug)]
 pub struct MempoolStore {
     // This is the "main" data structure storing Mempool entries. All other structures in the
     // MempoolStore contain ids (hashes) of entries, sorted according to some order of interest.
-    pub txs_by_id: BTreeMap<Id<Transaction>, TxMempoolEntry>,
+    pub txs_by_id: TrackedMap<Id<Transaction>, Tracked<TxMempoolEntry, StrictDropPolicy>>,
 
     // Mempool entries sorted by descendant score.
     // We keep this index so that when the mempool grows full, we know which transactions are the
@@ -75,34 +88,37 @@ pub struct MempoolStore {
     //  max(fee/size of entry's tx, fee/size with all descendants).
     //  TODO if we wish to follow Bitcoin Bore, "size" is not simply the encoded size, but
     // rather a value that takes into account witness and sigop data (see CTxMemPoolEntry::GetTxSize).
-    pub txs_by_descendant_score: BTreeMap<DescendantScore, BTreeSet<Id<Transaction>>>,
+    pub txs_by_descendant_score: TrackedTxIdMultiMap<DescendantScore>,
 
     // Mempool entries sorted by ancestor score.
     // This is used to select the most economically attractive transactions for block production.
     // The ancestor score of an entry is defined as
     //  min(score/size of entry's tx, score/size with all ancestors).
-    pub txs_by_ancestor_score: BTreeMap<AncestorScore, BTreeSet<Id<Transaction>>>,
+    pub txs_by_ancestor_score: TrackedTxIdMultiMap<AncestorScore>,
 
     // Entries that have remained in the mempool for a long time (see DEFAULT_MEMPOOL_EXPIRY) are
     // evicted. To efficiently know which entries to evict, we store the mempool entries sorted by
     // their creation time, from earliest to latest.
-    pub txs_by_creation_time: BTreeMap<Time, BTreeSet<Id<Transaction>>>,
+    pub txs_by_creation_time: TrackedTxIdMultiMap<Time>,
 
     // TODO add txs_by_ancestor_score index, which will be used by the block production subsystem
     // to select the best transactions for the next block
     //
     // We keep the information of which inputs are spent by entries currently in the mempool.
     // This allows us to recognize conflicts (double-spends) and handle them
-    pub spender_txs: BTreeMap<TxInput, Id<Transaction>>,
+    pub spender_txs: Tracked<BTreeMap<TxInput, Id<Transaction>>>,
 
     // Track transactions by internal unique sequence number. This is used to recover the order in
     // which the transactions have been inserted into the mempool, so they can be re-inserted in
     // the same order after a reorg. We keep both mapping from transactions to sequence numbers and
     // the mapping from sequence number back to transaction. The sequence number to be allocated to
     // the next incoming transaction is kept separately.
-    pub txs_by_seq_no: BTreeMap<usize, Id<Transaction>>,
-    pub seq_nos_by_tx: BTreeMap<Id<Transaction>, usize>,
+    txs_by_seq_no: Tracked<BTreeMap<usize, Id<Transaction>>>,
+    seq_nos_by_tx: Tracked<BTreeMap<Id<Transaction>, usize>>,
     next_seq_no: usize,
+
+    /// Memory usage accumulator
+    mem_tracker: mem_usage::MemUsageTracker,
 }
 
 // If a transaction is removed from the mempool for any reason other than inclusion in a block,
@@ -123,14 +139,15 @@ pub enum MempoolRemovalReason {
 impl MempoolStore {
     pub fn new() -> Self {
         Self {
-            txs_by_descendant_score: BTreeMap::new(),
-            txs_by_ancestor_score: BTreeMap::new(),
-            txs_by_id: BTreeMap::new(),
-            txs_by_creation_time: BTreeMap::new(),
-            spender_txs: BTreeMap::new(),
-            txs_by_seq_no: BTreeMap::new(),
-            seq_nos_by_tx: BTreeMap::new(),
+            txs_by_descendant_score: Tracked::default(),
+            txs_by_ancestor_score: Tracked::default(),
+            txs_by_id: Tracked::default(),
+            txs_by_creation_time: Tracked::default(),
+            spender_txs: Tracked::default(),
+            txs_by_seq_no: Tracked::default(),
+            seq_nos_by_tx: Tracked::default(),
             next_seq_no: 0,
+            mem_tracker: mem_usage::MemUsageTracker::new(),
         }
     }
 
@@ -139,11 +156,15 @@ impl MempoolStore {
     }
 
     pub fn get_entry(&self, id: &Id<Transaction>) -> Option<&TxMempoolEntry> {
-        self.txs_by_id.get(id)
+        self.txs_by_id.get(id).map(|tx| tx.deref())
     }
 
     pub fn contains(&self, id: &Id<Transaction>) -> bool {
         self.txs_by_id.contains_key(id)
+    }
+
+    pub fn memory_usage(&self) -> usize {
+        self.mem_tracker.get_usage()
     }
 
     pub fn assert_valid(&self) {
@@ -153,13 +174,37 @@ impl MempoolStore {
 
     #[cfg(test)]
     fn assert_valid_inner(&self) {
-        let entries = self.txs_by_descendant_score.values().flatten().collect::<Vec<_>>();
+        fn map_size<K, V: mem_usage::MemoryUsage>(map: &BTreeMap<K, V>) -> usize {
+            use mem_usage::MemoryUsage;
+            let vals_size = map.values().map(|v| v.indirect_memory_usage()).sum::<usize>();
+            map.indirect_memory_usage() + vals_size
+        }
+        let expected_size = map_size(&self.txs_by_id)
+            + map_size(&self.txs_by_descendant_score)
+            + map_size(&self.txs_by_ancestor_score)
+            + map_size(&self.txs_by_seq_no)
+            + map_size(&self.spender_txs)
+            + map_size(&self.txs_by_creation_time)
+            + map_size(&self.seq_nos_by_tx);
+        assert_eq!(
+            self.mem_tracker.get_usage(),
+            expected_size,
+            "Memory size tracker out of sync",
+        );
+
+        let entries = self
+            .txs_by_descendant_score
+            .values()
+            .flat_map(|ids| ids.deref())
+            .collect::<Vec<_>>();
+
         for id in self.txs_by_id.keys() {
             assert_eq!(
                 entries.iter().filter(|entry_id| ***entry_id == *id).count(),
                 1
             )
         }
+
         for entry in self.txs_by_id.values() {
             for child in &entry.children {
                 assert!(self.txs_by_id.get(child).expect("child").parents.contains(entry.tx_id()))
@@ -168,67 +213,89 @@ impl MempoolStore {
     }
 
     fn append_to_parents(&mut self, entry: &TxMempoolEntry) {
-        for parent in entry.unconfirmed_parents() {
-            self.txs_by_id
-                .get_mut(parent)
-                .expect("append_to_parents")
-                .get_children_mut()
-                .insert(*entry.tx_id());
-        }
+        self.mem_tracker.modify(&mut self.txs_by_id, |txs_by_id, tracker| {
+            for parent_id in entry.unconfirmed_parents() {
+                tracker.modify(
+                    txs_by_id.get_mut(parent_id).expect("append_to_parents"),
+                    |parent, _| parent.get_children_mut().insert(*entry.tx_id()),
+                );
+            }
+        })
     }
 
     fn remove_from_parents(&mut self, entry: &TxMempoolEntry) {
-        for parent in entry.unconfirmed_parents() {
-            self.txs_by_id
-                .get_mut(parent)
-                .expect("remove_from_parents")
-                .get_children_mut()
-                .remove(entry.tx_id());
-        }
+        self.mem_tracker.modify(&mut self.txs_by_id, |txs_by_id, tracker| {
+            for parent_id in entry.unconfirmed_parents() {
+                tracker.modify(
+                    txs_by_id.get_mut(parent_id).expect("remove_from_parents"),
+                    |parent, _| parent.get_children_mut().remove(entry.tx_id()),
+                );
+            }
+        })
     }
 
     fn remove_from_children(&mut self, entry: &TxMempoolEntry) {
-        for child in entry.unconfirmed_children() {
-            self.txs_by_id
-                .get_mut(child)
-                .expect("remove_from_children")
-                .get_parents_mut()
-                .remove(entry.tx_id());
-        }
+        self.mem_tracker.modify(&mut self.txs_by_id, |txs_by_id, tracker| {
+            for child_id in entry.unconfirmed_children() {
+                tracker.modify(
+                    txs_by_id.get_mut(child_id).expect("remove_from_children"),
+                    |child, _| child.get_parents_mut().remove(entry.tx_id()),
+                );
+            }
+        })
     }
 
     fn update_ancestor_state_for_add(
         &mut self,
         entry: &TxMempoolEntry,
     ) -> Result<(), MempoolPolicyError> {
-        for ancestor in entry.unconfirmed_ancestors(self).0 {
-            let ancestor = self.txs_by_id.get_mut(&ancestor).expect("ancestor");
-            ancestor.fees_with_descendants = (ancestor.fees_with_descendants + entry.fee)
-                .ok_or(MempoolPolicyError::AncestorFeeUpdateOverflow)?;
-            ancestor.size_with_descendants += entry.size();
-            ancestor.count_with_descendants += 1;
+        for ancestor_id in entry.unconfirmed_ancestors(self).0 {
+            self.mem_tracker.modify(&mut self.txs_by_id, |txs_by_id, tracker| {
+                tracker.modify(
+                    txs_by_id.get_mut(&ancestor_id).expect("ancestor"),
+                    |ancestor, _| {
+                        let total_fee = (ancestor.fees_with_descendants + entry.fee)
+                            .ok_or(MempoolPolicyError::AncestorFeeUpdateOverflow)?;
+                        ancestor.fees_with_descendants = total_fee;
+                        ancestor.size_with_descendants += entry.size();
+                        ancestor.count_with_descendants += 1;
+                        Ok(())
+                    },
+                )
+            })?
         }
         Ok(())
     }
 
     fn update_ancestor_state_for_drop(&mut self, entry: &TxMempoolEntry) {
         for ancestor in entry.unconfirmed_ancestors(self).0 {
-            let ancestor = self.txs_by_id.get_mut(&ancestor).expect("ancestor");
-            ancestor.fees_with_descendants =
-                (ancestor.fees_with_descendants - entry.fee).expect("fee with descendants");
-            ancestor.size_with_descendants -= entry.size();
-            ancestor.count_with_descendants -= 1;
+            self.mem_tracker.modify(&mut self.txs_by_id, |txs_by_id, tracker| {
+                tracker.modify(
+                    txs_by_id.get_mut(&ancestor).expect("ancestor"),
+                    |ancestor, _| {
+                        ancestor.fees_with_descendants = (ancestor.fees_with_descendants
+                            - entry.fee)
+                            .expect("fee with descendants");
+                        ancestor.size_with_descendants -= entry.size();
+                        ancestor.count_with_descendants -= 1;
+                    },
+                )
+            })
         }
     }
 
     fn mark_outpoints_as_spent(&mut self, entry: &TxMempoolEntry) {
-        for input in entry.entry.transaction().inputs().iter() {
-            self.spender_txs.insert(input.clone(), *entry.tx_id());
+        for input in entry.transaction().inputs().iter() {
+            self.mem_tracker.modify(&mut self.spender_txs, |spender_txs, _| {
+                spender_txs.insert(input.clone(), *entry.tx_id());
+            })
         }
     }
 
     fn unspend_outpoints(&mut self, entry: &TxMempoolEntry) {
-        self.spender_txs.retain(|_, id| id != entry.tx_id())
+        self.mem_tracker.modify(&mut self.spender_txs, |spender_txs, _| {
+            spender_txs.retain(|_, id| id != entry.tx_id());
+        })
     }
 
     pub fn add_tx(&mut self, entry: TxMempoolEntry) -> Result<(), MempoolPolicyError> {
@@ -236,29 +303,42 @@ impl MempoolStore {
         self.update_ancestor_state_for_add(&entry)?;
         self.mark_outpoints_as_spent(&entry);
 
-        let tx_id = entry.tx_id();
+        let tx_id = *entry.tx_id();
         let seq_no = self.next_seq_no;
         self.next_seq_no += 1;
 
-        self.txs_by_id.insert(*tx_id, entry.clone());
-
         self.add_to_descendant_score_index(&entry);
         self.add_to_ancestor_score_index(&entry);
-        self.txs_by_creation_time
-            .entry(entry.creation_time())
-            .or_default()
-            .insert(*tx_id);
-        self.txs_by_seq_no.insert(seq_no, *tx_id);
-        self.seq_nos_by_tx.insert(*tx_id, seq_no);
+        self.mem_tracker.modify(
+            &mut self.txs_by_creation_time,
+            |txs_by_creation_time, tracker| {
+                tracker.modify(
+                    txs_by_creation_time.entry(entry.creation_time()).or_default(),
+                    |entry, _| entry.insert(tx_id),
+                );
+            },
+        );
+
+        self.mem_tracker.modify(&mut self.txs_by_seq_no, |m, _| m.insert(seq_no, tx_id));
+        self.mem_tracker.modify(&mut self.seq_nos_by_tx, |m, _| m.insert(tx_id, seq_no));
+
+        let entry = self.mem_tracker.track(entry);
+        let prev = self.mem_tracker.modify(&mut self.txs_by_id, |m, _| m.insert(tx_id, entry));
+        assert!(prev.is_none(), "Entry already in store");
         Ok(())
     }
 
     fn add_to_descendant_score_index(&mut self, entry: &TxMempoolEntry) {
         self.refresh_ancestors(entry);
-        self.txs_by_descendant_score
-            .entry(entry.descendant_score())
-            .or_default()
-            .insert(*entry.tx_id());
+        self.mem_tracker.modify(
+            &mut self.txs_by_descendant_score,
+            |by_desc_score, tracker| {
+                tracker.modify(
+                    by_desc_score.entry(entry.descendant_score()).or_default(),
+                    |map_entry, _| map_entry.insert(*entry.tx_id()),
+                )
+            },
+        );
     }
 
     fn add_to_ancestor_score_index(&mut self, entry: &TxMempoolEntry) {
@@ -266,10 +346,12 @@ impl MempoolStore {
         // because such children would be orphans.
         // When we implement disconnecting a block, we'll need to clean up the mess we're leaving
         // here.
-        self.txs_by_ancestor_score
-            .entry(entry.ancestor_score())
-            .or_default()
-            .insert(*entry.tx_id());
+        self.mem_tracker.modify(&mut self.txs_by_ancestor_score, |anc_score, tracker| {
+            tracker.modify(
+                anc_score.entry(entry.ancestor_score()).or_default(),
+                |e, _| e.insert(*entry.tx_id()),
+            )
+        });
     }
 
     fn refresh_ancestors(&mut self, entry: &TxMempoolEntry) {
@@ -277,58 +359,76 @@ impl MempoolStore {
         // in txs_by_descendant_score may no longer be correct. We thus remove all ancestors and
         // reinsert them, taking the new, updated fees into account
         let ancestors = entry.unconfirmed_ancestors(self);
-        for entries in self.txs_by_descendant_score.values_mut() {
-            entries.retain(|id| !ancestors.contains(id))
-        }
-        for ancestor_id in ancestors.0 {
-            let ancestor = self.txs_by_id.get(&ancestor_id).expect("Inconsistent mempool state");
-            self.txs_by_descendant_score
-                .entry(ancestor.descendant_score())
-                .or_default()
-                .insert(ancestor_id);
-        }
+        self.mem_tracker.modify(&mut self.txs_by_descendant_score, |by_ds, tracker| {
+            for entries in by_ds.values_mut() {
+                tracker.modify(entries, |e, _| e.retain(|id| !ancestors.contains(id)));
+            }
+            for ancestor_id in ancestors.0 {
+                let ancestor =
+                    self.txs_by_id.get(&ancestor_id).expect("Inconsistent mempool state");
+                tracker.modify(
+                    by_ds.entry(ancestor.descendant_score()).or_default(),
+                    |e, _| e.insert(ancestor_id),
+                );
+            }
 
-        self.txs_by_descendant_score.retain(|_score, txs| !txs.is_empty());
+            by_ds.retain(|_score, txs| !txs.is_empty())
+        });
     }
 
     /// refresh descendants with new ancestor scores
     fn refresh_descendants(&mut self, entry: &TxMempoolEntry) {
         let descendants = entry.unconfirmed_descendants(self);
-        for entries in self.txs_by_ancestor_score.values_mut() {
-            entries.retain(|id| !descendants.contains(id))
-        }
-        for descendant_id in descendants.0 {
-            let descendant =
-                self.txs_by_id.get(&descendant_id).expect("Inconsistent mempool state");
-            self.txs_by_ancestor_score
-                .entry(descendant.ancestor_score())
-                .or_default()
-                .insert(descendant_id);
-        }
+        self.mem_tracker.modify(&mut self.txs_by_ancestor_score, |by_as, tracker| {
+            for entries in by_as.values_mut() {
+                tracker.modify(entries, |e, _| e.retain(|id| !descendants.contains(id)));
+            }
+            for descendant_id in descendants.0 {
+                let descendant =
+                    self.txs_by_id.get(&descendant_id).expect("Inconsistent mempool state");
+                tracker.modify(
+                    by_as.entry(descendant.ancestor_score()).or_default(),
+                    |e, _| e.insert(descendant_id),
+                );
+            }
 
-        self.txs_by_descendant_score.retain(|_score, txs| !txs.is_empty());
+            tracker.modify(&mut self.txs_by_descendant_score, |by_ds, _| {
+                by_ds.retain(|_score, txs| !txs.is_empty())
+            });
+        })
     }
 
     fn update_descendant_state_for_drop(&mut self, entry: &TxMempoolEntry) {
-        for descendant in entry.unconfirmed_descendants(self).0 {
-            let descendant = self.txs_by_id.get_mut(&descendant).expect("descendant");
-            descendant.fees_with_ancestors =
-                (descendant.fees_with_ancestors - entry.fee).expect("fee with descendants");
-            descendant.size_with_ancestors -= entry.size();
-            descendant.count_with_ancestors -= 1;
+        for descendant_id in entry.unconfirmed_descendants(self).0 {
+            self.mem_tracker.modify(&mut self.txs_by_id, |by_id, tracker| {
+                tracker.modify(
+                    by_id.get_mut(&descendant_id).expect("descendant"),
+                    |descendant, _| {
+                        descendant.fees_with_ancestors = (descendant.fees_with_ancestors
+                            - entry.fee)
+                            .expect("fee with descendants");
+                        descendant.size_with_ancestors -= entry.size();
+                        descendant.count_with_ancestors -= 1;
+                    },
+                )
+            })
         }
     }
 
     pub fn remove_tx(&mut self, tx_id: &Id<Transaction>, reason: MempoolRemovalReason) {
         log::info!("remove_tx: {}", tx_id.get());
-        if let Some(entry) = self.txs_by_id.remove(tx_id) {
+        let entry = self.mem_tracker.modify(&mut self.txs_by_id, |by_id, _| by_id.remove(tx_id));
+
+        if let Some(entry) = entry {
+            let entry = self.mem_tracker.release(entry);
             self.update_ancestor_state_for_drop(&entry);
             if reason == MempoolRemovalReason::Block {
                 self.update_descendant_state_for_drop(&entry)
             }
             self.drop_tx(&entry);
         } else {
-            assert!(!self.txs_by_descendant_score.values().flatten().any(|id| *id == *tx_id));
+            let txs_by_score = self.txs_by_descendant_score.values().map(Deref::deref);
+            assert!(!txs_by_score.flatten().any(|id| *id == *tx_id));
             assert!(!self.spender_txs.iter().any(|(_, id)| *id == *tx_id));
         }
     }
@@ -349,50 +449,50 @@ impl MempoolStore {
 
     fn remove_from_ancestor_score_index(&mut self, entry: &TxMempoolEntry) {
         self.refresh_descendants(entry);
-        let map_entry =
-            self.txs_by_ancestor_score.entry(entry.ancestor_score()).and_modify(|entries| {
-                entries.remove(entry.tx_id());
+        self.mem_tracker.modify(&mut self.txs_by_ancestor_score, |by_as, tracker| {
+            let map_entry = by_as.entry(entry.ancestor_score()).and_modify(|entries| {
+                tracker.modify(entries, |e, _| e.remove(entry.tx_id()));
             });
 
-        match map_entry {
-            Occupied(entries) if entries.get().is_empty() => drop(entries.remove_entry()),
-            _ => {}
-        };
+            match map_entry {
+                Occupied(entries) if entries.get().is_empty() => drop(entries.remove_entry()),
+                _ => (),
+            };
+        })
     }
 
     fn remove_from_descendant_score_index(&mut self, entry: &TxMempoolEntry) {
         self.refresh_ancestors(entry);
-        let map_entry =
-            self.txs_by_descendant_score
-                .entry(entry.descendant_score())
-                .and_modify(|entries| {
-                    entries.remove(entry.tx_id());
-                });
+        self.mem_tracker.modify(&mut self.txs_by_descendant_score, |by_ds, tracker| {
+            let map_entry = by_ds.entry(entry.descendant_score()).and_modify(|entries| {
+                tracker.modify(entries, |e, _| e.remove(entry.tx_id()));
+            });
 
-        match map_entry {
-            Occupied(entries) if entries.get().is_empty() => drop(entries.remove_entry()),
-            _ => {}
-        };
+            match map_entry {
+                Occupied(entries) if entries.get().is_empty() => drop(entries.remove_entry()),
+                _ => {}
+            };
+        })
     }
 
     fn remove_from_creation_time_index(&mut self, entry: &TxMempoolEntry) {
-        self.txs_by_creation_time.entry(entry.creation_time()).and_modify(|entries| {
-            entries.remove(entry.tx_id());
-        });
-        if self
-            .txs_by_creation_time
-            .get(&entry.creation_time())
-            .expect("key must exist")
-            .is_empty()
-        {
-            self.txs_by_creation_time.remove(&entry.creation_time());
-        }
+        self.mem_tracker.modify(&mut self.txs_by_creation_time, |by_ct, tracker| {
+            by_ct.entry(entry.creation_time()).and_modify(|entries| {
+                tracker.modify(entries, |e, _| e.remove(entry.tx_id()));
+            });
+
+            if by_ct.get(&entry.creation_time()).expect("key must exist").is_empty() {
+                by_ct.remove(&entry.creation_time());
+            }
+        })
     }
 
     fn remove_from_seq_no_index(&mut self, entry: &TxMempoolEntry) {
         let tx_id = entry.tx_id();
-        let seq_no = self.seq_nos_by_tx.remove(tx_id).expect("tx entry must exist");
-        self.txs_by_seq_no.remove(&seq_no).expect("tx with given seq no must exist");
+        let seq = self.mem_tracker.modify(&mut self.seq_nos_by_tx, |sn, _| sn.remove(tx_id));
+        let seq = seq.expect("Seq no for given transaction must exist");
+        let tx_id_seq = self.mem_tracker.modify(&mut self.txs_by_seq_no, |txs, _| txs.remove(&seq));
+        assert_eq!(tx_id_seq, Some(*tx_id), "Inconsistent transaction seq nos");
     }
 
     pub fn drop_conflicts(&mut self, conflicts: Conflicts) {
@@ -428,16 +528,26 @@ impl MempoolStore {
     }
 
     /// Take all the transactions from the store in the original order of insertion
-    pub fn into_transactions(self) -> impl Iterator<Item = TxEntry> {
-        let Self {
-            mut txs_by_id,
-            txs_by_seq_no,
-            ..
-        } = self;
+    pub fn into_transactions(mut self) -> impl Iterator<Item = TxEntry> {
+        use mem_usage::MemUsageTracker;
 
-        txs_by_seq_no
+        let mut txs_by_id = MemUsageTracker::forget(std::mem::take(&mut self.txs_by_id));
+        let txs_by_seq_no = MemUsageTracker::forget(std::mem::take(&mut self.txs_by_seq_no));
+
+        txs_by_seq_no.into_values().map(move |id| {
+            MemUsageTracker::forget(txs_by_id.remove(&id).expect("entry must be present")).entry
+        })
+    }
+}
+
+#[cfg(test)]
+impl Drop for MempoolStore {
+    fn drop(&mut self) {
+        // Clean up all the tracked stuff that could assert during testing. We do not miss any
+        // memory size updates because the tracker is being destroyed at the same time.
+        mem_usage::MemUsageTracker::forget(std::mem::take(&mut self.txs_by_id))
             .into_values()
-            .map(move |id| txs_by_id.remove(&id).expect("transaction must be present").entry)
+            .for_each(|entry| std::mem::drop(mem_usage::MemUsageTracker::forget(entry)));
     }
 }
 

--- a/mempool/src/pool/tests/expiry.rs
+++ b/mempool/src/pool/tests/expiry.rs
@@ -16,7 +16,6 @@
 use common::chain::tokens::OutputValue;
 
 use super::*;
-use crate::SystemUsageEstimator;
 
 #[rstest]
 #[trace]
@@ -53,7 +52,7 @@ async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
         Arc::clone(chainstate.get_chain_config()),
         start_chainstate(chainstate).await,
         mock_clock,
-        SystemUsageEstimator {},
+        StoreMemoryUsageEstimator,
     );
     mempool.add_transaction(parent)?.assert_in_mempool();
 
@@ -113,7 +112,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
         config,
         chainstate_interface,
         mock_clock,
-        SystemUsageEstimator {},
+        StoreMemoryUsageEstimator,
     );
 
     let parent_id = parent.transaction().get_id();

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -669,7 +669,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
     let ids = entries.iter().map(|entry| *entry.tx_id()).collect::<Vec<_>>();
 
     for entry in entries.into_iter() {
-        mempool.store.add_tx(entry)?;
+        mempool.store.add_tx_entry(entry)?;
     }
 
     let entry1 = mempool.store.get_entry(ids.get(0).expect("index")).expect("entry");

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -30,6 +30,14 @@ pub use test_utils::{
 
 use super::*;
 
+mockall::mock! {
+    pub MemoryUsageEstimator {}
+
+    impl MemoryUsageEstimator for MemoryUsageEstimator {
+        fn estimate_memory_usage(&self, store: &MempoolStore) -> usize;
+    }
+}
+
 impl TxStatus {
     /// Fetch status of given instruction from mempool, doing some integrity checks
     pub fn fetch<T>(mempool: &Mempool<T>, tx_id: &Id<Transaction>) -> Option<Self> {
@@ -104,7 +112,7 @@ pub fn estimate_tx_size(num_inputs: usize, num_outputs: usize) -> usize {
     result
 }
 
-pub async fn try_get_fee<M: GetMemoryUsage>(mempool: &Mempool<M>, tx: &SignedTransaction) -> Fee {
+pub async fn try_get_fee<M>(mempool: &Mempool<M>, tx: &SignedTransaction) -> Fee {
     let tx_clone = tx.clone();
 
     // Outputs in this vec are:

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -93,7 +93,6 @@ async fn initialize(
         Arc::clone(&chain_config),
         subsystem::Handle::clone(&chainstate),
         Default::default(),
-        mempool::SystemUsageEstimator {},
     );
     let mempool = manager.add_subsystem_with_custom_eventloop("mempool", {
         move |call, shutdn| mempool.run(call, shutdn)

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -71,12 +71,7 @@ pub fn start_subsystems_with_chainstate(
 
     let chainstate = manager.add_subsystem("p2p-test-chainstate", chainstate);
 
-    let mempool = mempool::make_mempool(
-        chain_config,
-        chainstate.clone(),
-        Default::default(),
-        mempool::SystemUsageEstimator {},
-    );
+    let mempool = mempool::make_mempool(chain_config, chainstate.clone(), Default::default());
     let mempool = manager.add_subsystem_with_custom_eventloop("p2p-test-mempool", {
         move |call, shutdn| mempool.run(call, shutdn)
     });

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -428,7 +428,6 @@ impl SyncManagerHandleBuilder {
             Arc::clone(&chain_config),
             chainstate.clone(),
             time_getter.clone(),
-            mempool::SystemUsageEstimator {},
         );
         let mempool = manager.add_subsystem_with_custom_eventloop("p2p-sync-test-mempool", {
             move |call, shutdn| mempool.run(call, shutdn)

--- a/p2p/tests/shutdown.rs
+++ b/p2p/tests/shutdown.rs
@@ -52,7 +52,6 @@ async fn shutdown_timeout() {
         Arc::clone(&chain_config),
         chainstate.clone(),
         Default::default(),
-        mempool::SystemUsageEstimator {},
     );
     let mempool = manager.add_subsystem_with_custom_eventloop("shutdown-test-mempool", {
         move |call, shutdown| mempool.run(call, shutdown)

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -222,7 +222,6 @@ async fn start_node(chain_config: Arc<ChainConfig>) -> (subsystem::Manager, Sock
         Arc::clone(&chain_config),
         chainstate.clone(),
         Default::default(),
-        mempool::SystemUsageEstimator {},
     );
     let mempool = manager.add_subsystem_with_custom_eventloop("wallet-cli-test-mempool", {
         move |call, shutdn| mempool.run(call, shutdn)

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -89,7 +89,6 @@ pub async fn start_subsystems(
         Arc::clone(&chain_config),
         chainstate_handle.clone(),
         Default::default(),
-        mempool::SystemUsageEstimator {},
     );
     let mempool_handle = manager.add_subsystem_with_custom_eventloop("test-mempool", {
         move |call, shutdn| mempool.run(call, shutdn)


### PR DESCRIPTION
Notes:
* This is built on top of #928
* Contains multiple lines of defences to prevent the users from forgetting to update the memory usage when objects tracked for memory usage are changed, created, or deleted.
* This is best effort. Not guaranteed to be accurate but should be reasonably close.
* Most of the substantive changes are in `mempool/src/pool/store/*.rs`

Todo:
* [x] Try to get rid of interior mutability in the `Tracker` type. Should be possible but failed to achieve so far
* [x] More tests