### PR TITLE
Allow only a single in-flight peer request per transaction

### DIFF
--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -23,8 +23,11 @@ use chainstate::{
 };
 use chainstate_test_framework::TestFramework;
 use common::{
-    chain::{config::ChainConfig, Block},
-    primitives::Idable,
+    chain::{
+        config::ChainConfig, signature::inputsig::InputWitness, tokens::OutputValue, Block,
+        GenBlock, OutPointSourceId, SignedTransaction, Transaction, TxInput, TxOutput,
+    },
+    primitives::{Amount, Id, Idable},
     time_getter::TimeGetter,
 };
 use mempool::{MempoolHandle, MempoolSubsystemInterface};
@@ -88,6 +91,16 @@ pub fn create_n_blocks(tf: &mut TestFramework, n: usize) -> Vec<Block> {
     }
 
     blocks
+}
+
+pub fn create_simple_transaction(out_point: Id<GenBlock>) -> SignedTransaction {
+    let tx = Transaction::new(
+        0x00,
+        vec![TxInput::from_utxo(OutPointSourceId::from(out_point), 0)],
+        vec![TxOutput::Burn(OutputValue::Coin(Amount::from_atoms(1)))],
+    )
+    .unwrap();
+    SignedTransaction::new(tx, vec![InputWitness::NoSignature(None)]).unwrap()
 }
 
 pub struct P2pBasicTestTimeGetter {

--- a/p2p/src/sync/request_tracker.rs
+++ b/p2p/src/sync/request_tracker.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use common::{chain::Transaction, primitives::Id};
+use futures::never::Never;
+use logging::log;
+use tokio::sync::mpsc;
+
+use crate::{
+    sync::types::{PeerEvent, RequestTrackerEvent},
+    types::peer_id::PeerId,
+    utils::oneshot_queue::OneshotQueue,
+};
+
+/// Request tracker is responsible for tracking resource requests among peers.
+///
+/// For example, we may receive identical transaction announcements from multiple peers
+/// concurrently. We want to only allow a single in-flight transaction body request. For that, a
+/// peer must first get a permit from request tracker before executing the request.
+pub struct RequestTracker {
+    peer_event_receiver: mpsc::UnboundedReceiver<PeerEvent>,
+
+    /// Channel for communication between peers and request tracker.
+    request_tracker_receiver: mpsc::UnboundedReceiver<RequestTrackerEvent>,
+
+    // Map of transactions for which we need to request a body.
+    pending_transaction_requests: BTreeMap<Id<Transaction>, OneshotQueue<PeerId>>,
+}
+
+impl RequestTracker {
+    pub fn new(
+        peer_event_receiver: mpsc::UnboundedReceiver<PeerEvent>,
+        request_tracker_receiver: mpsc::UnboundedReceiver<RequestTrackerEvent>,
+    ) -> Self {
+        Self {
+            peer_event_receiver,
+            request_tracker_receiver,
+            pending_transaction_requests: BTreeMap::new(),
+        }
+    }
+
+    pub async fn run(mut self) -> Never {
+        log::info!("Starting request tracker");
+
+        loop {
+            tokio::select! {
+                event = self.peer_event_receiver.recv() => {
+                    if let Some(event) = event {
+                        self.handle_peer_event(event);
+                    }
+                },
+
+                event = self.request_tracker_receiver.recv() => {
+                    if let Some(event) = event {
+                        self.handle_request_tracker_event(event);
+                    }
+                },
+            }
+        }
+    }
+
+    fn handle_peer_event(&mut self, event: PeerEvent) {
+        match event {
+            PeerEvent::Disconnected(peer_id) => {
+                self.remove_pending_transaction_requests_for_peer(peer_id);
+            }
+        }
+    }
+
+    fn handle_request_tracker_event(&mut self, event: RequestTrackerEvent) {
+        match event {
+            RequestTrackerEvent::RequestTransactionPermit(payload) => {
+                let requests = &mut self.pending_transaction_requests;
+                match requests.get_mut(&payload.tx_id) {
+                    Some(queue) => {
+                        // The transaction is in progress. Enqueue this peer transaction request.
+                        payload.allow_tx.send(queue.enqueue(payload.peer_id))
+                    }
+                    None => {
+                        // The transaction is not in progress. Create a queue for processing peer
+                        // transaction requests.
+                        let mut queue = OneshotQueue::new();
+                        // Enqueue the peer.
+                        payload.allow_tx.send(queue.enqueue(payload.peer_id));
+                        // Allow the enqueued peer to immediately process.
+                        queue.send_dequeue();
+                        requests.insert(payload.tx_id, queue);
+                    }
+                }
+            }
+            RequestTrackerEvent::CompleteTransaction(payload) => {
+                let requests = &mut self.pending_transaction_requests;
+                match payload.result {
+                    Ok(_) => {
+                        // If the transaction was processed successfully, remove it from the map.
+                        // Remaining waiters get automatically cancelled after drop.
+                        requests.remove(&payload.tx_id);
+                    }
+                    Err(_) => {
+                        // If the transaction failed, notify the next peer in the queue, if any.
+                        let Some(queue) = requests.get_mut(&payload.tx_id) else {
+                            return;
+                        };
+
+                        if queue.send_dequeue().is_some() {
+                            log::debug!(
+                                "failed to request transaction {} from peer {}; trying next peer",
+                                payload.tx_id,
+                                payload.peer_id,
+                            );
+                        } else {
+                            log::warn!(
+                                "failed to request transaction {} from peer {}; no more peers \
+                                available for the transaction",
+                                payload.tx_id,
+                                payload.peer_id,
+                            );
+                            requests.remove(&payload.tx_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn remove_pending_transaction_requests_for_peer(&mut self, peer_id: PeerId) {
+        let requests = &mut self.pending_transaction_requests;
+        let mut tx_to_remove = vec![];
+        for (tx_id, gate) in requests.iter_mut() {
+            if gate.remove(&peer_id).is_none() && gate.send_dequeue().is_none() {
+                tx_to_remove.push(*tx_id);
+            }
+        }
+        for tx in tx_to_remove {
+            requests.remove(&tx);
+        }
+    }
+}

--- a/p2p/src/utils/mod.rs
+++ b/p2p/src/utils/mod.rs
@@ -14,4 +14,5 @@
 // limitations under the License.
 
 pub mod oneshot_nofail;
+pub mod oneshot_queue;
 pub mod rate_limiter;

--- a/p2p/src/utils/oneshot_queue.rs
+++ b/p2p/src/utils/oneshot_queue.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+
+use tokio::sync::oneshot::{channel, Receiver, Sender};
+
+/// A queue to notify receivers in a oneshot manner.
+#[derive(Debug)]
+pub struct OneshotQueue<K: Eq> {
+    queue: VecDeque<(K, Sender<()>)>,
+}
+
+impl<K: Eq> OneshotQueue<K> {
+    pub fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+
+    /// Appends a listener to the back of the queue. Stores the listener key. This key is later
+    /// returned through `send_dequeue` to inform the caller who is next.
+    pub fn enqueue(&mut self, key: K) -> Receiver<()> {
+        let (tx, rx) = channel();
+        self.queue.push_back((key, tx));
+        rx
+    }
+
+    /// Attempts to send a value to the next listener in the queue. Returns the listener key when
+    /// a listener was available.
+    pub fn send_dequeue(&mut self) -> Option<K> {
+        if let Some((key, tx)) = self.queue.pop_front() {
+            let _ = tx.send(());
+            return Some(key);
+        }
+        None
+    }
+
+    /// Removes and returns the element matching `key` from the queue.
+    pub fn remove(&mut self, key: &K) -> Option<K> {
+        // While this is computationally O(n), it is a deliberate trade-off. We want the subscribers
+        // to form a FIFO queue. Therefore, we don't use a `BTreeMap`, for example. In most cases,
+        // we expect all the subscribers to get dropped. This makes this method not to be on a hot
+        // path. It can tolerate a sub-optimal complexity.
+        let mut index = None;
+        for (i, (k, _)) in self.queue.iter().enumerate() {
+            if k == key {
+                index = Some(i);
+                break;
+            }
+        }
+        index.and_then(|i| self.queue.remove(i).map(|(key, _)| key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn enqueue_send_dequeue_remove() {
+        let mut target = OneshotQueue::new();
+        let first = target.enqueue(1);
+        let second = target.enqueue(2);
+        let third = target.enqueue(3);
+
+        assert_eq!(target.remove(&2), Some(2));
+        assert!(matches!(
+            second.await,
+            Err(oneshot::error::RecvError { .. })
+        ));
+
+        assert_eq!(target.send_dequeue(), Some(1));
+        assert_eq!(first.await, Ok(()));
+
+        drop(target);
+        assert!(matches!(third.await, Err(oneshot::error::RecvError { .. })));
+    }
+
+    #[tokio::test]
+    async fn empty_queue() {
+        let mut target = OneshotQueue::new();
+
+        assert_eq!(target.remove(&1), None);
+        assert_eq!(target.send_dequeue(), None);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/mintlayer/mintlayer-core/issues/829

## Problem

Currently, when we receive the same transaction announcement from multiple peers, we request the transaction body from all of them. In most cases, this is unnecessary.

## Solution

Use block sync manager to synchronize transaction requests. Block sync manager acts a bit like a semaphore with a single permit. Competing peers are permitted in a FIFO order. Every transaction is synchronized separately.

If a peer successfully completes the transaction request, other waiting peers are cancelled. If a peer fails the transaction request (due to a timeout in receiving a response, for example) or gets disconnected, next waiting peer is permitted. If there are no more available peers for the transaction, the transaction body request is dropped.

## Questions / Considerations

- Should we allow requesting transaction body from more than a single peer at a time? For example, we could make this configurable. This would increase the chance of successfully receiving a transaction body early.

-----

Below are three different scenarios that have been tested. In all the scenarios two peers want to request for the same transaction body.

- Peer 1 succeeds, peer 2 is cancelled

![image](https://github.com/mintlayer/mintlayer-core/assets/2970736/ed4478ef-5605-46f6-b880-f163cc85157a)

- Peer 1 fails due to a timeout, peer 2 succeeds

![image](https://github.com/mintlayer/mintlayer-core/assets/2970736/51ff0f64-d60a-45b1-9112-b930b6be900d)

- Peer 1 gets disconnected, peer 2 succeeds

![image](https://github.com/mintlayer/mintlayer-core/assets/2970736/0ad7b1ab-ce53-43cc-b3ff-f3c15aacea51)

