### PR TITLE
Use a proper error type for load cookie util

### DIFF
--- a/wallet/wallet-cli-lib/src/errors.rs
+++ b/wallet/wallet-cli-lib/src/errors.rs
@@ -15,6 +15,8 @@
 
 use std::path::PathBuf;
 
+use utils::cookie::LoadCookieError;
+
 #[derive(thiserror::Error, Debug)]
 pub enum WalletCliError {
     #[error("Controller error: {0}")]
@@ -24,9 +26,9 @@ pub enum WalletCliError {
     #[error("File {0} I/O error: {1}")]
     FileError(PathBuf, std::io::Error),
     #[error(
-        "RPC authentication cookie-file read error: {0}: {1}. Please make sure the node is started."
+        "RPC authentication cookie-file read error: {0}. Please make sure the node is started."
     )]
-    CookieFileReadError(PathBuf, String),
+    CookieFileReadError(#[from] LoadCookieError),
     #[error("Invalid config: {0}")]
     InvalidConfig(String),
     #[error("Invalid quoting")]

--- a/wallet/wallet-cli-lib/src/lib.rs
+++ b/wallet/wallet-cli-lib/src/lib.rs
@@ -84,11 +84,9 @@ pub async fn run(
         (None, None, None) => {
             let cookie_file_path =
                 default_data_dir_for_chain(chain_type.name()).join(COOKIE_FILENAME);
-            load_cookie(cookie_file_path.clone())
-                .map_err(|e| WalletCliError::CookieFileReadError(cookie_file_path, e))?
+            load_cookie(cookie_file_path)?
         }
-        (Some(cookie_file_path), None, None) => load_cookie(&cookie_file_path)
-            .map_err(|e| WalletCliError::CookieFileReadError(cookie_file_path.into(), e))?,
+        (Some(cookie_file_path), None, None) => load_cookie(cookie_file_path)?,
         (None, Some(username), Some(password)) => (username, password),
         _ => {
             return Err(WalletCliError::InvalidConfig(


### PR DESCRIPTION
Switches from `Result<(String, String), String>` to `Result<(String, String), LoadCookieError>` which makes it easier to extend the error cases in the `load_cookie` util.