### PR TITLE
mempool: Transaction eviction

### DIFF
--- a/mempool/src/config.rs
+++ b/mempool/src/config.rs
@@ -17,6 +17,32 @@ use std::time::Duration;
 
 pub type Time = Duration;
 
+/// Mempool size configuration
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Clone, Copy)]
+pub struct MempoolMaxSize(usize);
+
+impl MempoolMaxSize {
+    pub fn from_bytes(n: usize) -> Self {
+        Self(n)
+    }
+
+    pub fn as_bytes(&self) -> usize {
+        self.0
+    }
+}
+
+impl Default for MempoolMaxSize {
+    fn default() -> Self {
+        Self::from_bytes(MAX_MEMPOOL_SIZE_BYTES)
+    }
+}
+
+impl std::fmt::Display for MempoolMaxSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}B", self.0)
+    }
+}
+
 pub const ENABLE_RBF: bool = false;
 
 // Number of times we try to add transaction if the tip moves during validation

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2022-2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{error::Error, tx_accumulator::TransactionAccumulator, MempoolEvent, TxStatus};
+use crate::{
+    error::Error, tx_accumulator::TransactionAccumulator, MempoolEvent, MempoolMaxSize, TxStatus,
+};
 use common::{
     chain::{GenBlock, SignedTransaction, Transaction},
     primitives::Id,
@@ -54,6 +56,15 @@ pub trait MempoolInterface: Send + Sync {
         &mut self,
         handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>,
     ) -> Result<(), Error>;
+
+    /// Get current memory usage
+    fn memory_usage(&self) -> usize;
+
+    /// Get maximum mempool size
+    fn get_max_size(&self) -> MempoolMaxSize;
+
+    /// Set the maximum mempool size
+    fn set_max_size(&mut self, max_size: MempoolMaxSize) -> Result<(), Error>;
 }
 
 #[async_trait::async_trait]

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     error::Error, pool::memory_usage_estimator::StoreMemoryUsageEstimator,
-    tx_accumulator::TransactionAccumulator, MempoolEvent, MempoolInterface,
+    tx_accumulator::TransactionAccumulator, MempoolEvent, MempoolInterface, MempoolMaxSize,
     MempoolSubsystemInterface, TxStatus,
 };
 use chainstate::chainstate_interface::ChainstateInterface;
@@ -145,6 +145,18 @@ impl MempoolInterface for Mempool {
     ) -> Result<(), Error> {
         self.subscribe_to_events(handler);
         Ok(())
+    }
+
+    fn memory_usage(&self) -> usize {
+        Mempool::memory_usage(self)
+    }
+
+    fn get_max_size(&self) -> MempoolMaxSize {
+        self.max_size()
+    }
+
+    fn set_max_size(&mut self, max_size: MempoolMaxSize) -> Result<(), Error> {
+        self.set_max_size(max_size)
     }
 }
 

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -19,6 +19,7 @@ use common::{
     chain::Block,
     primitives::{BlockHeight, Id},
 };
