### PR TITLE
preliminary_header_check now fails if the block's parent is invalid

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -57,7 +57,6 @@ impl BanScore for BlockError {
             BlockError::BlockAlreadyExists(_) => 0,
             BlockError::BlockAlreadyProcessed(_) => 0,
             BlockError::InvalidBlockAlreadyProcessed(_) => 100,
-            BlockError::InvalidParent(_) => 100,
             BlockError::BlockCommitError(_, _, _) => 0,
             BlockError::BlockStatusCommitError(_, _, _) => 0,
             BlockError::BlockProofCalculationError(_) => 100,
@@ -256,6 +255,7 @@ impl BanScore for CheckBlockError {
             CheckBlockError::AttemptedToAddBlockBeforeReorgLimit(_, _, _) => 100,
             CheckBlockError::StateUpdateFailed(err) => err.ban_score(),
             CheckBlockError::EpochSealError(err) => err.ban_score(),
+            CheckBlockError::InvalidParent(_) => 100,
         }
     }
 }

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -222,14 +222,24 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     }
 
     /// Read previous block from storage and return its BlockIndex.
+    fn get_previous_block_index_by_header(
+        &self,
+        block_header: &SignedBlockHeader,
+    ) -> Result<GenBlockIndex, PropertyQueryError> {
+        let prev_block_id = block_header.prev_block_id();
+        self.get_gen_block_index(prev_block_id)
+            .log_err()?
+            .ok_or(PropertyQueryError::PrevBlockIndexNotFound(*prev_block_id))
+    }
+
+    /// Read previous block from storage and return its BlockIndex.
+    // FIXME: rename it? Or maybe delete it and rename get_previous_block_index_by_header to
+    // get_previous_block_index?
     fn get_previous_block_index(
         &self,
         block_index: &BlockIndex,
     ) -> Result<GenBlockIndex, PropertyQueryError> {
-        let prev_block_id = block_index.prev_block_id();
-        self.get_gen_block_index(prev_block_id)
-            .log_err()?
-            .ok_or(PropertyQueryError::PrevBlockIndexNotFound(*prev_block_id))
+        self.get_previous_block_index_by_header(block_index.block_header())
     }
 
     pub fn get_ancestor(
@@ -451,7 +461,22 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         Ok(())
     }
 
+    // Return Ok(()) if the specified block has a valid parent and an error otherwise.
+    pub fn check_block_parent(
+        &self,
+        block_header: &SignedBlockHeader,
+    ) -> Result<(), CheckBlockError> {
+        let parent_block_index = self.get_previous_block_index_by_header(block_header)?;
+        ensure!(
+            parent_block_index.status().is_valid(),
+            CheckBlockError::InvalidParent(block_header.block_id())
+        );
+
+        Ok(())
+    }
+
     pub fn check_block_header(&self, header: &SignedBlockHeader) -> Result<(), CheckBlockError> {
+        self.check_block_parent(header).log_err()?;
         self.check_header_size(header).log_err()?;
         self.enforce_checkpoints(header).log_err()?;
         self.check_block_height_vs_max_reorg_depth(header)?;
@@ -718,30 +743,6 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         self.db_tx.get_block(*block_index.block_id()).log_err()
     }
 
-    /// Given a new block, obtain its previous block's block index; if not found, return
-    /// the appropriate BlockError.
-    // Note: the suffix "or_block_error" helps distinguish this function from another
-    // get_previous_block_index function in ChainstateRef, which returns PropertyQueryError.
-    fn get_previous_block_index_or_block_error(
-        &self,
-        block: &WithId<Block>,
-    ) -> Result<GenBlockIndex, BlockError> {
-        self.get_gen_block_index(&block.prev_block_id())
-            .map_err(BlockError::BlockLoadError)?
-            .ok_or(BlockError::PrevBlockNotFound)
-    }
-
-    // Return Ok(()) if the specified block has a valid parent and an error otherwise.
-    pub fn check_block_parent(&self, block: &WithId<Block>) -> Result<(), BlockError> {
-        let parent_block_index = self.get_previous_block_index_or_block_error(block)?;
-        ensure!(
-            parent_block_index.status().is_valid(),
-            BlockError::InvalidParent(block.get_id())
-        );
-
-        Ok(())
-    }
-
     pub fn check_block(&self, block: &WithId<Block>) -> Result<(), CheckBlockError> {
         self.check_block_header(block.header()).log_err()?;
 
@@ -827,12 +828,26 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         Ok(result)
     }
 
+    /// Given a new block's header, obtain its previous block's block index; if not found,
+    /// return the appropriate BlockError.
+    // Note: the suffix "or_block_error" helps distinguish this function from other
+    // get_previous_block_index functions in ChainstateRef, which return PropertyQueryError.
+    fn get_previous_block_index_or_block_error(
+        &self,
+        block_header: &SignedBlockHeader,
+    ) -> Result<GenBlockIndex, BlockError> {
+        self.get_gen_block_index(block_header.prev_block_id())
+            .map_err(BlockError::BlockLoadError)?
+            .ok_or(BlockError::PrevBlockNotFound)
+    }
+
     pub fn new_block_index(
         &self,
         block: &WithId<Block>,
         block_status: BlockStatus,
     ) -> Result<BlockIndex, BlockError> {
-        let prev_block_index = self.get_previous_block_index_or_block_error(block).log_err()?;
+        let prev_block_index =
+            self.get_previous_block_index_or_block_error(block.header()).log_err()?;
 
         // Set the block height
         let height = prev_block_index.block_height().next_height();

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -62,8 +62,6 @@ pub enum BlockError {
     BlockAlreadyProcessed(Id<Block>),
     #[error("Block {0} has already been processed and marked as invalid")]
     InvalidBlockAlreadyProcessed(Id<Block>),
-    #[error("Block {0} has invalid parent block")]
-    InvalidParent(Id<Block>),
     #[error(
         "Failed to commit block data to database for block {0} after {1} attempts with error {2}"
     )]
@@ -134,6 +132,8 @@ pub enum CheckBlockError {
     TransactionVerifierError(#[from] TransactionVerifierStorageError),
     #[error("Error during sealing an epoch: {0}")]
     EpochSealError(#[from] EpochSealError),
+    #[error("Block {0} has invalid parent block")]
+    InvalidParent(Id<Block>),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
So, Jaanus needs a way to check if a block has an invalid parent in order to ban it. We've discussed it a little bit and decided that `ChainstateInterface::preliminary_header_check` should return an appropriate error in this case, so that p2p can just rely on the error's ban score.

There is a choice about where inside `Chainstate::preliminary_header_check` the call to `check_block_parent` can be placed. There are basically two options - put it directly into `preliminary_header_check` or into `ChainstateRef::check_block_header`. I decided to go with the latter, because having a `check_block_header` function that doesn't check the block's parent is kind of strange and looks like an oversight. But it has a drawback currently - in `integrate_block` we end up checking the parent twice, first we do it explicitly in order to advance to the `ParentOk` stage, and then implicitly via `check_block`, which calls `check_block_header`. There is a FIXME inside `integrate_block` that goes into more details on this.