### PR TITLE
Use a dedicated error when initializing net upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,6 @@ checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
 name = "common"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bech32",
  "bitcoin-bech32",
  "crypto",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,7 +16,6 @@ serialization = { path = "../serialization" }
 typename = { path = "../utils/typename" }
 utils = {path = '../utils'}
 
-anyhow.workspace = true
 bech32.workspace = true
 fixed-hash.workspace = true
 generic-array.workspace = true


### PR DESCRIPTION
Removes dependency to `anyhow` in the common library crate.