### PR TITLE
Fix for ChainstateRef::get_block_height_in_main_chain

### DIFF
--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -132,6 +132,10 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             .map(Locator::new)
     }
 
+    pub fn is_block_in_main_chain(&self, id: &Id<GenBlock>) -> Result<bool, PropertyQueryError> {
+        self.chainstate_ref.is_block_in_main_chain(id)
+    }
+
     pub fn get_block_height_in_main_chain(
         &self,
         id: &Id<GenBlock>,

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -47,7 +47,7 @@ pub trait ChainstateInterface: Send {
     fn preliminary_block_check(&self, block: Block) -> Result<Block, ChainstateError>;
     fn preliminary_header_check(&self, header: SignedBlockHeader) -> Result<(), ChainstateError>;
     fn get_best_block_id(&self) -> Result<Id<GenBlock>, ChainstateError>;
-    fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError>;
+    fn is_block_in_main_chain(&self, block_id: &Id<GenBlock>) -> Result<bool, ChainstateError>;
     fn get_block_height_in_main_chain(
         &self,
         block_id: &Id<GenBlock>,

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -91,14 +91,11 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
     }
 
     fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError> {
-        // FIXME: should it just delegate to ChainstateRef::is_block_in_main_chain?
-        // (but it'll have to be added to ChainstateQuery too).
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
-            .get_block_height_in_main_chain(&(*block_id).into())
+            .is_block_in_main_chain(&(*block_id).into())
             .map_err(ChainstateError::FailedToReadProperty)
-            .map(|ht| ht.is_some())
     }
 
     fn get_block_height_in_main_chain(

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -91,6 +91,8 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
     }
 
     fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError> {
+        // FIXME: should it just delegate to ChainstateRef::is_block_in_main_chain?
+        // (but it'll have to be added to ChainstateQuery too).
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -90,11 +90,11 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
             .map_err(ChainstateError::FailedToReadProperty)
     }
 
-    fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError> {
+    fn is_block_in_main_chain(&self, block_id: &Id<GenBlock>) -> Result<bool, ChainstateError> {
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
-            .is_block_in_main_chain(&(*block_id).into())
+            .is_block_in_main_chain(block_id)
             .map_err(ChainstateError::FailedToReadProperty)
     }
 

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -76,7 +76,7 @@ where
         self.deref().get_best_block_id()
     }
 
-    fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError> {
+    fn is_block_in_main_chain(&self, block_id: &Id<GenBlock>) -> Result<bool, ChainstateError> {
         self.deref().is_block_in_main_chain(block_id)
     }
 

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -219,6 +219,10 @@ impl TestFramework {
     pub fn into_chainstate(self) -> TestChainstate {
         self.chainstate
     }
+
+    pub fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> bool {
+        self.chainstate.is_block_in_main_chain(block_id).unwrap()
+    }
 }
 
 #[rstest]

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -221,7 +221,7 @@ impl TestFramework {
     }
 
     pub fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> bool {
-        self.chainstate.is_block_in_main_chain(block_id).unwrap()
+        self.chainstate.is_block_in_main_chain(&(*block_id).into()).unwrap()
     }
 }
 

--- a/chainstate/test-suite/src/tests/basic_tests.rs
+++ b/chainstate/test-suite/src/tests/basic_tests.rs
@@ -53,11 +53,11 @@ fn test_is_block_in_main_chain(#[case] seed: Seed) {
     tf.create_chain(&tf.genesis().get_id().into(), 1, &mut rng).unwrap();
 
     let block1_id = tf.index_at(1).block_id();
-    assert!(tf.chainstate.is_block_in_main_chain(block1_id).unwrap());
+    assert!(tf.chainstate.is_block_in_main_chain(&(*block1_id).into()).unwrap());
 
     let block2_id = tf.index_at(2).block_id();
-    assert!(tf.chainstate.is_block_in_main_chain(block2_id).unwrap());
+    assert!(tf.chainstate.is_block_in_main_chain(&(*block2_id).into()).unwrap());
 
     let block3_id = tf.index_at(3).block_id();
-    assert!(!tf.chainstate.is_block_in_main_chain(block3_id).unwrap());
+    assert!(!tf.chainstate.is_block_in_main_chain(&(*block3_id).into()).unwrap());
 }

--- a/chainstate/test-suite/src/tests/basic_tests.rs
+++ b/chainstate/test-suite/src/tests/basic_tests.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_test_framework::TestFramework;
+use common::primitives::Idable;
+use rstest::rstest;
+use test_utils::random::make_seedable_rng;
+use test_utils::random::Seed;
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn test_get_block_height_in_main_chain(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let mut tf = TestFramework::builder(&mut rng).build();
+
+    tf.create_chain(&tf.genesis().get_id().into(), 2, &mut rng).unwrap();
+    tf.create_chain(&tf.genesis().get_id().into(), 1, &mut rng).unwrap();
+
+    let block1_id = tf.index_at(1).block_id();
+    let block1_height = tf.chainstate.get_block_height_in_main_chain(&(*block1_id).into()).unwrap();
+    assert_eq!(block1_height, Some(1.into()));
+
+    let block2_id = tf.index_at(2).block_id();
+    let block2_height = tf.chainstate.get_block_height_in_main_chain(&(*block2_id).into()).unwrap();
+    assert_eq!(block2_height, Some(2.into()));
+
+    let block3_id = tf.index_at(3).block_id();
+    let block3_height = tf.chainstate.get_block_height_in_main_chain(&(*block3_id).into()).unwrap();
+    assert_eq!(block3_height, None);
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn test_is_block_in_main_chain(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let mut tf = TestFramework::builder(&mut rng).build();
+
+    tf.create_chain(&tf.genesis().get_id().into(), 2, &mut rng).unwrap();
+    tf.create_chain(&tf.genesis().get_id().into(), 1, &mut rng).unwrap();
+
+    let block1_id = tf.index_at(1).block_id();
+    assert!(tf.chainstate.is_block_in_main_chain(block1_id).unwrap());
+
+    let block2_id = tf.index_at(2).block_id();
+    assert!(tf.chainstate.is_block_in_main_chain(block2_id).unwrap());
+
+    let block3_id = tf.index_at(3).block_id();
+    assert!(!tf.chainstate.is_block_in_main_chain(block3_id).unwrap());
+}

--- a/chainstate/test-suite/src/tests/bootstrap.rs
+++ b/chainstate/test-suite/src/tests/bootstrap.rs
@@ -32,9 +32,10 @@ fn check_height_order<C: ChainstateInterface>(blocks: &[Id<Block>], chainstate: 
     let mut last_height = 0;
     for block_id in blocks {
         let height = chainstate
-            .get_block_height_in_main_chain(&block_id.get().into())
+            .get_block_index(block_id)
             .expect("Database error")
-            .expect("We loaded this from chainstate");
+            .expect("Block index not found")
+            .block_height();
         let current_height: u64 = height.into();
         assert!(current_height >= last_height);
         last_height = current_height;

--- a/chainstate/test-suite/src/tests/mod.rs
+++ b/chainstate/test-suite/src/tests/mod.rs
@@ -26,6 +26,7 @@ use crypto::random::Rng;
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
 
+mod basic_tests;
 mod block_status;
 mod bootstrap;
 mod chainstate_accounting_storage_tests;

--- a/chainstate/test-suite/src/tests/reorgs_tests.rs
+++ b/chainstate/test-suite/src/tests/reorgs_tests.rs
@@ -232,7 +232,7 @@ fn check_reorg_to_first_chain(tf: &mut TestFramework, events: &EventList, rng: &
         2,
         TestSpentStatus::NotInMainchain,
     );
-    assert!(!is_block_in_main_chain(tf, tf.index_at(3).block_id()));
+    assert!(!tf.is_block_in_main_chain(tf.index_at(3).block_id()));
     // b4
     check_block_reorg_state(
         tf,
@@ -242,7 +242,7 @@ fn check_reorg_to_first_chain(tf: &mut TestFramework, events: &EventList, rng: &
         3,
         TestSpentStatus::NotInMainchain,
     );
-    assert!(!is_block_in_main_chain(tf, tf.index_at(4).block_id()));
+    assert!(!tf.is_block_in_main_chain(tf.index_at(4).block_id()));
     // b5
     check_block_reorg_state(
         tf,
@@ -252,7 +252,7 @@ fn check_reorg_to_first_chain(tf: &mut TestFramework, events: &EventList, rng: &
         3,
         TestSpentStatus::Spent,
     );
-    assert!(is_block_in_main_chain(tf, tf.index_at(5).block_id()));
+    assert!(tf.is_block_in_main_chain(tf.index_at(5).block_id()));
     // b6
     check_block_reorg_state(
         tf,
@@ -262,7 +262,7 @@ fn check_reorg_to_first_chain(tf: &mut TestFramework, events: &EventList, rng: &
         4,
         TestSpentStatus::Unspent,
     );
-    assert!(is_block_in_main_chain(tf, tf.index_at(6).block_id()));
+    assert!(tf.is_block_in_main_chain(tf.index_at(6).block_id()));
 }
 
 fn check_make_alternative_chain_longer(
@@ -297,7 +297,7 @@ fn check_make_alternative_chain_longer(
         2,
         TestSpentStatus::Spent,
     );
-    assert!(is_block_in_main_chain(tf, tf.index_at(3).block_id()));
+    assert!(tf.is_block_in_main_chain(tf.index_at(3).block_id()));
     // b4
     check_block_reorg_state(
         tf,
@@ -307,7 +307,7 @@ fn check_make_alternative_chain_longer(
         3,
         TestSpentStatus::Unspent,
     );
-    assert!(is_block_in_main_chain(tf, tf.index_at(4).block_id()));
+    assert!(tf.is_block_in_main_chain(tf.index_at(4).block_id()));
 }
 
 fn check_simple_fork(tf: &mut TestFramework, events: &EventList, rng: &mut impl Rng) {
@@ -334,7 +334,7 @@ fn check_simple_fork(tf: &mut TestFramework, events: &EventList, rng: &mut impl 
         1,
         TestSpentStatus::Spent,
     );
-    assert!(is_block_in_main_chain(tf, tf.index_at(1).block_id()));
+    assert!(tf.is_block_in_main_chain(tf.index_at(1).block_id()));
     // b2
     check_block_reorg_state(
         tf,
@@ -344,7 +344,7 @@ fn check_simple_fork(tf: &mut TestFramework, events: &EventList, rng: &mut impl 
         2,
         TestSpentStatus::Unspent,
     );
-    assert!(is_block_in_main_chain(tf, tf.index_at(2).block_id()));
+    assert!(tf.is_block_in_main_chain(tf.index_at(2).block_id()));
     // b3
     check_block_reorg_state(
         tf,
@@ -354,7 +354,7 @@ fn check_simple_fork(tf: &mut TestFramework, events: &EventList, rng: &mut impl 
         2,
         TestSpentStatus::NotInMainchain,
     );
-    assert!(!is_block_in_main_chain(tf, tf.index_at(3).block_id()));
+    assert!(!tf.is_block_in_main_chain(tf.index_at(3).block_id()));
 }
 
 fn check_last_event(tf: &mut TestFramework, events: &EventList) {
@@ -365,7 +365,7 @@ fn check_last_event(tf: &mut TestFramework, events: &EventList) {
     match events.last() {
         Some((block_id, block_height)) => {
             let block_index = tf.block_indexes.last().unwrap();
-            if is_block_in_main_chain(tf, block_index.block_id()) {
+            if tf.is_block_in_main_chain(block_index.block_id()) {
                 // If block not in main chain then it means we didn't receive a new tip event. Nothing to check!
                 assert_eq!(block_id, block_index.block_id());
                 assert_eq!(block_height, &block_index.block_height());
@@ -429,15 +429,6 @@ fn check_block_at_height(
         let expected_block_id: Option<Id<GenBlock>> = expected_block_id.map(|id| (*id).into());
         assert_eq!(real_next_block_id, expected_block_id);
     }
-}
-
-fn is_block_in_main_chain(tf: &TestFramework, block_id: &Id<Block>) -> bool {
-    let block_index = tf.block_index(&(*block_id).into());
-    let height = block_index.block_height();
-    tf.chainstate
-        .get_block_id_from_height(&height)
-        .unwrap()
-        .map_or(false, |id| id == block_index.block_id())
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -48,7 +48,7 @@ mockall::mock! {
         fn get_best_block_id(&self) -> Result<Id<GenBlock>, ChainstateError>;
         fn get_best_block_height(&self) -> Result<BlockHeight, ChainstateError>;
         fn get_best_block_header(&self) -> Result<SignedBlockHeader, ChainstateError>;
-        fn is_block_in_main_chain(&self, block_id: &Id<Block>) -> Result<bool, ChainstateError>;
+        fn is_block_in_main_chain(&self, block_id: &Id<GenBlock>) -> Result<bool, ChainstateError>;
         fn get_block_height_in_main_chain(
             &self,
             block_id: &Id<GenBlock>,


### PR DESCRIPTION
`ChainstateRef::get_block_height_in_main_chain` was returning `Some(height)` even for blocks not on the mainchain; because of this, `ChainstateInterface::is_block_in_main_chain` worked incorrectly, returning true for all blocks.

What's interesting, `ChainstateInterface::is_block_in_main_chain` and `ChainstateRef::is_block_in_main_chain` have separate implementations; the latter also used (and still does) `get_block_height_in_main_chain` but it did it in a strange way, always rechecking its result by calling `get_block_id_by_height`. I simplified it.

One piece of code did rely in the wrong behaviour of `get_block_height_in_main_chain` - it's `check_height_order` in `chainstate/test-suite/src/tests/bootstrap.rs`. I fixed it.

Finally, `chainstate/test-suite/src/tests/reorgs_tests.rs` had its own implementation of `is_block_in_main_chain`, I removed it.