### PR TITLE
Remove Clone bound from p2p networking service messaging handle

### DIFF
--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -74,7 +74,7 @@ pub trait NetworkingService {
     type ConnectivityHandle: Send;
 
     /// A handle for sending messages and announcements to peers.
-    type MessagingHandle: Send + Sync + Clone;
+    type MessagingHandle: Send + Sync;
 
     /// A receiver for syncing events.
     type SyncingEventReceiver: Send;


### PR DESCRIPTION
Removing the trait bound because it is not needed.