### PR TITLE
Consume self when running a manager

### DIFF
--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -71,7 +71,7 @@ where
     .await
     .unwrap();
 
-    let mut sync1 = BlockSyncManager::<N>::new(
+    let sync1 = BlockSyncManager::<N>::new(
         Arc::clone(&chain_config),
         Arc::clone(&p2p_config),
         messaging_handle,

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -152,7 +152,7 @@ where
         let shutdown_ = Arc::clone(&shutdown);
         let peer_manager_task = tokio::spawn(async move {
             match peer_manager.run().await {
-                Ok(_) => unreachable!(),
+                Ok(never) => match never {},
                 // The channel can be closed during the shutdown process.
                 Err(P2pError::ChannelClosed) if shutdown_.load() => {
                     log::info!("Peer manager is shut down");
@@ -177,7 +177,7 @@ where
         let shutdown_ = Arc::clone(&shutdown);
         let sync_manager_task = tokio::spawn(async move {
             match sync_manager.run().await {
-                Ok(_) => unreachable!(),
+                Ok(never) => match never {},
                 // The channel can be closed during the shutdown process.
                 Err(P2pError::ChannelClosed) if shutdown_.load() => {
                     log::info!("Sync manager is shut down");

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -141,7 +141,7 @@ where
         // a `oneshot::channel` object that must be used to send the response.
         let (tx_peer_manager, rx_peer_manager) = mpsc::unbounded_channel();
 
-        let mut peer_manager = peer_manager::PeerManager::<T, _>::new(
+        let peer_manager = peer_manager::PeerManager::<T, _>::new(
             Arc::clone(&chain_config),
             Arc::clone(&p2p_config),
             conn,
@@ -164,7 +164,7 @@ where
             }
         });
 
-        let mut sync_manager = sync::BlockSyncManager::<T>::new(
+        let sync_manager = sync::BlockSyncManager::<T>::new(
             chain_config,
             p2p_config,
             messaging_handle.clone(),

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -261,7 +261,7 @@ where
     }
 
     /// Runs the backend events loop.
-    pub async fn run(&mut self) -> crate::Result<Never> {
+    pub async fn run(mut self) -> crate::Result<Never> {
         loop {
             tokio::select! {
                 // Select from the channels in the specified order
@@ -273,7 +273,7 @@ where
                 },
                 // Process pending commands
                 callback = self.command_queue.select_next_some(), if !self.command_queue.is_empty() => {
-                    callback(self)?;
+                    callback(&mut self)?;
                 },
                 // Handle peer events.
                 event = self.peer_chan.1.recv() => {
@@ -329,21 +329,19 @@ where
         };
 
         let backend_tx = self.peer_chan.0.clone();
-        let chain_config = Arc::clone(&self.chain_config);
-        let p2p_config = Arc::clone(&self.p2p_config);
-        let shutdown = Arc::clone(&self.shutdown);
 
+        let peer = peer::Peer::<T>::new(
+            remote_peer_id,
+            peer_role,
+            Arc::clone(&self.chain_config),
+            Arc::clone(&self.p2p_config),
+            socket,
+            receiver_address,
+            backend_tx,
+            peer_rx,
+        );
+        let shutdown = Arc::clone(&self.shutdown);
         let handle = tokio::spawn(async move {
-            let mut peer = peer::Peer::<T>::new(
-                remote_peer_id,
-                peer_role,
-                chain_config,
-                p2p_config,
-                socket,
-                receiver_address,
-                backend_tx,
-                peer_rx,
-            );
             match peer.run().await {
                 Ok(()) => {}
                 Err(P2pError::ChannelClosed) if shutdown.load() => {}

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -129,22 +129,19 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
         let socket = transport.bind(bind_addresses).await?;
         let local_addresses = socket.local_addresses().expect("to have bind address available");
 
-        let p2p_config_ = Arc::clone(&p2p_config);
-        let shutdown_ = Arc::clone(&shutdown);
+        let backend = backend::Backend::<T>::new(
+            transport,
+            socket,
+            chain_config,
+            Arc::clone(&p2p_config),
+            cmd_rx,
+            conn_tx,
+            sync_tx,
+            Arc::clone(&shutdown),
+            shutdown_receiver,
+            subscribers_receiver,
+        );
         let backend_task = tokio::spawn(async move {
-            let mut backend = backend::Backend::<T>::new(
-                transport,
-                socket,
-                chain_config,
-                p2p_config_,
-                cmd_rx,
-                conn_tx,
-                sync_tx,
-                shutdown_,
-                shutdown_receiver,
-                subscribers_receiver,
-            );
-
             match backend.run().await {
                 Ok(_) => unreachable!(),
                 Err(P2pError::ChannelClosed) if shutdown.load() => {

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -143,7 +143,7 @@ impl<T: TransportSocket> NetworkingService for DefaultNetworkingService<T> {
         );
         let backend_task = tokio::spawn(async move {
             match backend.run().await {
-                Ok(_) => unreachable!(),
+                Ok(never) => match never {},
                 Err(P2pError::ChannelClosed) if shutdown.load() => {
                     log::info!("Backend is shut down");
                 }

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -263,7 +263,7 @@ where
         Ok(())
     }
 
-    pub async fn run(&mut self) -> crate::Result<()> {
+    pub async fn run(mut self) -> crate::Result<()> {
         // handshake with remote peer and send peer's info to backend
         let handshake_res = timeout(PEER_HANDSHAKE_TIMEOUT, self.handshake()).await;
         match handshake_res {

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -1210,7 +1210,7 @@ where
         }
     }
 
-    pub async fn run(&mut self) -> crate::Result<Never> {
+    pub async fn run(mut self) -> crate::Result<Never> {
         self.run_internal(None).await
     }
 }

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -628,7 +628,7 @@ async fn connection_timeout_rpc_notified<T>(
     .unwrap();
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
-    let mut peer_manager = peer_manager::PeerManager::<T, _>::new(
+    let peer_manager = peer_manager::PeerManager::<T, _>::new(
         Arc::clone(&config),
         Arc::clone(&p2p_config),
         conn,

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -133,7 +133,7 @@ where
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
 {
-    let (mut peer_manager, tx, shutdown_sender, subscribers_sender) =
+    let (peer_manager, tx, shutdown_sender, subscribers_sender) =
         make_peer_manager_custom::<T>(transport, addr, chain_config, p2p_config, time_getter).await;
     tokio::spawn(async move {
         peer_manager.run().await.unwrap();

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -79,7 +79,7 @@ async fn ping_timeout() {
         conn_rx,
     );
 
-    let mut peer_manager = PeerManager::new(
+    let peer_manager = PeerManager::new(
         Arc::clone(&chain_config),
         Arc::clone(&p2p_config),
         connectivity_handle,

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -110,7 +110,7 @@ where
     }
 
     /// Runs the sync manager event loop.
-    pub async fn run(&mut self) -> Result<Never> {
+    pub async fn run(mut self) -> Result<Never> {
         log::info!("Starting SyncManager");
 
         let mut new_tip_receiver = subscribe_to_new_tip(&self.chainstate_handle).await?;

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -119,7 +119,7 @@ impl SyncManagerHandle {
             events_receiver: messaging_receiver,
         };
 
-        let mut sync = BlockSyncManager::new(
+        let sync = BlockSyncManager::new(
             chain_config,
             p2p_config,
             messaging_handle,


### PR DESCRIPTION
Small refactoring that I wanted to do separately from feature PRs to reduce noise.

Consume `self` when running a manager object. It doesn't make sense to be able to run such objects multiple times. This also aligns with how a subsystem is run.