### PR TITLE
Derive Hash for Id

### DIFF
--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -89,7 +89,7 @@ impl<'de> serde::Deserialize<'de> for H256 {
     }
 }
 
-#[derive(PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize)]
+#[derive(PartialEq, Eq, Hash, Encode, Decode, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct Id<T> {
     id: H256,


### PR DESCRIPTION
Small change but to a primitive type. This PR serves as a place to discuss whether it is viable to derive `Hash` for `Id<T>`.

It is often useful to track entities in a hashmap where the key is the entity ID (i.e `HashMap<Id<_>, _>`. Currently, we'd need to represent it as `HashMap<H256, _>` and then use `Id<_>::get(&self)` before accessing the hashmap.