### PR TITLE
Add support for lock then transfer in the Wallet

### DIFF
--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -52,6 +52,43 @@ fn gen_random_password(rng: &mut (impl Rng + CryptoRng)) -> String {
     (0..rng.gen_range(1..100)).map(|_| rng.gen::<char>()).collect()
 }
 
+fn gen_random_lock_then_transfer(
+    rng: &mut (impl Rng + CryptoRng),
+    amount: Amount,
+    pkh: PublicKeyHash,
+    lock_for_blocks: u64,
+    current_block_height: BlockHeight,
+    seconds_between_blocks: u64,
+    current_timestamp: BlockTimestamp,
+) -> TxOutput {
+    match rng.gen_range(0..4) {
+        0 => TxOutput::LockThenTransfer(
+            OutputValue::Coin(amount),
+            Destination::Address(pkh),
+            OutputTimeLock::ForBlockCount(lock_for_blocks),
+        ),
+        1 => TxOutput::LockThenTransfer(
+            OutputValue::Coin(amount),
+            Destination::Address(pkh),
+            OutputTimeLock::UntilHeight(current_block_height.checked_add(lock_for_blocks).unwrap()),
+        ),
+        2 => TxOutput::LockThenTransfer(
+            OutputValue::Coin(amount),
+            Destination::Address(pkh),
+            OutputTimeLock::ForSeconds(seconds_between_blocks * lock_for_blocks),
+        ),
+        _ => TxOutput::LockThenTransfer(
+            OutputValue::Coin(amount),
+            Destination::Address(pkh),
+            OutputTimeLock::UntilTime(
+                current_timestamp
+                    .add_int_seconds(seconds_between_blocks * lock_for_blocks)
+                    .unwrap(),
+            ),
+        ),
+    }
+}
+
 fn get_address(
     chain_config: &ChainConfig,
     mnemonic: &str,
@@ -810,4 +847,157 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             not_enough_tokens_to_transfer
         ))
     )
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn lock_then_transfer(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    let db = create_wallet_in_memory().unwrap();
+    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    wallet.create_account(DEFAULT_ACCOUNT_INDEX).unwrap();
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    let timestamp = chain_config.genesis_block().timestamp().add_int_seconds(10).unwrap();
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
+    let address = get_address(
+        &chain_config,
+        MNEMONIC,
+        DEFAULT_ACCOUNT_INDEX,
+        KeyPurpose::ReceiveFunds,
+        0.try_into().unwrap(),
+    );
+    let block1 = Block::new(
+        vec![],
+        chain_config.genesis_block_id(),
+        timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![
+            make_address_output(address.clone(), block1_amount).unwrap()
+        ]),
+    )
+    .unwrap();
+
+    let seconds_between_blocks = rng.gen_range(10..100);
+    let block1_id = block1.get_id();
+    // not important that it is not the actual median
+    wallet.set_median_time(timestamp);
+    let timestamp = block1.timestamp().add_int_seconds(seconds_between_blocks).unwrap();
+    wallet.scan_new_blocks(BlockHeight::new(0), vec![block1]).unwrap();
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, block1_amount);
+
+    let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pkh = PublicKeyHash::try_from(address2.data(&chain_config).unwrap()).unwrap();
+
+    let amount_fraction = (block1_amount.into_atoms() - NETWORK_FEE) / 10;
+
+    let block_count_lock = rng.gen_range(1..10);
+    let amount_to_lock_then_transfer = Amount::from_atoms(rng.gen_range(1..amount_fraction));
+    let new_output = gen_random_lock_then_transfer(
+        &mut rng,
+        amount_to_lock_then_transfer,
+        pkh,
+        block_count_lock,
+        BlockHeight::new(2),
+        seconds_between_blocks,
+        timestamp,
+    );
+
+    let lock_then_transfer_transaction = wallet
+        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+        .unwrap();
+
+    let block2 = Block::new(
+        vec![lock_then_transfer_transaction],
+        block1_id.into(),
+        timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(address, block1_amount).unwrap()]),
+    )
+    .unwrap();
+
+    // not important that it is not the actual median
+    wallet.set_median_time(timestamp);
+    let mut timestamp = block2.timestamp().add_int_seconds(seconds_between_blocks).unwrap();
+    wallet.scan_new_blocks(BlockHeight::new(1), vec![block2]).unwrap();
+
+    let currency_balances = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+        )
+        .unwrap();
+    let balance_without_locked_transer =
+        (((block1_amount * 2).unwrap() - amount_to_lock_then_transfer).unwrap()
+            - Amount::from_atoms(NETWORK_FEE))
+        .unwrap();
+
+    assert_eq!(
+        currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
+        balance_without_locked_transer
+    );
+
+    // check that for block_count_lock, the amount is not included
+    for idx in 0..block_count_lock {
+        let currency_balances = wallet
+            .get_balance(
+                DEFAULT_ACCOUNT_INDEX,
+                UtxoType::Transfer | UtxoType::LockThenTransfer,
+            )
+            .unwrap();
+        assert_eq!(
+            currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
+            balance_without_locked_transer
+        );
+
+        let new_block = Block::new(
+            vec![],
+            chain_config.genesis_block_id(),
+            timestamp,
+            ConsensusData::None,
+            BlockReward::new(vec![]),
+        )
+        .unwrap();
+        // not important that it is not the actual median
+        wallet.set_median_time(timestamp);
+        timestamp = new_block.timestamp().add_int_seconds(seconds_between_blocks).unwrap();
+        wallet.scan_new_blocks(BlockHeight::new(2 + idx), vec![new_block]).unwrap();
+    }
+
+    // check that after block_count_lock, the amount is included
+    let currency_balances = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+        )
+        .unwrap();
+    assert_eq!(
+        currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
+        (balance_without_locked_transer + amount_to_lock_then_transfer).unwrap()
+    );
 }

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -896,7 +896,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
     let seconds_between_blocks = rng.gen_range(10..100);
     let block1_id = block1.get_id();
     // not important that it is not the actual median
