### PR TITLE
Update RegTest Genesis to include PoS pools using fixed staking and VRF keys

### DIFF
--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -570,7 +570,7 @@ pub fn regtest_genesis_values() -> (
     )
 }
 
-pub fn create_regtest_pos_genesis() -> Genesis {
+pub fn create_regtest_pos_genesis(premine_destination: Destination) -> Genesis {
     let (
         genesis_pool_id,
         genesis_stake_pool_data,
@@ -583,10 +583,15 @@ pub fn create_regtest_pos_genesis() -> Genesis {
     let create_genesis_pool_txoutput =
         TxOutput::CreateStakePool(genesis_pool_id, genesis_stake_pool_data);
 
+    let premine_output = TxOutput::Transfer(
+        OutputValue::Coin(Amount::from_atoms(100_000_000_000_000_000_000)),
+        premine_destination,
+    );
+
     Genesis::new(
         String::new(),
         BlockTimestamp::from_int_seconds(1639975460),
-        vec![create_genesis_pool_txoutput],
+        vec![premine_output, create_genesis_pool_txoutput],
     )
 }
 

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -29,13 +29,14 @@ use crate::chain::tokens::OutputValue;
 use crate::chain::transaction::Destination;
 use crate::chain::upgrades::NetUpgrades;
 use crate::chain::TxOutput;
-use crate::chain::{GenBlock, Genesis};
+use crate::chain::{GenBlock, Genesis, PoolId};
 use crate::chain::{PoWChainConfig, UpgradeVersion};
 use crate::primitives::id::{Id, Idable, WithId};
 use crate::primitives::per_thousand::PerThousand;
 use crate::primitives::semver::SemVer;
 use crate::primitives::{Amount, BlockDistance, BlockHeight, H256};
 use crypto::key::hdkd::{child_number::ChildNumber, u31::U31};
+use crypto::{key::PrivateKey, vrf::VRFPrivateKey};
 use std::num::NonZeroU64;
 use std::sync::Arc;
 use std::time::Duration;
@@ -522,6 +523,70 @@ fn create_testnet_genesis() -> Genesis {
         genesis_message,
         BlockTimestamp::from_int_seconds(1686148208),
         vec![mint_output, initial_pool],
+    )
+}
+
+pub fn regtest_genesis_values() -> (
+    PoolId,
+    Box<StakePoolData>,
+    PrivateKey,
+    PublicKey,
+    VRFPrivateKey,
+    VRFPublicKey,
+) {
+    let genesis_pool_id =
+        decode_hex::<PoolId>("123c4c600097c513e088b9be62069f0c74c7671c523c8e3469a1c3f14b7ea2c4");
+
+    let genesis_stake_private_key = decode_hex::<PrivateKey>(
+        "008717e6946febd3a33ccdc3f3a27629ec80c33461c33a0fc56b4836fcedd26638",
+    );
+
+    let genesis_stake_public_key = decode_hex::<PublicKey>(
+        "0003c53526caf73cd990148e127cb57249a5e266d78df23968642c976a532197fdaa",
+    );
+
+    let genesis_vrf_private_key = decode_hex::<VRFPrivateKey>("003fcf7b813bec2a293f574b842988895278b396dd72471de2583b242097a59f06e9f3cd7b78d45750afd17292031373fddb5e7a8090db51221038f5e05f29998e");
+
+    let genesis_vrf_public_key = decode_hex::<VRFPublicKey>(
+        "00fa2f59dc7a7e176058e4f2d155cfa03ee007340e0285447892158823d332f744",
+    );
+
+    let genesis_pool_stake_data = Box::new(StakePoolData::new(
+        MIN_STAKE_POOL_PLEDGE,
+        Destination::PublicKey(genesis_stake_public_key.clone()),
+        genesis_vrf_public_key.clone(),
+        Destination::PublicKey(genesis_stake_public_key.clone()),
+        PerThousand::new(1000).expect("Valid per thousand"),
+        Amount::ZERO,
+    ));
+
+    (
+        genesis_pool_id,
+        genesis_pool_stake_data,
+        genesis_stake_private_key,
+        genesis_stake_public_key,
+        genesis_vrf_private_key,
+        genesis_vrf_public_key,
+    )
+}
+
+pub fn create_regtest_pos_genesis() -> Genesis {
+    let (
+        genesis_pool_id,
+        genesis_stake_pool_data,
+        _genesis_stake_private_key,
+        _genesis_stake_public_key,
+        _genesis_vrf_private_key,
+        _genesis_vrf_public_key,
+    ) = regtest_genesis_values();
+
+    let create_genesis_pool_txoutput =
+        TxOutput::CreateStakePool(genesis_pool_id, genesis_stake_pool_data);
+
+    Genesis::new(
+        String::new(),
+        BlockTimestamp::from_int_seconds(1639975460),
+        vec![create_genesis_pool_txoutput],
     )
 }
 

--- a/common/src/chain/mod.rs
+++ b/common/src/chain/mod.rs
@@ -34,8 +34,8 @@ pub use gen_block::{GenBlock, GenBlockId};
 pub use genesis::Genesis;
 pub use mlt::Mlt;
 pub use pos::{
-    create_testnet_pos_config, create_unittest_pos_config, get_initial_randomness,
-    initial_difficulty, DelegationId, PoSChainConfig, PoolId,
+    create_regtest_pos_config, create_testnet_pos_config, create_unittest_pos_config,
+    get_initial_randomness, initial_difficulty, DelegationId, PoSChainConfig, PoolId,
 };
 pub use pow::PoWChainConfig;
 pub use upgrades::*;

--- a/common/src/chain/pos.rs
+++ b/common/src/chain/pos.rs
@@ -129,6 +129,18 @@ pub fn create_unittest_pos_config() -> PoSChainConfig {
     }
 }
 
+pub fn create_regtest_pos_config() -> PoSChainConfig {
+    PoSChainConfig {
+        target_limit: Uint256::MAX,
+        target_block_time: NonZeroU64::new(2 * 60).expect("cannot be 0"),
+        reward_maturity_distance: 2000.into(),
+        decommission_maturity_distance: 2000.into(),
+        spend_share_maturity_distance: 2000.into(),
+        block_count_to_average_for_blocktime: 5,
+        difficulty_change_limit: PerThousand::new(100).expect("must be valid"),
+    }
+}
+
 pub const fn initial_difficulty(chain_type: ChainType) -> Uint256 {
     match chain_type {
         // TODO: Decide what to use on Mainnet.

--- a/common/src/chain/upgrades/netupgrade.rs
+++ b/common/src/chain/upgrades/netupgrade.rs
@@ -17,7 +17,7 @@ use std::ops::Range;
 
 use crate::chain::config::ChainType;
 use crate::chain::pow::limit;
-use crate::chain::{create_unittest_pos_config, initial_difficulty, PoSChainConfig};
+use crate::chain::{create_regtest_pos_config, initial_difficulty, PoSChainConfig};
 use crate::primitives::{BlockHeight, Compact};
 
 #[derive(Debug, Clone)]
@@ -50,7 +50,7 @@ impl NetUpgrades<UpgradeVersion> {
                 BlockHeight::new(1),
                 UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                     initial_difficulty: initial_difficulty(ChainType::Regtest).into(),
-                    config: create_unittest_pos_config(),
+                    config: create_regtest_pos_config(),
                 }),
             ),
         ])

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -34,7 +34,7 @@ use common::{
             create_regtest_pos_genesis, Builder as ChainConfigBuilder, ChainConfig, ChainType,
             EmissionScheduleTabular,
         },
