### PR TITLE
Remove redundant broadcast_message helper in p2p tests

### DIFF
--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -62,7 +62,7 @@ async fn unknown_prev_block(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     handle
-        .broadcast_message(
+        .send_message(
             peer,
             SyncMessage::HeaderList(HeaderList::new(vec![block_2.header().clone()])),
         )
@@ -97,7 +97,7 @@ async fn invalid_timestamp() {
     )
     .unwrap();
     handle
-        .broadcast_message(
+        .send_message(
             peer,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
@@ -146,7 +146,7 @@ async fn invalid_consensus_data() {
     )
     .unwrap();
     handle
-        .broadcast_message(
+        .send_message(
             peer,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
@@ -218,7 +218,7 @@ async fn unconnected_headers(#[case] seed: Seed) {
 
     // First announcement: the peer score shouldn't be changed.
     handle
-        .broadcast_message(
+        .send_message(
             peer,
             SyncMessage::HeaderList(HeaderList::new(vec![orphan_block.header().clone()])),
         )
@@ -231,7 +231,7 @@ async fn unconnected_headers(#[case] seed: Seed) {
 
     // Second announcement: misbehavior.
     handle
-        .broadcast_message(
+        .send_message(
             peer,
             SyncMessage::HeaderList(HeaderList::new(vec![orphan_block.header().clone()])),
         )
@@ -271,7 +271,7 @@ async fn valid_block(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     handle
-        .broadcast_message(
+        .send_message(
             peer,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -186,14 +186,10 @@ impl SyncManagerHandle {
         self.connected_peers.lock().unwrap().remove(&peer);
     }
 
+    /// Sends an announcement to the sync manager.
     pub async fn send_message(&mut self, peer: PeerId, message: SyncMessage) {
         let sync_tx = self.connected_peers.lock().unwrap().get(&peer).unwrap().clone();
         sync_tx.send(message).await.unwrap();
-    }
-
-    /// Sends an announcement to the sync manager.
-    pub async fn broadcast_message(&mut self, peer: PeerId, message: SyncMessage) {
-        self.send_message(peer, message).await;
     }
 
     /// Receives a message from the sync manager.

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -65,7 +65,7 @@ async fn invalid_transaction(#[case] seed: Seed) {
     let tx = Transaction::new(0x00, vec![], vec![]).unwrap();
     let tx = SignedTransaction::new(tx, vec![]).unwrap();
     handle
-        .broadcast_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
+        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
         .await;
 
     let (sent_to, message) = handle.message().await;
@@ -108,7 +108,7 @@ async fn initial_block_download() {
 
     let tx = transaction(chain_config.genesis_block_id());
     handle
-        .broadcast_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
+        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
         .await;
 
     handle.assert_no_event().await;
@@ -167,7 +167,7 @@ async fn no_transaction_service(#[case] seed: Seed) {
 
     let tx = transaction(chain_config.genesis_block_id());
     handle
-        .broadcast_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
+        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
         .await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
@@ -230,7 +230,7 @@ async fn too_many_announcements(#[case] seed: Seed) {
 
     let tx = transaction(chain_config.genesis_block_id());
     handle
-        .broadcast_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
+        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
         .await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
@@ -271,7 +271,7 @@ async fn duplicated_announcement(#[case] seed: Seed) {
 
     let tx = transaction(chain_config.genesis_block_id());
     handle
-        .broadcast_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
+        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
         .await;
 
     let (sent_to, message) = handle.message().await;
@@ -282,7 +282,7 @@ async fn duplicated_announcement(#[case] seed: Seed) {
     );
 
     handle
-        .broadcast_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
+        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
         .await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
@@ -326,7 +326,7 @@ async fn valid_transaction(#[case] seed: Seed) {
 
     let tx = transaction(chain_config.genesis_block_id());
     handle
-        .broadcast_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
+        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
         .await;
 
     let (sent_to, message) = handle.message().await;


### PR DESCRIPTION
In p2p sync test helpers, there are two methods `send_message` and `broadcast_message`. The latter simply invokes the former. `broadcast_message` can be removed. The term "broadcast" typically refers to broadcasting a message to a set of peers whereas "send" refers to sending to a single peer (which is the case here).