### PR TITLE
Fix typo; prefer try op; unify p2p manager creation

### DIFF
--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -103,6 +103,6 @@ where
         &mut self,
         handler: Arc<dyn Fn(P2pEvent) + Send + Sync>,
     ) -> crate::Result<()> {
-        self.subscribers_sender.send(handler).map_err(Into::into)
+        Ok(self.subscribers_sender.send(handler)?)
     }
 }

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -199,12 +199,10 @@ where
     }
 
     fn send_message(&mut self, peer: PeerId, message: PeerManagerMessage) -> crate::Result<()> {
-        self.cmd_tx
-            .send(types::Command::SendMessage {
-                peer,
-                message: message.into(),
-            })
-            .map_err(Into::into)
+        Ok(self.cmd_tx.send(types::Command::SendMessage {
+            peer,
+            message: message.into(),
+        })?)
     }
 
     fn local_addresses(&self) -> &[S::Address] {
@@ -218,12 +216,10 @@ where
 
 impl<T: TransportSocket> MessagingService for MessagingHandle<T> {
     fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()> {
-        self.command_sender
-            .send(types::Command::SendMessage {
-                peer,
-                message: message.into(),
-            })
-            .map_err(Into::into)
+        Ok(self.command_sender.send(types::Command::SendMessage {
+            peer,
+            message: message.into(),
+        })?)
     }
 
     fn broadcast_message(&mut self, message: SyncMessage) -> crate::Result<()> {


### PR DESCRIPTION
Small refactorings I didn't want to mix with my other PRs:

- Create block sync manager in a similar pattern as peer manager is created.
- Fix comment typo when shutting down the subsystem.
- Remove reduntant array `.into_iter()` when shutting down the subsystem.
- Prefer the `?` where reasonable.