### PR TITLE
Do not spawn but return a future from p2p networking service

### DIFF
--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
@@ -25,10 +25,8 @@ use std::{
 };
 
 use async_trait::async_trait;
-use tokio::{
-    sync::{mpsc, oneshot},
-    task::JoinHandle,
-};
+use futures::{future::BoxFuture, never::Never};
+use tokio::sync::{mpsc, oneshot};
 
 use common::{
     chain::ChainConfig,
@@ -120,7 +118,7 @@ impl NetworkingService for MockNetworkingService {
     type MessagingHandle = ();
     type SyncingEventReceiver = MockSyncingEventReceiver;
 
-    async fn start(
+    async fn initialize(
         _transport: Self::Transport,
         _bind_addresses: Vec<Self::Address>,
         _chain_config: Arc<ChainConfig>,
@@ -132,7 +130,7 @@ impl NetworkingService for MockNetworkingService {
         Self::ConnectivityHandle,
         Self::MessagingHandle,
         Self::SyncingEventReceiver,
-        JoinHandle<()>,
+        BoxFuture<'async_trait, p2p::Result<Never>>,
     )> {
         unreachable!()
     }

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -65,7 +65,7 @@ where
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
 
-    let (mut conn1, messaging_handle, sync_event_receiver, _) = N::start(
+    let (mut conn1, messaging_handle, sync_event_receiver, run_backend) = N::initialize(
         T::make_transport(),
         vec![T::make_address()],
         Arc::clone(&chain_config),
@@ -76,6 +76,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     let mut sync1 = BlockSyncManager::<N>::new(
         Arc::clone(&chain_config),
@@ -90,7 +91,7 @@ where
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn2, mut messaging_handle_2, mut sync2, _) = N::start(
+    let (mut conn2, mut messaging_handle_2, mut sync2, run_backend) = N::initialize(
         T::make_transport(),
         vec![T::make_address()],
         Arc::clone(&chain_config),
@@ -101,6 +102,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     let (_address, _peer_info1, peer_info2) =
         connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;

--- a/p2p/src/net/default_backend/tests.rs
+++ b/p2p/src/net/default_backend/tests.rs
@@ -40,7 +40,7 @@ where
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn1, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (mut conn1, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![A::make_address()],
         Arc::clone(&config),
@@ -51,10 +51,11 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (conn2, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (conn2, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![A::make_address()],
         Arc::clone(&config),
@@ -65,6 +66,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     let addr = conn2.local_addresses();
     conn1.connect(addr[0].clone()).unwrap();
@@ -111,7 +113,7 @@ where
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn1, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (mut conn1, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![A::make_address()],
         Arc::clone(&config),
@@ -122,10 +124,11 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn2, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (mut conn2, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![A::make_address()],
         Arc::clone(&config),
@@ -136,6 +139,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     let bind_address = conn2.local_addresses();
     conn1.connect(bind_address[0].clone()).unwrap();
@@ -180,7 +184,7 @@ where
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn1, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (mut conn1, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![A::make_address()],
         Arc::clone(&config),
@@ -191,10 +195,11 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn2, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (mut conn2, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![A::make_address()],
         config,
@@ -205,6 +210,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     conn1.connect(conn2.local_addresses()[0].clone()).unwrap();
     let res2 = conn2.poll_next().await;
@@ -247,7 +253,7 @@ where
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn1, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (mut conn1, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![A::make_address()],
         Arc::clone(&config),
@@ -258,10 +264,11 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (conn2, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (conn2, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![A::make_address()],
         Arc::clone(&config),
@@ -272,6 +279,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     // Try connect to self
     let addr = conn1.local_addresses();
@@ -338,7 +346,7 @@ where
     let shutdown = Arc::new(AtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn, _, _, _) = DefaultNetworkingService::<T>::start(
+    let (mut conn, _, _, run_backend) = DefaultNetworkingService::<T>::initialize(
         A::make_transport(),
         vec![],
         Arc::clone(&config),
@@ -349,6 +357,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     // Try to connect to some broken peer
     conn.connect(addr[0].clone()).unwrap();

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -24,10 +24,8 @@ use std::{
 };
 
 use async_trait::async_trait;
-use tokio::{
-    sync::{mpsc, oneshot},
-    task::JoinHandle,
-};
+use futures::{future::BoxFuture, never::Never};
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{
     config,
@@ -83,7 +81,7 @@ pub trait NetworkingService {
     type SyncingEventReceiver: Send;
 
     /// Initializes the network service provider.
-    async fn start(
+    async fn initialize(
         transport: Self::Transport,
         bind_addresses: Vec<Self::Address>,
         chain_config: Arc<common::chain::ChainConfig>,
@@ -95,7 +93,7 @@ pub trait NetworkingService {
         Self::ConnectivityHandle,
         Self::MessagingHandle,
         Self::SyncingEventReceiver,
-        JoinHandle<()>,
+        BoxFuture<'async_trait, crate::Result<Never>>,
     )>;
 }
 

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -543,7 +543,7 @@ where
     let shutdown = Arc::new(AtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (mut conn, _, _, _) = T::start(
+    let (mut conn, _, _, run_backend) = T::initialize(
         transport,
         vec![addr1],
         Arc::clone(&config),
@@ -554,6 +554,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
 
     // This will fail immediately because it is trying to connect to the closed port
     conn.connect(addr2).expect("dial to succeed");
@@ -614,7 +615,7 @@ async fn connection_timeout_rpc_notified<T>(
     let shutdown = Arc::new(AtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (conn, _, _, _) = T::start(
+    let (conn, _, _, run_backend) = T::initialize(
         transport,
         vec![addr1],
         Arc::clone(&config),
@@ -625,6 +626,7 @@ async fn connection_timeout_rpc_notified<T>(
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
     let mut peer_manager = peer_manager::PeerManager::<T, _>::new(

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -69,7 +69,7 @@ where
     let shutdown = Arc::new(AtomicBool::new(false));
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
-    let (conn, _, _, _) = T::start(
+    let (conn, _, _, run_backend) = T::initialize(
         transport,
         vec![addr],
         Arc::clone(&chain_config),
@@ -80,6 +80,7 @@ where
     )
     .await
     .unwrap();
+    tokio::spawn(run_backend);
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
     let peer_manager = PeerManager::<T, _>::new(

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -23,6 +23,7 @@ use std::{
 
 use async_trait::async_trait;
 use crypto::random::Rng;
+use futures::{future::BoxFuture, never::Never};
 use itertools::Itertools;
 use tokio::{
     sync::{
@@ -450,7 +451,7 @@ impl NetworkingService for NetworkingServiceStub {
     type MessagingHandle = MessagingHandleMock;
     type SyncingEventReceiver = SyncingEventReceiverMock;
 
-    async fn start(
+    async fn initialize(
         _: Self::Transport,
         _: Vec<Self::Address>,
         _: Arc<ChainConfig>,
@@ -462,7 +463,7 @@ impl NetworkingService for NetworkingServiceStub {
         Self::ConnectivityHandle,
         Self::MessagingHandle,
         Self::SyncingEventReceiver,
-        JoinHandle<()>,
+        BoxFuture<'async_trait, crate::Result<Never>>,
     )> {
         panic!("Stub service shouldn't be used directly");
     }


### PR DESCRIPTION
First of a series of PRs to resolve https://github.com/mintlayer/mintlayer-core/issues/888.

Refactors the `NetworkingService` trait such that the `start` method no longer spawns a task but instead returns a future. The name of the method was renamed to `initialize` to avoid confusion. `start` might be implied to spawn a task. This allows for a more granular control of async coroutine orchestration at the consumer level (p2p subsystem, for example).

I'm even thinking if it makes sense to match the interface of `NetworkingService` to that of `BlockSyncManager` and `PeerManager` which have `new` and `run` methods. This means `DefaultNetworkingService` would become the owner of `Backend`. However, I need to first ensure this wouldn't introduce any circular dependency.

Note that similar idea was also proposed in https://github.com/mintlayer/mintlayer-core/pull/943.