### PR TITLE
Miscellaneous atomics-related changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,16 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-traits"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29ec3788e96fb4fdb275ccb9d62811f2fa903d76c5eb4dd6fe7d09a7ed5871f"
-dependencies = [
- "cfg-if",
- "rustc_version 0.3.3",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4073,16 +4063,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
-name = "pest"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,7 +4699,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -4731,7 +4711,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn 1.0.109",
  "unicode-ident",
 ]
@@ -4770,20 +4750,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver",
 ]
 
 [[package]]
@@ -5006,27 +4977,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "send_wrapper"
@@ -5369,7 +5322,7 @@ dependencies = [
  "chacha20poly1305 0.9.1",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "rustc_version 0.4.0",
+ "rustc_version",
  "sha2 0.10.6",
  "subtle",
 ]
@@ -6201,12 +6154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6298,7 +6245,6 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "utils"
 version = "0.1.0"
 dependencies = [
- "atomic-traits",
  "criterion",
  "crypto",
  "directories",

--- a/p2p/src/net/default_backend/transport/impls/channel.rs
+++ b/p2p/src/net/default_backend/transport/impls/channel.rs
@@ -17,7 +17,7 @@ use std::{
     collections::BTreeMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{
-        atomic::{AtomicU16, AtomicU32, Ordering},
+        atomic::{AtomicU32 as StdAtomicU32, Ordering},
         Mutex,
     },
 };
@@ -32,6 +32,7 @@ use tokio::{
         oneshot::{self, Sender},
     },
 };
