### PR TITLE
Intorduce `mempool-types` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,8 +3216,8 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "logging",
+ "mempool-types",
  "mockall",
- "p2p-types",
  "parking_lot 0.12.1",
  "pos_accounting",
  "rpc",
@@ -3231,6 +3231,14 @@ dependencies = [
  "tokio",
  "utils",
  "utxo",
+]
+
+[[package]]
+name = "mempool-types"
+version = "0.1.0"
+dependencies = [
+ "p2p-types",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,6 +6478,7 @@ dependencies = [
  "consensus",
  "crypto",
  "logging",
+ "mempool-types",
  "node-comm",
  "rstest",
  "serialization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "dns_server",                   # DNS-server.
   "logging",                      # Logging engine and its interfaces.
   "mempool",                      # Mempool interface and implementation.
+  "mempool/types",                # Common mempool types.
   "merkletree",                   # Merkle tree implementation with merkle proofs.
   "mocks",                        # Mock implementations of our traits (used for testing)
   "node-daemon",                  # Node terminal binary.

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -14,7 +14,7 @@ chainstate-types = { path = '../chainstate/types' }
 common = { path = '../common' }
 crypto = { path = '../crypto' }
 logging = { path = '../logging' }
-p2p-types = { path = '../p2p/types' }
+mempool-types = { path = 'types' }
 pos_accounting = { path = '../pos_accounting' }
 rpc = { path = '../rpc' }
 serialization = { path = '../serialization' }

--- a/mempool/src/pool/orphans/test.rs
+++ b/mempool/src/pool/orphans/test.rs
@@ -72,9 +72,8 @@ fn random_tx_entry(rng: &mut impl Rng) -> TxEntry {
     let signatures = vec![InputWitness::NoSignature(None); n_inputs];
     let transaction = SignedTransaction::new(transaction, signatures).unwrap();
     let insertion_time = Time::from_secs(rng.gen());
-    let origin = crate::TxOrigin::TEST;
 
-    TxEntry::new(transaction, insertion_time, origin)
+    TxEntry::new(transaction, insertion_time, crate::TxOrigin::LocalMempool)
 }
 
 #[rstest]

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -628,7 +628,7 @@ impl TxMempoolEntry {
         ancestors: BTreeSet<TxMempoolEntry>,
         creation_time: Time,
     ) -> Result<TxMempoolEntry, MempoolPolicyError> {
-        let entry = TxEntry::new(tx, creation_time, crate::TxOrigin::TEST);
+        let entry = TxEntry::new(tx, creation_time, crate::TxOrigin::LocalMempool);
         Self::new(TxEntryWithFee::new(entry, fee), parents, ancestors)
     }
 

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -38,9 +38,26 @@ mockall::mock! {
     }
 }
 
-impl TxStatus {
+pub trait TxOriginExt {
+    /// Origin that serves as a reasonable default for testing
+    const TEST: Self;
+}
+
+impl TxOriginExt for TxOrigin {
+    const TEST: Self = TxOrigin::LocalMempool;
+}
+
+pub trait TxStatusExt: Sized {
     /// Fetch status of given instruction from mempool, doing some integrity checks
-    pub fn fetch<T>(mempool: &Mempool<T>, tx_id: &Id<Transaction>) -> Option<Self> {
+    fn fetch<T>(mempool: &Mempool<T>, tx_id: &Id<Transaction>) -> Option<Self>;
+
+    /// Assert the status of the transaction that the tx is in mempool
+    fn assert_in_mempool(&self);
+}
+
+impl TxStatusExt for TxStatus {
+    /// Fetch status of given instruction from mempool, doing some integrity checks
+    fn fetch<T>(mempool: &Mempool<T>, tx_id: &Id<Transaction>) -> Option<Self> {
         let in_mempool = mempool.contains_transaction(tx_id);
         let in_orphan_pool = mempool.contains_orphan_transaction(tx_id);
         match (in_mempool, in_orphan_pool) {
@@ -52,7 +69,7 @@ impl TxStatus {
     }
 
     /// Assert the status of the transaction that the tx is in mempool
-    pub fn assert_in_mempool(&self) {
+    fn assert_in_mempool(&self) {
         assert!(self.in_mempool());
     }
 }

--- a/mempool/types/Cargo.toml
+++ b/mempool/types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mempool-types"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+p2p-types = { path = '../../p2p/types' }
+
+serde.workspace = true

--- a/mempool/types/src/lib.rs
+++ b/mempool/types/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,20 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(clippy::clone_on_ref_ptr)]
+mod tx_origin;
+mod tx_status;
 
-pub use config::MempoolMaxSize;
-pub use interface::{make_mempool, MempoolInterface, MempoolSubsystemInterface};
-pub use mempool_types::{TxOrigin, TxStatus};
-
-mod config;
-pub mod error;
-pub mod event;
-mod interface;
-mod pool;
-pub mod rpc;
-pub mod tx_accumulator;
-
-pub type MempoolHandle = subsystem::Handle<dyn MempoolInterface>;
-
-pub type Result<T> = core::result::Result<T, error::Error>;
+pub use tx_origin::TxOrigin;
+pub use tx_status::TxStatus;

--- a/mempool/types/src/tx_origin.rs
+++ b/mempool/types/src/tx_origin.rs
@@ -44,9 +44,3 @@ impl std::fmt::Display for TxOrigin {
         }
     }
 }
-
-#[cfg(test)]
-impl TxOrigin {
-    /// Origin that serves as a reasonable default for testing
-    pub const TEST: Self = Self::LocalMempool;
-}

--- a/mempool/types/src/tx_status.rs
+++ b/mempool/types/src/tx_status.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,20 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![deny(clippy::clone_on_ref_ptr)]
+/// Result of adding transaction to the mempool
+#[derive(
+    Debug, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, serde::Serialize, serde::Deserialize,
+)]
+#[must_use = "Please check whether the tx was accepted to main mempool or orphan pool"]
+pub enum TxStatus {
+    /// Transaction is in mempool
+    InMempool,
+    /// Transaction is in orphan pool
+    InOrphanPool,
+}
 
-pub use config::MempoolMaxSize;
-pub use interface::{make_mempool, MempoolInterface, MempoolSubsystemInterface};
-pub use mempool_types::{TxOrigin, TxStatus};
+impl TxStatus {
+    pub fn in_mempool(&self) -> bool {
+        self == &TxStatus::InMempool
+    }
 
-mod config;
-pub mod error;
-pub mod event;
-mod interface;
-mod pool;
-pub mod rpc;
-pub mod tx_accumulator;
-
-pub type MempoolHandle = subsystem::Handle<dyn MempoolInterface>;
-
-pub type Result<T> = core::result::Result<T, error::Error>;
+    pub fn in_orphan_pool(&self) -> bool {
+        self == &TxStatus::InOrphanPool
+    }
+}

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -604,7 +604,8 @@ impl CommandHandler {
             }
 
             WalletCommand::SubmitTransaction { transaction } => {
-                rpc_client
+                // TODO: Take status into account
+                let _status = rpc_client
                     .submit_transaction(transaction.take())
                     .await
                     .map_err(WalletCliError::RpcError)?;
@@ -682,7 +683,8 @@ impl CommandHandler {
             WalletCommand::SendToAddress { address, amount } => {
                 let amount = parse_coin_amount(chain_config, &amount)?;
                 let address = parse_address(chain_config, &address)?;
-                controller_opt
+                // TODO: Take status into account
+                let _status = controller_opt
                     .as_mut()
                     .ok_or(WalletCliError::NoWallet)?
                     .send_to_address(
@@ -701,7 +703,8 @@ impl CommandHandler {
             } => {
                 let amount = parse_coin_amount(chain_config, &amount)?;
                 let decomission_key = decomission_key.map(HexEncoded::take);
-                controller_opt
+                // TODO: Take status into account
+                let _status = controller_opt
                     .as_mut()
                     .ok_or(WalletCliError::NoWallet)?
                     .create_stake_pool_tx(

--- a/wallet/wallet-controller/Cargo.toml
+++ b/wallet/wallet-controller/Cargo.toml
@@ -11,6 +11,7 @@ common = { path = "../../common" }
 consensus = { path = "../../consensus" }
 crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
+mempool-types = { path = "../../mempool/types" }
 node-comm = { path = "../wallet-node-client" }
 serialization = { path = "../../serialization" }
 utils = { path = "../../utils" }

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -39,6 +39,7 @@ use crypto::{
     vrf::VRFPublicKey,
 };
 use logging::log;
+use mempool_types::TxStatus;
 pub use node_comm::node_traits::{ConnectedPeer, NodeInterface, PeerId};
 pub use node_comm::{
     handles_client::WalletHandlesClient, make_rpc_client, rpc_client::NodeRpcClient,
@@ -214,7 +215,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         account_index: U31,
         address: Address,
         amount: Amount,
-    ) -> Result<(), ControllerError<T>> {
+    ) -> Result<TxStatus, ControllerError<T>> {
         let output = make_address_output(address, amount).map_err(ControllerError::WalletError)?;
         let tx = self
             .wallet
@@ -231,7 +232,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         account_index: U31,
         amount: Amount,
         decomission_key: Option<PublicKey>,
-    ) -> Result<(), ControllerError<T>> {
+    ) -> Result<TxStatus, ControllerError<T>> {
         let tx = self
             .wallet
             .create_stake_pool_tx(account_index, amount, decomission_key)

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -27,6 +27,7 @@ use common::{
 use consensus::GenerateBlockInputData;
 use crypto::random::{seq::IteratorRandom, CryptoRng, Rng};
 use logging::log;
+use mempool_types::TxStatus;
 use node_comm::{
     node_traits::{ConnectedPeer, PeerId},
     rpc_client::NodeRpcError,
@@ -178,7 +179,7 @@ impl NodeInterface for MockNode {
     async fn submit_block(&self, _block: Block) -> Result<(), Self::Error> {
         unreachable!()
     }
-    async fn submit_transaction(&self, _tx: SignedTransaction) -> Result<(), Self::Error> {
+    async fn submit_transaction(&self, _tx: SignedTransaction) -> Result<TxStatus, Self::Error> {
         unreachable!()
     }
 

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -146,10 +146,11 @@ impl NodeInterface for WalletHandlesClient {
         Ok(())
     }
 
-    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
-        // TODO: Should this return mempool::TxStatus?
-        let _ = self.p2p.call_async_mut(move |this| this.submit_transaction(tx)).await??;
-        Ok(())
+    async fn submit_transaction(
+        &self,
+        tx: SignedTransaction,
+    ) -> Result<mempool::TxStatus, Self::Error> {
+        Ok(self.p2p.call_async_mut(move |this| this.submit_transaction(tx)).await??)
     }
 
     async fn node_shutdown(&self) -> Result<(), Self::Error> {

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -46,7 +46,10 @@ pub trait NodeInterface {
         transactions: Option<Vec<SignedTransaction>>,
     ) -> Result<Block, Self::Error>;
     async fn submit_block(&self, block: Block) -> Result<(), Self::Error>;
-    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error>;
+    async fn submit_transaction(
+        &self,
+        tx: SignedTransaction,
+    ) -> Result<mempool::TxStatus, Self::Error>;
 
     async fn node_shutdown(&self) -> Result<(), Self::Error>;
     async fn node_version(&self) -> Result<String, Self::Error>;

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -20,6 +20,7 @@ use common::{
     primitives::{Amount, BlockHeight, Id},
 };
 use consensus::GenerateBlockInputData;
+use mempool::TxStatus;
 use p2p::{interface::types::ConnectedPeer, rpc::P2pRpcClient, types::peer_id::PeerId};
 use serialization::hex_encoded::HexEncoded;
 
@@ -102,12 +103,11 @@ impl NodeInterface for NodeRpcClient {
             .await
             .map_err(NodeRpcError::ResponseError)
     }
-    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
-        // TODO: Should this return tx status?
-        let _ = P2pRpcClient::submit_transaction(&self.http_client, tx.into())
+    async fn submit_transaction(&self, tx: SignedTransaction) -> Result<TxStatus, Self::Error> {
+        let status = P2pRpcClient::submit_transaction(&self.http_client, tx.into())
             .await
             .map_err(NodeRpcError::ResponseError)?;
-        Ok(())
+        Ok(status)
     }
 
     async fn node_shutdown(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
Allows for wallet interfaces to return `TxStatus` as other transactions submission interfaces do.

This is on top of #1031 