### PR TITLE
Use simplified atomic in p2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3923,6 +3923,7 @@ dependencies = [
  "serialization",
  "subsystem",
  "tokio",
+ "utils",
 ]
 
 [[package]]

--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
@@ -20,7 +20,7 @@
 use std::{
     collections::BTreeMap,
     net::{IpAddr, SocketAddr},
-    sync::{atomic::AtomicBool, Arc, Mutex},
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -48,6 +48,7 @@ use p2p::{
     P2pEventHandler,
 };
 use p2p_test_utils::P2pBasicTestTimeGetter;
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     crawler_p2p::crawler_manager::{
@@ -125,7 +126,7 @@ impl NetworkingService for MockNetworkingService {
         _bind_addresses: Vec<Self::Address>,
         _chain_config: Arc<ChainConfig>,
         _p2p_config: Arc<P2pConfig>,
-        _shutdown: Arc<AtomicBool>,
+        _shutdown: Arc<SeqCstAtomicBool>,
         _shutdown_receiver: oneshot::Receiver<()>,
         _subscribers_receiver: mpsc::UnboundedReceiver<P2pEventHandler>,
     ) -> p2p::Result<(

--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::Arc;
 
 use clap::Parser;
 use futures::never::Never;
@@ -28,6 +28,7 @@ use p2p::{
     config::{NodeType, P2pConfig},
     net::NetworkingService,
 };
+use utils::atomics::SeqCstAtomicBool;
 use utils::default_data_dir::{default_data_dir_for_chain, prepare_data_dir};
 
 mod config;
@@ -73,7 +74,7 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<Never, error::DnsServerErro
     });
 
     let transport = p2p::make_p2p_transport();
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
 

--- a/p2p/backend-test-suite/Cargo.toml
+++ b/p2p/backend-test-suite/Cargo.toml
@@ -14,6 +14,7 @@ p2p = { path = "../../p2p" }
 p2p-test-utils = { path = "../p2p-test-utils" }
 serialization = { path = "../../serialization" }
 subsystem = { path = "../../subsystem/" }
+utils = { path = "../../utils/" }
 
 futures.workspace = true
 libtest-mimic.workspace = true

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -13,13 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    fmt::Debug,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{fmt::Debug, sync::Arc};
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -29,7 +23,6 @@ use common::{
     primitives::Idable,
     time_getter::TimeGetter,
 };
-
 use p2p::{
     error::P2pError,
     message::{HeaderList, SyncMessage},
@@ -41,6 +34,7 @@ use p2p::{
     testing_utils::{connect_and_accept_services, test_p2p_config, TestTransportMaker},
     PeerManagerEvent,
 };
+use utils::atomics::SeqCstAtomicBool;
 
 tests![invalid_pubsub_block,];
 
@@ -61,7 +55,7 @@ where
     let p2p_config = Arc::new(test_p2p_config());
     let (chainstate, mempool, shutdown_trigger, subsystem_manager_handle) =
         p2p_test_utils::start_subsystems(Arc::clone(&chain_config));
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
 
@@ -158,7 +152,7 @@ where
         e => panic!("invalid event received: {e:?}"),
     }
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender.send(());
     let _ = sync1_handle.await.unwrap();
     shutdown_trigger.initiate();

--- a/p2p/backend-test-suite/src/connect.rs
+++ b/p2p/backend-test-suite/src/connect.rs
@@ -15,13 +15,7 @@
 
 //! Connection tests.
 
-use std::{
-    fmt::Debug,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{fmt::Debug, sync::Arc};
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -30,6 +24,7 @@ use p2p::{
     error::{DialError, P2pError},
     net::{ConnectivityService, MessagingService, NetworkingService, SyncingEventReceiver},
 };
+use utils::atomics::SeqCstAtomicBool;
 
 tests![connect, connect_address_in_use, connect_accept,];
 
@@ -44,7 +39,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     N::start(
@@ -59,7 +54,7 @@ where
     .await
     .unwrap();
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender.send(());
 }
 
@@ -75,7 +70,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender_1, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (connectivity, _messaging_handle, _sync, _) = N::start(
@@ -111,7 +106,7 @@ where
         ))
     ));
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender_2.send(());
     let _ = shutdown_sender_1.send(());
 }
@@ -129,7 +124,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender_1, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (mut service1, _, _, _) = N::start(
@@ -162,7 +157,7 @@ where
     service2.connect(conn_addr[0].clone()).unwrap();
     service1.poll_next().await.unwrap();
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender_2.send(());
     let _ = shutdown_sender_1.send(());
 }

--- a/p2p/backend-test-suite/src/events.rs
+++ b/p2p/backend-test-suite/src/events.rs
@@ -13,14 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    fmt::Debug,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 
 use tokio::{
     sync::{
@@ -38,6 +31,7 @@ use p2p::{
     },
     P2pEvent,
 };
+use utils::atomics::SeqCstAtomicBool;
 
 tests![peer_events,];
 
@@ -52,7 +46,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender_1, shutdown_receiver) = oneshot::channel();
     let (subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (mut service1, _, _sync, _) = N::start(
@@ -106,7 +100,7 @@ where
         Some(P2pEvent::PeerDisconnected(info.peer_id))
     );
 
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.store(true);
     let _ = shutdown_sender_2.send(());
     let _ = shutdown_sender_1.send(());
 }

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -18,13 +18,7 @@ pub mod peer;
 pub mod transport;
 pub mod types;
 
