### PR TITLE
Implementation of a "simplified" wrapper for atomics

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -20,10 +20,7 @@ mod pos;
 mod pow;
 mod validator;
 
-use std::sync::{
-    atomic::{AtomicBool, AtomicU64},
-    Arc,
-};
+use std::sync::Arc;
 
 use chainstate_types::{
     pos_randomness::PoSRandomness, BlockIndex, GenBlockIndex, PropertyQueryError,
@@ -41,6 +38,7 @@ use common::{
     primitives::BlockHeight,
 };
 use serialization::{Decode, Encode};
+use utils::atomics::{RelAtomicBool, SynAtomicU64};
 
 use crate::pos::input_data::generate_pos_consensus_data_and_reward;
 use crate::pow::input_data::generate_pow_consensus_data_and_reward;
@@ -179,8 +177,8 @@ pub fn finalize_consensus_data(
     chain_config: &ChainConfig,
     block_header: &mut BlockHeader,
     block_height: BlockHeight,
-    block_timestamp_seconds: Arc<AtomicU64>,
-    stop_flag: Arc<AtomicBool>,
+    block_timestamp_seconds: Arc<SynAtomicU64>,
+    stop_flag: Arc<RelAtomicBool>,
     finalize_data: FinalizeBlockInputData,
 ) -> Result<SignedBlockHeader, ConsensusCreationError> {
     match chain_config.net_upgrade().consensus_status(block_height.next_height()) {

--- a/consensus/src/pow/work.rs
+++ b/consensus/src/pow/work.rs
@@ -15,7 +15,7 @@
 
 #![allow(dead_code)]
 
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::Arc;
 
 use chainstate_types::{BlockIndex, BlockIndexHandle, GenBlockIndex, PropertyQueryError};
 use common::{
@@ -28,6 +28,7 @@ use common::{
     primitives::{BlockHeight, Compact, Idable, H256},
     Uint256,
 };
+use utils::atomics::RelAtomicBool;
 
 use crate::pow::{
     error::ConsensusPoWError,
@@ -240,7 +241,7 @@ pub fn mine(
     block_header: &mut BlockHeader,
     max_nonce: u128,
     bits: Compact,
-    stop_flag: Arc<AtomicBool>,
+    stop_flag: Arc<RelAtomicBool>,
 ) -> Result<MiningResult, ConsensusPoWError> {
     let mut data = Box::new(PoWData::new(bits, 0));
     for nonce in 0..max_nonce {
@@ -252,7 +253,7 @@ pub fn mine(
             return Ok(MiningResult::Success);
         }
 
-        if stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+        if stop_flag.load() {
             return Ok(MiningResult::Stopped);
         }
     }

--- a/utils/src/atomics/atomic_traits.rs
+++ b/utils/src/atomics/atomic_traits.rs
@@ -1,0 +1,186 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Atomic traits. Unlike traits from the `atomic_traits` crate, these are implemented
+//! for `loom` types too.
+//!
+//! Note: functions that are not implemented by `loom` atomics (such as `get_mut`) are missing
+//! here too.
+//! We also omit deprecated functions, such as `compare_and_swap`, and don't support `AtomicPtr`.
+
+use crate::sync::atomic::{
+    AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
+    AtomicU64, AtomicU8, AtomicUsize, Ordering,
+};
+
+/// A trait that contains basic atomic operations common for all atomic types.
+pub trait Atomic {
+    type Type;
+
+    fn load(&self, order: Ordering) -> Self::Type;
+    fn store(&self, val: Self::Type, order: Ordering);
+    fn swap(&self, val: Self::Type, order: Ordering) -> Self::Type;
+
+    fn compare_exchange(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type>;
+
+    fn compare_exchange_weak(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type>;
+
+    fn fetch_update<F>(
+        &self,
+        fetch_order: Ordering,
+        set_order: Ordering,
+        f: F,
+    ) -> Result<Self::Type, Self::Type>
+    where
+        F: FnMut(Self::Type) -> Option<Self::Type>;
+
+    fn fetch_and(&self, val: Self::Type, order: Ordering) -> Self::Type;
+    fn fetch_nand(&self, val: Self::Type, order: Ordering) -> Self::Type;
+    fn fetch_or(&self, val: Self::Type, order: Ordering) -> Self::Type;
+    fn fetch_xor(&self, val: Self::Type, order: Ordering) -> Self::Type;
+}
+
+/// A trait that contains atomic operations specific to atomic integers.
+pub trait AtomicNum: Atomic {
+    fn fetch_add(&self, val: Self::Type, order: Ordering) -> Self::Type;
+    fn fetch_sub(&self, val: Self::Type, order: Ordering) -> Self::Type;
+    fn fetch_max(&self, val: Self::Type, order: Ordering) -> Self::Type;
+    fn fetch_min(&self, val: Self::Type, order: Ordering) -> Self::Type;
+}
+
+/// This trait is implemented for primitive types which have an atomic counterpart.
+pub trait HasStdAtomic {
+    type AtomicType;
+}
+
+macro_rules! impl_atomic {
+    ($atomic_type:ident, $primitive_type:ident) => {
+        impl Atomic for $atomic_type {
+            type Type = $primitive_type;
+
+            fn load(&self, order: Ordering) -> Self::Type {
+                self.load(order)
+            }
+
+            fn store(&self, val: Self::Type, order: Ordering) {
+                self.store(val, order)
+            }
+
+            fn swap(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.swap(val, order)
+            }
+
+            fn compare_exchange(
+                &self,
+                current: Self::Type,
+                new: Self::Type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<Self::Type, Self::Type> {
+                self.compare_exchange(current, new, success, failure)
+            }
+
+            fn compare_exchange_weak(
+                &self,
+                current: Self::Type,
+                new: Self::Type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<Self::Type, Self::Type> {
+                self.compare_exchange_weak(current, new, success, failure)
+            }
+
+            fn fetch_update<F>(
+                &self,
+                fetch_order: Ordering,
+                set_order: Ordering,
+                f: F,
+            ) -> Result<Self::Type, Self::Type>
+            where
+                F: FnMut(Self::Type) -> Option<Self::Type>,
+            {
+                self.fetch_update(fetch_order, set_order, f)
+            }
+
+            fn fetch_and(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.fetch_and(val, order)
+            }
+
+            fn fetch_nand(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.fetch_nand(val, order)
+            }
+
+            fn fetch_or(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.fetch_or(val, order)
+            }
+
+            fn fetch_xor(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.fetch_xor(val, order)
+            }
+        }
+
+        impl HasStdAtomic for $primitive_type {
+            type AtomicType = $atomic_type;
+        }
+    };
+}
+
+macro_rules! impl_atomic_num {
+    ($atomic_type:ident, $primitive_type:ident) => {
+        impl_atomic! {$atomic_type, $primitive_type}
+
+        impl AtomicNum for $atomic_type {
+            fn fetch_add(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.fetch_add(val, order)
+            }
+
+            fn fetch_sub(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.fetch_sub(val, order)
+            }
+
+            fn fetch_max(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.fetch_max(val, order)
+            }
+
+            fn fetch_min(&self, val: Self::Type, order: Ordering) -> Self::Type {
+                self.fetch_min(val, order)
+            }
+        }
+    };
+}
+
+impl_atomic!(AtomicBool, bool);
+impl_atomic_num!(AtomicI8, i8);
+impl_atomic_num!(AtomicU8, u8);
+impl_atomic_num!(AtomicI16, i16);
+impl_atomic_num!(AtomicU16, u16);
+impl_atomic_num!(AtomicI32, i32);
+impl_atomic_num!(AtomicU32, u32);
+impl_atomic_num!(AtomicI64, i64);
+impl_atomic_num!(AtomicU64, u64);
+impl_atomic_num!(AtomicIsize, isize);
+impl_atomic_num!(AtomicUsize, usize);

--- a/utils/src/atomics/mod.rs
+++ b/utils/src/atomics/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,24 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod atomics;
-pub mod blockuntilzero;
-pub mod bloom_filters;
-pub mod config_setting;
-pub mod const_value;
-pub mod cookie;
-pub mod counttracker;
-pub mod default_data_dir;
-pub mod ensure;
-pub mod eventhandler;
-pub mod exp_rand;
-pub mod maybe_encrypted;
-pub mod newtype;
-pub mod once_destructor;
-pub mod qrcode;
-pub mod set_flag;
-pub mod shallow_clone;
-pub mod tap_error_log;
+pub mod atomic_traits;
+pub mod simple_atomic;
 
-mod concurrency_impl;
-pub use concurrency_impl::*;
+pub use self::atomic_traits::{Atomic as AtomicTrait, AtomicNum as AtomicNumTrait};
+pub use simple_atomic::*;

--- a/utils/src/atomics/simple_atomic.rs
+++ b/utils/src/atomics/simple_atomic.rs
@@ -1,0 +1,249 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module implements "simplified" atomic types, which use predefined memory orderings.
+//!
+//! They come in two variants: the "relaxed" ones, whose operations always use the "Relaxed"
+//! memory ordering, and "synchronizing" ones, whose stores are always "Release" and loads
+//! are always "Acquire".
+//!
+//! The reason for having them is that there are basically two use cases for an atomic type:
+//! 1) a low-level thread synchronization primitive;
+//! 2) a way to get interior mutability and/or circumvent borrow checker's restrictions.
+//!
+//! In the first case, the atomic operations should normally use the "synchronizing"
+//! memory orderings, such as "Acquire" and "Release", and in the second case the
+//! (generally cheaper) "Relaxed" ordering is enough.
+//!
+//! Additionally, sometimes atomic types can appear at the API boundary of a module or a package,
+//! which may lead to a situation where a load is performed in one module and a store in another.
+//! In this case, using the standard atomics effectively breaks encapsulation because,
+//! on the one hand, the memory orderings used by modules are their implementation details
+//! but, on the other hand, they must still agree with each other. Using a simplified atomic
+//! in this case basically encodes the purpose of the atomic in its type's name and makes
+//! the orderings a part of the module's interface.
+
+use crate::atomics::{atomic_traits::HasStdAtomic, AtomicNumTrait, AtomicTrait};
+use std::marker::PhantomData;
+
+use crate::concurrency_impl::sync::atomic::Ordering;
+
+mod private {
+    #[doc(hidden)]
+    pub trait Sealed {}
+}
+
+/// A predefined set of orderings to use by the [Atomic] type.
+pub trait Orderings: private::Sealed {
+    const ORD_LOAD: Ordering;
+    const ORD_STORE: Ordering;
+    const ORD_LOAD_STORE: Ordering;
+}
+
+/// A generic implementation of a simplified atomic type that uses a predefined set
+/// of memory orderings.
+pub struct Atomic<T, Ord>(<T as HasStdAtomic>::AtomicType, PhantomData<Ord>)
+where
+    T: HasStdAtomic;
+
+/// Methods that are not specific to atomic types.
+impl<T, Ord> Atomic<T, Ord>
+where
+    T: HasStdAtomic,
+    <T as HasStdAtomic>::AtomicType: From<T>,
+    Ord: Orderings,
+{
+    pub fn new(val: T) -> Self {
+        let inner: <T as HasStdAtomic>::AtomicType = val.into();
+        Self(inner, PhantomData)
+    }
+
+    pub fn inner(&self) -> &<T as HasStdAtomic>::AtomicType {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> <T as HasStdAtomic>::AtomicType {
+        self.0
+    }
+}
+
+/// Methods common to all atomic types.
+impl<T, Ord> Atomic<T, Ord>
+where
+    T: HasStdAtomic,
+    <T as HasStdAtomic>::AtomicType: AtomicTrait<Type = T>,
+    Ord: Orderings,
+{
+    pub fn load(&self) -> T {
+        self.0.load(Ord::ORD_LOAD)
+    }
+
+    pub fn store(&self, val: T) {
+        self.0.store(val, Ord::ORD_STORE)
+    }
+
+    pub fn swap(&self, val: T) -> T {
+        self.0.swap(val, Ord::ORD_LOAD_STORE)
+    }
+
+    // Note: no compare_and_swap because it's deprecated
+
+    pub fn compare_exchange(&self, current: T, new: T) -> Result<T, T> {
+        self.0.compare_exchange(current, new, Ord::ORD_LOAD_STORE, Ord::ORD_LOAD)
+    }
+
+    pub fn compare_exchange_weak(&self, current: T, new: T) -> Result<T, T> {
+        self.0.compare_exchange_weak(current, new, Ord::ORD_LOAD_STORE, Ord::ORD_LOAD)
+    }
+
+    pub fn fetch_update<F>(&self, f: F) -> Result<T, T>
+    where
+        F: FnMut(T) -> Option<T>,
+    {
+        self.0.fetch_update(Ord::ORD_LOAD_STORE, Ord::ORD_LOAD, f)
+    }
+
+    pub fn fetch_and(&self, val: T) -> T {
+        self.0.fetch_and(val, Ord::ORD_LOAD_STORE)
+    }
+
+    pub fn fetch_nand(&self, val: T) -> T {
+        self.0.fetch_nand(val, Ord::ORD_LOAD_STORE)
+    }
+
+    pub fn fetch_or(&self, val: T) -> T {
+        self.0.fetch_or(val, Ord::ORD_LOAD_STORE)
+    }
+
+    pub fn fetch_xor(&self, val: T) -> T {
+        self.0.fetch_xor(val, Ord::ORD_LOAD_STORE)
+    }
+}
+
+/// Methods that are specific to atomic numbers.
+impl<T, Ord> Atomic<T, Ord>
+where
+    T: HasStdAtomic,
+    <T as HasStdAtomic>::AtomicType: AtomicNumTrait<Type = T>,
+    Ord: Orderings,
+{
+    pub fn fetch_add(&self, val: T) -> T {
+        self.0.fetch_add(val, Ord::ORD_LOAD_STORE)
+    }
+
+    pub fn fetch_sub(&self, val: T) -> T {
+        self.0.fetch_sub(val, Ord::ORD_LOAD_STORE)
+    }
+
+    pub fn fetch_max(&self, val: T) -> T {
+        self.0.fetch_max(val, Ord::ORD_LOAD_STORE)
+    }
+
+    pub fn fetch_min(&self, val: T) -> T {
+        self.0.fetch_min(val, Ord::ORD_LOAD_STORE)
+    }
+}
+
+impl<T, Ord> Default for Atomic<T, Ord>
+where
+    T: HasStdAtomic + Default,
+    <T as HasStdAtomic>::AtomicType: From<T>,
+    Ord: Orderings,
+{
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T, Ord> From<T> for Atomic<T, Ord>
+where
+    T: HasStdAtomic,
+    <T as HasStdAtomic>::AtomicType: From<T>,
+    Ord: Orderings,
+{
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T, Ord> std::fmt::Debug for Atomic<T, Ord>
+where
+    T: HasStdAtomic + std::fmt::Debug,
+    <T as HasStdAtomic>::AtomicType: AtomicTrait<Type = T>,
+    Ord: Orderings,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Note: here we deliberately don't delegate to the wrapped type's Debug implementation,
+        // so that the output doesn't depend on whether we're running with loom ot not.
+        // Also note that we always use the Relaxed ordering for printing, just like
+        // the standard atomic types do.
+        std::fmt::Debug::fmt(&self.0.load(Ordering::Relaxed), f)
+    }
+}
+
+#[doc(hidden)]
+pub struct RelOrderings;
+
+impl Orderings for RelOrderings {
+    const ORD_LOAD: Ordering = Ordering::Relaxed;
+    const ORD_STORE: Ordering = Ordering::Relaxed;
+    const ORD_LOAD_STORE: Ordering = Ordering::Relaxed;
+}
+
+impl private::Sealed for RelOrderings {}
+
+/// The "relaxed" variant of the atomic.
+pub type RelAtomic<T> = Atomic<T, RelOrderings>;
+
+pub type RelAtomicBool = RelAtomic<bool>;
+pub type RelAtomicI8 = RelAtomic<i8>;
+pub type RelAtomicU8 = RelAtomic<u8>;
+pub type RelAtomicI16 = RelAtomic<i16>;
+pub type RelAtomicU16 = RelAtomic<u16>;
+pub type RelAtomicI32 = RelAtomic<i32>;
+pub type RelAtomicU32 = RelAtomic<u32>;
+pub type RelAtomicI64 = RelAtomic<i64>;
+pub type RelAtomicU64 = RelAtomic<u64>;
+pub type RelAtomicIsize = RelAtomic<isize>;
+pub type RelAtomicUsize = RelAtomic<usize>;
+
+#[doc(hidden)]
+pub struct SynOrderings;
+
+impl Orderings for SynOrderings {
+    const ORD_LOAD: Ordering = Ordering::Acquire;
+    const ORD_STORE: Ordering = Ordering::Release;
+    const ORD_LOAD_STORE: Ordering = Ordering::AcqRel;
+}
+
+impl private::Sealed for SynOrderings {}
+
+/// The "synchronizing" variant of the atomic.
+///
+/// Note: the prefix "Syn" has nothing to do with the standard `Sync` trait; both [RelAtomic<T>] and [SynAtomic<T>]
+/// are `Sync`.
+pub type SynAtomic<T> = Atomic<T, SynOrderings>;
+
+pub type SynAtomicBool = SynAtomic<bool>;
+pub type SynAtomicI8 = SynAtomic<i8>;
+pub type SynAtomicU8 = SynAtomic<u8>;
+pub type SynAtomicI16 = SynAtomic<i16>;
+pub type SynAtomicU16 = SynAtomic<u16>;
+pub type SynAtomicI32 = SynAtomic<i32>;
+pub type SynAtomicU32 = SynAtomic<u32>;
+pub type SynAtomicI64 = SynAtomic<i64>;
+pub type SynAtomicU64 = SynAtomic<u64>;
+pub type SynAtomicIsize = SynAtomic<isize>;
+pub type SynAtomicUsize = SynAtomic<usize>;

--- a/utils/src/shallow_clone.rs
+++ b/utils/src/shallow_clone.rs
@@ -82,7 +82,7 @@ mod impl_checks {
     assert_impl_all!(&u32: ShallowClone);
     assert_impl_all!(&[u32]: ShallowClone);
     assert_impl_all!(&[u32; 10]: ShallowClone);
-    assert_impl_all!(std::sync::Arc<Vec<u32>>: ShallowClone);
+    assert_impl_all!(Arc<Vec<u32>>: ShallowClone);
 
     assert_not_impl_any!(Vec<u32>: ShallowClone);
     assert_not_impl_any!([u32; 10]: ShallowClone);

--- a/utils/tests/simple_atomic.rs
+++ b/utils/tests/simple_atomic.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use utils::{atomics::RelAtomicU32, concurrency};
+
+// Here we have simple tests that basically check that the correct function of the wrapped
+// type is called by each function of the "Atomic" wrapper.
+// Note that this will also indirectly check the correctness of implementation of "Atomic"
+// traits, which are used by the wrapper.
+
+#[test]
+fn test_load_store_swap() {
+    concurrency::model(|| {
+        let a = RelAtomicU32::new(1);
+        assert_eq!(a.load(), 1);
+
+        a.store(2);
+        assert_eq!(a.load(), 2);
+
+        assert_eq!(a.swap(3), 2);
+        assert_eq!(a.load(), 3);
+    });
+}
+
+#[test]
+fn test_compare_exchange() {
+    concurrency::model(|| {
+        let a = RelAtomicU32::new(1);
+
+        assert_eq!(a.compare_exchange(2, 1), Err(1));
+        assert_eq!(a.load(), 1);
+
+        assert_eq!(a.compare_exchange(1, 2), Ok(1));
+        assert_eq!(a.load(), 2);
+    });
+}
+
+#[test]
+fn test_compare_exchange_weak() {
+    concurrency::model(|| {
+        let a = RelAtomicU32::new(1);
+
+        assert_eq!(a.compare_exchange_weak(2, 1), Err(1));
+        assert_eq!(a.load(), 1);
+
+        let result = a.compare_exchange_weak(1, 2);
+        assert!(result == Ok(1) || result == Err(1));
+    });
+}
+
+#[test]
+fn test_fetch_update() {
+    concurrency::model(|| {
+        let a = RelAtomicU32::new(1);
+
+        assert_eq!(
+            a.fetch_update(|x| {
+                assert_eq!(x, 1);
+                None
+            }),
+            Err(1)
+        );
+        assert_eq!(a.load(), 1);
+
+        assert_eq!(
+            a.fetch_update(|x| {
+                assert_eq!(x, 1);
+                Some(2)
+            }),
+            Ok(1)
+        );
+        assert_eq!(a.load(), 2);
+    });
+}
+
+#[test]
+fn test_bit_ops() {
+    concurrency::model(|| {
+        let a = RelAtomicU32::new(0b1100);
+        assert_eq!(a.fetch_and(0b1010), 0b1100);
+        assert_eq!(a.load(), 0b1000);
+
+        a.store(0b1100);
+        assert_eq!(a.fetch_nand(0b1010), 0b1100);
+        assert_eq!(a.load(), 0b11111111_11111111_11111111_11110111);
+
+        a.store(0b1100);
+        assert_eq!(a.fetch_or(0b1010), 0b1100);
+        assert_eq!(a.load(), 0b1110);
+
+        a.store(0b1100);
+        assert_eq!(a.fetch_xor(0b1010), 0b1100);
+        assert_eq!(a.load(), 0b0110);
+    });
+}
+
+#[test]
+fn test_num_ops() {
+    concurrency::model(|| {
+        let a = RelAtomicU32::new(10);
+
+        assert_eq!(a.fetch_add(20), 10);
+        assert_eq!(a.load(), 30);
+
+        assert_eq!(a.fetch_sub(20), 30);
+        assert_eq!(a.load(), 10);
+
+        assert_eq!(a.fetch_max(100), 10);
+        assert_eq!(a.load(), 100);
+        assert_eq!(a.fetch_max(10), 100);
+        assert_eq!(a.load(), 100);
+
+        assert_eq!(a.fetch_min(10), 100);
+        assert_eq!(a.load(), 10);
+        assert_eq!(a.fetch_min(100), 10);
+        assert_eq!(a.load(), 10);
+    });
+}
+
+#[test]
+fn test_default_debug_from() {
+    concurrency::model(|| {
+        let a = <RelAtomicU32 as Default>::default();
+        assert_eq!(a.load(), 0);
+
+        let a: RelAtomicU32 = 123.into();
+        assert_eq!(a.load(), 123);
+
+        assert_eq!(format!("{a:?}"), "123");
+    });
+}


### PR DESCRIPTION
Here is an implementation of the wrapper for atomics that we've discussed earlier. 

The code has a couple of FIXMEs, those are basically my questions to reviewers. I'm not sure whether I should implement them, turn into proper TODOs or just delete them.

For now, I only used "simplified" atomics in a couple of places, mainly as an example (if this PR gets approved, I plan to change (most of) the other places too).
Note that the replaced AtomicU64 is the one that I've mentioned in our discussion - it used to use SeqCst on loads and Relaxed on stores, which didn't make much sense. I've replaced it with RelAtomicU64, which is the "relaxed" variant.

Edit: I forgot to mention, I also had to introduce traits for standard atomic types, similar to what the crate "atomic_traits" has, so that I could implement them for "loom" atomics too and then use them in my implementation of the wrapper.
Probably, we can get rid of the "atomic_traits" crate now. (Note though that the current version of my atomic traits doesn't support AtomicPtr. But I suppose it's not something we will miss).