### PR TITLE
Turn peer activity into an enum and add a test for a disconnect bug

### DIFF
--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -226,6 +226,21 @@ impl SyncManagerHandle {
         }
     }
 
+    pub async fn assert_no_disconnect_peer_event(&mut self, id: PeerId) {
+        time::timeout(SHORT_TIMEOUT, async {
+            loop {
+                match self.peer_manager_receiver.recv().await.unwrap() {
+                    PeerManagerEvent::Disconnect(peer_id, _) if id == peer_id => {
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .unwrap_err();
+    }
+
     /// Panics if there is an event from the peer manager.
     pub async fn assert_no_peer_manager_event(&mut self) {
         time::timeout(SHORT_TIMEOUT, self.peer_manager_receiver.recv())

--- a/p2p/src/sync/tests/peer_events.rs
+++ b/p2p/src/sync/tests/peer_events.rs
@@ -13,7 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{sync::tests::helpers::SyncManagerHandle, types::peer_id::PeerId};
+use std::sync::Arc;
+
+use chainstate::BlockSource;
+use chainstate_test_framework::TestFramework;
+use common::chain::{block::timestamp::BlockTimestamp, config::create_unit_test_config};
+use p2p_test_utils::P2pBasicTestTimeGetter;
+use test_utils::random::Seed;
+
+use crate::{
+    message::{HeaderList, SyncMessage},
+    sync::tests::helpers::SyncManagerHandle,
+    testing_utils::test_p2p_config,
+    types::peer_id::PeerId,
+};
 
 // Check that the header list request is sent to a newly connected peer.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -59,6 +72,68 @@ async fn disconnect_peer() {
     handle.connect_peer(peer).await;
     handle.disconnect_peer(peer);
     handle.assert_no_error().await;
+
+    handle.join_subsystem_manager().await;
+}
+
+#[rstest::rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn do_not_disconnect_peer_after_receiving_known_header_list(#[case] seed: Seed) {
+    // Original bug description:
+    //
+    // There are two connected and fully synchronized nodes: Node1 and Node2.
+    // Node1 generates a new block and sends a header notification to the Node2.
+    // Node2 sends a header list message to all connected peers.
+    // Node1 receives the headers list messages but does nothing because the specific block is already known.
+    // Node1 unexpectedly disconnects Node2.
+    //
+    // Test case based on a simplified scenario:
+    //
+    // t = 0                     | Node has block; connects to a peer; peer sends a header list with the same block
+    // t = sync_stalling_timeout | Node checks for peer timeout; should not disconnect
+
+    let mut rng = test_utils::random::make_seedable_rng(seed);
+    let time = P2pBasicTestTimeGetter::new();
+    let chain_config = Arc::new(create_unit_test_config());
+    let p2p_config = Arc::new(test_p2p_config());
+
+    let mut tf = TestFramework::builder(&mut rng)
+        .with_chain_config(chain_config.as_ref().clone())
+        .with_time_getter(time.get_time_getter())
+        .build();
+    let block = tf
+        .make_block_builder()
+        .with_timestamp(BlockTimestamp::from_duration_since_epoch(
+            time.get_time_getter().get_time(),
+        ))
+        .build();
+    tf.process_block(block.clone(), BlockSource::Local).unwrap();
+
+    let mut handle = SyncManagerHandle::builder()
+        .with_chain_config(Arc::clone(&chain_config))
+        .with_p2p_config(Arc::clone(&p2p_config))
+        .with_time_getter(time.get_time_getter())
+        .with_chainstate(tf.into_chainstate())
+        .build()
+        .await;
+
+    // Connect peer and assume we requested a header list.
+    let peer = PeerId::new();
+    handle.connect_peer(peer).await;
+
+    // Peer sends us a header list but we already know the containing block.
+    let msg = SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()]));
+    handle.send_message(peer, msg).await;
+
+    // Advance time across the timeout boundary. This would trigger a disconnect in a scenario
+    // where we expect additional data from the peer. However, in this case we don't expect
+    // additional data and therefore no disconnection should take place.
+    time.advance_time(*p2p_config.sync_stalling_timeout);
+
+    // Ensure the peer does not get disconnected.
+    handle.assert_no_disconnect_peer_event(peer).await;
 
     handle.join_subsystem_manager().await;
 }

--- a/p2p/src/types/peer_activity.rs
+++ b/p2p/src/types/peer_activity.rs
@@ -13,7 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod ip_address;
-pub mod peer_activity;
-pub mod peer_address;
-pub mod peer_id;
+use std::time::Duration;
+
+/// Activity with a peer.
+#[derive(Debug)]
+pub enum PeerActivity {
+    /// Node is pending for further actions with a peer.
+    Pending,
+    /// Node has sent a header list request to a peer and is expecting a header list response.
+    ExpectingHeaderList {
+        /// A time when the header list request was sent.
+        time: Duration,
+    },
+    /// Node has sent a block list request to a peer and is expecting block responses.
+    ExpectingBlocks {
+        /// A time when either the block list request was sent or last block response was received.
+        time: Duration,
+    },
+}


### PR DESCRIPTION
Resolves two TODOs in P2P block sync manager:
1. Turn peer activity from `Option<Duration>` to a new `PeerActivity` enum that better conveys the intent. It also allows to more easily expand the existing peer timeout logic.
2. Add a test for a previously fixed bug where a node unexpectedly disconnected a peer after it had sent a header list with all known blocks.