### PR TITLE
Remove dependency to void

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "utils",
- "void",
 ]
 
 [[package]]
@@ -1537,6 +1536,7 @@ dependencies = [
  "common",
  "crypto",
  "directories",
+ "futures",
  "logging",
  "p2p",
  "p2p-test-utils",
@@ -1551,7 +1551,6 @@ dependencies = [
  "trust-dns-client",
  "trust-dns-server",
  "utils",
- "void",
 ]
 
 [[package]]
@@ -3904,7 +3903,6 @@ dependencies = [
  "tokio-socks",
  "tokio-util",
  "utils",
- "void",
 ]
 
 [[package]]
@@ -6366,12 +6364,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,6 @@ tower-http = "0.4"
 trust-dns-client = "0.22"
 trust-dns-server = "0.22"
 variant_count = "1.1"
-void = "1.0"
 zeroize = "1.5"
 
 [profile.dev]

--- a/blockprod/Cargo.toml
+++ b/blockprod/Cargo.toml
@@ -29,7 +29,6 @@ slave-pool.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
-void.workspace = true
 
 [dev-dependencies]
 chainstate-storage = { path = "../chainstate/storage/" }

--- a/dns_server/Cargo.toml
+++ b/dns_server/Cargo.toml
@@ -17,6 +17,7 @@ storage = { path = "../storage" }
 storage-lmdb = { path = "../storage/lmdb" }
 utils = { path = '../utils' }
 
+futures = { workspace = true }
 tokio = { workspace = true, default-features = false }
 
 trust-dns-client.workspace = true
@@ -24,7 +25,6 @@ trust-dns-server.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 parity-scale-codec.workspace = true
-void.workspace = true
 clap = { workspace = true, features = ["derive"] }
 directories.workspace = true
 

--- a/dns_server/src/crawler_p2p/crawler_manager/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/mod.rs
@@ -26,6 +26,7 @@ use std::{
 
 use common::{chain::ChainConfig, time_getter::TimeGetter};
 use crypto::random::make_pseudo_rng;
+use futures::never::Never;
 use logging::log;
 use p2p::{
     message::{AnnounceAddrRequest, PeerManagerMessage, PingRequest, PingResponse},
@@ -326,7 +327,7 @@ where
         );
     }
 
-    pub async fn run(&mut self) -> Result<void::Void, DnsServerError> {
+    pub async fn run(&mut self) -> Result<Never, DnsServerError> {
         let mut heartbeat_timer = tokio::time::interval(HEARTBEAT_INTERVAL);
 
         loop {

--- a/dns_server/src/dns_server/mod.rs
+++ b/dns_server/src/dns_server/mod.rs
@@ -25,6 +25,7 @@ use std::{
 };
 
 use crypto::random::{make_pseudo_rng, SliceRandom};
+use futures::never::Never;
 use tokio::{net::UdpSocket, sync::mpsc};
 use trust_dns_client::rr::{rdata::SOA, LowerName, Name, RData, RecordSet, RecordType, RrKey};
 use trust_dns_server::{
@@ -107,7 +108,7 @@ impl DnsServer {
         })
     }
 
-    pub async fn run(self) -> Result<void::Void, DnsServerError> {
+    pub async fn run(self) -> Result<Never, DnsServerError> {
         let DnsServer {
             auth,
             server,

--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -16,6 +16,7 @@
 use std::sync::{atomic::AtomicBool, Arc};
 
 use clap::Parser;
+use futures::never::Never;
 use tokio::sync::{mpsc, oneshot};
 
 use common::primitives::user_agent::UserAgent;
@@ -37,7 +38,7 @@ mod error;
 const DNS_SERVER_USER_AGENT: &str = "MintlayerDnsSeedServer";
 const DNS_SERVER_DB_NAME: &str = "dns_server";
 
-async fn run(config: Arc<DnsServerConfig>) -> Result<void::Void, error::DnsServerError> {
+async fn run(config: Arc<DnsServerConfig>) -> Result<Never, error::DnsServerError> {
     let (dns_server_cmd_tx, dns_server_cmd_rx) = mpsc::unbounded_channel();
 
     let chain_type = match config.network {

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -38,7 +38,6 @@ thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-socks.workspace = true
 tokio-util = { workspace = true, default-features = false, features = ["codec"] }
-void.workspace = true
 
 [dev-dependencies]
 chainstate-storage = { path = "../chainstate/storage" }

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -25,12 +25,11 @@ use std::{
     },
 };
 
-use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt};
+use futures::{future::BoxFuture, never::Never, stream::FuturesUnordered, FutureExt, StreamExt};
 use tokio::{
     sync::{mpsc, oneshot},
     time::timeout,
 };
-use void::Void;
 
 use common::chain::ChainConfig;
 use crypto::random::{make_pseudo_rng, Rng, SliceRandom};
@@ -261,7 +260,7 @@ where
     }
 
     /// Runs the backend events loop.
-    pub async fn run(&mut self) -> crate::Result<Void> {
+    pub async fn run(&mut self) -> crate::Result<Never> {
         loop {
             tokio::select! {
                 // Select from the channels in the specified order

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -27,8 +27,8 @@ use std::{
     time::Duration,
 };
 
+use futures::never::Never;
 use tokio::sync::mpsc;
-use void::Void;
 
 use chainstate::ban_score::BanScore;
 use common::{
@@ -1132,7 +1132,7 @@ where
     async fn run_internal(
         &mut self,
         loop_started_tx: Option<oneshot_nofail::Sender<()>>,
-    ) -> crate::Result<Void> {
+    ) -> crate::Result<Never> {
         // Run heartbeat right away to start outbound connections
         self.heartbeat().await;
         // Last time when heartbeat was called
@@ -1210,7 +1210,7 @@ where
         }
     }
 
-    pub async fn run(&mut self) -> crate::Result<Void> {
+    pub async fn run(&mut self) -> crate::Result<Never> {
         self.run_internal(None).await
     }
 }

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -26,8 +26,8 @@ use std::{
     },
 };
 
+use futures::never::Never;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use void::Void;
 
 use chainstate::{chainstate_interface::ChainstateInterface, ChainstateHandle};
 use common::{
@@ -113,7 +113,7 @@ where
     }
 
     /// Runs the sync manager event loop.
-    pub async fn run(&mut self) -> Result<Void> {
+    pub async fn run(&mut self) -> Result<Never> {
         log::info!("Starting SyncManager");
 
         let mut new_tip_receiver = subscribe_to_new_tip(&self.chainstate_handle).await?;


### PR DESCRIPTION
Ideally, we would use the [never](https://doc.rust-lang.org/std/primitive.never.html) type from standard library to represent a function that never returns. However, that is still a nightly-only experimental API.

Meanwhile, we can either use `std::convert::Infallible` or `futures::never::Never`. `std::convert::Infallible` is typically used for error types. `futures::never::Never` is currently a type alias for `std::convert::Infallible` but will be changed to the standard library never type once that becomes stable. Since most of our crates already either explicitly or implicitly include the `futures` crate, using `futures::never::Never` wouldn't add any additional dependency. This allows us to get rid of the dependency to `void` crate altogether.

Note that this idea was also proposed in https://github.com/mintlayer/mintlayer-core/pull/943.