### PR TITLE
Change VRF key derivation

### DIFF
--- a/crypto/src/key/secp256k1/extended_keys.rs
+++ b/crypto/src/key/secp256k1/extended_keys.rs
@@ -65,7 +65,7 @@ fn to_key_and_chain_code(
 
 impl Secp256k1ExtendedPrivateKey {
     pub fn new_master(seed: &[u8]) -> Result<Secp256k1ExtendedPrivateKey, DerivationError> {
-        // Create a new mac with the appropriate BIP39 constant
+        // Create a new mac with the appropriate BIP32 constant
         let mut mac = new_hmac_sha_512(b"Bitcoin seed");
 
         mac.update(seed);

--- a/crypto/src/key/secp256k1/extended_keys.rs
+++ b/crypto/src/key/secp256k1/extended_keys.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::key::hdkd::chain_code::CHAINCODE_LENGTH;
 use crate::key::hdkd::derivation_path::DerivationPath;
 use crate::key::hdkd::{
     chain_code::ChainCode,
@@ -22,14 +21,13 @@ use crate::key::hdkd::{
 };
 use crate::key::secp256k1::{Secp256k1PrivateKey, Secp256k1PublicKey};
 use crate::random::{CryptoRng, Rng};
-use generic_array::{sequence::Split, typenum::U32, GenericArray};
+use crate::util::{self, new_hmac_sha_512};
 use hmac::{Hmac, Mac};
 use secp256k1;
 use secp256k1::SECP256K1;
 use serialization::{Decode, Encode};
 use sha2::Sha512;
 use std::cmp::Ordering;
-use zeroize::Zeroize;
 
 /// Given a tree of keys that are derived from a master key using BIP32 rules, this struct represents
 /// the private key at one of the nodes of this tree.
@@ -42,10 +40,6 @@ pub struct Secp256k1ExtendedPrivateKey {
     chain_code: ChainCode,
     /// The private key to be used to derive child keys of this node using BIP32 rules
     private_key: Secp256k1PrivateKey,
-}
-
-fn new_hmac_sha_512(key: &[u8]) -> Hmac<Sha512> {
-    Hmac::<Sha512>::new_from_slice(key).expect("HMAC can take key of any size")
 }
 
 impl PartialOrd for Secp256k1ExtendedPrivateKey {
@@ -63,27 +57,10 @@ impl Ord for Secp256k1ExtendedPrivateKey {
 fn to_key_and_chain_code(
     mac: Hmac<Sha512>,
 ) -> Result<(secp256k1::SecretKey, ChainCode), DerivationError> {
-    // Finalize the hmac
-    let mut result = mac.finalize().into_bytes();
-
-    // Split in to two 32 byte arrays
-    let (mut secret_key_bytes, mut chain_code_bytes): (
-        GenericArray<u8, U32>,
-        GenericArray<u8, U32>,
-    ) = result.split();
-    result.zeroize();
-
-    // Create the secret key key
-    let secret_key = secp256k1::SecretKey::from_slice(&secret_key_bytes)
-        .map_err(|_| DerivationError::KeyDerivationError)?;
-    secret_key_bytes.zeroize();
-
-    // Chain code
-    let chain_code: [u8; CHAINCODE_LENGTH] = chain_code_bytes.into();
-    let chain_code = ChainCode::from(chain_code);
-    chain_code_bytes.zeroize();
-
-    Ok((secret_key, chain_code))
+    util::to_key_and_chain_code(mac, |secret_key_bytes| {
+        secp256k1::SecretKey::from_slice(secret_key_bytes)
+            .map_err(|_| DerivationError::KeyDerivationError)
+    })
 }
 
 impl Secp256k1ExtendedPrivateKey {
@@ -273,7 +250,6 @@ mod test {
     use bip39::Mnemonic;
     use rstest::rstest;
     use std::str::FromStr;
-    use test_utils::random::{make_seedable_rng, Seed};
     use test_utils::{assert_encoded_eq, decode_from_hex};
 
     #[test]
@@ -410,19 +386,5 @@ mod test {
         let pk = pk.unwrap();
         assert_encoded_eq(&path, path_encoded);
         assert_encoded_eq(&pk, format!("{path_encoded}{chaincode}{public}").as_str());
-    }
-
-    #[rstest]
-    #[trace]
-    #[case(Seed::from_entropy())]
-    /// Test to prove that hmac-sha512 can be used with keys of any size, since there's an expect in it
-    fn mac_key_of_any_size(#[case] seed: Seed) {
-        let mut rng = make_seedable_rng(seed);
-
-        let key_size = rng.gen_range(0..=1000);
-
-        let key = (0..key_size).map(|_| rng.gen::<u8>()).collect::<Vec<_>>();
-
-        let _hmac = new_hmac_sha_512(&key);
     }
 }

--- a/crypto/src/util/mod.rs
+++ b/crypto/src/util/mod.rs
@@ -13,4 +13,66 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use generic_array::{sequence::Split, typenum::U32, GenericArray};
+use hmac::{Hmac, Mac};
+use sha2::Sha512;
+use zeroize::Zeroize;
+
+use crate::key::hdkd::{
+    chain_code::{ChainCode, CHAINCODE_LENGTH},
+    derivable::DerivationError,
+};
+
 pub mod eq;
+
+pub fn new_hmac_sha_512(key: &[u8]) -> Hmac<Sha512> {
+    Hmac::<Sha512>::new_from_slice(key).expect("HMAC can take key of any size")
+}
+
+pub fn to_key_and_chain_code<SecretKey>(
+    mac: Hmac<Sha512>,
+    to_key: impl FnOnce(&[u8]) -> Result<SecretKey, DerivationError>,
+) -> Result<(SecretKey, ChainCode), DerivationError> {
+    // Finalize the hmac
+    let mut result = mac.finalize().into_bytes();
+
+    // Split in to two 32 byte arrays
+    let (mut secret_key_bytes, mut chain_code_bytes): (
+        GenericArray<u8, U32>,
+        GenericArray<u8, U32>,
+    ) = result.split();
+    result.zeroize();
+
+    // Create the secret key key
+    let secret_key = to_key(secret_key_bytes.as_slice())?;
+    secret_key_bytes.zeroize();
+
+    // Chain code
+    let chain_code: [u8; CHAINCODE_LENGTH] = chain_code_bytes.into();
+    let chain_code = ChainCode::from(chain_code);
+    chain_code_bytes.zeroize();
+
+    Ok((secret_key, chain_code))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::random::Rng;
+    use rstest::rstest;
+    use test_utils::random::{make_seedable_rng, Seed};
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    /// Test to prove that hmac-sha512 can be used with keys of any size, since there's an expect in it
+    fn mac_key_of_any_size(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+
+        let key_size = rng.gen_range(0..=1000);
+
+        let key = (0..key_size).map(|_| rng.gen::<u8>()).collect::<Vec<_>>();
+
+        let _hmac = new_hmac_sha_512(&key);
+    }
+}

--- a/crypto/src/vrf/mod.rs
+++ b/crypto/src/vrf/mod.rs
@@ -180,8 +180,10 @@ impl ExtendedVRFPrivateKey {
         seed: &[u8],
         keykind: VRFKeyKind,
     ) -> Result<ExtendedVRFPrivateKey, DerivationError> {
-        // Create a new mac with the appropriate BIP39 constant
-        let mut mac = new_hmac_sha_512(b"Bitcoin seed");
+        // Create a new mac with the appropriate BIP32 constant
+        // Have a different constant from the Secp256k1 so that in case it is leaked the VRF key
+        // will remain safe
+        let mut mac = new_hmac_sha_512(b"Bitcoin VRF seed");
 
         mac.update(seed);
 

--- a/crypto/src/vrf/mod.rs
+++ b/crypto/src/vrf/mod.rs
@@ -194,6 +194,10 @@ impl ExtendedVRFPrivateKey {
             chain_code,
         })
     }
+
+    pub fn private_key(self) -> VRFPrivateKey {
+        self.private_key
+    }
 }
 
 impl Derivable for ExtendedVRFPrivateKey {

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -21,9 +21,7 @@ use common::Uint256;
 pub use utxo_selector::UtxoSelectorError;
 
 use crate::account::utxo_selector::{select_coins, OutputGroup};
-use crate::key_chain::{
-    make_path_to_vrf_key, vrf_from_private_key, AccountKeyChain, KeyChainError,
-};
+use crate::key_chain::{make_path_to_vrf_key, AccountKeyChain, KeyChainError};
 use crate::send_request::{make_address_output, make_address_output_token, make_stake_output};
 use crate::{SendRequest, WalletError, WalletResult};
 use common::address::Address;
@@ -261,9 +259,11 @@ impl Account {
         db_tx: &impl WalletStorageReadUnlocked,
     ) -> WalletResult<(VRFPrivateKey, VRFPublicKey)> {
         let vrf_key_path = make_path_to_vrf_key(&self.chain_config, self.account_index());
-        let private_key =
-            self.key_chain.get_private_key_for_path(&vrf_key_path, db_tx)?.private_key();
-        Ok(vrf_from_private_key(&private_key))
+        let vrf_private_key =
+            self.key_chain.get_private_vrf_key_for_path(&vrf_key_path, db_tx)?.private_key();
+        let vrf_public_key = VRFPublicKey::from_private_key(&vrf_private_key);
+
+        Ok((vrf_private_key, vrf_public_key))
     }
 
     pub fn get_vrf_public_key(

--- a/wallet/src/key_chain/master_key_chain/mod.rs
+++ b/wallet/src/key_chain/master_key_chain/mod.rs
@@ -89,6 +89,14 @@ impl MasterKeyChain {
         Ok(key)
     }
 
+    pub fn load_root_vrf_key(
+        db_tx: &impl WalletStorageReadUnlocked,
+    ) -> KeyChainResult<ExtendedVRFPrivateKey> {
+        let key = db_tx.get_root_key()?.ok_or(KeyChainError::KeyChainNotInitialized)?.root_vrf_key;
+
+        Ok(key)
+    }
+
     /// Creates a Master key chain, checks the database for an existing one
     pub fn new_from_existing_database(
         chain_config: Arc<ChainConfig>,

--- a/wallet/src/key_chain/master_key_chain/mod.rs
+++ b/wallet/src/key_chain/master_key_chain/mod.rs
@@ -19,15 +19,15 @@ use common::chain::ChainConfig;
 use crypto::key::extended::ExtendedPrivateKey;
 use crypto::key::hdkd::derivable::Derivable;
 use crypto::key::hdkd::u31::U31;
-use itertools::Itertools;
+use crypto::vrf::ExtendedVRFPrivateKey;
 use std::sync::Arc;
 use utils::ensure;
 use wallet_storage::{
     StoreTxRwUnlocked, WalletStorageReadLocked, WalletStorageReadUnlocked,
     WalletStorageWriteUnlocked,
 };
-use wallet_types::{RootKeyContent, RootKeyId};
-use zeroize::Zeroize;
+
+use super::DEFAULT_VRF_KEY_KIND;
 
 pub struct MasterKeyChain {
     /// The specific chain this KeyChain is based on, this will affect the address format
@@ -38,14 +38,14 @@ impl MasterKeyChain {
     pub fn mnemonic_to_root_key(
         mnemonic_str: &str,
         passphrase: Option<&str>,
-    ) -> KeyChainResult<ExtendedPrivateKey> {
-        let mut mnemonic = bip39::Mnemonic::parse(mnemonic_str).map_err(KeyChainError::Bip39)?;
-        let mut seed = mnemonic.to_seed(passphrase.unwrap_or(""));
-        let root_key = ExtendedPrivateKey::new_master(&seed, DEFAULT_KEY_KIND)?;
-        // TODO(SECURITY) confirm that the mnemonic is erased on drop
-        mnemonic.zeroize();
-        seed.zeroize();
-        Ok(root_key)
+    ) -> KeyChainResult<(ExtendedPrivateKey, ExtendedVRFPrivateKey)> {
+        let mnemonic = zeroize::Zeroizing::new(
+            bip39::Mnemonic::parse(mnemonic_str).map_err(KeyChainError::Bip39)?,
+        );
+        let seed = zeroize::Zeroizing::new(mnemonic.to_seed(passphrase.unwrap_or("")));
+        let root_key = ExtendedPrivateKey::new_master(seed.as_ref(), DEFAULT_KEY_KIND)?;
+        let root_vrf_key = ExtendedVRFPrivateKey::new_master(seed.as_ref(), DEFAULT_VRF_KEY_KIND)?;
+        Ok((root_key, root_vrf_key))
     }
 
     pub fn new_from_mnemonic<B: storage::Backend>(
@@ -57,23 +57,26 @@ impl MasterKeyChain {
         // TODO: Do not store the master key here, store only the key relevant to the mintlayer
         // (see make_account_path)
 
-        let root_key = Self::mnemonic_to_root_key(mnemonic_str, passphrase)?;
-        Self::new_from_root_key(chain_config, db_tx, root_key)
+        let (root_key, root_vrf_key) = Self::mnemonic_to_root_key(mnemonic_str, passphrase)?;
+        Self::new_from_root_key(chain_config, db_tx, root_key, root_vrf_key)
     }
 
     pub fn new_from_root_key<B: storage::Backend>(
         chain_config: Arc<ChainConfig>,
         db_tx: &mut StoreTxRwUnlocked<B>,
         root_key: ExtendedPrivateKey,
+        root_vrf_key: ExtendedVRFPrivateKey,
     ) -> KeyChainResult<Self> {
         if !root_key.get_derivation_path().is_root() {
             return Err(KeyChainError::KeyNotRoot);
         }
 
-        let key_id = RootKeyId::from(root_key.to_public_key());
-        let key_content = RootKeyContent::from(root_key);
+        let key_content = wallet_types::keys::RootKeys {
+            root_key,
+            root_vrf_key,
+        };
 
-        db_tx.set_root_key(&key_id, &key_content)?;
+        db_tx.set_root_key(&key_content)?;
 
         Ok(MasterKeyChain { chain_config })
     }
@@ -81,12 +84,7 @@ impl MasterKeyChain {
     pub fn load_root_key(
         db_tx: &impl WalletStorageReadUnlocked,
     ) -> KeyChainResult<ExtendedPrivateKey> {
-        let key = db_tx
-            .get_all_root_keys()?
-            .into_values()
-            .exactly_one()
-            .map_err(|_| KeyChainError::OnlyOneRootKeyIsSupported)?
-            .into_key();
+        let key = db_tx.get_root_key()?.ok_or(KeyChainError::KeyChainNotInitialized)?.root_key;
 
         Ok(key)
     }
@@ -97,10 +95,9 @@ impl MasterKeyChain {
         db_tx: &impl WalletStorageReadLocked,
     ) -> KeyChainResult<Self> {
         ensure!(
-            db_tx.exactly_one_root_key()?,
-            KeyChainError::OnlyOneRootKeyIsSupported
+            db_tx.root_keys_exist()?,
+            KeyChainError::KeyChainNotInitialized
         );
-        // The current format supports a single root key
         Ok(MasterKeyChain { chain_config })
     }
 

--- a/wallet/src/key_chain/master_key_chain/mod.rs
+++ b/wallet/src/key_chain/master_key_chain/mod.rs
@@ -21,7 +21,6 @@ use crypto::key::hdkd::derivable::Derivable;
 use crypto::key::hdkd::u31::U31;
 use crypto::vrf::ExtendedVRFPrivateKey;
 use std::sync::Arc;
-use utils::ensure;
 use wallet_storage::{
     StoreTxRwUnlocked, WalletStorageReadLocked, WalletStorageReadUnlocked,
     WalletStorageWriteUnlocked,
@@ -102,10 +101,7 @@ impl MasterKeyChain {
         chain_config: Arc<ChainConfig>,
         db_tx: &impl WalletStorageReadLocked,
     ) -> KeyChainResult<Self> {
-        ensure!(
-            db_tx.root_keys_exist()?,
-            KeyChainError::KeyChainNotInitialized
-        );
+        db_tx.check_root_keys_sanity()?;
         Ok(MasterKeyChain { chain_config })
     }
 

--- a/wallet/src/key_chain/mod.rs
+++ b/wallet/src/key_chain/mod.rs
@@ -58,6 +58,7 @@ pub const BIP44_KEY_INDEX: usize = 4;
 
 /// Default cryptography type
 const DEFAULT_KEY_KIND: ExtendedKeyKind = ExtendedKeyKind::Secp256k1Schnorr;
+const DEFAULT_VRF_KEY_KIND: VRFKeyKind = VRFKeyKind::Schnorrkel;
 /// Default size of the number of unused addresses that need to be checked after the
 /// last used address.
 pub const LOOKAHEAD_SIZE: u32 = 20;
@@ -89,8 +90,8 @@ pub enum KeyChainError {
     KeysNotInSameHierarchy,
     #[error("Invalid key purpose index {0}")]
     InvalidKeyPurpose(ChildNumber),
-    #[error("Only one root key is supported")]
-    OnlyOneRootKeyIsSupported,
+    #[error("KeyChain not initialized missing root keys")]
+    KeyChainNotInitialized,
     #[error("Cannot issue more keys, lookahead exceeded")]
     LookAheadExceeded,
     #[error("The provided key is not a root in a hierarchy")]

--- a/wallet/src/key_chain/mod.rs
+++ b/wallet/src/key_chain/mod.rs
@@ -33,8 +33,7 @@ mod with_purpose;
 
 pub use account_key_chain::AccountKeyChain;
 use crypto::key::hdkd::u31::U31;
-use crypto::key::PrivateKey;
-use crypto::vrf::{VRFKeyKind, VRFPrivateKey, VRFPublicKey};
+use crypto::vrf::VRFKeyKind;
 pub use master_key_chain::MasterKeyChain;
 
 use common::address::pubkeyhash::PublicKeyHashError;
@@ -45,7 +44,6 @@ use crypto::key::extended::ExtendedKeyKind;
 use crypto::key::hdkd::child_number::ChildNumber;
 use crypto::key::hdkd::derivable::DerivationError;
 use crypto::key::hdkd::derivation_path::DerivationPath;
-use serialization::Encode;
 use wallet_types::keys::{KeyPurpose, KeyPurposeError};
 use wallet_types::AccountId;
 
@@ -149,15 +147,6 @@ fn get_purpose_and_index(
     })?;
     let key_index = path[BIP44_KEY_INDEX];
     Ok((purpose, key_index))
-}
-
-/// Derive a VRF private key from a normal PrivateKey
-pub fn vrf_from_private_key(private_key: &PrivateKey) -> (VRFPrivateKey, VRFPublicKey) {
-    // TODO: This whole thing is a temporary solution. The proper way is to use BIP-44 secrets.
-    let bytes = private_key.encode();
-    let key_hash = crypto::hash::hash::<crypto::hash::Sha3_512, _>(bytes);
-    VRFPrivateKey::new_using_random_bytes(&key_hash[0..32], VRFKeyKind::Schnorrkel)
-        .expect("should not fail")
 }
 
 #[cfg(test)]

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -96,7 +96,7 @@ fn get_address(
     purpose: KeyPurpose,
     address_index: U31,
 ) -> Address {
-    let root_key = MasterKeyChain::mnemonic_to_root_key(mnemonic, None).unwrap();
+    let (root_key, _root_vrf_key) = MasterKeyChain::mnemonic_to_root_key(mnemonic, None).unwrap();
     let mut address_path = make_account_path(chain_config, account_index).into_vec();
     address_path.push(purpose.get_deterministic_index());
     address_path.push(ChildNumber::from_normal(address_index));

--- a/wallet/storage/src/internal/mod.rs
+++ b/wallet/storage/src/internal/mod.rs
@@ -218,7 +218,7 @@ impl<B: storage::Backend> WalletStorageReadLocked for Store<B> {
         fn get_accounts_info(&self) -> crate::Result<BTreeMap<AccountId, AccountInfo>>;
         fn get_address(&self, id: &AccountDerivationPathId) -> crate::Result<Option<Address>>;
         fn get_addresses(&self, account_id: &AccountId) -> crate::Result<BTreeMap<AccountDerivationPathId, Address>>;
-        fn root_keys_exist(&self) -> crate::Result<bool>;
+        fn check_root_keys_sanity(&self) -> crate::Result<()>;
         fn get_keychain_usage_state(&self, id: &AccountKeyPurposeId) -> crate::Result<Option<KeychainUsageState>>;
         fn get_keychain_usage_states(&self, account_id: &AccountId) -> crate::Result<BTreeMap<AccountKeyPurposeId, KeychainUsageState>>;
         fn get_public_key(&self, id: &AccountDerivationPathId) -> crate::Result<Option<ExtendedPublicKey>>;

--- a/wallet/storage/src/internal/mod.rs
+++ b/wallet/storage/src/internal/mod.rs
@@ -218,7 +218,7 @@ impl<B: storage::Backend> WalletStorageReadLocked for Store<B> {
         fn get_accounts_info(&self) -> crate::Result<BTreeMap<AccountId, AccountInfo>>;
         fn get_address(&self, id: &AccountDerivationPathId) -> crate::Result<Option<Address>>;
         fn get_addresses(&self, account_id: &AccountId) -> crate::Result<BTreeMap<AccountDerivationPathId, Address>>;
-        fn exactly_one_root_key(&self) -> crate::Result<bool>;
+        fn root_keys_exist(&self) -> crate::Result<bool>;
         fn get_keychain_usage_state(&self, id: &AccountKeyPurposeId) -> crate::Result<Option<KeychainUsageState>>;
         fn get_keychain_usage_states(&self, account_id: &AccountId) -> crate::Result<BTreeMap<AccountKeyPurposeId, KeychainUsageState>>;
         fn get_public_key(&self, id: &AccountDerivationPathId) -> crate::Result<Option<ExtendedPublicKey>>;

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -168,7 +168,10 @@ macro_rules! impl_read_ops {
                     .map_err(crate::Error::from)
                     .map(Iterator::count)
                     .and_then(|count| {
-                        ensure!(count == 1, crate::Error::WalletWithoutARootKey);
+                        ensure!(
+                            count == 1,
+                            crate::Error::WalletSanityErrorInvalidRootKeyCount(count)
+                        );
                         Ok(())
                     })
             }

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -25,8 +25,8 @@ pub use internal::{Store, StoreTxRo, StoreTxRoUnlocked, StoreTxRw, StoreTxRwUnlo
 use std::collections::BTreeMap;
 
 use wallet_types::{
-    AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletTxId,
-    KeychainUsageState, RootKeyContent, RootKeyId, WalletTx,
+    keys::RootKeys, AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId,
+    AccountWalletTxId, KeychainUsageState, WalletTx,
 };
 
 /// Wallet Errors
@@ -64,7 +64,7 @@ pub trait WalletStorageReadLocked {
         &self,
         account_id: &AccountId,
     ) -> Result<BTreeMap<AccountDerivationPathId, Address>>;
-    fn exactly_one_root_key(&self) -> Result<bool>;
+    fn root_keys_exist(&self) -> Result<bool>;
     fn get_keychain_usage_state(
         &self,
         id: &AccountKeyPurposeId,
@@ -83,8 +83,7 @@ pub trait WalletStorageReadLocked {
 
 /// Queries on persistent wallet data with access to encrypted data
 pub trait WalletStorageReadUnlocked: WalletStorageReadLocked {
-    fn get_root_key(&self, id: &RootKeyId) -> Result<Option<RootKeyContent>>;
-    fn get_all_root_keys(&self) -> Result<BTreeMap<RootKeyId, RootKeyContent>>;
+    fn get_root_key(&self) -> Result<Option<RootKeys>>;
 }
 
 /// Queries on persistent wallet data for encryption
@@ -120,8 +119,8 @@ pub trait WalletStorageWriteLocked: WalletStorageReadLocked {
 
 /// Modifying operations on persistent wallet data with access to encrypted data
 pub trait WalletStorageWriteUnlocked: WalletStorageReadUnlocked + WalletStorageWriteLocked {
-    fn set_root_key(&mut self, id: &RootKeyId, content: &RootKeyContent) -> Result<()>;
-    fn del_root_key(&mut self, id: &RootKeyId) -> Result<()>;
+    fn set_root_key(&mut self, content: &RootKeys) -> Result<()>;
+    fn del_root_key(&mut self) -> Result<()>;
 }
 
 /// Modifying operations on persistent wallet data for encryption

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -44,8 +44,8 @@ pub enum Error {
     WalletAlreadyUnlocked,
     #[error("Cannot lock the wallet without setting a password")]
     WalletLockedWithoutAPassword,
-    #[error("Wallet file without a root key")]
-    WalletWithoutARootKey,
+    #[error("Wallet file corrupted root keys expected 1 got {0}")]
+    WalletSanityErrorInvalidRootKeyCount(usize),
 }
 
 /// Possibly failing result of wallet storage query

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -44,6 +44,8 @@ pub enum Error {
     WalletAlreadyUnlocked,
     #[error("Cannot lock the wallet without setting a password")]
     WalletLockedWithoutAPassword,
+    #[error("Wallet file without a root key")]
+    WalletWithoutARootKey,
 }
 
 /// Possibly failing result of wallet storage query
@@ -64,7 +66,7 @@ pub trait WalletStorageReadLocked {
         &self,
         account_id: &AccountId,
     ) -> Result<BTreeMap<AccountDerivationPathId, Address>>;
-    fn root_keys_exist(&self) -> Result<bool>;
+    fn check_root_keys_sanity(&self) -> Result<()>;
     fn get_keychain_usage_state(
         &self,
         id: &AccountKeyPurposeId,

--- a/wallet/storage/src/schema.rs
+++ b/wallet/storage/src/schema.rs
@@ -15,13 +15,13 @@
 
 //! Wallet database schema
 
-use crate::RootKeyContent;
 use common::address::Address;
 use crypto::key::extended::ExtendedPublicKey;
 use utils::maybe_encrypted::MaybeEncrypted;
 use wallet_types::{
+    keys::{RootKeyConstant, RootKeys},
     AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletTxId,
-    KeychainUsageState, RootKeyId, WalletTx,
+    KeychainUsageState, WalletTx,
 };
 
 storage::decl_schema! {
@@ -34,7 +34,7 @@ storage::decl_schema! {
         /// Store keychain usage states
         pub DBKeychainUsageStates: Map<AccountKeyPurposeId, KeychainUsageState>,
         /// Store for all the private keys in this wallet
-        pub DBRootKeys: Map<RootKeyId, MaybeEncrypted<RootKeyContent>>,
+        pub DBRootKeys: Map<RootKeyConstant, MaybeEncrypted<RootKeys>>,
         /// Store for all the public keys in this wallet
         pub DBPubKeys: Map<AccountDerivationPathId, ExtendedPublicKey>,
         /// Store for all the addresses that belong to an account

--- a/wallet/types/src/keys.rs
+++ b/wallet/types/src/keys.rs
@@ -119,6 +119,8 @@ impl KeychainUsageState {
     }
 }
 
+/// Just an empty struct used as key for the DB table
+/// It only represents a single value as there can be only one root key
 #[derive(PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
 pub struct RootKeyConstant;
 

--- a/wallet/types/src/keys.rs
+++ b/wallet/types/src/keys.rs
@@ -14,9 +14,10 @@
 // limitations under the License.
 
 use crate::keys::KeyPurpose::{Change, ReceiveFunds};
-use crypto::key::extended::{ExtendedPrivateKey, ExtendedPublicKey};
+use crypto::key::extended::ExtendedPrivateKey;
 use crypto::key::hdkd::child_number::ChildNumber;
 use crypto::key::hdkd::u31::U31;
+use crypto::vrf::ExtendedVRFPrivateKey;
 use serialization::{Decode, Encode};
 
 /// The index of the receiving key hierarchy
@@ -118,40 +119,13 @@ impl KeychainUsageState {
     }
 }
 
-/// The key id is described by it's public key
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
-pub struct RootKeyId(ExtendedPublicKey);
+#[derive(PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+pub struct RootKeyConstant;
 
-impl RootKeyId {
-    pub fn into_key(self) -> ExtendedPublicKey {
-        self.0
-    }
-}
-
-impl From<ExtendedPublicKey> for RootKeyId {
-    fn from(key: ExtendedPublicKey) -> Self {
-        Self(key)
-    }
-}
-
-/// The useful content of this key e.g. a private key or an address depending on the usage
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
-pub struct RootKeyContent(ExtendedPrivateKey);
-
-impl RootKeyContent {
-    pub fn into_key(self) -> ExtendedPrivateKey {
-        self.0
-    }
-
-    pub fn as_key(&self) -> &ExtendedPrivateKey {
-        &self.0
-    }
-}
-
-impl From<ExtendedPrivateKey> for RootKeyContent {
-    fn from(key: ExtendedPrivateKey) -> Self {
-        Self(key)
-    }
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct RootKeys {
+    pub root_key: ExtendedPrivateKey,
+    pub root_vrf_key: ExtendedVRFPrivateKey,
 }
 
 #[cfg(test)]

--- a/wallet/types/src/lib.rs
+++ b/wallet/types/src/lib.rs
@@ -21,5 +21,5 @@ pub mod wallet_tx;
 
 pub use account_id::{AccountDerivationPathId, AccountId, AccountKeyPurposeId, AccountWalletTxId};
 pub use account_info::AccountInfo;
-pub use keys::{KeyPurpose, KeychainUsageState, RootKeyContent, RootKeyId};
+pub use keys::{KeyPurpose, KeychainUsageState, RootKeys};
 pub use wallet_tx::{BlockInfo, WalletTx};

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -116,7 +116,7 @@ fn create_custom_regtest_genesis(rng: &mut impl Rng) -> Genesis {
     );
 
     let vrf_pub_key = decode_hex::<VRFPublicKey>(
-        "00d88105442d4af7dd6c3464c44d1ef7a1b0df363279742dd2139573f58c7c6153",
+        "0020b95f66e824fc0df1ff13ba63d6727e013e1ea465cc37c2415a69cc408cf375",
     );
 
     let mint_output = TxOutput::Transfer(

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -116,7 +116,7 @@ fn create_custom_regtest_genesis(rng: &mut impl Rng) -> Genesis {
     );
 
     let vrf_pub_key = decode_hex::<VRFPublicKey>(
-        "007a0d90de05984977d4b3cb3f75342a81820a8ec79aa95181186b67fc93ed5a2e",
+        "00d88105442d4af7dd6c3464c44d1ef7a1b0df363279742dd2139573f58c7c6153",
     );
 
     let mint_output = TxOutput::Transfer(


### PR DESCRIPTION
- remove the temporary solution that was creating VRF keys from a secp256k1 key hash
- generate and store a root VRF key from the seed phrase
- derive the account VRF keys from the root VRF key and the derivation path as in BIP44

closes #929 