-    wallet.set_median_time(timestamp);
+    wallet.set_median_time(timestamp).unwrap();
     let timestamp = block1.timestamp().add_int_seconds(seconds_between_blocks).unwrap();
     wallet.scan_new_blocks(BlockHeight::new(0), vec![block1]).unwrap();
 
@@ -942,7 +942,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
     .unwrap();
 
     // not important that it is not the actual median
-    wallet.set_median_time(timestamp);
+    wallet.set_median_time(timestamp).unwrap();
     let mut timestamp = block2.timestamp().add_int_seconds(seconds_between_blocks).unwrap();
     wallet.scan_new_blocks(BlockHeight::new(1), vec![block2]).unwrap();
 
@@ -984,7 +984,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
         )
         .unwrap();
         // not important that it is not the actual median
-        wallet.set_median_time(timestamp);
+        wallet.set_median_time(timestamp).unwrap();
         timestamp = new_block.timestamp().add_int_seconds(seconds_between_blocks).unwrap();
         wallet.scan_new_blocks(BlockHeight::new(2 + idx), vec![new_block]).unwrap();
     }

--- a/wallet/storage/src/internal/mod.rs
+++ b/wallet/storage/src/internal/mod.rs
@@ -15,7 +15,7 @@
 
 use std::collections::BTreeMap;
 
-use common::address::Address;
+use common::{address::Address, chain::block::timestamp::BlockTimestamp};
 use crypto::key::extended::ExtendedPublicKey;
 
 use crate::{
@@ -223,6 +223,7 @@ impl<B: storage::Backend> WalletStorageReadLocked for Store<B> {
         fn get_keychain_usage_states(&self, account_id: &AccountId) -> crate::Result<BTreeMap<AccountKeyPurposeId, KeychainUsageState>>;
         fn get_public_key(&self, id: &AccountDerivationPathId) -> crate::Result<Option<ExtendedPublicKey>>;
         fn get_public_keys(&self, account_id: &AccountId) -> crate::Result<BTreeMap<AccountDerivationPathId, ExtendedPublicKey>>;
+        fn get_median_time(&self) -> crate::Result<Option<BlockTimestamp>>;
     }
 }
 
@@ -239,6 +240,7 @@ impl<B: storage::Backend> WalletStorageWriteLocked for Store<B> {
         fn del_keychain_usage_state(&mut self, id: &AccountKeyPurposeId) -> crate::Result<()>;
         fn set_public_key(&mut self, id: &AccountDerivationPathId, content: &ExtendedPublicKey) -> crate::Result<()>;
         fn det_public_key(&mut self, id: &AccountDerivationPathId) -> crate::Result<()>;
+        fn set_median_time(&mut self, median_time: BlockTimestamp) -> crate::Result<()>;
     }
 }
 

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -19,7 +19,7 @@ mod internal;
 mod is_transaction_seal;
 pub mod schema;
 
-use common::address::Address;
+use common::{address::Address, chain::block::timestamp::BlockTimestamp};
 use crypto::{kdf::KdfChallenge, key::extended::ExtendedPublicKey, symkey::SymmetricKey};
 pub use internal::{Store, StoreTxRo, StoreTxRoUnlocked, StoreTxRw, StoreTxRwUnlocked};
 use std::collections::BTreeMap;
@@ -78,6 +78,7 @@ pub trait WalletStorageReadLocked {
         &self,
         account_id: &AccountId,
     ) -> Result<BTreeMap<AccountDerivationPathId, ExtendedPublicKey>>;
+    fn get_median_time(&self) -> Result<Option<BlockTimestamp>>;
 }
 
 /// Queries on persistent wallet data with access to encrypted data
@@ -114,6 +115,7 @@ pub trait WalletStorageWriteLocked: WalletStorageReadLocked {
         content: &ExtendedPublicKey,
     ) -> Result<()>;
     fn det_public_key(&mut self, id: &AccountDerivationPathId) -> Result<()>;