+pub use config::MempoolMaxSize;
 pub use interface::{
     mempool_interface::{MempoolInterface, MempoolSubsystemInterface},
     mempool_interface_impl::make_mempool,

--- a/mempool/src/pool/memory_usage_estimator.rs
+++ b/mempool/src/pool/memory_usage_estimator.rs
@@ -23,10 +23,7 @@ pub trait MemoryUsageEstimator: Send + Sync + 'static {
 pub struct StoreMemoryUsageEstimator;
 
 impl MemoryUsageEstimator for StoreMemoryUsageEstimator {
-    fn estimate_memory_usage(&self, _store: &MempoolStore) -> usize {
-        // TODO: Just a temporary value to emulate the original behavior. In order for eviction to
-        // work properly, we need to get transaction verifier and mempool to agree on transaction
-        // dependencies.
-        0
+    fn estimate_memory_usage(&self, store: &MempoolStore) -> usize {
+        store.memory_usage()
     }
 }

--- a/mempool/src/pool/orphans/mod.rs
+++ b/mempool/src/pool/orphans/mod.rs
@@ -157,7 +157,7 @@ impl TxOrphanPool {
         !entry.requires().any(|dep| match dep {
             // Always consider account deps. TODO: can be optimized in the future
             TxDependency::DelegationAccount(_) => false,
-            TxDependency::Transaction(tx_id) => self.maps.by_tx_id.contains_key(&tx_id),
+            TxDependency::TxOutput(tx_id, _) => self.maps.by_tx_id.contains_key(&tx_id),
         })
     }
 

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -164,7 +164,6 @@ impl MempoolStore {
         self.txs_by_id.contains_key(id)
     }
 
-    #[allow(unused)]
     pub fn memory_usage(&self) -> usize {
         self.mem_tracker.get_usage()
     }

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::{memory_usage_estimator::StoreMemoryUsageEstimator, *};
-use crate::tx_accumulator::DefaultTxAccumulator;
+use crate::{config::MempoolMaxSize, tx_accumulator::DefaultTxAccumulator};
 use ::utils::atomics::SeqCstAtomicU64;
 use chainstate::{
     make_chainstate, BlockSource, ChainstateConfig, DefaultTransactionVerificationStrategy,
@@ -1576,7 +1576,7 @@ async fn mempool_full_real(#[case] seed: Seed) {
     // Set up mempool such that exactly one of the transactions does not fit
     let tf = TestFramework::builder(&mut rng).build();
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
-    mempool.max_size = memory_size - 1;
+    mempool.max_size = MempoolMaxSize::from_bytes(memory_size - 1);
 
     // Attempt to add all the transactions but one
     let (last_tx, initial_txs) = txs.split_last().unwrap();
@@ -1596,7 +1596,7 @@ async fn mempool_full_real(#[case] seed: Seed) {
 
     // Bump the memory limit again, and re-insert the evicted transaction(s). Also reset the
     // rolling fee since recently evicted transactions bump it up.
-    mempool.max_size = memory_size;
+    mempool.max_size = MempoolMaxSize::from_bytes(memory_size);
     mempool.drop_rolling_fee();
 
     for tx in txs {

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -1495,7 +1495,7 @@ fn check_txs_sorted_by_descendant_sore<M>(mempool: &Mempool<M>) {
 #[trace]
 #[case(Seed::from_entropy())]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn mempool_full(#[case] seed: Seed) -> anyhow::Result<()> {
+async fn mempool_full_mock(#[case] seed: Seed) -> anyhow::Result<()> {
     logging::init_logging::<&str>(None);
 
     let mut rng = make_seedable_rng(seed);
@@ -1532,6 +1532,88 @@ async fn mempool_full(#[case] seed: Seed) -> anyhow::Result<()> {
     assert_eq!(res, Err(MempoolPolicyError::MempoolFull.into()));
     mempool.store.assert_valid();
     Ok(())
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[case::fail(Seed(1))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mempool_full_real(#[case] seed: Seed) {
+    logging::init_logging::<&str>(None);
+    let mut rng = make_seedable_rng(seed);
+
+    let num_txs = rng.gen_range(5..20);
+    let time = TimeGetter::default().get_time();
+    let txs: Vec<_> = generate_transaction_graph(&mut rng, time).take(num_txs).collect();
+
+    let encoded_size: usize = txs.iter().map(|tx| tx.transaction().encoded_size()).sum();
+
+    // Get total memory size without memory limit
+    let memory_size = {
+        let mut storage = MempoolStore::new();
+        for entry in &txs {
+            storage.add_transaction(entry.clone()).expect("tx insertion to succeed");
+            log::trace!("Storage mem usage updated: {}", storage.memory_usage());
+        }
+
+        // Dump some stats. Useful for rough insights into the overhead taken up by mempool
+        // metadata compared to "raw" encoded transaction size.
+        log::debug!(
+            "STATS: {} txs, {} ins, {} outs, {}B encoded, {}B mem consumption",
+            num_txs,
+            txs.iter().map(|tx| tx.transaction().inputs().len()).sum::<usize>(),
+            txs.iter().map(|tx| tx.transaction().outputs().len()).sum::<usize>(),
+            encoded_size,
+            storage.memory_usage(),
+        );
+
+        storage.memory_usage()
+    };
+
+    assert!(memory_size >= encoded_size);
+
+    // Set up mempool such that exactly one of the transactions does not fit
+    let tf = TestFramework::builder(&mut rng).build();
+    let mut mempool = setup_with_chainstate(tf.chainstate()).await;
+    mempool.max_size = memory_size - 1;
+
+    // Attempt to add all the transactions but one
+    let (txs, last_tx) = {
+        let mut txs = txs;
+        let last_tx = txs.pop().unwrap();
+        (txs, last_tx)
+    };
+    for tx in &txs {
+        let (entry, _) = tx.clone().into_entry_and_fee();
+        assert_eq!(
+            mempool.add_transaction_entry(entry),
+            Ok(TxStatus::InMempool)
+        );
+        log::trace!("Mempool mem usage updated: {}", mempool.memory_usage());
+    }
+    assert_eq!(mempool.store.txs_by_id.len(), num_txs - 1);
+
+    // Add the last transaction, check the memory limit kicked in and the total number of
+    // transactions has not increased.
+    let (last_tx, _) = last_tx.into_entry_and_fee();
+    let _ = mempool.add_transaction_entry(last_tx);
+    assert!(mempool.store.txs_by_id.len() < num_txs);
+
+    // Bump the memory limit again, and re-insert the evicted transaction(s)
+    mempool.max_size = memory_size;
+    for tx in txs {
+        if mempool.contains_transaction(tx.tx_id()) {
+            continue;
+        }
+        let (entry, _) = tx.into_entry_and_fee();
+        assert_eq!(
+            mempool.add_transaction_entry(entry),
+            Ok(TxStatus::InMempool)
+        );
+    }
+
+    assert_eq!(mempool.store.txs_by_id.len(), num_txs, "Some txs missing");
 }
 
 #[rstest]

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -24,7 +24,7 @@ use common::{
 use mempool::{
     error::{Error, TxValidationError},
     tx_accumulator::TransactionAccumulator,
-    MempoolEvent, MempoolInterface, MempoolSubsystemInterface, TxStatus,
+    MempoolEvent, MempoolInterface, MempoolMaxSize, MempoolSubsystemInterface, TxStatus,
 };
 use subsystem::{subsystem::CallError, CallRequest, ShutdownRequest};
 use utils::atomics::AcqRelAtomicBool;
@@ -145,6 +145,18 @@ impl MempoolInterface for MempoolInterfaceMock {
         } else {
             Ok(())
         }
+    }
+
+    fn memory_usage(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn get_max_size(&self) -> MempoolMaxSize {
+        unimplemented!()
+    }
+
+    fn set_max_size(&mut self, _max_size: MempoolMaxSize) -> Result<(), Error> {
+        unimplemented!()
     }
 }
 

--- a/test/functional/mempool_basic_reorg.py
+++ b/test/functional/mempool_basic_reorg.py
@@ -8,7 +8,6 @@ Check that:
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mintlayer import *
-import time
 
 class MempoolTxSubmissionTest(BitcoinTestFramework):
 

--- a/test/functional/mempool_eviction.py
+++ b/test/functional/mempool_eviction.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Mempool tx eviction test
+
+Check that:
+* Transactions are properly evicted from mempool if size limit is reached
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+from test_framework.mintlayer import *
+import time
+
+class MempoolTxEvictionTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[]]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.sync_all(self.nodes[0:1])
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Get chain tip
+        genesis_id = node.chainstate_best_block_id()
+        self.log.debug('Initial tip: {}'.format(genesis_id))
+
+        # Prepare three transactions, each spending the previous one in sequence
+        (tx1, tx1_id) = make_tx([ reward_input(genesis_id) ], [ 1_000_000 ] )
+        (tx2, tx2_id) = make_tx([ tx_input(tx1_id) ], [ 900_000 ] )
+        (tx3, tx3_id) = make_tx([ tx_input(tx2_id) ], [ 800_000 ] )
+
+        # Submit the transactions
+        node.mempool_submit_transaction(tx1)
+        node.mempool_submit_transaction(tx2)
+        node.mempool_submit_transaction(tx3)
+        assert node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2_id)
+        assert node.mempool_contains_tx(tx3_id)
+
+        # Set the mempool limit to evict the last transaction
+        node.mempool_set_max_size(node.mempool_memory_usage() - 1)
+        assert node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2_id)
+        assert not node.mempool_contains_tx(tx3_id)
+
+        # Try to re-add the transaction, check it failed
+        assert_raises_rpc_error(None, "fee threshold not met", node.mempool_submit_transaction, tx3)
+
+        # Set the mempool limit to evict the second last transaction too
+        node.mempool_set_max_size(node.mempool_memory_usage() - 1)
+        assert node.mempool_contains_tx(tx1_id)
+        assert not node.mempool_contains_tx(tx2_id)
+        assert not node.mempool_contains_tx(tx3_id)
+
+        # Reset the mempool size to fit all transactions. Submit the missing transactions again
+        # in the opposite order, check they both make their way in.
+        node.mempool_set_max_size(300_000_000)
+        node.mempool_submit_transaction(tx3)
+        node.mempool_submit_transaction(tx2)
+        assert node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2_id)
+        assert node.mempool_contains_tx(tx3_id)
+
+        # Evict all transactions and reset the size afterwards
+        node.mempool_set_max_size(20)
+        node.mempool_set_max_size(300_000_000)
+        assert not node.mempool_contains_tx(tx1_id)
+
+        # Add a transaction that pays two outputs
+        (tx1, tx1_id) = make_tx([ reward_input(genesis_id) ], [ 100_000_000, 100_000_000 ])
+        node.mempool_submit_transaction(tx1)
+
+        # Add two transactions with CPFP semantics
+        (tx2a, tx2a_id) = make_tx([ tx_input(tx1_id) ], [ 99_000_000 ])
+        (tx3a, tx3a_id) = make_tx([ tx_input(tx2a_id) ], [ 90_000_000 ])
+        node.mempool_submit_transaction(tx2a)
+        node.mempool_submit_transaction(tx3a)
+
+        # Limit the mempool size so no more transactions fit
+        node.mempool_set_max_size(node.mempool_memory_usage())
+        assert node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2a_id)
+        assert node.mempool_contains_tx(tx3a_id)
+
+        # Add a transaction that pays higher fees than the previous two, so both need to be evicted
+        (tx2b, tx2b_id) = make_tx([ tx_input(tx1_id, index = 1) ], [ 50_000_000, 5_000_000 ])
+        node.mempool_submit_transaction(tx2b)
+        assert node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2b_id)
+        assert not node.mempool_contains_tx(tx2a_id)
+        assert not node.mempool_contains_tx(tx3a_id)
+
+
+if __name__ == '__main__':
+    MempoolTxEvictionTest().main()
+

--- a/test/functional/test_framework/mintlayer.py
+++ b/test/functional/test_framework/mintlayer.py
@@ -58,7 +58,7 @@ def make_tx(inputs, output_amounts, flags = 0):
     }
     signed_tx = {
         'transaction': tx,
-        'signatures': [witness for _ in outputs],
+        'signatures': [witness for _ in inputs],
     }
     tx_id = hash_object(base_tx_obj, tx)
     encoded_tx = signed_tx_obj.encode(signed_tx).to_hex()[2:]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -106,6 +106,7 @@ BASE_SCRIPTS = [
     'p2p_relay_transactions.py',
     'feature_lmdb_backend_test.py',
     'mempool_basic_reorg.py',
+    'mempool_eviction.py',
     'mempool_submit_tx.py',
     'mempool_submit_orphan.py',
 

--- a/utils/src/graph_traversals.rs
+++ b/utils/src/graph_traversals.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+
+/// Generic depth-first traversal over a DAG in post order.
+///
+/// This function produces an iterator which yields elements of a post-order traversal of given
+/// directed acyclic graph starting at given root. Graph edges are characterized by the `children`
+/// parameter which is a function that, given an element (node), produces an iterator over elements
+/// that are pointed to by it.
+///
+/// Note the input has to be a DAG. The algorithm does not check for cycles.
+pub fn dag_depth_postorder<'a, T, I, F>(root: T, children: F) -> impl Iterator<Item = T> + 'a
+where
+    T: Clone + Ord + 'a,
+    I: IntoIterator<Item = T> + 'a,
+    F: Fn(&T) -> I + 'a,
+{
+    // Keep track of already visited items
+    let mut visited = BTreeSet::from_iter([root.clone()]);
+
+    // Stack of items paired with iterator over the item's children that have to be visited before
+    // the item itself is emitted.
+    let mut stack = vec![(children(&root).into_iter(), root)];
+
+    let iter_fn = move || {
+        stack.pop().map(|(mut top_children, mut top_item)| {
+            // Keep pushing items onto the stack until we find one with no further children.
+            while let Some(next_top_item) = top_children.next() {
+                if visited.contains(&next_top_item) {
+                    continue;
+                }
+
+                stack.push((top_children, top_item));
+                visited.insert(next_top_item.clone());
+
+                top_item = next_top_item;
+                top_children = children(&top_item).into_iter();
+            }
+
+            top_item
+        })
+    };
+
+    std::iter::from_fn(iter_fn)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn sequence() {
+        let children = |n: &i32| std::iter::once(*n + 1).filter(|n| *n < 5);
+        let traversal: Vec<_> = dag_depth_postorder(0, children).collect();
+        assert_eq!(traversal, vec![4, 3, 2, 1, 0]);
+    }
+
+    #[test]
+    fn lattice() {
+        let children = |n: &i32| {
+            let children = match n {
+                0 => &[1, 2, 3][..],
+                1 | 2 | 3 => &[4][..],
+                4 => &[][..],
+                _ => panic!("unreachable graph node"),
+            };
+            children.iter().copied()
+        };
+        let traversal: Vec<_> = dag_depth_postorder(0, children).collect();
+        assert_eq!(traversal, vec![4, 1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn diamond_refs() {
+        let children = |n: &&i32| {
+            let children = match n {
+                0 => &[1, 2][..],
+                1 | 2 => &[3][..],
+                3 => &[][..],
+                _ => panic!("unreachable graph node"),
+            };
+            children.iter()
+        };
+        let traversal: Vec<_> = dag_depth_postorder(&0, children).collect();
+        assert_eq!(traversal, vec![&3, &1, &2, &0]);
+    }
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -24,6 +24,7 @@ pub mod default_data_dir;
 pub mod ensure;
 pub mod eventhandler;
 pub mod exp_rand;
+pub mod graph_traversals;
 pub mod maybe_encrypted;
 pub mod newtype;
 pub mod once_destructor;


### PR DESCRIPTION
* Make mempool transaction dependencies more precise
* Evict transactions from mempool (and disconnect from its tx verifier) when mempool is full
* Transactions are removed in depth-first post-order starting from the evicted transaction to make sure they are disconnected in the correct order
* There's a (very inefficient) fallback mechanism in case transaction verifier and mempool still disagree about transaction dependencies. Ideally there would be single point of truth for this but does not seem to be easily achievable at the moment so left for future work.