### PR TITLE
mempool: Propagate transactions once fully validated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,8 +3240,8 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "logging",
+ "mempool-types",
  "mockall",
- "p2p-types",
  "parking_lot 0.12.1",
  "pos_accounting",
  "rpc",
@@ -3255,6 +3255,14 @@ dependencies = [
  "tokio",
  "utils",
  "utxo",
+]
+
+[[package]]
+name = "mempool-types"
+version = "0.1.0"
+dependencies = [
+ "p2p-types",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6502,6 +6502,7 @@ dependencies = [
  "consensus",
  "crypto",
  "logging",
+ "mempool-types",
  "node-comm",
  "rstest",
  "serialization",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,6 +3241,7 @@ dependencies = [
  "jsonrpsee",
  "logging",
  "mockall",
+ "p2p-types",
  "parking_lot 0.12.1",
  "pos_accounting",
  "rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "dns_server",                   # DNS-server.
   "logging",                      # Logging engine and its interfaces.
   "mempool",                      # Mempool interface and implementation.
+  "mempool/types",                # Common mempool types.
   "merkletree",                   # Merkle tree implementation with merkle proofs.
   "mocks",                        # Mock implementations of our traits (used for testing)
   "node-daemon",                  # Node terminal binary.

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -14,6 +14,7 @@ chainstate-types = { path = '../chainstate/types' }
 common = { path = '../common' }
 crypto = { path = '../crypto' }
 logging = { path = '../logging' }
+p2p-types = { path = '../p2p/types' }
 pos_accounting = { path = '../pos_accounting' }
 rpc = { path = '../rpc' }
 serialization = { path = '../serialization' }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -14,7 +14,7 @@ chainstate-types = { path = '../chainstate/types' }
 common = { path = '../common' }
 crypto = { path = '../crypto' }
 logging = { path = '../logging' }
-p2p-types = { path = '../p2p/types' }
+mempool-types = { path = 'types' }
 pos_accounting = { path = '../pos_accounting' }
 rpc = { path = '../rpc' }
 serialization = { path = '../serialization' }

--- a/mempool/src/error/mod.rs
+++ b/mempool/src/error/mod.rs
@@ -24,7 +24,7 @@ use common::primitives::H256;
 
 use crate::pool::fee::Fee;
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum Error {
     #[error(transparent)]
     Validity(#[from] TxValidationError),
@@ -34,7 +34,7 @@ pub enum Error {
     Orphan(#[from] OrphanPoolError),
 }
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum MempoolPolicyError {
     #[error(transparent)]
     Conflict(#[from] MempoolConflictError),
@@ -81,7 +81,7 @@ pub enum MempoolPolicyError {
     RelayFeeOverflow,
 }
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum TxValidationError {
     #[error("Chainstate error")]
     ChainstateError(#[from] ChainstateError),

--- a/mempool/src/event.rs
+++ b/mempool/src/event.rs
@@ -23,15 +23,15 @@ use crate::{
     TxOrigin,
 };
 
-/// Event triggered when an orphan has been fully validated
+/// Event triggered when a transaction has been fully validated
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct OrphanProcessed {
+pub struct TransactionProcessed {
     tx_id: Id<Transaction>,
     origin: TxOrigin,
     result: crate::Result<()>,
 }
 
-impl OrphanProcessed {
+impl TransactionProcessed {
     fn new(tx_id: Id<Transaction>, origin: TxOrigin, result: crate::Result<()>) -> Self {
         Self {
             tx_id,
@@ -94,12 +94,12 @@ impl NewTip {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum MempoolEvent {
     NewTip(NewTip),
-    OrphanProcessed(OrphanProcessed),
+    TransactionProcessed(TransactionProcessed),
 }
 
-impl From<OrphanProcessed> for MempoolEvent {
-    fn from(event: OrphanProcessed) -> Self {
-        Self::OrphanProcessed(event)
+impl From<TransactionProcessed> for MempoolEvent {
+    fn from(event: TransactionProcessed) -> Self {
+        Self::TransactionProcessed(event)
     }
 }
 

--- a/mempool/src/event.rs
+++ b/mempool/src/event.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::{
+    chain::{Block, Transaction},
+    primitives::{BlockHeight, Id},
+};
+
+use crate::{
+    error::{Error, MempoolBanScore},
+    TxOrigin,
+};
+
+/// Event triggered when an orphan has been fully validated
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct OrphanProcessed {
+    tx_id: Id<Transaction>,
+    origin: TxOrigin,
+    result: crate::Result<()>,
+}
+
+impl OrphanProcessed {
+    fn new(tx_id: Id<Transaction>, origin: TxOrigin, result: crate::Result<()>) -> Self {
+        Self {
+            tx_id,
+            origin,
+            result,
+        }
+    }
+
+    pub fn accepted(tx_id: Id<Transaction>, origin: TxOrigin) -> Self {
+        Self::new(tx_id, origin, Ok(()))
+    }
+
+    pub fn rejected(tx_id: Id<Transaction>, err: Error, origin: TxOrigin) -> Self {
+        Self::new(tx_id, origin, Err(err))
+    }
+
+    pub fn result(&self) -> &crate::Result<()> {
+        &self.result
+    }
+
+    pub fn was_accepted(&self) -> bool {
+        self.result.is_ok()
+    }
+
+    pub fn ban_score(&self) -> u32 {
+        self.result.as_ref().map_or_else(|err| err.mempool_ban_score(), |_| 0)
+    }
+
+    pub fn tx_id(&self) -> &Id<Transaction> {
+        &self.tx_id
+    }
+
+    pub fn origin(&self) -> TxOrigin {
+        self.origin
+    }
+}
+
+/// Event triggered when mempool has synced up to given tip
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NewTip {
+    block_id: Id<Block>,
+    height: BlockHeight,
+}
+
+impl NewTip {
+    pub fn new(block_id: Id<Block>, height: BlockHeight) -> Self {
+        Self { block_id, height }
+    }
+
+    pub fn block_id(&self) -> &Id<Block> {
+        &self.block_id
+    }
+
+    pub fn block_height(&self) -> BlockHeight {
+        self.height
+    }
+}
+
+/// Events emitted by mempool
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum MempoolEvent {
+    NewTip(NewTip),
+    OrphanProcessed(OrphanProcessed),
+}
+
+impl From<OrphanProcessed> for MempoolEvent {
+    fn from(event: OrphanProcessed) -> Self {
+        Self::OrphanProcessed(event)
+    }
+}
+
+impl From<NewTip> for MempoolEvent {
+    fn from(event: NewTip) -> Self {
+        Self::NewTip(event)
+    }
+}

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -14,7 +14,8 @@
 // limitations under the License.
 
 use crate::{
-    error::Error, tx_accumulator::TransactionAccumulator, MempoolEvent, MempoolMaxSize, TxStatus,
+    error::Error, event::MempoolEvent, tx_accumulator::TransactionAccumulator, MempoolMaxSize,
+    TxOrigin, TxStatus,
 };
 use common::{
     chain::{GenBlock, SignedTransaction, Transaction},
@@ -25,7 +26,11 @@ use subsystem::{CallRequest, ShutdownRequest};
 
 pub trait MempoolInterface: Send + Sync {
     /// Add a transaction to mempool
-    fn add_transaction(&mut self, tx: SignedTransaction) -> Result<TxStatus, Error>;
+    fn add_transaction(
+        &mut self,
+        tx: SignedTransaction,
+        origin: TxOrigin,
+    ) -> Result<TxStatus, Error>;
 
     /// Get all transactions from mempool
     fn get_all(&self) -> Vec<SignedTransaction>;
@@ -52,10 +57,7 @@ pub trait MempoolInterface: Send + Sync {
     ) -> Result<Box<dyn TransactionAccumulator>, Error>;
 
     /// Subscribe to events emitted by mempool
-    fn subscribe_to_events(
-        &mut self,
-        handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>,
-    ) -> Result<(), Error>;
+    fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>);
 
     /// Get current memory usage
     fn memory_usage(&self) -> usize;

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 use crate::{
-    error::Error, pool::memory_usage_estimator::StoreMemoryUsageEstimator,
-    tx_accumulator::TransactionAccumulator, MempoolEvent, MempoolInterface, MempoolMaxSize,
-    MempoolSubsystemInterface, TxStatus,
+    error::Error, event::MempoolEvent, pool::memory_usage_estimator::StoreMemoryUsageEstimator,
+    tx_accumulator::TransactionAccumulator, MempoolInterface, MempoolMaxSize,
+    MempoolSubsystemInterface, TxOrigin, TxStatus,
 };
 use chainstate::chainstate_interface::ChainstateInterface;
 use common::{
@@ -104,8 +104,12 @@ impl MempoolSubsystemInterface for MempoolInit {
 }
 
 impl MempoolInterface for Mempool {
-    fn add_transaction(&mut self, tx: SignedTransaction) -> Result<TxStatus, Error> {
-        self.add_transaction(tx)
+    fn add_transaction(
+        &mut self,
+        tx: SignedTransaction,
+        origin: TxOrigin,
+    ) -> Result<TxStatus, Error> {
+        self.add_transaction(tx, origin)
     }
 
     fn get_all(&self) -> Vec<SignedTransaction> {
@@ -139,12 +143,8 @@ impl MempoolInterface for Mempool {
         Ok(self.collect_txs(tx_accumulator))
     }
 
-    fn subscribe_to_events(
-        &mut self,
-        handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>,
-    ) -> Result<(), Error> {
+    fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>) {
         self.subscribe_to_events(handler);
-        Ok(())
     }
 
     fn memory_usage(&self) -> usize {

--- a/mempool/src/interface/mod.rs
+++ b/mempool/src/interface/mod.rs
@@ -13,5 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod mempool_interface;
-pub mod mempool_interface_impl;
+mod mempool_interface;
+mod mempool_interface_impl;
+
+pub use mempool_interface::{MempoolInterface, MempoolSubsystemInterface};
+pub use mempool_interface_impl::make_mempool;

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -15,32 +15,23 @@
 
 #![deny(clippy::clone_on_ref_ptr)]
 
-use common::{
-    chain::Block,
-    primitives::{BlockHeight, Id},
-};
 pub use config::MempoolMaxSize;
-pub use interface::{
-    mempool_interface::{MempoolInterface, MempoolSubsystemInterface},
-    mempool_interface_impl::make_mempool,
-};
-
-use crate::error::Error as MempoolError;
+pub use interface::{make_mempool, MempoolInterface, MempoolSubsystemInterface};
+pub use tx_origin::TxOrigin;
 
 mod config;
 pub mod error;
+pub mod event;
 mod interface;
 mod pool;
 pub mod rpc;
 pub mod tx_accumulator;
-
-#[derive(Debug, Clone)]
-pub enum MempoolEvent {
-    NewTip(Id<Block>, BlockHeight),
-}
+mod tx_origin;
 
 /// Result of adding transaction to the mempool
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, serde::Serialize)]
+#[derive(
+    Debug, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, serde::Serialize, serde::Deserialize,
+)]
 #[must_use = "Please check whether the tx was accepted to main mempool or orphan pool"]
 pub enum TxStatus {
     /// Transaction is in mempool
@@ -61,4 +52,4 @@ impl TxStatus {
 
 pub type MempoolHandle = subsystem::Handle<dyn MempoolInterface>;
 
-pub type Result<T> = core::result::Result<T, MempoolError>;
+pub type Result<T> = core::result::Result<T, error::Error>;

--- a/mempool/src/pool/entry.rs
+++ b/mempool/src/pool/entry.rs
@@ -21,7 +21,7 @@ use common::{
     primitives::{Id, Idable},
 };
 
-use super::{Fee, Time};
+use super::{Fee, Time, TxOrigin};
 
 /// A dependency of a transaction on a previous account state.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -84,11 +84,12 @@ pub struct TxEntry {
     transaction: SignedTransaction,
     creation_time: Time,
     encoded_size: usize,
+    origin: TxOrigin,
 }
 
 impl TxEntry {
     /// Create a new mempool transaction entry
-    pub fn new(transaction: SignedTransaction, creation_time: Time) -> Self {
+    pub fn new(transaction: SignedTransaction, creation_time: Time, origin: TxOrigin) -> Self {
         let tx_id = transaction.transaction().get_id();
         let encoded_size = serialization::Encode::encoded_size(&transaction);
         Self {
@@ -96,6 +97,7 @@ impl TxEntry {
             transaction,
             creation_time,
             encoded_size,
+            origin,
         }
     }
 
@@ -117,6 +119,11 @@ impl TxEntry {
     /// Encoded size of this entry
     pub fn size(&self) -> usize {
         self.encoded_size
+    }
+
+    /// Where we got this transaction
+    pub fn origin(&self) -> TxOrigin {
+        self.origin
     }
 
     /// Dependency graph edges this entry requires

--- a/mempool/src/pool/orphans/test.rs
+++ b/mempool/src/pool/orphans/test.rs
@@ -72,9 +72,8 @@ fn random_tx_entry(rng: &mut impl Rng) -> TxEntry {
     let signatures = vec![InputWitness::NoSignature(None); n_inputs];
     let transaction = SignedTransaction::new(transaction, signatures).unwrap();
     let insertion_time = Time::from_secs(rng.gen());
-    let origin = crate::TxOrigin::TEST;
 
-    TxEntry::new(transaction, insertion_time, origin)
+    TxEntry::new(transaction, insertion_time, crate::TxOrigin::LocalMempool)
 }
 
 #[rstest]

--- a/mempool/src/pool/orphans/test.rs
+++ b/mempool/src/pool/orphans/test.rs
@@ -72,8 +72,9 @@ fn random_tx_entry(rng: &mut impl Rng) -> TxEntry {
     let signatures = vec![InputWitness::NoSignature(None); n_inputs];
     let transaction = SignedTransaction::new(transaction, signatures).unwrap();
     let insertion_time = Time::from_secs(rng.gen());
+    let origin = crate::TxOrigin::TEST;
 
-    TxEntry::new(transaction, insertion_time)
+    TxEntry::new(transaction, insertion_time, origin)
 }
 
 #[rstest]

--- a/mempool/src/pool/reorg.rs
+++ b/mempool/src/pool/reorg.rs
@@ -26,7 +26,7 @@ use logging::log;
 use utils::tap_error_log::LogError;
 use utxo::UtxosStorageRead;
 
-use super::{MemoryUsageEstimator, Mempool};
+use super::{MemoryUsageEstimator, Mempool, TxOrigin};
 
 /// An error that can happen in mempool on chain reorg
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -147,7 +147,7 @@ pub fn refresh_mempool<M: MemoryUsageEstimator>(
 
     for tx in txs_to_insert {
         let tx_id = tx.transaction().get_id();
-        if let Err(e) = mempool.add_transaction(tx) {
+        if let Err(e) = mempool.add_transaction(tx, TxOrigin::PastBlock) {
             log::debug!("Disconnected transaction {tx_id:?} no longer validates: {e:?}")
         }
     }

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -628,7 +628,7 @@ impl TxMempoolEntry {
         ancestors: BTreeSet<TxMempoolEntry>,
         creation_time: Time,
     ) -> Result<TxMempoolEntry, MempoolPolicyError> {
-        let entry = TxEntry::new(tx, creation_time, crate::TxOrigin::TEST);
+        let entry = TxEntry::new(tx, creation_time, crate::TxOrigin::LocalMempool);
         Self::new(TxEntryWithFee::new(entry, fee), parents, ancestors)
     }
 

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -628,7 +628,7 @@ impl TxMempoolEntry {
         ancestors: BTreeSet<TxMempoolEntry>,
         creation_time: Time,
     ) -> Result<TxMempoolEntry, MempoolPolicyError> {
-        let entry = TxEntry::new(tx, creation_time);
+        let entry = TxEntry::new(tx, creation_time, crate::TxOrigin::TEST);
         Self::new(TxEntryWithFee::new(entry, fee), parents, ancestors)
     }
 

--- a/mempool/src/pool/tests/expiry.rs
+++ b/mempool/src/pool/tests/expiry.rs
@@ -55,7 +55,7 @@ async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
         mock_clock,
         StoreMemoryUsageEstimator,
     );
-    mempool.add_transaction(parent)?.assert_in_mempool();
+    mempool.add_transaction(parent, TxOrigin::TEST)?.assert_in_mempool();
 
     let flags = 0;
     let outpoint_source_id = OutPointSourceId::Transaction(parent_id);
@@ -71,7 +71,7 @@ async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
     mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1);
 
     assert_eq!(
-        mempool.add_transaction(child),
+        mempool.add_transaction(child, TxOrigin::TEST),
         Err(MempoolPolicyError::DescendantOfExpiredTransaction.into())
     );
 
@@ -117,7 +117,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
     );
 
     let parent_id = parent.transaction().get_id();
-    mempool.add_transaction(parent.clone())?.assert_in_mempool();
+    mempool.add_transaction(parent.clone(), TxOrigin::TEST)?.assert_in_mempool();
 
     let flags = 0;
     let outpoint_source_id = OutPointSourceId::Transaction(parent_id);
@@ -141,7 +141,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
     let child_1_id = child_1.transaction().get_id();
 
     let expired_tx_id = child_0.transaction().get_id();
-    mempool.add_transaction(child_0)?.assert_in_mempool();
+    mempool.add_transaction(child_0, TxOrigin::TEST)?.assert_in_mempool();
 
     // Simulate the parent being added to a block
     // We have to do this because if we leave this parent in the mempool then it will be
@@ -163,7 +163,7 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
         .await??;
     mock_time.store(DEFAULT_MEMPOOL_EXPIRY.as_secs() + 1);
 
-    mempool.add_transaction(child_1)?.assert_in_mempool();
+    mempool.add_transaction(child_1, TxOrigin::TEST)?.assert_in_mempool();
     assert!(!mempool.contains_transaction(&expired_tx_id));
     assert!(mempool.contains_transaction(&child_1_id));
     mempool.store.assert_valid();

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -105,7 +105,7 @@ async fn add_single_tx() -> anyhow::Result<()> {
 
     let tx_clone = tx.clone();
     let tx_id = tx.transaction().get_id();
-    mempool.add_transaction(tx)?.assert_in_mempool();
+    mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
     assert!(mempool.contains_transaction(&tx_id));
     let all_txs = mempool.get_all();
     assert_eq!(all_txs, vec![tx_clone]);
@@ -140,7 +140,7 @@ async fn txs_sorted(#[case] seed: Seed) -> anyhow::Result<()> {
     }
     let initial_tx = tx_builder.build();
     let initial_tx_id = initial_tx.transaction().get_id();
-    mempool.add_transaction(initial_tx)?.assert_in_mempool();
+    mempool.add_transaction(initial_tx, TxOrigin::TEST)?.assert_in_mempool();
     for i in 0..target_txs {
         let tx = TransactionBuilder::new()
             .add_input(
@@ -152,7 +152,7 @@ async fn txs_sorted(#[case] seed: Seed) -> anyhow::Result<()> {
                 Destination::AnyoneCanSpend,
             ))
             .build();
-        mempool.add_transaction(tx.clone())?.assert_in_mempool();
+        mempool.add_transaction(tx.clone(), TxOrigin::TEST)?.assert_in_mempool();
     }
 
     let mut fees = Vec::new();
@@ -170,7 +170,7 @@ async fn txs_sorted(#[case] seed: Seed) -> anyhow::Result<()> {
 async fn tx_no_inputs() {
     let mut mempool = setup().await;
     let tx = TransactionBuilder::new().build();
-    let res = mempool.add_transaction(tx);
+    let res = mempool.add_transaction(tx, TxOrigin::TEST);
 
     assert_eq!(
         res,
@@ -249,7 +249,7 @@ async fn tx_no_outputs(#[case] seed: Seed) -> anyhow::Result<()> {
         .build();
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
     assert_eq!(
-        mempool.add_transaction(tx),
+        mempool.add_transaction(tx, TxOrigin::TEST),
         Err(MempoolPolicyError::NoOutputs.into())
     );
     mempool.store.assert_valid();
@@ -287,7 +287,7 @@ async fn tx_duplicate_inputs() -> anyhow::Result<()> {
     .expect("invalid witness count");
 
     assert!(matches!(
-        mempool.add_transaction(tx),
+        mempool.add_transaction(tx, TxOrigin::TEST),
         Err(Error::Validity(_)),
     ));
     mempool.store.assert_valid();
@@ -311,9 +311,9 @@ async fn tx_already_in_mempool() -> anyhow::Result<()> {
     )
     .await?;
 
-    mempool.add_transaction(tx.clone())?.assert_in_mempool();
+    mempool.add_transaction(tx.clone(), TxOrigin::TEST)?.assert_in_mempool();
     assert_eq!(
-        mempool.add_transaction(tx),
+        mempool.add_transaction(tx, TxOrigin::TEST),
         Err(MempoolPolicyError::TransactionAlreadyInMempool.into())
     );
     mempool.store.assert_valid();
@@ -356,7 +356,10 @@ async fn outpoint_not_found(#[case] seed: Seed) -> anyhow::Result<()> {
     )
     .expect("invalid witness count");
 
-    assert_eq!(mempool.add_transaction(tx), Ok(TxStatus::InOrphanPool));
+    assert_eq!(
+        mempool.add_transaction(tx, TxOrigin::TEST),
+        Ok(TxStatus::InOrphanPool)
+    );
     mempool.store.assert_valid();
 
     Ok(())
@@ -391,7 +394,7 @@ async fn tx_too_big(#[case] seed: Seed) -> anyhow::Result<()> {
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
 
     assert_eq!(
-        mempool.add_transaction(tx),
+        mempool.add_transaction(tx, TxOrigin::TEST),
         Err(MempoolPolicyError::ExceedsMaxBlockSize.into())
     );
     mempool.store.assert_valid();
@@ -493,7 +496,7 @@ async fn one_ancestor_replaceability_signal_is_enough(#[case] seed: Seed) -> any
     let tx = tx_builder.build();
 
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
-    mempool.add_transaction(tx.clone())?.assert_in_mempool();
+    mempool.add_transaction(tx.clone(), TxOrigin::TEST)?.assert_in_mempool();
 
     let flags_replaceable = 1;
     let flags_irreplaceable = 0;
@@ -517,8 +520,12 @@ async fn one_ancestor_replaceability_signal_is_enough(#[case] seed: Seed) -> any
     )
     .await?;
 
-    mempool.add_transaction(ancestor_with_signal.clone())?.assert_in_mempool();
-    mempool.add_transaction(ancestor_without_signal.clone())?.assert_in_mempool();
+    mempool
+        .add_transaction(ancestor_with_signal.clone(), TxOrigin::TEST)?
+        .assert_in_mempool();
+    mempool
+        .add_transaction(ancestor_without_signal.clone(), TxOrigin::TEST)?
+        .assert_in_mempool();
 
     let input_with_replaceable_parent = TxInput::from_utxo(
         OutPointSourceId::Transaction(ancestor_with_signal.transaction().get_id()),
@@ -549,7 +556,7 @@ async fn one_ancestor_replaceability_signal_is_enough(#[case] seed: Seed) -> any
     .await?;
     let replaced_tx_id = replaced_tx.transaction().get_id();
 
-    mempool.add_transaction(replaced_tx)?.assert_in_mempool();
+    mempool.add_transaction(replaced_tx, TxOrigin::TEST)?.assert_in_mempool();
 
     let replacing_tx = SignedTransaction::new(
         Transaction::new(
@@ -561,7 +568,7 @@ async fn one_ancestor_replaceability_signal_is_enough(#[case] seed: Seed) -> any
     )
     .expect("invalid witness count");
 
-    let result = mempool.add_transaction(replacing_tx);
+    let result = mempool.add_transaction(replacing_tx, TxOrigin::TEST);
     if ENABLE_RBF {
         assert_eq!(result, Ok(TxStatus::InMempool));
         assert!(!mempool.contains_transaction(&replaced_tx_id));
@@ -733,7 +740,7 @@ async fn test_bip125_max_replacements(
     let input = tx.transaction().inputs().first().expect("one input").clone();
     let outputs = tx.transaction().outputs().to_owned();
     let tx_id = tx.transaction().get_id();
-    mempool.add_transaction(tx)?.assert_in_mempool();
+    mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
 
     let flags = 0;
     let outpoint_source_id = OutPointSourceId::Transaction(tx_id);
@@ -748,7 +755,7 @@ async fn test_bip125_max_replacements(
             flags,
         )
         .await?;
-        mempool.add_transaction(tx)?.assert_in_mempool();
+        mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
     }
     let mempool_size_before_replacement = mempool.store.txs_by_id.len();
 
@@ -761,7 +768,7 @@ async fn test_bip125_max_replacements(
         flags,
     )
     .await?;
-    mempool.add_transaction(replacement_tx)?.assert_in_mempool();
+    mempool.add_transaction(replacement_tx, TxOrigin::TEST)?.assert_in_mempool();
     let mempool_size_after_replacement = mempool.store.txs_by_id.len();
 
     assert_eq!(
@@ -825,7 +832,7 @@ async fn spends_new_unconfirmed(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx = tx_builder.build();
     let outpoint_source_id = OutPointSourceId::Transaction(tx.transaction().get_id());
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
-    mempool.add_transaction(tx)?.assert_in_mempool();
+    mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
 
     let input1 = TxInput::from_utxo(outpoint_source_id.clone(), 0);
     let input2 = TxInput::from_utxo(outpoint_source_id, 1);
@@ -840,7 +847,7 @@ async fn spends_new_unconfirmed(#[case] seed: Seed) -> anyhow::Result<()> {
         flags,
     )
     .await?;
-    mempool.add_transaction(replaced_tx)?.assert_in_mempool();
+    mempool.add_transaction(replaced_tx, TxOrigin::TEST)?.assert_in_mempool();
     let relay_fee = get_relay_fee_from_tx_size(TX_SPEND_INPUT_SIZE);
     let replacement_fee: Fee = Amount::from_atoms(100 + relay_fee).into();
     let incoming_tx = tx_spend_several_inputs(
@@ -855,7 +862,7 @@ async fn spends_new_unconfirmed(#[case] seed: Seed) -> anyhow::Result<()> {
     )
     .await?;
 
-    let res = mempool.add_transaction(incoming_tx);
+    let res = mempool.add_transaction(incoming_tx, TxOrigin::TEST);
     assert_eq!(res, Err(Error::Orphan(OrphanPoolError::MempoolConflict)));
     mempool.store.assert_valid();
     Ok(())
@@ -917,7 +924,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
         mock_clock,
         mock_usage,
     );
-    mempool.add_transaction(parent.clone())?.assert_in_mempool();
+    mempool.add_transaction(parent.clone(), TxOrigin::TEST)?.assert_in_mempool();
     log::debug!("after adding parent");
 
     let flags = 0;
@@ -949,9 +956,9 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     .await?;
     let child_1_id = child_1.transaction().get_id();
     log::debug!("child_1_id {}", child_1_id.get());
-    mempool.add_transaction(child_0.clone())?.assert_in_mempool();
+    mempool.add_transaction(child_0.clone(), TxOrigin::TEST)?.assert_in_mempool();
     log::debug!("added child_0");
-    mempool.add_transaction(child_1)?.assert_in_mempool();
+    mempool.add_transaction(child_1, TxOrigin::TEST)?.assert_in_mempool();
     log::debug!("added child_1");
 
     assert_eq!(mempool.store.txs_by_id.len(), 2);
@@ -999,7 +1006,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
         child_2.encoded_size(),
         mempool.get_minimum_rolling_fee()
     );
-    let res = mempool.add_transaction(child_2);
+    let res = mempool.add_transaction(child_2, TxOrigin::TEST);
     log::debug!("result of adding child2 {:?}", res);
     assert!(matches!(
         res,
@@ -1021,7 +1028,9 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     let child_2_high_fee_outpt =
         UtxoOutPoint::new(OutPointSourceId::Transaction(child_2_high_fee_id), 0);
     log::debug!("before child2_high_fee");
-    mempool.add_transaction(child_2_high_fee.clone())?.assert_in_mempool();
+    mempool
+        .add_transaction(child_2_high_fee.clone(), TxOrigin::TEST)?
+        .assert_in_mempool();
 
     assert!(mempool.contains_transaction(&child_2_high_fee_id));
     assert!(mempool
@@ -1049,7 +1058,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
         .chainstate_handle
         .call_mut(|this| this.process_block(block, BlockSource::Local))
         .await??;
-    mempool.new_tip_set(Id::new(H256::zero()), BlockHeight::new(1));
+    mempool.on_new_tip(Id::new(H256::zero()), BlockHeight::new(1));
 
     assert!(!mempool.contains_transaction(&child_2_high_fee_id));
     assert!(mempool
@@ -1082,7 +1091,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
         "First attempt to add dummy which pays a fee of {:?}",
         try_get_fee(&mempool, &dummy_tx).await
     );
-    let res = mempool.add_transaction(dummy_tx.clone());
+    let res = mempool.add_transaction(dummy_tx.clone(), TxOrigin::TEST);
 
     log::debug!("Result of first attempt to add dummy: {res:?}");
     assert!(matches!(
@@ -1102,7 +1111,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
 
     mock_time.store(mock_time.load() + halflife.as_secs());
     log::debug!("Second attempt to add dummy");
-    mempool.add_transaction(dummy_tx)?.assert_in_mempool();
+    mempool.add_transaction(dummy_tx, TxOrigin::TEST)?.assert_in_mempool();
     log::debug!(
         "minimum rolling fee after first second to add dummy: {:?}",
         mempool.get_minimum_rolling_fee()
@@ -1130,7 +1139,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
         ))
         .build();
 
-    mempool.add_transaction(another_dummy)?.assert_in_mempool();
+    mempool.add_transaction(another_dummy, TxOrigin::TEST)?.assert_in_mempool();
     assert_eq!(
         mempool.get_minimum_rolling_fee(),
         FeeRate::new(Amount::from_atoms(0))
@@ -1202,7 +1211,7 @@ async fn different_size_txs(#[case] seed: Seed) -> anyhow::Result<()> {
         );
         let tx = tx_builder.build();
         let before_adding_tx_i = Instant::now();
-        mempool.add_transaction(tx)?.assert_in_mempool();
+        mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
         log::debug!(
             "time spent adding tx {}: {:?}",
             i,
@@ -1241,7 +1250,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_id = tx.transaction().get_id();
 
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
-    mempool.add_transaction(tx)?.assert_in_mempool();
+    mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
 
     let outpoint_source_id = OutPointSourceId::Transaction(tx_id);
 
@@ -1263,7 +1272,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
     log::debug!("tx id is: {}", tx_id);
     log::debug!("tx_a_id : {}", tx_a_id.get());
     log::debug!("tx_a fee : {:?}", try_get_fee(&mempool, &tx_a).await);
-    mempool.add_transaction(tx_a)?.assert_in_mempool();
+    mempool.add_transaction(tx_a, TxOrigin::TEST)?.assert_in_mempool();
 
     let tx_b = tx_spend_input(
         &mempool,
@@ -1276,7 +1285,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_b_id = tx_b.transaction().get_id();
     log::debug!("tx_b_id : {}", tx_b_id.get());
     log::debug!("tx_b fee : {:?}", try_get_fee(&mempool, &tx_b).await);
-    mempool.add_transaction(tx_b)?.assert_in_mempool();
+    mempool.add_transaction(tx_b, TxOrigin::TEST)?.assert_in_mempool();
 
     let tx_c = tx_spend_input(
         &mempool,
@@ -1289,7 +1298,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_c_id = tx_c.transaction().get_id();
     log::debug!("tx_c_id : {}", tx_c_id.get());
     log::debug!("tx_c fee : {:?}", try_get_fee(&mempool, &tx_c).await);
-    mempool.add_transaction(tx_c)?.assert_in_mempool();
+    mempool.add_transaction(tx_c, TxOrigin::TEST)?.assert_in_mempool();
 
     let entry_tx = mempool.store.txs_by_id.get(&tx_id).expect("tx");
     let entry_tx_id = *entry_tx.tx_id();
@@ -1397,7 +1406,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_id = tx.transaction().get_id();
 
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
-    mempool.add_transaction(tx)?.assert_in_mempool();
+    mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
 
     let outpoint_source_id = OutPointSourceId::Transaction(tx_id);
 
@@ -1418,7 +1427,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_a_id = tx_a.transaction().get_id();
     log::debug!("tx_a_id : {}", tx_a_id.get());
     log::debug!("tx_a fee : {:?}", try_get_fee(&mempool, &tx_a).await);
-    mempool.add_transaction(tx_a)?.assert_in_mempool();
+    mempool.add_transaction(tx_a, TxOrigin::TEST)?.assert_in_mempool();
 
     let tx_b = tx_spend_input(
         &mempool,
@@ -1431,7 +1440,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_b_id = tx_b.transaction().get_id();
     log::debug!("tx_b_id : {}", tx_b_id.get());
     log::debug!("tx_b fee : {:?}", try_get_fee(&mempool, &tx_b).await);
-    mempool.add_transaction(tx_b)?.assert_in_mempool();
+    mempool.add_transaction(tx_b, TxOrigin::TEST)?.assert_in_mempool();
 
     let tx_c = tx_spend_input(
         &mempool,
@@ -1444,7 +1453,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     let tx_c_id = tx_c.transaction().get_id();
     log::debug!("tx_c_id : {}", tx_c_id.get());
     log::debug!("tx_c fee : {:?}", try_get_fee(&mempool, &tx_c).await);
-    mempool.add_transaction(tx_c)?.assert_in_mempool();
+    mempool.add_transaction(tx_c, TxOrigin::TEST)?.assert_in_mempool();
 
     let entry_a = mempool.store.txs_by_id.get(&tx_a_id).expect("tx_a");
     log::debug!("entry a has score {:?}", entry_a.descendant_score());
@@ -1531,7 +1540,7 @@ async fn mempool_full_mock(#[case] seed: Seed) -> anyhow::Result<()> {
         "mempool_full: tx has id {}",
         tx.transaction().get_id().get()
     );
-    let res = mempool.add_transaction(tx);
+    let res = mempool.add_transaction(tx, TxOrigin::TEST);
     assert_eq!(res, Err(MempoolPolicyError::MempoolFull.into()));
     mempool.store.assert_valid();
     Ok(())
@@ -1641,7 +1650,7 @@ async fn no_empty_bags_in_indices(#[case] seed: Seed) -> anyhow::Result<()> {
     let parent_id = parent.transaction().get_id();
 
     let outpoint_source_id = OutPointSourceId::Transaction(parent.transaction().get_id());
-    mempool.add_transaction(parent)?.assert_in_mempool();
+    mempool.add_transaction(parent, TxOrigin::TEST)?.assert_in_mempool();
     let num_child_txs = num_outputs;
     let flags = 0;
     let fee = get_relay_fee_from_tx_size(estimate_tx_size(1, num_outputs));
@@ -1661,7 +1670,7 @@ async fn no_empty_bags_in_indices(#[case] seed: Seed) -> anyhow::Result<()> {
     let ids = txs.iter().map(|tx| tx.transaction().get_id()).collect::<Vec<_>>();
 
     for tx in txs {
-        mempool.add_transaction(tx)?.assert_in_mempool();
+        mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
     }
 
     mempool.store.remove_tx(&parent_id, MempoolRemovalReason::Block);
@@ -1705,7 +1714,7 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
     }
     let initial_tx = tx_builder.build();
     let initial_tx_id = initial_tx.transaction().get_id();
-    mempool.add_transaction(initial_tx)?.assert_in_mempool();
+    mempool.add_transaction(initial_tx, TxOrigin::TEST)?.assert_in_mempool();
     for i in 0..target_txs {
         let tx = TransactionBuilder::new()
             .add_input(
@@ -1717,7 +1726,7 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
                 Destination::AnyoneCanSpend,
             ))
             .build();
-        mempool.add_transaction(tx.clone())?.assert_in_mempool();
+        mempool.add_transaction(tx.clone(), TxOrigin::TEST)?.assert_in_mempool();
     }
 
     let size_limit = 1_000;

--- a/mempool/src/pool/tests/reorg.rs
+++ b/mempool/src/pool/tests/reorg.rs
@@ -48,7 +48,10 @@ async fn basic_reorg(#[case] seed: Seed) {
         .add_anyone_can_spend_output(10_000_000)
         .build();
     let tx1_id = tx1.transaction().get_id();
-    mempool.add_transaction(tx1.clone()).expect("adding tx1").assert_in_mempool();
+    mempool
+        .add_transaction(tx1.clone(), TxOrigin::TEST)
+        .expect("adding tx1")
+        .assert_in_mempool();
 
     // Add another transaction
     let tx2 = TransactionBuilder::new()
@@ -59,7 +62,10 @@ async fn basic_reorg(#[case] seed: Seed) {
         .add_anyone_can_spend_output(9_000_000)
         .build();
     let tx2_id = tx2.transaction().get_id();
-    mempool.add_transaction(tx2.clone()).expect("adding tx2").assert_in_mempool();
+    mempool
+        .add_transaction(tx2.clone(), TxOrigin::TEST)
+        .expect("adding tx2")
+        .assert_in_mempool();
 
     // Check the transactions are there
     assert!(mempool.contains_transaction(&tx1_id));
@@ -78,7 +84,7 @@ async fn basic_reorg(#[case] seed: Seed) {
         .await
         .unwrap()
         .expect("block1");
-    mempool.new_tip_set(block1_id, BlockHeight::new(1));
+    mempool.on_new_tip(block1_id, BlockHeight::new(1));
     assert!(!mempool.contains_transaction(&tx1_id));
     assert!(mempool.contains_transaction(&tx2_id));
 
@@ -93,7 +99,7 @@ async fn basic_reorg(#[case] seed: Seed) {
         .await
         .unwrap()
         .expect("block2");
-    mempool.new_tip_set(block2_id, BlockHeight::new(2));
+    mempool.on_new_tip(block2_id, BlockHeight::new(2));
     assert!(!mempool.contains_transaction(&tx1_id));
     assert!(!mempool.contains_transaction(&tx2_id));
 
@@ -108,7 +114,7 @@ async fn basic_reorg(#[case] seed: Seed) {
             .unwrap()
             .expect(name);
     }
-    mempool.new_tip_set(block4_id, BlockHeight::new(3));
+    mempool.on_new_tip(block4_id, BlockHeight::new(3));
     assert!(!mempool.contains_transaction(&tx1_id));
     assert!(mempool.contains_transaction(&tx2_id));
 }
@@ -133,7 +139,10 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
         .add_anyone_can_spend_output(10_000_000)
         .build();
     let tx1_id = tx1.transaction().get_id();
-    mempool.add_transaction(tx1.clone()).expect("adding tx1").assert_in_mempool();
+    mempool
+        .add_transaction(tx1.clone(), TxOrigin::TEST)
+        .expect("adding tx1")
+        .assert_in_mempool();
 
     // Add another transaction
     let tx2 = TransactionBuilder::new()
@@ -144,7 +153,10 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
         .add_anyone_can_spend_output(9_000_000)
         .build();
     let tx2_id = tx2.transaction().get_id();
-    mempool.add_transaction(tx2.clone()).expect("adding tx2").assert_in_mempool();
+    mempool
+        .add_transaction(tx2.clone(), TxOrigin::TEST)
+        .expect("adding tx2")
+        .assert_in_mempool();
 
     // Check the transactions are there
     assert!(mempool.contains_transaction(&tx1_id));
@@ -158,7 +170,7 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
         .await
         .unwrap()
         .expect("block1");
-    mempool.new_tip_set(block1_id, BlockHeight::new(1));
+    mempool.on_new_tip(block1_id, BlockHeight::new(1));
     assert!(!mempool.contains_transaction(&tx1_id));
     assert!(!mempool.contains_transaction(&tx2_id));
 
@@ -173,7 +185,7 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
             .unwrap()
             .expect(name);
     }
-    mempool.new_tip_set(block3_id, BlockHeight::new(2));
+    mempool.on_new_tip(block3_id, BlockHeight::new(2));
     assert!(mempool.contains_transaction(&tx1_id));
     assert!(mempool.contains_transaction(&tx2_id));
 }

--- a/mempool/src/pool/tests/replacement.rs
+++ b/mempool/src/pool/tests/replacement.rs
@@ -51,7 +51,7 @@ async fn test_replace_tx(
         "created a tx with fee {:?}",
         try_get_fee(&mempool, &original).await
     );
-    mempool.add_transaction(original)?.assert_in_mempool();
+    mempool.add_transaction(original, TxOrigin::TEST)?.assert_in_mempool();
 
     let flags = 0;
     let replacement = tx_spend_input(
@@ -67,7 +67,7 @@ async fn test_replace_tx(
         "created a replacement with fee {:?}",
         try_get_fee(&mempool, &replacement).await
     );
-    mempool.add_transaction(replacement)?.assert_in_mempool();
+    mempool.add_transaction(replacement, TxOrigin::TEST)?.assert_in_mempool();
     assert!(!mempool.contains_transaction(&original_id));
     mempool.store.assert_valid();
 
@@ -100,7 +100,7 @@ async fn try_replace_irreplaceable(#[case] seed: Seed) -> anyhow::Result<()> {
     .await
     .expect("should be able to spend here");
     let original_id = original.transaction().get_id();
-    mempool.add_transaction(original)?.assert_in_mempool();
+    mempool.add_transaction(original, TxOrigin::TEST)?.assert_in_mempool();
 
     let flags = 0;
     let replacement_fee = (original_fee + Fee::new(Amount::from_atoms(1000))).unwrap();
@@ -114,12 +114,12 @@ async fn try_replace_irreplaceable(#[case] seed: Seed) -> anyhow::Result<()> {
     .await
     .expect("should be able to spend here");
     assert_eq!(
-        mempool.add_transaction(replacement.clone()),
+        mempool.add_transaction(replacement.clone(), TxOrigin::TEST),
         Err(MempoolPolicyError::from(MempoolConflictError::Irreplacable).into())
     );
 
     mempool.store.remove_tx(&original_id, MempoolRemovalReason::Block);
-    mempool.add_transaction(replacement)?.assert_in_mempool();
+    mempool.add_transaction(replacement, TxOrigin::TEST)?.assert_in_mempool();
     mempool.store.assert_valid();
 
     Ok(())
@@ -190,7 +190,7 @@ async fn tx_replace_child(#[case] seed: Seed) -> anyhow::Result<()> {
         .with_flags(1)
         .build();
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
-    mempool.add_transaction(tx.clone())?.assert_in_mempool();
+    mempool.add_transaction(tx.clone(), TxOrigin::TEST)?.assert_in_mempool();
 
     let outpoint_source_id = OutPointSourceId::Transaction(tx.transaction().get_id());
     let child_tx_input = TxInput::from_utxo(outpoint_source_id, 0);
@@ -205,7 +205,7 @@ async fn tx_replace_child(#[case] seed: Seed) -> anyhow::Result<()> {
         flags,
     )
     .await?;
-    mempool.add_transaction(child_tx)?.assert_in_mempool();
+    mempool.add_transaction(child_tx, TxOrigin::TEST)?.assert_in_mempool();
 
     let relay_fee = get_relay_fee_from_tx_size(TX_SPEND_INPUT_SIZE);
     let replacement_fee: Fee = Amount::from_atoms(relay_fee + 100).into();
@@ -217,7 +217,7 @@ async fn tx_replace_child(#[case] seed: Seed) -> anyhow::Result<()> {
         flags,
     )
     .await?;
-    mempool.add_transaction(replacement_tx)?.assert_in_mempool();
+    mempool.add_transaction(replacement_tx, TxOrigin::TEST)?.assert_in_mempool();
     mempool.store.assert_valid();
     Ok(())
 }
@@ -244,7 +244,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
         .build();
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
     let tx_id = tx.transaction().get_id();
-    mempool.add_transaction(tx)?.assert_in_mempool();
+    mempool.add_transaction(tx, TxOrigin::TEST)?.assert_in_mempool();
 
     let outpoint_source_id = OutPointSourceId::Transaction(tx_id);
     let input = TxInput::from_utxo(outpoint_source_id, 0);
@@ -264,7 +264,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     .await?;
     let replaced_tx_fee = try_get_fee(&mempool, &replaced_tx).await;
     let replaced_id = replaced_tx.transaction().get_id();
-    mempool.add_transaction(replaced_tx)?.assert_in_mempool();
+    mempool.add_transaction(replaced_tx, TxOrigin::TEST)?.assert_in_mempool();
 
     // Create some children for this transaction
     let descendant_outpoint_source_id = OutPointSourceId::Transaction(replaced_id);
@@ -279,7 +279,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     )
     .await?;
     let descendant1_id = descendant1.transaction().get_id();
-    mempool.add_transaction(descendant1)?.assert_in_mempool();
+    mempool.add_transaction(descendant1, TxOrigin::TEST)?.assert_in_mempool();
 
     let descendant2_fee: Fee = Amount::from_atoms(100).into();
     let descendant2 = tx_spend_input(
@@ -291,7 +291,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     )
     .await?;
     let descendant2_id = descendant2.transaction().get_id();
-    mempool.add_transaction(descendant2)?.assert_in_mempool();
+    mempool.add_transaction(descendant2, TxOrigin::TEST)?.assert_in_mempool();
 
     //Create a new incoming transaction that conflicts with `replaced_tx` because it spends
     //`input`. It will be rejected because its fee exactly equals (so is not greater than) the
@@ -310,7 +310,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     .await?;
 
     assert_eq!(
-        mempool.add_transaction(incoming_tx),
+        mempool.add_transaction(incoming_tx, TxOrigin::TEST),
         Err(MempoolPolicyError::TransactionFeeLowerThanConflictsWithDescendants.into())
     );
 
@@ -324,7 +324,7 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
         no_rbf,
     )
     .await?;
-    mempool.add_transaction(incoming_tx)?.assert_in_mempool();
+    mempool.add_transaction(incoming_tx, TxOrigin::TEST)?.assert_in_mempool();
 
     assert!(!mempool.contains_transaction(&replaced_id));
     assert!(!mempool.contains_transaction(&descendant1_id));

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -38,9 +38,26 @@ mockall::mock! {
     }
 }
 
-impl TxStatus {
+pub trait TxOriginExt {
+    /// Origin that serves as a reasonable default for testing
+    const TEST: Self;
+}
+
+impl TxOriginExt for TxOrigin {
+    const TEST: Self = TxOrigin::LocalMempool;
+}
+
+pub trait TxStatusExt: Sized {
     /// Fetch status of given instruction from mempool, doing some integrity checks
-    pub fn fetch<T>(mempool: &Mempool<T>, tx_id: &Id<Transaction>) -> Option<Self> {
+    fn fetch<T>(mempool: &Mempool<T>, tx_id: &Id<Transaction>) -> Option<Self>;
+
+    /// Assert the status of the transaction that the tx is in mempool
+    fn assert_in_mempool(&self);
+}
+
+impl TxStatusExt for TxStatus {
+    /// Fetch status of given instruction from mempool, doing some integrity checks
+    fn fetch<T>(mempool: &Mempool<T>, tx_id: &Id<Transaction>) -> Option<Self> {
         let in_mempool = mempool.contains_transaction(tx_id);
         let in_orphan_pool = mempool.contains_orphan_transaction(tx_id);
         match (in_mempool, in_orphan_pool) {
@@ -52,7 +69,7 @@ impl TxStatus {
     }
 
     /// Assert the status of the transaction that the tx is in mempool
-    pub fn assert_in_mempool(&self) {
+    fn assert_in_mempool(&self) {
         assert!(self.in_mempool());
     }
 }

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -236,6 +236,7 @@ pub fn generate_transaction_graph(
                 .map(|(i, amt)| (TxInput::from_utxo(tx_id.into(), i as u32), amt)),
         );
 
-        TxEntryWithFee::new(TxEntry::new(tx, time), Fee::new(Amount::from_atoms(total)))
+        let entry = TxEntry::new(tx, time, TxOrigin::TEST);
+        TxEntryWithFee::new(entry, Fee::new(Amount::from_atoms(total)))
     })
 }

--- a/mempool/src/tx_origin.rs
+++ b/mempool/src/tx_origin.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use p2p_types::peer_id::PeerId;
+
+/// Tracks where a transaction originates
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum TxOrigin {
+    /// Transaction was submitted to local node's mempool. It should not be propagated further.
+    LocalMempool,
+
+    /// Transaction was submitted via local node's RPC subsystem. It should be propagated if valid.
+    LocalP2p,
+
+    /// Transaction was in a block but moved into the mempool upon a reorg.
+    PastBlock,
+
+    /// Transaction was received from a peer.
+    ///
+    /// If it eventually turns out to be valid, it should be propagated further to other peers.
+    /// If it's not valid, the original peer should be penalized as appropriate.
+    Peer(PeerId),
+}
+
+impl std::fmt::Display for TxOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TxOrigin::LocalMempool => write!(f, "local node mempool"),
+            TxOrigin::LocalP2p => write!(f, "local node p2p"),
+            TxOrigin::PastBlock => write!(f, "reorged-out block"),
+            TxOrigin::Peer(peer_id) => write!(f, "peer node {peer_id}"),
+        }
+    }
+}
+
+#[cfg(test)]
+impl TxOrigin {
+    /// Origin that serves as a reasonable default for testing
+    pub const TEST: Self = Self::LocalMempool;
+}

--- a/mempool/types/Cargo.toml
+++ b/mempool/types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mempool-types"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+p2p-types = { path = '../../p2p/types' }
+
+serde.workspace = true

--- a/mempool/types/src/lib.rs
+++ b/mempool/types/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,20 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(clippy::clone_on_ref_ptr)]
+mod tx_origin;
+mod tx_status;
 
-pub use config::MempoolMaxSize;
-pub use interface::{make_mempool, MempoolInterface, MempoolSubsystemInterface};
-pub use mempool_types::{TxOrigin, TxStatus};
-
-mod config;
-pub mod error;
-pub mod event;
-mod interface;
-mod pool;
-pub mod rpc;
-pub mod tx_accumulator;
-
-pub type MempoolHandle = subsystem::Handle<dyn MempoolInterface>;
-
-pub type Result<T> = core::result::Result<T, error::Error>;
+pub use tx_origin::TxOrigin;
+pub use tx_status::TxStatus;

--- a/mempool/types/src/tx_origin.rs
+++ b/mempool/types/src/tx_origin.rs
@@ -44,9 +44,3 @@ impl std::fmt::Display for TxOrigin {
         }
     }
 }
-
-#[cfg(test)]
-impl TxOrigin {
-    /// Origin that serves as a reasonable default for testing
-    pub const TEST: Self = Self::LocalMempool;
-}

--- a/mempool/types/src/tx_status.rs
+++ b/mempool/types/src/tx_status.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,20 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(clippy::clone_on_ref_ptr)]
+/// Result of adding transaction to the mempool
+#[derive(
+    Debug, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, serde::Serialize, serde::Deserialize,
+)]
+#[must_use = "Please check whether the tx was accepted to main mempool or orphan pool"]
+pub enum TxStatus {
+    /// Transaction is in mempool
+    InMempool,
+    /// Transaction is in orphan pool
+    InOrphanPool,
+}
 
-pub use config::MempoolMaxSize;
-pub use interface::{make_mempool, MempoolInterface, MempoolSubsystemInterface};
-pub use mempool_types::{TxOrigin, TxStatus};
+impl TxStatus {
+    pub fn in_mempool(&self) -> bool {
+        self == &TxStatus::InMempool
+    }
 
-mod config;
-pub mod error;
-pub mod event;
-mod interface;
-mod pool;
-pub mod rpc;
-pub mod tx_accumulator;
-
-pub type MempoolHandle = subsystem::Handle<dyn MempoolInterface>;
-
-pub type Result<T> = core::result::Result<T, error::Error>;
+    pub fn in_orphan_pool(&self) -> bool {
+        self == &TxStatus::InOrphanPool
+    }
+}

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -34,7 +34,6 @@ pub trait P2pInterface: Send + Sync {
     async fn submit_transaction(
         &mut self,
         tx: SignedTransaction,
-        origin: mempool::TxOrigin,
     ) -> crate::Result<mempool::TxStatus>;
 
     fn subscribe_to_events(

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -31,7 +31,11 @@ pub trait P2pInterface: Send + Sync {
     async fn add_reserved_node(&mut self, addr: String) -> crate::Result<()>;
     async fn remove_reserved_node(&mut self, addr: String) -> crate::Result<()>;
 
-    async fn submit_transaction(&mut self, tx: SignedTransaction) -> crate::Result<()>;
+    async fn submit_transaction(
+        &mut self,
+        tx: SignedTransaction,
+        origin: mempool::TxOrigin,
+    ) -> crate::Result<mempool::TxStatus>;
 
     fn subscribe_to_events(
         &mut self,

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -90,11 +90,16 @@ where
         Ok(())
     }
 
-    async fn submit_transaction(&mut self, tx: SignedTransaction) -> crate::Result<()> {
+    async fn submit_transaction(
+        &mut self,
+        tx: SignedTransaction,
+        origin: mempool::TxOrigin,
+    ) -> crate::Result<mempool::TxStatus> {
         crate::sync::process_incoming_transaction(
             &self.mempool_handle,
             &mut self.messaging_handle,
             tx,
+            origin,
         )
         .await
     }

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -59,9 +59,8 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
     async fn submit_transaction(
         &mut self,
         tx: SignedTransaction,
-        origin: mempool::TxOrigin,
     ) -> crate::Result<mempool::TxStatus> {
-        self.deref_mut().submit_transaction(tx, origin).await
+        self.deref_mut().submit_transaction(tx).await
     }
 
     fn subscribe_to_events(

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -56,8 +56,12 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
         self.deref_mut().remove_reserved_node(addr).await
     }
 
-    async fn submit_transaction(&mut self, tx: SignedTransaction) -> crate::Result<()> {
-        self.deref_mut().submit_transaction(tx).await
+    async fn submit_transaction(
+        &mut self,
+        tx: SignedTransaction,
+        origin: mempool::TxOrigin,
+    ) -> crate::Result<mempool::TxStatus> {
+        self.deref_mut().submit_transaction(tx, origin).await
     }
 
     fn subscribe_to_events(

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -81,7 +81,6 @@ struct P2p<T: NetworkingService> {
     /// A sender for the peer manager events.
     pub tx_peer_manager: mpsc::UnboundedSender<PeerManagerEvent<T>>,
     mempool_handle: MempoolHandle,
-    messaging_handle: T::MessagingHandle,
 
     backend_shutdown_sender: oneshot::Sender<()>,
 
@@ -169,7 +168,7 @@ where
         let sync_manager = sync::BlockSyncManager::<T>::new(
             chain_config,
             p2p_config,
-            messaging_handle.clone(),
+            messaging_handle,
             sync_event_receiver,
             chainstate_handle,
             mempool_handle.clone(),
@@ -194,7 +193,6 @@ where
         Ok(Self {
             tx_peer_manager,
             mempool_handle,
-            messaging_handle,
             shutdown,
             backend_shutdown_sender,
             backend_task,

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -96,11 +96,7 @@ impl P2pRpcServer for super::P2pHandle {
     }
 
     async fn submit_transaction(&self, tx: HexEncoded<SignedTransaction>) -> RpcResult<TxStatus> {
-        rpc::handle_result(
-            self.call_async_mut(move |this| {
-                this.submit_transaction(tx.take(), mempool::TxOrigin::LocalP2p)
-            })
-            .await,
-        )
+        let res = self.call_async_mut(move |this| this.submit_transaction(tx.take())).await;
+        rpc::handle_result(res)
     }
 }

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -535,10 +535,12 @@ where
         }
 
         if let Some(transaction) = tx {
-            super::process_incoming_transaction(
+            let origin = mempool::TxOrigin::Peer(self.id());
+            let _ = super::process_incoming_transaction(
                 &self.mempool_handle,
                 &mut self.messaging_handle,
                 transaction,
+                origin,
             )
             .await?;
         }

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -536,13 +536,10 @@ where
 
         if let Some(transaction) = tx {
             let origin = mempool::TxOrigin::Peer(self.id());
-            let _ = super::process_incoming_transaction(
-                &self.mempool_handle,
-                &mut self.messaging_handle,
-                transaction,
-                origin,
-            )
-            .await?;
+            let _tx_status = self
+                .mempool_handle
+                .call_mut(move |m| m.add_transaction(transaction, origin))
+                .await??;
         }
 
         Ok(())

--- a/test/functional/p2p_submit_orphan.py
+++ b/test/functional/p2p_submit_orphan.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Mempool orphan submission test
+
+Check that:
+* After submitting a transaction with a missing input UTXO, it ends up in the orphan pool
+* After submitting a transaction that defines the UTXO, both are in non-orphan mempool
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.mintlayer import (make_tx, reward_input, tx_input)
+import scalecodec
+import time
+
+class MempoolOrphanSubmissionTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 2)
+        self.sync_all(self.nodes[0:3])
+
+    def run_test(self):
+        node0 = self.nodes[0]
+
+        # Get genesis ID
+        genesis_id = self.nodes[0].chainstate_block_id_at_height(0)
+
+        (tx1, tx1_id) = make_tx([ reward_input(genesis_id) ], [ 1_000_000 ] )
+        (tx2, tx2_id) = make_tx([ tx_input(tx1_id) ], [ 900_000 ] )
+
+        # Submit the dependent transaction first, check it is in orphan pool
+        node0.p2p_submit_transaction(tx2)
+        assert not node0.mempool_contains_tx(tx2_id)
+        assert node0.mempool_contains_orphan_tx(tx2_id)
+
+        # Wait for a while to give enough time for the transactions to propagate through the
+        # network. It should not happen, the submitted transaction should be held up in node0's
+        # orphan pool for now.
+        time.sleep(2)
+        for node in self.nodes[1:3]:
+            assert not node.mempool_contains_tx(tx1_id)
+            assert not node.mempool_contains_orphan_tx(tx1_id)
+            assert not node.mempool_contains_tx(tx2_id)
+            assert not node.mempool_contains_orphan_tx(tx2_id)
+
+        # Submit the first transaction, resolving the sequence
+        node0.p2p_submit_transaction(tx1)
+        assert node0.mempool_contains_tx(tx1_id)
+        assert node0.mempool_contains_tx(tx2_id)
+        assert not node0.mempool_contains_orphan_tx(tx1_id)
+        assert not node0.mempool_contains_orphan_tx(tx2_id)
+
+        # Check both transactions have propagated to the last peer
+        for node in self.nodes[1:3]:
+            self.wait_until(
+                lambda: node.mempool_contains_tx(tx1_id) and node.mempool_contains_tx(tx2_id),
+                timeout = 5,
+            )
+
+
+if __name__ == '__main__':
+    MempoolOrphanSubmissionTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -102,6 +102,7 @@ BASE_SCRIPTS = [
     # vv Tests less than 30s vv
     'example_test.py',
     'p2p_ping.py',
+    'p2p_submit_orphan.py',
     'p2p_syncing_test.py',
     'p2p_relay_transactions.py',
     'feature_lmdb_backend_test.py',

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -604,7 +604,8 @@ impl CommandHandler {
             }
 
             WalletCommand::SubmitTransaction { transaction } => {
-                rpc_client
+                // TODO: Take status into account
+                let _status = rpc_client
                     .submit_transaction(transaction.take())
                     .await
                     .map_err(WalletCliError::RpcError)?;
@@ -682,7 +683,8 @@ impl CommandHandler {
             WalletCommand::SendToAddress { address, amount } => {
                 let amount = parse_coin_amount(chain_config, &amount)?;
                 let address = parse_address(chain_config, &address)?;
-                controller_opt
+                // TODO: Take status into account
+                let _status = controller_opt
                     .as_mut()
                     .ok_or(WalletCliError::NoWallet)?
                     .send_to_address(
@@ -701,7 +703,8 @@ impl CommandHandler {
             } => {
                 let amount = parse_coin_amount(chain_config, &amount)?;
                 let decomission_key = decomission_key.map(HexEncoded::take);
-                controller_opt
+                // TODO: Take status into account
+                let _status = controller_opt
                     .as_mut()
                     .ok_or(WalletCliError::NoWallet)?
                     .create_stake_pool_tx(

--- a/wallet/wallet-controller/Cargo.toml
+++ b/wallet/wallet-controller/Cargo.toml
@@ -11,6 +11,7 @@ common = { path = "../../common" }
 consensus = { path = "../../consensus" }
 crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
+mempool-types = { path = "../../mempool/types" }
 node-comm = { path = "../wallet-node-client" }
 serialization = { path = "../../serialization" }
 utils = { path = "../../utils" }

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -39,6 +39,7 @@ use crypto::{
     vrf::VRFPublicKey,
 };
 use logging::log;
+use mempool_types::TxStatus;
 pub use node_comm::node_traits::{ConnectedPeer, NodeInterface, PeerId};
 pub use node_comm::{
     handles_client::WalletHandlesClient, make_rpc_client, rpc_client::NodeRpcClient,
@@ -214,7 +215,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         account_index: U31,
         address: Address,
         amount: Amount,
-    ) -> Result<(), ControllerError<T>> {
+    ) -> Result<TxStatus, ControllerError<T>> {
         let output = make_address_output(address, amount).map_err(ControllerError::WalletError)?;
         let tx = self
             .wallet
@@ -231,7 +232,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         account_index: U31,
         amount: Amount,
         decomission_key: Option<PublicKey>,
-    ) -> Result<(), ControllerError<T>> {
+    ) -> Result<TxStatus, ControllerError<T>> {
         let tx = self
             .wallet
             .create_stake_pool_tx(account_index, amount, decomission_key)

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -27,6 +27,7 @@ use common::{
 use consensus::GenerateBlockInputData;
 use crypto::random::{seq::IteratorRandom, CryptoRng, Rng};
 use logging::log;
+use mempool_types::TxStatus;
 use node_comm::{
     node_traits::{ConnectedPeer, PeerId},
     rpc_client::NodeRpcError,
@@ -178,7 +179,7 @@ impl NodeInterface for MockNode {
     async fn submit_block(&self, _block: Block) -> Result<(), Self::Error> {
         unreachable!()
     }
-    async fn submit_transaction(&self, _tx: SignedTransaction) -> Result<(), Self::Error> {
+    async fn submit_transaction(&self, _tx: SignedTransaction) -> Result<TxStatus, Self::Error> {
         unreachable!()
     }
 

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -147,7 +147,11 @@ impl NodeInterface for WalletHandlesClient {
     }
 
     async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
-        self.p2p.call_async_mut(move |this| this.submit_transaction(tx)).await??;
+        // TODO: Should this return mempool::TxStatus?
+        let _ = self
+            .p2p
+            .call_async_mut(move |this| this.submit_transaction(tx, mempool::TxOrigin::LocalP2p))
+            .await??;
         Ok(())
     }
 

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -148,10 +148,7 @@ impl NodeInterface for WalletHandlesClient {
 
     async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
         // TODO: Should this return mempool::TxStatus?
-        let _ = self
-            .p2p
-            .call_async_mut(move |this| this.submit_transaction(tx, mempool::TxOrigin::LocalP2p))
-            .await??;
+        let _ = self.p2p.call_async_mut(move |this| this.submit_transaction(tx)).await??;
         Ok(())
     }
 

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -146,10 +146,11 @@ impl NodeInterface for WalletHandlesClient {
         Ok(())
     }
 
-    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
-        // TODO: Should this return mempool::TxStatus?
-        let _ = self.p2p.call_async_mut(move |this| this.submit_transaction(tx)).await??;
-        Ok(())
+    async fn submit_transaction(
+        &self,
+        tx: SignedTransaction,
+    ) -> Result<mempool::TxStatus, Self::Error> {
+        Ok(self.p2p.call_async_mut(move |this| this.submit_transaction(tx)).await??)
     }
 
     async fn node_shutdown(&self) -> Result<(), Self::Error> {

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -46,7 +46,10 @@ pub trait NodeInterface {
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error>;
     async fn submit_block(&self, block: Block) -> Result<(), Self::Error>;
-    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error>;
+    async fn submit_transaction(
+        &self,
+        tx: SignedTransaction,
+    ) -> Result<mempool::TxStatus, Self::Error>;
 
     async fn node_shutdown(&self) -> Result<(), Self::Error>;
     async fn node_version(&self) -> Result<String, Self::Error>;

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -103,9 +103,11 @@ impl NodeInterface for NodeRpcClient {
             .map_err(NodeRpcError::ResponseError)
     }
     async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
-        P2pRpcClient::submit_transaction(&self.http_client, tx.into())
+        // TODO: Should this return tx status?
+        let _ = P2pRpcClient::submit_transaction(&self.http_client, tx.into())
             .await
-            .map_err(NodeRpcError::ResponseError)
+            .map_err(NodeRpcError::ResponseError)?;
+        Ok(())
     }
 
     async fn node_shutdown(&self) -> Result<(), Self::Error> {

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -20,6 +20,7 @@ use common::{
     primitives::{Amount, BlockHeight, Id},
 };
 use consensus::GenerateBlockInputData;
+use mempool::TxStatus;
 use p2p::{interface::types::ConnectedPeer, rpc::P2pRpcClient, types::peer_id::PeerId};
 use serialization::hex_encoded::HexEncoded;
 
@@ -102,12 +103,11 @@ impl NodeInterface for NodeRpcClient {
             .await
             .map_err(NodeRpcError::ResponseError)
     }
-    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
-        // TODO: Should this return tx status?
-        let _ = P2pRpcClient::submit_transaction(&self.http_client, tx.into())
+    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<TxStatus, Self::Error> {
+        let status = P2pRpcClient::submit_transaction(&self.http_client, tx.into())
             .await
             .map_err(NodeRpcError::ResponseError)?;
-        Ok(())
+        Ok(status)
     }
 
     async fn node_shutdown(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
Once an orphan transaction has been fully processed and moved outside of the orphan pool, we take action according to the outcome:
* If the transaction is valid, we pass it on to peers as appropriate.
* If the transaction is not valid, we punish the originator.