-        NetUpgrades,
+        Destination, NetUpgrades,
     },
     primitives::semver::SemVer,
 };
@@ -327,7 +327,7 @@ fn regtest_chain_config(options: &ChainConfigOptions) -> Result<ChainConfig> {
     if chain_pos_netupgrades.unwrap_or(false) {
         builder = builder
             .net_upgrades(NetUpgrades::regtest_with_pos())
-            .genesis_custom(create_regtest_pos_genesis());
+            .genesis_custom(create_regtest_pos_genesis(Destination::AnyoneCanSpend));
     }
 
     Ok(builder.build())

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -30,7 +30,10 @@ use paste::paste;
 use chainstate::rpc::ChainstateRpcServer;
 use common::{
     chain::{
-        config::{Builder as ChainConfigBuilder, ChainConfig, ChainType, EmissionScheduleTabular},
+        config::{
+            create_regtest_pos_genesis, Builder as ChainConfigBuilder, ChainConfig, ChainType,
+            EmissionScheduleTabular,
+        },
         NetUpgrades,
     },
     primitives::semver::SemVer,
@@ -322,8 +325,9 @@ fn regtest_chain_config(options: &ChainConfigOptions) -> Result<ChainConfig> {
     update_builder!(max_block_size_with_smart_contracts);
 
     if chain_pos_netupgrades.unwrap_or(false) {
-        let net_upgrades = NetUpgrades::regtest_with_pos();
-        builder = builder.net_upgrades(net_upgrades);
+        builder = builder
+            .net_upgrades(NetUpgrades::regtest_with_pos())
+            .genesis_custom(create_regtest_pos_genesis());
     }
 
     Ok(builder.build())


### PR DESCRIPTION
These RegTest genesis values will be needed for the Python functional tests for PoS.

This is part of #1004 