-use std::{
-    marker::PhantomData,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::{marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::{
@@ -33,6 +27,7 @@ use tokio::{
 };
 
 use logging::log;
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     error::P2pError,
@@ -119,7 +114,7 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
         bind_addresses: Vec<Self::Address>,
         chain_config: Arc<common::chain::ChainConfig>,
         p2p_config: Arc<P2pConfig>,
-        shutdown: Arc<AtomicBool>,
+        shutdown: Arc<SeqCstAtomicBool>,
         shutdown_receiver: oneshot::Receiver<()>,
         subscribers_receiver: mpsc::UnboundedReceiver<P2pEventHandler>,
     ) -> crate::Result<(
@@ -152,11 +147,11 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
 
             match backend.run().await {
                 Ok(_) => unreachable!(),
-                Err(P2pError::ChannelClosed) if shutdown.load(Ordering::SeqCst) => {
+                Err(P2pError::ChannelClosed) if shutdown.load() => {
                     log::info!("Backend is shut down");
                 }
                 Err(e) => {
-                    shutdown.store(true, Ordering::SeqCst);
+                    shutdown.store(true);
                     log::error!("Failed to run backend: {e}");
                 }
             }

--- a/p2p/src/net/default_backend/tests.rs
+++ b/p2p/src/net/default_backend/tests.rs
@@ -36,7 +36,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
@@ -107,7 +107,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
@@ -176,7 +176,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
@@ -243,7 +243,7 @@ where
 {
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
 
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
@@ -335,7 +335,7 @@ where
 
     let config = Arc::new(common::chain::config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (mut conn, _, _, _) = DefaultNetworkingService::<T>::start(

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -16,18 +16,15 @@
 pub mod default_backend;
 pub mod types;
 
-use std::{
-    fmt::Debug,
-    hash::Hash,
-    str::FromStr,
-    sync::{atomic::AtomicBool, Arc},
-};
+use std::{fmt::Debug, hash::Hash, str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::{
     sync::{mpsc, oneshot},
     task::JoinHandle,
 };
+
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     config,
@@ -88,7 +85,7 @@ pub trait NetworkingService {
         bind_addresses: Vec<Self::Address>,
         chain_config: Arc<common::chain::ChainConfig>,
         p2p_config: Arc<config::P2pConfig>,
-        shutdown: Arc<AtomicBool>,
+        shutdown: Arc<SeqCstAtomicBool>,
         shutdown_receiver: oneshot::Receiver<()>,
         subscribers_receiver: mpsc::UnboundedReceiver<P2pEventHandler>,
     ) -> crate::Result<(

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -15,7 +15,7 @@
 
 use std::{
     net::SocketAddr,
-    sync::{atomic::AtomicBool, Arc},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -39,6 +39,7 @@ use crate::{
     utils::oneshot_nofail,
 };
 use common::{chain::config, primitives::user_agent::mintlayer_core_user_agent};
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     error::{DialError, P2pError, ProtocolError},
@@ -540,7 +541,7 @@ where
 {
     let config = Arc::new(config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (mut conn, _, _, _) = T::start(
@@ -611,7 +612,7 @@ async fn connection_timeout_rpc_notified<T>(
 {
     let config = Arc::new(config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (_shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (_subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (conn, _, _, _) = T::start(

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -18,10 +18,7 @@ mod ban;
 mod connections;
 mod ping;
 
-use std::{
-    sync::{atomic::AtomicBool, Arc},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -31,6 +28,7 @@ use tokio::{
     sync::mpsc::{UnboundedReceiver, UnboundedSender},
     time::timeout,
 };
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     expect_recv,
@@ -66,7 +64,7 @@ where
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
 {
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender, shutdown_receiver) = oneshot::channel();
     let (subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (conn, _, _, _) = T::start(

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -17,7 +17,7 @@ use std::{
     collections::BTreeMap,
     net::{IpAddr, SocketAddr},
     panic,
-    sync::{atomic::AtomicBool, Arc, Mutex},
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
@@ -51,6 +51,7 @@ use common::{
 };
 use mempool::{MempoolHandle, MempoolSubsystemInterface};
 use subsystem::manager::{ManagerJoinHandle, ShutdownTrigger};
+use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     config::NodeType,
@@ -455,7 +456,7 @@ impl NetworkingService for NetworkingServiceStub {
         _: Vec<Self::Address>,
         _: Arc<ChainConfig>,
         _: Arc<P2pConfig>,
-        _: Arc<AtomicBool>,
+        _: Arc<SeqCstAtomicBool>,
         _: oneshot::Receiver<()>,
         _: mpsc::UnboundedReceiver<P2pEventHandler>,
     ) -> Result<(


### PR DESCRIPTION
The `shundown` flag, which used the SeqCst ordering, was replaced with `SeqCstAtomicBool`.

This PR depends on PR  #982.