### PR TITLE
Skip first immediate peer stalling interval tick

### DIFF
--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -156,6 +156,9 @@ where
     async fn main_loop(&mut self) -> Result<()> {
         let mut stalling_interval = tokio::time::interval(*self.p2p_config.sync_stalling_timeout);
         stalling_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // The first tick completes immediately. Since we are dealing with a stalling check, we skip
+        // the first tick.
+        stalling_interval.tick().await;
 
         if self.common_services.has_service(Service::Blocks) {
             self.request_headers().await?;


### PR DESCRIPTION
The main loop of the block sync manager peer task periodically checks if a peer has stalled and should be disconnected. There is no value in immediately checking for that, therefore, the initial check can be skipped.

This also fixes an intermittent failure in `sync::tests::peer_events::do_not_disconnect_peer_after_receiving_known_header_list` that didn't expect for the stalling interval to trigger.