+use utils::sync::atomic::AtomicU16;
 
 use crate::{
     error::DialError,
@@ -47,7 +48,9 @@ type IncomingConnection = (SocketAddr, Sender<DuplexStream>);
 static CONNECTIONS: Lazy<Mutex<BTreeMap<SocketAddr, UnboundedSender<IncomingConnection>>>> =
     Lazy::new(Default::default);
 
-static NEXT_IP_ADDRESS: AtomicU32 = AtomicU32::new(1);
+// Note: we can't use utils::sync::atomic::AtomicU32 here, because loom types don't have a const
+// constructor function.
+static NEXT_IP_ADDRESS: StdAtomicU32 = StdAtomicU32::new(1);
 
 /// Creating a new transport is like adding a new "host" to the network with a new unique IPv4 address.
 ///

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -16,10 +16,6 @@
 use std::{
     collections::{BTreeSet, VecDeque},
     mem,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
     time::Duration,
 };
 
@@ -44,6 +40,10 @@ use mempool::{
     MempoolHandle,
 };
 use utils::const_value::ConstValue;
+use utils::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use crate::{
     config::P2pConfig,

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -39,11 +39,9 @@ use mempool::{
     error::{Error as MempoolError, MempoolPolicyError},
     MempoolHandle,
 };
+use utils::atomics::AcqRelAtomicBool;
 use utils::const_value::ConstValue;
-use utils::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use utils::sync::Arc;
 
 use crate::{
     config::P2pConfig,
@@ -74,7 +72,7 @@ pub struct Peer<T: NetworkingService> {
     peer_manager_sender: UnboundedSender<PeerManagerEvent<T>>,
     messaging_handle: T::MessagingHandle,
     sync_rx: Receiver<SyncMessage>,
-    is_initial_block_download: Arc<AtomicBool>,
+    is_initial_block_download: Arc<AcqRelAtomicBool>,
     /// A list of headers received via the `HeaderListResponse` message that we haven't yet
     /// requested the blocks for.
     known_headers: Vec<SignedBlockHeader>,
@@ -114,7 +112,7 @@ where
         peer_manager_sender: UnboundedSender<PeerManagerEvent<T>>,
         sync_rx: Receiver<SyncMessage>,
         messaging_handle: T::MessagingHandle,
-        is_initial_block_download: Arc<AtomicBool>,
+        is_initial_block_download: Arc<AcqRelAtomicBool>,
         time_getter: TimeGetter,
     ) -> Self {
         let local_services: Services = (*p2p_config.node_type).into();
@@ -220,7 +218,7 @@ where
         }
         log::trace!("locator: {locator:#?}");
 
-        if self.is_initial_block_download.load(Ordering::Acquire) {
+        if self.is_initial_block_download.load() {
             // TODO: Check if a peer has permissions to ask for headers during the initial block download.
             log::debug!("Ignoring headers request because the node is in initial block download");
             return Ok(());
@@ -248,7 +246,7 @@ where
             block_ids.len(),
         );
 
-        if self.is_initial_block_download.load(Ordering::Acquire) {
+        if self.is_initial_block_download.load() {
             log::debug!("Ignoring blocks request because the node is in initial block download");
             return Ok(());
         }
@@ -517,7 +515,7 @@ where
     async fn handle_transaction_announcement(&mut self, tx: Id<Transaction>) -> Result<()> {
         log::debug!("Transaction announcement from {} peer: {tx}", self.id());
 
-        if self.is_initial_block_download.load(Ordering::Acquire) {
+        if self.is_initial_block_download.load() {
             log::debug!(
                 "Ignoring transaction announcement because the node is in initial block download"
             );

--- a/storage/lmdb/src/lib.rs
+++ b/storage/lmdb/src/lib.rs
@@ -145,16 +145,12 @@ impl LmdbImpl {
         })
     }
 
-    // FIXME: I'd like to replace the SeqCst ordering here with Release, because it looks
-    // like an overkill, provided that the loads are only Acquire (unless these store operations
-    // must be in total order with some other SeqCst operations on some other atomic, but this
-    // shouldn't be true). Or maybe we should go in the other direction and make the load SeqCst?
     fn schedule_map_resize(&self) {
-        self.map_resize_scheduled.store(true, Ordering::SeqCst);
+        self.map_resize_scheduled.store(true, Ordering::Release);
     }
 
     fn unschedule_map_resize(&self) {
-        self.map_resize_scheduled.store(false, Ordering::SeqCst);
+        self.map_resize_scheduled.store(false, Ordering::Release);
     }
 
     fn resize_if_resize_scheduled(&self) {

--- a/test-utils/src/test_dir.rs
+++ b/test-utils/src/test_dir.rs
@@ -19,6 +19,8 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
     sync::{
+        // Note: we can't use simplified atomics or loom version of std atomics here,
+        // because this code can be called from tests that are not loom-ready.
         atomic::{AtomicU32, Ordering},
         Arc,
     },

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -10,7 +10,6 @@ crypto = { path = "../crypto/" }
 logging = {path = '../logging'}
 serialization = { path = "../serialization" }
 
-atomic-traits.workspace = true
 directories.workspace = true
 num-traits.workspace = true
 probabilistic-collections.workspace = true

--- a/utils/src/blockuntilzero.rs
+++ b/utils/src/blockuntilzero.rs
@@ -13,18 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use atomic_traits::{Atomic, NumOps};
 use num_traits::{One, Zero};
 use std::{
     sync::{atomic::Ordering, Arc},
     time::Duration,
 };
 
+use crate::atomics::atomic_traits::{Atomic, AtomicNum};
 use crate::counttracker::CountTracker;
 
 pub struct BlockUntilZero<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum + From<<T as Atomic>::Type>,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
     <T as Atomic>::Type: Ord,
@@ -34,14 +34,15 @@ where
 
 impl<T> BlockUntilZero<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum + From<<T as Atomic>::Type>,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
     <T as Atomic>::Type: Ord,
 {
     pub fn new() -> Self {
+        let value: T = <T as Atomic>::Type::zero().into();
         Self {
-            value: Arc::new(<T as Atomic>::new(<T as Atomic>::Type::zero())),
+            value: Arc::new(value),
         }
     }
 
@@ -63,7 +64,7 @@ where
 
 impl<T> Default for BlockUntilZero<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum + From<<T as Atomic>::Type>,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
     <T as Atomic>::Type: Ord,
@@ -75,7 +76,7 @@ where
 
 impl<T> Drop for BlockUntilZero<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum + From<<T as Atomic>::Type>,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
     <T as Atomic>::Type: Ord,

--- a/utils/src/counttracker.rs
+++ b/utils/src/counttracker.rs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use atomic_traits::{Atomic, NumOps};
+use crate::atomics::atomic_traits::{Atomic, AtomicNum};
 use num_traits::{One, Zero};
 use std::sync::Arc;
-
 #[must_use = "CountTracker is useless without holding its object"]
 pub struct CountTracker<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
 {
@@ -29,7 +28,7 @@ where
 
 impl<T> CountTracker<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
 {
@@ -48,7 +47,7 @@ where
 
 impl<T> Drop for CountTracker<T>
 where
-    T: Atomic + NumOps,
+    T: AtomicNum,
     <T as Atomic>::Type: One,
     <T as Atomic>::Type: Zero,
 {

--- a/utils/src/eventhandler.rs
+++ b/utils/src/eventhandler.rs
@@ -15,7 +15,8 @@
 
 use crate::blockuntilzero::BlockUntilZero;
 
-use std::sync::{atomic::AtomicI32, Arc};
+use crate::sync::atomic::AtomicI32;
+use std::sync::Arc;
 
 pub type EventHandler<E> = Arc<dyn Fn(E) + Send + Sync>;
 


### PR DESCRIPTION
1) blockuntilzero and counttracker in utils now use custom (loom-aware) atomic traits; because of this, the "atomic-traits" crate is no longer needed, so I removed it from the project.
2) in some other places std atomics were replaced with utils::sync atomics.
(Plus I also replaced one more atomic with a simplified one).

As I've mentioned during the daily, I wasn't able to replace all existing atomics with the simplified ones or at least with loom versions of the standard ones because:
1) Loom atomics' "new" function is not const, so static atomics won't compile. The solution might be to use lazy_static but that kind of defeats the purpose of the atomic, because lazy_static itself uses synchronization primitives under the hood (that are probably heavier than a single atomic).
2) Sometimes code that uses atomics is called from tests that are not "loom-ready" (i.e. they don't call concurrency::model). Probably, we should disable those tests under cfg(loom).
The atomic in test-utils/src/test_dir.rs is one of such atomics.
3) In one case tests failed with the error "Model exceeded maximum number of branches. This is often caused by an algorithm requiring the processor to make progress, e.g. spin locks.", this happened after replacing the atomic in storage/lmdb/src/lib.rs. Googling suggests that this might be fixable by increasing the "max_branches" setting of the loom model.

For now just I added comments about the issues. I don't plan to fix them in the nearby future.

There are also a couple of FIXMEs, that I would like to discuss.