+    fn set_median_time(&mut self, median_time: BlockTimestamp) -> Result<()>;
 }
 
 /// Modifying operations on persistent wallet data with access to encrypted data

--- a/wallet/types/src/lib.rs
+++ b/wallet/types/src/lib.rs
@@ -22,4 +22,4 @@ pub mod wallet_tx;
 pub use account_id::{AccountDerivationPathId, AccountId, AccountKeyPurposeId, AccountWalletTxId};
 pub use account_info::AccountInfo;
 pub use keys::{KeyPurpose, KeychainUsageState, RootKeyContent, RootKeyId};
-pub use wallet_tx::WalletTx;
+pub use wallet_tx::{BlockInfo, WalletTx};

--- a/wallet/wallet-controller/src/sync/mod.rs
+++ b/wallet/wallet-controller/src/sync/mod.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{Block, ChainConfig, GenBlock},
+    chain::{block::timestamp::BlockTimestamp, Block, ChainConfig, GenBlock},
     primitives::{BlockHeight, Id},
 };
 use logging::log;
@@ -32,6 +32,8 @@ pub trait SyncingWallet {
         common_block_height: BlockHeight,
         blocks: Vec<Block>,
     ) -> WalletResult<()>;
+
+    fn update_median_time(&mut self, median_time: BlockTimestamp);
 }
 
 impl SyncingWallet for DefaultWallet {
@@ -45,6 +47,10 @@ impl SyncingWallet for DefaultWallet {
         blocks: Vec<Block>,
     ) -> WalletResult<()> {
         self.scan_new_blocks(common_block_height, blocks)
+    }
+
+    fn update_median_time(&mut self, median_time: BlockTimestamp) {
+        self.set_median_time(median_time)
     }
 }
 
@@ -117,6 +123,8 @@ pub async fn sync_once<T: NodeInterface>(
         wallet
             .scan_blocks(common_block_height, vec![block])
             .map_err(ControllerError::WalletError)?;
+
+        wallet.update_median_time(chain_info.median_time);
 
         log::info!(
             "Node chainstate updated, block height: {}, tip block id: {}",

--- a/wallet/wallet-controller/src/sync/mod.rs
+++ b/wallet/wallet-controller/src/sync/mod.rs
@@ -33,7 +33,7 @@ pub trait SyncingWallet {
         blocks: Vec<Block>,
     ) -> WalletResult<()>;
 
-    fn update_median_time(&mut self, median_time: BlockTimestamp);
+    fn update_median_time(&mut self, median_time: BlockTimestamp) -> WalletResult<()>;
 }
 
 impl SyncingWallet for DefaultWallet {
@@ -49,7 +49,7 @@ impl SyncingWallet for DefaultWallet {
         self.scan_new_blocks(common_block_height, blocks)
     }
 
-    fn update_median_time(&mut self, median_time: BlockTimestamp) {
+    fn update_median_time(&mut self, median_time: BlockTimestamp) -> WalletResult<()> {
         self.set_median_time(median_time)
     }
 }
@@ -124,7 +124,9 @@ pub async fn sync_once<T: NodeInterface>(
             .scan_blocks(common_block_height, vec![block])
             .map_err(ControllerError::WalletError)?;
 
-        wallet.update_median_time(chain_info.median_time);
+        wallet
+            .update_median_time(chain_info.median_time)
+            .map_err(ControllerError::WalletError)?;
 
         log::info!(
             "Node chainstate updated, block height: {}, tip block id: {}",

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -96,8 +96,9 @@ impl SyncingWallet for MockWallet {
         Ok(())
     }
 
-    fn update_median_time(&mut self, median_time: BlockTimestamp) {
-        self.latest_median_time = median_time
+    fn update_median_time(&mut self, median_time: BlockTimestamp) -> WalletResult<()> {
+        self.latest_median_time = median_time;
+        Ok(())
     }
 }
 

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -41,6 +41,7 @@ struct MockWallet {
     genesis_id: Id<GenBlock>,
     blocks: Vec<Id<Block>>,
     new_tip_tx: mpsc::UnboundedSender<Id<Block>>,
+    latest_median_time: BlockTimestamp,
 }
 
 impl MockWallet {
@@ -49,6 +50,7 @@ impl MockWallet {
             genesis_id: chain_config.genesis_block_id(),
             blocks: Vec::new(),
             new_tip_tx,
+            latest_median_time: chain_config.genesis_block().timestamp(),
         }
     }
 
@@ -92,6 +94,10 @@ impl SyncingWallet for MockWallet {
         );
 
         Ok(())
+    }
+
+    fn update_median_time(&mut self, median_time: BlockTimestamp) {
+        self.latest_median_time = median_time
     }
 }
 


### PR DESCRIPTION
Fix Wallet output cache to properly filter out locked outputs.