### PR TITLE
SeqCst atomics were added; other atomics were renamed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,6 +3940,7 @@ dependencies = [
  "subsystem",
  "test-utils",
  "tokio",
+ "utils",
 ]
 
 [[package]]
@@ -5701,6 +5702,7 @@ dependencies = [
  "hex",
  "rand_chacha 0.3.1",
  "serialization",
+ "utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,6 +3923,7 @@ dependencies = [
  "serialization",
  "subsystem",
  "tokio",
+ "utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,16 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-traits"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29ec3788e96fb4fdb275ccb9d62811f2fa903d76c5eb4dd6fe7d09a7ed5871f"
-dependencies = [
- "cfg-if",
- "rustc_version 0.3.3",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,16 +4065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "pest"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4721,7 +4701,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -4733,7 +4713,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn 1.0.109",
  "unicode-ident",
 ]
@@ -4772,20 +4752,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver",
 ]
 
 [[package]]
@@ -5008,27 +4979,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "send_wrapper"
@@ -5371,7 +5324,7 @@ dependencies = [
  "chacha20poly1305 0.9.1",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "rustc_version 0.4.0",
+ "rustc_version",
  "sha2 0.10.6",
  "subtle",
 ]
@@ -6204,12 +6157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6301,7 +6248,6 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "utils"
 version = "0.1.0"
 dependencies = [
- "atomic-traits",
  "criterion",
  "crypto",
  "directories",

--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::Ordering;
-
 use common::{
     chain::{transaction::TxInput, Destination, GenBlock, OutPointSourceId, PoolId},
     primitives::{Id, H256},
@@ -43,7 +41,7 @@ async fn collect_transactions_collect_txs_failed() {
     let (mut manager, chain_config, chainstate, _mempool) = setup_blockprod_test(None);
 
     let mock_mempool = MempoolInterfaceMock::new();
-    mock_mempool.collect_txs_should_error.store(true, Ordering::Relaxed);
+    mock_mempool.collect_txs_should_error.store(true);
 
     let mock_mempool_subsystem = manager.add_subsystem_with_custom_eventloop("mock-mempool", {
         let mock_mempool = mock_mempool.clone();
@@ -66,7 +64,7 @@ async fn collect_transactions_collect_txs_failed() {
 
             let accumulator = block_production.collect_transactions().await;
 
-            let collected_transactions = mock_mempool.collect_txs_called.load(Ordering::Relaxed);
+            let collected_transactions = mock_mempool.collect_txs_called.load();
             assert!(collected_transactions, "Expected collect_tx() to be called");
 
             match accumulator {
@@ -113,7 +111,7 @@ async fn collect_transactions_subsystem_error() {
 
         let accumulator = block_production.collect_transactions().await;
 
-        let collected_transactions = mock_mempool.collect_txs_called.load(Ordering::Relaxed);
+        let collected_transactions = mock_mempool.collect_txs_called.load();
         assert!(
             !collected_transactions,
             "Expected collect_tx() to not be called"
@@ -160,7 +158,7 @@ async fn collect_transactions_succeeded() {
 
             let accumulator = block_production.collect_transactions().await;
 
-            let collected_transactions = mock_mempool.collect_txs_called.load(Ordering::Relaxed);
+            let collected_transactions = mock_mempool.collect_txs_called.load();
             assert!(collected_transactions, "Expected collect_tx() to be called");
 
             assert!(

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -60,7 +60,8 @@ mod test {
         },
         primitives::Idable,
     };
-    use std::sync::{atomic::Ordering, Arc};
+    use std::sync::Arc;
+    use utils::atomics::SeqCstAtomicU64;
 
     fn make_block(prev_block: Id<GenBlock>, time: BlockTimestampInternalType) -> Block {
         Block::new(
@@ -166,7 +167,7 @@ mod test {
         utils::concurrency::model(|| {
             let chain_config = Arc::new(create_unit_test_config());
 
-            let current_time = Arc::new(std::sync::atomic::AtomicU64::new(
+            let current_time = Arc::new(SeqCstAtomicU64::new(
                 chain_config.genesis_block().timestamp().as_int_seconds(),
             ));
 
@@ -185,11 +186,11 @@ mod test {
             .unwrap();
 
             // we use unordered block times, and ensure that the median will be in the right spot
-            let block1_time = current_time.load(Ordering::SeqCst) + 1;
-            let block2_time = current_time.load(Ordering::SeqCst) + 10;
-            let block3_time = current_time.load(Ordering::SeqCst) + 17;
-            let block4_time = current_time.load(Ordering::SeqCst) + 18;
-            let block5_time = current_time.load(Ordering::SeqCst) + 20;
+            let block1_time = current_time.load() + 1;
+            let block2_time = current_time.load() + 10;
+            let block3_time = current_time.load() + 17;
+            let block4_time = current_time.load() + 18;
+            let block5_time = current_time.load() + 20;
 
             let block1 = make_block(chainstate.chain_config.genesis_block_id(), block1_time);
             let block2 = make_block(block1.get_id().into(), block2_time);

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -187,10 +187,10 @@ mod test {
 
             // we use unordered block times, and ensure that the median will be in the right spot
             let block1_time = current_time.load() + 1;
-            let block2_time = current_time.load() + 10;
-            let block3_time = current_time.load() + 17;
+            let block2_time = current_time.load() + 20;
+            let block3_time = current_time.load() + 10;
             let block4_time = current_time.load() + 18;
-            let block5_time = current_time.load() + 20;
+            let block5_time = current_time.load() + 17;
 
             let block1 = make_block(chainstate.chain_config.genesis_block_id(), block1_time);
             let block2 = make_block(block1.get_id().into(), block2_time);
@@ -244,21 +244,21 @@ mod test {
                 // median time for block of height 3
                 let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(&chainstate_ref, &block3.get_id().into());
-                assert_eq!(median, BlockTimestamp::from_int_seconds(block2_time));
+                assert_eq!(median, BlockTimestamp::from_int_seconds(block3_time));
             }
 
             {
                 // median time for block of height 4
                 let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(&chainstate_ref, &block4.get_id().into());
-                assert_eq!(median, BlockTimestamp::from_int_seconds(block2_time));
+                assert_eq!(median, BlockTimestamp::from_int_seconds(block3_time));
             }
 
             {
                 // median time for block of height 5
                 let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
                 let median = calculate_median_time_past(&chainstate_ref, &block5.get_id().into());
-                assert_eq!(median, BlockTimestamp::from_int_seconds(block3_time));
+                assert_eq!(median, BlockTimestamp::from_int_seconds(block5_time));
             }
         });
     }

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{atomic::AtomicU64, Arc};
+use std::sync::Arc;
 
 use chainstate::{BlockError, ChainstateConfig, DefaultTransactionVerificationStrategy};
 use common::{
@@ -32,6 +32,7 @@ use crate::{
     },
     TestFramework, TestStore,
 };
+use utils::atomics::SeqCstAtomicU64;
 
 pub enum TxVerificationStrategy {
     Default,
@@ -111,8 +112,8 @@ impl TestFrameworkBuilder {
     /// Create the TimeGetter of the TestFramework, with the following logic:
     /// The default TimeGetter of the TestFramework simply loads the value of time from an atomic u64
     /// If a custom TimeGetter is supplied, then this value won't exist
-    fn create_time_getter_and_value(&self) -> (TimeGetter, Option<Arc<AtomicU64>>) {
-        let time_value = Arc::new(AtomicU64::new(
+    fn create_time_getter_and_value(&self) -> (TimeGetter, Option<Arc<SeqCstAtomicU64>>) {
+        let time_value = Arc::new(SeqCstAtomicU64::new(
             self.chain_config.genesis_block().timestamp().as_int_seconds(),
         ));
 

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -38,7 +38,7 @@ use common::{
     primitives::BlockHeight,
 };
 use serialization::{Decode, Encode};
-use utils::atomics::{RelAtomicBool, SynAtomicU64};
+use utils::atomics::{AcqRelAtomicU64, RelaxedAtomicBool};
 
 use crate::pos::input_data::generate_pos_consensus_data_and_reward;
 use crate::pow::input_data::generate_pow_consensus_data_and_reward;
@@ -177,8 +177,8 @@ pub fn finalize_consensus_data(
     chain_config: &ChainConfig,
     block_header: &mut BlockHeader,
     block_height: BlockHeight,
-    block_timestamp_seconds: Arc<SynAtomicU64>,
-    stop_flag: Arc<RelAtomicBool>,
+    block_timestamp_seconds: Arc<AcqRelAtomicU64>,
+    stop_flag: Arc<RelaxedAtomicBool>,
     finalize_data: FinalizeBlockInputData,
 ) -> Result<SignedBlockHeader, ConsensusCreationError> {
     match chain_config.net_upgrade().consensus_status(block_height.next_height()) {

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -39,7 +39,7 @@ use common::{
 use crypto::vrf::VRFPublicKey;
 use pos_accounting::PoSAccountingView;
 use std::sync::Arc;
-use utils::atomics::{RelAtomicBool, SynAtomicU64};
+use utils::atomics::{AcqRelAtomicU64, RelaxedAtomicBool};
 use utils::ensure;
 use utxo::UtxosView;
 
@@ -216,9 +216,9 @@ where
 pub fn stake(
     pos_data: &mut Box<PoSData>,
     block_header: &mut BlockHeader,
-    block_timestamp_seconds: Arc<SynAtomicU64>,
+    block_timestamp_seconds: Arc<AcqRelAtomicU64>,
     finalize_pos_data: PoSFinalizeBlockInputData,
-    stop_flag: Arc<RelAtomicBool>,
+    stop_flag: Arc<RelaxedAtomicBool>,
 ) -> Result<StakeResult, ConsensusPoSError> {
     let sealed_epoch_randomness = finalize_pos_data.sealed_epoch_randomness();
     let vrf_pk = finalize_pos_data.vrf_public_key();

--- a/consensus/src/pow/work.rs
+++ b/consensus/src/pow/work.rs
@@ -28,7 +28,7 @@ use common::{
     primitives::{BlockHeight, Compact, Idable, H256},
     Uint256,
 };
-use utils::atomics::RelAtomicBool;
+use utils::atomics::RelaxedAtomicBool;
 
 use crate::pow::{
     error::ConsensusPoWError,
@@ -241,7 +241,7 @@ pub fn mine(
     block_header: &mut BlockHeader,
     max_nonce: u128,
     bits: Compact,
-    stop_flag: Arc<RelAtomicBool>,
+    stop_flag: Arc<RelaxedAtomicBool>,
 ) -> Result<MiningResult, ConsensusPoWError> {
     let mut data = Box::new(PoWData::new(bits, 0));
     for nonce in 0..max_nonce {

--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
@@ -20,7 +20,7 @@
 use std::{
     collections::BTreeMap,
     net::{IpAddr, SocketAddr},
-    sync::{atomic::AtomicBool, Arc, Mutex},
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -48,6 +48,7 @@ use p2p::{
     P2pEventHandler,
 };
 use p2p_test_utils::P2pBasicTestTimeGetter;
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     crawler_p2p::crawler_manager::{
@@ -125,7 +126,7 @@ impl NetworkingService for MockNetworkingService {
         _bind_addresses: Vec<Self::Address>,
         _chain_config: Arc<ChainConfig>,
         _p2p_config: Arc<P2pConfig>,
-        _shutdown: Arc<AtomicBool>,
+        _shutdown: Arc<SeqCstAtomicBool>,
         _shutdown_receiver: oneshot::Receiver<()>,
         _subscribers_receiver: mpsc::UnboundedReceiver<P2pEventHandler>,
     ) -> p2p::Result<(

--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::Arc;
 
 use clap::Parser;
 use futures::never::Never;
@@ -28,6 +28,7 @@ use p2p::{
     config::{NodeType, P2pConfig},
     net::NetworkingService,
 };
+use utils::atomics::SeqCstAtomicBool;
 use utils::default_data_dir::{default_data_dir_for_chain, prepare_data_dir};
 
 mod config;
@@ -73,7 +74,7 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<Never, error::DnsServerErro
     });
 
     let transport = p2p::make_p2p_transport();
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
 

--- a/mempool/src/pool/tests/expiry.rs
+++ b/mempool/src/pool/tests/expiry.rs
@@ -16,13 +16,14 @@
 use common::chain::tokens::OutputValue;
 
 use super::*;
+use ::utils::atomics::SeqCstAtomicU64;
 
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
-    let mock_time = Arc::new(AtomicU64::new(0));
+    let mock_time = Arc::new(SeqCstAtomicU64::new(0));
     let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     logging::init_logging::<&str>(None);
 
@@ -67,7 +68,7 @@ async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
     )
     .await?;
     let child_id = child.transaction().get_id();
-    mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1, Ordering::SeqCst);
+    mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1);
 
     assert_eq!(
         mempool.add_transaction(child),
@@ -102,7 +103,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
     }
     let parent = tx_builder.build();
 
-    let mock_time = Arc::new(AtomicU64::new(0));
+    let mock_time = Arc::new(SeqCstAtomicU64::new(0));
     let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     let chainstate = tf.chainstate();
     let config = Arc::clone(chainstate.get_chain_config());
@@ -160,7 +161,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
         .chainstate_handle
         .call_mut(|this| this.process_block(block, BlockSource::Local))
         .await??;
-    mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1, Ordering::SeqCst);
+    mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1);
 
     mempool.add_transaction(child_1)?.assert_in_mempool();
     assert!(!mempool.contains_transaction(&expired_tx_id));

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -15,10 +15,7 @@
 
 #![allow(clippy::unwrap_used)]
 
-use std::sync::{
-    atomic::{AtomicBool, Ordering::Relaxed},
-    Arc,
-};
+use std::sync::Arc;
 
 use common::{
     chain::{GenBlock, SignedTransaction, Transaction},
@@ -30,21 +27,22 @@ use mempool::{
     MempoolEvent, MempoolInterface, MempoolSubsystemInterface, TxStatus,
 };
 use subsystem::{subsystem::CallError, CallRequest, ShutdownRequest};
+use utils::atomics::RelaxedAtomicBool;
 
 #[derive(Clone)]
 pub struct MempoolInterfaceMock {
-    pub add_transaction_called: Arc<AtomicBool>,
-    pub add_transaction_should_error: Arc<AtomicBool>,
-    pub get_all_called: Arc<AtomicBool>,
-    pub get_all_should_error: Arc<AtomicBool>,
-    pub contains_transaction_called: Arc<AtomicBool>,
-    pub contains_transaction_should_error: Arc<AtomicBool>,
-    pub collect_txs_called: Arc<AtomicBool>,
-    pub collect_txs_should_error: Arc<AtomicBool>,
-    pub subscribe_to_events_called: Arc<AtomicBool>,
-    pub subscribe_to_events_should_error: Arc<AtomicBool>,
-    pub run_called: Arc<AtomicBool>,
-    pub run_should_error: Arc<AtomicBool>,
+    pub add_transaction_called: Arc<RelaxedAtomicBool>,
+    pub add_transaction_should_error: Arc<RelaxedAtomicBool>,
+    pub get_all_called: Arc<RelaxedAtomicBool>,
+    pub get_all_should_error: Arc<RelaxedAtomicBool>,
+    pub contains_transaction_called: Arc<RelaxedAtomicBool>,
+    pub contains_transaction_should_error: Arc<RelaxedAtomicBool>,
+    pub collect_txs_called: Arc<RelaxedAtomicBool>,
+    pub collect_txs_should_error: Arc<RelaxedAtomicBool>,
+    pub subscribe_to_events_called: Arc<RelaxedAtomicBool>,
+    pub subscribe_to_events_should_error: Arc<RelaxedAtomicBool>,
+    pub run_called: Arc<RelaxedAtomicBool>,
+    pub run_should_error: Arc<RelaxedAtomicBool>,
 }
 
 impl Default for MempoolInterfaceMock {
@@ -56,18 +54,18 @@ impl Default for MempoolInterfaceMock {
 impl MempoolInterfaceMock {
     pub fn new() -> MempoolInterfaceMock {
         MempoolInterfaceMock {
-            add_transaction_called: Arc::new(AtomicBool::new(false)),
-            add_transaction_should_error: Arc::new(AtomicBool::new(false)),
-            get_all_called: Arc::new(AtomicBool::new(false)),
-            get_all_should_error: Arc::new(AtomicBool::new(false)),
-            contains_transaction_called: Arc::new(AtomicBool::new(false)),
-            contains_transaction_should_error: Arc::new(AtomicBool::new(false)),
-            collect_txs_called: Arc::new(AtomicBool::new(false)),
-            collect_txs_should_error: Arc::new(AtomicBool::new(false)),
-            subscribe_to_events_called: Arc::new(AtomicBool::new(false)),
-            subscribe_to_events_should_error: Arc::new(AtomicBool::new(false)),
-            run_called: Arc::new(AtomicBool::new(false)),
-            run_should_error: Arc::new(AtomicBool::new(false)),
+            add_transaction_called: Arc::new(RelaxedAtomicBool::new(false)),
+            add_transaction_should_error: Arc::new(RelaxedAtomicBool::new(false)),
+            get_all_called: Arc::new(RelaxedAtomicBool::new(false)),
+            get_all_should_error: Arc::new(RelaxedAtomicBool::new(false)),
+            contains_transaction_called: Arc::new(RelaxedAtomicBool::new(false)),
+            contains_transaction_should_error: Arc::new(RelaxedAtomicBool::new(false)),
+            collect_txs_called: Arc::new(RelaxedAtomicBool::new(false)),
+            collect_txs_should_error: Arc::new(RelaxedAtomicBool::new(false)),
+            subscribe_to_events_called: Arc::new(RelaxedAtomicBool::new(false)),
+            subscribe_to_events_should_error: Arc::new(RelaxedAtomicBool::new(false)),
+            run_called: Arc::new(RelaxedAtomicBool::new(false)),
+            run_should_error: Arc::new(RelaxedAtomicBool::new(false)),
         }
     }
 }
@@ -78,9 +76,9 @@ const SUBSYSTEM_ERROR: Error =
 #[async_trait::async_trait]
 impl MempoolInterface for MempoolInterfaceMock {
     fn add_transaction(&mut self, _tx: SignedTransaction) -> Result<TxStatus, Error> {
-        self.add_transaction_called.store(true, Relaxed);
+        self.add_transaction_called.store(true);
 
-        if self.add_transaction_should_error.load(Relaxed) {
+        if self.add_transaction_should_error.load() {
             Err(SUBSYSTEM_ERROR)
         } else {
             Ok(TxStatus::InMempool)
@@ -88,9 +86,9 @@ impl MempoolInterface for MempoolInterfaceMock {
     }
 
     fn get_all(&self) -> Result<Vec<SignedTransaction>, Error> {
-        self.get_all_called.store(true, Relaxed);
+        self.get_all_called.store(true);
 
-        if self.get_all_should_error.load(Relaxed) {
+        if self.get_all_should_error.load() {
             Err(SUBSYSTEM_ERROR)
         } else {
             Ok(vec![])
@@ -98,9 +96,9 @@ impl MempoolInterface for MempoolInterfaceMock {
     }
 
     fn contains_transaction(&self, _tx: &Id<Transaction>) -> Result<bool, Error> {
-        self.contains_transaction_called.store(true, Relaxed);
+        self.contains_transaction_called.store(true);
 
-        if self.contains_transaction_should_error.load(Relaxed) {
+        if self.contains_transaction_should_error.load() {
             Err(SUBSYSTEM_ERROR)
         } else {
             Ok(true)
@@ -127,9 +125,9 @@ impl MempoolInterface for MempoolInterfaceMock {
         &self,
         tx_accumulator: Box<dyn TransactionAccumulator + Send>,
     ) -> Result<Box<dyn TransactionAccumulator>, Error> {
-        self.collect_txs_called.store(true, Relaxed);
+        self.collect_txs_called.store(true);
 
-        if self.collect_txs_should_error.load(Relaxed) {
+        if self.collect_txs_should_error.load() {
             Err(SUBSYSTEM_ERROR)
         } else {
             Ok(tx_accumulator)
@@ -140,9 +138,9 @@ impl MempoolInterface for MempoolInterfaceMock {
         &mut self,
         _handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>,
     ) -> Result<(), Error> {
-        self.subscribe_to_events_called.store(true, Relaxed);
+        self.subscribe_to_events_called.store(true);
 
-        if self.subscribe_to_events_should_error.load(Relaxed) {
+        if self.subscribe_to_events_should_error.load() {
             Err(SUBSYSTEM_ERROR)
         } else {
             Ok(())
@@ -157,9 +155,9 @@ impl MempoolSubsystemInterface for MempoolInterfaceMock {
         mut call_rq: CallRequest<dyn MempoolInterface>,
         mut shut_rq: ShutdownRequest,
     ) {
-        self.run_called.store(true, Relaxed);
+        self.run_called.store(true);
 
-        if !self.run_should_error.load(Relaxed) {
+        if !self.run_should_error.load() {
             tokio::select! {
                 call = call_rq.recv() => call(&mut self).await,
                 () = shut_rq.recv() => return,

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -27,22 +27,22 @@ use mempool::{
     MempoolEvent, MempoolInterface, MempoolSubsystemInterface, TxStatus,
 };
 use subsystem::{subsystem::CallError, CallRequest, ShutdownRequest};
-use utils::atomics::RelaxedAtomicBool;
+use utils::atomics::AcqRelAtomicBool;
 
 #[derive(Clone)]
 pub struct MempoolInterfaceMock {
-    pub add_transaction_called: Arc<RelaxedAtomicBool>,
-    pub add_transaction_should_error: Arc<RelaxedAtomicBool>,
-    pub get_all_called: Arc<RelaxedAtomicBool>,
-    pub get_all_should_error: Arc<RelaxedAtomicBool>,
-    pub contains_transaction_called: Arc<RelaxedAtomicBool>,
-    pub contains_transaction_should_error: Arc<RelaxedAtomicBool>,
-    pub collect_txs_called: Arc<RelaxedAtomicBool>,
-    pub collect_txs_should_error: Arc<RelaxedAtomicBool>,
-    pub subscribe_to_events_called: Arc<RelaxedAtomicBool>,
-    pub subscribe_to_events_should_error: Arc<RelaxedAtomicBool>,
-    pub run_called: Arc<RelaxedAtomicBool>,
-    pub run_should_error: Arc<RelaxedAtomicBool>,
+    pub add_transaction_called: Arc<AcqRelAtomicBool>,
+    pub add_transaction_should_error: Arc<AcqRelAtomicBool>,
+    pub get_all_called: Arc<AcqRelAtomicBool>,
+    pub get_all_should_error: Arc<AcqRelAtomicBool>,
+    pub contains_transaction_called: Arc<AcqRelAtomicBool>,
+    pub contains_transaction_should_error: Arc<AcqRelAtomicBool>,
+    pub collect_txs_called: Arc<AcqRelAtomicBool>,
+    pub collect_txs_should_error: Arc<AcqRelAtomicBool>,
+    pub subscribe_to_events_called: Arc<AcqRelAtomicBool>,
+    pub subscribe_to_events_should_error: Arc<AcqRelAtomicBool>,
+    pub run_called: Arc<AcqRelAtomicBool>,
+    pub run_should_error: Arc<AcqRelAtomicBool>,
 }
 
 impl Default for MempoolInterfaceMock {
@@ -54,18 +54,18 @@ impl Default for MempoolInterfaceMock {
 impl MempoolInterfaceMock {
     pub fn new() -> MempoolInterfaceMock {
         MempoolInterfaceMock {
-            add_transaction_called: Arc::new(RelaxedAtomicBool::new(false)),
-            add_transaction_should_error: Arc::new(RelaxedAtomicBool::new(false)),
-            get_all_called: Arc::new(RelaxedAtomicBool::new(false)),
-            get_all_should_error: Arc::new(RelaxedAtomicBool::new(false)),
-            contains_transaction_called: Arc::new(RelaxedAtomicBool::new(false)),
-            contains_transaction_should_error: Arc::new(RelaxedAtomicBool::new(false)),
-            collect_txs_called: Arc::new(RelaxedAtomicBool::new(false)),
-            collect_txs_should_error: Arc::new(RelaxedAtomicBool::new(false)),
-            subscribe_to_events_called: Arc::new(RelaxedAtomicBool::new(false)),
-            subscribe_to_events_should_error: Arc::new(RelaxedAtomicBool::new(false)),
-            run_called: Arc::new(RelaxedAtomicBool::new(false)),
-            run_should_error: Arc::new(RelaxedAtomicBool::new(false)),
+            add_transaction_called: Arc::new(AcqRelAtomicBool::new(false)),
+            add_transaction_should_error: Arc::new(AcqRelAtomicBool::new(false)),
+            get_all_called: Arc::new(AcqRelAtomicBool::new(false)),
+            get_all_should_error: Arc::new(AcqRelAtomicBool::new(false)),
+            contains_transaction_called: Arc::new(AcqRelAtomicBool::new(false)),
+            contains_transaction_should_error: Arc::new(AcqRelAtomicBool::new(false)),
+            collect_txs_called: Arc::new(AcqRelAtomicBool::new(false)),
+            collect_txs_should_error: Arc::new(AcqRelAtomicBool::new(false)),
+            subscribe_to_events_called: Arc::new(AcqRelAtomicBool::new(false)),
+            subscribe_to_events_should_error: Arc::new(AcqRelAtomicBool::new(false)),
+            run_called: Arc::new(AcqRelAtomicBool::new(false)),
+            run_should_error: Arc::new(AcqRelAtomicBool::new(false)),
         }
     }
 }

--- a/p2p/backend-test-suite/Cargo.toml
+++ b/p2p/backend-test-suite/Cargo.toml
@@ -14,6 +14,7 @@ p2p = { path = "../../p2p" }
 p2p-test-utils = { path = "../p2p-test-utils" }
 serialization = { path = "../../serialization" }
 subsystem = { path = "../../subsystem/" }
+utils = { path = "../../utils/" }
 
 futures.workspace = true
 libtest-mimic.workspace = true

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -13,13 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    fmt::Debug,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{fmt::Debug, sync::Arc};
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -29,7 +23,6 @@ use common::{
     primitives::Idable,
     time_getter::TimeGetter,
 };
-
 use p2p::{
     error::P2pError,
     message::{HeaderList, SyncMessage},
@@ -41,6 +34,7 @@ use p2p::{
     testing_utils::{connect_and_accept_services, test_p2p_config, TestTransportMaker},
     PeerManagerEvent,
 };
+use utils::atomics::SeqCstAtomicBool;
 
 tests![invalid_pubsub_block,];
 
@@ -61,7 +55,7 @@ where
     let p2p_config = Arc::new(test_p2p_config());
     let (chainstate, mempool, shutdown_trigger, subsystem_manager_handle) =
         p2p_test_utils::start_subsystems(Arc::clone(&chain_config));
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
 
@@ -158,7 +152,7 @@ where
         e => panic!("invalid event received: {e:?}"),
     }
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender.send(());
     let _ = sync1_handle.await.unwrap();
     shutdown_trigger.initiate();

--- a/p2p/backend-test-suite/src/connect.rs
+++ b/p2p/backend-test-suite/src/connect.rs
@@ -15,13 +15,7 @@
 
 //! Connection tests.
 
-use std::{
-    fmt::Debug,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{fmt::Debug, sync::Arc};
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -30,6 +24,7 @@ use p2p::{
     error::{DialError, P2pError},
     net::{ConnectivityService, MessagingService, NetworkingService, SyncingEventReceiver},
 };
+use utils::atomics::SeqCstAtomicBool;
 
 tests![connect, connect_address_in_use, connect_accept,];
 
@@ -44,7 +39,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     N::start(
@@ -59,7 +54,7 @@ where
     .await
     .unwrap();
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender.send(());
 }
 
@@ -75,7 +70,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender_1, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (connectivity, _messaging_handle, _sync, _) = N::start(
@@ -111,7 +106,7 @@ where
         ))
     ));
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender_2.send(());
     let _ = shutdown_sender_1.send(());
 }
@@ -129,7 +124,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender_1, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (mut service1, _, _, _) = N::start(
@@ -162,7 +157,7 @@ where
     service2.connect(conn_addr[0].clone()).unwrap();
     service1.poll_next().await.unwrap();
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender_2.send(());
     let _ = shutdown_sender_1.send(());
 }

--- a/p2p/backend-test-suite/src/events.rs
+++ b/p2p/backend-test-suite/src/events.rs
@@ -13,14 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    fmt::Debug,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use tokio::{
     sync::{
@@ -38,6 +31,7 @@ use p2p::{
     },
     P2pEvent,
 };
+use utils::atomics::SeqCstAtomicBool;
 
 tests![peer_events,];
 
@@ -52,7 +46,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender_1, shutdown_receiver) = oneshot::channel();
     let (subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (mut service1, _, _sync, _) = N::start(
@@ -106,7 +100,7 @@ where
         Some(P2pEvent::PeerDisconnected(info.peer_id))
     );
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender_2.send(());
     let _ = shutdown_sender_1.send(());
 }

--- a/p2p/p2p-test-utils/Cargo.toml
+++ b/p2p/p2p-test-utils/Cargo.toml
@@ -14,6 +14,7 @@ crypto = { path = "../../crypto/" }
 mempool = { path = "../../mempool/" }
 subsystem = { path = "../../subsystem/" }
 test-utils = { path = "../../test-utils" }
+utils = { path = "../../utils" }
 
 portpicker.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -15,13 +15,7 @@
 
 #![allow(clippy::unwrap_used)]
 
-use std::{
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use chainstate::{
     chainstate_interface::ChainstateInterface, make_chainstate, ChainstateConfig,
@@ -36,6 +30,7 @@ use common::{
 use mempool::{MempoolHandle, MempoolSubsystemInterface};
 use subsystem::manager::{ManagerJoinHandle, ShutdownTrigger};
 use test_utils::mock_time_getter::mocked_time_getter_milliseconds;
+use utils::atomics::SeqCstAtomicU64;
 
 pub fn start_subsystems(
     chain_config: Arc<ChainConfig>,
@@ -96,7 +91,7 @@ pub fn create_n_blocks(tf: &mut TestFramework, n: usize) -> Vec<Block> {
 }
 
 pub struct P2pBasicTestTimeGetter {
-    current_time_millis: Arc<AtomicU64>,
+    current_time_millis: Arc<SeqCstAtomicU64>,
 }
 
 impl P2pBasicTestTimeGetter {
@@ -104,7 +99,7 @@ impl P2pBasicTestTimeGetter {
         let current_time = std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap();
-        let current_time_millis = Arc::new(AtomicU64::new(current_time.as_millis() as u64));
+        let current_time_millis = Arc::new(SeqCstAtomicU64::new(current_time.as_millis() as u64));
         Self {
             current_time_millis,
         }
@@ -115,7 +110,6 @@ impl P2pBasicTestTimeGetter {
     }
 
     pub fn advance_time(&self, duration: Duration) {
-        self.current_time_millis
-            .fetch_add(duration.as_millis() as u64, Ordering::SeqCst);
+        self.current_time_millis.fetch_add(duration.as_millis() as u64);
     }
 }

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -18,13 +18,7 @@ pub mod peer;
 pub mod transport;
 pub mod types;
 
-use std::{
-    marker::PhantomData,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::{
@@ -33,6 +27,7 @@ use tokio::{
 };
 
 use logging::log;
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     error::P2pError,
@@ -119,7 +114,7 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
         bind_addresses: Vec<Self::Address>,
         chain_config: Arc<common::chain::ChainConfig>,
         p2p_config: Arc<P2pConfig>,
-        shutdown: Arc<AtomicBool>,
+        shutdown: Arc<SeqCstAtomicBool>,
         shutdown_receiver: oneshot::Receiver<()>,
         subscribers_receiver: mpsc::UnboundedReceiver<P2pEventHandler>,
     ) -> crate::Result<(
@@ -152,11 +147,11 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
 
             match backend.run().await {
                 Ok(_) => unreachable!(),
-                Err(P2pError::ChannelClosed) if shutdown.load(Ordering::SeqCst) => {
+                Err(P2pError::ChannelClosed) if shutdown.load() => {
                     log::info!("Backend is shut down");
                 }
                 Err(e) => {
-                    shutdown.store(true, Ordering::SeqCst);
+                    shutdown.store(true);
                     log::error!("Failed to run backend: {e}");
                 }
             }

--- a/p2p/src/net/default_backend/tests.rs
+++ b/p2p/src/net/default_backend/tests.rs
@@ -36,7 +36,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
@@ -107,7 +107,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
@@ -176,7 +176,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
@@ -243,7 +243,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
@@ -335,7 +335,7 @@ where
 
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (mut conn, _, _, _) = DefaultNetworkingService::<T>::start(

--- a/p2p/src/net/default_backend/transport/impls/channel.rs
+++ b/p2p/src/net/default_backend/transport/impls/channel.rs
@@ -17,7 +17,7 @@ use std::{
     collections::BTreeMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{
-        atomic::{AtomicU16, AtomicU32, Ordering},
+        atomic::{AtomicU32 as StdAtomicU32, Ordering},
         Mutex,
     },
 };
@@ -32,6 +32,7 @@ use tokio::{
         oneshot::{self, Sender},
     },
 };
+use utils::sync::atomic::AtomicU16;
 
 use crate::{
     error::DialError,
@@ -47,7 +48,9 @@ type IncomingConnection = (SocketAddr, Sender<DuplexStream>);
 static CONNECTIONS: Lazy<Mutex<BTreeMap<SocketAddr, UnboundedSender<IncomingConnection>>>> =
     Lazy::new(Default::default);
 
-static NEXT_IP_ADDRESS: AtomicU32 = AtomicU32::new(1);
+// Note: we can't use utils::sync::atomic::AtomicU32 here, because loom types don't have a const
+// constructor function.
+static NEXT_IP_ADDRESS: StdAtomicU32 = StdAtomicU32::new(1);
 
 /// Creating a new transport is like adding a new "host" to the network with a new unique IPv4 address.
 ///

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -16,18 +16,15 @@
 pub mod default_backend;
 pub mod types;
 
-use std::{
-    fmt::Debug,
-    hash::Hash,
-    str::FromStr,
-    sync::{atomic::AtomicBool, Arc},
-};
+use std::{fmt::Debug, hash::Hash, str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::{
     sync::{mpsc, oneshot},
     task::JoinHandle,
 };
+
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     config,
@@ -88,7 +85,7 @@ pub trait NetworkingService {
         bind_addresses: Vec<Self::Address>,
         chain_config: Arc<common::chain::ChainConfig>,
         p2p_config: Arc<config::P2pConfig>,
-        shutdown: Arc<AtomicBool>,
+        shutdown: Arc<SeqCstAtomicBool>,
         shutdown_receiver: oneshot::Receiver<()>,
         subscribers_receiver: mpsc::UnboundedReceiver<P2pEventHandler>,
     ) -> crate::Result<(

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -15,7 +15,7 @@
 
 use std::{
     net::SocketAddr,
-    sync::{atomic::AtomicBool, Arc},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -39,6 +39,7 @@ use crate::{
     utils::oneshot_nofail,
 };
 use common::{chain::config, primitives::user_agent::mintlayer_core_user_agent};
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     error::{DialError, P2pError, ProtocolError},
@@ -540,7 +541,7 @@ where
 {
     let config = Arc::new(config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (mut conn, _, _, _) = T::start(
@@ -611,7 +612,7 @@ async fn connection_timeout_rpc_notified<T>(
 {
     let config = Arc::new(config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (conn, _, _, _) = T::start(

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -18,10 +18,7 @@ mod ban;
 mod connections;
 mod ping;
 
-use std::{
-    sync::{atomic::AtomicBool, Arc},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -31,6 +28,7 @@ use tokio::{
     sync::mpsc::{UnboundedReceiver, UnboundedSender},
     time::timeout,
 };
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     expect_recv,
@@ -66,7 +64,7 @@ where
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
 {
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (conn, _, _, _) = T::start(

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -16,10 +16,6 @@
 use std::{
     collections::{BTreeSet, VecDeque},
     mem,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
     time::Duration,
 };
 
@@ -44,6 +40,10 @@ use mempool::{
     MempoolHandle,
 };
 use utils::const_value::ConstValue;
+use utils::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use crate::{
     config::P2pConfig,

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -17,7 +17,7 @@ use std::{
     collections::BTreeMap,
     net::{IpAddr, SocketAddr},
     panic,
-    sync::{atomic::AtomicBool, Arc, Mutex},
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -51,6 +51,7 @@ use common::{
 };
 use mempool::{MempoolHandle, MempoolSubsystemInterface};
 use subsystem::manager::{ManagerJoinHandle, ShutdownTrigger};
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     config::NodeType,
@@ -469,7 +470,7 @@ impl NetworkingService for NetworkingServiceStub {
         _: Vec<Self::Address>,
         _: Arc<ChainConfig>,
         _: Arc<P2pConfig>,
-        _: Arc<AtomicBool>,
+        _: Arc<SeqCstAtomicBool>,
         _: oneshot::Receiver<()>,
         _: mpsc::UnboundedReceiver<P2pEventHandler>,
     ) -> Result<(

--- a/storage/lmdb/src/lib.rs
+++ b/storage/lmdb/src/lib.rs
@@ -145,16 +145,12 @@ impl LmdbImpl {
         })
     }
 
-    // FIXME: I'd like to replace the SeqCst ordering here with Release, because it looks
-    // like an overkill, provided that the loads are only Acquire (unless these store operations
-    // must be in total order with some other SeqCst operations on some other atomic, but this
-    // shouldn't be true). Or maybe we should go in the other direction and make the load SeqCst?
     fn schedule_map_resize(&self) {
-        self.map_resize_scheduled.store(true, Ordering::SeqCst);
+        self.map_resize_scheduled.store(true, Ordering::Release);
     }
 
     fn unschedule_map_resize(&self) {
-        self.map_resize_scheduled.store(false, Ordering::SeqCst);
+        self.map_resize_scheduled.store(false, Ordering::Release);
     }
 
     fn resize_if_resize_scheduled(&self) {

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 common = {path = '../common'}
 crypto = {path = '../crypto'}
 serialization = { path = '../serialization' }
+utils = { path = '../utils' }
 
 hex.workspace = true
 rand_chacha.workspace = true

--- a/test-utils/src/test_dir.rs
+++ b/test-utils/src/test_dir.rs
@@ -19,6 +19,8 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
     sync::{
+        // Note: we can't use simplified atomics or loom version of std atomics here,
+        // because this code can be called from tests that are not loom-ready.
         atomic::{AtomicU32, Ordering},
         Arc,
     },

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -10,7 +10,6 @@ crypto = { path = "../crypto/" }
 logging = {path = '../logging'}
 serialization = { path = "../serialization" }
 
-atomic-traits.workspace = true
 directories.workspace = true
 num-traits.workspace = true
 probabilistic-collections.workspace = true

--- a/utils/src/atomics/simple_atomic.rs
+++ b/utils/src/atomics/simple_atomic.rs
@@ -15,19 +15,19 @@
 
 //! This module implements "simplified" atomic types, which use predefined memory orderings.
 //!
-//! They come in two variants: the "relaxed" ones, whose operations always use the "Relaxed"
-//! memory ordering, and "synchronizing" ones, whose stores are always "Release" and loads
-//! are always "Acquire".
+//! They come in three variants: one is the "relaxed" atomics, whose operations always use
+//! the "Relaxed" memory ordering, and the other two are the "synchronizing" ones, which use
+//! "acquire-release" and "sequentially-consistent" orderings respectively.
 //!
-//! The reason for having them is that there are basically two use cases for an atomic type:
+//! The reason for having them is that, first of all, there are basically two use cases
+//! for an atomic type:
 //! 1) a low-level thread synchronization primitive;
 //! 2) a way to get interior mutability and/or circumvent borrow checker's restrictions.
 //!
 //! In the first case, the atomic operations should normally use the "synchronizing"
-//! memory orderings, such as "Acquire" and "Release", and in the second case the
-//! (generally cheaper) "Relaxed" ordering is enough.
+//! memory orderings and in the second case the (generally cheaper) "Relaxed" ordering is enough.
 //!
-//! Additionally, sometimes atomic types can appear at the API boundary of a module or a package,
+//! Secondly, sometimes atomic types can appear at the API boundary of a module or a package,
 //! which may lead to a situation where a load is performed in one module and a store in another.
 //! In this case, using the standard atomics effectively breaks encapsulation because,
 //! on the one hand, the memory orderings used by modules are their implementation details
@@ -194,56 +194,83 @@ where
 }
 
 #[doc(hidden)]
-pub struct RelOrderings;
+pub struct RelaxedOrderings;
 
-impl Orderings for RelOrderings {
+impl Orderings for RelaxedOrderings {
     const ORD_LOAD: Ordering = Ordering::Relaxed;
     const ORD_STORE: Ordering = Ordering::Relaxed;
     const ORD_LOAD_STORE: Ordering = Ordering::Relaxed;
 }
 
-impl private::Sealed for RelOrderings {}
+impl private::Sealed for RelaxedOrderings {}
 
 /// The "relaxed" variant of the atomic.
-pub type RelAtomic<T> = Atomic<T, RelOrderings>;
+pub type RelaxedAtomic<T> = Atomic<T, RelaxedOrderings>;
 
-pub type RelAtomicBool = RelAtomic<bool>;
-pub type RelAtomicI8 = RelAtomic<i8>;
-pub type RelAtomicU8 = RelAtomic<u8>;
-pub type RelAtomicI16 = RelAtomic<i16>;
-pub type RelAtomicU16 = RelAtomic<u16>;
-pub type RelAtomicI32 = RelAtomic<i32>;
-pub type RelAtomicU32 = RelAtomic<u32>;
-pub type RelAtomicI64 = RelAtomic<i64>;
-pub type RelAtomicU64 = RelAtomic<u64>;
-pub type RelAtomicIsize = RelAtomic<isize>;
-pub type RelAtomicUsize = RelAtomic<usize>;
+pub type RelaxedAtomicBool = RelaxedAtomic<bool>;
+pub type RelaxedAtomicI8 = RelaxedAtomic<i8>;
+pub type RelaxedAtomicU8 = RelaxedAtomic<u8>;
+pub type RelaxedAtomicI16 = RelaxedAtomic<i16>;
+pub type RelaxedAtomicU16 = RelaxedAtomic<u16>;
+pub type RelaxedAtomicI32 = RelaxedAtomic<i32>;
+pub type RelaxedAtomicU32 = RelaxedAtomic<u32>;
+pub type RelaxedAtomicI64 = RelaxedAtomic<i64>;
+pub type RelaxedAtomicU64 = RelaxedAtomic<u64>;
+pub type RelaxedAtomicIsize = RelaxedAtomic<isize>;
+pub type RelaxedAtomicUsize = RelaxedAtomic<usize>;
 
 #[doc(hidden)]
-pub struct SynOrderings;
+pub struct AcqRelOrderings;
 
-impl Orderings for SynOrderings {
+impl Orderings for AcqRelOrderings {
     const ORD_LOAD: Ordering = Ordering::Acquire;
     const ORD_STORE: Ordering = Ordering::Release;
     const ORD_LOAD_STORE: Ordering = Ordering::AcqRel;
 }
 
-impl private::Sealed for SynOrderings {}
+impl private::Sealed for AcqRelOrderings {}
 
-/// The "synchronizing" variant of the atomic.
+/// The "acquire-release" variant of the atomic.
 ///
-/// Note: the prefix "Syn" has nothing to do with the standard `Sync` trait; both [RelAtomic<T>] and [SynAtomic<T>]
-/// are `Sync`.
-pub type SynAtomic<T> = Atomic<T, SynOrderings>;
+pub type AcqRelAtomic<T> = Atomic<T, AcqRelOrderings>;
 
-pub type SynAtomicBool = SynAtomic<bool>;
-pub type SynAtomicI8 = SynAtomic<i8>;
-pub type SynAtomicU8 = SynAtomic<u8>;
-pub type SynAtomicI16 = SynAtomic<i16>;
-pub type SynAtomicU16 = SynAtomic<u16>;
-pub type SynAtomicI32 = SynAtomic<i32>;
-pub type SynAtomicU32 = SynAtomic<u32>;
-pub type SynAtomicI64 = SynAtomic<i64>;
-pub type SynAtomicU64 = SynAtomic<u64>;
-pub type SynAtomicIsize = SynAtomic<isize>;
-pub type SynAtomicUsize = SynAtomic<usize>;
+pub type AcqRelAtomicBool = AcqRelAtomic<bool>;
+pub type AcqRelAtomicI8 = AcqRelAtomic<i8>;
+pub type AcqRelAtomicU8 = AcqRelAtomic<u8>;
+pub type AcqRelAtomicI16 = AcqRelAtomic<i16>;
+pub type AcqRelAtomicU16 = AcqRelAtomic<u16>;
+pub type AcqRelAtomicI32 = AcqRelAtomic<i32>;
+pub type AcqRelAtomicU32 = AcqRelAtomic<u32>;
+pub type AcqRelAtomicI64 = AcqRelAtomic<i64>;
+pub type AcqRelAtomicU64 = AcqRelAtomic<u64>;
+pub type AcqRelAtomicIsize = AcqRelAtomic<isize>;
+pub type AcqRelAtomicUsize = AcqRelAtomic<usize>;
+
+#[doc(hidden)]
+pub struct SeqCstOrderings;
+
+impl Orderings for SeqCstOrderings {
+    const ORD_LOAD: Ordering = Ordering::SeqCst;
+    const ORD_STORE: Ordering = Ordering::SeqCst;
+    const ORD_LOAD_STORE: Ordering = Ordering::SeqCst;
+}
+
+impl private::Sealed for SeqCstOrderings {}
+
+/// The "sequentially-consistent" variant of the atomic.
+///
+/// This is more expensive than [AcqRelAtomic] and gives an additional guarantee:
+/// there exists a single total order of all SeqCst operations that is observed by all threads.
+pub type SeqCstAtomic<T> = Atomic<T, SeqCstOrderings>;
+
+pub type SeqCstAtomicBool = SeqCstAtomic<bool>;
+pub type SeqCstAtomicI8 = SeqCstAtomic<i8>;
+pub type SeqCstAtomicU8 = SeqCstAtomic<u8>;
+pub type SeqCstAtomicI16 = SeqCstAtomic<i16>;
+pub type SeqCstAtomicU16 = SeqCstAtomic<u16>;
+pub type SeqCstAtomicI32 = SeqCstAtomic<i32>;
+pub type SeqCstAtomicU32 = SeqCstAtomic<u32>;
+pub type SeqCstAtomicI64 = SeqCstAtomic<i64>;
+pub type SeqCstAtomicU64 = SeqCstAtomic<u64>;
+pub type SeqCstAtomicIsize = SeqCstAtomic<isize>;
+pub type SeqCstAtomicUsize = SeqCstAtomic<usize>;

--- a/utils/src/blockuntilzero.rs
+++ b/utils/src/blockuntilzero.rs
@@ -13,18 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use atomic_traits::{Atomic, NumOps};
 use num_traits::{One, Zero};
 use std::{
     sync::{atomic::Ordering, Arc},
     time::Duration,
 };
 
+use crate::atomics::atomic_traits::{Atomic, AtomicNum};
 use crate::counttracker::CountTracker;
 
 pub struct BlockUntilZero<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum + From<<T as Atomic>::Type>,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
     <T as Atomic>::Type: Ord,
@@ -34,14 +34,15 @@ where
 
 impl<T> BlockUntilZero<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum + From<<T as Atomic>::Type>,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
     <T as Atomic>::Type: Ord,
 {
     pub fn new() -> Self {
+        let value: T = <T as Atomic>::Type::zero().into();
         Self {
-            value: Arc::new(<T as Atomic>::new(<T as Atomic>::Type::zero())),
+            value: Arc::new(value),
         }
     }
 
@@ -63,7 +64,7 @@ where
 
 impl<T> Default for BlockUntilZero<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum + From<<T as Atomic>::Type>,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
     <T as Atomic>::Type: Ord,
@@ -75,7 +76,7 @@ where
 
 impl<T> Drop for BlockUntilZero<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum + From<<T as Atomic>::Type>,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
     <T as Atomic>::Type: Ord,

--- a/utils/src/counttracker.rs
+++ b/utils/src/counttracker.rs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use atomic_traits::{Atomic, NumOps};
+use crate::atomics::atomic_traits::{Atomic, AtomicNum};
 use num_traits::{One, Zero};
 use std::sync::Arc;
-
 #[must_use = "CountTracker is useless without holding its object"]
 pub struct CountTracker<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
 {
@@ -29,7 +28,7 @@ where
 
 impl<T> CountTracker<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
 {
@@ -48,7 +47,7 @@ where
 
 impl<T> Drop for CountTracker<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
 {

--- a/utils/src/eventhandler.rs
+++ b/utils/src/eventhandler.rs
@@ -15,7 +15,8 @@
 
 use crate::blockuntilzero::BlockUntilZero;
 
-use std::sync::{atomic::AtomicI32, Arc};
+use crate::sync::atomic::AtomicI32;
+use std::sync::Arc;
 
 pub type EventHandler<E> = Arc<dyn Fn(E) + Send + Sync>;
 

--- a/utils/tests/simple_atomic.rs
+++ b/utils/tests/simple_atomic.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use utils::{atomics::RelAtomicU32, concurrency};
+use utils::{atomics::RelaxedAtomicU32, concurrency};
 
 // Here we have simple tests that basically check that the correct function of the wrapped
 // type is called by each function of the "Atomic" wrapper.
@@ -23,7 +23,7 @@ use utils::{atomics::RelAtomicU32, concurrency};
 #[test]
 fn test_load_store_swap() {
     concurrency::model(|| {
-        let a = RelAtomicU32::new(1);
+        let a = RelaxedAtomicU32::new(1);
         assert_eq!(a.load(), 1);
 
         a.store(2);
@@ -37,7 +37,7 @@ fn test_load_store_swap() {
 #[test]
 fn test_compare_exchange() {
     concurrency::model(|| {
-        let a = RelAtomicU32::new(1);
+        let a = RelaxedAtomicU32::new(1);
 
         assert_eq!(a.compare_exchange(2, 1), Err(1));
         assert_eq!(a.load(), 1);
@@ -50,7 +50,7 @@ fn test_compare_exchange() {
 #[test]
 fn test_compare_exchange_weak() {
     concurrency::model(|| {
-        let a = RelAtomicU32::new(1);
+        let a = RelaxedAtomicU32::new(1);
 
         assert_eq!(a.compare_exchange_weak(2, 1), Err(1));
         assert_eq!(a.load(), 1);
@@ -63,7 +63,7 @@ fn test_compare_exchange_weak() {
 #[test]
 fn test_fetch_update() {
     concurrency::model(|| {
-        let a = RelAtomicU32::new(1);
+        let a = RelaxedAtomicU32::new(1);
 
         assert_eq!(
             a.fetch_update(|x| {
@@ -88,7 +88,7 @@ fn test_fetch_update() {
 #[test]
 fn test_bit_ops() {
     concurrency::model(|| {
-        let a = RelAtomicU32::new(0b1100);
+        let a = RelaxedAtomicU32::new(0b1100);
         assert_eq!(a.fetch_and(0b1010), 0b1100);
         assert_eq!(a.load(), 0b1000);
 
@@ -109,7 +109,7 @@ fn test_bit_ops() {
 #[test]
 fn test_num_ops() {
     concurrency::model(|| {
-        let a = RelAtomicU32::new(10);
+        let a = RelaxedAtomicU32::new(10);
 
         assert_eq!(a.fetch_add(20), 10);
         assert_eq!(a.load(), 30);
@@ -132,10 +132,10 @@ fn test_num_ops() {
 #[test]
 fn test_default_debug_from() {
     concurrency::model(|| {
-        let a = <RelAtomicU32 as Default>::default();
+        let a = <RelaxedAtomicU32 as Default>::default();
         assert_eq!(a.load(), 0);
 
-        let a: RelAtomicU32 = 123.into();
+        let a: RelaxedAtomicU32 = 123.into();
         assert_eq!(a.load(), 123);
 
         assert_eq!(format!("{a:?}"), "123");


### PR DESCRIPTION
Here I add the SeqCstAtomic. The main reason is that currently many atomics in the codebase use this ordering and, when replacing them with "simple atomics", I only wanted to ensure consistency, while not changing the existing semantics (at least for now).
The second reason is that it makes sense to have this variant just for completeness.

Because of this addition, I also decided to rename the old ones. The reason is that in the presence of SeqCst, the Syn prefix became kind of confusing, because it suggested that SeqCst is not a "synchronizing" atomic.