### PR TITLE
Removing logging for a common occurrence

### DIFF
--- a/blockprod/src/detail/job_manager/jobs_container.rs
+++ b/blockprod/src/detail/job_manager/jobs_container.rs
@@ -76,10 +76,7 @@ impl JobsContainer {
     /// Returns true if the job was removed, false if it was not found.
     fn remove_job(&mut self, job_key: JobKey, and_stop: bool) -> bool {
         match self.jobs.entry(job_key) {
-            Entry::Vacant(j) => {
-                log::error!("Attempted to stop non-existent job: {j:?}");
-                false
-            }
+            Entry::Vacant(_) => false,
             Entry::Occupied(entry) => {
                 let removed_job = entry.remove();
 


### PR DESCRIPTION
When there is a new tip within chainstate, `JobManager` will stop all jobs that will be out of date within `handle_chainstate_event()`. Any currently running thread that's still in `process_block()` will notice this event and exit. However, to make sure that `JobManager` always cleans up regardless, there is a `OnceDestructor` to stop the job within `JobManager` which will duplicate the call.

I don't believe by removing this logging event will mask an issue.