### PR TITLE
mempool: Detect some conflicting orphan transactions

### DIFF
--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -47,37 +47,25 @@ impl MempoolBanScore for MempoolPolicyError {
             MempoolPolicyError::NoInputs => 100,
             MempoolPolicyError::NoOutputs => 100,
             MempoolPolicyError::ExceedsMaxBlockSize => 100,
+            MempoolPolicyError::RelayFeeOverflow => 100,
 
             // Errors to do with transaction conflicts and replacements are not punished since the
             // peer may not be aware of all the transactions the node has in the mempool.
             // This could be refined later.
+            MempoolPolicyError::Conflict(_) => 0,
             MempoolPolicyError::MempoolFull => 0,
             MempoolPolicyError::TransactionAlreadyInMempool => 0,
-            MempoolPolicyError::ConflictWithIrreplaceableTransaction => 0,
-            MempoolPolicyError::TooManyPotentialReplacements => 0,
             MempoolPolicyError::ConflictsFeeOverflow => 0,
             MempoolPolicyError::TransactionFeeLowerThanConflictsWithDescendants => 0,
-            MempoolPolicyError::ReplacementFeeLowerThanOriginal {
-                replacement_tx: _,
-                replacement_fee: _,
-                original_tx: _,
-                original_fee: _,
-            } => 0,
-            MempoolPolicyError::SpendsNewUnconfirmedOutput => 0,
+            MempoolPolicyError::ReplacementFeeLowerThanOriginal { .. } => 0,
             MempoolPolicyError::AdditionalFeesUnderflow => 0,
 
             // The peer should not pass transactions not meeting the minimal fee threshold
-            MempoolPolicyError::InsufficientFeesToRelay {
-                tx_fee: _,
-                relay_fee: _,
-            } => 100,
+            MempoolPolicyError::InsufficientFeesToRelay { .. } => 100,
             MempoolPolicyError::InsufficientFeesToRelayRBF => 100,
 
             // Rolling fee may be out of sync
-            MempoolPolicyError::RollingFeeThresholdNotMet {
-                minimum_fee: _,
-                tx_fee: _,
-            } => 0,
+            MempoolPolicyError::RollingFeeThresholdNotMet { .. } => 0,
 
             // These depend on other transactions we have in the mempool so don't hold the peer
             // liable for these errors. Could be refined later.
@@ -86,7 +74,6 @@ impl MempoolBanScore for MempoolPolicyError {
             MempoolPolicyError::FeeOverflow => 0,
             MempoolPolicyError::GetParentError => 0,
             MempoolPolicyError::DescendantOfExpiredTransaction => 0,
-            MempoolPolicyError::RelayFeeOverflow => 100,
         }
     }
 }

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -255,7 +255,7 @@ impl MempoolStore {
             self.mem_tracker.modify(&mut self.txs_by_id, |txs_by_id, tracker| {
                 tracker.modify(
                     txs_by_id.get_mut(&ancestor_id).expect("ancestor"),
-                    |ancestor, _| {
+                    |ancestor, _| -> Result<(), MempoolPolicyError> {
                         let total_fee = (ancestor.fees_with_descendants + entry.fee)
                             .ok_or(MempoolPolicyError::AncestorFeeUpdateOverflow)?;
                         ancestor.fees_with_descendants = total_fee;
@@ -264,7 +264,7 @@ impl MempoolStore {
                         Ok(())
                     },
                 )
-            })?
+            })?;
         }
         Ok(())
     }

--- a/mempool/src/pool/tests/replacement.rs
+++ b/mempool/src/pool/tests/replacement.rs
@@ -115,7 +115,7 @@ async fn try_replace_irreplaceable(#[case] seed: Seed) -> anyhow::Result<()> {
     .expect("should be able to spend here");
     assert_eq!(
         mempool.add_transaction(replacement.clone()),
-        Err(MempoolPolicyError::ConflictWithIrreplaceableTransaction.into())
+        Err(MempoolPolicyError::from(MempoolConflictError::Irreplacable).into())
     );
 
     mempool.store.remove_tx(&original_id, MempoolRemovalReason::Block);

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -171,6 +171,23 @@ fn output_coin_amount(output: &TxOutput) -> Amount {
     }
 }
 
+pub fn make_tx(
+    rng: &mut (impl Rng + CryptoRng),
+    ins: &[(OutPointSourceId, u32)],
+    outs: &[u128],
+) -> SignedTransaction {
+    let builder = ins.iter().fold(TransactionBuilder::new(), |b, (s, n)| {
+        b.add_input(TxInput::from_utxo(s.clone(), *n), empty_witness(rng))
+    });
+    let builder = outs.iter().fold(builder, |b, a| {
+        b.add_output(TxOutput::Transfer(
+            OutputValue::Coin(Amount::from_atoms(*a)),
+            Destination::AnyoneCanSpend,
+        ))
+    });
+    builder.build()
+}
+
 /// Generate a valid transaction graph.
 ///
 /// This produces an infinite iterator but taking too many items may not be valid:


### PR DESCRIPTION
Detect if an orphan transaction conflicts with a transaction already in mempool and reject it if it does.