### PR TITLE
Add chainstate-test-framework::PoSBlockBuilder

### DIFF
--- a/chainstate/test-framework/Cargo.toml
+++ b/chainstate/test-framework/Cargo.toml
@@ -12,6 +12,7 @@ chainstate = { path = '..' }
 chainstate-storage = { path = '../storage' }
 chainstate-types = { path = '../types' }
 common = { path = '../../common' }
+consensus = { path = '../../consensus' }
 crypto = { path = '../../crypto' }
 pos_accounting = {path = '../../pos_accounting'}
 serialization = {path = "../../serialization"}

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -152,6 +152,7 @@ impl TestFramework {
             let block = self
                 .make_pos_block_builder(rng)
                 .with_parent(prev_block_id)
+                .with_block_signing_key(staking_sk.clone())
                 .with_stake_spending_key(staking_sk.clone())
                 .with_vrf_key(staking_vrf_sk.clone())
                 .build();

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -26,11 +26,16 @@ use common::{
     primitives::{id::WithId, BlockHeight, Id, Idable},
     time_getter::TimeGetter,
 };
-use crypto::random::{CryptoRng, Rng};
+use crypto::{
+    key::PrivateKey,
+    random::{CryptoRng, Rng},
+    vrf::VRFPrivateKey,
+};
 
 use rstest::rstest;
 
 use crate::{
+    pos_block_builder::PoSBlockBuilder,
     utils::{outputs_from_block, outputs_from_genesis},
     BlockBuilder, TestChainstate, TestFrameworkBuilder, TestStore,
 };
@@ -61,6 +66,10 @@ impl TestFramework {
     /// Returns a block builder instance that can be used for block construction and processing.
     pub fn make_block_builder(&mut self) -> BlockBuilder {
         BlockBuilder::new(self)
+    }
+
+    pub fn make_pos_block_builder(&mut self, rng: &mut (impl Rng + CryptoRng)) -> PoSBlockBuilder {
+        PoSBlockBuilder::new(self, rng)
     }
 
     /// Get the current time using the time getter that was supplied to the test-framework
@@ -122,6 +131,29 @@ impl TestFramework {
                 .make_block_builder()
                 .add_test_transaction_with_parent(prev_block_id, rng)
                 .with_parent(prev_block_id)
+                .build();
+            prev_block_id = block.get_id().into();
+            self.process_block(block, BlockSource::Local)?;
+        }
+
+        Ok(prev_block_id)
+    }
+
+    pub fn create_chain_pos(
+        &mut self,
+        parent_block: &Id<GenBlock>,
+        blocks: usize,
+        rng: &mut (impl Rng + CryptoRng),
+        staking_sk: &PrivateKey,
+        staking_vrf_sk: &VRFPrivateKey,
+    ) -> Result<Id<GenBlock>, ChainstateError> {
+        let mut prev_block_id = *parent_block;
+        for _ in 0..blocks {
+            let block = self
+                .make_pos_block_builder(rng)
+                .with_parent(prev_block_id)
+                .with_stake_spending_key(staking_sk.clone())
+                .with_vrf_key(staking_vrf_sk.clone())
                 .build();
             prev_block_id = block.get_id().into();
             self.process_block(block, BlockSource::Local)?;

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -32,7 +32,7 @@ pub type TestChainstate = Box<dyn chainstate::chainstate_interface::ChainstateIn
 pub use {
     crate::utils::{
         anyonecanspend_address, create_chain_config_with_staking_pool, empty_witness,
-        get_output_value,
+        get_output_value, get_target_block_time, pos_mine, produce_kernel_signature,
     },
     block_builder::BlockBuilder,
     framework::TestFramework,

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -18,6 +18,7 @@
 mod block_builder;
 mod framework;
 mod framework_builder;
+mod pos_block_builder;
 mod transaction_builder;
 mod tx_verification_strategy;
 mod utils;
@@ -29,7 +30,10 @@ pub type TestStore = chainstate_storage::inmemory::Store;
 pub type TestChainstate = Box<dyn chainstate::chainstate_interface::ChainstateInterface>;
 
 pub use {
-    crate::utils::{anyonecanspend_address, empty_witness, get_output_value},
+    crate::utils::{
+        anyonecanspend_address, create_chain_config_with_staking_pool, empty_witness,
+        get_output_value,
+    },
     block_builder::BlockBuilder,
     framework::TestFramework,
     framework_builder::{OrphanErrorHandler, TestFrameworkBuilder, TxVerificationStrategy},

--- a/chainstate/test-framework/src/pos_block_builder.rs
+++ b/chainstate/test-framework/src/pos_block_builder.rs
@@ -1,0 +1,371 @@
+// Copyright (c) 2022 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::TestFramework;
+use chainstate::{BlockSource, ChainstateError};
+use chainstate_types::pos_randomness::PoSRandomness;
+use chainstate_types::vrf_tools::construct_transcript;
+use chainstate_types::{BlockIndex, EpochStorageRead};
+use common::chain::block::block_body::BlockBody;
+use common::chain::block::consensus_data::PoSData;
+use common::chain::block::signed_block_header::{BlockHeaderSignature, BlockHeaderSignatureData};
+use common::chain::block::{BlockHeader, BlockRewardTransactable};
+use common::chain::config::EpochIndex;
+use common::chain::signature::inputsig::standard_signature::StandardInputSignature;
+use common::chain::signature::sighash::sighashtype::SigHashType;
+use common::chain::{Destination, PoolId, RequiredConsensus, UtxoOutPoint};
+use common::primitives::{Amount, Compact, Idable};
+use common::{
+    chain::{
+        block::{timestamp::BlockTimestamp, BlockReward, ConsensusData},
+        signature::inputsig::InputWitness,
+        signed_transaction::SignedTransaction,
+        Block, GenBlock, TxOutput,
+    },
+    primitives::{Id, H256},
+};
+use crypto::key::{KeyKind, PrivateKey, PublicKey};
+use crypto::random::{CryptoRng, Rng};
+use crypto::vrf::{VRFKeyKind, VRFPrivateKey, VRFPublicKey};
+use serialization::Encode;
+
+/// The block builder that allows construction and processing of a block.
+pub struct PoSBlockBuilder<'f> {
+    framework: &'f mut TestFramework,
+    prev_block_hash: Id<GenBlock>,
+    timestamp: BlockTimestamp,
+    reward: BlockReward,
+    consensus_data: Option<ConsensusData>,
+    block_signing_key: Option<PrivateKey>,
+    transactions: Vec<SignedTransaction>,
+
+    staking_pool: Option<PoolId>,
+    staking_outpoint: Option<UtxoOutPoint>,
+
+    staker_sk: PrivateKey,
+    staker_vrf_sk: VRFPrivateKey,
+}
+
+impl<'f> PoSBlockBuilder<'f> {
+    /// Creates a new builder instance.
+    pub fn new(framework: &'f mut TestFramework, rng: &mut (impl Rng + CryptoRng)) -> Self {
+        let transactions = Vec::new();
+        let prev_block_hash = framework.chainstate.get_best_block_id().unwrap();
+        let timestamp = BlockTimestamp::from_duration_since_epoch(framework.time_getter.get_time());
+        let reward = BlockReward::new(Vec::new());
+
+        let (staker_vrf_sk, _) = VRFPrivateKey::new_from_rng(rng, VRFKeyKind::Schnorrkel);
+        let (staker_sk, _) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
+
+        let staking_pool =
+            framework.chainstate.get_chain_config().genesis_block().utxos().iter().find_map(
+                |output| match output {
+                    TxOutput::Transfer(_, _)
+                    | TxOutput::LockThenTransfer(_, _, _)
+                    | TxOutput::Burn(_)
+                    | TxOutput::ProduceBlockFromStake(_, _)
+                    | TxOutput::CreateDelegationId(_, _)
+                    | TxOutput::DelegateStaking(_, _) => None,
+                    | TxOutput::CreateStakePool(pool_id, _) => Some(*pool_id),
+                },
+            );
+
+        Self {
+            framework,
+            transactions,
+            prev_block_hash,
+            timestamp,
+            consensus_data: None,
+            reward,
+            block_signing_key: None,
+            staking_pool,
+            staking_outpoint: None,
+            staker_sk,
+            staker_vrf_sk,
+        }
+    }
+
+    /// Replaces the transactions.
+    pub fn with_transactions(mut self, transactions: Vec<SignedTransaction>) -> Self {
+        self.transactions = transactions;
+        self
+    }
+
+    /// Appends the given transaction to the transactions list.
+    pub fn add_transaction(mut self, transaction: SignedTransaction) -> Self {
+        self.transactions.push(transaction);
+        self
+    }
+
+    /// Overrides the previous block hash that is deduced by default as the best block.
+    pub fn with_parent(mut self, prev_block_hash: Id<GenBlock>) -> Self {
+        self.prev_block_hash = prev_block_hash;
+        self
+    }
+
+    /// Overrides the previous block hash by a random value making the resulting block an orphan.
+    pub fn make_orphan(mut self, rng: &mut impl Rng) -> Self {
+        self.prev_block_hash = Id::new(H256::random_using(rng));
+        self
+    }
+
+    /// Overrides the timestamp that is equal to the current time by default.
+    //pub fn with_timestamp(mut self, timestamp: BlockTimestamp) -> Self {
+    //    self.timestamp = timestamp;
+    //    self
+    //}
+
+    /// Overrides the consensus data that is `ConsensusData::None` by default.
+    pub fn with_consensus_data(mut self, data: PoSData) -> Self {
+        self.consensus_data = Some(ConsensusData::PoS(Box::new(data)));
+        self
+    }
+
+    /// Overrides the block reward that is empty by default.
+    pub fn with_reward(mut self, reward: Vec<TxOutput>) -> Self {
+        self.reward = BlockReward::new(reward);
+        self
+    }
+
+    pub fn with_block_signing_key(mut self, block_signing_key: PrivateKey) -> Self {
+        self.block_signing_key = Some(block_signing_key);
+        self
+    }
+
+    pub fn with_stake_spending_key(mut self, staker_key: PrivateKey) -> Self {
+        self.staker_sk = staker_key;
+        self
+    }
+
+    pub fn with_vrf_key(mut self, staker_vrf_key: VRFPrivateKey) -> Self {
+        self.staker_vrf_sk = staker_vrf_key;
+        self
+    }
+
+    fn build_impl(self) -> (Block, &'f mut TestFramework) {
+        let (consensus_data, block_timestamp) = match self.consensus_data {
+            Some(data) => (data, self.timestamp),
+            None => {
+                let (pos_data, block_timestamp) = self.mine_pos_block();
+                (ConsensusData::PoS(Box::new(pos_data)), block_timestamp)
+            }
+        };
+        let block_body = BlockBody::new(self.reward, self.transactions);
+        let merkle_proxy = block_body.merkle_tree_proxy().unwrap();
+        let unsigned_header = BlockHeader::new(
+            self.prev_block_hash,
+            merkle_proxy.merkle_tree().root(),
+            merkle_proxy.witness_merkle_tree().root(),
+            block_timestamp,
+            consensus_data,
+        );
+
+        let signed_header = if let Some(key) = self.block_signing_key {
+            let signature = key.sign_message(&unsigned_header.encode()).unwrap();
+            let sig_data = BlockHeaderSignatureData::new(signature);
+            let done_signature = BlockHeaderSignature::HeaderSignature(sig_data);
+            unsigned_header.with_signature(done_signature)
+        } else {
+            unsigned_header.with_no_signature()
+        };
+
+        (
+            Block::new_from_header(signed_header, block_body).unwrap(),
+            self.framework,
+        )
+    }
+
+    /// Builds a block without processing it.
+    pub fn build(self) -> Block {
+        self.build_impl().0
+    }
+
+    /// Constructs a block and processes it by the chainstate.
+    pub fn build_and_process(self) -> Result<Option<BlockIndex>, ChainstateError> {
+        let (block, framework) = self.build_impl();
+        framework.process_block(block, BlockSource::Local)
+        // FIXME: framework advance time
+    }
+
+    fn mine_pos_block(&self) -> (PoSData, BlockTimestamp) {
+        //let parent = tf.best_block_index();
+        let parent_block_index = self.framework.block_index(&self.prev_block_hash);
+        let staking_pool = self.staking_pool.expect("staking pool id must be set");
+        //tf.set_time_seconds_since_epoch(parent.block_timestamp().as_int_seconds() + 1);
+
+        let kernel_input = self.staking_outpoint.clone().unwrap_or_else(|| {
+            // if staking outpoint is not set try to extract it from the parent
+            match &parent_block_index {
+                chainstate_types::GenBlockIndex::Block(block_index) => {
+                    match block_index.block_header().header().consensus_data() {
+                        ConsensusData::None | ConsensusData::PoW(_) => {
+                            unimplemented!()
+                        }
+                        ConsensusData::PoS(_) => {
+                            UtxoOutPoint::new(parent_block_index.block_id().into(), 0)
+                        }
+                    }
+                }
+                chainstate_types::GenBlockIndex::Genesis(genesis) => {
+                    let output_index = genesis
+                        .utxos()
+                        .iter()
+                        .position(|output| match output {
+                            TxOutput::Transfer(..)
+                            | TxOutput::LockThenTransfer(..)
+                            | TxOutput::Burn(..)
+                            | TxOutput::ProduceBlockFromStake(..)
+                            | TxOutput::CreateDelegationId(..)
+                            | TxOutput::DelegateStaking(..) => false,
+                            TxOutput::CreateStakePool(pool_id, _) => *pool_id == staking_pool,
+                        })
+                        .unwrap();
+                    UtxoOutPoint::new(genesis.get_id().into(), output_index as u32)
+                }
+            }
+        });
+        //let kernel_inputs = vec![kernel_input];
+        let staking_destination =
+            Destination::PublicKey(PublicKey::from_private_key(&self.staker_sk));
+        let kernel_outputs =
+            vec![TxOutput::ProduceBlockFromStake(staking_destination.clone(), staking_pool)];
+
+        let kernel_sig = produce_kernel_signature(
+            self.framework,
+            &self.staker_sk,
+            kernel_outputs.as_slice(),
+            staking_destination,
+            self.prev_block_hash,
+            kernel_input.clone(),
+        );
+
+        let new_block_height = parent_block_index.block_height().next_height();
+        // FIXME: calculate???
+        let current_difficulty = match self
+            .framework
+            .chainstate
+            .get_chain_config()
+            .net_upgrade()
+            .consensus_status(new_block_height)
+        {
+            RequiredConsensus::PoS(status) => status,
+            RequiredConsensus::PoW(_) | RequiredConsensus::IgnoreConsensus => {
+                panic!("Invalid consensus")
+            }
+        }
+        .get_chain_config()
+        .target_limit();
+        let chain_config = self.framework.chainstate.get_chain_config().as_ref();
+        let randomness = match chain_config.sealed_epoch_index(&new_block_height) {
+            Some(epoch) => self
+                .framework
+                .storage
+                .get_epoch_data(epoch)
+                .unwrap()
+                .unwrap()
+                .randomness()
+                .clone(),
+            None => PoSRandomness::new(chain_config.initial_randomness()),
+        };
+        let pool_balance =
+            self.framework.chainstate.get_stake_pool_balance(staking_pool).unwrap().unwrap();
+
+        pos_mine(
+            BlockTimestamp::from_duration_since_epoch(self.framework.current_time()),
+            kernel_input,
+            InputWitness::Standard(kernel_sig),
+            &self.staker_vrf_sk,
+            randomness,
+            staking_pool,
+            pool_balance,
+            0,
+            current_difficulty.into(),
+        )
+        .unwrap()
+    }
+}
+
+fn produce_kernel_signature(
+    tf: &TestFramework,
+    staking_sk: &PrivateKey,
+    reward_outputs: &[TxOutput],
+    staking_destination: Destination,
+    kernel_utxo_block_id: Id<GenBlock>,
+    kernel_outpoint: UtxoOutPoint,
+) -> StandardInputSignature {
+    let block_outputs = tf.outputs_from_genblock(kernel_utxo_block_id);
+    let utxo = &block_outputs.get(&kernel_outpoint.tx_id()).unwrap()
+        [kernel_outpoint.output_index() as usize];
+
+    let kernel_inputs = vec![kernel_outpoint.into()];
+
+    let block_reward_tx =
+        BlockRewardTransactable::new(Some(kernel_inputs.as_slice()), Some(reward_outputs), None);
+    StandardInputSignature::produce_uniparty_signature_for_input(
+        staking_sk,
+        SigHashType::default(),
+        staking_destination,
+        &block_reward_tx,
+        std::iter::once(Some(utxo)).collect::<Vec<_>>().as_slice(),
+        0,
+    )
+    .unwrap()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pos_mine(
+    initial_timestamp: BlockTimestamp,
+    kernel_outpoint: UtxoOutPoint,
+    kernel_witness: InputWitness,
+    vrf_sk: &VRFPrivateKey,
+    sealed_epoch_randomness: PoSRandomness,
+    pool_id: PoolId,
+    pool_balance: Amount,
+    epoch_index: EpochIndex,
+    target: Compact,
+) -> Option<(PoSData, BlockTimestamp)> {
+    let mut timestamp = initial_timestamp;
+
+    for _ in 0..1000 {
+        let transcript =
+            construct_transcript(epoch_index, &sealed_epoch_randomness.value(), timestamp);
+        let vrf_data = vrf_sk.produce_vrf_data(transcript.into());
+
+        let pos_data = PoSData::new(
+            vec![kernel_outpoint.clone().into()],
+            vec![kernel_witness.clone()],
+            pool_id,
+            vrf_data,
+            target,
+        );
+
+        let vrf_pk = VRFPublicKey::from_private_key(vrf_sk);
+        if consensus::check_pos_hash(
+            epoch_index,
+            &sealed_epoch_randomness,
+            &pos_data,
+            &vrf_pk,
+            timestamp,
+            pool_balance,
+        )
+        .is_ok()
+        {
+            return Some((pos_data, timestamp));
+        }
+
+        timestamp = timestamp.add_int_seconds(1).unwrap();
+    }
+    None
+}

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -30,7 +30,7 @@ use common::{
     Uint256,
 };
 use crypto::{
-    key::{PrivateKey, PublicKey},
+    key::PublicKey,
     random::{CryptoRng, Rng},
     vrf::VRFPublicKey,
 };
@@ -336,9 +336,10 @@ pub fn create_chain_config_with_staking_pool(
         )),
     );
 
+    let genesis_time = common::time_getter::TimeGetter::default().get_time();
     let genesis = Genesis::new(
         String::new(),
-        BlockTimestamp::from_int_seconds(1685025323),
+        BlockTimestamp::from_duration_since_epoch(genesis_time),
         vec![mint_output, pool],
     );
 

--- a/chainstate/test-suite/benches/benches.rs
+++ b/chainstate/test-suite/benches/benches.rs
@@ -15,7 +15,7 @@
 
 use chainstate_test_framework::TestFramework;
 use common::{
-    chain::{stakelock::StakePoolData, Destination, Mlt, PoolId},
+    chain::{config::create_unit_test_config, stakelock::StakePoolData, Destination, PoolId},
     primitives::{per_thousand::PerThousand, Amount, BlockDistance, BlockHeight, Idable, H256},
 };
 use crypto::{
@@ -54,8 +54,9 @@ pub fn pos_reorg(c: &mut Criterion) {
     let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
 
     let pool_id = PoolId::new(H256::random_using(&mut rng));
+    let stake_pool_pledge = create_unit_test_config().min_stake_pool_pledge();
     let stake_pool_data = StakePoolData::new(
-        Amount::from_atoms(40_000_000 * Mlt::ATOMS_PER_MLT),
+        stake_pool_pledge,
         Destination::PublicKey(staking_pk),
         vrf_pk,
         Destination::AnyoneCanSpend,

--- a/chainstate/test-suite/benches/benches.rs
+++ b/chainstate/test-suite/benches/benches.rs
@@ -13,8 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chainstate_test_framework::TestFramework;
+use chainstate_test_framework::{create_chain_config_with_staking_pool, TestFramework};
 use common::primitives::Idable;
+use crypto::{
+    key::{KeyKind, PrivateKey},
+    vrf::{VRFKeyKind, VRFPrivateKey},
+};
 use test_utils::random::make_seedable_rng;
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -22,14 +26,30 @@ use criterion::{criterion_group, criterion_main, Criterion};
 // TODO: rework for PoS
 pub fn reorg(c: &mut Criterion) {
     let mut rng = make_seedable_rng(1111.into());
-    let mut tf = TestFramework::builder(&mut rng).build();
+    let (staking_sk, staking_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+    let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
 
-    let common_block_id = tf.create_chain(&tf.genesis().get_id().into(), 5, &mut rng).unwrap();
+    let chain_config = create_chain_config_with_staking_pool(&mut rng, &staking_pk, &vrf_pk);
+    let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
 
-    tf.create_chain(&common_block_id, 1000, &mut rng).unwrap();
+    let common_block_id = tf
+        .create_chain_pos(
+            &tf.genesis().get_id().into(),
+            5,
+            &mut rng,
+            &staking_sk,
+            &vrf_sk,
+        )
+        .unwrap();
+
+    tf.create_chain_pos(&common_block_id, 1000, &mut rng, &staking_sk, &vrf_sk)
+        .unwrap();
 
     c.bench_function("Reorg", |b| {
-        b.iter(|| tf.create_chain(&common_block_id, 1001, &mut rng).unwrap())
+        b.iter(|| {
+            tf.create_chain_pos(&common_block_id, 1001, &mut rng, &staking_sk, &vrf_sk)
+                .unwrap()
+        })
     });
 }
 

--- a/chainstate/test-suite/benches/benches.rs
+++ b/chainstate/test-suite/benches/benches.rs
@@ -13,8 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chainstate_test_framework::{create_chain_config_with_staking_pool, TestFramework};
-use common::{chain::create_unittest_pos_config, primitives::Idable};
+use chainstate_test_framework::TestFramework;
+use common::{
+    chain::{stakelock::StakePoolData, Destination, Mlt, PoolId},
+    primitives::{per_thousand::PerThousand, Amount, BlockDistance, BlockHeight, Idable, H256},
+};
 use crypto::{
     key::{KeyKind, PrivateKey},
     vrf::{VRFKeyKind, VRFPrivateKey},
@@ -25,7 +28,14 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 pub fn pow_reorg(c: &mut Criterion) {
     let mut rng = make_seedable_rng(1111.into());
-    let mut tf = TestFramework::builder(&mut rng).build();
+    let mut tf = TestFramework::builder(&mut rng)
+        .with_chain_config(
+            common::chain::config::Builder::new(common::chain::config::ChainType::Regtest)
+                .net_upgrades(common::chain::NetUpgrades::unit_tests())
+                .max_depth_for_reorg(BlockDistance::new(5000))
+                .build(),
+        )
+        .build();
 
     let common_block_id = tf.create_chain(&tf.genesis().get_id().into(), 5, &mut rng).unwrap();
 
@@ -33,7 +43,7 @@ pub fn pow_reorg(c: &mut Criterion) {
 
     c.bench_function("PoW reorg", |b| {
         b.iter(|| {
-            tf.create_chain(&common_block_id, 1000, &mut rng).unwrap();
+            tf.create_chain(&common_block_id, 1001, &mut rng).unwrap();
         })
     });
 }
@@ -43,9 +53,27 @@ pub fn pos_reorg(c: &mut Criterion) {
     let (staking_sk, staking_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
     let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
 
-    let chain_config = create_chain_config_with_staking_pool(&mut rng, &staking_pk, &vrf_pk);
+    let pool_id = PoolId::new(H256::random_using(&mut rng));
+    let stake_pool_data = StakePoolData::new(
+        Amount::from_atoms(40_000_000 * Mlt::ATOMS_PER_MLT),
+        Destination::PublicKey(staking_pk),
+        vrf_pk,
+        Destination::AnyoneCanSpend,
+        PerThousand::new(1000).unwrap(),
+        Amount::ZERO,
+    );
+    let mint_amount = Amount::from_atoms(1000);
+
+    let chain_config = chainstate_test_framework::create_chain_config_with_staking_pool(
+        mint_amount,
+        pool_id,
+        stake_pool_data,
+    )
+    .max_depth_for_reorg(BlockDistance::new(5000))
+    .build();
+    let target_block_time =
+        chainstate_test_framework::get_target_block_time(&chain_config, BlockHeight::new(1));
     let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
-    let target_block_time = create_unittest_pos_config().target_block_time();
     tf.progress_time_seconds_since_epoch(target_block_time.get());
 
     let common_block_id = tf
@@ -63,7 +91,7 @@ pub fn pos_reorg(c: &mut Criterion) {
 
     c.bench_function("PoS reorg", |b| {
         b.iter(|| {
-            tf.create_chain_pos(&common_block_id, 100, &mut rng, &staking_sk, &vrf_sk)
+            tf.create_chain_pos(&common_block_id, 101, &mut rng, &staking_sk, &vrf_sk)
                 .unwrap();
         })
     });

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -26,8 +26,10 @@ use chainstate_test_framework::{
 };
 use common::{
     chain::{
-        config::Builder as ConfigBuilder, stakelock::StakePoolData, tokens::OutputValue,
-        Destination, GenBlock, Mlt, OutPointSourceId, PoolId, TxInput, TxOutput, UtxoOutPoint,
+        config::{create_unit_test_config, Builder as ConfigBuilder},
+        stakelock::StakePoolData,
+        tokens::OutputValue,
+        Destination, GenBlock, OutPointSourceId, PoolId, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Id, Idable, H256},
 };
@@ -245,8 +247,9 @@ fn long_chain_reorg(#[case] seed: Seed) {
         let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
 
         let pool_id = PoolId::new(H256::random_using(&mut rng));
+        let stake_pool_pledge = create_unit_test_config().min_stake_pool_pledge();
         let stake_pool_data = StakePoolData::new(
-            Amount::from_atoms(40_000_000 * Mlt::ATOMS_PER_MLT),
+            stake_pool_pledge,
             Destination::PublicKey(staking_pk),
             vrf_pk,
             Destination::AnyoneCanSpend,

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -15,9 +15,7 @@
 
 use std::{num::NonZeroU64, time::Duration};
 
-use super::helpers::pos::{
-    calculate_new_target, create_stake_pool_data_with_all_reward_to_owner, pos_mine,
-};
+use super::helpers::pos::{calculate_new_target, create_stake_pool_data_with_all_reward_to_owner};
 
 use chainstate::{
     chainstate_interface::ChainstateInterface, BlockError, BlockSource, ChainstateError,
@@ -48,7 +46,7 @@ use common::{
         timelock::OutputTimeLock,
         tokens::OutputValue,
         AccountNonce, AccountOutPoint, AccountSpending, Block, ConsensusUpgrade, Destination,
-        GenBlock, Genesis, NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId,
+        GenBlock, Genesis, Mlt, NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId,
         SignedTransaction, TxInput, TxOutput, UpgradeVersion, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Id, Idable, H256},
@@ -400,7 +398,7 @@ fn pos_basic(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -489,7 +487,7 @@ fn pos_block_signature(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint.clone(),
         InputWitness::NoSignature(None),
@@ -555,7 +553,7 @@ fn pos_block_signature(#[case] seed: Seed) {
         stake_pool_outpoint.clone(),
     );
 
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -622,7 +620,7 @@ fn pos_invalid_kernel_input(#[case] seed: Seed) {
     let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time() + Duration::from_secs(1)),
         invalid_kernel_input,
         InputWitness::NoSignature(None),
@@ -702,7 +700,7 @@ fn pos_invalid_vrf(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (valid_pos_data, valid_block_timestamp) = pos_mine(
+    let (valid_pos_data, valid_block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -857,7 +855,7 @@ fn pos_invalid_pool_id(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (valid_pos_data, block_timestamp) = pos_mine(
+    let (valid_pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -947,7 +945,7 @@ fn not_sealed_pool_cannot_be_used(#[case] seed: Seed) {
     let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
         InputWitness::NoSignature(None),
@@ -1017,7 +1015,7 @@ fn spend_stake_pool_in_block_reward(#[case] seed: Seed) {
     let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1058,7 +1056,7 @@ fn spend_stake_pool_in_block_reward(#[case] seed: Seed) {
     );
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         block_2_reward_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1108,7 +1106,7 @@ fn spend_stake_pool_in_block_reward(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         block_3_reward_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1163,7 +1161,7 @@ fn mismatched_pools_in_kernel_and_reward(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint1,
         InputWitness::NoSignature(None),
@@ -1274,7 +1272,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint.clone(),
         InputWitness::Standard(kernel_sig),
@@ -1314,7 +1312,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         block_c_kernel_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1355,7 +1353,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1396,7 +1394,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         (tf.chainstate.get_chain_config().min_stake_pool_pledge() + block_subsidy).unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         block_e_kernel_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1452,7 +1450,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         tf.chainstate.get_chain_config().min_stake_pool_pledge() + (block_subsidy * 2).unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         block_f_reward_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1533,7 +1531,7 @@ fn decommission_from_produce_block(#[case] seed: Seed) {
     let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint1,
         InputWitness::Standard(kernel_sig),
@@ -1579,7 +1577,7 @@ fn decommission_from_produce_block(#[case] seed: Seed) {
     );
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint2,
         InputWitness::Standard(kernel_sig),
@@ -1693,7 +1691,7 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
     // prepare and process block_a <- block_b with StakePool -> ProduceBlockFromStake kernel
     let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
     let current_difficulty = calculate_new_target(&mut tf, block_a_height.next_height()).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint1,
         InputWitness::Standard(kernel_sig),
@@ -1824,7 +1822,7 @@ fn pos_stake_testnet_genesis(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         stake_pool_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1876,7 +1874,7 @@ fn pos_stake_testnet_genesis(#[case] seed: Seed) {
             .unwrap();
     let new_block_height = tf.best_block_index().block_height().next_height();
     let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         block_1_reward_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -1930,7 +1928,7 @@ fn mine_pos_block(
         PoSAccountingStorageRead::<TipStorageTag>::get_pool_balance(&tf.storage, pool_id)
             .unwrap()
             .unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
+    let (pos_data, block_timestamp) = chainstate_test_framework::pos_mine(
         BlockTimestamp::from_duration_since_epoch(tf.current_time()),
         kernel_input_outpoint,
         InputWitness::Standard(kernel_sig),
@@ -2103,30 +2101,9 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
     let (staking_sk, staking_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
-    let target_block_time = create_unittest_pos_config().target_block_time().get();
 
-    let upgrades = vec![
-        (
-            BlockHeight::new(0),
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
-        ),
-        (
-            BlockHeight::new(2),
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
-                initial_difficulty: MIN_DIFFICULTY.into(),
-                config: create_unittest_pos_config(),
-            }),
-        ),
-    ];
-    let net_upgrades = NetUpgrades::initialize(upgrades).expect("valid net-upgrades");
-    let chain_config = ConfigBuilder::test_chain().net_upgrades(net_upgrades).build();
-
-    let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
-
-    // Process block_1 and create stake pool and delegation
-    let min_pledge_atoms = tf.chainstate.get_chain_config().min_stake_pool_pledge().into_atoms();
-    let amount_to_stake = Amount::from_atoms(rng.gen_range(min_pledge_atoms..min_pledge_atoms * 3));
-    let amount_to_delegate = Amount::from_atoms(rng.gen_range(100..100_000));
+    let pool_id = PoolId::new(H256::random_using(&mut rng));
+    let amount_to_stake = Amount::from_atoms(40_000_000 * Mlt::ATOMS_PER_MLT);
 
     let staker_reward_per_block = Amount::from_atoms(1000);
     let stake_pool_data = StakePoolData::new(
@@ -2137,6 +2114,22 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
         PerThousand::new(0).unwrap(),
         staker_reward_per_block,
     );
+
+    let amount_to_delegate = Amount::from_atoms(rng.gen_range(100..100_000));
+    // mint amount == amount to delegate to avoid dealing with fees
+    let chain_config = chainstate_test_framework::create_chain_config_with_staking_pool(
+        amount_to_delegate,
+        pool_id,
+        stake_pool_data,
+    )
+    .build();
+    let target_block_time =
+        chainstate_test_framework::get_target_block_time(&chain_config, BlockHeight::new(1));
+    let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
+    tf.progress_time_seconds_since_epoch(target_block_time.get());
+
+    // Process block_1: create delegation and delegate some amount
+
     let block_subsidy =
         tf.chainstate.get_chain_config().block_subsidy_at_height(&BlockHeight::from(1));
     let delegation_reward_per_block = (block_subsidy - staker_reward_per_block).unwrap();
@@ -2145,17 +2138,13 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
         OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
         0,
     );
-    let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
     let delegation_id = pos_accounting::make_delegation_id(&genesis_outpoint);
+
     let tx1 = TransactionBuilder::new()
         .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
         .add_output(TxOutput::Transfer(
             OutputValue::Coin(amount_to_delegate),
             Destination::AnyoneCanSpend,
-        ))
-        .add_output(TxOutput::CreateStakePool(
-            pool_id,
-            Box::new(stake_pool_data),
         ))
         .add_output(TxOutput::CreateDelegationId(
             Destination::AnyoneCanSpend,
@@ -2171,84 +2160,25 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
         .add_output(TxOutput::DelegateStaking(amount_to_delegate, delegation_id))
         .build();
 
-    tf.make_block_builder()
+    tf.make_pos_block_builder(&mut rng)
         .with_transactions(vec![tx1, tx2])
-        .build_and_process()
-        .unwrap();
-    tf.progress_time_seconds_since_epoch(target_block_time);
-
-    // Process block_2 and distribute reward
-    let stake_pool_outpoint = UtxoOutPoint::new(tx1_id.into(), 1);
-    let staking_destination = Destination::PublicKey(PublicKey::from_private_key(&staking_sk));
-    let reward_outputs =
-        vec![TxOutput::ProduceBlockFromStake(staking_destination.clone(), pool_id)];
-
-    let kernel_sig = produce_kernel_signature(
-        &tf,
-        &staking_sk,
-        reward_outputs.as_slice(),
-        staking_destination.clone(),
-        tf.best_block_id(),
-        stake_pool_outpoint.clone(),
-    );
-
-    let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
-    let new_block_height = tf.best_block_index().block_height().next_height();
-    let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
-        BlockTimestamp::from_duration_since_epoch(tf.current_time()),
-        stake_pool_outpoint,
-        InputWitness::Standard(kernel_sig),
-        &vrf_sk,
-        // no epoch is sealed yet so use initial randomness
-        PoSRandomness::new(initial_randomness),
-        pool_id,
-        amount_to_stake,
-        0,
-        current_difficulty,
-    )
-    .expect("should be able to mine");
-    tf.make_block_builder()
         .with_block_signing_key(staking_sk.clone())
-        .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
-        .with_reward(reward_outputs.clone())
-        .with_timestamp(block_timestamp)
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
         .build_and_process()
         .unwrap();
-    tf.progress_time_seconds_since_epoch(target_block_time);
+    tf.progress_time_seconds_since_epoch(target_block_time.get());
 
-    // Process block_3 and spend part of the share including reward
-    let block_2_reward_outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward(tf.chainstate.get_best_block_id().unwrap()),
-        0,
-    );
+    // Process block_2: distribute some reward
+    tf.make_pos_block_builder(&mut rng)
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
+        .build_and_process()
+        .unwrap();
+    tf.progress_time_seconds_since_epoch(target_block_time.get());
 
-    let kernel_sig = produce_kernel_signature(
-        &tf,
-        &staking_sk,
-        reward_outputs.as_slice(),
-        staking_destination.clone(),
-        tf.best_block_id(),
-        block_2_reward_outpoint.clone(),
-    );
-
-    let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
-    let new_block_height = tf.best_block_index().block_height().next_height();
-    let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
-        BlockTimestamp::from_duration_since_epoch(tf.current_time()),
-        block_2_reward_outpoint,
-        InputWitness::Standard(kernel_sig),
-        &vrf_sk,
-        // no epoch is sealed yet so use initial randomness
-        PoSRandomness::new(initial_randomness),
-        pool_id,
-        amount_to_stake,
-        0,
-        current_difficulty,
-    )
-    .expect("should be able to mine");
-
+    // Process block_3: spend part of the share including reward
     let amount_to_withdraw = Amount::from_atoms(rng.gen_range(1..amount_to_delegate.into_atoms()));
     let tx_input_spend_from_delegation = AccountOutPoint::new(
         AccountNonce::new(0),
@@ -2266,49 +2196,18 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
         ))
         .build();
 
-    tf.make_block_builder()
+    tf.make_pos_block_builder(&mut rng)
         .with_block_signing_key(staking_sk.clone())
-        .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
-        .with_reward(reward_outputs.clone())
-        .with_timestamp(block_timestamp)
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
         .add_transaction(tx)
         .build_and_process()
         .unwrap();
-    tf.progress_time_seconds_since_epoch(target_block_time);
+    tf.progress_time_seconds_since_epoch(target_block_time.get());
 
     // Process block_4 and spend some share including reward
-    let block_3_reward_outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward(tf.chainstate.get_best_block_id().unwrap()),
-        0,
-    );
-
-    let kernel_sig = produce_kernel_signature(
-        &tf,
-        &staking_sk,
-        reward_outputs.as_slice(),
-        staking_destination,
-        tf.best_block_id(),
-        block_3_reward_outpoint.clone(),
-    );
-
-    let initial_randomness = tf.chainstate.get_chain_config().initial_randomness();
-    let new_block_height = tf.best_block_index().block_height().next_height();
-    let current_difficulty = calculate_new_target(&mut tf, new_block_height).unwrap();
-    let (pos_data, block_timestamp) = pos_mine(
-        BlockTimestamp::from_duration_since_epoch(tf.current_time()),
-        block_3_reward_outpoint,
-        InputWitness::Standard(kernel_sig),
-        &vrf_sk,
-        // no epoch is sealed yet so use initial randomness
-        PoSRandomness::new(initial_randomness),
-        pool_id,
-        amount_to_stake,
-        0,
-        current_difficulty,
-    )
-    .expect("should be able to mine");
     let delegation_balance = (amount_to_delegate - amount_to_withdraw)
-        .and_then(|balance| balance + (delegation_reward_per_block * 2).unwrap())
+        .and_then(|balance| balance + (delegation_reward_per_block * 3).unwrap())
         .unwrap();
 
     // try overspend
@@ -2331,11 +2230,10 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
             .build();
 
         let res = tf
-            .make_block_builder()
+            .make_pos_block_builder(&mut rng)
             .with_block_signing_key(staking_sk.clone())
-            .with_consensus_data(ConsensusData::PoS(Box::new(pos_data.clone())))
-            .with_reward(reward_outputs.clone())
-            .with_timestamp(block_timestamp)
+            .with_stake_spending_key(staking_sk.clone())
+            .with_vrf_key(vrf_sk.clone())
             .add_transaction(tx)
             .build_and_process()
             .unwrap_err();
@@ -2366,11 +2264,10 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
         ))
         .build();
 
-    tf.make_block_builder()
-        .with_block_signing_key(staking_sk)
-        .with_consensus_data(ConsensusData::PoS(Box::new(pos_data)))
-        .with_reward(reward_outputs)
-        .with_timestamp(block_timestamp)
+    tf.make_pos_block_builder(&mut rng)
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk)
+        .with_vrf_key(vrf_sk)
         .add_transaction(tx)
         .build_and_process()
         .unwrap();
@@ -2382,3 +2279,5 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     .unwrap();
     assert_eq!(None, res_pool_balance);
 }
+
+// TODO: rewrite more tests using `PoSBlockBuilder`

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -36,7 +36,7 @@ use common::{
             consensus_data::PoSData, timestamp::BlockTimestamp, BlockRewardTransactable,
             ConsensusData,
         },
-        config::{Builder as ConfigBuilder, ChainType, EpochIndex},
+        config::{create_unit_test_config, Builder as ConfigBuilder, ChainType, EpochIndex},
         create_unittest_pos_config,
         signature::{
             inputsig::{standard_signature::StandardInputSignature, InputWitness},
@@ -46,7 +46,7 @@ use common::{
         timelock::OutputTimeLock,
         tokens::OutputValue,
         AccountNonce, AccountOutPoint, AccountSpending, Block, ConsensusUpgrade, Destination,
-        GenBlock, Genesis, Mlt, NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId,
+        GenBlock, Genesis, NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId,
         SignedTransaction, TxInput, TxOutput, UpgradeVersion, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Id, Idable, H256},
@@ -2103,7 +2103,7 @@ fn spend_from_delegation_with_reward(#[case] seed: Seed) {
     let (staking_sk, staking_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
 
     let pool_id = PoolId::new(H256::random_using(&mut rng));
-    let amount_to_stake = Amount::from_atoms(40_000_000 * Mlt::ATOMS_PER_MLT);
+    let amount_to_stake = create_unit_test_config().min_stake_pool_pledge();
 
     let staker_reward_per_block = Amount::from_atoms(1000);
     let stake_pool_data = StakePoolData::new(

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -15,7 +15,7 @@
 
 use std::{num::NonZeroU64, time::Duration};
 
-use super::helpers::pos::{calculate_new_target, pos_mine};
+use super::helpers::pos::calculate_new_target;
 
 use chainstate::{
     chainstate_interface::ChainstateInterface, BlockError, ChainstateError, CheckBlockError,
@@ -167,7 +167,7 @@ fn stable_block_time(#[case] seed: Seed) {
         )
         .unwrap();
 
-        let (pos_data, valid_block_timestamp) = pos_mine(
+        let (pos_data, valid_block_timestamp) = chainstate_test_framework::pos_mine(
             initial_block_time,
             UtxoOutPoint::new(best_block_source_id, 0),
             InputWitness::Standard(kernel_sig),


### PR DESCRIPTION
Introduce `PoSBlockBuilder` that should be a convenient tool to create PoS blocks in unit tests. I reworked one test in `pos_processing_tests.rs` as an example, more tests can be reworked later. So I think #972 can be closed.

Though the main motivation for this change was that there were no way to test long chain reorgs for PoS. In #967 I introduced in-memory reorg which was effectively not tested after I disabled it for PoW.

