### PR TITLE
Remove datadir from functional tests node config

### DIFF
--- a/test/functional/test_framework/.mintlayer/config.toml
+++ b/test/functional/test_framework/.mintlayer/config.toml
@@ -1,5 +1,3 @@
-datadir = "."
-
 [chainstate]
 max_db_commit_attempts = 10
 max_orphan_blocks = 512


### PR DESCRIPTION
The `datadir` field no longer exists in `NodeConfigFile` as seen [here](https://github.com/mintlayer/mintlayer-core/blob/77b5f434293e0edc6fd5ed57269a4ff78bbbb3de/node-lib/src/config_files/mod.rs#L37C10-L45). This pull request removes it from the functional tests config file to avoid potential confusion.