### PR TITLE
Remove redundant explicit p2p error conversions

### DIFF
--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -40,7 +40,7 @@ where
         self.tx_peer_manager
             .send(PeerManagerEvent::Connect(addr, tx))
             .map_err(|_| P2pError::ChannelClosed)?;
-        rx.await.map_err(P2pError::from)?
+        rx.await?
     }
 
     async fn disconnect(&mut self, peer_id: PeerId) -> crate::Result<()> {
@@ -49,31 +49,25 @@ where
         self.tx_peer_manager
             .send(PeerManagerEvent::Disconnect(peer_id, tx))
             .map_err(|_| P2pError::ChannelClosed)?;
-        rx.await.map_err(P2pError::from)?
+        rx.await?
     }
 
     async fn get_peer_count(&self) -> crate::Result<usize> {
         let (tx, rx) = oneshot_nofail::channel();
-        self.tx_peer_manager
-            .send(PeerManagerEvent::GetPeerCount(tx))
-            .map_err(P2pError::from)?;
-        rx.await.map_err(P2pError::from)
+        self.tx_peer_manager.send(PeerManagerEvent::GetPeerCount(tx))?;
+        Ok(rx.await?)
     }
 
     async fn get_bind_addresses(&self) -> crate::Result<Vec<String>> {
         let (tx, rx) = oneshot_nofail::channel();
-        self.tx_peer_manager
-            .send(PeerManagerEvent::GetBindAddresses(tx))
-            .map_err(P2pError::from)?;
-        rx.await.map_err(P2pError::from)
+        self.tx_peer_manager.send(PeerManagerEvent::GetBindAddresses(tx))?;
+        Ok(rx.await?)
     }
 
     async fn get_connected_peers(&self) -> crate::Result<Vec<ConnectedPeer>> {
         let (tx, rx) = oneshot_nofail::channel();
-        self.tx_peer_manager
-            .send(PeerManagerEvent::GetConnectedPeers(tx))
-            .map_err(P2pError::from)?;
-        rx.await.map_err(P2pError::from)
+        self.tx_peer_manager.send(PeerManagerEvent::GetConnectedPeers(tx))?;
+        Ok(rx.await?)
     }
 
     async fn add_reserved_node(&mut self, addr: String) -> crate::Result<()> {

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -183,19 +183,19 @@ where
             address
         );
 
-        self.cmd_tx.send(types::Command::Connect { address }).map_err(P2pError::from)
+        Ok(self.cmd_tx.send(types::Command::Connect { address })?)
     }
 
     fn accept(&mut self, peer_id: PeerId) -> crate::Result<()> {
         log::debug!("accept new peer, peer_id: {peer_id}");
 
-        self.cmd_tx.send(types::Command::Accept { peer_id }).map_err(P2pError::from)
+        Ok(self.cmd_tx.send(types::Command::Accept { peer_id })?)
     }
 
     fn disconnect(&mut self, peer_id: PeerId) -> crate::Result<()> {
         log::debug!("close connection with remote, peer_id: {peer_id}");
 
-        self.cmd_tx.send(types::Command::Disconnect { peer_id }).map_err(P2pError::from)
+        Ok(self.cmd_tx.send(types::Command::Disconnect { peer_id })?)
     }
 
     fn send_message(&mut self, peer: PeerId, message: PeerManagerMessage) -> crate::Result<()> {
@@ -241,12 +241,10 @@ impl<T: TransportSocket> MessagingService for MessagingHandle<T> {
             }
         };
 
-        self.command_sender
-            .send(types::Command::AnnounceData {
-                service,
-                message: message.into(),
-            })
-            .map_err(P2pError::from)
+        Ok(self.command_sender.send(types::Command::AnnounceData {
+            service,
+            message: message.into(),
+        })?)
     }
 }
 

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -127,20 +127,18 @@ where
                 // Send PeerInfoReceived before sending handshake to remote peer!
                 // Backend is expected to receive PeerInfoReceived before outgoing connection has chance to complete handshake,
                 // It's required to reliable detect self-connects.
-                self.tx
-                    .send((
-                        self.peer_id,
-                        PeerEvent::PeerInfoReceived {
-                            protocol,
-                            network,
-                            services,
-                            user_agent,
-                            version,
-                            receiver_address,
-                            handshake_nonce,
-                        },
-                    ))
-                    .map_err(P2pError::from)?;
+                self.tx.send((
+                    self.peer_id,
+                    PeerEvent::PeerInfoReceived {
+                        protocol,
+                        network,
+                        services,
+                        user_agent,
+                        version,
+                        receiver_address,
+                        handshake_nonce,
+                    },
+                ))?;
 
                 self.socket
                     .send(types::Message::Handshake(
@@ -180,20 +178,18 @@ where
                     return Err(P2pError::ProtocolError(ProtocolError::HandshakeExpected));
                 };
 
-                self.tx
-                    .send((
-                        self.peer_id,
-                        PeerEvent::PeerInfoReceived {
-                            protocol,
-                            network,
-                            services,
-                            user_agent,
-                            version,
-                            receiver_address,
-                            handshake_nonce,
-                        },
-                    ))
-                    .map_err(P2pError::from)?;
+                self.tx.send((
+                    self.peer_id,
+                    PeerEvent::PeerInfoReceived {
+                        protocol,
+                        network,
+                        services,
+                        user_agent,
+                        version,
+                        receiver_address,
+                        handshake_nonce,
+                    },
+                ))?;
             }
         }
 


### PR DESCRIPTION
Remove explicit `.map_err(P2pError::from)` conversions which can be done implicitly. I believe this to be the more idiomatic way but am happy to be challenged on that statement.