### PR TITLE
time_value in TestFramework is now a simplified atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3939,6 +3939,7 @@ dependencies = [
  "subsystem",
  "test-utils",
  "tokio",
+ "utils",
 ]
 
 [[package]]
@@ -5700,6 +5701,7 @@ dependencies = [
  "hex",
  "rand_chacha 0.3.1",
  "serialization",
+ "utils",
 ]
 
 [[package]]

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -60,7 +60,8 @@ mod test {
         },
         primitives::Idable,
     };
-    use std::sync::{atomic::Ordering, Arc};
+    use std::sync::Arc;
+    use utils::atomics::SeqCstAtomicU64;
 
     fn make_block(prev_block: Id<GenBlock>, time: BlockTimestampInternalType) -> Block {
         Block::new(
@@ -166,7 +167,7 @@ mod test {
         utils::concurrency::model(|| {
             let chain_config = Arc::new(create_unit_test_config());
 
-            let current_time = Arc::new(std::sync::atomic::AtomicU64::new(
+            let current_time = Arc::new(SeqCstAtomicU64::new(
                 chain_config.genesis_block().timestamp().as_int_seconds(),
             ));
 
@@ -185,11 +186,11 @@ mod test {
             .unwrap();
 
             // we use unordered block times, and ensure that the median will be in the right spot
-            let block1_time = current_time.load(Ordering::SeqCst) + 1;
-            let block2_time = current_time.load(Ordering::SeqCst) + 10;
-            let block3_time = current_time.load(Ordering::SeqCst) + 17;
-            let block4_time = current_time.load(Ordering::SeqCst) + 18;
-            let block5_time = current_time.load(Ordering::SeqCst) + 20;
+            let block1_time = current_time.load() + 1;
+            let block2_time = current_time.load() + 10;
+            let block3_time = current_time.load() + 17;
+            let block4_time = current_time.load() + 18;
+            let block5_time = current_time.load() + 20;
 
             let block1 = make_block(chainstate.chain_config.genesis_block_id(), block1_time);
             let block2 = make_block(block1.get_id().into(), block2_time);

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -13,11 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::BTreeMap,
-    sync::{atomic::AtomicU64, Arc},
-    time::Duration,
-};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use chainstate::{chainstate_interface::ChainstateInterface, BlockSource, ChainstateError};
 use chainstate_types::{BlockIndex, GenBlockIndex};
@@ -34,6 +30,7 @@ use crate::{
     utils::{outputs_from_block, outputs_from_genesis},
     BlockBuilder, TestChainstate, TestFrameworkBuilder, TestStore,
 };
+use utils::atomics::SeqCstAtomicU64;
 
 /// The `Chainstate` wrapper that simplifies operations and checks in the tests.
 pub struct TestFramework {
@@ -43,7 +40,7 @@ pub struct TestFramework {
     // A clone of the TimeGetter supplied to the chainstate
     pub time_getter: TimeGetter,
     // current time since epoch; if None, it means a custom TimeGetter was supplied and this is useless
-    pub time_value: Option<Arc<AtomicU64>>,
+    pub time_value: Option<Arc<SeqCstAtomicU64>>,
 }
 
 pub type BlockOutputs = BTreeMap<OutPointSourceId, Vec<TxOutput>>;
@@ -72,7 +69,7 @@ impl TestFramework {
     /// this function increases the time value
     pub fn progress_time_seconds_since_epoch(&mut self, secs: u64) {
         match &self.time_value {
-            Some(v) => v.fetch_add(secs, std::sync::atomic::Ordering::SeqCst),
+            Some(v) => v.fetch_add(secs),
             None => {
                 panic!("Cannot progress time in TestFramework when custom time getter is supplied")
             }
@@ -83,7 +80,7 @@ impl TestFramework {
     /// this function sets the time value to whatever is provided
     pub fn set_time_seconds_since_epoch(&mut self, val: u64) {
         match &self.time_value {
-            Some(v) => v.store(val, std::sync::atomic::Ordering::SeqCst),
+            Some(v) => v.store(val),
             None => {
                 panic!("Cannot progress time in TestFramework when custom time getter is supplied")
             }

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{atomic::AtomicU64, Arc};
+use std::sync::Arc;
 
 use chainstate::{BlockError, ChainstateConfig, DefaultTransactionVerificationStrategy};
 use common::{
@@ -32,6 +32,7 @@ use crate::{
     },
     TestFramework, TestStore,
 };
+use utils::atomics::SeqCstAtomicU64;
 
 pub enum TxVerificationStrategy {
     Default,
@@ -111,8 +112,8 @@ impl TestFrameworkBuilder {
     /// Create the TimeGetter of the TestFramework, with the following logic:
     /// The default TimeGetter of the TestFramework simply loads the value of time from an atomic u64
     /// If a custom TimeGetter is supplied, then this value won't exist
-    fn create_time_getter_and_value(&self) -> (TimeGetter, Option<Arc<AtomicU64>>) {
-        let time_value = Arc::new(AtomicU64::new(
+    fn create_time_getter_and_value(&self) -> (TimeGetter, Option<Arc<SeqCstAtomicU64>>) {
+        let time_value = Arc::new(SeqCstAtomicU64::new(
             self.chain_config.genesis_block().timestamp().as_int_seconds(),
         ));
 

--- a/mempool/src/pool/tests/expiry.rs
+++ b/mempool/src/pool/tests/expiry.rs
@@ -17,13 +17,14 @@ use common::chain::tokens::OutputValue;
 
 use super::*;
 use crate::SystemUsageEstimator;
+use ::utils::atomics::SeqCstAtomicU64;
 
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
-    let mock_time = Arc::new(AtomicU64::new(0));
+    let mock_time = Arc::new(SeqCstAtomicU64::new(0));
     let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     logging::init_logging::<&str>(None);
 
@@ -68,7 +69,7 @@ async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
     )
     .await?;
     let child_id = child.transaction().get_id();
-    mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1, Ordering::SeqCst);
+    mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1);
 
     assert_eq!(
         mempool.add_transaction(child),
@@ -103,7 +104,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
     }
     let parent = tx_builder.build();
 
-    let mock_time = Arc::new(AtomicU64::new(0));
+    let mock_time = Arc::new(SeqCstAtomicU64::new(0));
     let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     let chainstate = tf.chainstate();
     let config = Arc::clone(chainstate.get_chain_config());
@@ -161,7 +162,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
         .chainstate_handle
         .call_mut(|this| this.process_block(block, BlockSource::Local))
         .await??;
-    mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1, Ordering::SeqCst);
+    mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1);
 
     mempool.add_transaction(child_1)?.assert_in_mempool();
     assert!(!mempool.contains_transaction(&expired_tx_id));

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     get_memory_usage::MockGetMemoryUsage, tx_accumulator::DefaultTxAccumulator,
     SystemUsageEstimator,
 };
+use ::utils::atomics::SeqCstAtomicU64;
 use chainstate::{
     make_chainstate, BlockSource, ChainstateConfig, DefaultTransactionVerificationStrategy,
 };
@@ -32,10 +33,7 @@ use common::{
     },
     primitives::{Id, Idable, H256},
 };
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 
 mod expiry;
 mod orphans;
@@ -872,7 +870,7 @@ async fn spends_new_unconfirmed(#[case] seed: Seed) -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     logging::init_logging::<&str>(None);
-    let mock_time = Arc::new(AtomicU64::new(0));
+    let mock_time = Arc::new(SeqCstAtomicU64::new(0));
     let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     let mut mock_usage = MockGetMemoryUsage::new();
     // Add parent
@@ -1072,10 +1070,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     // between txs. Finally, when the fee rate falls under INCREMENTAL_RELAY_THRESHOLD, we
     // observer that it is set to zero
     let halflife = ROLLING_FEE_BASE_HALFLIFE / 4;
-    mock_time.store(
-        mock_time.load(Ordering::SeqCst) + halflife.as_secs(),
-        Ordering::SeqCst,
-    );
+    mock_time.store(mock_time.load() + halflife.as_secs());
     let dummy_tx = TransactionBuilder::new()
         .add_input(
             TxInput::from_utxo(OutPointSourceId::Transaction(child_2_high_fee_id), 0),
@@ -1108,10 +1103,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
         rolling_fee / NonZeroUsize::new(2).expect("nonzero")
     );
 
-    mock_time.store(
-        mock_time.load(Ordering::SeqCst) + halflife.as_secs(),
-        Ordering::SeqCst,
-    );
+    mock_time.store(mock_time.load() + halflife.as_secs());
     log::debug!("Second attempt to add dummy");
     mempool.add_transaction(dummy_tx)?.assert_in_mempool();
     log::debug!(
@@ -1128,10 +1120,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     );
 
     // Add another dummy until rolling feerate drops to zero
-    mock_time.store(
-        mock_time.load(Ordering::SeqCst) + halflife.as_secs(),
-        Ordering::SeqCst,
-    );
+    mock_time.store(mock_time.load() + halflife.as_secs());
 
     let another_dummy = TransactionBuilder::new()
         .add_input(

--- a/p2p/p2p-test-utils/Cargo.toml
+++ b/p2p/p2p-test-utils/Cargo.toml
@@ -14,6 +14,7 @@ crypto = { path = "../../crypto/" }
 mempool = { path = "../../mempool/" }
 subsystem = { path = "../../subsystem/" }
 test-utils = { path = "../../test-utils" }
+utils = { path = "../../utils" }
 
 portpicker.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -15,13 +15,7 @@
 
 #![allow(clippy::unwrap_used)]
 
-use std::{
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use chainstate::{
     chainstate_interface::ChainstateInterface, make_chainstate, ChainstateConfig,
@@ -36,6 +30,7 @@ use common::{
 use mempool::{MempoolHandle, MempoolSubsystemInterface};
 use subsystem::manager::{ManagerJoinHandle, ShutdownTrigger};
 use test_utils::mock_time_getter::mocked_time_getter_milliseconds;
+use utils::atomics::SeqCstAtomicU64;
 
 pub fn start_subsystems(
     chain_config: Arc<ChainConfig>,
@@ -101,7 +96,7 @@ pub fn create_n_blocks(tf: &mut TestFramework, n: usize) -> Vec<Block> {
 }
 
 pub struct P2pBasicTestTimeGetter {
-    current_time_millis: Arc<AtomicU64>,
+    current_time_millis: Arc<SeqCstAtomicU64>,
 }
 
 impl P2pBasicTestTimeGetter {
@@ -109,7 +104,7 @@ impl P2pBasicTestTimeGetter {
         let current_time = std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap();
-        let current_time_millis = Arc::new(AtomicU64::new(current_time.as_millis() as u64));
+        let current_time_millis = Arc::new(SeqCstAtomicU64::new(current_time.as_millis() as u64));
         Self {
             current_time_millis,
         }
@@ -120,7 +115,6 @@ impl P2pBasicTestTimeGetter {
     }
 
     pub fn advance_time(&self, duration: Duration) {
-        self.current_time_millis
-            .fetch_add(duration.as_millis() as u64, Ordering::SeqCst);
+        self.current_time_millis.fetch_add(duration.as_millis() as u64);
     }
 }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 common = {path = '../common'}
 crypto = {path = '../crypto'}
 serialization = { path = '../serialization' }
+utils = { path = '../utils' }
 
 hex.workspace = true
 rand_chacha.workspace = true


### PR DESCRIPTION
time_value in TestFrameword, which used SeqCst ordering, was replaced with `SeqCstAtomicU64`.

This PR depends on PR #982.