### PR TITLE
Fix the random token issuance amount in 'issue_and_transfer_tokens' test

### DIFF
--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -733,7 +733,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     assert_eq!(*token_amount, token_amount_to_issue);
 
     let tokens_to_transfer =
-        Amount::from_atoms(rng.gen_range(1..token_amount_to_issue.into_atoms()));
+        Amount::from_atoms(rng.gen_range(1..=token_amount_to_issue.into_atoms()));
 
     let some_other_address = PublicKeyHash::from_low_u64_be(1);
     let new_output = TxOutput::Transfer(
@@ -775,10 +775,12 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             Currency::Token(token_id) => Some((token_id, amount)),
         })
         .collect_vec();
-    assert_eq!(token_balances.len(), 1);
-    let (_token_id, token_amount) = token_balances.first().expect("some");
+    assert!(token_balances.len() <= 1);
+    let token_amount = token_balances
+        .first()
+        .map_or(Amount::ZERO, |(_token_id, token_amount)| *token_amount);
     assert_eq!(
-        *token_amount,
+        token_amount,
         (token_amount_to_issue - tokens_to_transfer).expect("")
     );
 


### PR DESCRIPTION
The CI caught [a failure](https://github.com/mintlayer/mintlayer-core/actions/runs/5322405108/jobs/9638806808#step:7:51334) in the following test:
```rust
---- wallet::tests::issue_and_transfer_tokens::case_1 stdout ----
------------ TEST ARGUMENTS ------------
seed = Seed(8346885526136640763)
-------------- TEST START --------------
thread 'wallet::tests::issue_and_transfer_tokens::case_1' panicked at 'cannot sample empty range', /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/rng.rs:134:9
```

Looks like we need to issue a minimum of 2 tokens (was min 1 before) since the test expects to transfer some and ensure there's still an existing balance (min 1) left.