### PR TITLE
Perform in memory reorg before validating a block in a branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "chainstate-types",
  "common",
  "consensus",
+ "criterion",
  "crypto",
  "expect-test",
  "hex",

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -61,9 +61,7 @@ impl BanScore for BlockError {
             BlockError::TxIndexConfigError => 0,
             BlockError::TxIndexConstructionError(_) => 100,
             BlockError::PoSAccountingError(err) => err.ban_score(),
-            BlockError::RandomnessError(err) => err.ban_score(),
             BlockError::InvariantBrokenBlockNotFoundAfterConnect(_) => 0,
-            BlockError::SpendStakeError(_) => 100,
             BlockError::EpochSealError(err) => err.ban_score(),
         }
     }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -234,6 +234,8 @@ impl BanScore for CheckBlockError {
             CheckBlockError::WitnessMerkleRootMismatch => 100,
             // even though this may be an invariant error, we treat it strictly
             CheckBlockError::PrevBlockNotFound(_, _) => 100,
+            CheckBlockError::TransactionVerifierError(err) => err.ban_score(),
+            CheckBlockError::BlockNotFound(_) => 100,
             CheckBlockError::BlockTimeOrderInvalid(_, _) => 100,
             CheckBlockError::BlockFromTheFuture => 100,
             CheckBlockError::BlockSizeError(err) => err.ban_score(),
@@ -249,8 +251,7 @@ impl BanScore for CheckBlockError {
             CheckBlockError::ParentCheckpointMismatch(_, _, _) => 100,
             CheckBlockError::GetAncestorError(_) => 100,
             CheckBlockError::AttemptedToAddBlockBeforeReorgLimit(_, _, _) => 100,
-            CheckBlockError::StateUpdateFailed(_) => todo!(),
-            CheckBlockError::TransactionVerifierError(_) => todo!(),
+            CheckBlockError::StateUpdateFailed(err) => err.ban_score(),
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -23,6 +23,7 @@ use tx_verifier::{
 };
 
 use super::{
+    chainstateref::EpochSealError,
     transaction_verifier::{
         error::{ConnectTransactionError, TokensError},
         storage::TransactionVerifierStorageError,
@@ -63,7 +64,7 @@ impl BanScore for BlockError {
             BlockError::RandomnessError(err) => err.ban_score(),
             BlockError::InvariantBrokenBlockNotFoundAfterConnect(_) => 0,
             BlockError::SpendStakeError(_) => 100,
-            BlockError::PoolDataNotFound(_) => 0,
+            BlockError::EpochSealError(err) => err.ban_score(),
         }
     }
 }
@@ -252,6 +253,7 @@ impl BanScore for CheckBlockError {
             CheckBlockError::GetAncestorError(_) => 100,
             CheckBlockError::AttemptedToAddBlockBeforeReorgLimit(_, _, _) => 100,
             CheckBlockError::StateUpdateFailed(err) => err.ban_score(),
+            CheckBlockError::EpochSealError(err) => err.ban_score(),
         }
     }
 }
