### PR TITLE
mempool: Interface cleanup

### DIFF
--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -28,19 +28,19 @@ pub trait MempoolInterface: Send + Sync {
     fn add_transaction(&mut self, tx: SignedTransaction) -> Result<TxStatus, Error>;
 
     /// Get all transactions from mempool
-    fn get_all(&self) -> Result<Vec<SignedTransaction>, Error>;
+    fn get_all(&self) -> Vec<SignedTransaction>;
 
     /// Get a specific transaction from the main mempool (non-orphan)
-    fn transaction(&self, id: &Id<Transaction>) -> Result<Option<SignedTransaction>, Error>;
+    fn transaction(&self, id: &Id<Transaction>) -> Option<SignedTransaction>;
 
     /// Get a specific transaction from the orphan pool
-    fn orphan_transaction(&self, id: &Id<Transaction>) -> Result<Option<SignedTransaction>, Error>;
+    fn orphan_transaction(&self, id: &Id<Transaction>) -> Option<SignedTransaction>;
 
     /// Check given transaction is contained in the main mempool (non-orphan)
-    fn contains_transaction(&self, tx: &Id<Transaction>) -> Result<bool, Error>;
+    fn contains_transaction(&self, tx: &Id<Transaction>) -> bool;
 
     /// Check given transaction is contained in the main mempool (non-orphan)
-    fn contains_orphan_transaction(&self, tx: &Id<Transaction>) -> Result<bool, Error>;
+    fn contains_orphan_transaction(&self, tx: &Id<Transaction>) -> bool;
 
     /// Best block ID according to mempool. May be temporarily out of sync with chainstate.
     fn best_block_id(&self) -> Id<GenBlock>;

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -108,24 +108,24 @@ impl MempoolInterface for Mempool {
         self.add_transaction(tx)
     }
 
-    fn get_all(&self) -> Result<Vec<SignedTransaction>, Error> {
-        Ok(self.get_all())
+    fn get_all(&self) -> Vec<SignedTransaction> {
+        self.get_all()
     }
 
-    fn contains_transaction(&self, tx_id: &Id<Transaction>) -> Result<bool, Error> {
-        Ok(self.contains_transaction(tx_id))
+    fn contains_transaction(&self, tx_id: &Id<Transaction>) -> bool {
+        self.contains_transaction(tx_id)
     }
 
-    fn transaction(&self, id: &Id<Transaction>) -> Result<Option<SignedTransaction>, Error> {
-        Ok(self.transaction(id).cloned())
+    fn transaction(&self, id: &Id<Transaction>) -> Option<SignedTransaction> {
+        self.transaction(id).cloned()
     }
 
-    fn contains_orphan_transaction(&self, tx: &Id<Transaction>) -> Result<bool, Error> {
-        Ok(self.contains_orphan_transaction(tx))
+    fn contains_orphan_transaction(&self, tx: &Id<Transaction>) -> bool {
+        self.contains_orphan_transaction(tx)
     }
 
-    fn orphan_transaction(&self, id: &Id<Transaction>) -> Result<Option<SignedTransaction>, Error> {
-        Ok(self.orphan_transaction(id).cloned())
+    fn orphan_transaction(&self, id: &Id<Transaction>) -> Option<SignedTransaction> {
+        self.orphan_transaction(id).cloned()
     }
 
     fn best_block_id(&self) -> Id<GenBlock> {

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -34,9 +34,7 @@ pub struct MempoolInterfaceMock {
     pub add_transaction_called: Arc<AcqRelAtomicBool>,
     pub add_transaction_should_error: Arc<AcqRelAtomicBool>,
     pub get_all_called: Arc<AcqRelAtomicBool>,
-    pub get_all_should_error: Arc<AcqRelAtomicBool>,
     pub contains_transaction_called: Arc<AcqRelAtomicBool>,
-    pub contains_transaction_should_error: Arc<AcqRelAtomicBool>,
     pub collect_txs_called: Arc<AcqRelAtomicBool>,
     pub collect_txs_should_error: Arc<AcqRelAtomicBool>,
     pub subscribe_to_events_called: Arc<AcqRelAtomicBool>,
@@ -57,9 +55,7 @@ impl MempoolInterfaceMock {
             add_transaction_called: Arc::new(AcqRelAtomicBool::new(false)),
             add_transaction_should_error: Arc::new(AcqRelAtomicBool::new(false)),
             get_all_called: Arc::new(AcqRelAtomicBool::new(false)),
-            get_all_should_error: Arc::new(AcqRelAtomicBool::new(false)),
             contains_transaction_called: Arc::new(AcqRelAtomicBool::new(false)),
-            contains_transaction_should_error: Arc::new(AcqRelAtomicBool::new(false)),
             collect_txs_called: Arc::new(AcqRelAtomicBool::new(false)),
             collect_txs_should_error: Arc::new(AcqRelAtomicBool::new(false)),
             subscribe_to_events_called: Arc::new(AcqRelAtomicBool::new(false)),
@@ -85,36 +81,26 @@ impl MempoolInterface for MempoolInterfaceMock {
         }
     }
 
-    fn get_all(&self) -> Result<Vec<SignedTransaction>, Error> {
+    fn get_all(&self) -> Vec<SignedTransaction> {
         self.get_all_called.store(true);
-
-        if self.get_all_should_error.load() {
-            Err(SUBSYSTEM_ERROR)
-        } else {
-            Ok(vec![])
-        }
+        Vec::new()
     }
 
-    fn contains_transaction(&self, _tx: &Id<Transaction>) -> Result<bool, Error> {
+    fn contains_transaction(&self, _tx: &Id<Transaction>) -> bool {
         self.contains_transaction_called.store(true);
-
-        if self.contains_transaction_should_error.load() {
-            Err(SUBSYSTEM_ERROR)
-        } else {
-            Ok(true)
-        }
+        true
     }
 
-    fn contains_orphan_transaction(&self, _tx: &Id<Transaction>) -> Result<bool, Error> {
-        Ok(true)
+    fn contains_orphan_transaction(&self, _tx: &Id<Transaction>) -> bool {
+        true
     }
 
-    fn transaction(&self, _id: &Id<Transaction>) -> Result<Option<SignedTransaction>, Error> {
-        unimplemented!()
+    fn transaction(&self, _id: &Id<Transaction>) -> Option<SignedTransaction> {
+        None
     }
 
-    fn orphan_transaction(&self, _: &Id<Transaction>) -> Result<Option<SignedTransaction>, Error> {
-        unimplemented!()
+    fn orphan_transaction(&self, _: &Id<Transaction>) -> Option<SignedTransaction> {
+        None
     }
 
     fn best_block_id(&self) -> Id<GenBlock> {

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -482,7 +482,7 @@ where
             )));
         }
 
-        let tx = self.mempool_handle.call(move |m| m.transaction(&id)).await??;
+        let tx = self.mempool_handle.call(move |m| m.transaction(&id)).await?;
         let res = match tx {
             Some(tx) => TransactionResponse::Found(tx),
             None => TransactionResponse::NotFound(id),
@@ -550,7 +550,7 @@ where
             ));
         }
 
-        if !(self.mempool_handle.call(move |m| m.contains_transaction(&tx)).await??) {
+        if !(self.mempool_handle.call(move |m| m.contains_transaction(&tx)).await?) {
             self.messaging_handle
                 .send_message(self.id(), SyncMessage::TransactionRequest(tx))?;
             assert!(self.announced_transactions.insert(tx));


### PR DESCRIPTION
Make some of the API entry points that cannot actually error out return the value directly. Avoid using redundant `Result` wrapper.