@@ -469,6 +471,18 @@ impl BanScore for ChainstateError {
             ChainstateError::ProcessBlockError(e) => e.ban_score(),
             ChainstateError::FailedToReadProperty(_) => 0,
             ChainstateError::BootstrapError(_) => 0,
+        }
+    }
+}
+
+impl BanScore for EpochSealError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            EpochSealError::StorageError(_) => 0,
+            EpochSealError::PoSAccountingError(err) => err.ban_score(),
+            EpochSealError::SpendStakeError(_) => 100,
+            EpochSealError::RandomnessError(err) => err.ban_score(),
+            EpochSealError::PoolDataNotFound(_) => 0,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -249,6 +249,8 @@ impl BanScore for CheckBlockError {
             CheckBlockError::ParentCheckpointMismatch(_, _, _) => 100,
             CheckBlockError::GetAncestorError(_) => 100,
             CheckBlockError::AttemptedToAddBlockBeforeReorgLimit(_, _, _) => 100,
+            CheckBlockError::StateUpdateFailed(_) => todo!(),
+            CheckBlockError::TransactionVerifierError(_) => todo!(),
         }
     }
 }

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -13,12 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chainstate_storage::{
-    BlockchainStorageRead, BlockchainStorageWrite, SealedStorageTag, TipStorageTag,
-};
+use chainstate_storage::{BlockchainStorageWrite, SealedStorageTag};
 use chainstate_types::{
     pos_randomness::{PoSRandomness, PoSRandomnessError},
-    ConsumedEpochDataCache, EpochData, EpochStorageRead, EpochStorageWrite,
+    EpochData, EpochStorageRead, EpochStorageWrite,
 };
 use common::{
     chain::{
@@ -263,7 +261,7 @@ mod tests {
     use std::num::NonZeroU64;
 
     use super::*;
-    use chainstate_storage::mock::MockStoreTxRw;
+    use chainstate_storage::{mock::MockStoreTxRw, TipStorageTag};
     use chainstate_types::{vrf_tools::construct_transcript, EpochDataCache};
     use common::{
         chain::{

--- a/chainstate/src/detail/chainstateref/in_memory_reorg.rs
+++ b/chainstate/src/detail/chainstateref/in_memory_reorg.rs
@@ -1,0 +1,157 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_storage::BlockchainStorageRead;
+use chainstate_types::{ConsumedEpochDataCache, EpochDataCache, GenBlockIndex, PropertyQueryError};
+use common::{
+    chain::{block::BlockHeader, Block, GenBlock, GenBlockId},
+    primitives::{id::WithId, Id},
+};
+use tx_verifier::{
+    flush_to_storage, transaction_verifier::TransactionVerifierDelta, TransactionVerifier,
+    TransactionVerifierConfig,
+};
+use utils::tap_error_log::LogError;
+
+use crate::{calculate_median_time_past, CheckBlockError, TransactionVerificationStrategy};
+
+use super::{epoch_seal, ChainstateRef};
+
+impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> ChainstateRef<'a, S, V> {
+    // Disconnect all blocks from the mainchain up until common ancestor of provided block
+    // and then connect all block in the new branch.
+    // All these operations are performed via `TransactionVerifier` without db modifications
+    // and the resulting delta is returned.
+    pub fn reorganize_in_memory(
+        &self,
+        new_block_header: &BlockHeader,
+        best_block_id: Id<GenBlock>,
+    ) -> Result<(TransactionVerifierDelta, ConsumedEpochDataCache), CheckBlockError> {
+        let prev_block_id = new_block_header.prev_block_id();
+        let new_chain = match self
+            .get_gen_block_index(prev_block_id)
+            .log_err()?
+            .ok_or(PropertyQueryError::PrevBlockIndexNotFound(*prev_block_id))?
+        {
+            GenBlockIndex::Block(block_index) => self.get_new_chain(&block_index).log_err()?,
+            GenBlockIndex::Genesis(_) => Vec::new(),
+        };
+
+        let common_ancestor_id = match new_chain.first() {
+            Some(block_index) => block_index.prev_block_id(),
+            None => prev_block_id,
+        };
+
+        let mut tx_verifier = TransactionVerifier::new(
+            self,
+            self.chain_config,
+            TransactionVerifierConfig::new(false),
+        );
+
+        // during reorg epoch seal can change so it needs to be tracked as well
+        let mut epoch_data_cache = EpochDataCache::new(&self.db_tx);
+
+        // Disconnect the current chain if it is not a genesis
+        if let GenBlockId::Block(best_block_id) = best_block_id.classify(self.chain_config) {
+            let mainchain_tip = self
+                .get_block_index(&best_block_id)
+                .map_err(|_| CheckBlockError::BlockNotFound(best_block_id.into()))
+                .log_err()?
+                .expect("Can't get block index. Inconsistent DB");
+
+            let mut to_disconnect = GenBlockIndex::Block(mainchain_tip);
+            while to_disconnect.block_id() != *common_ancestor_id {
+                let to_disconnect_block = match to_disconnect {
+                    GenBlockIndex::Genesis(_) => panic!("Attempt to disconnect genesis"),
+                    GenBlockIndex::Block(block_index) => block_index,
+                };
+
+                let block = self
+                    .get_block_from_index(&to_disconnect_block)
+                    .log_err()?
+                    .expect("Inconsistent DB");
+
+                // Disconnect transactions
+                let cached_inputs = self
+                    .tx_verification_strategy
+                    .disconnect_block(
+                        TransactionVerifier::new,
+                        &tx_verifier,
+                        self.chain_config,
+                        TransactionVerifierConfig::new(false),
+                        &block.into(),
+                    )?
+                    .consume()?;
+
+                flush_to_storage(&mut tx_verifier, cached_inputs)?;
+
+                to_disconnect = self
+                    .get_previous_block_index(&to_disconnect_block)
+                    .expect("Previous block index retrieval failed");
+
+                epoch_seal::update_epoch_data(
+                    &mut epoch_data_cache,
+                    &tx_verifier,
+                    self.chain_config,
+                    epoch_seal::BlockStateEventWithIndex::Disconnect(to_disconnect.block_height()),
+                )?;
+            }
+        }
+
+        // Connect the new chain
+        for new_tip_block_index in new_chain {
+            let new_tip: WithId<Block> = self
+                .get_block_from_index(&new_tip_block_index)
+                .log_err()?
+                .ok_or(CheckBlockError::BlockNotFound(
+                    (*new_tip_block_index.block_id()).into(),
+                ))?
+                .into();
+
+            // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
+            let median_time_past = calculate_median_time_past(self, &new_tip.prev_block_id());
+
+            let connected_txs = self
+                .tx_verification_strategy
+                .connect_block(
+                    TransactionVerifier::new,
+                    &tx_verifier,
+                    self.chain_config,
+                    TransactionVerifierConfig::new(false),
+                    &new_tip_block_index,
+                    &new_tip,
+                    median_time_past,
+                )
+                .log_err()?
+                .consume()?;
+
+            flush_to_storage(&mut tx_verifier, connected_txs)?;
+
+            epoch_seal::update_epoch_data(
+                &mut epoch_data_cache,
+                &tx_verifier,
+                self.chain_config,
+                epoch_seal::BlockStateEventWithIndex::Connect(
+                    new_tip_block_index.block_height(),
+                    &new_tip,
+                ),
+            )?;
+        }
+
+        let consumed_verifier = tx_verifier.consume()?;
+        let consumed_epoch_data = epoch_data_cache.consume();
+        Ok((consumed_verifier, consumed_epoch_data))
+    }
+}

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -874,6 +874,9 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> Chainsta
         block_index: &BlockIndex,
         block: &WithId<Block>,
     ) -> Result<(), BlockError> {
+        // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
+        let median_time_past = calculate_median_time_past(self, &block.prev_block_id());
+
         let verifier_config = TransactionVerifierConfig {
             tx_index_enabled: *self.chainstate_config.tx_index_enabled,
         };
@@ -881,12 +884,12 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> Chainsta
             .tx_verification_strategy
             .connect_block(
                 TransactionVerifier::new,
-                self,
                 &*self,
                 self.chain_config,
                 verifier_config,
                 block_index,
                 block,
+                median_time_past,
             )
             .log_err()?;
 

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -100,6 +100,8 @@ pub enum CheckBlockError {
     PrevBlockNotFound(Id<GenBlock>, Id<Block>),
     #[error("Previous block with id {0} retrieval error starting from block {1}")]
     PrevBlockRetrievalError(PropertyQueryError, Id<GenBlock>, Id<Block>),
+    #[error("Block {0} not found in database")]
+    BlockNotFound(Id<GenBlock>),
     #[error("Block time ({0:?}) must be equal or higher than the median of its ancestors ({1:?})")]
     BlockTimeOrderInvalid(BlockTimestamp, BlockTimestamp),
     #[error("Block time must be a notch higher than the previous block")]

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -90,6 +90,8 @@ pub enum CheckBlockError {
     PropertyQueryError(#[from] PropertyQueryError),
     #[error("Block merkle root calculation failed for block {0} with error: {1}")]
     MerkleRootCalculationFailed(Id<Block>, BlockMerkleTreeError),
+    #[error("Failed to update the internal blockchain state: {0}")]
+    StateUpdateFailed(#[from] ConnectTransactionError),
     #[error("Block has an invalid merkle root")]
     MerkleRootMismatch,
     #[error("Block has an invalid witness merkle root")]
@@ -122,6 +124,8 @@ pub enum CheckBlockError {
     GetAncestorError(#[from] GetAncestorError),
     #[error("Attempted to add a block before reorg limit (attempted at height: {0} while current height is: {1} and min allowed is: {2})")]
     AttemptedToAddBlockBeforeReorgLimit(BlockHeight, BlockHeight, BlockHeight),
+    #[error("TransactionVerifier error: {0}")]
+    TransactionVerifierError(#[from] TransactionVerifierStorageError),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use super::{
+    chainstateref::EpochSealError,
     orphan_blocks::OrphanAddError,
     transaction_verifier::{
         error::{ConnectTransactionError, TokensError},
@@ -78,8 +79,8 @@ pub enum BlockError {
     InvariantBrokenBlockNotFoundAfterConnect(Id<Block>),
     #[error("Error during stake spending: {0}")]
     SpendStakeError(#[from] SpendStakeError),
-    #[error("Data of pool {0} not found")]
-    PoolDataNotFound(PoolId),
+    #[error("Error during sealing an epoch: {0}")]
+    EpochSealError(#[from] EpochSealError),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
@@ -128,6 +129,8 @@ pub enum CheckBlockError {
     AttemptedToAddBlockBeforeReorgLimit(BlockHeight, BlockHeight, BlockHeight),
     #[error("TransactionVerifier error: {0}")]
     TransactionVerifierError(#[from] TransactionVerifierStorageError),
+    #[error("Error during sealing an epoch: {0}")]
+    EpochSealError(#[from] EpochSealError),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -21,21 +21,18 @@ use super::{
         storage::TransactionVerifierStorageError,
     },
 };
-use chainstate_types::{pos_randomness::PoSRandomnessError, GetAncestorError, PropertyQueryError};
+use chainstate_types::{GetAncestorError, PropertyQueryError};
 use common::{
     chain::{
         block::{block_body::BlockMerkleTreeError, timestamp::BlockTimestamp},
-        Block, GenBlock, PoolId, Transaction,
+        Block, GenBlock, Transaction,
     },
     primitives::{BlockHeight, Id},
 };
 use consensus::ConsensusVerificationError;
 
 use thiserror::Error;
-use tx_verifier::transaction_verifier::{
-    error::{SpendStakeError, TxIndexError},
-    storage::HasTxIndexDisabledError,
-};
+use tx_verifier::transaction_verifier::{error::TxIndexError, storage::HasTxIndexDisabledError};
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum BlockError {
@@ -73,12 +70,8 @@ pub enum BlockError {
     TxIndexConstructionError(#[from] TxIndexError),
     #[error("PoS accounting error: {0}")]
     PoSAccountingError(#[from] pos_accounting::Error),
-    #[error("PoS randomness error: `{0}`")]
-    RandomnessError(#[from] PoSRandomnessError),
     #[error("Inconsistent db, block not found after connect: {0}")]
     InvariantBrokenBlockNotFoundAfterConnect(Id<Block>),
-    #[error("Error during stake spending: {0}")]
-    SpendStakeError(#[from] SpendStakeError),
     #[error("Error during sealing an epoch: {0}")]
     EpochSealError(#[from] EpochSealError),
 }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -291,7 +291,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
                 .log_err()?;
 
             chainstate_ref
-                .check_block(&block, false)
+                .check_block(&block)
                 .map_err(BlockError::CheckBlockFailed)
                 .log_err()?;
 
@@ -473,14 +473,14 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
     ) -> Result<WithId<Block>, BlockError> {
         let chainstate_ref = self.make_db_tx_ro().map_err(BlockError::from)?;
 
-        chainstate_ref.check_block(&block, false).log_err()?;
+        chainstate_ref.check_block(&block).log_err()?;
 
         Ok(block)
     }
 
     pub fn preliminary_header_check(&self, header: SignedBlockHeader) -> Result<(), BlockError> {
         let chainstate_ref = self.make_db_tx_ro().map_err(BlockError::from)?;
-        chainstate_ref.check_block_header(&header, false).log_err()?;
+        chainstate_ref.check_block_header(&header).log_err()?;
         Ok(())
     }
 

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -49,7 +49,9 @@ use chainstate_storage::{
     BlockchainStorage, BlockchainStorageRead, BlockchainStorageWrite, SealedStorageTag,
     TipStorageTag, TransactionRw, Transactional,
 };
-use chainstate_types::{pos_randomness::PoSRandomness, BlockIndex, EpochData, PropertyQueryError};
+use chainstate_types::{
+    pos_randomness::PoSRandomness, BlockIndex, EpochData, EpochStorageWrite, PropertyQueryError,
+};
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp},

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -18,7 +18,7 @@ use crate::{
     tx_verification_strategy_utils::{
         construct_reward_tx_indices, construct_tx_indices, take_front_tx_index,
     },
-    BlockError, TransactionVerifierMakerFn,
+    TransactionVerifierMakerFn,
 };
 use chainstate_types::BlockIndex;
 use common::{
@@ -61,7 +61,7 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         block_index: &BlockIndex,
         block: &WithId<Block>,
         median_time_past: BlockTimestamp,
-    ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
+    ) -> Result<TransactionVerifier<C, S, U, A>, ConnectTransactionError>
     where
         C: AsRef<ChainConfig>,
         S: TransactionVerifierStorageRef,
@@ -123,7 +123,7 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
         chain_config: C,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
+    ) -> Result<TransactionVerifier<C, S, U, A>, ConnectTransactionError>
     where
         C: AsRef<ChainConfig>,
         S: TransactionVerifierStorageRef,

--- a/chainstate/src/detail/tx_verification_strategy/mod.rs
+++ b/chainstate/src/detail/tx_verification_strategy/mod.rs
@@ -18,18 +18,19 @@ pub use default_strategy::DefaultTransactionVerificationStrategy;
 
 pub mod tx_verification_strategy_utils;
 
-use crate::BlockError;
-
 use chainstate_types::BlockIndex;
 use common::{
     chain::{block::timestamp::BlockTimestamp, Block, ChainConfig},
     primitives::id::WithId,
 };
 use pos_accounting::PoSAccountingView;
-use tx_verifier::transaction_verifier::{
-    config::TransactionVerifierConfig,
-    storage::{TransactionVerifierStorageError, TransactionVerifierStorageRef},
-    TransactionVerifier,
+use tx_verifier::{
+    error::ConnectTransactionError,
+    transaction_verifier::{
+        config::TransactionVerifierConfig,
+        storage::{TransactionVerifierStorageError, TransactionVerifierStorageRef},
+        TransactionVerifier,
+    },
 };
 use utxo::UtxosView;
 
@@ -62,7 +63,7 @@ pub trait TransactionVerificationStrategy: Sized + Send {
         block_index: &BlockIndex,
         block: &WithId<Block>,
         median_time_past: BlockTimestamp,
-    ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
+    ) -> Result<TransactionVerifier<C, S, U, A>, ConnectTransactionError>
     where
         S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
@@ -84,7 +85,7 @@ pub trait TransactionVerificationStrategy: Sized + Send {
         chain_config: C,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
+    ) -> Result<TransactionVerifier<C, S, U, A>, ConnectTransactionError>
     where
         C: AsRef<ChainConfig>,
         S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,

--- a/chainstate/src/detail/tx_verification_strategy/mod.rs
+++ b/chainstate/src/detail/tx_verification_strategy/mod.rs
@@ -14,23 +14,24 @@
 // limitations under the License.
 
 pub mod default_strategy;
+pub use default_strategy::DefaultTransactionVerificationStrategy;
+
 pub mod tx_verification_strategy_utils;
 
-pub use default_strategy::DefaultTransactionVerificationStrategy;
-use pos_accounting::PoSAccountingView;
-use utxo::UtxosView;
-
 use crate::BlockError;
-use chainstate_types::{BlockIndex, BlockIndexHandle};
+
+use chainstate_types::BlockIndex;
 use common::{
-    chain::{Block, ChainConfig},
+    chain::{block::timestamp::BlockTimestamp, Block, ChainConfig},
     primitives::id::WithId,
 };
+use pos_accounting::PoSAccountingView;
 use tx_verifier::transaction_verifier::{
     config::TransactionVerifierConfig,
     storage::{TransactionVerifierStorageError, TransactionVerifierStorageRef},
     TransactionVerifier,
 };
+use utxo::UtxosView;
 
 // TODO: replace with trait_alias when stabilized
 pub trait TransactionVerifierMakerFn<C, S, U, A>:
@@ -52,18 +53,17 @@ pub trait TransactionVerificationStrategy: Sized + Send {
     /// state. It just returns a TransactionVerifier that can be
     /// used to update the database/storage state.
     #[allow(clippy::too_many_arguments)]
-    fn connect_block<C, H, S, M, U, A>(
+    fn connect_block<C, S, M, U, A>(
         &self,
         tx_verifier_maker: M,
-        block_index_handle: &H,
         storage_backend: S,
         chain_config: C,
         verifier_config: TransactionVerifierConfig,
         block_index: &BlockIndex,
         block: &WithId<Block>,
+        median_time_past: BlockTimestamp,
     ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
     where
-        H: BlockIndexHandle,
         S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         C: AsRef<ChainConfig>,

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -15,7 +15,7 @@
 
 use std::collections::BTreeMap;
 
-use chainstate_types::{BlockIndex, EpochData};
+use chainstate_types::{BlockIndex, EpochData, EpochStorageRead, EpochStorageWrite};
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockReward},
@@ -248,9 +248,16 @@ impl<B: storage::Backend> BlockchainStorageRead for Store<B> {
             epoch_index: EpochIndex,
         ) -> crate::Result<Option<DeltaMergeUndo>>;
 
-        fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
-
         fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
+    }
+}
+
+impl<B: storage::Backend> EpochStorageRead for Store<B> {
+    delegate_to_transaction! {
+        fn get_epoch_data(
+            &self,
+            epoch_index: EpochIndex,
+        ) -> crate::Result<Option<EpochData>>;
     }
 }
 
@@ -400,11 +407,20 @@ impl<B: storage::Backend> BlockchainStorageWrite for Store<B> {
 
         fn del_accounting_epoch_undo_delta(&mut self, epoch_index: EpochIndex) -> crate::Result<()>;
 
-        fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
-        fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
-
         fn set_account_nonce_count(&mut self, account: AccountType, nonce: AccountNonce) -> crate::Result<()>;
         fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
+    }
+}
+
+impl<B: storage::Backend> EpochStorageWrite for Store<B> {
+    delegate_to_transaction! {
+        fn set_epoch_data(
+            &mut self,
+            epoch_index: u64,
+            epoch_data: &EpochData,
+        ) -> crate::Result<()>;
+
+        fn del_epoch_data(&mut self, epoch_index: EpochIndex) -> crate::Result<()>;
     }
 }
 

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -26,7 +26,7 @@ use std::collections::BTreeMap;
 use common::chain::block::signed_block_header::SignedBlockHeader;
 pub use internal::Store;
 
-use chainstate_types::{BlockIndex, EpochData, EpochStorageRead, EpochStorageWrite};
+use chainstate_types::{BlockIndex, EpochStorageRead, EpochStorageWrite};
 use common::chain::block::BlockReward;
 use common::chain::config::EpochIndex;
 use common::chain::tokens::{TokenAuxiliaryData, TokenId};

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -26,7 +26,7 @@ use std::collections::BTreeMap;
 use common::chain::block::signed_block_header::SignedBlockHeader;
 pub use internal::Store;
 
-use chainstate_types::{BlockIndex, EpochData};
+use chainstate_types::{BlockIndex, EpochData, EpochStorageRead, EpochStorageWrite};
 use common::chain::block::BlockReward;
 use common::chain::config::EpochIndex;
 use common::chain::tokens::{TokenAuxiliaryData, TokenId};
@@ -58,6 +58,7 @@ pub trait BlockchainStorageRead:
     UtxosStorageRead<Error = crate::Error>
     + PoSAccountingStorageRead<SealedStorageTag>
     + PoSAccountingStorageRead<TipStorageTag>
+    + EpochStorageRead
 {
     /// Get storage version
     fn get_storage_version(&self) -> crate::Result<u32>;
@@ -90,9 +91,6 @@ pub trait BlockchainStorageRead:
 
     /// Get mainchain block by its height
     fn get_block_id_by_height(&self, height: &BlockHeight) -> crate::Result<Option<Id<GenBlock>>>;
-
-    /// Get mainchain epoch data by its index
-    fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
 
     /// Get token creation tx
     fn get_token_aux_data(&self, token_id: &TokenId) -> crate::Result<Option<TokenAuxiliaryData>>;
@@ -128,6 +126,7 @@ pub trait BlockchainStorageWrite:
     + UtxosStorageWrite
     + PoSAccountingStorageWrite<SealedStorageTag>
     + PoSAccountingStorageWrite<TipStorageTag>
+    + EpochStorageWrite
 {
     /// Set storage version
     fn set_storage_version(&mut self, version: u32) -> Result<()>;
@@ -166,12 +165,6 @@ pub trait BlockchainStorageWrite:
 
     /// Remove block id from given mainchain height
     fn del_block_id_at_height(&mut self, height: &BlockHeight) -> Result<()>;
-
-    /// Set the mainchain epoch data of the given epoch index
-    fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> Result<()>;
-
-    /// Remove the mainchain epoch data of the given epoch index
-    fn del_epoch_data(&mut self, epoch_index: u64) -> Result<()>;
 
     /// Set data associated with token issuance (and ACL changes in the future)
     fn set_token_aux_data(&mut self, token_id: &TokenId, data: &TokenAuxiliaryData) -> Result<()>;

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -17,7 +17,7 @@
 
 use std::collections::BTreeMap;
 
-use chainstate_types::{BlockIndex, EpochData};
+use chainstate_types::{BlockIndex, EpochData, EpochStorageRead, EpochStorageWrite};
 use common::chain::block::signed_block_header::SignedBlockHeader;
 use common::chain::tokens::{TokenAuxiliaryData, TokenId};
 use common::{
@@ -57,7 +57,6 @@ mockall::mock! {
             tx_id: &OutPointSourceId,
         ) -> crate::Result<Option<TxMainChainIndex>>;
 
-
         fn get_mainchain_tx_by_position(
             &self,
             tx_index: &TxMainChainPosition,
@@ -88,9 +87,11 @@ mockall::mock! {
             epoch_index: EpochIndex,
         ) -> crate::Result<Option<DeltaMergeUndo>>;
 
-        fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
-
         fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
+    }
+
+    impl EpochStorageRead for Store {
+        fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
     }
 
     impl UtxosStorageRead for Store {
@@ -188,11 +189,13 @@ mockall::mock! {
         ) -> crate::Result<()>;
         fn del_accounting_epoch_undo_delta(&mut self, epoch_index: EpochIndex) -> crate::Result<()>;
 
-        fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
-        fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
-
         fn set_account_nonce_count(&mut self, account: AccountType, nonce: AccountNonce) -> crate::Result<()>;
         fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
+    }
+
+    impl EpochStorageWrite for Store {
+        fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
+        fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
     }
 
     impl UtxosStorageWrite for Store {
@@ -333,9 +336,11 @@ mockall::mock! {
             epoch_index: EpochIndex,
         ) -> crate::Result<Option<DeltaMergeUndo>>;
 
-        fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
-
         fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
+    }
+
+    impl EpochStorageRead for StoreTxRo {
+        fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
     }
 
     impl crate::UtxosStorageRead for StoreTxRo {
@@ -443,9 +448,11 @@ mockall::mock! {
             epoch_index: EpochIndex,
         ) -> crate::Result<Option<DeltaMergeUndo>>;
 
-        fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
-
        fn get_account_nonce_count(&self, account: AccountType) -> crate::Result<Option<AccountNonce>>;
+    }
+
+    impl EpochStorageRead for StoreTxRw {
+        fn get_epoch_data(&self, epoch_index: u64) -> crate::Result<Option<EpochData>>;
     }
 
     impl UtxosStorageRead for StoreTxRw {
@@ -544,11 +551,13 @@ mockall::mock! {
         ) -> crate::Result<()>;
         fn del_accounting_epoch_undo_delta(&mut self, epoch_index: EpochIndex) -> crate::Result<()>;
 
-        fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
-        fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
-
         fn set_account_nonce_count(&mut self, account: AccountType, nonce: AccountNonce) -> crate::Result<()>;
         fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()>;
+    }
+
+    impl EpochStorageWrite for StoreTxRw {
+        fn set_epoch_data(&mut self, epoch_index: u64, epoch_data: &EpochData) -> crate::Result<()>;
+        fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()>;
     }
 
     impl UtxosStorageWrite for StoreTxRw {

--- a/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
@@ -14,16 +14,15 @@
 // limitations under the License.
 
 use chainstate::{
-    calculate_median_time_past,
     tx_verification_strategy_utils::{
         construct_reward_tx_indices, construct_tx_indices, take_front_tx_index,
     },
     BlockError, TransactionVerificationStrategy, TransactionVerifierMakerFn,
     TransactionVerifierStorageError,
 };
-use chainstate_types::{BlockIndex, BlockIndexHandle};
+use chainstate_types::BlockIndex;
 use common::{
-    chain::{Block, ChainConfig},
+    chain::{block::timestamp::BlockTimestamp, Block, ChainConfig},
     primitives::{id::WithId, Amount, Idable},
 };
 use pos_accounting::PoSAccountingView;
@@ -56,28 +55,24 @@ impl Default for DisposableTransactionVerificationStrategy {
 }
 
 impl TransactionVerificationStrategy for DisposableTransactionVerificationStrategy {
-    fn connect_block<C, H, S, M, U, A>(
+    fn connect_block<C, S, M, U, A>(
         &self,
         tx_verifier_maker: M,
-        block_index_handle: &H,
         storage_backend: S,
         chain_config: C,
         verifier_config: TransactionVerifierConfig,
         block_index: &BlockIndex,
         block: &WithId<Block>,
+        median_time_past: BlockTimestamp,
     ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
     where
         C: AsRef<ChainConfig>,
-        H: BlockIndexHandle,
         S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
         U: UtxosView,
         A: PoSAccountingView,
         M: TransactionVerifierMakerFn<C, S, U, A>,
         <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
-        // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp
-        let median_time_past =
-            calculate_median_time_past(block_index_handle, &block.prev_block_id());
         let block_subsidy =
             chain_config.as_ref().block_subsidy_at_height(&block_index.block_height());
 

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -19,8 +19,7 @@ use chainstate::{
     tx_verification_strategy_utils::{
         construct_reward_tx_indices, construct_tx_indices, take_front_tx_index,
     },
-    BlockError, TransactionVerificationStrategy, TransactionVerifierMakerFn,
-    TransactionVerifierStorageError,
+    TransactionVerificationStrategy, TransactionVerifierMakerFn, TransactionVerifierStorageError,
 };
 use chainstate_types::BlockIndex;
 use common::{
@@ -77,7 +76,7 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
         block_index: &BlockIndex,
         block: &WithId<Block>,
         median_time_past: BlockTimestamp,
-    ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
+    ) -> Result<TransactionVerifier<C, S, U, A>, ConnectTransactionError>
     where
         C: AsRef<ChainConfig>,
         S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,
@@ -110,7 +109,7 @@ impl TransactionVerificationStrategy for RandomizedTransactionVerificationStrate
         chain_config: C,
         verifier_config: TransactionVerifierConfig,
         block: &WithId<Block>,
-    ) -> Result<TransactionVerifier<C, S, U, A>, BlockError>
+    ) -> Result<TransactionVerifier<C, S, U, A>, ConnectTransactionError>
     where
         C: AsRef<ChainConfig>,
         S: TransactionVerifierStorageRef<Error = TransactionVerifierStorageError>,

--- a/chainstate/test-suite/Cargo.toml
+++ b/chainstate/test-suite/Cargo.toml
@@ -28,5 +28,10 @@ hex.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 expect-test.workspace = true
 rstest.workspace = true
+
+[[bench]]
+name = "benches"
+harness = false

--- a/chainstate/test-suite/benches/benches.rs
+++ b/chainstate/test-suite/benches/benches.rs
@@ -19,6 +19,7 @@ use test_utils::random::make_seedable_rng;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
+// TODO: rework for PoS
 pub fn reorg(c: &mut Criterion) {
     let mut rng = make_seedable_rng(1111.into());
     let mut tf = TestFramework::builder(&mut rng).build();

--- a/chainstate/test-suite/benches/benches.rs
+++ b/chainstate/test-suite/benches/benches.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_test_framework::TestFramework;
+use common::primitives::Idable;
+use test_utils::random::make_seedable_rng;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+pub fn reorg(c: &mut Criterion) {
+    let mut rng = make_seedable_rng(1111.into());
+    let mut tf = TestFramework::builder(&mut rng).build();
+
+    let common_block_id = tf.create_chain(&tf.genesis().get_id().into(), 5, &mut rng).unwrap();
+
+    tf.create_chain(&common_block_id, 1000, &mut rng).unwrap();
+
+    c.bench_function("Reorg", |b| {
+        b.iter(|| tf.create_chain(&common_block_id, 1001, &mut rng).unwrap())
+    });
+}
+
+criterion_group!(benches, reorg);
+criterion_main!(benches);

--- a/chainstate/test-suite/src/tests/helpers/block_index_handle_impl.rs
+++ b/chainstate/test-suite/src/tests/helpers/block_index_handle_impl.rs
@@ -92,11 +92,4 @@ impl<'a, S: BlockchainStorageRead> BlockIndexHandle for TestBlockIndexHandle<'a,
     ) -> Result<Option<common::chain::block::BlockReward>, PropertyQueryError> {
         unimplemented!()
     }
-
-    fn get_epoch_data(
-        &self,
-        _epoch_index: u64,
-    ) -> Result<Option<chainstate_types::EpochData>, PropertyQueryError> {
-        unimplemented!()
-    }
 }

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -30,6 +30,7 @@ use chainstate_test_framework::{
 use chainstate_types::{
     pos_randomness::{PoSRandomness, PoSRandomnessError},
     vrf_tools::{construct_transcript, ProofOfStakeVRFError},
+    EpochStorageRead,
 };
 use common::{
     chain::{

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -23,7 +23,7 @@ use chainstate::{
     chainstate_interface::ChainstateInterface, BlockError, BlockSource, ChainstateError,
     CheckBlockError, ConnectTransactionError, SpendStakeError,
 };
-use chainstate_storage::{BlockchainStorageRead, SealedStorageTag, TipStorageTag, Transactional};
+use chainstate_storage::{SealedStorageTag, TipStorageTag, Transactional};
 use chainstate_test_framework::{
     anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
 };

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -908,7 +908,7 @@ fn pos_invalid_pool_id(#[case] seed: Seed) {
 // Create a chain genesis <- block_1, where block_1 has valid StakePool output.
 // PoS consensus activates on height 2 and an epoch is sealed at height 2.
 // Try to crete block_2 with PoS data that has refer to staked pool.
-#[ignore] // FIXME: reconsider this test
+#[ignore = "Disabled because of switch from SealedStorageTag to TipStorageTag"]
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -935,10 +935,11 @@ fn not_sealed_pool_cannot_be_used(#[case] seed: Seed) {
         .epoch_length(NonZeroU64::new(3).unwrap()) // stake pool won't be sealed at height 1
         .sealed_epoch_distance_from_tip(TEST_SEALED_EPOCH_DISTANCE)
         .build();
+    let min_stake_pool_pledge = chain_config.min_stake_pool_pledge();
     let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
 
     let (stake_pool_data, staking_sk) =
-        create_stake_pool_data_with_all_reward_to_owner(&mut rng, Amount::from_atoms(1), vrf_pk);
+        create_stake_pool_data_with_all_reward_to_owner(&mut rng, min_stake_pool_pledge, vrf_pk);
     let (stake_pool_outpoint, pool_id) =
         add_block_with_stake_pool(&mut rng, &mut tf, stake_pool_data);
 
@@ -1230,25 +1231,39 @@ fn stake_pool_as_reward_output(#[case] seed: Seed) {
 }
 
 // Produce `genesis -> a -> b` chain, then a parallel `genesis -> a -> c -> d` that should trigger a reorg.
-// Block `a` has stake pool output. Also at block 'a' PoS activates.
+// Block `a` has stake pool output. PoS activates at height 2 with block `b` and `c`.
 // Blocks `b`, `c`, `d` have produce block from stake outputs.
-// Check that after reorg pool balance doesn't include reward from block `a`
-//
-// TODO: enable when mintlayer/mintlayer-core/issues/752 is implemented
-#[ignore]
+// Check that after reorg pool balance doesn't include reward from block `b`
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
 fn check_pool_balance_after_reorg(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
+    let target_block_time = create_unittest_pos_config().target_block_time().get();
 
     // create initial chain: genesis <- block_a
     let (mut tf, stake_pool_outpoint, pool_id, staking_sk) =
-        setup_test_chain_with_staked_pool(&mut rng, vrf_pk);
+        setup_test_chain_with_staked_pool(&mut rng, vrf_pk.clone());
     let block_a_id = tf.best_block_id();
 
+    let block_subsidy =
+        tf.chainstate.get_chain_config().block_subsidy_at_height(&BlockHeight::from(1));
+
     // prepare and process block_b with StakePool -> ProduceBlockFromStake kernel
+    let staking_destination = Destination::PublicKey(PublicKey::from_private_key(&staking_sk));
+    let reward_outputs =
+        vec![TxOutput::ProduceBlockFromStake(staking_destination.clone(), pool_id)];
+
+    let kernel_sig = produce_kernel_signature(
+        &tf,
+        &staking_sk,
+        reward_outputs.as_slice(),
+        staking_destination.clone(),
+        tf.best_block_id(),
+        stake_pool_outpoint.clone(),
+    );
+
     let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
     let sealed_pool_balance =
         PoSAccountingStorageRead::<SealedStorageTag>::get_pool_balance(&tf.storage, pool_id)
@@ -1259,7 +1274,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
     let (pos_data, block_timestamp) = pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint.clone(),
-        InputWitness::NoSignature(None),
+        InputWitness::Standard(kernel_sig),
         &vrf_sk,
         // no epoch is sealed yet so use initial randomness
         PoSRandomness::new(initial_randomness),
@@ -1269,16 +1284,25 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_block_signing_key(staking_sk.clone())
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
-        .with_reward(vec![reward_output])
+        .with_reward(reward_outputs.clone())
         .with_timestamp(block_timestamp)
         .build_and_process()
         .unwrap();
+    tf.progress_time_seconds_since_epoch(target_block_time);
 
     // prepare and process block_c with StakePool -> ProduceBlockFromStake kernel
+    let kernel_sig = produce_kernel_signature(
+        &tf,
+        &staking_sk,
+        reward_outputs.as_slice(),
+        staking_destination.clone(),
+        block_a_id,
+        stake_pool_outpoint.clone(),
+    );
+
     let sealed_pool_balance =
         PoSAccountingStorageRead::<SealedStorageTag>::get_pool_balance(&tf.storage, pool_id)
             .unwrap()
@@ -1286,9 +1310,9 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
     let (pos_data, block_timestamp) = pos_mine(
-        block_timestamp,
+        BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
-        InputWitness::NoSignature(None),
+        InputWitness::Standard(kernel_sig),
         &vrf_sk,
         // no epoch is sealed yet so use initial randomness
         PoSRandomness::new(initial_randomness),
@@ -1298,52 +1322,64 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
-    let block_c_index = tf
+
+    let block_c_randomness = PoSRandomness::from_block(
+        1,
+        block_timestamp,
+        &PoSRandomness::new(initial_randomness),
+        &pos_data,
+        &vrf_pk,
+    )
+    .unwrap();
+
+    let block_c = tf
         .make_block_builder()
         .with_block_signing_key(staking_sk.clone())
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
-        .with_reward(vec![reward_output])
+        .with_reward(reward_outputs.clone())
         .with_timestamp(block_timestamp)
         .with_parent(block_a_id)
-        .build_and_process()
-        .unwrap()
-        .unwrap();
+        .build();
+    let block_c_id = block_c.get_id();
+    tf.process_block(block_c, BlockSource::Local).unwrap();
+    tf.progress_time_seconds_since_epoch(target_block_time);
 
     // prepare and process block_d with ProduceBlockFromStake -> ProduceBlockFromStake kernel
-    let block_3_reward_outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward((*block_c_index.block_id()).into()),
-        0,
+    let block_d_reward_outpoint =
+        UtxoOutPoint::new(OutPointSourceId::BlockReward(block_c_id.into()), 0);
+    let kernel_sig = produce_kernel_signature(
+        &tf,
+        &staking_sk,
+        reward_outputs.as_slice(),
+        staking_destination,
+        block_c_id.into(),
+        block_d_reward_outpoint.clone(),
     );
 
-    // both sealed epoch and pre block randomness can be used
-    let sealed_epoch_randomness =
-        tf.storage.transaction_ro().unwrap().get_epoch_data(1).unwrap().unwrap();
+    // sealed epoch randomness is not in the db yet, so get it from block_c
+    // also sealed balance must be manually calculated
     let sealed_pool_balance =
-        PoSAccountingStorageRead::<SealedStorageTag>::get_pool_balance(&tf.storage, pool_id)
-            .unwrap()
-            .unwrap();
+        tf.chainstate.get_chain_config().min_stake_pool_pledge() + (block_subsidy * 3).unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
     let (pos_data, block_timestamp) = pos_mine(
-        block_timestamp,
-        block_3_reward_outpoint,
-        InputWitness::NoSignature(None),
+        BlockTimestamp::from_duration_since_epoch(tf.current_time()),
+        block_d_reward_outpoint,
+        InputWitness::Standard(kernel_sig),
         &vrf_sk,
-        *sealed_epoch_randomness.randomness(),
+        block_c_randomness,
         pool_id,
-        sealed_pool_balance,
+        sealed_pool_balance.unwrap(),
         2,
         current_difficulty,
     )
     .expect("should be able to mine");
-    let reward_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id);
     tf.make_block_builder()
         .with_block_signing_key(staking_sk)
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
-        .with_reward(vec![reward_output])
+        .with_reward(reward_outputs)
         .with_timestamp(block_timestamp)
-        .with_parent((*block_c_index.block_id()).into())
+        .with_parent(block_c_id.into())
         .build_and_process()
         .unwrap();
 
@@ -1486,12 +1522,9 @@ fn decommission_from_produce_block(#[case] seed: Seed) {
 }
 
 // Produce `genesis -> a` chain. Block `a` has 2 stake pool outputs (one to produce block and one to decommission)
-// Also at block 'a' PoS activates. At height 2 and 3 chain changes configuration of decommission maturity.
+// PoS activates at height 2. At height 3 chain changes configuration of decommission maturity.
 // The test creates block 'b' from block 'a'. And the block 'c' from block 'a'.
 // The goal of the test is to check that block 'c' follows the maturity rules from height 2 and not 3.
-//
-// TODO: enable when mintlayer/mintlayer-core/issues/752 is implemented
-#[ignore]
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -1549,13 +1582,25 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
     let block_a_id = tf.best_block_id();
     let block_a_height = tf.best_block_index().block_height();
 
+    let staking_destination = Destination::PublicKey(PublicKey::from_private_key(&staking_sk1));
+    let produce_block_output =
+        vec![TxOutput::ProduceBlockFromStake(staking_destination.clone(), pool_id1)];
+    let kernel_sig = produce_kernel_signature(
+        &tf,
+        &staking_sk1,
+        produce_block_output.as_slice(),
+        staking_destination,
+        tf.best_block_id(),
+        stake_pool_outpoint1.clone(),
+    );
+
     // prepare and process block_a <- block_b with StakePool -> ProduceBlockFromStake kernel
     let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
     let current_difficulty = calculate_new_target(&mut tf, block_a_height.next_height()).unwrap();
     let (pos_data, block_timestamp) = pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint1,
-        InputWitness::NoSignature(None),
+        InputWitness::Standard(kernel_sig),
         &vrf_sk_1,
         // no epoch is sealed yet so use initial randomness
         PoSRandomness::new(initial_randomness),
@@ -1571,11 +1616,11 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
     let initially_staked = Amount::from_atoms(1);
     let total_reward = (subsidy + initially_staked).unwrap();
 
-    let produce_block_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id1);
-    tf.make_block_builder()
+    let block_b_index = tf
+        .make_block_builder()
         .with_block_signing_key(staking_sk1.clone())
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data.clone())))
-        .with_reward(vec![produce_block_output])
+        .with_reward(produce_block_output.clone())
         .with_timestamp(block_timestamp)
         .build_and_process()
         .unwrap();
@@ -1589,11 +1634,11 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
         ))
         .build();
 
-    let produce_block_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id1);
+    //let produce_block_output = TxOutput::ProduceBlockFromStake(anyonecanspend_address(), pool_id1);
     tf.make_block_builder()
         .with_block_signing_key(staking_sk1)
         .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
-        .with_reward(vec![produce_block_output])
+        .with_reward(produce_block_output)
         .with_timestamp(block_timestamp)
         .with_parent(block_a_id)
         .add_transaction(tx)
@@ -1601,18 +1646,30 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
         .unwrap();
     tf.progress_time_seconds_since_epoch(target_block_time);
 
-    // no reorg happened so decommission has no effect
-    let res_pool_balance =
+    // no reorg happened so decommission has no effect on pool2
+    assert_eq!(
+        tf.best_block_id(),
+        block_b_index.unwrap().into_gen_block_index().block_id()
+    );
+
+    let total_subsidy =
+        tf.chainstate.get_chain_config().block_subsidy_at_height(&BlockHeight::from(1));
+    let initially_staked = tf.chainstate.get_chain_config().min_stake_pool_pledge();
+
+    let res_pool_balance_1 =
+        PoSAccountingStorageRead::<TipStorageTag>::get_pool_balance(&tf.storage, pool_id1)
+            .unwrap()
+            .unwrap();
+    assert_eq!(
+        (total_subsidy + initially_staked).unwrap(),
+        res_pool_balance_1
+    );
+
+    let res_pool_balance_2 =
         PoSAccountingStorageRead::<TipStorageTag>::get_pool_balance(&tf.storage, pool_id2)
             .unwrap()
             .unwrap();
-    let total_subsidy =
-        tf.chainstate.get_chain_config().block_subsidy_at_height(&BlockHeight::from(1)) * 3;
-    let initially_staked = Amount::from_atoms(1);
-    assert_eq!(
-        (total_subsidy.unwrap() + initially_staked).unwrap(),
-        res_pool_balance
-    );
+    assert_eq!(initially_staked, res_pool_balance_2);
 }
 
 #[rstest]

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -908,7 +908,7 @@ fn pos_invalid_pool_id(#[case] seed: Seed) {
 // Create a chain genesis <- block_1, where block_1 has valid StakePool output.
 // PoS consensus activates on height 2 and an epoch is sealed at height 2.
 // Try to crete block_2 with PoS data that has refer to staked pool.
-#[ignore = "Disabled because of switch from SealedStorageTag to TipStorageTag"]
+#[ignore] // FIXME: reconsider this test
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -953,7 +953,7 @@ fn not_sealed_pool_cannot_be_used(#[case] seed: Seed) {
         PoSRandomness::new(initial_randomness),
         pool_id,
         Amount::from_atoms(1),
-        1,
+        0,
         current_difficulty,
     )
     .expect("should be able to mine");

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -24,7 +24,7 @@ use chainstate_storage::{BlockchainStorageRead, Transactional};
 use chainstate_test_framework::{
     anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
 };
-use chainstate_types::vrf_tools::construct_transcript;
+use chainstate_types::{vrf_tools::construct_transcript, EpochStorageRead};
 use common::{
     chain::{
         block::{

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -20,7 +20,7 @@ use super::helpers::pos::{calculate_new_target, pos_mine};
 use chainstate::{
     chainstate_interface::ChainstateInterface, BlockError, ChainstateError, CheckBlockError,
 };
-use chainstate_storage::{BlockchainStorageRead, Transactional};
+use chainstate_storage::Transactional;
 use chainstate_test_framework::{
     anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
 };

--- a/chainstate/test-suite/src/tests/reorgs_tests.rs
+++ b/chainstate/test-suite/src/tests/reorgs_tests.rs
@@ -137,10 +137,8 @@ fn check_spend_tx_in_failed_block(tf: &mut TestFramework, events: &EventList, rn
     // Cause reorg on a failed block
     assert_eq!(
         tf.create_chain(&(*tf.index_at(12).block_id()).into(), 1, rng).unwrap_err(),
-        ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-            chainstate::CheckBlockError::StateUpdateFailed(
-                ConnectTransactionError::MissingOutputOrSpent
-            )
+        ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+            ConnectTransactionError::MissingOutputOrSpent
         ))
     );
 }
@@ -176,10 +174,8 @@ fn check_spend_tx_in_other_fork(tf: &mut TestFramework, rng: &mut impl Rng) {
     // Cause reorg on a failed block
     assert_eq!(
         tf.create_chain(&block_id.into(), 10, rng).unwrap_err(),
-        ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-            chainstate::CheckBlockError::StateUpdateFailed(
-                ConnectTransactionError::MissingOutputOrSpent
-            )
+        ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+            ConnectTransactionError::MissingOutputOrSpent
         ))
     );
 }
@@ -205,10 +201,8 @@ fn check_fork_that_double_spends(tf: &mut TestFramework, rng: &mut impl Rng) {
             .add_double_spend_transaction(block.get_id().into(), spend_from, rng)
             .build_and_process()
             .unwrap_err(),
-        ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-            chainstate::CheckBlockError::StateUpdateFailed(
-                ConnectTransactionError::MissingOutputOrSpent
-            )
+        ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+            ConnectTransactionError::MissingOutputOrSpent
         ))
     );
 }

--- a/chainstate/test-suite/src/tests/reorgs_tests.rs
+++ b/chainstate/test-suite/src/tests/reorgs_tests.rs
@@ -137,8 +137,10 @@ fn check_spend_tx_in_failed_block(tf: &mut TestFramework, events: &EventList, rn
     // Cause reorg on a failed block
     assert_eq!(
         tf.create_chain(&(*tf.index_at(12).block_id()).into(), 1, rng).unwrap_err(),
-        ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-            ConnectTransactionError::MissingOutputOrSpent
+        ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+            chainstate::CheckBlockError::StateUpdateFailed(
+                ConnectTransactionError::MissingOutputOrSpent
+            )
         ))
     );
 }
@@ -174,8 +176,10 @@ fn check_spend_tx_in_other_fork(tf: &mut TestFramework, rng: &mut impl Rng) {
     // Cause reorg on a failed block
     assert_eq!(
         tf.create_chain(&block_id.into(), 10, rng).unwrap_err(),
-        ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-            ConnectTransactionError::MissingOutputOrSpent
+        ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+            chainstate::CheckBlockError::StateUpdateFailed(
+                ConnectTransactionError::MissingOutputOrSpent
+            )
         ))
     );
 }
@@ -201,8 +205,10 @@ fn check_fork_that_double_spends(tf: &mut TestFramework, rng: &mut impl Rng) {
             .add_double_spend_transaction(block.get_id().into(), spend_from, rng)
             .build_and_process()
             .unwrap_err(),
-        ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-            ConnectTransactionError::MissingOutputOrSpent
+        ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+            chainstate::CheckBlockError::StateUpdateFailed(
+                ConnectTransactionError::MissingOutputOrSpent
+            )
         ))
     );
 }

--- a/chainstate/test-suite/src/tests/syncing_tests.rs
+++ b/chainstate/test-suite/src/tests/syncing_tests.rs
@@ -201,7 +201,7 @@ fn get_headers_genesis(#[case] seed: Seed) {
 fn get_headers_branching_chains(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let common_height = rng.gen_range(100..10_000);
+        let common_height = rng.gen_range(100..1000);
 
         let mut tf = TestFramework::builder(&mut rng)
             .with_chain_config(
@@ -214,9 +214,9 @@ fn get_headers_branching_chains(#[case] seed: Seed) {
         let common_block_id =
             tf.create_chain(&tf.genesis().get_id().into(), common_height, &mut rng).unwrap();
 
-        tf.create_chain(&common_block_id, rng.gen_range(100..2500), &mut rng).unwrap();
+        tf.create_chain(&common_block_id, rng.gen_range(100..250), &mut rng).unwrap();
         let locator = tf.chainstate.get_locator().unwrap();
-        tf.create_chain(&common_block_id, rng.gen_range(2500..5000), &mut rng).unwrap();
+        tf.create_chain(&common_block_id, rng.gen_range(250..500), &mut rng).unwrap();
 
         let headers = tf.chainstate.get_headers(locator, 2000).unwrap();
         let id = headers[0].prev_block_id();

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -91,13 +91,19 @@ pub struct Subsidy(pub Amount);
 #[derive(Debug, Eq, PartialEq)]
 pub struct TransactionVerifierDelta {
     tx_index_cache: BTreeMap<OutPointSourceId, CachedInputsOperation>,
-    pub utxo_cache: ConsumedUtxoCache,
+    utxo_cache: ConsumedUtxoCache,
     utxo_block_undo: BTreeMap<TransactionSource, UtxosBlockUndoEntry>,
     token_issuance_cache: ConsumedTokenIssuanceCache,
-    pub accounting_delta: PoSAccountingDeltaData,
+    accounting_delta: PoSAccountingDeltaData,
     accounting_delta_undo: BTreeMap<TransactionSource, AccountingBlockUndoEntry>,
     accounting_block_deltas: BTreeMap<TransactionSource, PoSAccountingDeltaData>,
     account_nonce: BTreeMap<AccountType, CachedOperation<AccountNonce>>,
+}
+
+impl TransactionVerifierDelta {
+    pub fn consume(self) -> (ConsumedUtxoCache, PoSAccountingDeltaData) {
+        (self.utxo_cache, self.accounting_delta)
+    }
 }
 
 /// The tool used to verify transactions and cache their updated states in memory

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -91,10 +91,10 @@ pub struct Subsidy(pub Amount);
 #[derive(Debug, Eq, PartialEq)]
 pub struct TransactionVerifierDelta {
     tx_index_cache: BTreeMap<OutPointSourceId, CachedInputsOperation>,
-    utxo_cache: ConsumedUtxoCache,
+    pub utxo_cache: ConsumedUtxoCache,
     utxo_block_undo: BTreeMap<TransactionSource, UtxosBlockUndoEntry>,
     token_issuance_cache: ConsumedTokenIssuanceCache,
-    accounting_delta: PoSAccountingDeltaData,
+    pub accounting_delta: PoSAccountingDeltaData,
     accounting_delta_undo: BTreeMap<TransactionSource, AccountingBlockUndoEntry>,
     accounting_block_deltas: BTreeMap<TransactionSource, PoSAccountingDeltaData>,
     account_nonce: BTreeMap<AccountType, CachedOperation<AccountNonce>>,

--- a/chainstate/types/src/block_index_handle.rs
+++ b/chainstate/types/src/block_index_handle.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{BlockIndex, EpochData, GenBlockIndex, PropertyQueryError};
+use crate::{BlockIndex, GenBlockIndex, PropertyQueryError};
 use common::{
     chain::{block::BlockReward, Block, GenBlock},
     primitives::{BlockHeight, Id},
@@ -45,6 +45,4 @@ pub trait BlockIndexHandle {
         &self,
         block_index: &BlockIndex,
     ) -> Result<Option<BlockReward>, PropertyQueryError>;
-
-    fn get_epoch_data(&self, epoch_index: u64) -> Result<Option<EpochData>, PropertyQueryError>;
 }

--- a/chainstate/types/src/epoch_data_cache.rs
+++ b/chainstate/types/src/epoch_data_cache.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use common::{
+    chain::{
+        block::{consensus_data::PoSData, ConsensusData},
+        config::EpochIndex,
+        Block, ChainConfig, TxOutput,
+    },
+    primitives::BlockHeight,
+};
+
+use crate::EpochData;
+
+pub trait EpochStorageRead {
+    fn get_epoch_data(
+        &self,
+        epoch_index: EpochIndex,
+    ) -> crate::storage_result::Result<Option<EpochData>>;
+}
+
+pub trait EpochStorageWrite {
+    fn set_epoch_data(
+        &mut self,
+        epoch_index: EpochIndex,
+        epoch_data: &EpochData,
+    ) -> crate::storage_result::Result<()>;
+
+    fn del_epoch_data(&mut self, epoch_index: EpochIndex) -> crate::storage_result::Result<()>;
+}
+
+pub struct EpochDataCache<P> {
+    parent: P,
+    data: BTreeMap<EpochIndex, EpochData>,
+}
+
+impl<P: EpochStorageRead> EpochDataCache<P> {
+    pub fn new(parent: P) -> Self {
+        Self {
+            parent,
+            data: BTreeMap::new(),
+        }
+    }
+}
+
+impl<P: EpochStorageRead> EpochStorageRead for EpochDataCache<P> {
+    fn get_epoch_data(
+        &self,
+        epoch_index: EpochIndex,
+    ) -> crate::storage_result::Result<Option<EpochData>> {
+        todo!()
+    }
+}
+
+impl<P: EpochStorageWrite> EpochStorageWrite for EpochDataCache<P> {
+    fn set_epoch_data(
+        &mut self,
+        epoch_index: u64,
+        epoch_data: &EpochData,
+    ) -> crate::storage_result::Result<()> {
+        todo!()
+    }
+
+    fn del_epoch_data(&mut self, epoch_index: EpochIndex) -> crate::storage_result::Result<()> {
+        todo!()
+    }
+}

--- a/chainstate/types/src/lib.rs
+++ b/chainstate/types/src/lib.rs
@@ -18,11 +18,18 @@ pub mod storage_result;
 pub mod vrf_tools;
 
 pub use crate::{
-    ancestor::block_index_ancestor_getter, ancestor::gen_block_index_getter,
-    block_index::BlockIndex, block_index_handle::BlockIndexHandle,
-    block_index_history_iter::BlockIndexHistoryIterator, epoch_data::EpochData,
-    error::GetAncestorError, error::PropertyQueryError, gen_block_index::GenBlockIndex,
-    height_skip::get_skip_height, locator::Locator,
+    ancestor::block_index_ancestor_getter,
+    ancestor::gen_block_index_getter,
+    block_index::BlockIndex,
+    block_index_handle::BlockIndexHandle,
+    block_index_history_iter::BlockIndexHistoryIterator,
+    epoch_data::EpochData,
+    epoch_data_cache::{EpochDataCache, EpochStorageRead, EpochStorageWrite},
+    error::GetAncestorError,
+    error::PropertyQueryError,
+    gen_block_index::GenBlockIndex,
+    height_skip::get_skip_height,
+    locator::Locator,
 };
 
 mod ancestor;
@@ -30,6 +37,7 @@ mod block_index;
 mod block_index_handle;
 mod block_index_history_iter;
 mod epoch_data;
+mod epoch_data_cache;
 mod error;
 mod gen_block_index;
 mod height_skip;

--- a/chainstate/types/src/lib.rs
+++ b/chainstate/types/src/lib.rs
@@ -24,7 +24,9 @@ pub use crate::{
     block_index_handle::BlockIndexHandle,
     block_index_history_iter::BlockIndexHistoryIterator,
     epoch_data::EpochData,
-    epoch_data_cache::{EpochDataCache, EpochStorageRead, EpochStorageWrite},
+    epoch_data_cache::{
+        ConsumedEpochDataCache, EpochDataCache, EpochStorageRead, EpochStorageWrite,
+    },
     error::GetAncestorError,
     error::PropertyQueryError,
     gen_block_index::GenBlockIndex,

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -101,7 +101,7 @@ fn randomness_of_sealed_epoch<S: EpochStorageRead>(
         Some(sealed_epoch_index) => {
             let epoch_data = epoch_storage
                 .get_epoch_data(sealed_epoch_index)
-                .map_err(|e| PropertyQueryError::StorageError(e))?;
+                .map_err(PropertyQueryError::StorageError)?;
             match epoch_data {
                 Some(d) => *d.randomness(),
                 None => {

--- a/consensus/src/pos/target.rs
+++ b/consensus/src/pos/target.rs
@@ -353,13 +353,6 @@ mod tests {
         ) -> Result<Option<common::chain::block::BlockReward>, PropertyQueryError> {
             unimplemented!()
         }
-
-        fn get_epoch_data(
-            &self,
-            _epoch_index: u64,
-        ) -> Result<Option<chainstate_types::EpochData>, PropertyQueryError> {
-            unimplemented!()
-        }
     }
 
     #[rstest]

--- a/consensus/src/validator.rs
+++ b/consensus/src/validator.rs
@@ -36,7 +36,6 @@ pub fn validate_consensus<H, U, P>(
     block_index_handle: &H,
     utxos_view: &U,
     pos_accounting_view: &P,
-    strict_pos_consensus_check: bool,
 ) -> Result<(), ConsensusVerificationError>
 where
     H: BlockIndexHandle,
@@ -72,7 +71,6 @@ where
             utxos_view,
             pos_accounting_view,
             header,
-            strict_pos_consensus_check,
         ),
     }
 }
@@ -116,7 +114,6 @@ fn validate_pos_consensus<H, U, P>(
     utxos_view: &U,
     pos_accounting_view: &P,
     header: &SignedBlockHeader,
-    strict_pos_consensus_check: bool,
 ) -> Result<(), ConsensusVerificationError>
 where
     H: BlockIndexHandle,
@@ -137,7 +134,6 @@ where
             block_index_handle,
             utxos_view,
             pos_accounting_view,
-            strict_pos_consensus_check,
         )
         .map_err(Into::into),
     }

--- a/consensus/src/validator.rs
+++ b/consensus/src/validator.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chainstate_types::BlockIndexHandle;
+use chainstate_types::{BlockIndexHandle, EpochStorageRead};
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockHeader, ConsensusData},
@@ -30,15 +30,17 @@ use crate::{
 };
 
 /// Checks if the given block identified by the header contains the correct consensus data.
-pub fn validate_consensus<H, U, P>(
+pub fn validate_consensus<H, E, U, P>(
     chain_config: &ChainConfig,
     header: &SignedBlockHeader,
     block_index_handle: &H,
+    epoch_data_storage: &E,
     utxos_view: &U,
     pos_accounting_view: &P,
 ) -> Result<(), ConsensusVerificationError>
 where
     H: BlockIndexHandle,
+    E: EpochStorageRead,
     U: UtxosView,
     P: PoSAccountingView<Error = pos_accounting::Error>,
 {
@@ -68,6 +70,7 @@ where
             chain_config,
             &pos_status,
             block_index_handle,
+            epoch_data_storage,
             utxos_view,
             pos_accounting_view,
             header,
@@ -107,16 +110,18 @@ fn validate_ignore_consensus(header: &BlockHeader) -> Result<(), ConsensusVerifi
     }
 }
 
-fn validate_pos_consensus<H, U, P>(
+fn validate_pos_consensus<H, E, U, P>(
     chain_config: &ChainConfig,
     pos_status: &PoSStatus,
     block_index_handle: &H,
+    epoch_data_storage: &E,
     utxos_view: &U,
     pos_accounting_view: &P,
     header: &SignedBlockHeader,
 ) -> Result<(), ConsensusVerificationError>
 where
     H: BlockIndexHandle,
+    E: EpochStorageRead,
     U: UtxosView,
     P: PoSAccountingView<Error = pos_accounting::Error>,
 {
@@ -132,6 +137,7 @@ where
             header,
             pos_data,
             block_index_handle,
+            epoch_data_storage,
             utxos_view,
             pos_accounting_view,
         )

--- a/pos_accounting/src/pool/delta/mod.rs
+++ b/pos_accounting/src/pool/delta/mod.rs
@@ -67,7 +67,6 @@ impl<P: PoSAccountingView> PoSAccountingDelta<P> {
         }
     }
 
-    #[cfg(test)]
     pub fn from_data(parent: P, data: PoSAccountingDeltaData) -> Self {
         Self { parent, data }
     }

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -81,6 +81,15 @@ impl<P: UtxosView> UtxosCache<P> {
         })
     }
 
+    pub fn from_data(parent: P, utxos: ConsumedUtxoCache) -> Result<Self, P::Error> {
+        Ok(UtxosCache {
+            parent,
+            current_block_hash: utxos.best_block,
+            utxos: utxos.container,
+            memory_usage: 0,
+        })
+    }
+
     pub fn set_best_block(&mut self, block_hash: Id<GenBlock>) {
         self.current_block_hash = block_hash;
     }


### PR DESCRIPTION
To validate a block with PoS in a branch we need a utxo set and accounting data to be up to that particular point in history and not the mainchain tip. So suggested solution is to perform in memory reorg and use the resulting data to validate a block. It's slow but relatively simple.

Regarding the speed if measuring the time of the `syncing_test::get_headers_branching_chains` test in debug with reorg depths of 1000 blocks the time is ~200s vs ~10s for prev version.  

Benchmark shows the time of 16.706s for 1000 blocks

Fixes #752