### PR TITLE
Formatting change example

### DIFF
--- a/accounting/src/delta/combine.rs
+++ b/accounting/src/delta/combine.rs
@@ -59,9 +59,9 @@ pub fn combine_amount_delta(
 ) -> Result<Option<Amount>, Error> {
     match (lhs, rhs) {
         (None, None) => Ok(None),
-        (None, Some(v)) => Ok(Some(
-            (*v).into_unsigned().ok_or(Error::ArithmeticErrorToUnsignedFailed)?,
-        )),
+        (None, Some(v)) => {
+            Ok(Some((*v).into_unsigned().ok_or(Error::ArithmeticErrorToUnsignedFailed)?))
+        }
         (Some(v), None) => Ok(Some(*v)),
         (Some(v1), Some(v2)) => {
             let v1 = v1.into_signed().ok_or(Error::ArithmeticErrorToSignedFailed)?;

--- a/accounting/src/delta/delta_amount_collection.rs
+++ b/accounting/src/delta/delta_amount_collection.rs
@@ -139,9 +139,7 @@ pub mod test {
         let mut collection =
             DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(2))]) };
 
-        collection
-            .merge_delta_amount_element('a', SignedAmount::from_atoms(-1))
-            .unwrap();
+        collection.merge_delta_amount_element('a', SignedAmount::from_atoms(-1)).unwrap();
         assert_eq!(collection.data.len(), 1);
         assert_eq!(collection.data.get(&'a').unwrap(), &SignedAmount::from_atoms(1))
     }
@@ -169,9 +167,7 @@ pub mod test {
         let mut collection =
             DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]) };
 
-        collection
-            .merge_delta_amount_element('a', SignedAmount::from_atoms(-1))
-            .unwrap();
+        collection.merge_delta_amount_element('a', SignedAmount::from_atoms(-1)).unwrap();
         assert!(collection.data.is_empty());
     }
 

--- a/accounting/src/delta/delta_amount_collection.rs
+++ b/accounting/src/delta/delta_amount_collection.rs
@@ -28,9 +28,7 @@ pub struct DeltaAmountCollection<K: Ord> {
 
 impl<K: Ord> DeltaAmountCollection<K> {
     pub fn new() -> Self {
-        Self {
-            data: BTreeMap::new(),
-        }
+        Self { data: BTreeMap::new() }
     }
 
     pub fn merge_delta_amounts(&mut self, delta_to_apply: Self) -> Result<(), Error> {
@@ -108,9 +106,7 @@ impl<K: Ord> DeltaAmountCollection<K> {
 
 impl<K: Ord> FromIterator<(K, SignedAmount)> for DeltaAmountCollection<K> {
     fn from_iter<I: IntoIterator<Item = (K, SignedAmount)>>(iter: I) -> Self {
-        DeltaAmountCollection {
-            data: BTreeMap::<K, SignedAmount>::from_iter(iter),
-        }
+        DeltaAmountCollection { data: BTreeMap::<K, SignedAmount>::from_iter(iter) }
     }
 }
 
@@ -120,47 +116,34 @@ pub mod test {
 
     #[test]
     fn test_add_empty() {
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::new(),
-        };
+        let mut collection = DeltaAmountCollection { data: BTreeMap::new() };
         collection.merge_delta_amount_element('a', SignedAmount::from_atoms(1)).unwrap();
         assert_eq!(collection.data.len(), 1);
-        assert_eq!(
-            collection.data.get(&'a').unwrap(),
-            &SignedAmount::from_atoms(1)
-        )
+        assert_eq!(collection.data.get(&'a').unwrap(), &SignedAmount::from_atoms(1))
     }
 
     #[test]
     fn test_add_existing() {
         // 1 add 1 = 2
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]) };
 
         collection.merge_delta_amount_element('a', SignedAmount::from_atoms(1)).unwrap();
         assert_eq!(collection.data.len(), 1);
-        assert_eq!(
-            collection.data.get(&'a').unwrap(),
-            &SignedAmount::from_atoms(2)
-        )
+        assert_eq!(collection.data.get(&'a').unwrap(), &SignedAmount::from_atoms(2))
     }
 
     #[test]
     fn test_add_neg_existing() {
         // 2 add -1 = 1
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::from_atoms(2))]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(2))]) };
 
         collection
             .merge_delta_amount_element('a', SignedAmount::from_atoms(-1))
             .unwrap();
         assert_eq!(collection.data.len(), 1);
-        assert_eq!(
-            collection.data.get(&'a').unwrap(),
-            &SignedAmount::from_atoms(1)
-        )
+        assert_eq!(collection.data.get(&'a').unwrap(), &SignedAmount::from_atoms(1))
     }
 
     #[test]
@@ -183,9 +166,8 @@ pub mod test {
     #[test]
     fn test_add_zero_sum() {
         // 1 add -1 = remove
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]) };
 
         collection
             .merge_delta_amount_element('a', SignedAmount::from_atoms(-1))
@@ -195,9 +177,8 @@ pub mod test {
 
     #[test]
     fn test_add_overflow() {
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::MAX)]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::MAX)]) };
 
         let res = collection.merge_delta_amount_element('a', SignedAmount::from_atoms(1));
         assert_eq!(res, Err(Error::ArithmeticErrorDeltaAdditionFailed));
@@ -205,9 +186,8 @@ pub mod test {
 
     #[test]
     fn test_add_underflow() {
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::MIN)]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::MIN)]) };
 
         let res = collection.merge_delta_amount_element('a', SignedAmount::from_atoms(-1));
         assert_eq!(res, Err(Error::ArithmeticErrorDeltaAdditionFailed));
@@ -216,23 +196,18 @@ pub mod test {
     #[test]
     fn test_add_unsign() {
         // 1 add 1 = 2
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]) };
 
         collection.add_unsigned('a', Amount::from_atoms(1)).unwrap();
         assert_eq!(collection.data.len(), 1);
-        assert_eq!(
-            collection.data.get(&'a').unwrap(),
-            &SignedAmount::from_atoms(2)
-        )
+        assert_eq!(collection.data.get(&'a').unwrap(), &SignedAmount::from_atoms(2))
     }
 
     #[test]
     fn test_add_unsign_overflow() {
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::from_atoms(2))]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(2))]) };
 
         let res = collection.add_unsigned('a', Amount::MAX);
         assert_eq!(res, Err(Error::ArithmeticErrorToSignedFailed));
@@ -241,24 +216,19 @@ pub mod test {
     #[test]
     fn test_sub_existing() {
         // 2 sub 1 = 1
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::from_atoms(2))]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(2))]) };
 
         collection.sub_unsigned('a', Amount::from_atoms(1)).unwrap();
         assert_eq!(collection.data.len(), 1);
-        assert_eq!(
-            collection.data.get(&'a').unwrap(),
-            &SignedAmount::from_atoms(1)
-        )
+        assert_eq!(collection.data.get(&'a').unwrap(), &SignedAmount::from_atoms(1))
     }
 
     #[test]
     fn test_sub_zero_sum() {
         // 1 sub 1 = remove
-        let mut collection = DeltaAmountCollection {
-            data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]),
-        };
+        let mut collection =
+            DeltaAmountCollection { data: BTreeMap::from([('a', SignedAmount::from_atoms(1))]) };
 
         collection.sub_unsigned('a', Amount::from_atoms(1)).unwrap();
         assert!(collection.data.is_empty());

--- a/accounting/src/delta/delta_data_collection/mod.rs
+++ b/accounting/src/delta/delta_data_collection/mod.rs
@@ -75,9 +75,7 @@ pub struct DeltaDataCollection<K, T> {
 
 impl<K: Ord + Copy, T: Clone + Eq> DeltaDataCollection<K, T> {
     pub fn new() -> Self {
-        Self {
-            data: BTreeMap::new(),
-        }
+        Self { data: BTreeMap::new() }
     }
 
     pub fn data(&self) -> &BTreeMap<K, DataDelta<T>> {
@@ -151,9 +149,7 @@ impl<K: Ord + Copy, T: Clone + Eq> DeltaDataCollection<K, T> {
 
 impl<K: Ord + Copy, T: Clone> FromIterator<(K, DataDelta<T>)> for DeltaDataCollection<K, T> {
     fn from_iter<I: IntoIterator<Item = (K, DataDelta<T>)>>(iter: I) -> Self {
-        DeltaDataCollection {
-            data: BTreeMap::<K, DataDelta<T>>::from_iter(iter.into_iter()),
-        }
+        DeltaDataCollection { data: BTreeMap::<K, DataDelta<T>>::from_iter(iter.into_iter()) }
     }
 }
 

--- a/accounting/src/delta/delta_data_collection/tests/mod.rs
+++ b/accounting/src/delta/delta_data_collection/tests/mod.rs
@@ -27,9 +27,7 @@ impl<T: Arbitrary + Clone + 'static> Arbitrary for DataDelta<T> {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        any::<(Option<T>, Option<T>)>()
-            .prop_map(|(x0, x1)| DataDelta::new(x0, x1))
-            .boxed()
+        any::<(Option<T>, Option<T>)>().prop_map(|(x0, x1)| DataDelta::new(x0, x1)).boxed()
     }
 }
 
@@ -115,9 +113,7 @@ fn merge_delta_into_empty_collection(#[case] delta: DataDelta<char>) {
 #[case(new_delta(Some('a'), Some('b')))]
 fn merge_delta_undo_into_empty_collection(#[case] delta: DataDelta<char>) {
     let mut collection: DeltaDataCollection<i32, char> = DeltaDataCollection::new();
-    collection
-        .undo_merge_delta_data_element(0, DataDeltaUndo::new(delta.clone()))
-        .unwrap();
+    collection.undo_merge_delta_data_element(0, DataDeltaUndo::new(delta.clone())).unwrap();
 
     assert_eq!(collection.data.len(), 1);
     assert_eq!(collection.data.into_iter().next().unwrap().1, delta);

--- a/accounting/src/delta/delta_data_collection/undo.rs
+++ b/accounting/src/delta/delta_data_collection/undo.rs
@@ -44,9 +44,7 @@ pub struct DeltaDataUndoCollection<K, T> {
 
 impl<K: Ord, T: Clone> DeltaDataUndoCollection<K, T> {
     pub fn new() -> Self {
-        Self {
-            data: BTreeMap::new(),
-        }
+        Self { data: BTreeMap::new() }
     }
 
     pub fn from_data(data: BTreeMap<K, DataDeltaUndo<T>>) -> Self {

--- a/blockprod/src/detail/job_manager/jobs_container.rs
+++ b/blockprod/src/detail/job_manager/jobs_container.rs
@@ -32,12 +32,7 @@ impl JobsContainer {
     }
 
     pub fn handle_add_job(&mut self, event: NewJobEvent) {
-        let NewJobEvent {
-            custom_id,
-            current_tip_id,
-            cancel_sender,
-            result_sender,
-        } = event;
+        let NewJobEvent { custom_id, current_tip_id, cancel_sender, result_sender } = event;
 
         let job_key = JobKey::new(custom_id, current_tip_id);
 

--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -98,10 +98,7 @@ impl BlockProduction {
     }
 
     pub async fn stop_all_jobs(&mut self) -> Result<usize, BlockProductionError> {
-        self.job_manager_handle
-            .stop_all_jobs()
-            .await
-            .map_err(BlockProductionError::JobManagerError)
+        self.job_manager_handle.stop_all_jobs().await.map_err(BlockProductionError::JobManagerError)
     }
 
     pub async fn stop_job(&mut self, job_key: JobKey) -> Result<bool, BlockProductionError> {

--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -127,12 +127,7 @@ impl BlockProduction {
         input_data: GenerateBlockInputData,
         time_getter: TimeGetter,
     ) -> Result<
-        (
-            ConsensusData,
-            BlockReward,
-            GenBlockIndex,
-            FinalizeBlockInputData,
-        ),
+        (ConsensusData, BlockReward, GenBlockIndex, FinalizeBlockInputData),
         BlockProductionError,
     > {
         let consensus_data = self
@@ -198,12 +193,7 @@ impl BlockProduction {
                         input_data,
                     )?;
 
-                    Ok((
-                        consensus_data,
-                        block_reward,
-                        best_block_index,
-                        finalize_block_data,
-                    ))
+                    Ok((consensus_data, block_reward, best_block_index, finalize_block_data))
                 }
             })
             .await?

--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -356,9 +356,8 @@ mod produce_block {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn overflow_max_blocktimestamp() {
-        let override_chain_config = Builder::new(ChainType::Regtest)
-            .max_future_block_time_offset(Duration::MAX)
-            .build();
+        let override_chain_config =
+            Builder::new(ChainType::Regtest).max_future_block_time_offset(Duration::MAX).build();
 
         let (manager, chain_config, chainstate, mempool) =
             setup_blockprod_test(Some(override_chain_config));
@@ -1563,10 +1562,7 @@ mod stop_all_jobs {
         let return_value = make_seedable_rng(seed).gen();
         let expected_value = return_value;
 
-        mock_job_manager
-            .expect_stop_all_jobs()
-            .times(1)
-            .returning(move || Ok(return_value));
+        mock_job_manager.expect_stop_all_jobs().times(1).returning(move || Ok(return_value));
 
         block_production.set_job_manager(mock_job_manager);
 

--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -138,10 +138,7 @@ mod collect_transactions {
             let accumulator = block_production.collect_transactions().await;
 
             let collected_transactions = mock_mempool.collect_txs_called.load();
-            assert!(
-                !collected_transactions,
-                "Expected collect_tx() not to be called"
-            );
+            assert!(!collected_transactions, "Expected collect_tx() not to be called");
 
             match accumulator {
                 Err(BlockProductionError::SubsystemCallError(_)) => {}
@@ -187,10 +184,7 @@ mod collect_transactions {
                 let collected_transactions = mock_mempool.collect_txs_called.load();
                 assert!(collected_transactions, "Expected collect_tx() to be called");
 
-                assert!(
-                    accumulator.is_ok(),
-                    "Expected collect_transactions() to succeed"
-                );
+                assert!(accumulator.is_ok(), "Expected collect_transactions() to succeed");
             }
         });
 
@@ -479,12 +473,8 @@ mod produce_block {
             mock_chainstate.expect_subscribe_to_events().times(1).returning(|_| ());
 
             let mut expected_return_values = vec![
-                Ok(GenBlockIndex::Genesis(Arc::clone(
-                    chain_config.genesis_block(),
-                ))),
-                Err(ChainstateError::FailedToReadProperty(
-                    PropertyQueryError::BestBlockNotFound,
-                )),
+                Ok(GenBlockIndex::Genesis(Arc::clone(chain_config.genesis_block()))),
+                Err(ChainstateError::FailedToReadProperty(PropertyQueryError::BestBlockNotFound)),
             ];
 
             mock_chainstate
@@ -541,12 +531,8 @@ mod produce_block {
             mock_chainstate.expect_subscribe_to_events().times(1).returning(|_| ());
 
             let mut expected_return_values = vec![
-                Ok(GenBlockIndex::Genesis(Arc::clone(
-                    chain_config.genesis_block(),
-                ))),
-                Ok(GenBlockIndex::Genesis(Arc::clone(
-                    create_testnet().genesis_block(),
-                ))),
+                Ok(GenBlockIndex::Genesis(Arc::clone(chain_config.genesis_block()))),
+                Ok(GenBlockIndex::Genesis(Arc::clone(create_testnet().genesis_block()))),
             ];
 
             mock_chainstate
@@ -1031,9 +1017,7 @@ mod produce_block {
 
             let consensus_types = vec![
                 ConsensusUpgrade::IgnoreConsensus,
-                ConsensusUpgrade::PoW {
-                    initial_difficulty: Uint256::MAX.into(),
-                },
+                ConsensusUpgrade::PoW { initial_difficulty: Uint256::MAX.into() },
                 ConsensusUpgrade::PoS {
                     initial_difficulty: Uint256::MAX.into(),
                     config: easy_pos_config,
@@ -1699,20 +1683,12 @@ mod stop_job {
             job_keys.push(job_key)
         }
 
-        assert_eq!(
-            job_keys.len(),
-            jobs_to_create,
-            "Failed to create {jobs_to_create} jobs"
-        );
+        assert_eq!(job_keys.len(), jobs_to_create, "Failed to create {jobs_to_create} jobs");
 
         while !job_keys.is_empty() {
             let current_jobs_count =
                 block_production.job_manager_handle.get_job_count().await.unwrap();
-            assert_eq!(
-                current_jobs_count,
-                job_keys.len(),
-                "Jobs count is incorrect"
-            );
+            assert_eq!(current_jobs_count, job_keys.len(), "Jobs count is incorrect");
 
             let job_key = job_keys.pop().unwrap();
 

--- a/blockprod/src/lib.rs
+++ b/blockprod/src/lib.rs
@@ -283,11 +283,7 @@ mod tests {
                     Box::pin(async move {
                         let stopped_jobs_count = this.stop_all().await;
 
-                        assert_eq!(
-                            stopped_jobs_count,
-                            Ok(0),
-                            "Failed to stop non-existent jobs"
-                        );
+                        assert_eq!(stopped_jobs_count, Ok(0), "Failed to stop non-existent jobs");
                         shutdown.initiate();
                     })
                 })

--- a/blockprod/src/lib.rs
+++ b/blockprod/src/lib.rs
@@ -64,9 +64,7 @@ pub type BlockProductionHandle = subsystem::Handle<Box<dyn BlockProductionInterf
 
 fn prepare_thread_pool(thread_count: u16) -> Arc<slave_pool::ThreadPool> {
     let mining_thread_pool = Arc::new(slave_pool::ThreadPool::new());
-    mining_thread_pool
-        .set_threads(thread_count)
-        .expect("Event thread-pool starting failed");
+    mining_thread_pool.set_threads(thread_count).expect("Event thread-pool starting failed");
     mining_thread_pool
 }
 

--- a/chainstate/launcher/src/lib.rs
+++ b/chainstate/launcher/src/lib.rs
@@ -55,10 +55,7 @@ pub fn make_chainstate(
     chain_config: Arc<ChainConfig>,
     config: ChainstateLauncherConfig,
 ) -> Result<Box<dyn ChainstateInterface>, Error> {
-    let ChainstateLauncherConfig {
-        storage_backend,
-        chainstate_config,
-    } = config;
+    let ChainstateLauncherConfig { storage_backend, chainstate_config } = config;
 
     let lmdb_resize_callback = MapResizeCallback::new(Box::new(|resize_info| {
         logging::log::info!("Lmdb resize happened: {:?}", resize_info)

--- a/chainstate/src/config.rs
+++ b/chainstate/src/config.rs
@@ -25,10 +25,7 @@ make_config_setting!(MaxOrphanBlocks, usize, 512);
 make_config_setting!(
     MinMaxBootstrapImportBufferSizes,
     (usize, usize),
-    (
-        DEFAULT_MIN_IMPORT_BUFFER_SIZE,
-        DEFAULT_MAX_IMPORT_BUFFER_SIZE,
-    )
+    (DEFAULT_MIN_IMPORT_BUFFER_SIZE, DEFAULT_MAX_IMPORT_BUFFER_SIZE,)
 );
 make_config_setting!(TxIndexEnabled, bool, false);
 make_config_setting!(MaxTipAge, Duration, Duration::from_secs(60 * 60 * 24));

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -207,10 +207,7 @@ impl BanScore for TxIndexError {
             TxIndexError::SerializationInvariantError(_) => 100,
             TxIndexError::DoubleSpendAttempt(_) => 100,
             TxIndexError::MissingOutputOrSpent => 100,
-            TxIndexError::OutputIndexOutOfRange {
-                tx_id: _,
-                source_output_index: _,
-            } => 100,
+            TxIndexError::OutputIndexOutOfRange { tx_id: _, source_output_index: _ } => 100,
         }
     }
 }
@@ -219,10 +216,7 @@ impl BanScore for GetAncestorError {
     fn ban_score(&self) -> u32 {
         match self {
             GetAncestorError::StorageError(_) => 0,
-            GetAncestorError::InvalidAncestorHeight {
-                block_height: _,
-                ancestor_height: _,
-            } => 100,
+            GetAncestorError::InvalidAncestorHeight { block_height: _, ancestor_height: _ } => 100,
             GetAncestorError::PrevBlockIndexNotFound(_) => 0,
             GetAncestorError::StartingPointNotFound(_) => 0,
         }

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -86,9 +86,7 @@ fn advance_epoch_seal<S: BlockchainStorageWrite>(
         let epoch_undo = db.batch_write_delta(epoch_delta).map_err(BlockError::from).log_err()?;
 
         // store undo delta for sealed epoch
-        db_tx
-            .set_accounting_epoch_undo_delta(epoch_index_to_seal, &epoch_undo)
-            .log_err()?;
+        db_tx.set_accounting_epoch_undo_delta(epoch_index_to_seal, &epoch_undo).log_err()?;
     }
 
     Ok(())
@@ -156,11 +154,8 @@ where
     S: EpochStorageRead,
     P: PoSAccountingView<Error = pos_accounting::Error>,
 {
-    let reward_output = block
-        .block_reward()
-        .outputs()
-        .get(0)
-        .ok_or(SpendStakeError::NoBlockRewardOutputs)?;
+    let reward_output =
+        block.block_reward().outputs().get(0).ok_or(SpendStakeError::NoBlockRewardOutputs)?;
 
     let vrf_pub_key = match reward_output {
         TxOutput::Transfer(_, _)

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -186,10 +186,7 @@ where
         .map(|index| epoch_data_cache.get_epoch_data(index))
         .transpose()?
         .flatten()
-        .map_or_else(
-            || PoSRandomness::at_genesis(chain_config),
-            |d| *d.randomness(),
-        );
+        .map_or_else(|| PoSRandomness::at_genesis(chain_config), |d| *d.randomness());
 
     let epoch_index = chain_config.epoch_index_from_height(block_height);
     PoSRandomness::from_block(
@@ -428,11 +425,6 @@ mod tests {
             db.expect_del_accounting_epoch_undo_delta().times(1).return_const(Ok(()));
         }
 
-        update_epoch_seal(
-            &mut db,
-            &chain_config,
-            BlockStateEvent::Disconnect(tip_height),
-        )
-        .unwrap();
+        update_epoch_seal(&mut db, &chain_config, BlockStateEvent::Disconnect(tip_height)).unwrap();
     }
 }

--- a/chainstate/src/detail/chainstateref/in_memory_reorg.rs
+++ b/chainstate/src/detail/chainstateref/in_memory_reorg.rs
@@ -115,9 +115,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             let new_tip: WithId<Block> = self
                 .get_block_from_index(&new_tip_block_index)
                 .log_err()?
-                .ok_or(CheckBlockError::BlockNotFound(
-                    (*new_tip_block_index.block_id()).into(),
-                ))?
+                .ok_or(CheckBlockError::BlockNotFound((*new_tip_block_index.block_id()).into()))?
                 .into();
 
             // The comparison for timelock is done with median_time_past based on BIP-113, i.e., the median time instead of the block timestamp

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -386,9 +386,9 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     }
 
     fn enforce_checkpoints(&self, header: &SignedBlockHeader) -> Result<(), CheckBlockError> {
-        let prev_block_index = self.get_gen_block_index(header.prev_block_id())?.ok_or(
-            CheckBlockError::PrevBlockNotFound(*header.prev_block_id(), header.get_id()),
-        )?;
+        let prev_block_index = self
+            .get_gen_block_index(header.prev_block_id())?
+            .ok_or(CheckBlockError::PrevBlockNotFound(*header.prev_block_id(), header.get_id()))?;
         let current_height = prev_block_index.block_height().next_height();
 
         // If the block height is at the exact checkpoint height, we need to check that the block id matches the checkpoint id
@@ -397,10 +397,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         {
             let expected_id = Id::<Block>::new(e.get());
             if expected_id != header.get_id() {
-                return Err(CheckBlockError::CheckpointMismatch(
-                    expected_id,
-                    header.get_id(),
-                ));
+                return Err(CheckBlockError::CheckpointMismatch(expected_id, header.get_id()));
             }
         }
 
@@ -430,9 +427,9 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         &self,
         header: &SignedBlockHeader,
     ) -> Result<(), CheckBlockError> {
-        let prev_block_index = self.get_gen_block_index(header.prev_block_id())?.ok_or(
-            PropertyQueryError::PrevBlockIndexNotFound(*header.prev_block_id()),
-        )?;
+        let prev_block_index = self
+            .get_gen_block_index(header.prev_block_id())?
+            .ok_or(PropertyQueryError::PrevBlockIndexNotFound(*header.prev_block_id()))?;
         let common_ancestor_height =
             self.last_common_ancestor_in_main_chain(&prev_block_index)?.block_height();
 
@@ -538,9 +535,9 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                         | TxOutput::ProduceBlockFromStake(_, _)
                         | TxOutput::Burn(_)
                         | TxOutput::CreateDelegationId(_, _)
-                        | TxOutput::DelegateStaking(_, _) => Err(
-                            CheckBlockError::InvalidBlockRewardOutputType(block.get_id()),
-                        ),
+                        | TxOutput::DelegateStaking(_, _) => {
+                            Err(CheckBlockError::InvalidBlockRewardOutputType(block.get_id()))
+                        }
                     },
                     ConsensusData::PoS(_) => {
                         match output {
@@ -551,9 +548,9 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                             | TxOutput::CreateStakePool(_, _)
                             | TxOutput::Burn(_)
                             | TxOutput::CreateDelegationId(_, _)
-                            | TxOutput::DelegateStaking(_, _) => Err(
-                                CheckBlockError::InvalidBlockRewardOutputType(block.get_id()),
-                            ),
+                            | TxOutput::DelegateStaking(_, _) => {
+                                Err(CheckBlockError::InvalidBlockRewardOutputType(block.get_id()))
+                            }
                         }
                     }
                 }
@@ -616,12 +613,10 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         let mut block_inputs = BTreeSet::new();
         for tx in block.transactions() {
             if tx.inputs().is_empty() || tx.outputs().is_empty() {
-                return Err(
-                    CheckBlockTransactionsError::EmptyInputsOutputsInTransactionInBlock(
-                        tx.transaction().get_id(),
-                        block.get_id(),
-                    ),
-                );
+                return Err(CheckBlockTransactionsError::EmptyInputsOutputsInTransactionInBlock(
+                    tx.transaction().get_id(),
+                    block.get_id(),
+                ));
             }
             let mut tx_inputs = BTreeSet::new();
             for input in tx.inputs() {
@@ -735,10 +730,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     // Return Ok(()) if the specified block has a valid parent and an error otherwise.
     pub fn check_block_parent(&self, block: &WithId<Block>) -> Result<(), BlockError> {
         let parent_block_index = self.get_previous_block_index_or_block_error(block)?;
-        ensure!(
-            parent_block_index.status().is_valid(),
-            BlockError::InvalidParent(block.get_id())
-        );
+        ensure!(parent_block_index.status().is_valid(), BlockError::InvalidParent(block.get_id()));
 
         Ok(())
     }
@@ -853,14 +845,8 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         // Set Chain Trust
         let prev_block_chaintrust: Uint256 = prev_block_index.chain_trust();
         let chain_trust = prev_block_chaintrust + current_block_proof;
-        let block_index = BlockIndex::new(
-            block,
-            chain_trust,
-            some_ancestor,
-            height,
-            time_max,
-            block_status,
-        );
+        let block_index =
+            BlockIndex::new(block, chain_trust, some_ancestor, height, time_max, block_status);
         Ok(block_index)
     }
 }

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -104,9 +104,9 @@ pub fn gen_block_index_getter<S: BlockchainStorageRead>(
     block_id: &Id<GenBlock>,
 ) -> Result<Option<GenBlockIndex>, storage_result::Error> {
     match block_id.classify(chain_config) {
-        GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(Arc::clone(
-            chain_config.genesis_block(),
-        )))),
+        GenBlockId::Genesis(_id) => {
+            Ok(Some(GenBlockIndex::Genesis(Arc::clone(chain_config.genesis_block()))))
+        }
         GenBlockId::Block(id) => db_tx.get_block_index(&id).map(|b| b.map(GenBlockIndex::Block)),
     }
 }

--- a/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
+++ b/chainstate/src/detail/chainstateref/tx_verifier_storage.rs
@@ -63,36 +63,28 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Transacti
         &self,
         tx_id: &OutPointSourceId,
     ) -> Result<Option<common::chain::TxMainChainIndex>, TransactionVerifierStorageError> {
-        self.db_tx
-            .get_mainchain_tx_index(tx_id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.get_mainchain_tx_index(tx_id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn get_token_aux_data(
         &self,
         token_id: &TokenId,
     ) -> Result<Option<TokenAuxiliaryData>, TransactionVerifierStorageError> {
-        self.db_tx
-            .get_token_aux_data(token_id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.get_token_aux_data(token_id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn get_accounting_undo(
         &self,
         id: Id<Block>,
     ) -> Result<Option<AccountingBlockUndo>, TransactionVerifierStorageError> {
-        self.db_tx
-            .get_accounting_undo(id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.get_accounting_undo(id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn get_account_nonce_count(
         &self,
         account: AccountType,
     ) -> Result<Option<AccountNonce>, TransactionVerifierStorageError> {
-        self.db_tx
-            .get_account_nonce_count(account)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.get_account_nonce_count(account).map_err(TransactionVerifierStorageError::from)
     }
 }
 
@@ -163,9 +155,7 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
         &mut self,
         tx_id: &OutPointSourceId,
     ) -> Result<(), TransactionVerifierStorageError> {
-        self.db_tx
-            .del_mainchain_tx_index(tx_id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.del_mainchain_tx_index(tx_id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn set_token_aux_data(
@@ -173,18 +163,14 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
         token_id: &TokenId,
         data: &TokenAuxiliaryData,
     ) -> Result<(), TransactionVerifierStorageError> {
-        self.db_tx
-            .set_token_aux_data(token_id, data)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.set_token_aux_data(token_id, data).map_err(TransactionVerifierStorageError::from)
     }
 
     fn del_token_aux_data(
         &mut self,
         token_id: &TokenId,
     ) -> Result<(), TransactionVerifierStorageError> {
-        self.db_tx
-            .del_token_aux_data(token_id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.del_token_aux_data(token_id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn set_token_id(
@@ -201,9 +187,7 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
         &mut self,
         issuance_tx_id: &Id<Transaction>,
     ) -> Result<(), TransactionVerifierStorageError> {
-        self.db_tx
-            .del_token_id(issuance_tx_id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.del_token_id(issuance_tx_id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn set_utxo_undo_data(
@@ -213,10 +197,9 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
     ) -> Result<(), TransactionVerifierStorageError> {
         // TODO: check tx_source at compile-time (mintlayer/mintlayer-core#633)
         match tx_source {
-            TransactionSource::Chain(id) => self
-                .db_tx
-                .set_undo_data(id, undo)
-                .map_err(TransactionVerifierStorageError::from),
+            TransactionSource::Chain(id) => {
+                self.db_tx.set_undo_data(id, undo).map_err(TransactionVerifierStorageError::from)
+            }
             TransactionSource::Mempool => {
                 panic!("Flushing mempool info into the storage is forbidden")
             }
@@ -318,9 +301,7 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy>
         &mut self,
         account: AccountType,
     ) -> Result<(), <Self as TransactionVerifierStorageRef>::Error> {
-        self.db_tx
-            .del_account_nonce_count(account)
-            .map_err(TransactionVerifierStorageError::from)
+        self.db_tx.del_account_nonce_count(account).map_err(TransactionVerifierStorageError::from)
     }
 }
 

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -31,11 +31,8 @@ pub fn calculate_median_time_past<H: BlockIndexHandle>(
     starting_block: &Id<GenBlock>,
 ) -> BlockTimestamp {
     let iter = BlockIndexHistoryIterator::new(*starting_block, block_index_handle);
-    let time_values = iter
-        .take(MEDIAN_TIME_SPAN)
-        .map(|bi| bi.block_timestamp())
-        .sorted()
-        .collect::<Vec<_>>();
+    let time_values =
+        iter.take(MEDIAN_TIME_SPAN).map(|bi| bi.block_timestamp()).sorted().collect::<Vec<_>>();
 
     time_values[time_values.len() / 2]
 }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -165,15 +165,10 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
             time_getter,
         );
 
-        chainstate
-            .process_tx_index_enabled_flag()
-            .map_err(crate::ChainstateError::from)?;
+        chainstate.process_tx_index_enabled_flag().map_err(crate::ChainstateError::from)?;
 
         if best_block_id.is_none() {
-            chainstate
-                .process_genesis()
-                .map_err(ChainstateError::ProcessBlockError)
-                .log_err()?;
+            chainstate.process_genesis().map_err(ChainstateError::ProcessBlockError).log_err()?;
         } else {
             chainstate.check_genesis().map_err(crate::ChainstateError::from)?;
         }
@@ -216,9 +211,8 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
         let block1_id = dbtx
             .get_block_id_by_height(&BlockHeight::new(1))?
             .ok_or(InitializationError::Block1Missing)?;
-        let block1 = dbtx
-            .get_block(Id::new(block1_id.get()))?
-            .ok_or(InitializationError::Block1Missing)?;
+        let block1 =
+            dbtx.get_block(Id::new(block1_id.get()))?.ok_or(InitializationError::Block1Missing)?;
         let stored_genesis_id = block1.prev_block_id();
 
         // Check storage genesis ID matches chain config genesis ID
@@ -232,11 +226,8 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
 
     /// Check that transaction index state is consistent between DB and config.
     fn process_tx_index_enabled_flag(&mut self) -> Result<(), BlockError> {
-        let mut db_tx = self
-            .chainstate_storage
-            .transaction_rw(None)
-            .map_err(BlockError::from)
-            .log_err()?;
+        let mut db_tx =
+            self.chainstate_storage.transaction_rw(None).map_err(BlockError::from).log_err()?;
 
         let tx_index_enabled = db_tx
             .get_is_mainchain_tx_index_enabled()
@@ -533,15 +524,9 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
             .expect("Genesis not constructed correctly");
 
         // Initialize storage with given info
-        let mut db_tx = self
-            .chainstate_storage
-            .transaction_rw(None)
-            .map_err(BlockError::from)
-            .log_err()?;
-        db_tx
-            .set_best_block_id(&genesis_id)
-            .map_err(BlockError::StorageError)
-            .log_err()?;
+        let mut db_tx =
+            self.chainstate_storage.transaction_rw(None).map_err(BlockError::from).log_err()?;
+        db_tx.set_best_block_id(&genesis_id).map_err(BlockError::StorageError).log_err()?;
         db_tx
             .set_block_id_at_height(&BlockHeight::zero(), &genesis_id)
             .map_err(BlockError::StorageError)

--- a/chainstate/src/detail/orphan_blocks/orphans_proxy_impl.rs
+++ b/chainstate/src/detail/orphan_blocks/orphans_proxy_impl.rs
@@ -29,9 +29,7 @@ impl OrphanBlocksRef for OrphansProxy {
 
     fn is_already_an_orphan(&self, block_id: &Id<Block>) -> bool {
         let block_id = *block_id;
-        self.call(move |o| o.is_already_an_orphan(&block_id))
-            .recv()
-            .expect(RECV_ERR_MSG)
+        self.call(move |o| o.is_already_an_orphan(&block_id)).recv().expect(RECV_ERR_MSG)
     }
 }
 
@@ -46,8 +44,6 @@ impl OrphanBlocksMut for OrphansProxy {
 
     fn take_all_children_of(&mut self, block_id: &Id<GenBlock>) -> Vec<WithId<Block>> {
         let block_id = *block_id;
-        self.call_mut(move |o| o.take_all_children_of(&block_id))
-            .recv()
-            .expect(RECV_ERR_MSG)
+        self.call_mut(move |o| o.take_all_children_of(&block_id)).recv().expect(RECV_ERR_MSG)
     }
 }

--- a/chainstate/src/detail/orphan_blocks/pool.rs
+++ b/chainstate/src/detail/orphan_blocks/pool.rs
@@ -98,9 +98,7 @@ impl OrphanBlocksPool {
         self.prune();
         let block_id = block.get_id();
         if self.orphan_by_id.contains_key(&block_id) {
-            return Err(Box::new(OrphanAddError::BlockAlreadyInOrphanList(
-                WithId::take(block),
-            )));
+            return Err(Box::new(OrphanAddError::BlockAlreadyInOrphanList(WithId::take(block))));
         }
 
         let rc_block = Rc::new(block);
@@ -421,11 +419,7 @@ mod tests {
             if let Some(blocks) = orphans_pool.orphan_by_prev_id.get(&block.prev_block_id()) {
                 assert_eq!(blocks.len(), 1);
             } else {
-                panic!(
-                    "block {:?} not found for key {:?}",
-                    block,
-                    block.prev_block_id()
-                );
+                panic!("block {:?} not found for key {:?}", block, block.prev_block_id());
             }
         });
         check_pool_length(&orphans_pool, blocks.len());

--- a/chainstate/src/detail/orphan_blocks/pool.rs
+++ b/chainstate/src/detail/orphan_blocks/pool.rs
@@ -104,10 +104,7 @@ impl OrphanBlocksPool {
         let rc_block = Rc::new(block);
         self.orphan_by_id.insert(block_id, rc_block.clone());
         self.orphan_ids.push(block_id);
-        self.orphan_by_prev_id
-            .entry(rc_block.prev_block_id())
-            .or_default()
-            .push(rc_block.clone());
+        self.orphan_by_prev_id.entry(rc_block.prev_block_id()).or_default().push(rc_block.clone());
         Ok(())
     }
 
@@ -598,10 +595,8 @@ mod tests {
         }
 
         // collect all children of sim_blocks's prev_id
-        let sim_parent_id = sim_blocks
-            .first()
-            .expect("this should return the first element")
-            .prev_block_id();
+        let sim_parent_id =
+            sim_blocks.first().expect("this should return the first element").prev_block_id();
         let children = orphans_pool.take_all_children_of(&sim_parent_id);
         assert_eq!(children.len(), sim_blocks.len());
 
@@ -672,10 +667,8 @@ mod tests {
         }
 
         // collect all children of sim_blocks's prev_id
-        let sim_parent_id = sim_blocks
-            .first()
-            .expect("this should return the first element")
-            .prev_block_id();
+        let sim_parent_id =
+            sim_blocks.first().expect("this should return the first element").prev_block_id();
         let children = orphans_pool.take_all_children_of(&sim_parent_id);
         assert_eq!(children.len(), sim_blocks.len());
 

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -73,9 +73,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         &self,
         height: &BlockHeight,
     ) -> Result<Option<Id<GenBlock>>, PropertyQueryError> {
-        self.chainstate_ref
-            .get_block_id_by_height(height)
-            .map(|res| res.map(Into::into))
+        self.chainstate_ref.get_block_id_by_height(height).map(|res| res.map(Into::into))
     }
 
     pub fn get_block(&self, id: Id<Block>) -> Result<Option<Block>, PropertyQueryError> {

--- a/chainstate/src/detail/test.rs
+++ b/chainstate/src/detail/test.rs
@@ -55,10 +55,7 @@ fn process_genesis_block() {
         let chainstate_ref = chainstate.make_db_tx_ro().unwrap();
 
         // Check the genesis block is properly set up
-        assert_eq!(
-            chainstate.query().unwrap().get_best_block_id().unwrap(),
-            genesis_id
-        );
+        assert_eq!(chainstate.query().unwrap().get_best_block_id().unwrap(), genesis_id);
         let genesis_index = chainstate_ref.get_gen_block_index(&genesis_id).unwrap().unwrap();
         assert_eq!(genesis_index.block_height(), BlockHeight::from(0));
         assert_eq!(genesis_index.block_id(), genesis_id);
@@ -111,10 +108,7 @@ mod with_rw_tx_tests {
 
     // Make some error that can be returned from "commit".
     fn make_commit_error() -> StorageError {
-        StorageError::Storage(storage::error::Recoverable::Io(
-            std::io::ErrorKind::Other,
-            "".into(),
-        ))
+        StorageError::Storage(storage::error::Recoverable::Io(std::io::ErrorKind::Other, "".into()))
     }
 
     fn make_chainstate(

--- a/chainstate/src/detail/tokens/check_utils.rs
+++ b/chainstate/src/detail/tokens/check_utils.rs
@@ -43,14 +43,8 @@ pub fn is_uri_valid(uri: &[u8]) -> bool {
 }
 
 pub fn check_media_hash(chain_config: &ChainConfig, hash: &[u8]) -> Result<(), TokensError> {
-    ensure!(
-        hash.len() >= chain_config.min_hash_len(),
-        TokensError::MediaHashTooShort
-    );
-    ensure!(
-        hash.len() <= chain_config.max_hash_len(),
-        TokensError::MediaHashTooLong
-    );
+    ensure!(hash.len() >= chain_config.min_hash_len(), TokensError::MediaHashTooShort);
+    ensure!(hash.len() <= chain_config.max_hash_len(), TokensError::MediaHashTooLong);
     Ok(())
 }
 

--- a/chainstate/src/detail/tokens/mod.rs
+++ b/chainstate/src/detail/tokens/mod.rs
@@ -50,24 +50,9 @@ pub fn check_nft_issuance_data(
     tx_id: Id<Transaction>,
     source_block_id: Id<Block>,
 ) -> Result<(), TokensError> {
-    check_token_ticker(
-        chain_config,
-        &issuance.metadata.ticker,
-        tx_id,
-        source_block_id,
-    )?;
-    check_nft_name(
-        chain_config,
-        &issuance.metadata.name,
-        tx_id,
-        source_block_id,
-    )?;
-    check_nft_description(
-        chain_config,
-        &issuance.metadata.description,
-        tx_id,
-        source_block_id,
-    )?;
+    check_token_ticker(chain_config, &issuance.metadata.ticker, tx_id, source_block_id)?;
+    check_nft_name(chain_config, &issuance.metadata.name, tx_id, source_block_id)?;
+    check_nft_description(chain_config, &issuance.metadata.description, tx_id, source_block_id)?;
 
     let icon_uri = Vec::<u8>::decode_all(&mut issuance.metadata.icon_uri.encode().as_slice())
         .map_err(|_| TokensError::IssueErrorIncorrectIconURI(tx_id, source_block_id))?;
@@ -131,10 +116,7 @@ pub fn check_tokens_issuance_data(
 
     // Check decimals
     if number_of_decimals > &chain_config.token_max_dec_count() {
-        return Err(TokensError::IssueErrorTooManyDecimals(
-            tx_id,
-            source_block_id,
-        ));
+        return Err(TokensError::IssueErrorTooManyDecimals(tx_id, source_block_id));
     }
 
     // Check URI

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -96,9 +96,7 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
             })
             .log_err()?;
 
-        tx_verifier
-            .check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy))
-            .log_err()?;
+        tx_verifier.check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy)).log_err()?;
 
         tx_verifier
             .connect_block_reward(

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -84,9 +84,7 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
             .try_fold(Amount::from_atoms(0), |total, tx| {
                 let fee = tx_verifier
                     .connect_transaction(
-                        &TransactionSourceForConnect::Chain {
-                            new_block_index: block_index,
-                        },
+                        &TransactionSourceForConnect::Chain { new_block_index: block_index },
                         tx,
                         &median_time_past,
                         take_front_tx_index(&mut tx_indices),

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -309,10 +309,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
         let second_block = tx.get_gen_block_index(second_block)?;
         if let (Some(first_block), Some(second_block)) = (first_block, second_block) {
             let common_ancestor = tx.last_common_ancestor(&first_block, &second_block)?;
-            Ok(Some((
-                common_ancestor.block_id(),
-                common_ancestor.block_height(),
-            )))
+            Ok(Some((common_ancestor.block_id(), common_ancestor.block_height())))
         } else {
             Ok(None)
         }

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -69,9 +69,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
     }
 
     fn preliminary_header_check(&self, header: SignedBlockHeader) -> Result<(), ChainstateError> {
-        self.chainstate
-            .preliminary_header_check(header)
-            .map_err(ChainstateError::ProcessBlockError)
+        self.chainstate.preliminary_header_check(header).map_err(ChainstateError::ProcessBlockError)
     }
 
     fn preliminary_block_check(&self, block: Block) -> Result<Block, ChainstateError> {
@@ -457,9 +455,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
             .make_db_tx_ro()
             .map_err(|e| ChainstateError::FailedToReadProperty(e.into()))?;
         let utxo_view = chainstate_ref.make_utxo_view();
-        utxo_view
-            .utxo(outpoint)
-            .map_err(|e| ChainstateError::FailedToReadProperty(e.into()))
+        utxo_view.utxo(outpoint).map_err(|e| ChainstateError::FailedToReadProperty(e.into()))
     }
 
     fn is_initial_block_download(&self) -> Result<bool, ChainstateError> {

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -354,25 +354,13 @@ mod tests {
     use common::time_getter::TimeGetter;
 
     fn test_interface_ref<C: ChainstateInterface>(chainstate: &C, chain_config: &ChainConfig) {
-        assert_eq!(
-            chainstate.get_best_block_id().unwrap(),
-            chain_config.genesis_block_id()
-        );
-        assert_eq!(
-            chainstate.get_best_block_height().unwrap(),
-            BlockHeight::new(0)
-        );
+        assert_eq!(chainstate.get_best_block_id().unwrap(), chain_config.genesis_block_id());
+        assert_eq!(chainstate.get_best_block_height().unwrap(), BlockHeight::new(0));
     }
 
     fn test_interface<C: ChainstateInterface>(chainstate: C, chain_config: &ChainConfig) {
-        assert_eq!(
-            chainstate.get_best_block_id().unwrap(),
-            chain_config.genesis_block_id()
-        );
-        assert_eq!(
-            chainstate.get_best_block_height().unwrap(),
-            BlockHeight::new(0)
-        );
+        assert_eq!(chainstate.get_best_block_id().unwrap(), chain_config.genesis_block_id());
+        assert_eq!(chainstate.get_best_block_height().unwrap(), BlockHeight::new(0));
     }
 
     #[test]

--- a/chainstate/src/rpc.rs
+++ b/chainstate/src/rpc.rs
@@ -107,9 +107,8 @@ impl ChainstateRpcServer for super::ChainstateHandle {
     }
 
     async fn submit_block(&self, block: HexEncoded<Block>) -> RpcResult<()> {
-        let res = self
-            .call_mut(move |this| this.process_block(block.take(), BlockSource::Local))
-            .await;
+        let res =
+            self.call_mut(move |this| this.process_block(block.take(), BlockSource::Local)).await;
         // remove the block index from the return value
         let res = res.map(|v| v.map(|_bi| ()));
         rpc::handle_result(res)
@@ -158,8 +157,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
             std::io::BufWriter::new(Box::new(file_obj));
 
         rpc::handle_result(
-            self.call(move |this| this.export_bootstrap_stream(writer, include_orphans))
-                .await,
+            self.call(move |this| this.export_bootstrap_stream(writer, include_orphans)).await,
         )
     }
 

--- a/chainstate/storage/src/internal/store_tx.rs
+++ b/chainstate/storage/src/internal/store_tx.rs
@@ -450,10 +450,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn del_token_id(&mut self, issuance_tx_id: &Id<Transaction>) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBIssuanceTxVsTokenId, _>()
-            .del(&issuance_tx_id)
-            .map_err(Into::into)
+        self.0.get_mut::<db::DBIssuanceTxVsTokenId, _>().del(&issuance_tx_id).map_err(Into::into)
     }
 
     fn set_accounting_undo_data(
@@ -477,10 +474,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn del_accounting_epoch_delta(&mut self, epoch_index: EpochIndex) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingEpochDelta, _>()
-            .del(epoch_index)
-            .map_err(Into::into)
+        self.0.get_mut::<db::DBAccountingEpochDelta, _>().del(epoch_index).map_err(Into::into)
     }
 
     fn set_accounting_epoch_undo_delta(
@@ -492,10 +486,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
     }
 
     fn del_accounting_epoch_undo_delta(&mut self, epoch_index: EpochIndex) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingEpochDeltaUndo, _>()
-            .del(epoch_index)
-            .map_err(Into::into)
+        self.0.get_mut::<db::DBAccountingEpochDeltaUndo, _>().del(epoch_index).map_err(Into::into)
     }
 
     fn set_account_nonce_count(
@@ -549,10 +540,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<TipStorageTag> for Stor
     }
 
     fn del_pool_balance(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolBalancesTip, _>()
-            .del(pool_id)
-            .map_err(Into::into)
+        self.0.get_mut::<db::DBAccountingPoolBalancesTip, _>().del(pool_id).map_err(Into::into)
     }
 
     fn set_pool_data(&mut self, pool_id: PoolId, pool_data: &PoolData) -> crate::Result<()> {
@@ -560,10 +548,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<TipStorageTag> for Stor
     }
 
     fn del_pool_data(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolDataTip, _>()
-            .del(pool_id)
-            .map_err(Into::into)
+        self.0.get_mut::<db::DBAccountingPoolDataTip, _>().del(pool_id).map_err(Into::into)
     }
 
     fn set_delegation_balance(
@@ -626,10 +611,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<SealedStorageTag> for S
     }
 
     fn del_pool_balance(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolBalancesSealed, _>()
-            .del(pool_id)
-            .map_err(Into::into)
+        self.0.get_mut::<db::DBAccountingPoolBalancesSealed, _>().del(pool_id).map_err(Into::into)
     }
 
     fn set_pool_data(&mut self, pool_id: PoolId, pool_data: &PoolData) -> crate::Result<()> {
@@ -637,10 +619,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<SealedStorageTag> for S
     }
 
     fn del_pool_data(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolDataSealed, _>()
-            .del(pool_id)
-            .map_err(Into::into)
+        self.0.get_mut::<db::DBAccountingPoolDataSealed, _>().del(pool_id).map_err(Into::into)
     }
 
     fn set_delegation_balance(

--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -106,10 +106,7 @@ fn test_storage_manipulation() {
         "Transaction format has changed, adjust the offset in this test",
     );
     let pos_tx0 = TxMainChainPosition::new(block0.get_id(), offset_tx0 as u32);
-    assert_eq!(
-        &store.get_mainchain_tx_by_position(&pos_tx0).unwrap().unwrap(),
-        &tx0
-    );
+    assert_eq!(&store.get_mainchain_tx_by_position(&pos_tx0).unwrap().unwrap(), &tx0);
 
     // Test setting and retrieving best chain id
     assert_eq!(store.get_best_block_id(), Ok(None));
@@ -123,19 +120,13 @@ fn test_storage_manipulation() {
     let out_id_tx0 = OutPointSourceId::from(tx0.get_id());
     assert_eq!(store.get_mainchain_tx_index(&out_id_tx0), Ok(None));
     assert_eq!(store.set_mainchain_tx_index(&out_id_tx0, &idx_tx0), Ok(()));
-    assert_eq!(
-        store.get_mainchain_tx_index(&out_id_tx0),
-        Ok(Some(idx_tx0.clone()))
-    );
+    assert_eq!(store.get_mainchain_tx_index(&out_id_tx0), Ok(Some(idx_tx0.clone())));
     assert_eq!(store.del_mainchain_tx_index(&out_id_tx0), Ok(()));
     assert_eq!(store.get_mainchain_tx_index(&out_id_tx0), Ok(None));
     assert_eq!(store.set_mainchain_tx_index(&out_id_tx0, &idx_tx0), Ok(()));
 
     // Retrieve transactions by ID using the index
-    assert_eq!(
-        store.get_mainchain_tx_index(&OutPointSourceId::from(tx1.get_id())),
-        Ok(None)
-    );
+    assert_eq!(store.get_mainchain_tx_index(&OutPointSourceId::from(tx1.get_id())), Ok(None));
     if let Ok(Some(index)) = store.get_mainchain_tx_index(&out_id_tx0) {
         if let SpendablePosition::Transaction(ref p) = index.position() {
             assert_eq!(store.get_mainchain_tx_by_position(p), Ok(Some(tx0)));
@@ -259,10 +250,8 @@ fn create_rand_utxo(rng: &mut (impl Rng + CryptoRng), block_height: u64) -> (Utx
 
     // generate utxo
     let utxo = Utxo::new_for_blockchain(output, BlockHeight::new(block_height));
-    let outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))),
-        0,
-    );
+    let outpoint =
+        UtxoOutPoint::new(OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))), 0);
 
     (utxo, outpoint)
 }
@@ -322,10 +311,7 @@ fn undo_test(#[case] seed: Seed) {
 
     // add undo data and check if it is there
     assert_eq!(store.set_undo_data(id0, &block_undo0), Ok(()));
-    assert_eq!(
-        store.get_undo_data(id0).unwrap().unwrap(),
-        block_undo0.clone()
-    );
+    assert_eq!(store.get_undo_data(id0).unwrap().unwrap(), block_undo0.clone());
 
     // insert, remove, and reinsert the next block_undo
 
@@ -335,16 +321,10 @@ fn undo_test(#[case] seed: Seed) {
 
     assert_eq!(store.get_undo_data(id1), Ok(None));
     assert_eq!(store.set_undo_data(id1, &block_undo1), Ok(()));
-    assert_eq!(
-        store.get_undo_data(id0).unwrap().unwrap(),
-        block_undo0.clone()
-    );
+    assert_eq!(store.get_undo_data(id0).unwrap().unwrap(), block_undo0.clone());
     assert_eq!(store.del_undo_data(id1), Ok(()));
     assert_eq!(store.get_undo_data(id1), Ok(None));
-    assert_eq!(
-        store.get_undo_data(id0).unwrap().unwrap(),
-        block_undo0.clone()
-    );
+    assert_eq!(store.get_undo_data(id0).unwrap().unwrap(), block_undo0.clone());
     assert_eq!(store.set_undo_data(id1, &block_undo1), Ok(()));
     assert_eq!(store.get_undo_data(id1).unwrap().unwrap(), block_undo1);
 }

--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -267,10 +267,8 @@ pub fn create_rand_block_undo(
     max_lim_of_tx_undos: u8,
 ) -> UtxosBlockUndo {
     let utxo_rng = rng.gen_range(1..max_lim_of_utxos);
-    let reward_utxos = (0..utxo_rng)
-        .enumerate()
-        .map(|(i, _)| create_rand_utxo(rng, i as u64).0)
-        .collect();
+    let reward_utxos =
+        (0..utxo_rng).enumerate().map(|(i, _)| create_rand_utxo(rng, i as u64).0).collect();
     let reward_undo = UtxosBlockRewardUndo::new(reward_utxos);
 
     let mut tx_undo = vec![];

--- a/chainstate/storage/src/mock/tests.rs
+++ b/chainstate/storage/src/mock/tests.rs
@@ -69,20 +69,15 @@ fn two_updates_second_fails() {
 fn mock_transaction_fail() {
     // Set up the mock store
     let mut store = MockStore::new();
-    let err_f = || {
-        Err(crate::Error::Storage(
-            storage::error::Recoverable::TransactionFailed,
-        ))
-    };
+    let err_f = || Err(crate::Error::Storage(storage::error::Recoverable::TransactionFailed));
     store.expect_transaction_ro().returning(err_f);
 
     // Check it returns an error
     match store.transaction_ro() {
         Ok(_) => panic!("Err expected"),
-        Err(e) => assert_eq!(
-            e,
-            crate::Error::Storage(storage::error::Recoverable::TransactionFailed)
-        ),
+        Err(e) => {
+            assert_eq!(e, crate::Error::Storage(storage::error::Recoverable::TransactionFailed))
+        }
     }
 }
 

--- a/chainstate/storage/src/mock/tests.rs
+++ b/chainstate/storage/src/mock/tests.rs
@@ -50,16 +50,8 @@ fn basic_fail() {
 fn two_updates_second_fails() {
     let mut store = MockStore::new();
     let mut seq = mockall::Sequence::new();
-    store
-        .expect_set_best_block_id()
-        .times(1)
-        .in_sequence(&mut seq)
-        .return_const(Ok(()));
-    store
-        .expect_set_best_block_id()
-        .times(1)
-        .in_sequence(&mut seq)
-        .return_const(Err(TXFAIL));
+    store.expect_set_best_block_id().times(1).in_sequence(&mut seq).return_const(Ok(()));
+    store.expect_set_best_block_id().times(1).in_sequence(&mut seq).return_const(Err(TXFAIL));
 
     assert!(store.set_best_block_id(&Id::new(HASH1)).is_ok());
     assert!(store.set_best_block_id(&Id::new(HASH2)).is_err());
@@ -88,10 +80,7 @@ fn mock_transaction() {
     store.expect_transaction_rw().returning(|_| {
         let mut mock_tx = MockStoreTxRw::new();
         mock_tx.expect_get_storage_version().return_const(Ok(3));
-        mock_tx
-            .expect_set_storage_version()
-            .with(mockall::predicate::eq(4))
-            .return_const(Ok(()));
+        mock_tx.expect_set_storage_version().with(mockall::predicate::eq(4)).return_const(Ok(()));
         mock_tx.expect_commit().times(1).return_const(Ok(()));
         Ok(mock_tx)
     });

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -176,10 +176,7 @@ impl<'f> BlockBuilder<'f> {
         let (mut witnesses, mut inputs, outputs) =
             self.make_test_inputs_outputs(parent_outputs, rng);
         let spend_from = self.framework.outputs_from_genblock(spend_from.into());
-        inputs.push(TxInput::from_utxo(
-            spend_from.keys().next().unwrap().clone(),
-            0,
-        ));
+        inputs.push(TxInput::from_utxo(spend_from.keys().next().unwrap().clone(), 0));
         witnesses.push(InputWitness::NoSignature(None));
         self.transactions.push(
             SignedTransaction::new(Transaction::new(0, inputs, outputs).unwrap(), witnesses)
@@ -243,10 +240,7 @@ impl<'f> BlockBuilder<'f> {
             unsigned_header.with_no_signature()
         };
 
-        (
-            Block::new_from_header(signed_header, block_body).unwrap(),
-            self.framework,
-        )
+        (Block::new_from_header(signed_header, block_body).unwrap(), self.framework)
     }
 
     /// Builds a block without processing it.

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -121,9 +121,8 @@ impl<'f> BlockBuilder<'f> {
 
     /// Returns regular transaction output(s) if any, otherwise returns block reward outputs
     fn filter_outputs(outputs: BlockOutputs) -> BlockOutputs {
-        let has_tx_outputs = outputs
-            .iter()
-            .any(|(output, _)| matches!(output, OutPointSourceId::Transaction(_)));
+        let has_tx_outputs =
+            outputs.iter().any(|(output, _)| matches!(output, OutPointSourceId::Transaction(_)));
         outputs
             .into_iter()
             .filter(|(output, _)| {

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -180,10 +180,7 @@ impl TestFramework {
     /// Returns a block identifier for the specified height.
     #[track_caller]
     pub fn block_id(&self, height: u64) -> Id<GenBlock> {
-        self.chainstate
-            .get_block_id_from_height(&BlockHeight::from(height))
-            .unwrap()
-            .unwrap()
+        self.chainstate.get_block_id_from_height(&BlockHeight::from(height)).unwrap().unwrap()
     }
 
     /// Returns the list of outputs from the selected block.

--- a/chainstate/test-framework/src/pos_block_builder.rs
+++ b/chainstate/test-framework/src/pos_block_builder.rs
@@ -180,10 +180,7 @@ impl<'f> PoSBlockBuilder<'f> {
         );
         self.framework.progress_time_seconds_since_epoch(target_block_time.get());
 
-        (
-            Block::new_from_header(signed_header, block_body).unwrap(),
-            self.framework,
-        )
+        (Block::new_from_header(signed_header, block_body).unwrap(), self.framework)
     }
 
     /// Builds a block without processing it.

--- a/chainstate/test-framework/src/transaction_builder.rs
+++ b/chainstate/test-framework/src/transaction_builder.rs
@@ -32,12 +32,7 @@ pub struct TransactionBuilder {
 
 impl TransactionBuilder {
     pub fn new() -> Self {
-        Self {
-            flags: 0,
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            witnesses: Vec::new(),
-        }
+        Self { flags: 0, inputs: Vec::new(), outputs: Vec::new(), witnesses: Vec::new() }
     }
 
     pub fn with_flags(mut self, flags: u128) -> Self {
@@ -101,10 +96,8 @@ fn build_transaction(#[case] seed: test_utils::random::Seed) {
 
     let flags = 1;
     let witness = InputWitness::NoSignature(None);
-    let input = TxInput::from_utxo(
-        OutPointSourceId::Transaction(Id::new(H256::random_using(&mut rng))),
-        0,
-    );
+    let input =
+        TxInput::from_utxo(OutPointSourceId::Transaction(Id::new(H256::random_using(&mut rng))), 0);
 
     let tx = TransactionBuilder::new()
         .with_flags(flags)

--- a/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/disposable_strategy.rs
@@ -88,9 +88,7 @@ impl TransactionVerificationStrategy for DisposableTransactionVerificationStrate
                 let mut tx_verifier = base_tx_verifier.derive_child();
                 let fee = tx_verifier
                     .connect_transaction(
-                        &TransactionSourceForConnect::Chain {
-                            new_block_index: block_index,
-                        },
+                        &TransactionSourceForConnect::Chain { new_block_index: block_index },
                         tx,
                         &median_time_past,
                         take_front_tx_index(&mut tx_indices),

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -60,9 +60,7 @@ pub struct RandomizedTransactionVerificationStrategy {
 
 impl RandomizedTransactionVerificationStrategy {
     pub fn new(seed: Seed) -> Self {
-        Self {
-            rng: RefCell::new(Box::new(make_seedable_rng(seed))),
-        }
+        Self { rng: RefCell::new(Box::new(make_seedable_rng(seed))) }
     }
 }
 
@@ -183,9 +181,7 @@ impl RandomizedTransactionVerificationStrategy {
                 // connect transactable using current verifier
 
                 tx_verifier.connect_transaction(
-                    &TransactionSourceForConnect::Chain {
-                        new_block_index: block_index,
-                    },
+                    &TransactionSourceForConnect::Chain { new_block_index: block_index },
                     &block.transactions()[tx_num],
                     median_time_past,
                     take_front_tx_index(&mut tx_indices),
@@ -235,9 +231,7 @@ impl RandomizedTransactionVerificationStrategy {
             } else {
                 // connect transactable using current verifier
                 let fee = tx_verifier.connect_transaction(
-                    &TransactionSourceForConnect::Chain {
-                        new_block_index: block_index,
-                    },
+                    &TransactionSourceForConnect::Chain { new_block_index: block_index },
                     &block.transactions()[tx_num],
                     median_time_past,
                     take_front_tx_index(tx_indices),

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -190,9 +190,7 @@ impl RandomizedTransactionVerificationStrategy {
             }
         }
 
-        tx_verifier
-            .check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy))
-            .log_err()?;
+        tx_verifier.check_block_reward(block, Fee(total_fees), Subsidy(block_subsidy)).log_err()?;
 
         tx_verifier
             .connect_block_reward(

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -107,11 +107,7 @@ pub fn create_utxo_data(
         },
     };
 
-    Some((
-        empty_witness(rng),
-        TxInput::from_utxo(outsrc, index as u32),
-        new_output,
-    ))
+    Some((empty_witness(rng), TxInput::from_utxo(outsrc, index as u32), new_output))
 }
 
 /// Given an output as in input creates multiple new random outputs.
@@ -180,11 +176,8 @@ pub fn create_multiple_utxo_data(
                         transfer.amount
                     };
                     vec![TxOutput::Burn(
-                        TokenTransfer {
-                            token_id: transfer.token_id,
-                            amount: amount_to_burn,
-                        }
-                        .into(),
+                        TokenTransfer { token_id: transfer.token_id, amount: amount_to_burn }
+                            .into(),
                     )]
                 } else {
                     // transfer tokens again
@@ -195,11 +188,7 @@ pub fn create_multiple_utxo_data(
                                 let amount =
                                     Amount::from_atoms(transfer.amount.into_atoms() / num_outputs);
                                 TxOutput::Transfer(
-                                    TokenTransfer {
-                                        token_id: transfer.token_id,
-                                        amount,
-                                    }
-                                    .into(),
+                                    TokenTransfer { token_id: transfer.token_id, amount }.into(),
                                     anyonecanspend_address(),
                                 )
                             })
@@ -234,11 +223,7 @@ pub fn create_multiple_utxo_data(
         },
     };
 
-    Some((
-        empty_witness(rng),
-        TxInput::from_utxo(outsrc, index as u32),
-        new_outputs,
-    ))
+    Some((empty_witness(rng), TxInput::from_utxo(outsrc, index as u32), new_outputs))
 }
 
 fn new_token_transfer_output(
@@ -285,12 +270,9 @@ fn new_token_burn_output(
 }
 
 pub fn outputs_from_genesis(genesis: &Genesis) -> BlockOutputs {
-    [(
-        OutPointSourceId::BlockReward(genesis.get_id().into()),
-        genesis.utxos().to_vec(),
-    )]
-    .into_iter()
-    .collect()
+    [(OutPointSourceId::BlockReward(genesis.get_id().into()), genesis.utxos().to_vec())]
+        .into_iter()
+        .collect()
 }
 
 pub fn outputs_from_block(blk: &Block) -> BlockOutputs {
@@ -322,10 +304,7 @@ pub fn create_chain_config_with_staking_pool(
     pool_data: StakePoolData,
 ) -> ConfigBuilder {
     let upgrades = vec![
-        (
-            BlockHeight::new(0),
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
-        ),
+        (BlockHeight::new(0), UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus)),
         (
             BlockHeight::new(1),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -327,9 +327,7 @@ pub fn create_chain_config_with_staking_pool(
     );
 
     let net_upgrades = NetUpgrades::initialize(upgrades).unwrap();
-    ConfigBuilder::new(ChainType::Regtest)
-        .net_upgrades(net_upgrades)
-        .genesis_custom(genesis)
+    ConfigBuilder::new(ChainType::Regtest).net_upgrades(net_upgrades).genesis_custom(genesis)
 }
 
 pub fn produce_kernel_signature(

--- a/chainstate/test-suite/benches/benches.rs
+++ b/chainstate/test-suite/benches/benches.rs
@@ -78,13 +78,7 @@ pub fn pos_reorg(c: &mut Criterion) {
     tf.progress_time_seconds_since_epoch(target_block_time.get());
 
     let common_block_id = tf
-        .create_chain_pos(
-            &tf.genesis().get_id().into(),
-            5,
-            &mut rng,
-            &staking_sk,
-            &vrf_sk,
-        )
+        .create_chain_pos(&tf.genesis().get_id().into(), 5, &mut rng, &staking_sk, &vrf_sk)
         .unwrap();
 
     tf.create_chain_pos(&common_block_id, 100, &mut rng, &staking_sk, &vrf_sk)

--- a/chainstate/test-suite/benches/benches.rs
+++ b/chainstate/test-suite/benches/benches.rs
@@ -81,13 +81,11 @@ pub fn pos_reorg(c: &mut Criterion) {
         .create_chain_pos(&tf.genesis().get_id().into(), 5, &mut rng, &staking_sk, &vrf_sk)
         .unwrap();
 
-    tf.create_chain_pos(&common_block_id, 100, &mut rng, &staking_sk, &vrf_sk)
-        .unwrap();
+    tf.create_chain_pos(&common_block_id, 100, &mut rng, &staking_sk, &vrf_sk).unwrap();
 
     c.bench_function("PoS reorg", |b| {
         b.iter(|| {
-            tf.create_chain_pos(&common_block_id, 101, &mut rng, &staking_sk, &vrf_sk)
-                .unwrap();
+            tf.create_chain_pos(&common_block_id, 101, &mut rng, &staking_sk, &vrf_sk).unwrap();
         })
     });
 }

--- a/chainstate/test-suite/src/tests/block_status.rs
+++ b/chainstate/test-suite/src/tests/block_status.rs
@@ -88,10 +88,7 @@ fn bad_parent(#[case] seed: Seed) {
         // Now create a block with a legit tx, but using block1 as the parent.
         let tx2 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Burn(some_coins(&mut rng)))
@@ -103,16 +100,10 @@ fn bad_parent(#[case] seed: Seed) {
             .build();
         let block2_id = block2.get_id();
         let error = tf.process_block(block2, BlockSource::Local).unwrap_err();
-        assert_eq!(
-            error,
-            ChainstateError::ProcessBlockError(BlockError::InvalidParent(block2_id))
-        );
+        assert_eq!(error, ChainstateError::ProcessBlockError(BlockError::InvalidParent(block2_id)));
 
         let block2_status = get_block_status(&tf, &block2_id);
-        assert_eq!(
-            block2_status.last_valid_stage(),
-            BlockValidationStage::Unchecked
-        );
+        assert_eq!(block2_status.last_valid_stage(), BlockValidationStage::Unchecked);
     });
 }
 
@@ -134,10 +125,7 @@ fn check_block_failure(#[case] seed: Seed) {
         tf.process_block(block, BlockSource::Local).unwrap_err();
 
         let block_status = get_block_status(&tf, &block_id);
-        assert_eq!(
-            block_status.last_valid_stage(),
-            BlockValidationStage::ParentOk
-        );
+        assert_eq!(block_status.last_valid_stage(), BlockValidationStage::ParentOk);
     });
 }
 
@@ -153,10 +141,7 @@ fn best_chain_activation_failure(#[case] seed: Seed) {
         // In the first block, create a tx that burns some coins.
         let tx1 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Burn(some_coins(&mut rng)))
@@ -174,10 +159,7 @@ fn best_chain_activation_failure(#[case] seed: Seed) {
                 TxInput::from_utxo(tx1.transaction().get_id().into(), 0),
                 empty_witness(&mut rng),
             )
-            .add_output(TxOutput::Transfer(
-                some_coins(&mut rng),
-                anyonecanspend_address(),
-            ))
+            .add_output(TxOutput::Transfer(some_coins(&mut rng), anyonecanspend_address()))
             .build();
 
         let block2 = tf.make_block_builder().with_transactions(vec![tx2]).build();
@@ -186,10 +168,7 @@ fn best_chain_activation_failure(#[case] seed: Seed) {
         tf.process_block(block2, BlockSource::Local).unwrap_err();
 
         let block2_status = get_block_status(&tf, &block2_id);
-        assert_eq!(
-            block2_status.last_valid_stage(),
-            BlockValidationStage::CheckBlockOk
-        );
+        assert_eq!(block2_status.last_valid_stage(), BlockValidationStage::CheckBlockOk);
     });
 }
 

--- a/chainstate/test-suite/src/tests/block_status.rs
+++ b/chainstate/test-suite/src/tests/block_status.rs
@@ -28,11 +28,7 @@ use test_utils::random::make_seedable_rng;
 use test_utils::random::Seed;
 
 fn get_block_status(tf: &TestFramework, block_id: &Id<Block>) -> BlockStatus {
-    tf.chainstate
-        .get_block_index(block_id)
-        .unwrap()
-        .expect("block index must be present")
-        .status()
+    tf.chainstate.get_block_index(block_id).unwrap().expect("block index must be present").status()
 }
 
 fn some_coins(rng: &mut (impl Rng + CryptoRng)) -> OutputValue {

--- a/chainstate/test-suite/src/tests/bootstrap.rs
+++ b/chainstate/test-suite/src/tests/bootstrap.rs
@@ -122,10 +122,7 @@ fn bootstrap_tests(#[case] seed: Seed) {
             assert!(chain1.iter().all(|item| tree_vec.contains(item)));
             assert!(chain2.iter().all(|item| tree_vec.contains(item)));
             assert!(chain3.iter().all(|item| tree_vec.contains(item)));
-            assert_eq!(
-                mainchain_vec.len(),
-                chain2.len() - len_to_cut_from_branch + new_branch_len
-            );
+            assert_eq!(mainchain_vec.len(), chain2.len() - len_to_cut_from_branch + new_branch_len);
             assert_eq!(tree_vec.len(), 45 + new_branch_len);
 
             check_height_order(&mainchain_vec, &tf1.chainstate);
@@ -148,10 +145,7 @@ fn bootstrap_tests(#[case] seed: Seed) {
                 .chain(chain4)
                 .collect::<BTreeSet<Id<Block>>>();
 
-            assert_eq!(
-                all_blocks,
-                tree_vec.iter().cloned().collect::<BTreeSet<Id<Block>>>()
-            );
+            assert_eq!(all_blocks, tree_vec.iter().cloned().collect::<BTreeSet<Id<Block>>>());
 
             tree_vec
         };

--- a/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
@@ -196,9 +196,7 @@ fn accounting_storage_two_blocks_one_epoch_no_seal(#[case] seed: Seed) {
             .expect("ok")
             .expect("some");
         assert_eq!(
-            tf.chainstate
-                .get_chain_config()
-                .epoch_index_from_height(&block1_index.block_height()),
+            tf.chainstate.get_chain_config().epoch_index_from_height(&block1_index.block_height()),
             expected_epoch_index
         );
         let block2_index = tf
@@ -208,9 +206,7 @@ fn accounting_storage_two_blocks_one_epoch_no_seal(#[case] seed: Seed) {
             .expect("ok")
             .expect("some");
         assert_eq!(
-            tf.chainstate
-                .get_chain_config()
-                .epoch_index_from_height(&block2_index.block_height()),
+            tf.chainstate.get_chain_config().epoch_index_from_height(&block2_index.block_height()),
             expected_epoch_index
         );
 
@@ -255,10 +251,8 @@ fn accounting_storage_two_blocks_one_epoch_no_seal(#[case] seed: Seed) {
             delegation_data: DeltaDataCollection::new(),
         };
 
-        let epoch_delta = storage
-            .get_accounting_epoch_delta(expected_epoch_index)
-            .expect("ok")
-            .expect("some");
+        let epoch_delta =
+            storage.get_accounting_epoch_delta(expected_epoch_index).expect("ok").expect("some");
         assert_eq!(epoch_delta, expected_epoch_delta);
 
         assert!(storage.get_accounting_epoch_undo_delta(0).unwrap().is_none());
@@ -310,9 +304,7 @@ fn accounting_storage_two_epochs_no_seal(#[case] seed: Seed) {
             .expect("ok")
             .expect("some");
         assert_eq!(
-            tf.chainstate
-                .get_chain_config()
-                .epoch_index_from_height(&block1_index.block_height()),
+            tf.chainstate.get_chain_config().epoch_index_from_height(&block1_index.block_height()),
             block1_epoch_index
         );
         let block2_index = tf
@@ -322,9 +314,7 @@ fn accounting_storage_two_epochs_no_seal(#[case] seed: Seed) {
             .expect("ok")
             .expect("some");
         assert_eq!(
-            tf.chainstate
-                .get_chain_config()
-                .epoch_index_from_height(&block2_index.block_height()),
+            tf.chainstate.get_chain_config().epoch_index_from_height(&block2_index.block_height()),
             block2_epoch_index
         );
 
@@ -361,10 +351,8 @@ fn accounting_storage_two_epochs_no_seal(#[case] seed: Seed) {
             delegation_data: DeltaDataCollection::new(),
         };
 
-        let epoch1_delta = storage
-            .get_accounting_epoch_delta(block1_epoch_index)
-            .expect("ok")
-            .expect("some");
+        let epoch1_delta =
+            storage.get_accounting_epoch_delta(block1_epoch_index).expect("ok").expect("some");
         assert_eq!(epoch1_delta, expected_epoch1_delta);
 
         let expected_epoch2_delta = pos_accounting::PoSAccountingDeltaData {
@@ -379,10 +367,8 @@ fn accounting_storage_two_epochs_no_seal(#[case] seed: Seed) {
             delegation_data: DeltaDataCollection::new(),
         };
 
-        let epoch2_delta = storage
-            .get_accounting_epoch_delta(block2_epoch_index)
-            .expect("ok")
-            .expect("some");
+        let epoch2_delta =
+            storage.get_accounting_epoch_delta(block2_epoch_index).expect("ok").expect("some");
         assert_eq!(epoch2_delta, expected_epoch2_delta);
 
         assert!(storage.get_accounting_epoch_undo_delta(0).unwrap().is_none());
@@ -439,9 +425,7 @@ fn accounting_storage_seal_one_epoch(#[case] seed: Seed) {
             .expect("ok")
             .expect("some");
         assert_eq!(
-            tf.chainstate
-                .get_chain_config()
-                .epoch_index_from_height(&block1_index.block_height()),
+            tf.chainstate.get_chain_config().epoch_index_from_height(&block1_index.block_height()),
             block1_epoch_index
         );
         let block2_index = tf
@@ -451,9 +435,7 @@ fn accounting_storage_seal_one_epoch(#[case] seed: Seed) {
             .expect("ok")
             .expect("some");
         assert_eq!(
-            tf.chainstate
-                .get_chain_config()
-                .epoch_index_from_height(&block2_index.block_height()),
+            tf.chainstate.get_chain_config().epoch_index_from_height(&block2_index.block_height()),
             block2_epoch_index
         );
 
@@ -496,10 +478,8 @@ fn accounting_storage_seal_one_epoch(#[case] seed: Seed) {
             delegation_data: DeltaDataCollection::new(),
         };
 
-        let epoch1_delta = storage
-            .get_accounting_epoch_delta(block1_epoch_index)
-            .expect("ok")
-            .expect("some");
+        let epoch1_delta =
+            storage.get_accounting_epoch_delta(block1_epoch_index).expect("ok").expect("some");
         assert_eq!(epoch1_delta, expected_epoch1_delta);
 
         let expected_epoch2_delta = pos_accounting::PoSAccountingDeltaData {
@@ -514,10 +494,8 @@ fn accounting_storage_seal_one_epoch(#[case] seed: Seed) {
             delegation_data: DeltaDataCollection::new(),
         };
 
-        let epoch2_delta = storage
-            .get_accounting_epoch_delta(block2_epoch_index)
-            .expect("ok")
-            .expect("some");
+        let epoch2_delta =
+            storage.get_accounting_epoch_delta(block2_epoch_index).expect("ok").expect("some");
         assert_eq!(epoch2_delta, expected_epoch2_delta);
 
         assert!(storage.get_accounting_epoch_undo_delta(0).unwrap().is_none());
@@ -564,9 +542,7 @@ fn accounting_storage_seal_every_block(#[case] seed: Seed) {
             .expect("ok")
             .expect("some");
         assert_eq!(
-            tf.chainstate
-                .get_chain_config()
-                .epoch_index_from_height(&block1_index.block_height()),
+            tf.chainstate.get_chain_config().epoch_index_from_height(&block1_index.block_height()),
             block1_epoch_index
         );
 
@@ -594,10 +570,8 @@ fn accounting_storage_seal_every_block(#[case] seed: Seed) {
             delegation_data: DeltaDataCollection::new(),
         };
 
-        let epoch1_delta = storage
-            .get_accounting_epoch_delta(block1_epoch_index)
-            .expect("ok")
-            .expect("some");
+        let epoch1_delta =
+            storage.get_accounting_epoch_delta(block1_epoch_index).expect("ok").expect("some");
         assert_eq!(epoch1_delta, expected_epoch1_delta);
 
         assert!(storage.get_accounting_epoch_undo_delta(0).unwrap().is_none());
@@ -646,9 +620,7 @@ fn accounting_storage_no_accounting_data(#[case] seed: Seed) {
             .expect("ok")
             .expect("some");
         assert_eq!(
-            tf.chainstate
-                .get_chain_config()
-                .epoch_index_from_height(&block1_index.block_height()),
+            tf.chainstate.get_chain_config().epoch_index_from_height(&block1_index.block_height()),
             block1_epoch_index
         );
 

--- a/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
@@ -48,13 +48,7 @@ fn create_pool_data(
     let (_, vrf_pk) = VRFPrivateKey::new_from_rng(rng, VRFKeyKind::Schnorrkel);
     let margin_ratio = PerThousand::new_from_rng(rng);
     let cost_per_block = Amount::from_atoms(rng.gen_range(0..1000));
-    PoolData::new(
-        decommission_destination,
-        pledged_amount,
-        vrf_pk,
-        margin_ratio,
-        cost_per_block,
-    )
+    PoolData::new(decommission_destination, pledged_amount, vrf_pk, margin_ratio, cost_per_block)
 }
 
 fn make_tx_with_stake_pool_from_genesis(
@@ -93,10 +87,8 @@ fn make_tx_with_stake_pool(
         )),
     );
 
-    let transfer_output = TxOutput::Transfer(
-        OutputValue::Coin(amount_to_transfer),
-        anyonecanspend_address(),
-    );
+    let transfer_output =
+        TxOutput::Transfer(OutputValue::Coin(amount_to_transfer), anyonecanspend_address());
 
     let tx_builder =
         TransactionBuilder::new().add_input(input0_outpoint.into(), empty_witness(rng));
@@ -104,15 +96,9 @@ fn make_tx_with_stake_pool(
     // random order of transfer and stake outputs so that tests can use different outpoint 0 or 1
     // to make the next pool
     let (tx, transfer_output_idx) = if rng.gen::<bool>() {
-        (
-            tx_builder.add_output(transfer_output).add_output(stake_output).build(),
-            0,
-        )
+        (tx_builder.add_output(transfer_output).add_output(stake_output).build(), 0)
     } else {
-        (
-            tx_builder.add_output(stake_output).add_output(transfer_output).build(),
-            1,
-        )
+        (tx_builder.add_output(stake_output).add_output(transfer_output).build(), 1)
     };
     let transfer_outpoint = UtxoOutPoint::new(
         OutPointSourceId::Transaction(tx.transaction().get_id()),
@@ -149,10 +135,7 @@ fn store_pool_data_and_balance(#[case] seed: Seed) {
 
         // utxo is stored
         db_tx.get_utxo(&tx_utxo_outpoint).expect("ok").expect("some");
-        assert_eq!(
-            db_tx.get_undo_data(block_id).expect("ok").expect("some").tx_undos().len(),
-            1
-        );
+        assert_eq!(db_tx.get_undo_data(block_id).expect("ok").expect("some").tx_undos().len(), 1);
 
         let expected_tip_storage_data = pos_accounting::PoSAccountingData {
             pool_data: BTreeMap::from([(pool_id, pool_data)]),
@@ -162,10 +145,7 @@ fn store_pool_data_and_balance(#[case] seed: Seed) {
             pool_delegation_shares: Default::default(),
         };
 
-        assert_eq!(
-            storage.read_accounting_data_tip().unwrap(),
-            expected_tip_storage_data
-        );
+        assert_eq!(storage.read_accounting_data_tip().unwrap(), expected_tip_storage_data);
 
         assert!(storage.read_accounting_data_sealed().unwrap().is_empty());
     });
@@ -249,10 +229,7 @@ fn accounting_storage_two_blocks_one_epoch_no_seal(#[case] seed: Seed) {
             pool_delegation_shares: Default::default(),
         };
 
-        assert_eq!(
-            storage.read_accounting_data_tip().unwrap(),
-            expected_tip_storage_data
-        );
+        assert_eq!(storage.read_accounting_data_tip().unwrap(), expected_tip_storage_data);
 
         // check that result is not stored to sealed
         assert!(storage.read_accounting_data_sealed().unwrap().is_empty());
@@ -366,10 +343,7 @@ fn accounting_storage_two_epochs_no_seal(#[case] seed: Seed) {
             pool_delegation_shares: Default::default(),
         };
 
-        assert_eq!(
-            storage.read_accounting_data_tip().unwrap(),
-            expected_tip_storage_data
-        );
+        assert_eq!(storage.read_accounting_data_tip().unwrap(), expected_tip_storage_data);
 
         // check that result is not stored to sealed
         assert!(storage.read_accounting_data_sealed().unwrap().is_empty());
@@ -497,10 +471,7 @@ fn accounting_storage_seal_one_epoch(#[case] seed: Seed) {
             delegation_data: Default::default(),
             pool_delegation_shares: Default::default(),
         };
-        assert_eq!(
-            storage.read_accounting_data_tip().unwrap(),
-            expected_tip_storage_data
-        );
+        assert_eq!(storage.read_accounting_data_tip().unwrap(), expected_tip_storage_data);
 
         // check that epoch1 is stored to sealed
         let expected_sealed_storage_data = pos_accounting::PoSAccountingData {
@@ -510,10 +481,7 @@ fn accounting_storage_seal_one_epoch(#[case] seed: Seed) {
             delegation_data: Default::default(),
             pool_delegation_shares: Default::default(),
         };
-        assert_eq!(
-            storage.read_accounting_data_sealed().unwrap(),
-            expected_sealed_storage_data
-        );
+        assert_eq!(storage.read_accounting_data_sealed().unwrap(), expected_sealed_storage_data);
 
         // check that deltas per block are stored
         let expected_epoch1_delta = pos_accounting::PoSAccountingDeltaData {
@@ -610,14 +578,8 @@ fn accounting_storage_seal_every_block(#[case] seed: Seed) {
             delegation_data: Default::default(),
             pool_delegation_shares: Default::default(),
         };
-        assert_eq!(
-            storage.read_accounting_data_tip().unwrap(),
-            expected_storage_data
-        );
-        assert_eq!(
-            storage.read_accounting_data_sealed().unwrap(),
-            expected_storage_data
-        );
+        assert_eq!(storage.read_accounting_data_tip().unwrap(), expected_storage_data);
+        assert_eq!(storage.read_accounting_data_sealed().unwrap(), expected_storage_data);
 
         // check that deltas per block are stored
         let expected_epoch1_delta = pos_accounting::PoSAccountingDeltaData {
@@ -668,10 +630,7 @@ fn accounting_storage_no_accounting_data(#[case] seed: Seed) {
 
         let tx1 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -73,10 +73,8 @@ fn store_coin(#[case] seed: Seed) {
 
         if *tf.chainstate.get_chainstate_config().tx_index_enabled {
             // tx index is stored
-            let tx_index = db_tx
-                .get_mainchain_tx_index(&tx_utxo_outpoint.tx_id())
-                .expect("ok")
-                .expect("some");
+            let tx_index =
+                db_tx.get_mainchain_tx_index(&tx_utxo_outpoint.tx_id()).expect("ok").expect("some");
             let tx_pos = match tx_index.position() {
                 SpendablePosition::Transaction(tx_pos) => tx_pos,
                 SpendablePosition::BlockReward(_) => unreachable!(),
@@ -226,11 +224,8 @@ fn reorg_store_coin(#[case] seed: Seed) {
         let tx_2_id = tx_2.transaction().get_id();
         let tx_2_utxo_outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(tx_2_id), 0);
 
-        let block_2 = tf
-            .make_block_builder()
-            .add_transaction(tx_2)
-            .with_parent(genesis_id.into())
-            .build();
+        let block_2 =
+            tf.make_block_builder().add_transaction(tx_2).with_parent(genesis_id.into()).build();
         let block_2_id = block_2.get_id();
         tf.process_block(block_2, BlockSource::Local).unwrap();
 
@@ -249,11 +244,8 @@ fn reorg_store_coin(#[case] seed: Seed) {
         let tx_3_id = tx_3.transaction().get_id();
         let tx_3_utxo_outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(tx_3_id), 0);
 
-        let block_3 = tf
-            .make_block_builder()
-            .add_transaction(tx_3)
-            .with_parent(block_2_id.into())
-            .build();
+        let block_3 =
+            tf.make_block_builder().add_transaction(tx_3).with_parent(block_2_id.into()).build();
         let block_3_id = block_3.get_id();
         tf.process_block(block_3, BlockSource::Local).unwrap();
 
@@ -281,11 +273,7 @@ fn reorg_store_coin(#[case] seed: Seed) {
                 SpendablePosition::BlockReward(_) => unreachable!(),
             };
             assert_eq!(
-                db_tx
-                    .get_mainchain_tx_by_position(tx_2_pos)
-                    .expect("ok")
-                    .expect("some")
-                    .get_id(),
+                db_tx.get_mainchain_tx_by_position(tx_2_pos).expect("ok").expect("some").get_id(),
                 tx_2_id
             );
             // tx index from block_3 is stored
@@ -298,11 +286,7 @@ fn reorg_store_coin(#[case] seed: Seed) {
                 SpendablePosition::BlockReward(_) => unreachable!(),
             };
             assert_eq!(
-                db_tx
-                    .get_mainchain_tx_by_position(tx_3_pos)
-                    .expect("ok")
-                    .expect("some")
-                    .get_id(),
+                db_tx.get_mainchain_tx_by_position(tx_3_pos).expect("ok").expect("some").get_id(),
                 tx_3_id
             );
         } else {
@@ -429,11 +413,8 @@ fn reorg_store_token(#[case] seed: Seed) {
         let tx_3_outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(tx_3_id), 0);
         let token_3_id = token_id(tx_3.transaction()).unwrap();
 
-        let block_3 = tf
-            .make_block_builder()
-            .add_transaction(tx_3)
-            .with_parent(block_2_id.into())
-            .build();
+        let block_3 =
+            tf.make_block_builder().add_transaction(tx_3).with_parent(block_2_id.into()).build();
         let block_3_id = block_3.get_id();
         tf.process_block(block_3, BlockSource::Local).unwrap();
 
@@ -456,11 +437,7 @@ fn reorg_store_token(#[case] seed: Seed) {
                 SpendablePosition::BlockReward(_) => unreachable!(),
             };
             assert_eq!(
-                db_tx
-                    .get_mainchain_tx_by_position(tx_2_pos)
-                    .expect("ok")
-                    .expect("some")
-                    .get_id(),
+                db_tx.get_mainchain_tx_by_position(tx_2_pos).expect("ok").expect("some").get_id(),
                 tx_2_id
             );
             // tx index from block_3 is stored
@@ -471,11 +448,7 @@ fn reorg_store_token(#[case] seed: Seed) {
                 SpendablePosition::BlockReward(_) => unreachable!(),
             };
             assert_eq!(
-                db_tx
-                    .get_mainchain_tx_by_position(tx_3_pos)
-                    .expect("ok")
-                    .expect("some")
-                    .get_id(),
+                db_tx.get_mainchain_tx_by_position(tx_3_pos).expect("ok").expect("some").get_id(),
                 tx_3_id
             );
         }

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -50,10 +50,7 @@ fn store_coin(#[case] seed: Seed) {
         // spend coin
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(tx_output.clone())
@@ -68,10 +65,7 @@ fn store_coin(#[case] seed: Seed) {
 
         // best block has changed
         let db_tx = storage.transaction_ro().unwrap();
-        assert_eq!(
-            db_tx.get_best_block_for_utxos().expect("ok"),
-            Id::<GenBlock>::from(block_id)
-        );
+        assert_eq!(db_tx.get_best_block_for_utxos().expect("ok"), Id::<GenBlock>::from(block_id));
         assert_eq!(
             db_tx.get_best_block_id().expect("ok").expect("some"),
             Id::<GenBlock>::from(block_id)
@@ -128,10 +122,7 @@ fn store_token(#[case] seed: Seed) {
         // issue a token
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -159,10 +150,7 @@ fn store_token(#[case] seed: Seed) {
         let db_tx = storage.transaction_ro().unwrap();
 
         // best block has changed
-        assert_eq!(
-            db_tx.get_best_block_for_utxos().expect("ok"),
-            Id::<GenBlock>::from(block_id)
-        );
+        assert_eq!(db_tx.get_best_block_for_utxos().expect("ok"), Id::<GenBlock>::from(block_id));
         assert_eq!(
             db_tx.get_best_block_id().expect("ok").expect("some"),
             Id::<GenBlock>::from(block_id)
@@ -183,10 +171,7 @@ fn store_token(#[case] seed: Seed) {
         }
 
         // token info is stored
-        assert_eq!(
-            db_tx.get_token_id(&tx_id).expect("ok").expect("some"),
-            token_id
-        );
+        assert_eq!(db_tx.get_token_id(&tx_id).expect("ok").expect("some"), token_id);
         let aux_data = db_tx.get_token_aux_data(&token_id).expect("ok").expect("some");
         let expected_aux_data = TokenAuxiliaryData::new(tx.transaction().clone(), block_id);
         assert_eq!(aux_data, expected_aux_data);
@@ -219,10 +204,8 @@ fn reorg_store_coin(#[case] seed: Seed) {
             )
             .add_output(tx_1_output)
             .build();
-        let tx_1_utxo_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::Transaction(tx_1.transaction().get_id()),
-            0,
-        );
+        let tx_1_utxo_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::Transaction(tx_1.transaction().get_id()), 0);
 
         let block_1 = tf.make_block_builder().add_transaction(tx_1).build();
         let block_1_id = block_1.get_id();
@@ -276,10 +259,7 @@ fn reorg_store_coin(#[case] seed: Seed) {
 
         // best block has changed
         let db_tx = storage.transaction_ro().unwrap();
-        assert_eq!(
-            db_tx.get_best_block_for_utxos().expect("ok"),
-            Id::<GenBlock>::from(block_3_id)
-        );
+        assert_eq!(db_tx.get_best_block_for_utxos().expect("ok"), Id::<GenBlock>::from(block_3_id));
         assert_eq!(
             db_tx.get_best_block_id().expect("ok").expect("some"),
             Id::<GenBlock>::from(block_3_id)
@@ -345,19 +325,13 @@ fn reorg_store_coin(#[case] seed: Seed) {
         assert_eq!(db_tx.get_undo_data(block_1_id).expect("ok"), None);
         // utxo from block_2 was deleted
         assert_eq!(db_tx.get_utxo(&tx_2_utxo_outpoint).expect("ok"), None);
-        assert_eq!(
-            db_tx.get_undo_data(block_2_id).expect("ok").expect("some").tx_undos().len(),
-            1
-        );
+        assert_eq!(db_tx.get_undo_data(block_2_id).expect("ok").expect("some").tx_undos().len(), 1);
         // utxo from block_3 is stored
         assert_eq!(
             db_tx.get_utxo(&tx_3_utxo_outpoint).expect("ok").expect("some").output(),
             &tx_3_output
         );
-        assert_eq!(
-            db_tx.get_undo_data(block_3_id).expect("ok").expect("some").tx_undos().len(),
-            1
-        );
+        assert_eq!(db_tx.get_undo_data(block_3_id).expect("ok").expect("some").tx_undos().len(), 1);
     });
 }
 
@@ -378,10 +352,7 @@ fn reorg_store_token(#[case] seed: Seed) {
         // create block
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -398,10 +369,8 @@ fn reorg_store_token(#[case] seed: Seed) {
                 tf.chainstate.get_chain_config().token_min_issuance_fee(),
             )))
             .build();
-        let tx_1_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::Transaction(tx_1.transaction().get_id()),
-            0,
-        );
+        let tx_1_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::Transaction(tx_1.transaction().get_id()), 0);
         let token_1_id = token_id(tx_1.transaction()).unwrap();
         let tx_1_id = tx_1.transaction().get_id();
 
@@ -412,10 +381,7 @@ fn reorg_store_token(#[case] seed: Seed) {
         let bbbb_tokens_amount = Amount::from_atoms(rng.gen_range(1..u128::MAX));
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -473,10 +439,7 @@ fn reorg_store_token(#[case] seed: Seed) {
 
         // best block has changed
         let db_tx = storage.transaction_ro().unwrap();
-        assert_eq!(
-            db_tx.get_best_block_for_utxos().expect("ok"),
-            Id::<GenBlock>::from(block_3_id)
-        );
+        assert_eq!(db_tx.get_best_block_for_utxos().expect("ok"), Id::<GenBlock>::from(block_3_id));
         assert_eq!(
             db_tx.get_best_block_id().expect("ok").expect("some"),
             Id::<GenBlock>::from(block_3_id)
@@ -484,10 +447,7 @@ fn reorg_store_token(#[case] seed: Seed) {
 
         if *tf.chainstate.get_chainstate_config().tx_index_enabled {
             // tx index from block_1 was deleted
-            assert_eq!(
-                db_tx.get_mainchain_tx_index(&tx_1_outpoint.tx_id()).expect("ok"),
-                None
-            );
+            assert_eq!(db_tx.get_mainchain_tx_index(&tx_1_outpoint.tx_id()).expect("ok"), None);
             // tx index from block_2 is stored
             let tx_2_index =
                 db_tx.get_mainchain_tx_index(&tx_2_outpoint.tx_id()).expect("ok").expect("some");
@@ -525,10 +485,7 @@ fn reorg_store_token(#[case] seed: Seed) {
         assert_eq!(token_1_id, token_2_id);
 
         // token issuance from tx block_2 was stored
-        assert_eq!(
-            db_tx.get_token_id(&tx_2_id).expect("ok").expect("some"),
-            token_2_id
-        );
+        assert_eq!(db_tx.get_token_id(&tx_2_id).expect("ok").expect("some"), token_2_id);
         let aux_data_b = db_tx.get_token_aux_data(&token_2_id).expect("ok").expect("some");
         let expected_aux_data_b = TokenAuxiliaryData::new(tx_2.transaction().clone(), block_2_id);
         assert_eq!(aux_data_b, expected_aux_data_b);

--- a/chainstate/test-suite/src/tests/double_spend_tests.rs
+++ b/chainstate/test-suite/src/tests/double_spend_tests.rs
@@ -131,10 +131,8 @@ fn double_spend_tx_in_the_same_block(#[case] seed: Seed) {
         let second_tx = tx_from_tx(&first_tx, rng.gen_range(1000..2000));
         let third_tx = tx_from_tx(&first_tx, rng.gen_range(1000..2000));
 
-        let block = tf
-            .make_block_builder()
-            .with_transactions(vec![first_tx, second_tx, third_tx])
-            .build();
+        let block =
+            tf.make_block_builder().with_transactions(vec![first_tx, second_tx, third_tx]).build();
         let block_id = block.get_id();
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),

--- a/chainstate/test-suite/src/tests/double_spend_tests.rs
+++ b/chainstate/test-suite/src/tests/double_spend_tests.rs
@@ -472,10 +472,7 @@ fn try_spend_burned_output_same_block(#[case] seed: Seed) {
 
         let first_tx = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Burn(OutputValue::Coin(Amount::from_atoms(
@@ -506,10 +503,7 @@ fn try_spend_burned_output_different_blocks(#[case] seed: Seed) {
 
         let first_tx = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Burn(OutputValue::Coin(Amount::from_atoms(

--- a/chainstate/test-suite/src/tests/events_tests.rs
+++ b/chainstate/test-suite/src/tests/events_tests.rs
@@ -144,9 +144,8 @@ fn orphan_block(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
 
         let (orphan_error_hook, errors) = orphan_error_hook();
-        let mut tf = TestFramework::builder(&mut rng)
-            .with_orphan_error_hook(orphan_error_hook)
-            .build();
+        let mut tf =
+            TestFramework::builder(&mut rng).with_orphan_error_hook(orphan_error_hook).build();
 
         let events = subscribe(&mut tf.chainstate, 1);
         assert!(!tf.chainstate.subscribers().is_empty());
@@ -171,9 +170,8 @@ fn custom_orphan_error_hook(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let (orphan_error_hook, errors) = orphan_error_hook();
-        let mut tf = TestFramework::builder(&mut rng)
-            .with_orphan_error_hook(orphan_error_hook)
-            .build();
+        let mut tf =
+            TestFramework::builder(&mut rng).with_orphan_error_hook(orphan_error_hook).build();
 
         let events = subscribe(&mut tf.chainstate, 1);
         assert!(!tf.chainstate.subscribers().is_empty());

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -79,13 +79,11 @@ fn token_issue_test(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorInvalidTickerLength(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorInvalidTickerLength(_, _)
                 ))
-            ))
+            )))
         ));
 
         // Ticker doesn't exist
@@ -114,13 +112,11 @@ fn token_issue_test(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorInvalidTickerLength(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorInvalidTickerLength(_, _)
                 ))
-            ))
+            )))
         ));
 
         {
@@ -167,13 +163,13 @@ fn token_issue_test(#[case] seed: Seed) {
 
                 assert!(matches!(
                     result,
-                    Err(ChainstateError::ProcessBlockError(
-                        BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                    Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                        CheckBlockError::CheckTransactionFailed(
                             CheckBlockTransactionsError::TokensError(
                                 TokensError::IssueErrorTickerHasNoneAlphaNumericChar(_, _)
                             )
-                        ))
-                    ))
+                        )
+                    )))
                 ));
             }
         }
@@ -204,11 +200,11 @@ fn token_issue_test(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueAmountIsZero(_, _))
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueAmountIsZero(_, _)
                 ))
-            ))
+            )))
         ));
 
         // Too many decimals
@@ -240,13 +236,13 @@ fn token_issue_test(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(
                             TokensError::IssueErrorTooManyDecimals(_, _)
                         )
-                    ))
-                ))
+                    )
+                )))
             ));
         }
 
@@ -282,13 +278,13 @@ fn token_issue_test(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(
                             TokensError::IssueErrorIncorrectMetadataURI(_, _)
                         )
-                    ))
-                ))
+                    )
+                )))
             ));
         }
 
@@ -318,13 +314,11 @@ fn token_issue_test(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorIncorrectMetadataURI(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorIncorrectMetadataURI(_, _)
                 ))
-            ))
+            )))
         ));
 
         // Valid case
@@ -456,9 +450,9 @@ fn token_transfer_test(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::AttemptToPrintMoney(_, _))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::AttemptToPrintMoney(_, _)
+            )))
         ));
 
         // Try to transfer token with wrong id
@@ -512,11 +506,11 @@ fn token_transfer_test(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::TransferZeroTokens(_, _))
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::TransferZeroTokens(_, _)
                 ))
-            ))
+            )))
         ));
 
         // Valid case - Transfer tokens
@@ -529,11 +523,8 @@ fn token_transfer_test(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: total_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -585,13 +576,11 @@ fn multiple_token_issuance_in_one_tx(#[case] seed: Seed) {
             .build_and_process();
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::MultipleTokenIssuanceInTransaction(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::MultipleTokenIssuanceInTransaction(_, _)
                 ))
-            ))
+            )))
         ));
 
         // Valid issuance
@@ -674,11 +663,9 @@ fn token_issuance_with_insufficient_fee(#[case] seed: Seed) {
         // Try to process tx with insufficient token fees
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::TokensError(
-                    TokensError::InsufficientTokenFees(_, _)
-                ))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::TokensError(TokensError::InsufficientTokenFees(_, _))
+            )))
         ));
 
         // Valid issuance
@@ -767,11 +754,8 @@ fn transfer_split_and_combine_tokens(#[case] seed: Seed) {
                         Destination::AnyoneCanSpend,
                     ))
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: quarter_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: quarter_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -795,11 +779,8 @@ fn transfer_split_and_combine_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: total_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -842,10 +823,7 @@ fn burn_tokens(#[case] seed: Seed) {
                         TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
-                    .add_output(TxOutput::Transfer(
-                        output_value,
-                        Destination::AnyoneCanSpend,
-                    ))
+                    .add_output(TxOutput::Transfer(output_value, Destination::AnyoneCanSpend))
                     .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
                     .build(),
             )
@@ -880,9 +858,9 @@ fn burn_tokens(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::AttemptToPrintMoney(_, _))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::AttemptToPrintMoney(_, _)
+            )))
         ));
 
         // Valid case: Burn 25% with burn data, and burn 25% by not specifying an output, and transfer the remaining 50%
@@ -895,18 +873,11 @@ fn burn_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
-                        TokenTransfer {
-                            token_id,
-                            amount: quarter_funds,
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: quarter_funds }.into(),
                     ))
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: half_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: half_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -928,18 +899,11 @@ fn burn_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
-                        TokenTransfer {
-                            token_id,
-                            amount: quarter_funds,
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: quarter_funds }.into(),
                     ))
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: quarter_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: quarter_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -961,11 +925,7 @@ fn burn_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
-                        TokenTransfer {
-                            token_id,
-                            amount: quarter_funds,
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: quarter_funds }.into(),
                     ))
                     .build(),
             )
@@ -985,11 +945,7 @@ fn burn_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        TokenTransfer {
-                            token_id,
-                            amount: quarter_funds,
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: quarter_funds }.into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -1043,10 +999,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
                         TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
-                    .add_output(TxOutput::Transfer(
-                        issuance_data,
-                        Destination::AnyoneCanSpend,
-                    ))
+                    .add_output(TxOutput::Transfer(issuance_data, Destination::AnyoneCanSpend))
                     .add_output(TxOutput::Transfer(
                         OutputValue::Coin(token_min_issuance_fee),
                         Destination::AnyoneCanSpend,
@@ -1077,11 +1030,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
-                        TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: total_funds }.into(),
                     ))
                     .add_output(TxOutput::Transfer(
                         OutputValue::Coin(Amount::from_atoms(123455)),
@@ -1106,11 +1055,8 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: total_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .add_output(TxOutput::Transfer(
@@ -1159,10 +1105,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
                         TxInput::from_utxo(c1_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
-                    .add_output(TxOutput::Transfer(
-                        output_value,
-                        Destination::AnyoneCanSpend,
-                    ))
+                    .add_output(TxOutput::Transfer(output_value, Destination::AnyoneCanSpend))
                     .build(),
             )
             .build_and_process()
@@ -1182,11 +1125,8 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: total_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .add_output(TxOutput::Transfer(
@@ -1218,11 +1158,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
-                        TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: total_funds }.into(),
                     ))
                     .add_output(TxOutput::Transfer(
                         OutputValue::Coin(Amount::from_atoms(123454)),
@@ -1253,11 +1189,7 @@ fn reorg_and_try_to_double_spend_tokens(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
-                        TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: total_funds }.into(),
                     ))
                     .add_output(TxOutput::Transfer(
                         OutputValue::Coin(Amount::from_atoms(123454)),
@@ -1332,10 +1264,7 @@ fn attempt_to_print_tokens_one_output(#[case] seed: Seed) {
                         TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
-                    .add_output(TxOutput::Transfer(
-                        output_value,
-                        Destination::AnyoneCanSpend,
-                    ))
+                    .add_output(TxOutput::Transfer(output_value, Destination::AnyoneCanSpend))
                     .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
                     .build(),
             )
@@ -1371,9 +1300,9 @@ fn attempt_to_print_tokens_one_output(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::AttemptToPrintMoney(_, _))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::AttemptToPrintMoney(_, _)
+            )))
         ));
 
         // Valid case - try to transfer correct amount of tokens
@@ -1386,11 +1315,8 @@ fn attempt_to_print_tokens_one_output(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: total_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -1430,10 +1356,7 @@ fn attempt_to_print_tokens_two_outputs(#[case] seed: Seed) {
                         TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
-                    .add_output(TxOutput::Transfer(
-                        output_value,
-                        Destination::AnyoneCanSpend,
-                    ))
+                    .add_output(TxOutput::Transfer(output_value, Destination::AnyoneCanSpend))
                     .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
                     .build(),
             )
@@ -1456,19 +1379,13 @@ fn attempt_to_print_tokens_two_outputs(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: total_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: total_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -1477,9 +1394,9 @@ fn attempt_to_print_tokens_two_outputs(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::AttemptToPrintMoney(_, _))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::AttemptToPrintMoney(_, _)
+            )))
         ));
 
         // Valid case - try to transfer correct amount of tokens
@@ -1492,11 +1409,8 @@ fn attempt_to_print_tokens_two_outputs(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        TokenData::TokenTransfer(TokenTransfer {
-                            token_id,
-                            amount: total_funds,
-                        })
-                        .into(),
+                        TokenData::TokenTransfer(TokenTransfer { token_id, amount: total_funds })
+                            .into(),
                         Destination::AnyoneCanSpend,
                     ))
                     .build(),
@@ -1534,10 +1448,7 @@ fn spend_different_token_than_one_in_input(#[case] seed: Seed) {
                         TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
-                    .add_output(TxOutput::Transfer(
-                        output_value,
-                        Destination::AnyoneCanSpend,
-                    ))
+                    .add_output(TxOutput::Transfer(output_value, Destination::AnyoneCanSpend))
                     .add_output(TxOutput::Transfer(
                         OutputValue::Coin((token_min_issuance_fee * 2).unwrap()),
                         Destination::AnyoneCanSpend,
@@ -1638,9 +1549,9 @@ fn spend_different_token_than_one_in_input(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::AttemptToPrintMoney(_, _))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::AttemptToPrintMoney(_, _)
+            )))
         ));
     })
 }
@@ -1692,10 +1603,7 @@ fn tokens_reorgs_and_cleanup_data(#[case] seed: Seed) {
         // Check id
         assert_eq!(issuance_block.get_id(), token_aux_data.issuance_block_id());
         let issuance_tx = &issuance_block.transactions()[0];
-        assert_eq!(
-            issuance_tx.transaction().get_id(),
-            token_aux_data.issuance_tx().get_id()
-        );
+        assert_eq!(issuance_tx.transaction().get_id(), token_aux_data.issuance_tx().get_id());
         // Check issuance storage in the chain and in the storage
         assert_eq!(
             get_output_value(&issuance_tx.transaction().outputs()[0]).unwrap(),
@@ -1711,13 +1619,11 @@ fn tokens_reorgs_and_cleanup_data(#[case] seed: Seed) {
 
         // Check that reorg happened
         let height = block_index.block_height();
-        assert!(
-            tf.chainstate.get_block_id_from_height(&height).unwrap().map_or(false, |id| &id
-                .classify(tf.chainstate.get_chain_config())
-                .chain_block_id()
-                .unwrap()
-                != block_index.block_id())
-        );
+        assert!(tf.chainstate.get_block_id_from_height(&height).unwrap().map_or(false, |id| &id
+            .classify(tf.chainstate.get_chain_config())
+            .chain_block_id()
+            .unwrap()
+            != block_index.block_id()));
 
         // Check that issuance transaction in the storage is removed
         assert!(tf
@@ -1771,9 +1677,9 @@ fn token_issuance_in_block_reward(#[case] seed: Seed) {
 
         assert!(matches!(
             tf.process_block(block, BlockSource::Local),
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::InvalidBlockRewardOutputType(_))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::InvalidBlockRewardOutputType(_)
+            )))
         ));
 
         // Check if it transfer
@@ -1793,18 +1699,14 @@ fn token_issuance_in_block_reward(#[case] seed: Seed) {
 
         assert!(matches!(
             tf.process_block(block, BlockSource::Local),
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::InvalidBlockRewardOutputType(_))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::InvalidBlockRewardOutputType(_)
+            )))
         ));
 
         // Check if it burn
         let reward_output = TxOutput::Burn(
-            TokenTransfer {
-                token_id: TokenId::random_using(&mut rng),
-                amount: total_funds,
-            }
-            .into(),
+            TokenTransfer { token_id: TokenId::random_using(&mut rng), amount: total_funds }.into(),
         );
         let block = tf
             .make_block_builder()
@@ -1814,9 +1716,9 @@ fn token_issuance_in_block_reward(#[case] seed: Seed) {
 
         assert!(matches!(
             tf.process_block(block, BlockSource::Local),
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::InvalidBlockRewardOutputType(_))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::InvalidBlockRewardOutputType(_)
+            )))
         ));
     })
 }
@@ -1884,10 +1786,7 @@ fn issue_and_transfer_in_the_same_block(#[case] seed: Seed) {
 
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -1905,10 +1804,7 @@ fn issue_and_transfer_in_the_same_block(#[case] seed: Seed) {
 
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::Transaction(tx_1.transaction().get_id()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx_1.transaction().get_id()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(

--- a/chainstate/test-suite/src/tests/helpers/block_index_handle_impl.rs
+++ b/chainstate/test-suite/src/tests/helpers/block_index_handle_impl.rs
@@ -30,10 +30,7 @@ pub struct TestBlockIndexHandle<'a, S> {
 
 impl<'a, S: BlockchainStorageRead> TestBlockIndexHandle<'a, S> {
     pub fn new(storage: S, chain_config: &'a ChainConfig) -> Self {
-        Self {
-            db_tx: storage,
-            chain_config,
-        }
+        Self { db_tx: storage, chain_config }
     }
 
     fn gen_block_index_getter(
@@ -41,9 +38,9 @@ impl<'a, S: BlockchainStorageRead> TestBlockIndexHandle<'a, S> {
         block_id: &Id<GenBlock>,
     ) -> Result<Option<GenBlockIndex>, storage_result::Error> {
         match block_id.classify(self.chain_config) {
-            GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(Arc::clone(
-                self.chain_config.genesis_block(),
-            )))),
+            GenBlockId::Genesis(_id) => {
+                Ok(Some(GenBlockIndex::Genesis(Arc::clone(self.chain_config.genesis_block()))))
+            }
             GenBlockId::Block(id) => {
                 self.db_tx.get_block_index(&id).map(|b| b.map(GenBlockIndex::Block))
             }

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -70,36 +70,28 @@ impl TransactionVerifierStorageRef for InMemoryStorageWrapper {
         &self,
         tx_id: &OutPointSourceId,
     ) -> Result<Option<TxMainChainIndex>, TransactionVerifierStorageError> {
-        self.storage
-            .get_mainchain_tx_index(tx_id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.storage.get_mainchain_tx_index(tx_id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn get_token_aux_data(
         &self,
         token_id: &TokenId,
     ) -> Result<Option<TokenAuxiliaryData>, TransactionVerifierStorageError> {
-        self.storage
-            .get_token_aux_data(token_id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.storage.get_token_aux_data(token_id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn get_accounting_undo(
         &self,
         id: Id<Block>,
     ) -> Result<Option<pos_accounting::AccountingBlockUndo>, TransactionVerifierStorageError> {
-        self.storage
-            .get_accounting_undo(id)
-            .map_err(TransactionVerifierStorageError::from)
+        self.storage.get_accounting_undo(id).map_err(TransactionVerifierStorageError::from)
     }
 
     fn get_account_nonce_count(
         &self,
         account: AccountType,
     ) -> Result<Option<AccountNonce>, TransactionVerifierStorageError> {
-        self.storage
-            .get_account_nonce_count(account)
-            .map_err(TransactionVerifierStorageError::from)
+        self.storage.get_account_nonce_count(account).map_err(TransactionVerifierStorageError::from)
     }
 }
 

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -38,10 +38,7 @@ pub struct InMemoryStorageWrapper {
 
 impl InMemoryStorageWrapper {
     pub fn new(storage: Store, chain_config: ChainConfig) -> Self {
-        Self {
-            storage,
-            chain_config,
-        }
+        Self { storage, chain_config }
     }
 }
 
@@ -60,9 +57,9 @@ impl TransactionVerifierStorageRef for InMemoryStorageWrapper {
         block_id: &Id<GenBlock>,
     ) -> Result<Option<GenBlockIndex>, storage_result::Error> {
         match block_id.classify(&self.chain_config) {
-            GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(Arc::clone(
-                self.chain_config.genesis_block(),
-            )))),
+            GenBlockId::Genesis(_id) => {
+                Ok(Some(GenBlockIndex::Genesis(Arc::clone(self.chain_config.genesis_block()))))
+            }
             GenBlockId::Block(id) => {
                 self.storage.get_block_index(&id).map(|b| b.map(GenBlockIndex::Block))
             }

--- a/chainstate/test-suite/src/tests/helpers/mod.rs
+++ b/chainstate/test-suite/src/tests/helpers/mod.rs
@@ -64,11 +64,7 @@ pub fn add_block_with_locked_output(
 
     let block_outputs = tf.outputs_from_genblock(tf.block_id(new_height.into()));
     assert!(block_outputs.contains_key(&tx_id.into()));
-    (
-        InputWitness::NoSignature(None),
-        TxInput::from_utxo(tx_id.into(), 1),
-        tx_id,
-    )
+    (InputWitness::NoSignature(None), TxInput::from_utxo(tx_id.into(), 1), tx_id)
 }
 
 pub fn new_pub_key_destination(rng: &mut (impl Rng + CryptoRng)) -> Destination {

--- a/chainstate/test-suite/src/tests/homomorphism.rs
+++ b/chainstate/test-suite/src/tests/homomorphism.rs
@@ -55,10 +55,7 @@ fn coins_homomorphism(#[case] seed: Seed) {
 
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(
@@ -69,10 +66,7 @@ fn coins_homomorphism(#[case] seed: Seed) {
 
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::Transaction(tx_1.transaction().get_id()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx_1.transaction().get_id()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -83,10 +77,7 @@ fn coins_homomorphism(#[case] seed: Seed) {
 
         let tx_3 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::Transaction(tx_2.transaction().get_id()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx_2.transaction().get_id()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -140,10 +131,7 @@ fn tokens_homomorphism(#[case] seed: Seed) {
 
         let tx_1 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(
@@ -164,10 +152,7 @@ fn tokens_homomorphism(#[case] seed: Seed) {
 
         let tx_2 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::Transaction(tx_1.transaction().get_id()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx_1.transaction().get_id()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(

--- a/chainstate/test-suite/src/tests/initialization.rs
+++ b/chainstate/test-suite/src/tests/initialization.rs
@@ -41,10 +41,7 @@ fn genesis_check_ok(num_blocks: u64, rng: &mut (impl Rng + CryptoRng)) {
                 .expect("block index to be returned");
         }
         // Check there are the expected number of blocks in the storage now
-        assert_eq!(
-            tf.chainstate.get_best_block_height().unwrap(),
-            num_blocks.into()
-        );
+        assert_eq!(tf.chainstate.get_best_block_height().unwrap(), num_blocks.into());
 
         // Extract the final storage and drop the test framework
         tf.storage
@@ -78,15 +75,11 @@ fn genesis_check_err(num_blocks: u64, rng: &mut (impl Rng + CryptoRng)) {
     use chainstate_storage::{BlockchainStorageRead, Transactional};
     let conf0 = ChainConfigBuilder::new(ChainType::Mainnet)
         .net_upgrades(NetUpgrades::unit_tests())
-        .genesis_unittest(common::chain::Destination::ScriptHash(Id::new(
-            [0x00; 32].into(),
-        )))
+        .genesis_unittest(common::chain::Destination::ScriptHash(Id::new([0x00; 32].into())))
         .build();
     let conf1 = ChainConfigBuilder::new(ChainType::Mainnet)
         .net_upgrades(NetUpgrades::unit_tests())
-        .genesis_unittest(common::chain::Destination::ScriptHash(Id::new(
-            [0x01; 32].into(),
-        )))
+        .genesis_unittest(common::chain::Destination::ScriptHash(Id::new([0x01; 32].into())))
         .build();
     assert_ne!(conf0.genesis_block_id(), conf1.genesis_block_id());
 
@@ -102,10 +95,7 @@ fn genesis_check_err(num_blocks: u64, rng: &mut (impl Rng + CryptoRng)) {
                 .expect("block index to be returned");
         }
         // Check the number of blocks in the storage matches
-        assert_eq!(
-            tf.chainstate.get_best_block_height().unwrap(),
-            num_blocks.into()
-        );
+        assert_eq!(tf.chainstate.get_best_block_height().unwrap(), num_blocks.into());
 
         tf.storage
     };

--- a/chainstate/test-suite/src/tests/mempool_output_timelock.rs
+++ b/chainstate/test-suite/src/tests/mempool_output_timelock.rs
@@ -49,11 +49,8 @@ fn output_lock_until_height(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let (chain_config, storage, mut tf) = setup(&mut rng);
-        let mut verifier = TransactionVerifier::new(
-            &storage,
-            &chain_config,
-            TransactionVerifierConfig::new(true),
-        );
+        let mut verifier =
+            TransactionVerifier::new(&storage, &chain_config, TransactionVerifierConfig::new(true));
 
         let block_height_that_unlocks = 10;
 
@@ -75,9 +72,7 @@ fn output_lock_until_height(#[case] seed: Seed) {
             let best_block_index = tf.best_block_index();
             assert!(matches!(
                 verifier.connect_transaction(
-                    &TransactionSourceForConnect::Mempool {
-                        current_best: &best_block_index,
-                    },
+                    &TransactionSourceForConnect::Mempool { current_best: &best_block_index },
                     &spend_locked_tx,
                     &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                     None
@@ -86,19 +81,14 @@ fn output_lock_until_height(#[case] seed: Seed) {
             ));
 
             tf.make_block_builder().build_and_process().unwrap();
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height)
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height));
         }
 
         // now we should be able to spend it at block_height_that_unlocks
         let best_block_index = tf.best_block_index();
         verifier
             .connect_transaction(
-                &TransactionSourceForConnect::Mempool {
-                    current_best: &best_block_index,
-                },
+                &TransactionSourceForConnect::Mempool { current_best: &best_block_index },
                 &spend_locked_tx,
                 &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                 None,
@@ -114,11 +104,8 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let (chain_config, storage, mut tf) = setup(&mut rng);
-        let mut verifier = TransactionVerifier::new(
-            &storage,
-            &chain_config,
-            TransactionVerifierConfig::new(true),
-        );
+        let mut verifier =
+            TransactionVerifier::new(&storage, &chain_config, TransactionVerifierConfig::new(true));
 
         let block_count_that_unlocks = 20;
         let block_height_with_locked_output = 1;
@@ -142,9 +129,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
             let best_block_index = tf.best_block_index();
             assert!(matches!(
                 verifier.connect_transaction(
-                    &TransactionSourceForConnect::Mempool {
-                        current_best: &best_block_index,
-                    },
+                    &TransactionSourceForConnect::Mempool { current_best: &best_block_index },
                     &spend_locked_tx,
                     &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                     None,
@@ -154,10 +139,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
 
             // create another block, with no transactions, and get the blockchain to progress
             tf.make_block_builder().build_and_process().unwrap();
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height)
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height));
         }
 
         // now we should be able to spend it at block_count_that_unlocks
@@ -166,9 +148,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
         let best_block_index = tf.best_block_index();
         verifier
             .connect_transaction(
-                &TransactionSourceForConnect::Mempool {
-                    current_best: &best_block_index,
-                },
+                &TransactionSourceForConnect::Mempool { current_best: &best_block_index },
                 &spend_locked_tx,
                 &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                 None,
@@ -184,11 +164,8 @@ fn output_lock_until_time(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let (chain_config, storage, mut tf) = setup(&mut rng);
-        let mut verifier = TransactionVerifier::new(
-            &storage,
-            &chain_config,
-            TransactionVerifierConfig::new(true),
-        );
+        let mut verifier =
+            TransactionVerifier::new(&storage, &chain_config, TransactionVerifierConfig::new(true));
 
         let genesis_timestamp = tf.genesis().timestamp();
         let lock_time = genesis_timestamp.as_int_seconds() + 4;
@@ -196,10 +173,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
             .take(8)
             .collect();
         // Check that without the last block the output remains locked.
-        assert_eq!(
-            median_block_time(&block_times[..block_times.len() - 1]),
-            lock_time - 1
-        );
+        assert_eq!(median_block_time(&block_times[..block_times.len() - 1]), lock_time - 1);
         // Check that the last block allows to unlock the output.
         assert_eq!(median_block_time(&block_times), lock_time);
 
@@ -211,10 +185,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
             OutputTimeLock::UntilTime(BlockTimestamp::from_int_seconds(lock_time)),
             BlockTimestamp::from_int_seconds(block_times[expected_height]),
         );
-        assert_eq!(
-            tf.best_block_index().block_height(),
-            BlockHeight::new(expected_height as u64),
-        );
+        assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(expected_height as u64),);
 
         let spend_locked_tx = TransactionBuilder::new()
             .add_input(locked_output.1.clone(), locked_output.0)
@@ -224,18 +195,13 @@ fn output_lock_until_time(#[case] seed: Seed) {
         // Skip the genesis block and the block that contains the locked output.
         for (block_time, height) in block_times.iter().skip(2).zip(expected_height..) {
             let mtp = tf.chainstate.calculate_median_time_past(&tf.best_block_id()).unwrap();
-            assert_eq!(
-                mtp.as_int_seconds(),
-                median_block_time(&block_times[..=height])
-            );
+            assert_eq!(mtp.as_int_seconds(), median_block_time(&block_times[..=height]));
 
             // Check that the output still cannot be spent.
             let best_block_index = tf.best_block_index();
             assert!(matches!(
                 verifier.connect_transaction(
-                    &TransactionSourceForConnect::Mempool {
-                        current_best: &best_block_index,
-                    },
+                    &TransactionSourceForConnect::Mempool { current_best: &best_block_index },
                     &spend_locked_tx,
                     &mtp,
                     None,
@@ -248,19 +214,14 @@ fn output_lock_until_time(#[case] seed: Seed) {
                 .with_timestamp(BlockTimestamp::from_int_seconds(*block_time))
                 .build_and_process()
                 .unwrap();
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height as u64 + 1),
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height as u64 + 1),);
         }
 
         // Check that the output can now be spent.
         let best_block_index = tf.best_block_index();
         verifier
             .connect_transaction(
-                &TransactionSourceForConnect::Mempool {
-                    current_best: &best_block_index,
-                },
+                &TransactionSourceForConnect::Mempool { current_best: &best_block_index },
                 &spend_locked_tx,
                 &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                 None,
@@ -276,11 +237,8 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let (chain_config, storage, mut tf) = setup(&mut rng);
-        let mut verifier = TransactionVerifier::new(
-            &storage,
-            &chain_config,
-            TransactionVerifierConfig::new(true),
-        );
+        let mut verifier =
+            TransactionVerifier::new(&storage, &chain_config, TransactionVerifierConfig::new(true));
 
         let genesis_timestamp = tf.genesis().timestamp();
         let block_times: Vec<_> = itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1)
@@ -289,10 +247,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
         let lock_seconds = 3;
         let unlock_time = block_times[1] + lock_seconds;
         // Check that without the last block the output remains locked.
-        assert_eq!(
-            median_block_time(&block_times[..block_times.len() - 1]),
-            unlock_time - 1
-        );
+        assert_eq!(median_block_time(&block_times[..block_times.len() - 1]), unlock_time - 1);
         // Check that the last block allows to unlock the output.
         assert_eq!(median_block_time(&block_times), unlock_time);
 
@@ -304,10 +259,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
             OutputTimeLock::ForSeconds(lock_seconds),
             BlockTimestamp::from_int_seconds(block_times[expected_height]),
         );
-        assert_eq!(
-            tf.best_block_index().block_height(),
-            BlockHeight::new(expected_height as u64),
-        );
+        assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(expected_height as u64),);
 
         let spend_locked_tx = TransactionBuilder::new()
             .add_input(locked_output.1.clone(), locked_output.0)
@@ -317,18 +269,13 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
         // Skip the genesis block and the block that contains the locked output.
         for (block_time, height) in block_times.iter().skip(2).zip(expected_height..) {
             let mtp = tf.chainstate.calculate_median_time_past(&tf.best_block_id()).unwrap();
-            assert_eq!(
-                mtp.as_int_seconds(),
-                median_block_time(&block_times[..=height])
-            );
+            assert_eq!(mtp.as_int_seconds(), median_block_time(&block_times[..=height]));
 
             // Check that the output still cannot be spent.
             let best_block_index = tf.best_block_index();
             assert!(matches!(
                 verifier.connect_transaction(
-                    &TransactionSourceForConnect::Mempool {
-                        current_best: &best_block_index,
-                    },
+                    &TransactionSourceForConnect::Mempool { current_best: &best_block_index },
                     &spend_locked_tx,
                     &mtp,
                     None
@@ -336,29 +283,21 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
                 Err(ConnectTransactionError::TimeLockViolation(_))
             ));
 
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height as u64),
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height as u64),);
 
             // Create another block, with no transactions, and get the blockchain to progress.
             tf.make_block_builder()
                 .with_timestamp(BlockTimestamp::from_int_seconds(*block_time))
                 .build_and_process()
                 .unwrap();
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height as u64 + 1),
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height as u64 + 1),);
         }
 
         // Check that the output can now be spent.
         let best_block_index = tf.best_block_index();
         verifier
             .connect_transaction(
-                &TransactionSourceForConnect::Mempool {
-                    current_best: &best_block_index,
-                },
+                &TransactionSourceForConnect::Mempool { current_best: &best_block_index },
                 &spend_locked_tx,
                 &BlockTimestamp::from_duration_since_epoch(time::get_time()),
                 None,

--- a/chainstate/test-suite/src/tests/mempool_output_timelock.rs
+++ b/chainstate/test-suite/src/tests/mempool_output_timelock.rs
@@ -169,9 +169,8 @@ fn output_lock_until_time(#[case] seed: Seed) {
 
         let genesis_timestamp = tf.genesis().timestamp();
         let lock_time = genesis_timestamp.as_int_seconds() + 4;
-        let block_times: Vec<_> = itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1)
-            .take(8)
-            .collect();
+        let block_times: Vec<_> =
+            itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1).take(8).collect();
         // Check that without the last block the output remains locked.
         assert_eq!(median_block_time(&block_times[..block_times.len() - 1]), lock_time - 1);
         // Check that the last block allows to unlock the output.
@@ -241,9 +240,8 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
             TransactionVerifier::new(&storage, &chain_config, TransactionVerifierConfig::new(true));
 
         let genesis_timestamp = tf.genesis().timestamp();
-        let block_times: Vec<_> = itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1)
-            .take(8)
-            .collect();
+        let block_times: Vec<_> =
+            itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1).take(8).collect();
         let lock_seconds = 3;
         let unlock_time = block_times[1] + lock_seconds;
         // Check that without the last block the output remains locked.

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -55,12 +55,8 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
             .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
             .build();
         let issuance_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
-        let block_index = tf
-            .make_block_builder()
-            .add_transaction(tx)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        let block_index =
+            tf.make_block_builder().add_transaction(tx).build_and_process().unwrap().unwrap();
 
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
@@ -142,12 +138,8 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
             .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
             .build();
         let issuance_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
-        let block_index = tf
-            .make_block_builder()
-            .add_transaction(tx)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        let block_index =
+            tf.make_block_builder().add_transaction(tx).build_and_process().unwrap().unwrap();
 
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
@@ -160,12 +152,8 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
             ))
             .build();
         let first_burn_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
-        let block_index = tf
-            .make_block_builder()
-            .add_transaction(tx)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        let block_index =
+            tf.make_block_builder().add_transaction(tx).build_and_process().unwrap().unwrap();
         let block = tf.block(*block_index.block_id());
         assert!(tf
             .outputs_from_genblock(block.get_id().into())

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -47,10 +47,7 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
 
         // Issuance
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::from_utxo(genesis_outpoint_id, 0),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(genesis_outpoint_id, 0), InputWitness::NoSignature(None))
             .add_output(TxOutput::Transfer(
                 random_nft_issuance(chain_config.clone(), &mut rng).into(),
                 Destination::AnyoneCanSpend,
@@ -90,9 +87,9 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::AttemptToPrintMoney(_, _))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::AttemptToPrintMoney(_, _)
+            )))
         ));
 
         // Burn zero NFT
@@ -105,11 +102,7 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
-                        TokenTransfer {
-                            token_id,
-                            amount: Amount::from_atoms(0),
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: Amount::from_atoms(0) }.into(),
                     ))
                     .build(),
             )
@@ -117,11 +110,11 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::TransferZeroTokens(_, _))
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::TransferZeroTokens(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -141,10 +134,7 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
 
         // Issuance
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::from_utxo(genesis_outpoint_id, 0),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(genesis_outpoint_id, 0), InputWitness::NoSignature(None))
             .add_output(TxOutput::Transfer(
                 random_nft_issuance(chain_config.clone(), &mut rng).into(),
                 Destination::AnyoneCanSpend,
@@ -164,16 +154,9 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
 
         // Burn
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::from_utxo(issuance_outpoint_id, 0),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(issuance_outpoint_id, 0), InputWitness::NoSignature(None))
             .add_output(TxOutput::Burn(
-                TokenTransfer {
-                    token_id,
-                    amount: Amount::from_atoms(1),
-                }
-                .into(),
+                TokenTransfer { token_id, amount: Amount::from_atoms(1) }.into(),
             ))
             .build();
         let first_burn_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -85,13 +85,11 @@ fn nft_name_too_long(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorInvalidNameLength(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorInvalidNameLength(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -138,13 +136,11 @@ fn nft_empty_name(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorInvalidNameLength(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorInvalidNameLength(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -203,13 +199,13 @@ fn nft_invalid_name(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(
                             TokensError::IssueErrorNameHasNoneAlphaNumericChar(_, _)
                         )
-                    ))
-                ))
+                    )
+                )))
             ));
         }
     })
@@ -263,13 +259,11 @@ fn nft_ticker_too_long(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorInvalidTickerLength(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorInvalidTickerLength(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -317,13 +311,11 @@ fn nft_empty_ticker(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorInvalidTickerLength(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorInvalidTickerLength(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -382,13 +374,13 @@ fn nft_invalid_ticker(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(
                             TokensError::IssueErrorTickerHasNoneAlphaNumericChar(_, _)
                         )
-                    ))
-                ))
+                    )
+                )))
             ));
         }
     })
@@ -442,13 +434,11 @@ fn nft_description_too_long(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorInvalidDescriptionLength(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorInvalidDescriptionLength(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -496,13 +486,11 @@ fn nft_empty_description(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorInvalidDescriptionLength(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorInvalidDescriptionLength(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -560,13 +548,13 @@ fn nft_invalid_description(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(
                             TokensError::IssueErrorDescriptionHasNoneAlphaNumericChar(_, _)
                         )
-                    ))
-                ))
+                    )
+                )))
             ));
         }
     })
@@ -619,13 +607,11 @@ fn nft_icon_uri_too_long(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorIncorrectIconURI(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorIncorrectIconURI(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -678,10 +664,7 @@ fn nft_icon_uri_empty(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            block_index.block_height(),
-            common::primitives::BlockHeight::from(1)
-        );
+        assert_eq!(block_index.block_height(), common::primitives::BlockHeight::from(1));
 
         let block = tf.block(*block_index.block_id());
         let outputs =
@@ -748,13 +731,13 @@ fn nft_icon_uri_invalid(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(
                             TokensError::IssueErrorIncorrectIconURI(_, _)
                         )
-                    ))
-                ))
+                    )
+                )))
             ));
         }
     })
@@ -808,13 +791,11 @@ fn nft_metadata_uri_too_long(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorIncorrectMetadataURI(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorIncorrectMetadataURI(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -866,10 +847,7 @@ fn nft_metadata_uri_empty(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            block_index.block_height(),
-            common::primitives::BlockHeight::from(1)
-        );
+        assert_eq!(block_index.block_height(), common::primitives::BlockHeight::from(1));
 
         let block = tf.block(*block_index.block_id());
         let outputs =
@@ -936,13 +914,13 @@ fn nft_metadata_uri_invalid(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(
                             TokensError::IssueErrorIncorrectMetadataURI(_, _)
                         )
-                    ))
-                ))
+                    )
+                )))
             ));
         }
     })
@@ -996,13 +974,11 @@ fn nft_media_uri_too_long(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::IssueErrorIncorrectMediaURI(_, _)
-                    )
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::IssueErrorIncorrectMediaURI(_, _)
                 ))
-            ))
+            )))
         ));
     })
 }
@@ -1056,10 +1032,7 @@ fn nft_media_uri_empty(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            block_index.block_height(),
-            common::primitives::BlockHeight::from(1)
-        );
+        assert_eq!(block_index.block_height(), common::primitives::BlockHeight::from(1));
 
         let block = tf.block(*block_index.block_id());
         let outputs =
@@ -1126,13 +1099,13 @@ fn nft_media_uri_invalid(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(
                             TokensError::IssueErrorIncorrectMediaURI(_, _)
                         )
-                    ))
-                ))
+                    )
+                )))
             ));
         }
     })
@@ -1204,11 +1177,11 @@ fn nft_media_hash_too_short(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(TokensError::MediaHashTooShort)
-                    ))
-                ))
+                    )
+                )))
             ));
         }
     })
@@ -1235,11 +1208,11 @@ fn nft_media_hash_too_long(#[case] seed: Seed) {
 
             assert!(matches!(
                 result,
-                Err(ChainstateError::ProcessBlockError(
-                    BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
+                Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::TokensError(TokensError::MediaHashTooLong)
-                    ))
-                ))
+                    )
+                )))
             ));
         }
     })
@@ -1343,19 +1316,13 @@ fn nft_valid_case(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            block_index.block_height(),
-            common::primitives::BlockHeight::from(1)
-        );
+        assert_eq!(block_index.block_height(), common::primitives::BlockHeight::from(1));
 
         let block = tf.block(*block_index.block_id());
         let outputs =
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let issuance_output = &outputs[0];
 
-        assert_eq!(
-            get_output_value(issuance_output).unwrap(),
-            output_value.into()
-        );
+        assert_eq!(get_output_value(issuance_output).unwrap(), output_value.into());
     })
 }

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -81,10 +81,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
                         TxInput::from_utxo(genesis_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
-                    .add_output(TxOutput::Transfer(
-                        issuance_data,
-                        Destination::AnyoneCanSpend,
-                    ))
+                    .add_output(TxOutput::Transfer(issuance_data, Destination::AnyoneCanSpend))
                     .add_output(TxOutput::Transfer(
                         OutputValue::Coin(token_min_issuance_fee),
                         Destination::AnyoneCanSpend,
@@ -119,11 +116,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Burn(
-                        TokenTransfer {
-                            token_id,
-                            amount: Amount::from_atoms(1),
-                        }
-                        .into(),
+                        TokenTransfer { token_id, amount: Amount::from_atoms(1) }.into(),
                     ))
                     .add_output(TxOutput::Transfer(
                         OutputValue::Coin(Amount::from_atoms(123455)),
@@ -209,10 +202,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
                         TxInput::from_utxo(c1_outpoint_id, 0),
                         InputWitness::NoSignature(None),
                     )
-                    .add_output(TxOutput::Transfer(
-                        output_value,
-                        Destination::AnyoneCanSpend,
-                    ))
+                    .add_output(TxOutput::Transfer(output_value, Destination::AnyoneCanSpend))
                     .build(),
             )
             .build_and_process()
@@ -228,16 +218,10 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
 
         // Second chain - B2
         let tx_2 = TransactionBuilder::new()
-            .add_input(
-                TxInput::from_utxo(issuance_outpoint_id, 0),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(issuance_outpoint_id, 0), InputWitness::NoSignature(None))
             .add_output(TxOutput::Transfer(
-                TokenData::TokenTransfer(TokenTransfer {
-                    token_id,
-                    amount: Amount::from_atoms(1),
-                })
-                .into(),
+                TokenData::TokenTransfer(TokenTransfer { token_id, amount: Amount::from_atoms(1) })
+                    .into(),
                 Destination::AnyoneCanSpend,
             ))
             .add_output(TxOutput::Transfer(
@@ -262,16 +246,9 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
                 TxInput::from_utxo(b2_outpoint_id.clone(), 0),
                 InputWitness::NoSignature(None),
             )
-            .add_input(
-                TxInput::from_utxo(b2_outpoint_id, 1),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(b2_outpoint_id, 1), InputWitness::NoSignature(None))
             .add_output(TxOutput::Burn(
-                TokenTransfer {
-                    token_id,
-                    amount: Amount::from_atoms(1),
-                }
-                .into(),
+                TokenTransfer { token_id, amount: Amount::from_atoms(1) }.into(),
             ))
             .add_output(TxOutput::Transfer(
                 OutputValue::Coin(Amount::from_atoms(123454)),
@@ -295,16 +272,9 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
                 TxInput::from_utxo(c2_outpoint_id.clone(), 0),
                 InputWitness::NoSignature(None),
             )
-            .add_input(
-                TxInput::from_utxo(c2_outpoint_id, 1),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(c2_outpoint_id, 1), InputWitness::NoSignature(None))
             .add_output(TxOutput::Burn(
-                TokenTransfer {
-                    token_id,
-                    amount: Amount::from_atoms(1),
-                }
-                .into(),
+                TokenTransfer { token_id, amount: Amount::from_atoms(1) }.into(),
             ))
             .add_output(TxOutput::Transfer(
                 OutputValue::Coin(Amount::from_atoms(123454)),
@@ -345,9 +315,9 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::MissingOutputOrSpent)
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::MissingOutputOrSpent
+            )))
         ));
     })
 }
@@ -409,10 +379,7 @@ fn nft_reorgs_and_cleanup_data(#[case] seed: Seed) {
         // Check id
         assert_eq!(issuance_block.get_id(), token_aux_data.issuance_block_id());
         let issuance_tx = &issuance_block.transactions()[0];
-        assert_eq!(
-            issuance_tx.transaction().get_id(),
-            token_aux_data.issuance_tx().get_id()
-        );
+        assert_eq!(issuance_tx.transaction().get_id(), token_aux_data.issuance_tx().get_id());
         // Check issuance storage in the chain and in the storage
         assert_eq!(
             get_output_value(&issuance_tx.outputs()[0]).unwrap(),
@@ -428,13 +395,11 @@ fn nft_reorgs_and_cleanup_data(#[case] seed: Seed) {
 
         // Check that reorg happened
         let height = block_index.block_height();
-        assert!(
-            tf.chainstate.get_block_id_from_height(&height).unwrap().map_or(false, |id| &id
-                .classify(tf.chainstate.get_chain_config())
-                .chain_block_id()
-                .unwrap()
-                != block_index.block_id())
-        );
+        assert!(tf.chainstate.get_block_id_from_height(&height).unwrap().map_or(false, |id| &id
+            .classify(tf.chainstate.get_chain_config())
+            .chain_block_id()
+            .unwrap()
+            != block_index.block_id()));
 
         // Check that issuance transaction in the storage is removed
         assert!(tf

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -94,12 +94,8 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .unwrap();
 
         let issuance_block = tf.block(*block_index.block_id());
-        let issuance_outpoint_id = tf
-            .outputs_from_genblock(issuance_block.get_id().into())
-            .keys()
-            .next()
-            .unwrap()
-            .clone();
+        let issuance_outpoint_id =
+            tf.outputs_from_genblock(issuance_block.get_id().into()).keys().next().unwrap().clone();
         let token_id = token_id(issuance_block.transactions()[0].transaction()).unwrap();
 
         // B1 - burn NFT in mainchain
@@ -128,12 +124,8 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
         let block_b1 = tf.block(*block_index.block_id());
-        let b1_outpoint_id = tf
-            .outputs_from_genblock(block_b1.get_id().into())
-            .keys()
-            .next()
-            .unwrap()
-            .clone();
+        let b1_outpoint_id =
+            tf.outputs_from_genblock(block_b1.get_id().into()).keys().next().unwrap().clone();
 
         // Try to transfer burnt NFT
         let result = tf
@@ -187,12 +179,8 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
         let block_c1 = tf.block(*block_index.block_id());
-        let c1_outpoint_id = tf
-            .outputs_from_genblock(block_c1.get_id().into())
-            .keys()
-            .next()
-            .unwrap()
-            .clone();
+        let c1_outpoint_id =
+            tf.outputs_from_genblock(block_c1.get_id().into()).keys().next().unwrap().clone();
         // Let's add D1
         let block_index = tf
             .make_block_builder()
@@ -209,12 +197,7 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
         let block_d1 = tf.block(*block_index.block_id());
-        let _ = tf
-            .outputs_from_genblock(block_d1.get_id().into())
-            .keys()
-            .next()
-            .unwrap()
-            .clone();
+        let _ = tf.outputs_from_genblock(block_d1.get_id().into()).keys().next().unwrap().clone();
 
         // Second chain - B2
         let tx_2 = TransactionBuilder::new()

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -74,12 +74,8 @@ fn nft_transfer_wrong_id(#[case] seed: Seed) {
             .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
             .build();
         let issuance_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
-        let block_index = tf
-            .make_block_builder()
-            .add_transaction(tx)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        let block_index =
+            tf.make_block_builder().add_transaction(tx).build_and_process().unwrap().unwrap();
         let block = tf.block(*block_index.block_id());
         assert_eq!(
             get_output_value(&block.transactions()[0].outputs()[0]).unwrap(),
@@ -266,12 +262,8 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
             .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
             .build();
         let first_issuance_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
-        let block_index = tf
-            .make_block_builder()
-            .add_transaction(tx)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        let block_index =
+            tf.make_block_builder().add_transaction(tx).build_and_process().unwrap().unwrap();
 
         let block = tf.block(*block_index.block_id());
         let first_token_id = token_id(block.transactions()[0].transaction()).unwrap();
@@ -317,12 +309,8 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
             .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
             .build();
         let second_issuance_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
-        let block_index = tf
-            .make_block_builder()
-            .add_transaction(tx)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        let block_index =
+            tf.make_block_builder().add_transaction(tx).build_and_process().unwrap().unwrap();
 
         let block = tf.block(*block_index.block_id());
         let _ = token_id(block.transactions()[0].transaction()).unwrap();
@@ -409,12 +397,8 @@ fn nft_valid_transfer(#[case] seed: Seed) {
             .add_output(TxOutput::Burn(OutputValue::Coin(token_min_issuance_fee)))
             .build();
         let issuance_outpoint_id: OutPointSourceId = tx.transaction().get_id().into();
-        let block_index = tf
-            .make_block_builder()
-            .add_transaction(tx)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        let block_index =
+            tf.make_block_builder().add_transaction(tx).build_and_process().unwrap().unwrap();
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
         assert_eq!(

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -66,10 +66,7 @@ fn nft_transfer_wrong_id(#[case] seed: Seed) {
         };
 
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::from_utxo(genesis_outpoint_id, 0),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(genesis_outpoint_id, 0), InputWitness::NoSignature(None))
             .add_output(TxOutput::Transfer(
                 output_value.clone().into(),
                 Destination::AnyoneCanSpend,
@@ -152,10 +149,7 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
         };
 
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::from_utxo(genesis_outpoint_id, 0),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(genesis_outpoint_id, 0), InputWitness::NoSignature(None))
             .add_output(TxOutput::Transfer(
                 output_value.clone().into(),
                 Destination::AnyoneCanSpend,
@@ -172,10 +166,7 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
         let block = tf.block(*block_index.block_id());
         let token_id = token_id(block.transactions()[0].transaction()).unwrap();
         assert_eq!(block.transactions()[0], tx);
-        assert_eq!(
-            get_output_value(&tx.outputs()[0]).unwrap(),
-            output_value.into()
-        );
+        assert_eq!(get_output_value(&tx.outputs()[0]).unwrap(), output_value.into());
 
         // Try to transfer 0 NFT
         let result = tf
@@ -200,11 +191,11 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::TransferZeroTokens(_, _))
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
+                    TokensError::TransferZeroTokens(_, _)
                 ))
-            ))
+            )))
         ));
 
         // Try to transfer more NFT than we have in input
@@ -230,9 +221,9 @@ fn nft_invalid_transfer(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::AttemptToPrintMoney(_, _))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::AttemptToPrintMoney(_, _)
+            )))
         ));
     })
 }
@@ -266,14 +257,8 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
         .into();
         let token_min_issuance_fee = tf.chainstate.get_chain_config().token_min_issuance_fee();
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::from_utxo(genesis_outpoint_id, 0),
-                InputWitness::NoSignature(None),
-            )
-            .add_output(TxOutput::Transfer(
-                output_value,
-                Destination::AnyoneCanSpend,
-            ))
+            .add_input(TxInput::from_utxo(genesis_outpoint_id, 0), InputWitness::NoSignature(None))
+            .add_output(TxOutput::Transfer(output_value, Destination::AnyoneCanSpend))
             .add_output(TxOutput::Transfer(
                 OutputValue::Coin((token_min_issuance_fee * 2).unwrap()),
                 Destination::AnyoneCanSpend,
@@ -379,9 +364,9 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
 
         assert!(matches!(
             result,
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::StateUpdateFailed(ConnectTransactionError::AttemptToPrintMoney(_, _))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                ConnectTransactionError::AttemptToPrintMoney(_, _)
+            )))
         ));
     })
 }
@@ -416,10 +401,7 @@ fn nft_valid_transfer(#[case] seed: Seed) {
         };
 
         let tx = TransactionBuilder::new()
-            .add_input(
-                TxInput::from_utxo(genesis_outpoint_id, 0),
-                InputWitness::NoSignature(None),
-            )
+            .add_input(TxInput::from_utxo(genesis_outpoint_id, 0), InputWitness::NoSignature(None))
             .add_output(TxOutput::Transfer(
                 output_value.clone().into(),
                 Destination::AnyoneCanSpend,
@@ -441,10 +423,8 @@ fn nft_valid_transfer(#[case] seed: Seed) {
         );
 
         // Valid case
-        let transfer_value = TokenData::TokenTransfer(TokenTransfer {
-            token_id,
-            amount: Amount::from_atoms(1),
-        });
+        let transfer_value =
+            TokenData::TokenTransfer(TokenTransfer { token_id, amount: Amount::from_atoms(1) });
         let block_index = tf
             .make_block_builder()
             .add_transaction(
@@ -470,9 +450,6 @@ fn nft_valid_transfer(#[case] seed: Seed) {
             tf.outputs_from_genblock(block.get_id().into()).values().next().unwrap().clone();
         let transfer_output = &outputs[0];
 
-        assert_eq!(
-            get_output_value(transfer_output).unwrap(),
-            transfer_value.into()
-        );
+        assert_eq!(get_output_value(transfer_output).unwrap(), transfer_value.into());
     })
 }

--- a/chainstate/test-suite/src/tests/output_timelock.rs
+++ b/chainstate/test-suite/src/tests/output_timelock.rs
@@ -95,10 +95,7 @@ fn output_lock_until_height(#[case] seed: Seed) {
 
         // let's create more blocks until block_height_that_unlocks - 1, and always fail to spend, and build up the chain
         for height in 3..block_height_that_unlocks {
-            assert_eq!(
-                BlockHeight::new(height - 1),
-                tf.best_block_index().block_height()
-            );
+            assert_eq!(BlockHeight::new(height - 1), tf.best_block_index().block_height());
             logging::log::info!("Submitting block of height: {}", height);
 
             // Create another block, and spend the first input from the previous block.
@@ -118,24 +115,15 @@ fn output_lock_until_height(#[case] seed: Seed) {
                     )
                 ))
             );
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height - 1)
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height - 1));
 
             // create another block, with no transactions, and get the blockchain to progress
             tf.make_block_builder().build_and_process().unwrap();
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height)
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height));
         }
 
         // now we should be able to spend it at block_height_that_unlocks
-        assert_eq!(
-            tf.best_block_id(),
-            tf.block_id(block_height_that_unlocks - 1)
-        );
+        assert_eq!(tf.best_block_id(), tf.block_id(block_height_that_unlocks - 1));
         tf.make_block_builder()
             .add_transaction(
                 TransactionBuilder::new()
@@ -256,10 +244,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
 
         // let's create more blocks until block_count_that_unlocks + block_height_with_locked_output, and always fail to spend, and build up the chain
         for height in 3..block_count_that_unlocks + block_height_with_locked_output {
-            assert_eq!(
-                BlockHeight::new(height - 1),
-                tf.best_block_index().block_height()
-            );
+            assert_eq!(BlockHeight::new(height - 1), tf.best_block_index().block_height());
             logging::log::info!("Submitting block of height: {}", height);
 
             // create another block, and spend the first input from the previous block
@@ -279,17 +264,11 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
                     )
                 ))
             );
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height - 1)
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height - 1));
 
             // create another block, with no transactions, and get the blockchain to progress
             tf.make_block_builder().build_and_process().unwrap();
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height)
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height));
         }
 
         // now we should be able to spend it at block_count_that_unlocks
@@ -410,10 +389,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
             .take(8)
             .collect();
         // Check that without the last block the output remains locked.
-        assert_eq!(
-            median_block_time(&block_times[..block_times.len() - 1]),
-            lock_time - 1
-        );
+        assert_eq!(median_block_time(&block_times[..block_times.len() - 1]), lock_time - 1);
         // Check that the last block allows to unlock the output.
         assert_eq!(median_block_time(&block_times), lock_time);
 
@@ -425,18 +401,12 @@ fn output_lock_until_time(#[case] seed: Seed) {
             OutputTimeLock::UntilTime(BlockTimestamp::from_int_seconds(lock_time)),
             BlockTimestamp::from_int_seconds(block_times[expected_height]),
         );
-        assert_eq!(
-            tf.best_block_index().block_height(),
-            BlockHeight::new(expected_height as u64),
-        );
+        assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(expected_height as u64),);
 
         // Skip the genesis block and the block that contains the locked output.
         for (block_time, height) in block_times.iter().skip(2).zip(expected_height..) {
             let mtp = tf.chainstate.calculate_median_time_past(&tf.best_block_id()).unwrap();
-            assert_eq!(
-                mtp.as_int_seconds(),
-                median_block_time(&block_times[..=height])
-            );
+            assert_eq!(mtp.as_int_seconds(), median_block_time(&block_times[..=height]));
 
             // Check that the output still cannot be spent.
             assert_eq!(
@@ -456,19 +426,13 @@ fn output_lock_until_time(#[case] seed: Seed) {
                     )
                 ))
             );
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height as u64),
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height as u64),);
             // Create another block, with no transactions, and get the blockchain to progress.
             tf.make_block_builder()
                 .with_timestamp(BlockTimestamp::from_int_seconds(*block_time))
                 .build_and_process()
                 .unwrap();
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height as u64 + 1),
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height as u64 + 1),);
         }
 
         // Check that the output can now be spent.
@@ -481,9 +445,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
             )
             // The block that is being validated isn't taken into account when calculating the
             // median time, so any time can be used here.
-            .with_timestamp(BlockTimestamp::from_int_seconds(
-                *block_times.last().unwrap(),
-            ))
+            .with_timestamp(BlockTimestamp::from_int_seconds(*block_times.last().unwrap()))
             .build_and_process()
             .unwrap();
         assert_eq!(
@@ -560,10 +522,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
         let lock_seconds = 3;
         let unlock_time = block_times[1] + lock_seconds;
         // Check that without the last block the output remains locked.
-        assert_eq!(
-            median_block_time(&block_times[..block_times.len() - 1]),
-            unlock_time - 1
-        );
+        assert_eq!(median_block_time(&block_times[..block_times.len() - 1]), unlock_time - 1);
         // Check that the last block allows to unlock the output.
         assert_eq!(median_block_time(&block_times), unlock_time);
 
@@ -575,18 +534,12 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
             OutputTimeLock::ForSeconds(lock_seconds),
             BlockTimestamp::from_int_seconds(block_times[expected_height]),
         );
-        assert_eq!(
-            tf.best_block_index().block_height(),
-            BlockHeight::new(expected_height as u64),
-        );
+        assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(expected_height as u64),);
 
         // Skip the genesis block and the block that contains the locked output.
         for (block_time, height) in block_times.iter().skip(2).zip(expected_height..) {
             let mtp = tf.chainstate.calculate_median_time_past(&tf.best_block_id()).unwrap();
-            assert_eq!(
-                mtp.as_int_seconds(),
-                median_block_time(&block_times[..=height])
-            );
+            assert_eq!(mtp.as_int_seconds(), median_block_time(&block_times[..=height]));
 
             // Check that the output still cannot be spent.
             assert_eq!(
@@ -606,20 +559,14 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
                     )
                 ))
             );
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height as u64),
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height as u64),);
 
             // Create another block, with no transactions, and get the blockchain to progress.
             tf.make_block_builder()
                 .with_timestamp(BlockTimestamp::from_int_seconds(*block_time))
                 .build_and_process()
                 .unwrap();
-            assert_eq!(
-                tf.best_block_index().block_height(),
-                BlockHeight::new(height as u64 + 1),
-            );
+            assert_eq!(tf.best_block_index().block_height(), BlockHeight::new(height as u64 + 1),);
         }
 
         // Check that the output can now be spent.
@@ -632,9 +579,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
             )
             // The block that is being validated isn't taken into account when calculating the
             // median time, so any time can be used here.
-            .with_timestamp(BlockTimestamp::from_int_seconds(
-                *block_times.last().unwrap(),
-            ))
+            .with_timestamp(BlockTimestamp::from_int_seconds(*block_times.last().unwrap()))
             .build_and_process()
             .unwrap();
         assert_eq!(

--- a/chainstate/test-suite/src/tests/output_timelock.rs
+++ b/chainstate/test-suite/src/tests/output_timelock.rs
@@ -385,9 +385,8 @@ fn output_lock_until_time(#[case] seed: Seed) {
 
         let genesis_timestamp = tf.genesis().timestamp();
         let lock_time = genesis_timestamp.as_int_seconds() + 4;
-        let block_times: Vec<_> = itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1)
-            .take(8)
-            .collect();
+        let block_times: Vec<_> =
+            itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1).take(8).collect();
         // Check that without the last block the output remains locked.
         assert_eq!(median_block_time(&block_times[..block_times.len() - 1]), lock_time - 1);
         // Check that the last block allows to unlock the output.
@@ -516,9 +515,8 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).with_time_getter(time_getter).build();
 
         let genesis_timestamp = tf.genesis().timestamp();
-        let block_times: Vec<_> = itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1)
-            .take(8)
-            .collect();
+        let block_times: Vec<_> =
+            itertools::iterate(genesis_timestamp.as_int_seconds(), |t| t + 1).take(8).collect();
         let lock_seconds = 3;
         let unlock_time = block_times[1] + lock_seconds;
         // Check that without the last block the output remains locked.

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -85,10 +85,8 @@ fn stake_pool_reorg(#[case] seed: Seed) {
             // prepare tx_a
             let destination_a = new_pub_key_destination(&mut rng);
             let (_, vrf_pub_key_a) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
-            let genesis_outpoint = UtxoOutPoint::new(
-                OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                0,
-            );
+            let genesis_outpoint =
+                UtxoOutPoint::new(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0);
             let pool_id_a = pos_accounting::make_pool_id(&genesis_outpoint);
             let tx_a = TransactionBuilder::new()
                 .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
@@ -120,10 +118,8 @@ fn stake_pool_reorg(#[case] seed: Seed) {
             // prepare tx_c
             let destination_c = new_pub_key_destination(&mut rng);
             let (_, vrf_pub_key_c) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
-            let tx_b_outpoint0 = UtxoOutPoint::new(
-                OutPointSourceId::Transaction(tx_b.transaction().get_id()),
-                0,
-            );
+            let tx_b_outpoint0 =
+                UtxoOutPoint::new(OutPointSourceId::Transaction(tx_b.transaction().get_id()), 0);
             let pool_id_c = pos_accounting::make_pool_id(&tx_b_outpoint0);
             let tx_c = TransactionBuilder::new()
                 .add_input(tx_b_outpoint0.into(), empty_witness(&mut rng))
@@ -144,10 +140,7 @@ fn stake_pool_reorg(#[case] seed: Seed) {
             let block_a = tf.make_block_builder().add_transaction(tx_a).build();
             let block_a_index =
                 tf.process_block(block_a.clone(), BlockSource::Local).unwrap().unwrap();
-            assert_eq!(
-                tf.best_block_id(),
-                Id::<GenBlock>::from(*block_a_index.block_id())
-            );
+            assert_eq!(tf.best_block_id(), Id::<GenBlock>::from(*block_a_index.block_id()));
 
             // create block b
             let block_b = tf
@@ -159,10 +152,7 @@ fn stake_pool_reorg(#[case] seed: Seed) {
             tf.process_block(block_b, BlockSource::Local).unwrap();
 
             // no reorg here
-            assert_eq!(
-                tf.best_block_id(),
-                Id::<GenBlock>::from(*block_a_index.block_id())
-            );
+            assert_eq!(tf.best_block_id(), Id::<GenBlock>::from(*block_a_index.block_id()));
 
             // create block c
             let block_c = tf
@@ -173,10 +163,7 @@ fn stake_pool_reorg(#[case] seed: Seed) {
                 .unwrap()
                 .unwrap();
 
-            assert_eq!(
-                tf.best_block_id(),
-                Id::<GenBlock>::from(*block_c.block_id())
-            );
+            assert_eq!(tf.best_block_id(), Id::<GenBlock>::from(*block_c.block_id()));
 
             // Accounting data in storage after reorg should equal to the data in storage for chain
             // where reorg never happened.
@@ -270,13 +257,7 @@ fn long_chain_reorg(#[case] seed: Seed) {
         tf.progress_time_seconds_since_epoch(target_block_time.get());
 
         let common_block_id = tf
-            .create_chain_pos(
-                &tf.genesis().get_id().into(),
-                5,
-                &mut rng,
-                &staking_sk,
-                &vrf_sk,
-            )
+            .create_chain_pos(&tf.genesis().get_id().into(), 5, &mut rng, &staking_sk, &vrf_sk)
             .unwrap();
 
         let old_tip = tf

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -61,9 +61,8 @@ fn stake_pool_reorg(#[case] seed: Seed) {
             2, // sealed is behind the tip by 2 epochs
         ];
 
-        for (epoch_length, sealed_epoch_distance_from_tip) in epoch_length_params
-            .into_iter()
-            .cartesian_product(sealed_epoch_distance_from_tip_params)
+        for (epoch_length, sealed_epoch_distance_from_tip) in
+            epoch_length_params.into_iter().cartesian_product(sealed_epoch_distance_from_tip_params)
         {
             let storage = Store::new_empty().unwrap();
             let mut rng = make_seedable_rng(seed);
@@ -260,13 +259,11 @@ fn long_chain_reorg(#[case] seed: Seed) {
             .create_chain_pos(&tf.genesis().get_id().into(), 5, &mut rng, &staking_sk, &vrf_sk)
             .unwrap();
 
-        let old_tip = tf
-            .create_chain_pos(&common_block_id, 100, &mut rng, &staking_sk, &vrf_sk)
-            .unwrap();
+        let old_tip =
+            tf.create_chain_pos(&common_block_id, 100, &mut rng, &staking_sk, &vrf_sk).unwrap();
 
-        let new_tip = tf
-            .create_chain_pos(&common_block_id, 101, &mut rng, &staking_sk, &vrf_sk)
-            .unwrap();
+        let new_tip =
+            tf.create_chain_pos(&common_block_id, 101, &mut rng, &staking_sk, &vrf_sk).unwrap();
 
         assert_ne!(old_tip, new_tip);
         assert_eq!(new_tip, tf.best_block_id());

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -154,10 +154,7 @@ fn add_block_with_2_stake_pools(
         .build();
     let outpoint2 = UtxoOutPoint::new(OutPointSourceId::Transaction(tx2.transaction().get_id()), 0);
 
-    tf.make_block_builder()
-        .with_transactions(vec![tx1, tx2])
-        .build_and_process()
-        .unwrap();
+    tf.make_block_builder().with_transactions(vec![tx1, tx2]).build_and_process().unwrap();
 
     tf.progress_time_seconds_since_epoch(1);
 

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -60,10 +60,7 @@ fn setup_test_chain_with_staked_pool(
 ) -> (TestFramework, PoolId, PrivateKey) {
     let difficulty = Uint256::MAX;
     let upgrades = vec![
-        (
-            BlockHeight::new(0),
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
-        ),
+        (BlockHeight::new(0), UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus)),
         (
             BlockHeight::new(2),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
@@ -102,10 +99,7 @@ fn setup_test_chain_with_staked_pool(
             TxInput::from_utxo(OutPointSourceId::BlockReward(genesis_id.into()), 0),
             empty_witness(rng),
         )
-        .add_output(TxOutput::CreateStakePool(
-            pool_id,
-            Box::new(stake_pool_data),
-        ))
+        .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
         .build();
     tf.make_block_builder().add_transaction(tx).build_and_process().unwrap();
 

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -63,9 +63,8 @@ use utxo::UtxoSource;
 fn invalid_block_reward_types(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let chain_config = ConfigBuilder::test_chain()
-            .empty_consensus_reward_maturity_distance(50.into())
-            .build();
+        let chain_config =
+            ConfigBuilder::test_chain().empty_consensus_reward_maturity_distance(50.into()).build();
         let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
 
         let coins = OutputValue::Coin(Amount::from_atoms(10));
@@ -176,11 +175,8 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
         );
 
         // Case 6: reward is locked for less than the required number of blocks
-        let reward_lock_distance: i64 = tf
-            .chainstate
-            .get_chain_config()
-            .empty_consensus_reward_maturity_distance()
-            .into();
+        let reward_lock_distance: i64 =
+            tf.chainstate.get_chain_config().empty_consensus_reward_maturity_distance().into();
 
         let block = tf
             .make_block_builder()
@@ -235,11 +231,8 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
         ));
 
         // Case 8: the correct, working case
-        let reward_lock_distance: i64 = tf
-            .chainstate
-            .get_chain_config()
-            .empty_consensus_reward_maturity_distance()
-            .into();
+        let reward_lock_distance: i64 =
+            tf.chainstate.get_chain_config().empty_consensus_reward_maturity_distance().into();
 
         let block = tf
             .make_block_builder()
@@ -297,11 +290,8 @@ fn orphans_chains(#[case] seed: Seed) {
         let last_block_index =
             tf.process_block(missing_block, BlockSource::Local).unwrap().unwrap();
         assert_eq!(last_block_index.block_height(), (MAX_ORPHANS_COUNT_IN_TEST as u64).into());
-        let current_best = tf
-            .best_block_id()
-            .classify(tf.chainstate.get_chain_config())
-            .chain_block_id()
-            .unwrap();
+        let current_best =
+            tf.best_block_id().classify(tf.chainstate.get_chain_config()).chain_block_id().unwrap();
         assert_eq!(
             tf.block_index(&current_best.into()).block_height(),
             (MAX_ORPHANS_COUNT_IN_TEST as u64).into()
@@ -440,11 +430,8 @@ fn straight_chain(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let genesis_index = tf
-            .chainstate
-            .get_gen_block_index(&tf.genesis().get_id().into())
-            .unwrap()
-            .unwrap();
+        let genesis_index =
+            tf.chainstate.get_gen_block_index(&tf.genesis().get_id().into()).unwrap().unwrap();
 
         assert_eq!(tf.best_block_id(), tf.genesis().get_id());
         assert_eq!(genesis_index.chain_trust(), Uint256::ZERO);
@@ -619,9 +606,8 @@ fn last_common_ancestor(#[case] seed: Seed) {
     let last_block_in_first_chain = tf.best_block_index();
 
     // Second branch of fork
-    let last_block_in_second_chain = tf
-        .create_chain(&split.block_id(), SECOND_CHAIN_LENGTH - SPLIT_HEIGHT, &mut rng)
-        .unwrap();
+    let last_block_in_second_chain =
+        tf.create_chain(&split.block_id(), SECOND_CHAIN_LENGTH - SPLIT_HEIGHT, &mut rng).unwrap();
     let last_block_in_second_chain = tf.block_index(&last_block_in_second_chain);
 
     assert_eq!(
@@ -715,8 +701,7 @@ fn consensus_type(#[case] seed: Seed) {
     ));
 
     // Create 4 more blocks with Consensus Now
-    tf.create_chain(&tf.genesis().get_id().into(), 4, &mut rng)
-        .expect("chain creation");
+    tf.create_chain(&tf.genesis().get_id().into(), 4, &mut rng).expect("chain creation");
 
     // The next block will be at height 5, so it is expected to be a PoW block. Let's crate a block
     // with ConsensusData::None and see that adding it fails
@@ -794,8 +779,7 @@ fn consensus_type(#[case] seed: Seed) {
     ));
 
     // Create blocks 10-14 without consensus data as required by net_upgrades
-    tf.create_chain(&prev_block.get_id().into(), 5, &mut rng)
-        .expect("chain creation");
+    tf.create_chain(&prev_block.get_id().into(), 5, &mut rng).expect("chain creation");
 
     // At height 15 we are again proof of work, ignoring consensus should fail
     let prev_block = tf.block(*tf.index_at(14).block_id());

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -229,9 +229,9 @@ fn invalid_block_reward_types(#[case] seed: Seed) {
 
         assert!(matches!(
             tf.process_block(block, BlockSource::Local),
-            Err(ChainstateError::ProcessBlockError(
-                BlockError::CheckBlockFailed(CheckBlockError::InvalidBlockRewardOutputType(_))
-            ))
+            Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                CheckBlockError::InvalidBlockRewardOutputType(_)
+            )))
         ));
 
         // Case 8: the correct, working case
@@ -296,10 +296,7 @@ fn orphans_chains(#[case] seed: Seed) {
         // now we submit the missing block (at height 1), and we expect all blocks to be processed
         let last_block_index =
             tf.process_block(missing_block, BlockSource::Local).unwrap().unwrap();
-        assert_eq!(
-            last_block_index.block_height(),
-            (MAX_ORPHANS_COUNT_IN_TEST as u64).into()
-        );
+        assert_eq!(last_block_index.block_height(), (MAX_ORPHANS_COUNT_IN_TEST as u64).into());
         let current_best = tf
             .best_block_id()
             .classify(tf.chainstate.get_chain_config())
@@ -370,10 +367,7 @@ fn spend_inputs_simple(#[case] seed: Seed) {
                 let tx_index = tx_index.unwrap();
                 for (idx, txo) in tx.transaction().outputs().iter().enumerate() {
                     let idx = idx as u32;
-                    assert_eq!(
-                        tx_index.get_spent_state(idx).unwrap(),
-                        OutputSpentState::Unspent
-                    );
+                    assert_eq!(tx_index.get_spent_state(idx).unwrap(), OutputSpentState::Unspent);
                     let utxo =
                         tf.chainstate.utxo(&UtxoOutPoint::new(tx_id.into(), idx)).unwrap().unwrap();
                     assert_eq!(utxo.output(), txo);
@@ -476,10 +470,7 @@ fn straight_chain(#[case] seed: Seed) {
 
             assert_eq!(new_block_index.prev_block_id(), &prev_block_id);
             assert!(new_block_index.chain_trust() > block_index.chain_trust());
-            assert_eq!(
-                new_block_index.block_height(),
-                block_index.block_height().next_height()
-            );
+            assert_eq!(new_block_index.block_height(), block_index.block_height().next_height());
 
             block_index = GenBlockIndex::Block(new_block_index);
             prev_blk_id = new_block.get_id().into();
@@ -505,10 +496,7 @@ fn get_ancestor_invalid_height(#[case] seed: Seed) {
             }
         )),
         tf.chainstate
-            .get_ancestor(
-                &tf.best_block_index(),
-                u64::try_from(invalid_height).unwrap().into()
-            )
+            .get_ancestor(&tf.best_block_index(), u64::try_from(invalid_height).unwrap().into())
             .unwrap_err()
     );
 }
@@ -529,10 +517,7 @@ fn get_ancestor(#[case] seed: Seed) {
         .expect("Chain creation to succeed");
 
     let ancestor = GenBlockIndex::Block(tf.index_at(ANCESTOR_HEIGHT).clone());
-    assert_eq!(
-        ancestor.block_height(),
-        BlockHeight::from(ANCESTOR_HEIGHT as u64)
-    );
+    assert_eq!(ancestor.block_height(), BlockHeight::from(ANCESTOR_HEIGHT as u64));
 
     let split = GenBlockIndex::Block(tf.index_at(SPLIT_HEIGHT).clone());
     assert_eq!(split.block_height(), BlockHeight::from(SPLIT_HEIGHT as u64));
@@ -549,12 +534,8 @@ fn get_ancestor(#[case] seed: Seed) {
     }
 
     // Create the first chain and test get_ancestor for this chain's  last block
-    tf.create_chain(
-        &split.block_id(),
-        FIRST_CHAIN_HEIGHT - SPLIT_HEIGHT,
-        &mut rng,
-    )
-    .expect("second chain");
+    tf.create_chain(&split.block_id(), FIRST_CHAIN_HEIGHT - SPLIT_HEIGHT, &mut rng)
+        .expect("second chain");
     let last_block_in_first_chain = tf.best_block_index();
 
     const ANCESTOR_IN_FIRST_CHAIN_HEIGHT: usize = 400;
@@ -600,11 +581,7 @@ fn get_ancestor(#[case] seed: Seed) {
 
     // Create a second chain and test get_ancestor for this chain's last block
     let last_block_in_second_chain = tf
-        .create_chain(
-            &split.block_id(),
-            SECOND_CHAIN_LENGTH - SPLIT_HEIGHT,
-            &mut rng,
-        )
+        .create_chain(&split.block_id(), SECOND_CHAIN_LENGTH - SPLIT_HEIGHT, &mut rng)
         .expect("second chain");
     assert_eq!(
         ancestor.block_id(),
@@ -637,21 +614,13 @@ fn last_common_ancestor(#[case] seed: Seed) {
     let split = GenBlockIndex::Block(tf.index_at(SPLIT_HEIGHT).clone());
 
     // First branch of fork
-    tf.create_chain(
-        &split.block_id(),
-        FIRST_CHAIN_HEIGHT - SPLIT_HEIGHT,
-        &mut rng,
-    )
-    .expect("Chain creation to succeed");
+    tf.create_chain(&split.block_id(), FIRST_CHAIN_HEIGHT - SPLIT_HEIGHT, &mut rng)
+        .expect("Chain creation to succeed");
     let last_block_in_first_chain = tf.best_block_index();
 
     // Second branch of fork
     let last_block_in_second_chain = tf
-        .create_chain(
-            &split.block_id(),
-            SECOND_CHAIN_LENGTH - SPLIT_HEIGHT,
-            &mut rng,
-        )
+        .create_chain(&split.block_id(), SECOND_CHAIN_LENGTH - SPLIT_HEIGHT, &mut rng)
         .unwrap();
     let last_block_in_second_chain = tf.block_index(&last_block_in_second_chain);
 
@@ -699,20 +668,14 @@ fn consensus_type(#[case] seed: Seed) {
         Uint256([0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF]);
 
     let upgrades = vec![
-        (
-            ignore_consensus,
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
-        ),
+        (ignore_consensus, UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus)),
         (
             pow,
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoW {
                 initial_difficulty: min_difficulty.into(),
             }),
         ),
-        (
-            ignore_again,
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
-        ),
+        (ignore_again, UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus)),
         (
             pow_again,
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoW {
@@ -898,10 +861,7 @@ fn pow(#[case] seed: Seed) {
         Uint256([0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0x0FFFFFFFFFFFFFFF]);
 
     let upgrades = vec![
-        (
-            ignore_consensus,
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
-        ),
+        (ignore_consensus, UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus)),
         (
             pow_consensus,
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoW {
@@ -941,11 +901,11 @@ fn pow(#[case] seed: Seed) {
         .expect("generate invalid block");
     assert!(matches!(
         tf.process_block(random_invalid_block.clone(), BlockSource::Local),
-        Err(ChainstateError::ProcessBlockError(
-            BlockError::CheckBlockFailed(CheckBlockError::ConsensusVerificationFailed(
-                ConsensusVerificationError::PoWError(ConsensusPoWError::InvalidPoW(_))
+        Err(ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+            CheckBlockError::ConsensusVerificationFailed(ConsensusVerificationError::PoWError(
+                ConsensusPoWError::InvalidPoW(_)
             ))
-        ))
+        )))
     ));
 
     // Now let's actually mine the block, i.e. find valid PoW and see that consensus checks pass
@@ -977,10 +937,7 @@ fn read_block_reward_from_storage(#[case] seed: Seed) {
         Uint256([0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0x0FFFFFFFFFFFFFFF]);
 
     let upgrades = vec![
-        (
-            ignore_consensus,
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
-        ),
+        (ignore_consensus, UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus)),
         (
             pow_consensus,
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoW {
@@ -1066,9 +1023,8 @@ fn blocks_from_the_future(#[case] seed: Seed) {
         let config = create_unit_test_config();
 
         // current time is genesis time
-        let current_time = Arc::new(SeqCstAtomicU64::new(
-            config.genesis_block().timestamp().as_int_seconds(),
-        ));
+        let current_time =
+            Arc::new(SeqCstAtomicU64::new(config.genesis_block().timestamp().as_int_seconds()));
         let time_getter = mocked_time_getter_seconds(Arc::clone(&current_time));
         let mut tf = TestFramework::builder(&mut rng)
             .with_chain_config(config)
@@ -1224,10 +1180,7 @@ fn burn_inputs_in_tx(#[case] seed: Seed) {
 
         let first_tx = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .build();

--- a/chainstate/test-suite/src/tests/reorgs_tests.rs
+++ b/chainstate/test-suite/src/tests/reorgs_tests.rs
@@ -119,8 +119,7 @@ fn check_spend_tx_in_failed_block(tf: &mut TestFramework, events: &EventList, rn
     const NEW_CHAIN_START_ON: usize = 6;
     const NEW_CHAIN_END_ON: usize = 11;
 
-    tf.create_chain(&(*tf.index_at(NEW_CHAIN_START_ON).block_id()).into(), 5, rng)
-        .unwrap();
+    tf.create_chain(&(*tf.index_at(NEW_CHAIN_START_ON).block_id()).into(), 5, rng).unwrap();
     check_last_event(tf, events);
 
     let block = tf.block(*tf.index_at(NEW_CHAIN_END_ON - 1).block_id());
@@ -152,8 +151,7 @@ fn check_spend_tx_in_other_fork(tf: &mut TestFramework, rng: &mut impl Rng) {
     //
     const NEW_CHAIN_START_ON: usize = 5;
     const NEW_CHAIN_END_ON: usize = 9;
-    tf.create_chain(&(*tf.index_at(NEW_CHAIN_START_ON).block_id()).into(), 1, rng)
-        .unwrap();
+    tf.create_chain(&(*tf.index_at(NEW_CHAIN_START_ON).block_id()).into(), 1, rng).unwrap();
     let block = tf.block(*tf.index_at(NEW_CHAIN_END_ON).block_id());
     let spend_from = *tf.index_at(3).block_id();
     let double_spend_block = tf

--- a/chainstate/test-suite/src/tests/reorgs_tests.rs
+++ b/chainstate/test-suite/src/tests/reorgs_tests.rs
@@ -119,12 +119,8 @@ fn check_spend_tx_in_failed_block(tf: &mut TestFramework, events: &EventList, rn
     const NEW_CHAIN_START_ON: usize = 6;
     const NEW_CHAIN_END_ON: usize = 11;
 
-    tf.create_chain(
-        &(*tf.index_at(NEW_CHAIN_START_ON).block_id()).into(),
-        5,
-        rng,
-    )
-    .unwrap();
+    tf.create_chain(&(*tf.index_at(NEW_CHAIN_START_ON).block_id()).into(), 5, rng)
+        .unwrap();
     check_last_event(tf, events);
 
     let block = tf.block(*tf.index_at(NEW_CHAIN_END_ON - 1).block_id());
@@ -156,12 +152,8 @@ fn check_spend_tx_in_other_fork(tf: &mut TestFramework, rng: &mut impl Rng) {
     //
     const NEW_CHAIN_START_ON: usize = 5;
     const NEW_CHAIN_END_ON: usize = 9;
-    tf.create_chain(
-        &(*tf.index_at(NEW_CHAIN_START_ON).block_id()).into(),
-        1,
-        rng,
-    )
-    .unwrap();
+    tf.create_chain(&(*tf.index_at(NEW_CHAIN_START_ON).block_id()).into(), 1, rng)
+        .unwrap();
     let block = tf.block(*tf.index_at(NEW_CHAIN_END_ON).block_id());
     let spend_from = *tf.index_at(3).block_id();
     let double_spend_block = tf
@@ -380,14 +372,13 @@ fn check_last_event(tf: &mut TestFramework, events: &EventList) {
 fn subscribe_to_events(tf: &mut TestFramework, events: &EventList) {
     let events = Arc::clone(events);
     // Event handler
-    let subscribe_func = Arc::new(
-        move |chainstate_event: ChainstateEvent| match chainstate_event {
+    let subscribe_func =
+        Arc::new(move |chainstate_event: ChainstateEvent| match chainstate_event {
             ChainstateEvent::NewTip(block_id, block_height) => {
                 events.lock().unwrap().push((block_id, block_height));
                 assert!(!events.lock().unwrap().is_empty());
             }
-        },
-    );
+        });
     tf.chainstate.subscribe_to_events(subscribe_func);
 }
 

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -95,10 +95,7 @@ fn signed_tx(#[case] seed: Seed) {
                 .expect("invalid witness count")
         };
 
-        tf.make_block_builder()
-            .with_transactions(vec![tx_1, tx_2])
-            .build_and_process()
-            .unwrap();
+        tf.make_block_builder().with_transactions(vec![tx_1, tx_2]).build_and_process().unwrap();
     });
 }
 
@@ -196,10 +193,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
                 .expect("invalid witness count")
         };
 
-        tf.make_block_builder()
-            .with_transactions(vec![tx_1, tx_2])
-            .build_and_process()
-            .unwrap();
+        tf.make_block_builder().with_transactions(vec![tx_1, tx_2]).build_and_process().unwrap();
     });
 }
 

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -69,10 +69,7 @@ fn signed_tx(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::Transaction(tx_1.transaction().get_id()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx_1.transaction().get_id()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -147,18 +144,12 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
                 ),
                 InputWitness::NoSignature(None),
             )
-            .add_output(TxOutput::Transfer(
-                OutputValue::Coin(Amount::from_atoms(100)),
-                destination,
-            ))
+            .add_output(TxOutput::Transfer(OutputValue::Coin(Amount::from_atoms(100)), destination))
             .build();
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::Transaction(tx_1.transaction().get_id()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx_1.transaction().get_id()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
@@ -252,18 +243,12 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
                 ),
                 InputWitness::NoSignature(None),
             )
-            .add_output(TxOutput::Transfer(
-                OutputValue::Coin(Amount::from_atoms(100)),
-                destination,
-            ))
+            .add_output(TxOutput::Transfer(OutputValue::Coin(Amount::from_atoms(100)), destination))
             .build();
 
         let tx = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::Transaction(tx_1.transaction().get_id()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::Transaction(tx_1.transaction().get_id()), 0),
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -63,18 +63,13 @@ fn stake_pool_basic(#[case] seed: Seed) {
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
 
-        let stake_pool_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-            0,
-        );
+        let stake_pool_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0);
         let pool_id = pos_accounting::make_pool_id(&stake_pool_outpoint);
 
         let tx = TransactionBuilder::new()
             .add_input(stake_pool_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
 
         let block = tf.make_block_builder().add_transaction(tx).build();
@@ -106,18 +101,13 @@ fn stake_pool_and_spend_coin_same_tx(#[case] seed: Seed) {
             Amount::from_atoms(rng.gen_range(min_stake_pool_pledge..(min_stake_pool_pledge * 10)));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
-        let genesis_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-            0,
-        );
+        let genesis_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0);
         let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let tx = TransactionBuilder::new()
             .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .add_output(TxOutput::Transfer(
                 OutputValue::Coin(Amount::from_atoms(rng.gen_range(100_000..200_000))),
                 anyonecanspend_address(),
@@ -147,18 +137,13 @@ fn stake_pool_and_issue_tokens_same_tx(#[case] seed: Seed) {
             Amount::from_atoms(rng.gen_range(min_stake_pool_pledge..(min_stake_pool_pledge * 10)));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
-        let genesis_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-            0,
-        );
+        let genesis_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0);
         let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let tx = TransactionBuilder::new()
             .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .add_output(TxOutput::Transfer(
                 random_token_issuance(tf.chainstate.get_chain_config().clone(), &mut rng).into(),
                 anyonecanspend_address(),
@@ -194,16 +179,10 @@ fn stake_pool_and_transfer_tokens_same_tx(#[case] seed: Seed) {
             Amount::from_atoms(rng.gen_range(min_stake_pool_pledge..(min_stake_pool_pledge * 10)));
         let tx0 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
-            .add_output(TxOutput::Transfer(
-                token_issuance_data.into(),
-                anyonecanspend_address(),
-            ))
+            .add_output(TxOutput::Transfer(token_issuance_data.into(), anyonecanspend_address()))
             .add_output(TxOutput::Transfer(
                 OutputValue::Coin(amount_to_stake),
                 anyonecanspend_address(),
@@ -232,17 +211,11 @@ fn stake_pool_and_transfer_tokens_same_tx(#[case] seed: Seed) {
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(
-                TokenData::TokenTransfer(TokenTransfer {
-                    token_id,
-                    amount: amount_to_issue,
-                })
-                .into(),
+                TokenData::TokenTransfer(TokenTransfer { token_id, amount: amount_to_issue })
+                    .into(),
                 anyonecanspend_address(),
             ))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
 
         let best_block_index = tf
@@ -252,10 +225,7 @@ fn stake_pool_and_transfer_tokens_same_tx(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            tf.best_block_id(),
-            Id::<GenBlock>::from(*best_block_index.block_id())
-        );
+        assert_eq!(tf.best_block_id(), Id::<GenBlock>::from(*best_block_index.block_id()));
     });
 }
 
@@ -274,22 +244,14 @@ fn stake_pool_twice(#[case] seed: Seed) {
             Amount::from_atoms(rng.gen_range(min_stake_pool_pledge..(min_stake_pool_pledge * 10)));
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
-        let genesis_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-            0,
-        );
+        let genesis_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0);
         let pool_id = pos_accounting::make_pool_id(&genesis_outpoint);
 
         let tx = TransactionBuilder::new()
             .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data.clone()),
-            ))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data.clone())))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
 
         let result = tf.make_block_builder().add_transaction(tx).build_and_process();
@@ -333,10 +295,7 @@ fn stake_pool_overspend(#[case] seed: Seed) {
 
         let tx = TransactionBuilder::new()
             .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
 
         let result = tf.make_block_builder().add_transaction(tx).build_and_process();
@@ -377,10 +336,7 @@ fn stake_pool_not_enough_pledge(#[case] seed: Seed) {
         );
         let tx = TransactionBuilder::new()
             .add_input(genesis_outpoint.clone().into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
         let tx_id = tx.transaction().get_id();
 
@@ -402,10 +358,7 @@ fn stake_pool_not_enough_pledge(#[case] seed: Seed) {
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, min_pledge, vrf_pk);
         let tx = TransactionBuilder::new()
             .add_input(genesis_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
 
         tf.make_block_builder().add_transaction(tx).build_and_process().unwrap();
@@ -428,18 +381,13 @@ fn decommission_from_stake_pool(#[case] seed: Seed) {
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
 
-        let stake_pool_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-            0,
-        );
+        let stake_pool_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0);
         let pool_id = pos_accounting::make_pool_id(&stake_pool_outpoint);
 
         let tx1 = TransactionBuilder::new()
             .add_input(stake_pool_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
         let stake_pool_tx_id = tx1.transaction().get_id();
 
@@ -508,18 +456,13 @@ fn decommission_from_stake_pool_same_block(#[case] seed: Seed) {
         let (stake_pool_data, _) =
             create_stake_pool_data_with_all_reward_to_owner(&mut rng, amount_to_stake, vrf_pk);
 
-        let stake_pool_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-            0,
-        );
+        let stake_pool_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0);
         let pool_id = pos_accounting::make_pool_id(&stake_pool_outpoint);
 
         let tx1 = TransactionBuilder::new()
             .add_input(stake_pool_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
         let stake_pool_tx_id = tx1.transaction().get_id();
 
@@ -575,18 +518,13 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
             Amount::ZERO,
         );
 
-        let stake_pool_outpoint = UtxoOutPoint::new(
-            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-            0,
-        );
+        let stake_pool_outpoint =
+            UtxoOutPoint::new(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0);
         let pool_id = pos_accounting::make_pool_id(&stake_pool_outpoint);
 
         let tx1 = TransactionBuilder::new()
             .add_input(stake_pool_outpoint.into(), empty_witness(&mut rng))
-            .add_output(TxOutput::CreateStakePool(
-                pool_id,
-                Box::new(stake_pool_data),
-            ))
+            .add_output(TxOutput::CreateStakePool(pool_id, Box::new(stake_pool_data)))
             .build();
 
         tf.make_block_builder().add_transaction(tx1).build_and_process().unwrap();

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -604,10 +604,6 @@ fn decommission_from_stake_pool_with_staker_key(#[case] seed: Seed) {
             SignedTransaction::new(tx, vec![InputWitness::Standard(decommission_sig)]).unwrap()
         };
 
-        tf.make_block_builder()
-            .add_transaction(tx2)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        tf.make_block_builder().add_transaction(tx2).build_and_process().unwrap().unwrap();
     });
 }

--- a/chainstate/test-suite/src/tests/syncing_tests.rs
+++ b/chainstate/test-suite/src/tests/syncing_tests.rs
@@ -152,8 +152,7 @@ fn get_headers(#[case] seed: Seed) {
         assert_eq!(expected[0].prev_block_id(), &locator[0]);
 
         // Produce more blocks than `HEADER_LIMIT`, so get_headers is truncated.
-        tf.create_chain(&last_block_id, header_limit - expected.len(), &mut rng)
-            .unwrap();
+        tf.create_chain(&last_block_id, header_limit - expected.len(), &mut rng).unwrap();
         let headers = tf.chainstate.get_headers(locator, header_limit).unwrap();
         assert_eq!(headers.len(), header_limit);
     });

--- a/chainstate/test-suite/src/tests/syncing_tests.rs
+++ b/chainstate/test-suite/src/tests/syncing_tests.rs
@@ -59,10 +59,7 @@ fn get_locator(#[case] seed: Seed) {
 
             // Check the locator length.
             let locator = btf.chainstate.get_locator().unwrap();
-            assert_eq!(
-                locator.len(),
-                blocks.next_power_of_two().trailing_zeros() as usize + 1
-            );
+            assert_eq!(locator.len(), blocks.next_power_of_two().trailing_zeros() as usize + 1);
 
             // Check the locator headers.
             let height =
@@ -131,10 +128,7 @@ fn get_headers(#[case] seed: Seed) {
 
         // The locator is from this exact chain, so `get_headers` should return an empty sequence.
         let locator = tf.chainstate.get_locator().unwrap();
-        assert_eq!(
-            tf.chainstate.get_headers(locator.clone(), header_limit).unwrap(),
-            vec![],
-        );
+        assert_eq!(tf.chainstate.get_headers(locator.clone(), header_limit).unwrap(), vec![],);
 
         // Produce more blocks. Now `get_headers` should return these blocks.
         let expected: Vec<_> = iter::from_fn(|| {
@@ -446,9 +440,9 @@ fn filter_already_existing_blocks_detached_headers(#[case] seed: Seed) {
         let filtered_headers = tf1.chainstate.filter_already_existing_blocks(headers[1..].to_vec());
         assert_eq!(
             filtered_headers,
-            Err(ChainstateError::FailedToReadProperty(
-                PropertyQueryError::BlockNotFound(Id::new(headers[1].prev_block_id().get()))
-            ))
+            Err(ChainstateError::FailedToReadProperty(PropertyQueryError::BlockNotFound(Id::new(
+                headers[1].prev_block_id().get()
+            ))))
         );
     });
 }

--- a/chainstate/test-suite/src/tests/tx_verifier_disconnect.rs
+++ b/chainstate/test-suite/src/tests/tx_verifier_disconnect.rs
@@ -95,9 +95,7 @@ fn attempt_to_disconnect_tx_mainchain(#[case] seed: Seed, #[case] num_blocks: us
         assert!(verifier
             .can_disconnect_transaction(&TransactionSource::Chain(block_id), &tx_id)
             .unwrap());
-        verifier
-            .disconnect_transaction(&TransactionSource::Chain(block_id), tx)
-            .unwrap();
+        verifier.disconnect_transaction(&TransactionSource::Chain(block_id), tx).unwrap();
     });
 }
 
@@ -122,12 +120,8 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
             .build();
         let tx0_id = tx0.transaction().get_id();
 
-        let best_block = tf
-            .make_block_builder()
-            .add_transaction(tx0)
-            .build_and_process()
-            .unwrap()
-            .unwrap();
+        let best_block =
+            tf.make_block_builder().add_transaction(tx0).build_and_process().unwrap().unwrap();
 
         let mut verifier =
             TransactionVerifier::new(&storage, &chain_config, TransactionVerifierConfig::new(true));
@@ -145,9 +139,7 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
             ))
             .build();
 
-        verifier
-            .connect_transaction(&tx_source, &tx1, &tf.genesis().timestamp(), None)
-            .unwrap();
+        verifier.connect_transaction(&tx_source, &tx1, &tf.genesis().timestamp(), None).unwrap();
 
         // create and connect a tx from mempool based on previous tx from mempool
         let tx2 = TransactionBuilder::new()
@@ -161,9 +153,7 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
             ))
             .build();
 
-        verifier
-            .connect_transaction(&tx_source, &tx2, &tf.genesis().timestamp(), None)
-            .unwrap();
+        verifier.connect_transaction(&tx_source, &tx2, &tf.genesis().timestamp(), None).unwrap();
 
         {
             // derived verifier that didn't connect a tx should not be able to disconnect it

--- a/chainstate/test-suite/src/tests/tx_verifier_disconnect.rs
+++ b/chainstate/test-suite/src/tests/tx_verifier_disconnect.rs
@@ -112,10 +112,7 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
         // create a block with a single tx based on genesis
         let tx0 = TransactionBuilder::new()
             .add_input(
-                TxInput::from_utxo(
-                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
-                    0,
-                ),
+                TxInput::from_utxo(OutPointSourceId::BlockReward(tf.genesis().get_id().into()), 0),
                 empty_witness(&mut rng),
             )
             .add_output(TxOutput::Transfer(
@@ -132,14 +129,9 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
             .unwrap()
             .unwrap();
 
-        let mut verifier = TransactionVerifier::new(
-            &storage,
-            &chain_config,
-            TransactionVerifierConfig::new(true),
-        );
-        let tx_source = TransactionSourceForConnect::Mempool {
-            current_best: &best_block.into(),
-        };
+        let mut verifier =
+            TransactionVerifier::new(&storage, &chain_config, TransactionVerifierConfig::new(true));
+        let tx_source = TransactionSourceForConnect::Mempool { current_best: &best_block.into() };
 
         // create and connect a tx from mempool based on best block
         let tx1 = TransactionBuilder::new()
@@ -214,9 +206,7 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
 
         assert_eq!(
             verifier.disconnect_transaction(&TransactionSource::Mempool, &tx1),
-            Err(ConnectTransactionError::TxUndoWithDependency(
-                tx1.transaction().get_id()
-            ))
+            Err(ConnectTransactionError::TxUndoWithDependency(tx1.transaction().get_id()))
         );
         verifier.disconnect_transaction(&TransactionSource::Mempool, &tx2).unwrap();
 

--- a/chainstate/tx-verifier/src/transaction_verifier/accounting_delta_adapter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/accounting_delta_adapter.rs
@@ -47,14 +47,8 @@ impl<P: PoSAccountingView> PoSAccountingDeltaAdapter<P> {
 
     pub fn consume(
         self,
-    ) -> (
-        PoSAccountingDeltaData,
-        BTreeMap<TransactionSource, PoSAccountingDeltaData>,
-    ) {
-        (
-            self.accounting_delta.consume(),
-            self.accounting_block_deltas,
-        )
+    ) -> (PoSAccountingDeltaData, BTreeMap<TransactionSource, PoSAccountingDeltaData>) {
+        (self.accounting_delta.consume(), self.accounting_block_deltas)
     }
 
     pub fn operations(&mut self, tx_source: TransactionSource) -> PoSAccountingOperationImpl<P> {

--- a/chainstate/tx-verifier/src/transaction_verifier/accounting_undo_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/accounting_undo_cache.rs
@@ -38,9 +38,7 @@ pub struct AccountingBlockUndoCache {
 
 impl AccountingBlockUndoCache {
     pub fn new() -> Self {
-        Self {
-            data: BTreeMap::new(),
-        }
+        Self { data: BTreeMap::new() }
     }
 
     #[cfg(test)]
@@ -72,10 +70,7 @@ impl AccountingBlockUndoCache {
                     let block_undo = fetcher_func(*block_id)?
                         .ok_or(ConnectTransactionError::MissingBlockUndo(*block_id))?;
                     Ok(&mut entry
-                        .insert(AccountingBlockUndoEntry {
-                            undo: block_undo,
-                            is_fresh: false,
-                        })
+                        .insert(AccountingBlockUndoEntry { undo: block_undo, is_fresh: false })
                         .undo)
                 }
                 TransactionSource::Mempool => Err(ConnectTransactionError::MissingMempoolTxsUndo),
@@ -119,10 +114,7 @@ impl AccountingBlockUndoCache {
         &mut self
             .data
             .entry(*tx_source)
-            .or_insert(AccountingBlockUndoEntry {
-                is_fresh: true,
-                undo: Default::default(),
-            })
+            .or_insert(AccountingBlockUndoEntry { is_fresh: true, undo: Default::default() })
             .undo
     }
 
@@ -133,10 +125,7 @@ impl AccountingBlockUndoCache {
     ) -> Result<(), AccountingBlockUndoError> {
         match self.data.entry(tx_source) {
             Entry::Vacant(e) => {
-                e.insert(AccountingBlockUndoEntry {
-                    undo: new_undo.clone(),
-                    is_fresh: true,
-                });
+                e.insert(AccountingBlockUndoEntry { undo: new_undo.clone(), is_fresh: true });
             }
             Entry::Occupied(mut e) => {
                 e.get_mut().undo.combine(new_undo.clone())?;
@@ -154,10 +143,7 @@ impl AccountingBlockUndoCache {
             // if current cache doesn't have such data - insert empty undo to be flushed to the parent
             self.data.insert(
                 tx_source,
-                AccountingBlockUndoEntry {
-                    undo: Default::default(),
-                    is_fresh: false,
-                },
+                AccountingBlockUndoEntry { undo: Default::default(), is_fresh: false },
             );
         }
         Ok(())

--- a/chainstate/tx-verifier/src/transaction_verifier/amounts_map.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/amounts_map.rs
@@ -36,9 +36,7 @@ impl AmountsMap {
     >(
         iter: T,
     ) -> Result<Self, ConnectTransactionError> {
-        let mut result = Self {
-            data: BTreeMap::new(),
-        };
+        let mut result = Self { data: BTreeMap::new() };
 
         iter.into_fallible_iter()
             .for_each(|(t, v)| insert_or_increase(&mut result.data, t, v).map_err(Into::into))?;
@@ -140,9 +138,7 @@ mod tests {
                 ]
                 .into_iter()
                 .map(Ok)
-                .chain(vec![Err(
-                    ConnectTransactionError::InvariantBrokenAlreadyUnspent,
-                )]),
+                .chain(vec![Err(ConnectTransactionError::InvariantBrokenAlreadyUnspent)]),
             );
 
             let expected = ConnectTransactionError::InvariantBrokenAlreadyUnspent;

--- a/chainstate/tx-verifier/src/transaction_verifier/cached_inputs_operation.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/cached_inputs_operation.rs
@@ -98,10 +98,7 @@ mod tests {
             let mut tx_index = tx_index;
             tx_index.spend(index, spender.clone()).unwrap();
             cached_operation.spend(index, spender).unwrap();
-            assert_eq!(
-                cached_operation,
-                CachedInputsOperation::Write(tx_index.clone())
-            );
+            assert_eq!(cached_operation, CachedInputsOperation::Write(tx_index.clone()));
 
             tx_index.unspend(index).unwrap();
             cached_operation.unspend(index).unwrap();
@@ -128,10 +125,7 @@ mod tests {
             let mut tx_index = tx_index;
             tx_index.spend(index, spender.clone()).unwrap();
             cached_operation.spend(index, spender).unwrap();
-            assert_eq!(
-                cached_operation,
-                CachedInputsOperation::Write(tx_index.clone())
-            );
+            assert_eq!(cached_operation, CachedInputsOperation::Write(tx_index.clone()));
 
             tx_index.unspend(index).unwrap();
             cached_operation.unspend(index).unwrap();

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -174,13 +174,9 @@ impl From<SpendError> for TxIndexError {
         match err {
             SpendError::AlreadySpent(spender) => TxIndexError::DoubleSpendAttempt(spender),
             SpendError::AlreadyUnspent => TxIndexError::InvariantBrokenAlreadyUnspent,
-            SpendError::OutOfRange {
-                tx_id,
-                source_output_index,
-            } => TxIndexError::OutputIndexOutOfRange {
-                tx_id,
-                source_output_index,
-            },
+            SpendError::OutOfRange { tx_id, source_output_index } => {
+                TxIndexError::OutputIndexOutOfRange { tx_id, source_output_index }
+            }
         }
     }
 }
@@ -208,10 +204,7 @@ pub enum TxIndexError {
     #[error("Block disconnect already-unspent (invariant broken)")]
     InvariantBrokenAlreadyUnspent,
     #[error("Input of tx {tx_id:?} has an out-of-range output index {source_output_index}")]
-    OutputIndexOutOfRange {
-        tx_id: Option<Spender>,
-        source_output_index: usize,
-    },
+    OutputIndexOutOfRange { tx_id: Option<Spender>, source_output_index: usize },
 }
 
 impl From<TxMainChainIndexError> for TxIndexError {

--- a/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/hierarchy.rs
@@ -313,27 +313,21 @@ impl<C, S: TransactionVerifierStorageRef, U: UtxosView, A: PoSAccountingView> Po
         &self,
         delegation_id: DelegationId,
     ) -> Result<Option<Amount>, Self::Error> {
-        self.accounting_delta_adapter
-            .accounting_delta()
-            .get_delegation_balance(delegation_id)
+        self.accounting_delta_adapter.accounting_delta().get_delegation_balance(delegation_id)
     }
 
     fn get_delegation_data(
         &self,
         delegation_id: DelegationId,
     ) -> Result<Option<DelegationData>, Self::Error> {
-        self.accounting_delta_adapter
-            .accounting_delta()
-            .get_delegation_data(delegation_id)
+        self.accounting_delta_adapter.accounting_delta().get_delegation_data(delegation_id)
     }
 
     fn get_pool_delegations_shares(
         &self,
         pool_id: PoolId,
     ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Self::Error> {
-        self.accounting_delta_adapter
-            .accounting_delta()
-            .get_pool_delegations_shares(pool_id)
+        self.accounting_delta_adapter.accounting_delta().get_pool_delegations_shares(pool_id)
     }
 
     fn get_pool_delegation_share(

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
@@ -118,10 +118,7 @@ pub fn check_reward_inputs_outputs_purposes(
                     | TxOutput::CreateDelegationId(..)
                     | TxOutput::DelegateStaking(..) => false,
                 });
-            ensure!(
-                all_lock_then_transfer,
-                ConnectTransactionError::InvalidOutputTypeInReward
-            );
+            ensure!(all_lock_then_transfer, ConnectTransactionError::InvalidOutputTypeInReward);
             Ok(())
         }
     }
@@ -176,10 +173,7 @@ fn is_valid_tx_with_accounting_input(tx: &Transaction) -> Result<(), ConnectTran
         })
         .exactly_one()
         .is_ok();
-    ensure!(
-        is_single_accounting_delegation_spend,
-        ConnectTransactionError::InvalidInputTypeInTx
-    );
+    ensure!(is_single_accounting_delegation_spend, ConnectTransactionError::InvalidInputTypeInTx);
 
     let all_lock_then_transfer_outputs = tx.outputs().iter().all(|output| match output {
         TxOutput::LockThenTransfer(..) => true,
@@ -190,10 +184,7 @@ fn is_valid_tx_with_accounting_input(tx: &Transaction) -> Result<(), ConnectTran
         | TxOutput::CreateDelegationId(..)
         | TxOutput::DelegateStaking(..) => false,
     });
-    ensure!(
-        all_lock_then_transfer_outputs,
-        ConnectTransactionError::InvalidOutputTypeInTx
-    );
+    ensure!(all_lock_then_transfer_outputs, ConnectTransactionError::InvalidOutputTypeInTx);
 
     Ok(())
 }
@@ -243,10 +234,7 @@ fn is_valid_one_to_any_combination_for_tx(
         let valid_inputs = are_inputs_valid_for_tx(std::slice::from_ref(input_utxo));
         ensure!(valid_inputs, ConnectTransactionError::InvalidInputTypeInTx);
         let valid_outputs = are_outputs_valid_for_tx(outputs);
-        ensure!(
-            valid_outputs,
-            ConnectTransactionError::InvalidOutputTypeInTx
-        );
+        ensure!(valid_outputs, ConnectTransactionError::InvalidOutputTypeInTx);
     }
     Ok(())
 }
@@ -282,10 +270,7 @@ fn is_valid_any_to_any_combination_for_tx(
     let valid_inputs = are_inputs_valid_for_tx(inputs_utxos);
     ensure!(valid_inputs, ConnectTransactionError::InvalidInputTypeInTx);
     let valid_outputs = are_outputs_valid_for_tx(outputs);
-    ensure!(
-        valid_outputs,
-        ConnectTransactionError::InvalidOutputTypeInTx
-    );
+    ensure!(valid_outputs, ConnectTransactionError::InvalidOutputTypeInTx);
     Ok(())
 }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
@@ -275,10 +275,7 @@ fn tx_one_to_many(#[case] seed: Seed) {
             number_of_outputs,
             extra_output,
         );
-        assert_eq!(
-            check_tx_inputs_outputs_purposes(&tx, &utxo_db),
-            expected_result
-        );
+        assert_eq!(check_tx_inputs_outputs_purposes(&tx, &utxo_db), expected_result);
     };
 
     // valid cases
@@ -291,11 +288,7 @@ fn tx_one_to_many(#[case] seed: Seed) {
     // invalid input
     let invalid_inputs = [burn(), create_delegation()];
     let valid_outputs = [lock_then_transfer(), transfer(), burn()];
-    check(
-        &invalid_inputs,
-        &valid_outputs,
-        Err(ConnectTransactionError::InvalidInputTypeInTx),
-    );
+    check(&invalid_inputs, &valid_outputs, Err(ConnectTransactionError::InvalidInputTypeInTx));
 
     // invalid output
     let valid_inputs = [stake_pool(), produce_block(), delegate_staking()];
@@ -307,11 +300,7 @@ fn tx_one_to_many(#[case] seed: Seed) {
         create_delegation(),
         delegate_staking(),
     ];
-    check(
-        &valid_inputs,
-        &invalid_outputs,
-        Err(ConnectTransactionError::InvalidInputTypeInTx),
-    );
+    check(&valid_inputs, &invalid_outputs, Err(ConnectTransactionError::InvalidInputTypeInTx));
 }
 
 #[rstest]
@@ -321,10 +310,7 @@ fn tx_spend_delegation(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let inputs = vec![TxInput::Account(AccountOutPoint::new(
         AccountNonce::new(0),
-        AccountSpending::Delegation(
-            DelegationId::new(H256::random_using(&mut rng)),
-            Amount::ZERO,
-        ),
+        AccountSpending::Delegation(DelegationId::new(H256::random_using(&mut rng)), Amount::ZERO),
     ))];
 
     let number_of_outputs = rng.gen_range(2..10);
@@ -467,10 +453,7 @@ fn tx_many_to_one(#[case] seed: Seed) {
             1,
             None,
         );
-        assert_eq!(
-            check_tx_inputs_outputs_purposes(&tx, &utxo_db),
-            expected_result
-        );
+        assert_eq!(check_tx_inputs_outputs_purposes(&tx, &utxo_db), expected_result);
     };
 
     // valid cases
@@ -487,11 +470,7 @@ fn tx_many_to_one(#[case] seed: Seed) {
 
     // invalid outputs
     let invalid_outputs = [produce_block()];
-    check(
-        &valid_inputs,
-        &invalid_outputs,
-        Err(ConnectTransactionError::InvalidOutputTypeInTx),
-    );
+    check(&valid_inputs, &invalid_outputs, Err(ConnectTransactionError::InvalidOutputTypeInTx));
 }
 
 #[rstest]
@@ -513,10 +492,7 @@ fn tx_many_to_many(#[case] seed: Seed) {
             number_of_outputs,
             None,
         );
-        assert_eq!(
-            check_tx_inputs_outputs_purposes(&tx, &utxo_db),
-            expected_result
-        );
+        assert_eq!(check_tx_inputs_outputs_purposes(&tx, &utxo_db), expected_result);
     };
 
     let mut rng = make_seedable_rng(seed);
@@ -528,20 +504,10 @@ fn tx_many_to_many(#[case] seed: Seed) {
 
     // invalid cases
     let invalid_outputs = [stake_pool(), produce_block()];
-    check(
-        &valid_inputs,
-        &invalid_outputs,
-        2,
-        Err(ConnectTransactionError::InvalidOutputTypeInTx),
-    );
+    check(&valid_inputs, &invalid_outputs, 2, Err(ConnectTransactionError::InvalidOutputTypeInTx));
 
     let invalid_outputs = [create_delegation(), produce_block()];
-    check(
-        &valid_inputs,
-        &invalid_outputs,
-        2,
-        Err(ConnectTransactionError::InvalidOutputTypeInTx),
-    );
+    check(&valid_inputs, &invalid_outputs, 2, Err(ConnectTransactionError::InvalidOutputTypeInTx));
 
     let invalid_inputs = [burn(), stake_pool(), produce_block(), create_delegation()];
     let invalid_outputs = [stake_pool(), produce_block(), create_delegation()];
@@ -745,10 +711,7 @@ fn reward_many_to_none(#[case] seed: Seed) {
         .enumerate()
         .map(|(i, output)| {
             (
-                UtxoOutPoint::new(
-                    OutPointSourceId::BlockReward(Id::new(H256::zero())),
-                    i as u32,
-                ),
+                UtxoOutPoint::new(OutPointSourceId::BlockReward(Id::new(H256::zero())), i as u32),
                 Utxo::new_for_mempool(output),
             )
         })

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests.rs
@@ -625,10 +625,8 @@ fn reward_one_to_none(#[case] seed: Seed) {
 
     let valid_kernels = [stake_pool(), produce_block()];
 
-    let input = get_random_outputs_combination(&mut rng, &valid_kernels, 1)
-        .into_iter()
-        .next()
-        .unwrap();
+    let input =
+        get_random_outputs_combination(&mut rng, &valid_kernels, 1).into_iter().next().unwrap();
     let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
 
     let best_block_id: Id<GenBlock> = Id::new(H256::random_using(&mut rng));

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -363,9 +363,9 @@ where
             .get_account_nonce_count(account.into())
             .map_err(|_| ConnectTransactionError::TxVerifierStorage)?
         {
-            Some(nonce) => nonce
-                .increment()
-                .ok_or(ConnectTransactionError::FailedToIncrementAccountNonce)?,
+            Some(nonce) => {
+                nonce.increment().ok_or(ConnectTransactionError::FailedToIncrementAccountNonce)?
+            }
             None => AccountNonce::new(0),
         };
         ensure!(
@@ -377,8 +377,7 @@ where
             )
         );
         // store new nonce
-        self.account_nonce
-            .insert(account.into(), CachedOperation::Write(account_input.nonce()));
+        self.account_nonce.insert(account.into(), CachedOperation::Write(account_input.nonce()));
 
         match account {
             AccountSpending::Delegation(delegation_id, withdraw_amount) => {
@@ -807,9 +806,7 @@ where
         tx_id: &Id<Transaction>,
     ) -> Result<bool, ConnectTransactionError> {
         let block_undo_fetcher = |id: Id<Block>| {
-            self.storage
-                .get_undo_data(id)
-                .map_err(|_| ConnectTransactionError::UndoFetchFailure)
+            self.storage.get_undo_data(id).map_err(|_| ConnectTransactionError::UndoFetchFailure)
         };
         match tx_source {
             TransactionSource::Chain(block_id) => {
@@ -848,9 +845,7 @@ where
         tx: &SignedTransaction,
     ) -> Result<(), ConnectTransactionError> {
         let block_undo_fetcher = |id: Id<Block>| {
-            self.storage
-                .get_undo_data(id)
-                .map_err(|_| ConnectTransactionError::UndoFetchFailure)
+            self.storage.get_undo_data(id).map_err(|_| ConnectTransactionError::UndoFetchFailure)
         };
         let tx_undo = self.utxo_block_undo.take_tx_undo(
             tx_source,
@@ -914,9 +909,7 @@ where
         let tx_source = TransactionSource::Chain(block.get_id());
 
         let block_undo_fetcher = |id: Id<Block>| {
-            self.storage
-                .get_undo_data(id)
-                .map_err(|_| ConnectTransactionError::UndoFetchFailure)
+            self.storage.get_undo_data(id).map_err(|_| ConnectTransactionError::UndoFetchFailure)
         };
         let reward_undo =
             self.utxo_block_undo.take_block_reward_undo(&tx_source, block_undo_fetcher)?;

--- a/chainstate/tx-verifier/src/transaction_verifier/reward_distribution.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/reward_distribution.rs
@@ -96,10 +96,8 @@ pub fn distribute_pos_reward<P: PoSAccountingView>(
         .operations(TransactionSource::Chain(block_id))
         .increase_pool_pledge_amount(pool_id, total_owner_reward)?;
 
-    let undos = delegation_undos
-        .into_iter()
-        .chain(std::iter::once(increase_pool_balance_undo))
-        .collect();
+    let undos =
+        delegation_undos.into_iter().chain(std::iter::once(increase_pool_balance_undo)).collect();
 
     Ok(AccountingBlockRewardUndo::new(undos))
 }
@@ -110,9 +108,9 @@ fn calculate_pool_owner_reward(
     mpt: PerThousand,
 ) -> Option<Amount> {
     let pool_owner_reward = match total_reward - cost_per_block {
-        Some(v) => (v * mpt.value().into())
-            .and_then(|v| v / 1000)
-            .and_then(|v| v + cost_per_block)?,
+        Some(v) => {
+            (v * mpt.value().into()).and_then(|v| v / 1000).and_then(|v| v + cost_per_block)?
+        }
         // if cost per block > total reward then give the reward to pool owner
         None => total_reward,
     };
@@ -501,11 +499,7 @@ mod tests {
         let expected_pool_balance = (original_pool_balance + reward).unwrap();
         assert_eq!(
             expected_pool_balance,
-            accounting_adapter
-                .accounting_delta()
-                .get_pool_balance(pool_id)
-                .unwrap()
-                .unwrap()
+            accounting_adapter.accounting_delta().get_pool_balance(pool_id).unwrap().unwrap()
         );
 
         let (consumed_data, _) = accounting_adapter.consume();

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_check.rs
@@ -54,14 +54,8 @@ where
     inputs.iter().enumerate().try_for_each(|(input_idx, input)| {
         // TODO: ensure that signature verification is tested in the test-suite, they seem to be tested only internally
         let destination = destination_getter.call(input)?;
-        verify_signature(
-            chain_config,
-            &destination,
-            transactable,
-            &inputs_utxos,
-            input_idx,
-        )
-        .map_err(ConnectTransactionError::SignatureVerificationFailed)
+        verify_signature(chain_config, &destination, transactable, &inputs_utxos, input_idx)
+            .map_err(ConnectTransactionError::SignatureVerificationFailed)
     })
 }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/signature_destination_getter.rs
@@ -134,9 +134,7 @@ impl<'a> SignatureDestinationGetter<'a> {
                 }
             };
 
-        Self {
-            f: Box::new(destination_getter),
-        }
+        Self { f: Box::new(destination_getter) }
     }
 
     pub fn new_for_block_reward<U: UtxosView>(utxos_view: &'a U) -> Self {
@@ -185,9 +183,7 @@ impl<'a> SignatureDestinationGetter<'a> {
                 }
             };
 
-        Self {
-            f: Box::new(destination_getter),
-        }
+        Self { f: Box::new(destination_getter) }
     }
 
     #[allow(dead_code)]

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
@@ -75,27 +75,12 @@ fn hierarchy_test_utxo(#[case] seed: Seed) {
         verifier
     };
 
-    assert_eq!(
-        verifier1.get_utxo(&outpoint0).unwrap().as_ref(),
-        Some(&utxo0)
-    );
-    assert_eq!(
-        verifier1.get_utxo(&outpoint1).unwrap().as_ref(),
-        Some(&utxo1)
-    );
+    assert_eq!(verifier1.get_utxo(&outpoint0).unwrap().as_ref(), Some(&utxo0));
+    assert_eq!(verifier1.get_utxo(&outpoint1).unwrap().as_ref(), Some(&utxo1));
     assert_eq!(verifier1.get_utxo(&outpoint2).unwrap(), None);
-    assert_eq!(
-        verifier2.get_utxo(&outpoint0).unwrap().as_ref(),
-        Some(&utxo0)
-    );
-    assert_eq!(
-        verifier2.get_utxo(&outpoint1).unwrap().as_ref(),
-        Some(&utxo1)
-    );
-    assert_eq!(
-        verifier2.get_utxo(&outpoint2).unwrap().as_ref(),
-        Some(&utxo2)
-    );
+    assert_eq!(verifier2.get_utxo(&outpoint0).unwrap().as_ref(), Some(&utxo0));
+    assert_eq!(verifier2.get_utxo(&outpoint1).unwrap().as_ref(), Some(&utxo1));
+    assert_eq!(verifier2.get_utxo(&outpoint2).unwrap().as_ref(), Some(&utxo2));
 }
 
 // Create the following hierarchy:
@@ -162,10 +147,7 @@ fn hierarchy_test_undo_from_chain(#[case] seed: Seed) {
             TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
         verifier.utxo_block_undo = UtxosBlockUndoCache::new_for_test(BTreeMap::from([(
             TransactionSource::Chain(block_undo_id_1),
-            UtxosBlockUndoEntry {
-                undo: block_undo_1.clone(),
-                is_fresh: true,
-            },
+            UtxosBlockUndoEntry { undo: block_undo_1.clone(), is_fresh: true },
         )]));
         verifier
     };
@@ -174,35 +156,17 @@ fn hierarchy_test_undo_from_chain(#[case] seed: Seed) {
         let mut verifier = verifier1.derive_child();
         verifier.utxo_block_undo = UtxosBlockUndoCache::new_for_test(BTreeMap::from([(
             TransactionSource::Chain(block_undo_id_2),
-            UtxosBlockUndoEntry {
-                undo: block_undo_2.clone(),
-                is_fresh: true,
-            },
+            UtxosBlockUndoEntry { undo: block_undo_2.clone(), is_fresh: true },
         )]));
         verifier
     };
 
-    assert_eq!(
-        verifier1.get_undo_data(block_undo_id_0).unwrap().as_ref(),
-        Some(&block_undo_0)
-    );
-    assert_eq!(
-        verifier1.get_undo_data(block_undo_id_1).unwrap().as_ref(),
-        Some(&block_undo_1)
-    );
+    assert_eq!(verifier1.get_undo_data(block_undo_id_0).unwrap().as_ref(), Some(&block_undo_0));
+    assert_eq!(verifier1.get_undo_data(block_undo_id_1).unwrap().as_ref(), Some(&block_undo_1));
     assert_eq!(verifier1.get_undo_data(block_undo_id_2).unwrap(), None);
-    assert_eq!(
-        verifier2.get_undo_data(block_undo_id_0).unwrap().as_ref(),
-        Some(&block_undo_0)
-    );
-    assert_eq!(
-        verifier2.get_undo_data(block_undo_id_1).unwrap().as_ref(),
-        Some(&block_undo_1)
-    );
-    assert_eq!(
-        verifier2.get_undo_data(block_undo_id_2).unwrap().as_ref(),
-        Some(&block_undo_2)
-    );
+    assert_eq!(verifier2.get_undo_data(block_undo_id_0).unwrap().as_ref(), Some(&block_undo_0));
+    assert_eq!(verifier2.get_undo_data(block_undo_id_1).unwrap().as_ref(), Some(&block_undo_1));
+    assert_eq!(verifier2.get_undo_data(block_undo_id_2).unwrap().as_ref(), Some(&block_undo_2));
 }
 
 // Create the following hierarchy:
@@ -263,28 +227,13 @@ fn hierarchy_test_tx_index(#[case] seed: Seed) {
         verifier
     };
 
-    assert_eq!(
-        verifier1.get_mainchain_tx_index(&outpoint0).unwrap().as_ref(),
-        Some(&tx_index_0)
-    );
-    assert_eq!(
-        verifier1.get_mainchain_tx_index(&outpoint1).unwrap().as_ref(),
-        Some(&tx_index_1)
-    );
+    assert_eq!(verifier1.get_mainchain_tx_index(&outpoint0).unwrap().as_ref(), Some(&tx_index_0));
+    assert_eq!(verifier1.get_mainchain_tx_index(&outpoint1).unwrap().as_ref(), Some(&tx_index_1));
     assert_eq!(verifier1.get_mainchain_tx_index(&outpoint2).unwrap(), None);
 
-    assert_eq!(
-        verifier2.get_mainchain_tx_index(&outpoint0).unwrap(),
-        Some(tx_index_0)
-    );
-    assert_eq!(
-        verifier2.get_mainchain_tx_index(&outpoint1).unwrap(),
-        Some(tx_index_1)
-    );
-    assert_eq!(
-        verifier2.get_mainchain_tx_index(&outpoint2).unwrap(),
-        Some(tx_index_2)
-    );
+    assert_eq!(verifier2.get_mainchain_tx_index(&outpoint0).unwrap(), Some(tx_index_0));
+    assert_eq!(verifier2.get_mainchain_tx_index(&outpoint1).unwrap(), Some(tx_index_1));
+    assert_eq!(verifier2.get_mainchain_tx_index(&outpoint2).unwrap(), Some(tx_index_2));
 }
 
 // Create the following hierarchy:
@@ -367,27 +316,12 @@ fn hierarchy_test_tokens(#[case] seed: Seed) {
         verifier
     };
 
-    assert_eq!(
-        verifier1.get_token_aux_data(&token_id_0).unwrap().as_ref(),
-        Some(&token_data_0)
-    );
-    assert_eq!(
-        verifier1.get_token_aux_data(&token_id_1).unwrap().as_ref(),
-        Some(&token_data_1)
-    );
+    assert_eq!(verifier1.get_token_aux_data(&token_id_0).unwrap().as_ref(), Some(&token_data_0));
+    assert_eq!(verifier1.get_token_aux_data(&token_id_1).unwrap().as_ref(), Some(&token_data_1));
     assert_eq!(verifier1.get_token_aux_data(&token_id_2).unwrap(), None);
-    assert_eq!(
-        verifier2.get_token_aux_data(&token_id_0).unwrap().as_ref(),
-        Some(&token_data_0)
-    );
-    assert_eq!(
-        verifier2.get_token_aux_data(&token_id_1).unwrap().as_ref(),
-        Some(&token_data_1)
-    );
-    assert_eq!(
-        verifier2.get_token_aux_data(&token_id_2).unwrap().as_ref(),
-        Some(&token_data_2)
-    );
+    assert_eq!(verifier2.get_token_aux_data(&token_id_0).unwrap().as_ref(), Some(&token_data_0));
+    assert_eq!(verifier2.get_token_aux_data(&token_id_1).unwrap().as_ref(), Some(&token_data_1));
+    assert_eq!(verifier2.get_token_aux_data(&token_id_2).unwrap().as_ref(), Some(&token_data_2));
 
     assert_eq!(
         verifier1
@@ -551,10 +485,7 @@ fn hierarchy_test_stake_pool(#[case] seed: Seed) {
         verifier.accounting_block_undo =
             AccountingBlockUndoCache::new_for_test(BTreeMap::from([(
                 TransactionSource::Chain(block_undo_id_1),
-                AccountingBlockUndoEntry {
-                    undo: block_undo,
-                    is_fresh: true,
-                },
+                AccountingBlockUndoEntry { undo: block_undo, is_fresh: true },
             )]));
         verifier
     };
@@ -576,64 +507,28 @@ fn hierarchy_test_stake_pool(#[case] seed: Seed) {
         verifier.accounting_block_undo =
             AccountingBlockUndoCache::new_for_test(BTreeMap::from([(
                 TransactionSource::Chain(block_undo_id_2),
-                AccountingBlockUndoEntry {
-                    undo: block_undo,
-                    is_fresh: true,
-                },
+                AccountingBlockUndoEntry { undo: block_undo, is_fresh: true },
             )]));
         verifier
     };
 
     // fetch pool balances
-    assert_eq!(
-        verifier1.get_pool_balance(pool_id_0).unwrap().as_ref(),
-        Some(&pool_balance0)
-    );
-    assert_eq!(
-        verifier1.get_pool_balance(pool_id_1).unwrap().as_ref(),
-        Some(&pool_balance1)
-    );
-    assert_eq!(
-        verifier1.get_pool_balance(pool_id_2).unwrap().as_ref(),
-        None
-    );
+    assert_eq!(verifier1.get_pool_balance(pool_id_0).unwrap().as_ref(), Some(&pool_balance0));
+    assert_eq!(verifier1.get_pool_balance(pool_id_1).unwrap().as_ref(), Some(&pool_balance1));
+    assert_eq!(verifier1.get_pool_balance(pool_id_2).unwrap().as_ref(), None);
 
-    assert_eq!(
-        verifier2.get_pool_balance(pool_id_0).unwrap().as_ref(),
-        Some(&pool_balance0)
-    );
-    assert_eq!(
-        verifier2.get_pool_balance(pool_id_1).unwrap().as_ref(),
-        Some(&pool_balance1)
-    );
-    assert_eq!(
-        verifier2.get_pool_balance(pool_id_2).unwrap().as_ref(),
-        Some(&pool_balance2)
-    );
+    assert_eq!(verifier2.get_pool_balance(pool_id_0).unwrap().as_ref(), Some(&pool_balance0));
+    assert_eq!(verifier2.get_pool_balance(pool_id_1).unwrap().as_ref(), Some(&pool_balance1));
+    assert_eq!(verifier2.get_pool_balance(pool_id_2).unwrap().as_ref(), Some(&pool_balance2));
 
     // fetch pool data
-    assert_eq!(
-        verifier1.get_pool_data(pool_id_0).unwrap(),
-        Some(pool_data0.clone().into())
-    );
-    assert_eq!(
-        verifier1.get_pool_data(pool_id_1).unwrap(),
-        Some(pool_data1.clone().into())
-    );
+    assert_eq!(verifier1.get_pool_data(pool_id_0).unwrap(), Some(pool_data0.clone().into()));
+    assert_eq!(verifier1.get_pool_data(pool_id_1).unwrap(), Some(pool_data1.clone().into()));
     assert_eq!(verifier1.get_pool_data(pool_id_2).unwrap(), None);
 
-    assert_eq!(
-        verifier2.get_pool_data(pool_id_0).unwrap(),
-        Some(pool_data0.into())
-    );
-    assert_eq!(
-        verifier2.get_pool_data(pool_id_1).unwrap(),
-        Some(pool_data1.into())
-    );
-    assert_eq!(
-        verifier2.get_pool_data(pool_id_2).unwrap(),
-        Some(pool_data2.into())
-    );
+    assert_eq!(verifier2.get_pool_data(pool_id_0).unwrap(), Some(pool_data0.into()));
+    assert_eq!(verifier2.get_pool_data(pool_id_1).unwrap(), Some(pool_data1.into()));
+    assert_eq!(verifier2.get_pool_data(pool_id_2).unwrap(), Some(pool_data2.into()));
 
     // fetch undo
     assert!(verifier1.get_accounting_undo(block_undo_id_0).unwrap().is_none());
@@ -693,26 +588,11 @@ fn hierarchy_test_nonce(#[case] seed: Seed) {
         verifier
     };
 
-    assert_eq!(
-        verifier1.get_account_nonce_count(account0).unwrap(),
-        Some(nonce0)
-    );
-    assert_eq!(
-        verifier1.get_account_nonce_count(account1).unwrap(),
-        Some(nonce1)
-    );
+    assert_eq!(verifier1.get_account_nonce_count(account0).unwrap(), Some(nonce0));
+    assert_eq!(verifier1.get_account_nonce_count(account1).unwrap(), Some(nonce1));
     assert_eq!(verifier1.get_account_nonce_count(account2).unwrap(), None);
 
-    assert_eq!(
-        verifier2.get_account_nonce_count(account0).unwrap(),
-        Some(nonce0)
-    );
-    assert_eq!(
-        verifier2.get_account_nonce_count(account1).unwrap(),
-        Some(nonce1)
-    );
-    assert_eq!(
-        verifier2.get_account_nonce_count(account2).unwrap(),
-        Some(nonce2)
-    );
+    assert_eq!(verifier2.get_account_nonce_count(account0).unwrap(), Some(nonce0));
+    assert_eq!(verifier2.get_account_nonce_count(account1).unwrap(), Some(nonce1));
+    assert_eq!(verifier2.get_account_nonce_count(account2).unwrap(), Some(nonce2));
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
@@ -56,11 +56,7 @@ fn hierarchy_test_utxo(#[case] seed: Seed) {
         .with(eq(outpoint0.clone()))
         .times(2)
         .return_const(Ok(Some(utxo0.clone())));
-    store
-        .expect_get_utxo()
-        .with(eq(outpoint2.clone()))
-        .times(1)
-        .return_const(Ok(None));
+    store.expect_get_utxo().with(eq(outpoint2.clone())).times(1).return_const(Ok(None));
 
     let verifier1 = {
         let mut verifier =
@@ -136,11 +132,7 @@ fn hierarchy_test_undo_from_chain(#[case] seed: Seed) {
         .with(eq(block_undo_id_0))
         .times(2)
         .return_const(Ok(Some(block_undo_0.clone())));
-    store
-        .expect_get_undo_data()
-        .with(eq(block_undo_id_2))
-        .times(1)
-        .return_const(Ok(None));
+    store.expect_get_undo_data().with(eq(block_undo_id_2)).times(1).return_const(Ok(None));
 
     let verifier1 = {
         let mut verifier =
@@ -280,11 +272,7 @@ fn hierarchy_test_tokens(#[case] seed: Seed) {
         .with(eq(token_data_0.issuance_tx().get_id()))
         .times(2)
         .return_const(Ok(Some(token_id_0)));
-    store
-        .expect_get_token_aux_data()
-        .with(eq(token_id_2))
-        .times(1)
-        .return_const(Ok(None));
+    store.expect_get_token_aux_data().with(eq(token_id_2)).times(1).return_const(Ok(None));
     store
         .expect_get_token_id_from_issuance_tx()
         .with(eq(token_data_2.issuance_tx().get_id()))
@@ -437,16 +425,8 @@ fn hierarchy_test_stake_pool(#[case] seed: Seed) {
         .with(eq(pool_id_0))
         .times(2)
         .return_const(Ok(Some(pool_balance0)));
-    store
-        .expect_get_pool_balance()
-        .with(eq(pool_id_1))
-        .times(3)
-        .return_const(Ok(None));
-    store
-        .expect_get_pool_balance()
-        .with(eq(pool_id_2))
-        .times(3)
-        .return_const(Ok(None));
+    store.expect_get_pool_balance().with(eq(pool_id_1)).times(3).return_const(Ok(None));
+    store.expect_get_pool_balance().with(eq(pool_id_2)).times(3).return_const(Ok(None));
 
     store
         .expect_get_pool_data()
@@ -456,16 +436,8 @@ fn hierarchy_test_stake_pool(#[case] seed: Seed) {
     store.expect_get_pool_data().with(eq(pool_id_1)).times(1).return_const(Ok(None));
     store.expect_get_pool_data().with(eq(pool_id_2)).times(2).return_const(Ok(None));
 
-    store
-        .expect_get_accounting_undo()
-        .with(eq(block_undo_id_0))
-        .times(2)
-        .return_const(Ok(None));
-    store
-        .expect_get_accounting_undo()
-        .with(eq(block_undo_id_2))
-        .times(1)
-        .return_const(Ok(None));
+    store.expect_get_accounting_undo().with(eq(block_undo_id_0)).times(2).return_const(Ok(None));
+    store.expect_get_accounting_undo().with(eq(block_undo_id_2)).times(1).return_const(Ok(None));
 
     let verifier1 = {
         let mut verifier =
@@ -569,11 +541,7 @@ fn hierarchy_test_nonce(#[case] seed: Seed) {
         .with(eq(account0))
         .times(2)
         .return_const(Ok(Some(nonce0)));
-    store
-        .expect_get_account_nonce_count()
-        .with(eq(account2))
-        .times(1)
-        .return_const(Ok(None));
+    store.expect_get_account_nonce_count().with(eq(account2)).times(1).return_const(Ok(None));
 
     let verifier1 = {
         let mut verifier =

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -73,10 +73,7 @@ fn utxo_set_from_chain_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_utxo_undo_data()
         .with(eq(TransactionSource::Chain(block_1_id)), eq(block_1_undo.clone()))
@@ -139,10 +136,7 @@ fn tx_index_set_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_mainchain_tx_index()
         .with(eq(outpoint1.clone()), eq(tx_index_1.clone()))
@@ -207,10 +201,7 @@ fn tokens_set_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_token_aux_data()
         .with(eq(token_id_1), eq(token_data_1.clone()))
@@ -286,16 +277,8 @@ fn utxo_del_from_chain_hierarchy(#[case] seed: Seed) {
 
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
-    store
-        .expect_get_utxo()
-        .with(eq(outpoint1.clone()))
-        .times(1)
-        .return_const(Ok(Some(utxo1)));
-    store
-        .expect_get_utxo()
-        .with(eq(outpoint2.clone()))
-        .times(1)
-        .return_const(Ok(Some(utxo2)));
+    store.expect_get_utxo().with(eq(outpoint1.clone())).times(1).return_const(Ok(Some(utxo1)));
+    store.expect_get_utxo().with(eq(outpoint2.clone())).times(1).return_const(Ok(Some(utxo2)));
 
     store
         .expect_del_utxo_undo_data()
@@ -308,10 +291,7 @@ fn utxo_del_from_chain_hierarchy(#[case] seed: Seed) {
         .times(1)
         .return_const(Ok(()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
@@ -359,20 +339,9 @@ fn tx_index_del_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
-    store
-        .expect_del_mainchain_tx_index()
-        .with(eq(outpoint1.clone()))
-        .times(1)
-        .return_const(Ok(()));
-    store
-        .expect_del_mainchain_tx_index()
-        .with(eq(outpoint2.clone()))
-        .times(1)
-        .return_const(Ok(()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_del_mainchain_tx_index().with(eq(outpoint1.clone())).times(1).return_const(Ok(()));
+    store.expect_del_mainchain_tx_index().with(eq(outpoint2.clone())).times(1).return_const(Ok(()));
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
@@ -420,20 +389,9 @@ fn tokens_del_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
-    store
-        .expect_del_token_aux_data()
-        .with(eq(token_id_1))
-        .times(1)
-        .return_const(Ok(()));
-    store
-        .expect_del_token_aux_data()
-        .with(eq(token_id_2))
-        .times(1)
-        .return_const(Ok(()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_del_token_aux_data().with(eq(token_id_1)).times(1).return_const(Ok(()));
+    store.expect_del_token_aux_data().with(eq(token_id_2)).times(1).return_const(Ok(()));
     store.expect_del_token_id().with(eq(tx_id_1)).times(1).return_const(Ok(()));
     store.expect_del_token_id().with(eq(tx_id_2)).times(1).return_const(Ok(()));
 
@@ -481,10 +439,7 @@ fn utxo_conflict_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
@@ -555,10 +510,7 @@ fn block_undo_from_chain_conflict_hierarchy(#[case] seed: Seed) {
         .times(1)
         .return_const(Ok(()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
@@ -608,10 +560,7 @@ fn tx_index_conflict_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_mainchain_tx_index()
         .with(eq(outpoint1.clone()), eq(tx_index_2.clone()))
@@ -670,10 +619,7 @@ fn tokens_conflict_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_token_aux_data()
         .with(eq(token_id_1), eq(token_data_1.clone()))
@@ -744,21 +690,10 @@ fn pos_accounting_stake_pool_set_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
 
-    store
-        .expect_get_pool_balance()
-        .with(eq(pool_id_1))
-        .times(1)
-        .return_const(Ok(None));
-    store
-        .expect_get_pool_balance()
-        .with(eq(pool_id_2))
-        .times(1)
-        .return_const(Ok(None));
+    store.expect_get_pool_balance().with(eq(pool_id_1)).times(1).return_const(Ok(None));
+    store.expect_get_pool_balance().with(eq(pool_id_2)).times(1).return_const(Ok(None));
 
     store.expect_get_pool_data().with(eq(pool_id_1)).times(1).return_const(Ok(None));
     store.expect_get_pool_data().with(eq(pool_id_2)).times(1).return_const(Ok(None));
@@ -812,10 +747,7 @@ fn pos_accounting_stake_pool_undo_set_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
 
     store.expect_get_pool_balance().return_const(Ok(None));
     store.expect_get_pool_data().return_const(Ok(None));
@@ -900,10 +832,7 @@ fn pos_accounting_stake_pool_undo_del_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
 
     store.expect_get_pool_balance().return_const(Ok(None));
     store.expect_get_pool_data().return_const(Ok(None));
@@ -973,10 +902,7 @@ fn nonce_set_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_account_nonce_count()
         .with(eq(account1), eq(nonce1))
@@ -1026,20 +952,9 @@ fn nonce_del_hierarchy(#[case] seed: Seed) {
     let mut store = mock::MockStore::new();
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store.expect_batch_write().times(1).return_const(Ok(()));
-    store
-        .expect_batch_write_delta()
-        .times(1)
-        .return_const(Ok(DeltaMergeUndo::new()));
-    store
-        .expect_del_account_nonce_count()
-        .with(eq(account0))
-        .times(1)
-        .return_const(Ok(()));
-    store
-        .expect_del_account_nonce_count()
-        .with(eq(account1))
-        .times(1)
-        .return_const(Ok(()));
+    store.expect_batch_write_delta().times(1).return_const(Ok(DeltaMergeUndo::new()));
+    store.expect_del_account_nonce_count().with(eq(account0)).times(1).return_const(Ok(()));
+    store.expect_del_account_nonce_count().with(eq(account1)).times(1).return_const(Ok(()));
 
     let mut verifier1 =
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -79,18 +79,12 @@ fn utxo_set_from_chain_hierarchy(#[case] seed: Seed) {
         .return_const(Ok(DeltaMergeUndo::new()));
     store
         .expect_set_utxo_undo_data()
-        .with(
-            eq(TransactionSource::Chain(block_1_id)),
-            eq(block_1_undo.clone()),
-        )
+        .with(eq(TransactionSource::Chain(block_1_id)), eq(block_1_undo.clone()))
         .times(1)
         .return_const(Ok(()));
     store
         .expect_set_utxo_undo_data()
-        .with(
-            eq(TransactionSource::Chain(block_2_id)),
-            eq(block_2_undo.clone()),
-        )
+        .with(eq(TransactionSource::Chain(block_2_id)), eq(block_2_undo.clone()))
         .times(1)
         .return_const(Ok(()));
 
@@ -99,10 +93,7 @@ fn utxo_set_from_chain_hierarchy(#[case] seed: Seed) {
     verifier1.utxo_cache.add_utxo(&outpoint1, utxo1, false).unwrap();
     verifier1.utxo_block_undo = UtxosBlockUndoCache::new_for_test(BTreeMap::from([(
         TransactionSource::Chain(block_1_id),
-        UtxosBlockUndoEntry {
-            undo: block_1_undo,
-            is_fresh: true,
-        },
+        UtxosBlockUndoEntry { undo: block_1_undo, is_fresh: true },
     )]));
 
     let verifier2 = {
@@ -110,10 +101,7 @@ fn utxo_set_from_chain_hierarchy(#[case] seed: Seed) {
         verifier.utxo_cache.add_utxo(&outpoint2, utxo2, false).unwrap();
         verifier.utxo_block_undo = UtxosBlockUndoCache::new_for_test(BTreeMap::from([(
             TransactionSource::Chain(block_2_id),
-            UtxosBlockUndoEntry {
-                undo: block_2_undo,
-                is_fresh: true,
-            },
+            UtxosBlockUndoEntry { undo: block_2_undo, is_fresh: true },
         )]));
         verifier
     };
@@ -330,10 +318,7 @@ fn utxo_del_from_chain_hierarchy(#[case] seed: Seed) {
     verifier1.utxo_cache.spend_utxo(&outpoint1).unwrap();
     verifier1.utxo_block_undo = UtxosBlockUndoCache::new_for_test(BTreeMap::from([(
         TransactionSource::Chain(block_1_id),
-        UtxosBlockUndoEntry {
-            undo: block_1_undo,
-            is_fresh: false,
-        },
+        UtxosBlockUndoEntry { undo: block_1_undo, is_fresh: false },
     )]));
 
     let verifier2 = {
@@ -341,10 +326,7 @@ fn utxo_del_from_chain_hierarchy(#[case] seed: Seed) {
         verifier.utxo_cache.spend_utxo(&outpoint2).unwrap();
         verifier.utxo_block_undo = UtxosBlockUndoCache::new_for_test(BTreeMap::from([(
             TransactionSource::Chain(block_2_id),
-            UtxosBlockUndoEntry {
-                undo: block_2_undo,
-                is_fresh: false,
-            },
+            UtxosBlockUndoEntry { undo: block_2_undo, is_fresh: false },
         )]));
         verifier
     };
@@ -547,32 +529,20 @@ fn block_undo_from_chain_conflict_hierarchy(#[case] seed: Seed) {
     let tx_1_id: Id<Transaction> = H256::from_low_u64_be(1).into();
     let block_undo_1 = UtxosBlockUndo::new(
         Some(UtxosBlockRewardUndo::new(vec![utxo1.clone()])),
-        BTreeMap::from([(
-            tx_1_id,
-            UtxosTxUndoWithSources::new(vec![Some(utxo2.clone())], vec![]),
-        )]),
+        BTreeMap::from([(tx_1_id, UtxosTxUndoWithSources::new(vec![Some(utxo2.clone())], vec![]))]),
     )
     .unwrap();
     let tx_2_id: Id<Transaction> = H256::from_low_u64_be(2).into();
     let block_undo_2 = UtxosBlockUndo::new(
         Some(UtxosBlockRewardUndo::new(vec![utxo3.clone()])),
-        BTreeMap::from([(
-            tx_2_id,
-            UtxosTxUndoWithSources::new(vec![Some(utxo4.clone())], vec![]),
-        )]),
+        BTreeMap::from([(tx_2_id, UtxosTxUndoWithSources::new(vec![Some(utxo4.clone())], vec![]))]),
     )
     .unwrap();
     let expected_block_undo = UtxosBlockUndo::new(
         Some(UtxosBlockRewardUndo::new(vec![utxo1, utxo3])),
         BTreeMap::from([
-            (
-                tx_1_id,
-                UtxosTxUndoWithSources::new(vec![Some(utxo2)], vec![]),
-            ),
-            (
-                tx_2_id,
-                UtxosTxUndoWithSources::new(vec![Some(utxo4)], vec![]),
-            ),
+            (tx_1_id, UtxosTxUndoWithSources::new(vec![Some(utxo2)], vec![])),
+            (tx_2_id, UtxosTxUndoWithSources::new(vec![Some(utxo4)], vec![])),
         ]),
     )
     .unwrap();
@@ -581,10 +551,7 @@ fn block_undo_from_chain_conflict_hierarchy(#[case] seed: Seed) {
     store.expect_get_best_block_for_utxos().return_const(Ok(H256::zero().into()));
     store
         .expect_set_utxo_undo_data()
-        .with(
-            eq(TransactionSource::Chain(block_id)),
-            eq(expected_block_undo),
-        )
+        .with(eq(TransactionSource::Chain(block_id)), eq(expected_block_undo))
         .times(1)
         .return_const(Ok(()));
     store.expect_batch_write().times(1).return_const(Ok(()));
@@ -597,20 +564,14 @@ fn block_undo_from_chain_conflict_hierarchy(#[case] seed: Seed) {
         TransactionVerifier::new(&store, &chain_config, TransactionVerifierConfig::new(true));
     verifier1.utxo_block_undo = UtxosBlockUndoCache::new_for_test(BTreeMap::from([(
         TransactionSource::Chain(block_id),
-        UtxosBlockUndoEntry {
-            undo: block_undo_1,
-            is_fresh: true,
-        },
+        UtxosBlockUndoEntry { undo: block_undo_1, is_fresh: true },
     )]));
 
     let verifier2 = {
         let mut verifier = verifier1.derive_child();
         verifier.utxo_block_undo = UtxosBlockUndoCache::new_for_test(BTreeMap::from([(
             TransactionSource::Chain(block_id),
-            UtxosBlockUndoEntry {
-                undo: block_undo_2,
-                is_fresh: true,
-            },
+            UtxosBlockUndoEntry { undo: block_undo_2, is_fresh: true },
         )]));
         verifier
     };
@@ -891,10 +852,7 @@ fn pos_accounting_stake_pool_undo_set_hierarchy(#[case] seed: Seed) {
         verifier.accounting_block_undo =
             AccountingBlockUndoCache::new_for_test(BTreeMap::from([(
                 TransactionSource::Chain(block_undo_id_1),
-                AccountingBlockUndoEntry {
-                    undo: block_undo,
-                    is_fresh: true,
-                },
+                AccountingBlockUndoEntry { undo: block_undo, is_fresh: true },
             )]));
         verifier
     };
@@ -917,10 +875,7 @@ fn pos_accounting_stake_pool_undo_set_hierarchy(#[case] seed: Seed) {
         verifier.accounting_block_undo =
             AccountingBlockUndoCache::new_for_test(BTreeMap::from([(
                 TransactionSource::Chain(block_undo_id_2),
-                AccountingBlockUndoEntry {
-                    undo: block_undo,
-                    is_fresh: true,
-                },
+                AccountingBlockUndoEntry { undo: block_undo, is_fresh: true },
             )]));
         verifier
     };
@@ -971,10 +926,7 @@ fn pos_accounting_stake_pool_undo_del_hierarchy(#[case] seed: Seed) {
         verifier.accounting_block_undo =
             AccountingBlockUndoCache::new_for_test(BTreeMap::from([(
                 TransactionSource::Chain(block_undo_id_1),
-                AccountingBlockUndoEntry {
-                    undo: Default::default(),
-                    is_fresh: false,
-                },
+                AccountingBlockUndoEntry { undo: Default::default(), is_fresh: false },
             )]));
         verifier
     };
@@ -985,10 +937,7 @@ fn pos_accounting_stake_pool_undo_del_hierarchy(#[case] seed: Seed) {
         verifier.accounting_block_undo =
             AccountingBlockUndoCache::new_for_test(BTreeMap::from([(
                 TransactionSource::Chain(block_undo_id_2),
-                AccountingBlockUndoEntry {
-                    undo: Default::default(),
-                    is_fresh: false,
-                },
+                AccountingBlockUndoEntry { undo: Default::default(), is_fresh: false },
             )]));
         verifier
     };

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mod.rs
@@ -30,10 +30,8 @@ use crypto::{
 use utxo::Utxo;
 
 fn create_utxo(rng: &mut (impl Rng + CryptoRng), value: UnsignedIntType) -> (UtxoOutPoint, Utxo) {
-    let outpoint = UtxoOutPoint::new(
-        OutPointSourceId::Transaction(Id::new(H256::random_using(rng))),
-        0,
-    );
+    let outpoint =
+        UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::random_using(rng))), 0);
     let (_, pub_key1) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
     let output1 = TxOutput::Transfer(
         OutputValue::Coin(Amount::from_atoms(value)),

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -61,9 +61,8 @@ fn check_timelock(
         OutputTimeLock::UntilHeight(h) => spend_height >= h,
         OutputTimeLock::UntilTime(t) => spending_time >= t,
         OutputTimeLock::ForBlockCount(d) => {
-            let d: i64 = (*d)
-                .try_into()
-                .map_err(|_| ConnectTransactionError::BlockHeightArithmeticError)?;
+            let d: i64 =
+                (*d).try_into().map_err(|_| ConnectTransactionError::BlockHeightArithmeticError)?;
             let d = BlockDistance::from(d);
             *spend_height
                 >= (source_block_height + d)

--- a/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/timelock_check.rs
@@ -77,10 +77,7 @@ fn check_timelock(
         }
     };
 
-    ensure!(
-        past_lock,
-        ConnectTransactionError::TimeLockViolation(outpoint.clone())
-    );
+    ensure!(past_lock, ConnectTransactionError::TimeLockViolation(outpoint.clone()));
 
     Ok(())
 }
@@ -269,8 +266,8 @@ pub fn check_output_maturity_setting(
         }
         OutputTimeLock::UntilHeight(_)
         | OutputTimeLock::UntilTime(_)
-        | OutputTimeLock::ForSeconds(_) => Err(
-            OutputMaturityError::InvalidOutputMaturitySettingType(outpoint),
-        ),
+        | OutputTimeLock::ForSeconds(_) => {
+            Err(OutputMaturityError::InvalidOutputMaturitySettingType(outpoint))
+        }
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/token_issuance_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/token_issuance_cache.rs
@@ -50,10 +50,7 @@ pub struct TokenIssuanceCache {
 
 impl TokenIssuanceCache {
     pub fn new() -> Self {
-        Self {
-            data: BTreeMap::new(),
-            txid_vs_tokenid: BTreeMap::new(),
-        }
+        Self { data: BTreeMap::new(), txid_vs_tokenid: BTreeMap::new() }
     }
 
     #[cfg(test)]
@@ -61,10 +58,7 @@ impl TokenIssuanceCache {
         data: BTreeMap<TokenId, CachedAuxDataOp>,
         txid_vs_tokenid: BTreeMap<Id<Transaction>, CachedTokenIndexOp>,
     ) -> Self {
-        Self {
-            data,
-            txid_vs_tokenid,
-        }
+        Self { data, txid_vs_tokenid }
     }
 
     // Token registration saves the token id in the database with the transaction that issued it, and possibly some additional auxiliary data;
@@ -112,9 +106,9 @@ impl TokenIssuanceCache {
     ) -> Result<(), TokensError> {
         match self.data.entry(token_id) {
             Entry::Occupied(mut entry) => match entry.get() {
-                CachedOperation::Write(_) | CachedOperation::Read(_) => Err(
-                    TokensError::InvariantBrokenRegisterIssuanceWithDuplicateId(token_id),
-                ),
+                CachedOperation::Write(_) | CachedOperation::Read(_) => {
+                    Err(TokensError::InvariantBrokenRegisterIssuanceWithDuplicateId(token_id))
+                }
                 CachedOperation::Erase => {
                     entry.insert(new_op);
                     Ok(())
@@ -134,9 +128,7 @@ impl TokenIssuanceCache {
                 e.insert(CachedAuxDataOp::Erase);
             }
             Entry::Vacant(_) => {
-                return Err(TokensError::InvariantBrokenUndoIssuanceOnNonexistentToken(
-                    token_id,
-                ))
+                return Err(TokensError::InvariantBrokenUndoIssuanceOnNonexistentToken(token_id))
             }
         }
         self.del_token_id(&tx.get_id())?;
@@ -208,10 +200,7 @@ impl TokenIssuanceCache {
     }
 
     pub fn consume(self) -> ConsumedTokenIssuanceCache {
-        ConsumedTokenIssuanceCache {
-            data: self.data,
-            txid_vs_tokenid: self.txid_vs_tokenid,
-        }
+        ConsumedTokenIssuanceCache { data: self.data, txid_vs_tokenid: self.txid_vs_tokenid }
     }
 }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/token_issuance_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/token_issuance_cache.rs
@@ -181,8 +181,7 @@ impl TokenIssuanceCache {
         issuance_tx_id: &Id<Transaction>,
         token_id: &TokenId,
     ) -> Result<(), TokensError> {
-        self.txid_vs_tokenid
-            .insert(*issuance_tx_id, CachedTokenIndexOp::Write(*token_id));
+        self.txid_vs_tokenid.insert(*issuance_tx_id, CachedTokenIndexOp::Write(*token_id));
         Ok(())
     }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/transferred_amount_check.rs
@@ -46,10 +46,7 @@ fn get_total_fee(
     let inputs_total = *inputs_total_map.get(&CoinOrTokenId::Coin).unwrap_or(&Amount::ZERO);
     (inputs_total - outputs_total)
         .map(Fee)
-        .ok_or(ConnectTransactionError::TxFeeTotalCalcFailed(
-            inputs_total,
-            outputs_total,
-        ))
+        .ok_or(ConnectTransactionError::TxFeeTotalCalcFailed(inputs_total, outputs_total))
 }
 
 fn check_transferred_amount(
@@ -164,9 +161,7 @@ where
                 let total_balance = pos_accounting_view
                     .get_delegation_balance(*delegation_id)
                     .map_err(|_| pos_accounting::Error::ViewFail)?
-                    .ok_or(ConnectTransactionError::DelegationBalanceNotFound(
-                        *delegation_id,
-                    ))?;
+                    .ok_or(ConnectTransactionError::DelegationBalanceNotFound(*delegation_id))?;
                 ensure!(
                     total_balance >= *withdraw_amount,
                     ConnectTransactionError::AttemptToPrintMoney(total_balance, *withdraw_amount)
@@ -654,10 +649,8 @@ mod tests {
             AccountNonce::new(0),
             AccountSpending::Delegation(delegation_id, withdraw_amount),
         ));
-        let output = TxOutput::Transfer(
-            OutputValue::Coin(withdraw_amount),
-            Destination::AnyoneCanSpend,
-        );
+        let output =
+            TxOutput::Transfer(OutputValue::Coin(withdraw_amount), Destination::AnyoneCanSpend);
         let tx = Transaction::new(0, vec![input], vec![output]).unwrap();
 
         check_transferred_amounts_and_get_fee(&utxo_db, &pos_accounting_db, &tx, |_id| Ok(None))

--- a/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tx_index_cache.rs
@@ -29,9 +29,7 @@ pub struct TxIndexCache {
 
 impl TxIndexCache {
     pub fn new() -> Self {
-        Self {
-            data: TxIndexMap::new(),
-        }
+        Self { data: TxIndexMap::new() }
     }
 
     #[cfg(test)]
@@ -89,9 +87,7 @@ impl TxIndexCache {
     ) -> Result<&mut CachedInputsOperation, TxIndexError> {
         match self.data.get_mut(outpoint) {
             Some(tx_index) => Ok(tx_index),
-            None => Err(TxIndexError::PreviouslyCachedInputNotFound(
-                outpoint.clone(),
-            )),
+            None => Err(TxIndexError::PreviouslyCachedInputNotFound(outpoint.clone())),
         }
     }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/tx_source.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tx_source.rs
@@ -50,9 +50,9 @@ impl<'a> TransactionSourceForConnect<'a> {
             TransactionSourceForConnect::Chain { new_block_index } => {
                 new_block_index.block_height()
             }
-            TransactionSourceForConnect::Mempool {
-                current_best: best_block_index,
-            } => best_block_index.block_height().next_height(),
+            TransactionSourceForConnect::Mempool { current_best: best_block_index } => {
+                best_block_index.block_height().next_height()
+            }
         }
     }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/utxos_undo_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/utxos_undo_cache.rs
@@ -36,9 +36,7 @@ pub struct UtxosBlockUndoCache {
 
 impl UtxosBlockUndoCache {
     pub fn new() -> Self {
-        Self {
-            data: BTreeMap::new(),
-        }
+        Self { data: BTreeMap::new() }
     }
 
     #[cfg(test)]
@@ -92,10 +90,7 @@ impl UtxosBlockUndoCache {
                     let block_undo = fetcher_func(*block_id)?
                         .ok_or(ConnectTransactionError::MissingBlockUndo(*block_id))?;
                     Ok(&mut entry
-                        .insert(UtxosBlockUndoEntry {
-                            undo: block_undo,
-                            is_fresh: false,
-                        })
+                        .insert(UtxosBlockUndoEntry { undo: block_undo, is_fresh: false })
                         .undo)
                 }
                 TransactionSource::Mempool => Err(ConnectTransactionError::MissingMempoolTxsUndo),
@@ -143,10 +138,7 @@ impl UtxosBlockUndoCache {
         &mut self
             .data
             .entry(*tx_source)
-            .or_insert(UtxosBlockUndoEntry {
-                is_fresh: true,
-                undo: Default::default(),
-            })
+            .or_insert(UtxosBlockUndoEntry { is_fresh: true, undo: Default::default() })
             .undo
     }
 
@@ -157,10 +149,7 @@ impl UtxosBlockUndoCache {
     ) -> Result<(), utxo::UtxosBlockUndoError> {
         match self.data.entry(tx_source) {
             Entry::Vacant(e) => {
-                e.insert(UtxosBlockUndoEntry {
-                    undo: new_undo.clone(),
-                    is_fresh: true,
-                });
+                e.insert(UtxosBlockUndoEntry { undo: new_undo.clone(), is_fresh: true });
             }
             Entry::Occupied(mut e) => {
                 e.get_mut().undo.combine(new_undo.clone())?;
@@ -178,10 +167,7 @@ impl UtxosBlockUndoCache {
             // if current cache doesn't have such data - insert empty undo to be flushed to the parent
             self.data.insert(
                 tx_source,
-                UtxosBlockUndoEntry {
-                    undo: Default::default(),
-                    is_fresh: false,
-                },
+                UtxosBlockUndoEntry { undo: Default::default(), is_fresh: false },
             );
         }
         Ok(())

--- a/chainstate/tx-verifier/src/transaction_verifier/utxos_undo_cache.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/utxos_undo_cache.rs
@@ -113,9 +113,7 @@ impl UtxosBlockUndoCache {
         if block_undo.has_children_of(tx_id) {
             Err(ConnectTransactionError::TxUndoWithDependency(*tx_id))
         } else {
-            block_undo
-                .take_tx_undo(tx_id)
-                .ok_or(ConnectTransactionError::MissingTxUndo(*tx_id))
+            block_undo.take_tx_undo(tx_id).ok_or(ConnectTransactionError::MissingTxUndo(*tx_id))
         }
     }
 

--- a/chainstate/types/src/ancestor.rs
+++ b/chainstate/types/src/ancestor.rs
@@ -113,9 +113,9 @@ pub fn gen_block_index_getter<S: BlockIndexHandle>(
     block_id: &Id<GenBlock>,
 ) -> Result<Option<GenBlockIndex>, PropertyQueryError> {
     match block_id.classify(chain_config) {
-        GenBlockId::Genesis(_id) => Ok(Some(GenBlockIndex::Genesis(Arc::clone(
-            chain_config.genesis_block(),
-        )))),
+        GenBlockId::Genesis(_id) => {
+            Ok(Some(GenBlockIndex::Genesis(Arc::clone(chain_config.genesis_block()))))
+        }
         GenBlockId::Block(id) => db_tx.get_block_index(&id).map(|b| b.map(GenBlockIndex::Block)),
     }
 }

--- a/chainstate/types/src/block_index_history_iter.rs
+++ b/chainstate/types/src/block_index_history_iter.rs
@@ -32,10 +32,7 @@ pub struct BlockIndexHistoryIterator<'a, H> {
 impl<'a, H: BlockIndexHandle> BlockIndexHistoryIterator<'a, H> {
     #[must_use]
     pub fn new(starting_id: Id<GenBlock>, block_index_handle: &'a H) -> Self {
-        Self {
-            next_id: Some(starting_id),
-            block_index_handle,
-        }
+        Self { next_id: Some(starting_id), block_index_handle }
     }
 }
 

--- a/chainstate/types/src/block_status.rs
+++ b/chainstate/types/src/block_status.rs
@@ -34,9 +34,7 @@ impl BlockStatus {
     pub const FULLY_CHECKED: BlockStatus = Self::new_at_stage(BlockValidationStage::FullyChecked);
 
     pub const fn new_at_stage(stage: BlockValidationStage) -> Self {
-        Self {
-            last_successful_validation_stage: stage,
-        }
+        Self { last_successful_validation_stage: stage }
     }
 
     pub const fn new() -> Self {

--- a/chainstate/types/src/epoch_data_cache.rs
+++ b/chainstate/types/src/epoch_data_cache.rs
@@ -45,17 +45,11 @@ pub struct EpochDataCache<P> {
 
 impl<P: EpochStorageRead> EpochDataCache<P> {
     pub fn new(parent: P) -> Self {
-        Self {
-            parent,
-            data: BTreeMap::new(),
-        }
+        Self { parent, data: BTreeMap::new() }
     }
 
     pub fn from_data(parent: P, data: ConsumedEpochDataCache) -> Self {
-        Self {
-            parent,
-            data: data.data,
-        }
+        Self { parent, data: data.data }
     }
 
     pub fn consume(self) -> ConsumedEpochDataCache {

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -65,10 +65,7 @@ pub enum GetAncestorError {
     #[error("Blockchain storage error: {0}")]
     StorageError(#[from] crate::storage_result::Error),
     #[error("Invalid ancestor height: sought ancestor with height {ancestor_height} for block with height {block_height}")]
-    InvalidAncestorHeight {
-        block_height: BlockHeight,
-        ancestor_height: BlockHeight,
-    },
+    InvalidAncestorHeight { block_height: BlockHeight, ancestor_height: BlockHeight },
     #[error("Previous block index not found {0}")]
     PrevBlockIndexNotFound(Id<GenBlock>),
     #[error("Starting point in ancestor getter not found {0}")]

--- a/chainstate/types/src/pos_randomness.rs
+++ b/chainstate/types/src/pos_randomness.rs
@@ -65,9 +65,7 @@ impl PoSRandomness {
 
     /// randomness at genesis
     pub fn at_genesis(chain_config: &ChainConfig) -> Self {
-        Self {
-            value: chain_config.initial_randomness(),
-        }
+        Self { value: chain_config.initial_randomness() }
     }
 
     pub fn value(&self) -> H256 {

--- a/chainstate/types/src/vrf_tools.rs
+++ b/chainstate/types/src/vrf_tools.rs
@@ -44,14 +44,8 @@ pub fn construct_transcript(
             RANDOMNESS_COMPONENT_LABEL,
             TranscriptComponent::RawData(random_seed.as_bytes().to_vec()),
         )
-        .attach(
-            SLOT_COMPONENT_LABEL,
-            TranscriptComponent::U64(block_timestamp.as_int_seconds()),
-        )
-        .attach(
-            EPOCH_INDEX_COMPONENT_LABEL,
-            TranscriptComponent::U64(epoch_index),
-        )
+        .attach(SLOT_COMPONENT_LABEL, TranscriptComponent::U64(block_timestamp.as_int_seconds()))
+        .attach(EPOCH_INDEX_COMPONENT_LABEL, TranscriptComponent::U64(epoch_index))
         .finalize()
 }
 

--- a/common/src/address/mod.rs
+++ b/common/src/address/mod.rs
@@ -100,9 +100,7 @@ impl Address {
     }
 
     pub fn from_str(cfg: &ChainConfig, address: &str) -> Result<Self, AddressError> {
-        let address = Self {
-            address: address.to_owned(),
-        };
+        let address = Self { address: address.to_owned() };
         address.data(cfg)?;
         Ok(address)
     }

--- a/common/src/chain/block/block_body/block_merkle.rs
+++ b/common/src/chain/block/block_body/block_merkle.rs
@@ -49,9 +49,8 @@ fn calcualte_generic_merkle_tree(
 ) -> Result<MerkleTree<H256, MerkleHasher>, MerkleTreeFormError> {
     let rewards_hash = id::hash_encoded(&body.reward);
 
-    let hashes: Vec<H256> = std::iter::once(rewards_hash)
-        .chain(body.transactions.iter().map(tx_hasher))
-        .collect();
+    let hashes: Vec<H256> =
+        std::iter::once(rewards_hash).chain(body.transactions.iter().map(tx_hasher)).collect();
     let tree = MerkleTree::<H256, MerkleHasher>::from_leaves(hashes)?;
     Ok(tree)
 }

--- a/common/src/chain/block/block_body/merkle_proxy.rs
+++ b/common/src/chain/block/block_body/merkle_proxy.rs
@@ -89,11 +89,7 @@ impl<T: tag::MerkleTreeTag> WrappedMerkleTree<T> {
     }
 
     fn internal_block_reward_leaf(&self) -> H256 {
-        *self
-            .merkle_tree
-            .node_from_bottom(0, 0)
-            .expect("Block reward leaf must exist")
-            .hash()
+        *self.merkle_tree.node_from_bottom(0, 0).expect("Block reward leaf must exist").hash()
     }
 
     fn internal_transaction_leaf(&self, index: usize) -> Option<H256> {

--- a/common/src/chain/block/block_body/merkle_proxy.rs
+++ b/common/src/chain/block/block_body/merkle_proxy.rs
@@ -75,10 +75,7 @@ pub struct WrappedMerkleTree<MerkleTreeTag> {
 
 impl<T: tag::MerkleTreeTag> From<MerkleTree<H256, MerkleHasher>> for WrappedMerkleTree<T> {
     fn from(merkle_tree: MerkleTree<H256, MerkleHasher>) -> Self {
-        Self {
-            merkle_tree,
-            _tag: std::marker::PhantomData,
-        }
+        Self { merkle_tree, _tag: std::marker::PhantomData }
     }
 }
 

--- a/common/src/chain/block/block_body/mod.rs
+++ b/common/src/chain/block/block_body/mod.rs
@@ -138,9 +138,7 @@ mod tests {
 
         let outputs = {
             let output_count = 1 + (rng.next_u32() as usize) % 10;
-            (0..output_count)
-                .map(|_| generate_random_invalid_output(rng))
-                .collect::<Vec<_>>()
+            (0..output_count).map(|_| generate_random_invalid_output(rng)).collect::<Vec<_>>()
         };
 
         let flags = rng.gen::<u128>();
@@ -152,9 +150,8 @@ mod tests {
 
     fn generate_random_invalid_block_reward(rng: &mut (impl Rng + CryptoRng)) -> BlockReward {
         let output_count = (rng.next_u32() as usize) % 10;
-        let outputs = (0..output_count)
-            .map(|_| generate_random_invalid_output(rng))
-            .collect::<Vec<_>>();
+        let outputs =
+            (0..output_count).map(|_| generate_random_invalid_output(rng)).collect::<Vec<_>>();
         BlockReward::new(outputs)
     }
 
@@ -165,9 +162,8 @@ mod tests {
         let mut rng = make_seedable_rng(seed);
 
         let reward = generate_random_invalid_block_reward(&mut rng);
-        let transactions = (0..=10)
-            .map(|_| generate_random_invalid_transaction(&mut rng))
-            .collect::<Vec<_>>();
+        let transactions =
+            (0..=10).map(|_| generate_random_invalid_transaction(&mut rng)).collect::<Vec<_>>();
 
         let block_body = BlockBody::new(reward.clone(), transactions.clone());
 
@@ -176,14 +172,11 @@ mod tests {
         let transaction_witness_hashes =
             transactions.iter().map(|tx| tx.serialized_hash()).collect::<Vec<_>>();
 
-        let transaction_ids = transactions
-            .iter()
-            .map(|tx| tx.transaction().get_id().get())
-            .collect::<Vec<_>>();
+        let transaction_ids =
+            transactions.iter().map(|tx| tx.transaction().get_id().get()).collect::<Vec<_>>();
 
-        let expected_merkle_leaves = std::iter::once(block_reward_witness_hash)
-            .chain(transaction_ids)
-            .collect::<Vec<_>>();
+        let expected_merkle_leaves =
+            std::iter::once(block_reward_witness_hash).chain(transaction_ids).collect::<Vec<_>>();
         let expected_witness_merkle_leaves = std::iter::once(block_reward_witness_hash)
             .chain(transaction_witness_hashes)
             .collect::<Vec<_>>();

--- a/common/src/chain/block/block_body/mod.rs
+++ b/common/src/chain/block/block_body/mod.rs
@@ -44,10 +44,7 @@ pub struct BlockBody {
 
 impl BlockBody {
     pub fn new(reward: BlockReward, transactions: Vec<SignedTransaction>) -> Self {
-        Self {
-            reward,
-            transactions,
-        }
+        Self { reward, transactions }
     }
 
     pub fn transactions(&self) -> &[SignedTransaction] {
@@ -199,10 +196,7 @@ mod tests {
         // Check leaf count
         let leaf_count = (transactions.len() + 1).next_power_of_two();
         assert_eq!(merkle_tree.raw_tree().leaf_count().get(), leaf_count as u32);
-        assert_eq!(
-            witness_merkle_tree.raw_tree().leaf_count().get(),
-            leaf_count as u32
-        );
+        assert_eq!(witness_merkle_tree.raw_tree().leaf_count().get(), leaf_count as u32);
 
         // Check leaves hashes
         let merkle_tree_leaves =

--- a/common/src/chain/block/block_reward.rs
+++ b/common/src/chain/block/block_reward.rs
@@ -57,11 +57,7 @@ impl<'a> BlockRewardTransactable<'a> {
         outputs: Option<&'a [TxOutput]>,
         witness: Option<&'a [InputWitness]>,
     ) -> Self {
-        Self {
-            inputs,
-            outputs,
-            witness,
-        }
+        Self { inputs, outputs, witness }
     }
 
     pub fn witness(&self) -> Option<&[InputWitness]> {

--- a/common/src/chain/block/block_size.rs
+++ b/common/src/chain/block/block_size.rs
@@ -40,11 +40,7 @@ impl BlockSize {
     }
 
     fn new_with_header_size(header_size: usize) -> Self {
-        BlockSize {
-            header: header_size,
-            from_txs: 0,
-            from_smart_contracts: 0,
-        }
+        BlockSize { header: header_size, from_txs: 0, from_smart_contracts: 0 }
     }
 
     pub fn size_from_txs(&self) -> usize {

--- a/common/src/chain/block/consensus_data.rs
+++ b/common/src/chain/block/consensus_data.rs
@@ -95,13 +95,7 @@ impl PoSData {
         vrf_data: VRFReturn,
         compact_target: Compact,
     ) -> Self {
-        Self {
-            kernel_inputs,
-            kernel_witness,
-            stake_pool_id,
-            vrf_data,
-            compact_target,
-        }
+        Self { kernel_inputs, kernel_witness, stake_pool_id, vrf_data, compact_target }
     }
 
     pub fn kernel_inputs(&self) -> &[TxInput] {

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -74,10 +74,7 @@ impl Block {
         consensus_data: ConsensusData,
         reward: BlockReward,
     ) -> Result<Self, BlockCreationError> {
-        let body = BlockBody {
-            reward,
-            transactions,
-        };
+        let body = BlockBody { reward, transactions };
 
         let merkle_proxy = body.merkle_tree_proxy()?;
         let tx_merkle_root = merkle_proxy.merkle_tree().root();
@@ -261,10 +258,7 @@ mod tests {
             timestamp: BlockTimestamp::from_int_seconds(rng.gen()),
         };
 
-        let body = BlockBody {
-            reward: BlockReward::new(Vec::new()),
-            transactions: Vec::new(),
-        };
+        let body = BlockBody { reward: BlockReward::new(Vec::new()), transactions: Vec::new() };
 
         let header = header.with_no_signature();
 
@@ -293,10 +287,7 @@ mod tests {
             timestamp: BlockTimestamp::from_int_seconds(rng.gen()),
         };
 
-        let body = BlockBody {
-            reward: BlockReward::new(Vec::new()),
-            transactions: Vec::new(),
-        };
+        let body = BlockBody { reward: BlockReward::new(Vec::new()), transactions: Vec::new() };
 
         let header = header.with_no_signature();
 
@@ -333,10 +324,7 @@ mod tests {
             OutputValue::Coin(Amount::from_atoms(1)),
             Destination::AnyoneCanSpend,
         )]);
-        let body = BlockBody {
-            reward,
-            transactions: Vec::new(),
-        };
+        let body = BlockBody { reward, transactions: Vec::new() };
 
         let header = header.with_no_signature();
 
@@ -363,10 +351,8 @@ mod tests {
         let one_transaction =
             SignedTransaction::new(Transaction::new(0, Vec::new(), Vec::new()).unwrap(), vec![])
                 .expect("invalid witness count");
-        let body = BlockBody {
-            reward: BlockReward::new(Vec::new()),
-            transactions: vec![one_transaction],
-        };
+        let body =
+            BlockBody { reward: BlockReward::new(Vec::new()), transactions: vec![one_transaction] };
 
         let header = header.with_no_signature();
 
@@ -396,10 +382,8 @@ mod tests {
             vec![InputWitness::NoSignature(Some(b"abc".to_vec()))],
         )
         .expect("invalid witness count");
-        let body = BlockBody {
-            reward: BlockReward::new(Vec::new()),
-            transactions: vec![one_transaction],
-        };
+        let body =
+            BlockBody { reward: BlockReward::new(Vec::new()), transactions: vec![one_transaction] };
 
         let merkle_root = body.merkle_tree_proxy().unwrap().merkle_tree().root();
         let witness_merkle_root = body.merkle_tree_proxy().unwrap().witness_merkle_tree().root();
@@ -420,10 +404,7 @@ mod tests {
             timestamp: BlockTimestamp::from_int_seconds(rng.gen()),
         };
 
-        let body = BlockBody {
-            reward: BlockReward::new(Vec::new()),
-            transactions: Vec::new(),
-        };
+        let body = BlockBody { reward: BlockReward::new(Vec::new()), transactions: Vec::new() };
 
         let header = header.with_no_signature();
 

--- a/common/src/chain/block/signed_block_header.rs
+++ b/common/src/chain/block/signed_block_header.rs
@@ -95,9 +95,8 @@ impl SignedBlockHeader {
         &mut self,
         consensus_data: ConsensusData,
     ) -> Result<(), SignedHeaderError> {
-        self.header_mut()
-            .ok_or(SignedHeaderError::AttemptedMutatingSignedHeader)?
-            .consensus_data = consensus_data;
+        self.header_mut().ok_or(SignedHeaderError::AttemptedMutatingSignedHeader)?.consensus_data =
+            consensus_data;
         Ok(())
     }
 

--- a/common/src/chain/block/signed_block_header.rs
+++ b/common/src/chain/block/signed_block_header.rs
@@ -59,10 +59,7 @@ pub struct SignedBlockHeader {
 
 impl SignedBlockHeader {
     pub fn new(signature: BlockHeaderSignature, block_header: BlockHeader) -> Self {
-        Self {
-            signature_data: signature,
-            block_header,
-        }
+        Self { signature_data: signature, block_header }
     }
 
     pub fn signature_data(&self) -> &BlockHeaderSignature {

--- a/common/src/chain/block/timestamp.rs
+++ b/common/src/chain/block/timestamp.rs
@@ -41,9 +41,7 @@ impl BlockTimestamp {
     }
 
     pub fn from_duration_since_epoch(duration: Duration) -> Self {
-        Self {
-            timestamp: duration.as_secs(),
-        }
+        Self { timestamp: duration.as_secs() }
     }
 
     pub fn as_duration_since_epoch(&self) -> Duration {

--- a/common/src/chain/chaintrust/asymptote.rs
+++ b/common/src/chain/chaintrust/asymptote.rs
@@ -145,9 +145,8 @@ mod tests {
 
     #[test]
     fn final_weights_resolvable() {
-        let int_weights = (0..(VEC_SIZE as usize))
-            .map(|t| get_weight_for_timeslot(t as u64))
-            .collect::<Vec<_>>();
+        let int_weights =
+            (0..(VEC_SIZE as usize)).map(|t| get_weight_for_timeslot(t as u64)).collect::<Vec<_>>();
 
         let diffs = int_weights
             .iter()

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -103,9 +103,8 @@ enum GenesisBlockInit {
 }
 
 impl GenesisBlockInit {
-    pub const TEST: Self = GenesisBlockInit::UnitTest {
-        premine_destination: Destination::AnyoneCanSpend,
-    };
+    pub const TEST: Self =
+        GenesisBlockInit::UnitTest { premine_destination: Destination::AnyoneCanSpend };
 }
 
 /// Builder for [ChainConfig]
@@ -238,9 +237,9 @@ impl Builder {
             GenesisBlockInit::Mainnet => create_mainnet_genesis(),
             GenesisBlockInit::Testnet => create_testnet_genesis(),
             GenesisBlockInit::Custom(genesis) => genesis,
-            GenesisBlockInit::UnitTest {
-                premine_destination,
-            } => create_unit_test_genesis(premine_destination),
+            GenesisBlockInit::UnitTest { premine_destination } => {
+                create_unit_test_genesis(premine_destination)
+            }
         };
         let genesis_block = Arc::new(WithId::new(genesis_block));
 
@@ -318,9 +317,7 @@ impl Builder {
 
     /// Set the genesis block to be the unit test version
     pub fn genesis_unittest(mut self, premine_destination: Destination) -> Self {
-        self.genesis_block = GenesisBlockInit::UnitTest {
-            premine_destination,
-        };
+        self.genesis_block = GenesisBlockInit::UnitTest { premine_destination };
         self
     }
 

--- a/common/src/chain/config/checkpoints.rs
+++ b/common/src/chain/config/checkpoints.rs
@@ -52,11 +52,8 @@ impl Checkpoints {
         }
 
         // Otherwise, find the closest checkpoint before the given height
-        let cp_before = self
-            .checkpoints
-            .range(..height)
-            .next_back()
-            .expect("Genesis must be there, at least.");
+        let cp_before =
+            self.checkpoints.range(..height).next_back().expect("Genesis must be there, at least.");
         (*cp_before.0, (*cp_before.1))
     }
 }

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -472,11 +472,7 @@ fn create_mainnet_genesis() -> Genesis {
         genesis_mint_destination,
     );
 
-    Genesis::new(
-        genesis_message,
-        BlockTimestamp::from_int_seconds(1639975460),
-        vec![output],
-    )
+    Genesis::new(genesis_message, BlockTimestamp::from_int_seconds(1639975460), vec![output])
 }
 
 fn create_testnet_genesis() -> Genesis {
@@ -526,14 +522,8 @@ fn create_testnet_genesis() -> Genesis {
     )
 }
 
-pub fn regtest_genesis_values() -> (
-    PoolId,
-    Box<StakePoolData>,
-    PrivateKey,
-    PublicKey,
-    VRFPrivateKey,
-    VRFPublicKey,
-) {
+pub fn regtest_genesis_values(
+) -> (PoolId, Box<StakePoolData>, PrivateKey, PublicKey, VRFPrivateKey, VRFPublicKey) {
     let genesis_pool_id =
         decode_hex::<PoolId>("123c4c600097c513e088b9be62069f0c74c7671c523c8e3469a1c3f14b7ea2c4");
 
@@ -603,11 +593,7 @@ fn create_unit_test_genesis(premine_destination: Destination) -> Genesis {
         premine_destination,
     );
 
-    Genesis::new(
-        genesis_message,
-        BlockTimestamp::from_int_seconds(1639975460),
-        vec![output],
-    )
+    Genesis::new(genesis_message, BlockTimestamp::from_int_seconds(1639975460), vec![output])
 }
 
 pub fn create_mainnet() -> ChainConfig {

--- a/common/src/chain/genesis.rs
+++ b/common/src/chain/genesis.rs
@@ -33,11 +33,7 @@ pub struct Genesis {
 
 impl Genesis {
     pub fn new(fun_message: String, timestamp: BlockTimestamp, utxos: Vec<TxOutput>) -> Self {
-        Self {
-            fun_message,
-            timestamp,
-            utxos,
-        }
+        Self { fun_message, timestamp, utxos }
     }
 
     pub fn utxos(&self) -> &[TxOutput] {

--- a/common/src/chain/pow.rs
+++ b/common/src/chain/pow.rs
@@ -126,10 +126,7 @@ mod tests {
 
         let mainnet_cfg = cfg.get_proof_of_work_config();
 
-        assert_eq!(
-            mainnet_cfg.no_retargeting(),
-            no_retargeting(ChainType::Mainnet)
-        );
+        assert_eq!(mainnet_cfg.no_retargeting(), no_retargeting(ChainType::Mainnet));
         assert_eq!(
             mainnet_cfg.allow_min_difficulty_blocks(),
             allow_min_difficulty_blocks(ChainType::Mainnet)

--- a/common/src/chain/tokens/mod.rs
+++ b/common/src/chain/tokens/mod.rs
@@ -38,10 +38,7 @@ pub struct TokenAuxiliaryData {
 
 impl TokenAuxiliaryData {
     pub fn new(issuance_tx: Transaction, issuance_block_id: Id<Block>) -> Self {
-        Self {
-            issuance_tx,
-            issuance_block_id,
-        }
+        Self { issuance_tx, issuance_block_id }
     }
 
     pub fn issuance_tx(&self) -> &Transaction {

--- a/common/src/chain/transaction/account_nonce.rs
+++ b/common/src/chain/transaction/account_nonce.rs
@@ -62,10 +62,7 @@ mod tests {
         assert_eq!(AccountNonce::new(u64::MAX).increment(), None);
 
         let v = rng.gen_range(0..u64::MAX - 1);
-        assert_eq!(
-            AccountNonce::new(v).increment(),
-            Some(AccountNonce::new(v + 1))
-        );
+        assert_eq!(AccountNonce::new(v).increment(), Some(AccountNonce::new(v + 1)));
     }
 
     #[rstest]
@@ -77,9 +74,6 @@ mod tests {
         assert_eq!(AccountNonce::new(0).decrement(), None);
 
         let v = rng.gen_range(1..u64::MAX);
-        assert_eq!(
-            AccountNonce::new(v).decrement(),
-            Some(AccountNonce::new(v - 1))
-        );
+        assert_eq!(AccountNonce::new(v).decrement(), Some(AccountNonce::new(v - 1)));
     }
 }

--- a/common/src/chain/transaction/output/classic_multisig.rs
+++ b/common/src/chain/transaction/output/classic_multisig.rs
@@ -47,10 +47,7 @@ impl ClassicMultisigChallenge {
         min_required_signatures: NonZeroU8,
         public_keys: Vec<PublicKey>,
     ) -> Result<Self, ClassicMultisigChallengeError> {
-        let res = Self {
-            min_required_signatures: min_required_signatures.get(),
-            public_keys,
-        };
+        let res = Self { min_required_signatures: min_required_signatures.get(), public_keys };
         res.is_valid(chain_config)?;
         Ok(res)
     }
@@ -74,12 +71,10 @@ impl ClassicMultisigChallenge {
         }
 
         if self.min_required_signatures as usize > self.public_keys.len() {
-            return Err(
-                ClassicMultisigChallengeError::MoreRequiredSignaturesThanPublicKeys(
-                    self.min_required_signatures,
-                    self.public_keys.len(),
-                ),
-            );
+            return Err(ClassicMultisigChallengeError::MoreRequiredSignaturesThanPublicKeys(
+                self.min_required_signatures,
+                self.public_keys.len(),
+            ));
         }
 
         Ok(())
@@ -109,10 +104,7 @@ mod tests {
         let chain_config = create_mainnet();
 
         // Notice that we circumvent the constructor because this struct can be decoded from data
-        let res = ClassicMultisigChallenge {
-            min_required_signatures: 1,
-            public_keys: vec![],
-        };
+        let res = ClassicMultisigChallenge { min_required_signatures: 1, public_keys: vec![] };
 
         assert_eq!(
             res.is_valid(&chain_config).unwrap_err(),
@@ -157,10 +149,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Notice that we circumvent the constructor because this struct can be decoded from data
-        let res = ClassicMultisigChallenge {
-            min_required_signatures,
-            public_keys,
-        };
+        let res = ClassicMultisigChallenge { min_required_signatures, public_keys };
 
         assert_eq!(
             res.is_valid(&chain_config).unwrap_err(),
@@ -188,10 +177,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         // Notice that we circumvent the constructor because this struct can be decoded from data
-        let res = ClassicMultisigChallenge {
-            min_required_signatures,
-            public_keys,
-        };
+        let res = ClassicMultisigChallenge { min_required_signatures, public_keys };
 
         assert_eq!(
             res.is_valid(&chain_config).unwrap_err(),

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkey_spend.rs
@@ -57,9 +57,8 @@ pub fn sign_pubkey_spending(
         return Err(TransactionSigError::SpendeePrivatePublicKeyMismatch);
     }
     let msg = sighash.encode();
-    let signature = private_key
-        .sign_message(&msg)
-        .map_err(TransactionSigError::ProducingSignatureFailed)?;
+    let signature =
+        private_key.sign_message(&msg).map_err(TransactionSigError::ProducingSignatureFailed)?;
 
     Ok(AuthorizedPublicKeySpend::new(signature))
 }

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
@@ -65,9 +65,8 @@ pub fn sign_address_spending(
         return Err(TransactionSigError::PublicKeyToAddressMismatch);
     }
     let msg = sighash.encode();
-    let signature = private_key
-        .sign_message(&msg)
-        .map_err(TransactionSigError::ProducingSignatureFailed)?;
+    let signature =
+        private_key.sign_message(&msg).map_err(TransactionSigError::ProducingSignatureFailed)?;
 
     Ok(AuthorizedPublicKeyHashSpend::new(public_key, signature))
 }

--- a/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_pubkeyhash_spend.rs
@@ -34,10 +34,7 @@ impl AuthorizedPublicKeyHashSpend {
     }
 
     pub fn new(public_key: PublicKey, signature: Signature) -> Self {
-        Self {
-            public_key,
-            signature,
-        }
+        Self { public_key, signature }
     }
 }
 

--- a/common/src/chain/transaction/signature/inputsig/classical_multisig/authorize_classical_multisig.rs
+++ b/common/src/chain/transaction/signature/inputsig/classical_multisig/authorize_classical_multisig.rs
@@ -63,10 +63,7 @@ pub struct AuthorizedClassicalMultisigSpend {
 
 impl AuthorizedClassicalMultisigSpend {
     pub fn new_empty(challenge: ClassicMultisigChallenge) -> Self {
-        Self {
-            signatures: BTreeMap::new(),
-            challenge,
-        }
+        Self { signatures: BTreeMap::new(), challenge }
     }
 
     pub fn available_signatures_count(&self) -> usize {
@@ -108,10 +105,7 @@ impl AuthorizedClassicalMultisigSpend {
     }
 
     pub fn new(signatures: BTreeMap<u8, Signature>, challenge: ClassicMultisigChallenge) -> Self {
-        Self {
-            signatures,
-            challenge,
-        }
+        Self { signatures, challenge }
     }
 }
 
@@ -218,12 +212,10 @@ pub fn sign_classical_multisig_spending(
     let spendee_pubkey = match challenge.public_keys().get(key_index as usize) {
         Some(k) => k,
         None => {
-            return Err(
-                ClassicalMultisigSigningError::InvalidClassicalMultisigKeyIndex(
-                    key_index,
-                    challenge.public_keys().len(),
-                ),
-            )
+            return Err(ClassicalMultisigSigningError::InvalidClassicalMultisigKeyIndex(
+                key_index,
+                challenge.public_keys().len(),
+            ))
         }
     };
 
@@ -245,12 +237,12 @@ pub fn sign_classical_multisig_spending(
         PartiallySignedMultisigChallenge::from_partial(chain_config, &msg, &current_signatures)?;
 
     match verifier.verify_signatures(chain_config)? {
-        super::multisig_partial_signature::SigsVerifyResult::CompleteAndValid => Ok(
-            ClassicalMultisigCompletionStatus::Complete(current_signatures),
-        ),
-        super::multisig_partial_signature::SigsVerifyResult::Incomplete => Ok(
-            ClassicalMultisigCompletionStatus::Incomplete(current_signatures),
-        ),
+        super::multisig_partial_signature::SigsVerifyResult::CompleteAndValid => {
+            Ok(ClassicalMultisigCompletionStatus::Complete(current_signatures))
+        }
+        super::multisig_partial_signature::SigsVerifyResult::Incomplete => {
+            Ok(ClassicalMultisigCompletionStatus::Incomplete(current_signatures))
+        }
         super::multisig_partial_signature::SigsVerifyResult::Invalid => {
             unreachable!(
                 "We checked the signatures then added a signature, so this should be unreachable"
@@ -424,10 +416,7 @@ mod tests {
             .into_iter()
             .take(min_required_signatures.get() as usize)
             .collect::<Vec<_>>();
-        assert_eq!(
-            indices_to_sign.len(),
-            min_required_signatures.get() as usize
-        );
+        assert_eq!(indices_to_sign.len(), min_required_signatures.get() as usize);
 
         let mut current_signatures = AuthorizedClassicalMultisigSpend::new_empty(challenge.clone());
 
@@ -561,10 +550,7 @@ mod tests {
         indices_to_sign.shuffle(&mut rng);
         let indices_to_sign =
             indices_to_sign.into_iter().take(min_required_signatures.get() as usize);
-        assert_eq!(
-            indices_to_sign.len(),
-            min_required_signatures.get() as usize
-        );
+        assert_eq!(indices_to_sign.len(), min_required_signatures.get() as usize);
 
         // Keep signing and adding signatures until it's complete
         let mut current_signatures = AuthorizedClassicalMultisigSpend::new_empty(challenge.clone());
@@ -718,10 +704,7 @@ mod tests {
         indices_to_sign.shuffle(&mut rng);
         let indices_to_sign =
             indices_to_sign.into_iter().take(min_required_signatures.get() as usize);
-        assert_eq!(
-            indices_to_sign.len(),
-            min_required_signatures.get() as usize
-        );
+        assert_eq!(indices_to_sign.len(), min_required_signatures.get() as usize);
 
         // Keep signing and adding signatures until it's complete
         let current_signatures = AuthorizedClassicalMultisigSpend::new_empty(challenge.clone());
@@ -901,14 +884,8 @@ mod tests {
                 current_signatures.challenge().clone(),
             );
 
-            assert_eq!(
-                current_signatures.challenge(),
-                tampered_with_signatures.challenge()
-            );
-            assert_ne!(
-                current_signatures.signatures(),
-                tampered_with_signatures.signatures()
-            );
+            assert_eq!(current_signatures.challenge(), tampered_with_signatures.challenge());
+            assert_ne!(current_signatures.signatures(), tampered_with_signatures.signatures());
             assert_ne!(current_signatures, tampered_with_signatures);
 
             // Now we sign again, and because the signature from before is invalid, this should fail

--- a/common/src/chain/transaction/signature/inputsig/classical_multisig/multisig_partial_signature.rs
+++ b/common/src/chain/transaction/signature/inputsig/classical_multisig/multisig_partial_signature.rs
@@ -34,10 +34,7 @@ impl<'a> PartiallySignedMultisigChallenge<'a> {
         message: &'a [u8],
         signatures: &'a AuthorizedClassicalMultisigSpend,
     ) -> Result<Self, PartiallySignedMultisigStructureError> {
-        let result = PartiallySignedMultisigChallenge {
-            signatures,
-            message,
-        };
+        let result = PartiallySignedMultisigChallenge { signatures, message };
         result.check_structurally_valid(chain_config)?;
         Ok(result)
     }
@@ -197,24 +194,13 @@ mod tests {
                 })
                 .collect::<BTreeMap<_, _>>();
 
-            Self {
-                chain_config,
-                challenge,
-                message_bytes,
-                priv_keys,
-                signatures_map,
-            }
+            Self { chain_config, challenge, message_bytes, priv_keys, signatures_map }
         }
     }
 
     fn check_valid_auth(rng: &mut impl Rng, data: &TestChallengeData) {
-        let TestChallengeData {
-            chain_config,
-            challenge,
-            message_bytes,
-            priv_keys,
-            signatures_map,
-        } = data;
+        let TestChallengeData { chain_config, challenge, message_bytes, priv_keys, signatures_map } =
+            data;
 
         // Valid cases with incomplete and complete signatures
         for sig_count in 0..priv_keys.len() {
@@ -264,13 +250,8 @@ mod tests {
         data: &TestChallengeData,
         expected_challenge_error: ClassicMultisigChallengeError,
     ) {
-        let TestChallengeData {
-            chain_config,
-            challenge,
-            message_bytes,
-            priv_keys,
-            signatures_map,
-        } = data;
+        let TestChallengeData { chain_config, challenge, message_bytes, priv_keys, signatures_map } =
+            data;
 
         // Valid cases with incomplete and complete signatures
         for sig_count in 0..priv_keys.len() {
@@ -296,13 +277,8 @@ mod tests {
     }
 
     fn check_tampered_sigs(rng: &mut impl Rng, data: &TestChallengeData) {
-        let TestChallengeData {
-            chain_config,
-            challenge,
-            message_bytes,
-            priv_keys,
-            signatures_map,
-        } = data;
+        let TestChallengeData { chain_config, challenge, message_bytes, priv_keys, signatures_map } =
+            data;
 
         for sig_count in 1..priv_keys.len() {
             let mut signatures_map =
@@ -348,13 +324,8 @@ mod tests {
     }
 
     fn check_wrong_key(rng: &mut (impl Rng + CryptoRng), data: &TestChallengeData) {
-        let TestChallengeData {
-            chain_config,
-            challenge,
-            message_bytes,
-            priv_keys,
-            signatures_map,
-        } = data;
+        let TestChallengeData { chain_config, challenge, message_bytes, priv_keys, signatures_map } =
+            data;
 
         for sig_count in 1..priv_keys.len() {
             let mut signatures_map =

--- a/common/src/chain/transaction/signature/inputsig/standard_signature.rs
+++ b/common/src/chain/transaction/signature/inputsig/standard_signature.rs
@@ -51,10 +51,7 @@ pub struct StandardInputSignature {
 
 impl StandardInputSignature {
     pub fn new(sighash_type: SigHashType, raw_signature: Vec<u8>) -> Self {
-        Self {
-            sighash_type,
-            raw_signature,
-        }
+        Self { sighash_type, raw_signature }
     }
 
     pub fn sighash_type(&self) -> SigHashType {
@@ -127,10 +124,7 @@ impl StandardInputSignature {
                 TransactionSigError::AttemptedToProduceClassicalMultisigSignatureForAnyoneCanSpend,
             ),
         };
-        Ok(Self {
-            sighash_type,
-            raw_signature: serialized_sig,
-        })
+        Ok(Self { sighash_type, raw_signature: serialized_sig })
     }
 
     pub fn produce_classical_multisig_signature_for_input(
@@ -157,10 +151,7 @@ impl StandardInputSignature {
 
         let serialized_sig = authorization.encode();
 
-        Ok(Self {
-            sighash_type,
-            raw_signature: serialized_sig,
-        })
+        Ok(Self { sighash_type, raw_signature: serialized_sig })
     }
 
     pub fn raw_signature(&self) -> &[u8] {
@@ -176,10 +167,7 @@ impl Decode for StandardInputSignature {
             .map_err(|_| serialization::Error::from("Invalid sighash byte"))?;
         let raw_sig = Vec::decode(input)?;
 
-        Ok(Self {
-            sighash_type: sighash,
-            raw_signature: raw_sig,
-        })
+        Ok(Self { sighash_type: sighash, raw_signature: raw_sig })
     }
 }
 

--- a/common/src/chain/transaction/signature/mod.rs
+++ b/common/src/chain/transaction/signature/mod.rs
@@ -156,10 +156,9 @@ pub fn verify_signature<T: Transactable>(
 ) -> Result<(), TransactionSigError> {
     let inputs = tx.inputs().ok_or(TransactionSigError::SignatureVerificationWithoutInputs)?;
     let sigs = tx.signatures().ok_or(TransactionSigError::SignatureVerificationWithoutSigs)?;
-    let input_witness = sigs.get(input_num).ok_or(TransactionSigError::InvalidSignatureIndex(
-        input_num,
-        inputs.len(),
-    ))?;
+    let input_witness = sigs
+        .get(input_num)
+        .ok_or(TransactionSigError::InvalidSignatureIndex(input_num, inputs.len()))?;
 
     match input_witness {
         InputWitness::NoSignature(_) => match outpoint_destination {

--- a/common/src/chain/transaction/signature/sighash/hashable.rs
+++ b/common/src/chain/transaction/signature/sighash/hashable.rs
@@ -170,9 +170,8 @@ mod tests {
         inputs_utxos_count: usize,
         rng: &mut (impl Rng + CryptoRng),
     ) {
-        let inputs = (0..inputs_count)
-            .map(|_| generate_random_invalid_input(rng))
-            .collect::<Vec<_>>();
+        let inputs =
+            (0..inputs_count).map(|_| generate_random_invalid_input(rng)).collect::<Vec<_>>();
 
         let inputs_utxos = (0..inputs_utxos_count)
             .map(|_| generate_random_invalid_output(rng))

--- a/common/src/chain/transaction/signature/sighash/hashable.rs
+++ b/common/src/chain/transaction/signature/sighash/hashable.rs
@@ -75,10 +75,7 @@ impl<'a> SignatureHashableInputs<'a> {
             ));
         }
 
-        let result = Self {
-            inputs,
-            inputs_utxos,
-        };
+        let result = Self { inputs, inputs_utxos };
 
         Ok(result)
     }
@@ -221,10 +218,7 @@ mod tests {
                     &inputs[index_to_hash],
                     inputs_count,
                 ),
-                Err(TransactionSigError::InvalidInputIndex(
-                    inputs_count,
-                    inputs.len(),
-                ))
+                Err(TransactionSigError::InvalidInputIndex(inputs_count, inputs.len(),))
             );
         }
     }

--- a/common/src/chain/transaction/signature/sighash/mod.rs
+++ b/common/src/chain/transaction/signature/sighash/mod.rs
@@ -50,9 +50,9 @@ fn stream_signature_hash<T: Signable>(
         None => return Err(TransactionSigError::SigHashRequestWithoutInputs),
     };
 
-    let target_input = inputs.get(target_input_num).ok_or(
-        TransactionSigError::InvalidInputIndex(target_input_num, inputs.len()),
-    )?;
+    let target_input = inputs
+        .get(target_input_num)
+        .ok_or(TransactionSigError::InvalidInputIndex(target_input_num, inputs.len()))?;
 
     hash_encoded_to(&mode.get(), stream);
 

--- a/common/src/chain/transaction/signature/sighash/sighashtype.rs
+++ b/common/src/chain/transaction/signature/sighash/sighashtype.rs
@@ -56,10 +56,7 @@ impl TryFrom<u8> for SigHashType {
     type Error = TransactionSigError;
 
     fn try_from(sighash_byte: u8) -> Result<Self, Self::Error> {
-        let ok = matches!(
-            sighash_byte & Self::MASK_OUT,
-            Self::ALL | Self::NONE | Self::SINGLE
-        );
+        let ok = matches!(sighash_byte & Self::MASK_OUT, Self::ALL | Self::NONE | Self::SINGLE);
         ok.then_some(Self(sighash_byte))
             .ok_or(TransactionSigError::InvalidSigHashValue(sighash_byte))
     }
@@ -126,15 +123,10 @@ mod test {
         assert_eq!(sighash_type.outputs_mode(), OutputsMode::Single);
 
         // Check try from
-        assert_eq!(
-            SigHashType::try_from(0),
-            Err(TransactionSigError::InvalidSigHashValue(0))
-        );
+        assert_eq!(SigHashType::try_from(0), Err(TransactionSigError::InvalidSigHashValue(0)));
         assert_eq!(
             SigHashType::try_from(SigHashType::ANYONECANPAY),
-            Err(TransactionSigError::InvalidSigHashValue(
-                SigHashType::ANYONECANPAY
-            ))
+            Err(TransactionSigError::InvalidSigHashValue(SigHashType::ANYONECANPAY))
         );
     }
 }

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -100,13 +100,7 @@ fn verify_no_signature(#[case] seed: Seed) {
             .collect_vec();
         let signed_tx = tx.with_signatures(witnesses).unwrap();
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &signed_tx,
-                &inputs_utxos_refs,
-                0
-            ),
+            verify_signature(&chain_config, &destination, &signed_tx, &inputs_utxos_refs, 0),
             Err(TransactionSigError::SignatureNotFound),
             "{destination:?}"
         );
@@ -144,13 +138,7 @@ fn verify_invalid_signature(#[case] seed: Seed) {
         let signed_tx = tx.with_signatures(witnesses).unwrap();
 
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &signed_tx,
-                &inputs_utxos_refs,
-                0
-            ),
+            verify_signature(&chain_config, &destination, &signed_tx, &inputs_utxos_refs, 0),
             Err(TransactionSigError::InvalidSignatureEncoding),
             "{sighash_type:?}, signature = {raw_signature:?}"
         );
@@ -191,10 +179,7 @@ fn verify_signature_invalid_signature_index(#[case] seed: Seed) {
                 &inputs_utxos_refs,
                 INVALID_SIGNATURE_INDEX
             ),
-            Err(TransactionSigError::InvalidSignatureIndex(
-                INVALID_SIGNATURE_INDEX,
-                3
-            )),
+            Err(TransactionSigError::InvalidSignatureIndex(INVALID_SIGNATURE_INDEX, 3)),
             "{sighash_type:?}"
         );
     }
@@ -228,13 +213,7 @@ fn verify_signature_wrong_destination(#[case] seed: Seed) {
         )
         .unwrap();
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &different_outpoint,
-                &tx,
-                &inputs_utxos_refs,
-                0
-            ),
+            verify_signature(&chain_config, &different_outpoint, &tx, &inputs_utxos_refs, 0),
             Err(TransactionSigError::SignatureVerificationFailed),
             "{sighash_type:?}"
         );
@@ -288,13 +267,7 @@ fn mutate_all(#[case] seed: Seed) {
         &outpoint_dest,
         true,
     );
-    check_mutate_output(
-        &chain_config,
-        &original_tx,
-        &inputs_utxos_refs,
-        &outpoint_dest,
-        true,
-    );
+    check_mutate_output(&chain_config, &original_tx, &inputs_utxos_refs, &outpoint_dest, true);
 }
 
 // ALL|ANYONECANPAY applies to one input and all outputs, so adding input is ok, but anything else isn't.
@@ -344,13 +317,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
         &outpoint_dest,
         true,
     );
-    check_mutate_output(
-        &chain_config,
-        &original_tx,
-        &inputs_utxos_refs,
-        &outpoint_dest,
-        true,
-    );
+    check_mutate_output(&chain_config, &original_tx, &inputs_utxos_refs, &outpoint_dest, true);
 }
 
 // NONE is applied to all inputs and none of the outputs, so the latter can be changed in any way.
@@ -400,13 +367,7 @@ fn mutate_none(#[case] seed: Seed) {
         &outpoint_dest,
         false,
     );
-    check_mutate_output(
-        &chain_config,
-        &original_tx,
-        &inputs_utxos_refs,
-        &outpoint_dest,
-        false,
-    );
+    check_mutate_output(&chain_config, &original_tx, &inputs_utxos_refs, &outpoint_dest, false);
 }
 
 // NONE|ANYONECANPAY is applied to only one input, so changing everything else is OK.
@@ -457,13 +418,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         &outpoint_dest,
         false,
     );
-    check_mutate_output(
-        &chain_config,
-        &original_tx,
-        &inputs_utxos_refs,
-        &outpoint_dest,
-        false,
-    );
+    check_mutate_output(&chain_config, &original_tx, &inputs_utxos_refs, &outpoint_dest, false);
 }
 
 // SINGLE is applied to all inputs and one output, so only adding an output is OK.
@@ -513,13 +468,7 @@ fn mutate_single(#[case] seed: Seed) {
         &outpoint_dest,
         false,
     );
-    check_mutate_output(
-        &chain_config,
-        &original_tx,
-        &inputs_utxos_refs,
-        &outpoint_dest,
-        true,
-    );
+    check_mutate_output(&chain_config, &original_tx, &inputs_utxos_refs, &outpoint_dest, true);
 }
 
 // SINGLE|ANYONECANPAY is applied to one input and one output so adding inputs and outputs is OK.
@@ -570,13 +519,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         &outpoint_dest,
         false,
     );
-    check_mutate_output(
-        &chain_config,
-        &original_tx,
-        &inputs_utxos_refs,
-        &outpoint_dest,
-        true,
-    );
+    check_mutate_output(&chain_config, &original_tx, &inputs_utxos_refs, &outpoint_dest, true);
 }
 
 fn sign_mutate_then_verify(
@@ -639,10 +582,8 @@ fn check_insert_input(
     let outpoint_source_id =
         OutPointSourceId::Transaction(Id::<Transaction>::new(H256::random_using(rng)));
 
-    let inputs_utxo = TxOutput::Transfer(
-        OutputValue::Coin(Amount::from_atoms(123)),
-        Destination::AnyoneCanSpend,
-    );
+    let inputs_utxo =
+        TxOutput::Transfer(OutputValue::Coin(Amount::from_atoms(123)), Destination::AnyoneCanSpend);
     let mut inputs_utxos = inputs_utxos.to_vec();
     inputs_utxos.push(Some(&inputs_utxo));
 
@@ -781,13 +722,7 @@ fn check_mutate_inputs_utxos(
         inputs_utxos[input] = Some(&inputs_utxo);
 
         assert!(matches!(
-            verify_signature(
-                chain_config,
-                outpoint_dest,
-                original_tx,
-                &inputs_utxos,
-                input
-            ),
+            verify_signature(chain_config, outpoint_dest, original_tx, &inputs_utxos, input),
             Err(TransactionSigError::SignatureVerificationFailed)
         ));
     }

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -58,16 +58,8 @@ fn test_mutate_tx_internal_data(#[case] seed: Seed) {
     let test_data = [
         (0, 31, Ok(())),
         (31, 0, Err(TransactionSigError::SignatureVerificationFailed)),
-        (
-            INPUTS,
-            OUTPUTS,
-            Err(TransactionSigError::SignatureVerificationFailed),
-        ),
-        (
-            31,
-            31,
-            Err(TransactionSigError::SignatureVerificationFailed),
-        ),
+        (INPUTS, OUTPUTS, Err(TransactionSigError::SignatureVerificationFailed)),
+        (31, 31, Err(TransactionSigError::SignatureVerificationFailed)),
     ];
 
     for ((destination, sighash_type), (inputs, outputs, expected)) in
@@ -79,13 +71,7 @@ fn test_mutate_tx_internal_data(#[case] seed: Seed) {
         let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, outputs).unwrap();
-        match sign_whole_tx(
-            tx,
-            &inputs_utxos_refs,
-            &private_key,
-            sighash_type,
-            &destination,
-        ) {
+        match sign_whole_tx(tx, &inputs_utxos_refs, &private_key, sighash_type, &destination) {
             Ok(signed_tx) => {
                 // Test flags change.
                 let updated_tx = change_flags(&mut rng, &signed_tx, 1234567890);
@@ -132,30 +118,9 @@ fn modify_and_verify(#[case] seed: Seed) {
             sighash_type,
             &destination,
         );
-        check_insert_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_mutate_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_insert_output(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
+        check_insert_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_mutate_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_insert_output(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
         check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, true);
     }
 
@@ -172,30 +137,9 @@ fn modify_and_verify(#[case] seed: Seed) {
             sighash_type,
             &destination,
         );
-        check_insert_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            false,
-        );
-        check_mutate_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_insert_output(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
+        check_insert_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, false);
+        check_mutate_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_insert_output(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
         check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, true);
     }
 
@@ -211,30 +155,9 @@ fn modify_and_verify(#[case] seed: Seed) {
             sighash_type,
             &destination,
         );
-        check_insert_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_mutate_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_insert_output(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            false,
-        );
+        check_insert_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_mutate_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_insert_output(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, false);
         check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, false);
     }
 
@@ -251,30 +174,9 @@ fn modify_and_verify(#[case] seed: Seed) {
             sighash_type,
             &destination,
         );
-        check_insert_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            false,
-        );
-        check_mutate_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_insert_output(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            false,
-        );
+        check_insert_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, false);
+        check_mutate_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_insert_output(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, false);
         check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, false);
     }
 
@@ -290,30 +192,9 @@ fn modify_and_verify(#[case] seed: Seed) {
             sighash_type,
             &destination,
         );
-        check_insert_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_mutate_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_insert_output(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            false,
-        );
+        check_insert_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_mutate_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_insert_output(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, false);
         check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, true);
     }
 
@@ -330,30 +211,9 @@ fn modify_and_verify(#[case] seed: Seed) {
             sighash_type,
             &destination,
         );
-        check_insert_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            false,
-        );
-        check_mutate_input(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            true,
-        );
-        check_insert_output(
-            &chain_config,
-            &mut rng,
-            &tx,
-            &inputs_utxos_refs,
-            &destination,
-            false,
-        );
+        check_insert_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, false);
+        check_mutate_input(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, true);
+        check_insert_output(&chain_config, &mut rng, &tx, &inputs_utxos_refs, &destination, false);
         check_mutate_output(&chain_config, &tx, &inputs_utxos_refs, &destination, true);
     }
 }
@@ -449,10 +309,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     );
 
     {
-        let tx = SignedTransactionWithUtxo {
-            tx: tx.clone(),
-            inputs_utxos: inputs_utxos.clone(),
-        };
+        let tx = SignedTransactionWithUtxo { tx: tx.clone(), inputs_utxos: inputs_utxos.clone() };
         let tx = mutate_first_input(&mut rng, &tx);
         assert_eq!(
             verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, 0),
@@ -461,15 +318,7 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     }
 
     let mutations = [add_input, remove_first_input, remove_middle_input, remove_last_input];
-    check_mutations(
-        &chain_config,
-        &mut rng,
-        &tx,
-        &inputs_utxos,
-        &destination,
-        mutations,
-        Ok(()),
-    );
+    check_mutations(&chain_config, &mut rng, &tx, &inputs_utxos, &destination, mutations, Ok(()));
 }
 
 #[rstest]
@@ -520,15 +369,7 @@ fn mutate_none(#[case] seed: Seed) {
         remove_middle_output,
         remove_last_output,
     ];
-    check_mutations(
-        &chain_config,
-        &mut rng,
-        &tx,
-        &inputs_utxos,
-        &destination,
-        mutations,
-        Ok(()),
-    );
+    check_mutations(&chain_config, &mut rng, &tx, &inputs_utxos, &destination, mutations, Ok(()));
 }
 
 #[rstest]
@@ -557,10 +398,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
     .unwrap();
 
     {
-        let tx = SignedTransactionWithUtxo {
-            tx: tx.clone(),
-            inputs_utxos: inputs_utxos.clone(),
-        };
+        let tx = SignedTransactionWithUtxo { tx: tx.clone(), inputs_utxos: inputs_utxos.clone() };
         let tx = mutate_first_input(&mut rng, &tx);
         let inputs = tx.tx.inputs().len();
 
@@ -570,13 +408,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         );
         for input in 1..inputs {
             assert_eq!(
-                verify_signature(
-                    &chain_config,
-                    &destination,
-                    &tx.tx,
-                    &inputs_utxos_refs,
-                    input
-                ),
+                verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, input),
                 Ok(())
             );
         }
@@ -604,15 +436,7 @@ fn mutate_none_anyonecanpay(#[case] seed: Seed) {
         remove_middle_output,
         remove_last_output,
     ];
-    check_mutations(
-        &chain_config,
-        &mut rng,
-        &tx,
-        &inputs_utxos,
-        &destination,
-        mutations,
-        Ok(()),
-    );
+    check_mutations(&chain_config, &mut rng, &tx, &inputs_utxos, &destination, mutations, Ok(()));
 }
 
 #[rstest]
@@ -647,10 +471,7 @@ fn mutate_single(#[case] seed: Seed) {
         remove_last_input,
         remove_first_output,
     ];
-    let tx = SignedTransactionWithUtxo {
-        tx,
-        inputs_utxos: inputs_utxos.clone(),
-    };
+    let tx = SignedTransactionWithUtxo { tx, inputs_utxos: inputs_utxos.clone() };
     for mutate in mutations.into_iter() {
         let tx = mutate(&mut rng, &tx);
         let total_inputs = tx.tx.inputs().len();
@@ -661,28 +482,13 @@ fn mutate_single(#[case] seed: Seed) {
         // result in the different error.
         for input in 0..total_inputs - 1 {
             assert_eq!(
-                verify_signature(
-                    &chain_config,
-                    &destination,
-                    &tx.tx,
-                    &inputs_utxos_refs,
-                    input
-                ),
+                verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, input),
                 Err(TransactionSigError::SignatureVerificationFailed)
             );
         }
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &inputs_utxos_refs,
-                total_inputs
-            ),
-            Err(TransactionSigError::InvalidSignatureIndex(
-                total_inputs,
-                total_inputs
-            )),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, total_inputs),
+            Err(TransactionSigError::InvalidSignatureIndex(total_inputs, total_inputs)),
         );
     }
 
@@ -695,24 +501,12 @@ fn mutate_single(#[case] seed: Seed) {
         // result in the `InvalidInputIndex` error.
         for input in 0..inputs - 1 {
             assert_eq!(
-                verify_signature(
-                    &chain_config,
-                    &destination,
-                    &tx.tx,
-                    &inputs_utxos_refs,
-                    input
-                ),
+                verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, input),
                 Ok(())
             );
         }
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &inputs_utxos_refs,
-                inputs
-            ),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, inputs),
             Err(TransactionSigError::InvalidSignatureIndex(inputs, inputs)),
         );
     }
@@ -730,28 +524,13 @@ fn mutate_single(#[case] seed: Seed) {
         );
         for input in 1..total_inputs - 1 {
             assert_eq!(
-                verify_signature(
-                    &chain_config,
-                    &destination,
-                    &tx.tx,
-                    &inputs_utxos_refs,
-                    input
-                ),
+                verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, input),
                 Ok(())
             );
         }
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &inputs_utxos_refs,
-                total_inputs
-            ),
-            Err(TransactionSigError::InvalidSignatureIndex(
-                total_inputs,
-                total_inputs
-            )),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, total_inputs),
+            Err(TransactionSigError::InvalidSignatureIndex(total_inputs, total_inputs)),
         );
     }
 }
@@ -781,10 +560,7 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
     .unwrap();
 
     let mutations = [add_input, remove_last_input, add_output, remove_last_output];
-    let tx = SignedTransactionWithUtxo {
-        tx,
-        inputs_utxos: inputs_utxos.clone(),
-    };
+    let tx = SignedTransactionWithUtxo { tx, inputs_utxos: inputs_utxos.clone() };
     for mutate in mutations.into_iter() {
         let tx = mutate(&mut rng, &tx);
         let total_inputs = tx.tx.inputs().len();
@@ -795,29 +571,14 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         // result in the `InvalidInputIndex` error.
         for input in 0..total_inputs - 1 {
             assert_eq!(
-                verify_signature(
-                    &chain_config,
-                    &destination,
-                    &tx.tx,
-                    &inputs_utxos_refs,
-                    input
-                ),
+                verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, input),
                 Ok(()),
                 "{input}"
             );
         }
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &inputs_utxos_refs,
-                total_inputs
-            ),
-            Err(TransactionSigError::InvalidSignatureIndex(
-                total_inputs,
-                total_inputs
-            ))
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, total_inputs),
+            Err(TransactionSigError::InvalidSignatureIndex(total_inputs, total_inputs))
         );
     }
 
@@ -834,29 +595,14 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         );
         for input in 1..total_inputs - 1 {
             assert_eq!(
-                verify_signature(
-                    &chain_config,
-                    &destination,
-                    &tx.tx,
-                    &inputs_utxos_refs,
-                    input
-                ),
+                verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, input),
                 Ok(()),
                 "## {input}"
             );
         }
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &inputs_utxos_refs,
-                total_inputs
-            ),
-            Err(TransactionSigError::InvalidSignatureIndex(
-                total_inputs,
-                total_inputs
-            )),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, total_inputs),
+            Err(TransactionSigError::InvalidSignatureIndex(total_inputs, total_inputs)),
         );
     }
 
@@ -871,29 +617,14 @@ fn mutate_single_anyonecanpay(#[case] seed: Seed) {
         // result in the `InvalidInputIndex` error.
         for input in 0..total_inputs - 1 {
             assert_eq!(
-                verify_signature(
-                    &chain_config,
-                    &destination,
-                    &tx.tx,
-                    &inputs_utxos_refs,
-                    input
-                ),
+                verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, input),
                 Err(TransactionSigError::SignatureVerificationFailed),
                 "{input}"
             );
         }
         assert_eq!(
-            verify_signature(
-                &chain_config,
-                &destination,
-                &tx.tx,
-                &inputs_utxos_refs,
-                total_inputs
-            ),
-            Err(TransactionSigError::InvalidSignatureIndex(
-                total_inputs,
-                total_inputs
-            )),
+            verify_signature(&chain_config, &destination, &tx.tx, &inputs_utxos_refs, total_inputs),
+            Err(TransactionSigError::InvalidSignatureIndex(total_inputs, total_inputs)),
         );
     }
 }
@@ -911,10 +642,7 @@ fn check_mutations<M, R>(
     R: Rng,
     M: IntoIterator<Item = fn(&mut R, &SignedTransactionWithUtxo) -> SignedTransactionWithUtxo>,
 {
-    let tx = SignedTransactionWithUtxo {
-        tx: tx.clone(),
-        inputs_utxos: inputs_utxos.to_vec(),
-    };
+    let tx = SignedTransactionWithUtxo { tx: tx.clone(), inputs_utxos: inputs_utxos.to_vec() };
     for mutate in mutations.into_iter() {
         let tx = mutate(rng, &tx);
         // The number of inputs can be changed by the `mutate` function.
@@ -923,17 +651,8 @@ fn check_mutations<M, R>(
             tx.inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         assert_eq!(
-            verify_signature(
-                chain_config,
-                destination,
-                &tx.tx,
-                &inputs_utxos_refs,
-                INVALID_INPUT
-            ),
-            Err(TransactionSigError::InvalidSignatureIndex(
-                INVALID_INPUT,
-                inputs
-            ))
+            verify_signature(chain_config, destination, &tx.tx, &inputs_utxos_refs, INVALID_INPUT),
+            Err(TransactionSigError::InvalidSignatureIndex(INVALID_INPUT, inputs))
         );
         for input in 0..inputs {
             assert_eq!(
@@ -955,10 +674,7 @@ fn add_input(_rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedTrans
     updater.witness.push(updater.witness[0].clone());
     let mut inputs_utxos = tx.inputs_utxos.clone();
     inputs_utxos.push(inputs_utxos[0].clone());
-    SignedTransactionWithUtxo {
-        tx: updater.generate_tx().unwrap(),
-        inputs_utxos,
-    }
+    SignedTransactionWithUtxo { tx: updater.generate_tx().unwrap(), inputs_utxos }
 }
 
 fn mutate_first_input(
@@ -1013,10 +729,7 @@ fn remove_first_input(
     updater.witness.remove(0);
     let mut inputs_utxos = tx.inputs_utxos.clone();
     inputs_utxos.remove(0);
-    SignedTransactionWithUtxo {
-        tx: updater.generate_tx().unwrap(),
-        inputs_utxos,
-    }
+    SignedTransactionWithUtxo { tx: updater.generate_tx().unwrap(), inputs_utxos }
 }
 
 fn remove_middle_input(
@@ -1029,10 +742,7 @@ fn remove_middle_input(
     updater.witness.remove(7);
     let mut inputs_utxos = tx.inputs_utxos.clone();
     inputs_utxos.remove(7);
-    SignedTransactionWithUtxo {
-        tx: updater.generate_tx().unwrap(),
-        inputs_utxos,
-    }
+    SignedTransactionWithUtxo { tx: updater.generate_tx().unwrap(), inputs_utxos }
 }
 
 fn remove_last_input(
@@ -1044,10 +754,7 @@ fn remove_last_input(
     updater.witness.pop().expect("Unexpected empty witness");
     let mut inputs_utxos = tx.inputs_utxos.clone();
     inputs_utxos.pop().expect("Unexpected empty witness");
-    SignedTransactionWithUtxo {
-        tx: updater.generate_tx().unwrap(),
-        inputs_utxos,
-    }
+    SignedTransactionWithUtxo { tx: updater.generate_tx().unwrap(), inputs_utxos }
 }
 
 fn add_output(_rng: &mut impl Rng, tx: &SignedTransactionWithUtxo) -> SignedTransactionWithUtxo {

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -291,13 +291,8 @@ fn mutate_all_anyonecanpay(#[case] seed: Seed) {
     )
     .unwrap();
 
-    let mutations = [
-        add_output,
-        mutate_output,
-        remove_first_output,
-        remove_middle_output,
-        remove_last_output,
-    ];
+    let mutations =
+        [add_output, mutate_output, remove_first_output, remove_middle_output, remove_last_output];
     check_mutations(
         &chain_config,
         &mut rng,
@@ -345,13 +340,8 @@ fn mutate_none(#[case] seed: Seed) {
     )
     .unwrap();
 
-    let mutations = [
-        add_input,
-        mutate_first_input,
-        remove_first_input,
-        remove_middle_input,
-        remove_last_input,
-    ];
+    let mutations =
+        [add_input, mutate_first_input, remove_first_input, remove_middle_input, remove_last_input];
     check_mutations(
         &chain_config,
         &mut rng,
@@ -362,13 +352,8 @@ fn mutate_none(#[case] seed: Seed) {
         Err(TransactionSigError::SignatureVerificationFailed),
     );
 
-    let mutations = [
-        add_output,
-        mutate_output,
-        remove_first_output,
-        remove_middle_output,
-        remove_last_output,
-    ];
+    let mutations =
+        [add_output, mutate_output, remove_first_output, remove_middle_output, remove_last_output];
     check_mutations(&chain_config, &mut rng, &tx, &inputs_utxos, &destination, mutations, Ok(()));
 }
 

--- a/common/src/chain/transaction/signature/tests/sign_and_verify.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_verify.rs
@@ -56,13 +56,8 @@ fn sign_and_verify_all_and_none(#[case] seed: Seed) {
         let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, outputs).unwrap();
-        let signed_tx = sign_whole_tx(
-            tx,
-            &inputs_utxos_refs,
-            &private_key,
-            sighash_type,
-            &destination,
-        );
+        let signed_tx =
+            sign_whole_tx(tx, &inputs_utxos_refs, &private_key, sighash_type, &destination);
         // `sign_whole_tx` does nothing if there no inputs.
         if destination == Destination::AnyoneCanSpend && inputs > 0 {
             assert_eq!(
@@ -249,13 +244,7 @@ fn sign_and_verify_single(#[case] seed: Seed) {
         let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
 
         let tx = generate_unsigned_tx(&mut rng, &destination, &inputs_utxos, outputs).unwrap();
-        match sign_whole_tx(
-            tx,
-            &inputs_utxos_refs,
-            &private_key,
-            sighash_type,
-            &destination,
-        ) {
+        match sign_whole_tx(tx, &inputs_utxos_refs, &private_key, sighash_type, &destination) {
             Ok(signed_tx) => {
                 verify_signed_tx(&chain_config, &signed_tx, &inputs_utxos_refs, &destination)
                     .expect("{sighash_type:X?}, {destination:?}")

--- a/common/src/chain/transaction/signature/tests/utils.rs
+++ b/common/src/chain/transaction/signature/tests/utils.rs
@@ -138,14 +138,7 @@ pub fn sign_whole_tx(
         .iter()
         .enumerate()
         .map(|(i, _input)| {
-            make_signature(
-                &tx,
-                inputs_utxos,
-                i,
-                private_key,
-                sighash_type,
-                destination.clone(),
-            )
+            make_signature(&tx, inputs_utxos, i, private_key, sighash_type, destination.clone())
         })
         .collect();
     let witnesses = sigs?.into_iter().map(InputWitness::Standard).collect_vec();
@@ -164,21 +157,11 @@ pub fn generate_and_sign_tx(
 ) -> Result<SignedTransaction, TransactionCreationError> {
     let tx = generate_unsigned_tx(rng, destination, inputs_utxos, outputs).unwrap();
     let inputs_utxos_refs = inputs_utxos.iter().map(|i| i.as_ref()).collect::<Vec<_>>();
-    let signed_tx = sign_whole_tx(
-        tx,
-        inputs_utxos_refs.as_slice(),
-        private_key,
-        sighash_type,
-        destination,
-    )
-    .unwrap();
+    let signed_tx =
+        sign_whole_tx(tx, inputs_utxos_refs.as_slice(), private_key, sighash_type, destination)
+            .unwrap();
     assert_eq!(
-        verify_signed_tx(
-            chain_config,
-            &signed_tx,
-            inputs_utxos_refs.as_slice(),
-            destination
-        ),
+        verify_signed_tx(chain_config, &signed_tx, inputs_utxos_refs.as_slice(), destination),
         Ok(())
     );
     Ok(signed_tx)

--- a/common/src/chain/transaction/signed_transaction.rs
+++ b/common/src/chain/transaction/signed_transaction.rs
@@ -36,10 +36,7 @@ impl SignedTransaction {
             signatures.len() == transaction.inputs().len(),
             TransactionCreationError::InvalidWitnessCount
         );
-        Ok(Self {
-            transaction,
-            signatures,
-        })
+        Ok(Self { transaction, signatures })
     }
 
     pub fn transaction(&self) -> &Transaction {
@@ -99,10 +96,7 @@ impl Decode for SignedTransaction {
             )
             .chain(err));
         }
-        Ok(Self {
-            transaction,
-            signatures: witness,
-        })
+        Ok(Self { transaction, signatures: witness })
     }
 }
 

--- a/common/src/chain/transaction/transaction_index/mod.rs
+++ b/common/src/chain/transaction/transaction_index/mod.rs
@@ -70,10 +70,7 @@ pub struct TxMainChainPosition {
 
 impl TxMainChainPosition {
     pub fn new(block_id: Id<Block>, byte_offset_in_block: u32) -> Self {
-        TxMainChainPosition {
-            block_id,
-            byte_offset_in_block,
-        }
+        TxMainChainPosition { block_id, byte_offset_in_block }
     }
 
     pub fn block_id(&self) -> &Id<Block> {
@@ -89,10 +86,7 @@ impl TxMainChainPosition {
 pub enum SpendError {
     AlreadySpent(Spender),
     AlreadyUnspent,
-    OutOfRange {
-        tx_id: Option<Spender>,
-        source_output_index: usize,
-    },
+    OutOfRange { tx_id: Option<Spender>, source_output_index: usize },
 }
 
 /// This enum represents that we can either spend from a block reward or a regular transaction
@@ -208,10 +202,9 @@ impl TxMainChainIndex {
         let index = index as usize;
 
         match self.spent.get_mut(index) {
-            None => Err(SpendError::OutOfRange {
-                tx_id: Some(spender),
-                source_output_index: index,
-            }),
+            None => {
+                Err(SpendError::OutOfRange { tx_id: Some(spender), source_output_index: index })
+            }
             Some(spent_state) => Self::spend_internal(spent_state, spender),
         }
     }
@@ -220,10 +213,7 @@ impl TxMainChainIndex {
         let index = index as usize;
 
         match self.spent.get_mut(index) {
-            None => Err(SpendError::OutOfRange {
-                tx_id: None,
-                source_output_index: index,
-            }),
+            None => Err(SpendError::OutOfRange { tx_id: None, source_output_index: index }),
             Some(spent_state) => Self::unspend_internal(spent_state),
         }
     }
@@ -266,10 +256,7 @@ impl TxMainChainIndex {
         let spent_vec = std::iter::repeat_with(|| OutputSpentState::Unspent)
             .take(output_count as usize)
             .collect();
-        let res = TxMainChainIndex {
-            position,
-            spent: spent_vec,
-        };
+        let res = TxMainChainIndex { position, spent: spent_vec };
         Ok(res)
     }
 }

--- a/common/src/chain/transaction/transaction_index/tests.rs
+++ b/common/src/chain/transaction/transaction_index/tests.rs
@@ -225,9 +225,7 @@ fn generate_random_invalid_transaction(rng: &mut (impl Rng + CryptoRng)) -> Tran
 
     let outputs = {
         let output_count = 1 + (rng.next_u32() as usize) % 10;
-        (0..output_count)
-            .map(|_| generate_random_invalid_output(rng))
-            .collect::<Vec<_>>()
+        (0..output_count).map(|_| generate_random_invalid_output(rng)).collect::<Vec<_>>()
     };
 
     let flags = rng.gen::<u128>();
@@ -238,9 +236,7 @@ fn generate_random_invalid_transaction(rng: &mut (impl Rng + CryptoRng)) -> Tran
 fn generate_random_invalid_block(rng: &mut (impl Rng + CryptoRng)) -> Block {
     let transactions = {
         let transaction_count = rng.next_u32() % 20;
-        (0..transaction_count)
-            .map(|_| generate_random_invalid_transaction(rng))
-            .collect::<Vec<_>>()
+        (0..transaction_count).map(|_| generate_random_invalid_transaction(rng)).collect::<Vec<_>>()
     };
     let transactions = transactions
         .into_iter()

--- a/common/src/chain/transaction/transaction_index/tests.rs
+++ b/common/src/chain/transaction/transaction_index/tests.rs
@@ -40,10 +40,7 @@ fn invalid_output_count_for_transaction() {
         H256::from_str("000000000000000000000000000000000000000000000000000000000000007b").unwrap();
     let pos = TxMainChainPosition::new(block_id.into(), 1).into();
     let tx_index = TxMainChainIndex::new(pos, 0);
-    assert_eq!(
-        tx_index.unwrap_err(),
-        TxMainChainIndexError::InvalidOutputCount
-    );
+    assert_eq!(tx_index.unwrap_err(), TxMainChainIndexError::InvalidOutputCount);
 }
 
 #[test]
@@ -70,17 +67,11 @@ fn basic_spending() {
     assert!(tx_index.get_spent_state(2).is_ok());
     assert_eq!(
         tx_index.get_spent_state(3).unwrap_err(),
-        SpendError::OutOfRange {
-            tx_id: None,
-            source_output_index: 3
-        }
+        SpendError::OutOfRange { tx_id: None, source_output_index: 3 }
     );
     assert_eq!(
         tx_index.get_spent_state(4).unwrap_err(),
-        SpendError::OutOfRange {
-            tx_id: None,
-            source_output_index: 4
-        }
+        SpendError::OutOfRange { tx_id: None, source_output_index: 4 }
     );
     assert_eq!(tx_index.output_count(), 3);
 
@@ -92,20 +83,14 @@ fn basic_spending() {
     };
 
     // check that all are unspent
-    assert_eq!(
-        p.block_id,
-        Into::<Id<Block>>::into(H256::from_low_u64_be(123))
-    );
+    assert_eq!(p.block_id, Into::<Id<Block>>::into(H256::from_low_u64_be(123)));
     for output in &tx_index.spent {
         assert_eq!(*output, OutputSpentState::Unspent);
     }
     assert!(!tx_index.all_outputs_spent());
 
     for i in 0..tx_index.output_count() {
-        assert_eq!(
-            tx_index.get_spent_state(i).unwrap(),
-            OutputSpentState::Unspent
-        );
+        assert_eq!(tx_index.get_spent_state(i).unwrap(), OutputSpentState::Unspent);
     }
 
     let tx_spending_output_0 = Id::<Transaction>::new(
@@ -127,14 +112,8 @@ fn basic_spending() {
         tx_index.get_spent_state(0).unwrap(),
         OutputSpentState::SpentBy(tx_spending_output_0.into())
     );
-    assert_eq!(
-        tx_index.get_spent_state(1).unwrap(),
-        OutputSpentState::Unspent
-    );
-    assert_eq!(
-        tx_index.get_spent_state(2).unwrap(),
-        OutputSpentState::Unspent
-    );
+    assert_eq!(tx_index.get_spent_state(1).unwrap(), OutputSpentState::Unspent);
+    assert_eq!(tx_index.get_spent_state(2).unwrap(), OutputSpentState::Unspent);
 
     assert!(!tx_index.all_outputs_spent());
 
@@ -172,10 +151,7 @@ fn basic_spending() {
 
     // check the new unspent state
     assert!(!tx_index.all_outputs_spent());
-    assert_eq!(
-        tx_index.get_spent_state(0).unwrap(),
-        OutputSpentState::Unspent
-    );
+    assert_eq!(tx_index.get_spent_state(0).unwrap(), OutputSpentState::Unspent);
     assert_eq!(
         tx_index.get_spent_state(1).unwrap(),
         OutputSpentState::SpentBy(tx_spending_output_1.into())
@@ -191,18 +167,9 @@ fn basic_spending() {
 
     // check the new unspent state
     assert!(!tx_index.all_outputs_spent());
-    assert_eq!(
-        tx_index.get_spent_state(0).unwrap(),
-        OutputSpentState::Unspent
-    );
-    assert_eq!(
-        tx_index.get_spent_state(1).unwrap(),
-        OutputSpentState::Unspent
-    );
-    assert_eq!(
-        tx_index.get_spent_state(2).unwrap(),
-        OutputSpentState::Unspent
-    );
+    assert_eq!(tx_index.get_spent_state(0).unwrap(), OutputSpentState::Unspent);
+    assert_eq!(tx_index.get_spent_state(1).unwrap(), OutputSpentState::Unspent);
+    assert_eq!(tx_index.get_spent_state(2).unwrap(), OutputSpentState::Unspent);
 }
 
 fn generate_random_h256(rng: &mut impl Rng) -> H256 {

--- a/common/src/chain/transaction/transaction_v1.rs
+++ b/common/src/chain/transaction/transaction_v1.rs
@@ -37,12 +37,7 @@ impl TransactionV1 {
         inputs: Vec<TxInput>,
         outputs: Vec<TxOutput>,
     ) -> Result<Self, TransactionCreationError> {
-        let tx = TransactionV1 {
-            version: VersionTag::default(),
-            flags,
-            inputs,
-            outputs,
-        };
+        let tx = TransactionV1 { version: VersionTag::default(), flags, inputs, outputs };
         Ok(tx)
     }
 

--- a/common/src/chain/transaction/utxo_outpoint.rs
+++ b/common/src/chain/transaction/utxo_outpoint.rs
@@ -66,10 +66,7 @@ pub struct UtxoOutPoint {
 
 impl UtxoOutPoint {
     pub fn new(outpoint_source_id: OutPointSourceId, output_index: u32) -> Self {
-        UtxoOutPoint {
-            id: outpoint_source_id,
-            index: output_index,
-        }
+        UtxoOutPoint { id: outpoint_source_id, index: output_index }
     }
 
     pub fn tx_id(&self) -> OutPointSourceId {

--- a/common/src/chain/upgrades/netupgrade.rs
+++ b/common/src/chain/upgrades/netupgrade.rs
@@ -158,11 +158,8 @@ impl<T: Ord> NetUpgrades<T> {
     pub fn height_range(&self, version: &T) -> Option<Range<BlockHeight>> {
         self.0.iter().enumerate().find(|(_, (_, elem_version))| elem_version == version).map(
             |(idx, &(start_h, _))| {
-                let end_h = if (idx + 1) < self.0.len() {
-                    self.0[idx + 1].0
-                } else {
-                    BlockHeight::max()
-                };
+                let end_h =
+                    if (idx + 1) < self.0.len() { self.0[idx + 1].0 } else { BlockHeight::max() };
                 start_h..end_h
             },
         )

--- a/common/src/chain/upgrades/netupgrade.rs
+++ b/common/src/chain/upgrades/netupgrade.rs
@@ -156,18 +156,16 @@ impl<T: Ord> NetUpgrades<T> {
     }
 
     pub fn height_range(&self, version: &T) -> Option<Range<BlockHeight>> {
-        self.0
-            .iter()
-            .enumerate()
-            .find(|(_, (_, elem_version))| elem_version == version)
-            .map(|(idx, &(start_h, _))| {
+        self.0.iter().enumerate().find(|(_, (_, elem_version))| elem_version == version).map(
+            |(idx, &(start_h, _))| {
                 let end_h = if (idx + 1) < self.0.len() {
                     self.0[idx + 1].0
                 } else {
                     BlockHeight::max()
                 };
                 start_h..end_h
-            })
+            },
+        )
     }
 
     pub fn version_at_height(&self, height: BlockHeight) -> Option<&(BlockHeight, T)> {

--- a/common/src/primitives/amount.rs
+++ b/common/src/primitives/amount.rs
@@ -187,9 +187,7 @@ impl std::ops::BitAnd for Amount {
     type Output = Self;
 
     fn bitand(self, other: Self) -> Self {
-        Amount {
-            val: self.val.bitand(other.val),
-        }
+        Amount { val: self.val.bitand(other.val) }
     }
 }
 
@@ -203,9 +201,7 @@ impl std::ops::BitOr for Amount {
     type Output = Self;
 
     fn bitor(self, other: Self) -> Self {
-        Amount {
-            val: self.val.bitor(other.val),
-        }
+        Amount { val: self.val.bitor(other.val) }
     }
 }
 
@@ -219,9 +215,7 @@ impl std::ops::BitXor for Amount {
     type Output = Self;
 
     fn bitxor(self, other: Self) -> Self {
-        Amount {
-            val: self.val.bitxor(other.val),
-        }
+        Amount { val: self.val.bitxor(other.val) }
     }
 }
 
@@ -235,9 +229,7 @@ impl std::ops::Not for Amount {
     type Output = Self;
 
     fn not(self) -> Self {
-        Amount {
-            val: self.val.not(),
-        }
+        Amount { val: self.val.not() }
     }
 }
 
@@ -297,18 +289,12 @@ mod tests {
 
     #[test]
     fn add_some() {
-        assert_eq!(
-            Amount { val: 2 } + Amount { val: 2 },
-            Some(Amount { val: 4 })
-        );
+        assert_eq!(Amount { val: 2 } + Amount { val: 2 }, Some(Amount { val: 4 }));
     }
 
     #[test]
     fn sub_some() {
-        assert_eq!(
-            Amount { val: 4 } - Amount { val: 2 },
-            Some(Amount { val: 2 })
-        );
+        assert_eq!(Amount { val: 4 } - Amount { val: 2 }, Some(Amount { val: 2 }));
     }
 
     #[test]
@@ -328,61 +314,35 @@ mod tests {
 
     #[test]
     fn add_overflow() {
-        assert_eq!(
-            Amount {
-                val: UnsignedIntType::MAX
-            } + Amount { val: 1 },
-            None
-        );
+        assert_eq!(Amount { val: UnsignedIntType::MAX } + Amount { val: 1 }, None);
     }
 
     #[test]
     fn sum_some() {
         let amounts = vec![Amount { val: 1 }, Amount { val: 2 }, Amount { val: 3 }];
-        assert_eq!(
-            amounts.into_iter().sum::<Option<Amount>>(),
-            Some(Amount { val: 6 })
-        );
+        assert_eq!(amounts.into_iter().sum::<Option<Amount>>(), Some(Amount { val: 6 }));
     }
 
     #[test]
     fn sum_overflow() {
-        let amounts = vec![
-            Amount { val: 1 },
-            Amount { val: 2 },
-            Amount {
-                val: UnsignedIntType::MAX - 2,
-            },
-        ];
+        let amounts =
+            vec![Amount { val: 1 }, Amount { val: 2 }, Amount { val: UnsignedIntType::MAX - 2 }];
         assert_eq!(amounts.into_iter().sum::<Option<Amount>>(), None);
     }
 
     #[test]
     fn sum_empty() {
-        assert_eq!(
-            vec![].into_iter().sum::<Option<Amount>>(),
-            Some(Amount::from_atoms(0))
-        )
+        assert_eq!(vec![].into_iter().sum::<Option<Amount>>(), Some(Amount::from_atoms(0)))
     }
 
     #[test]
     fn sub_underflow() {
-        assert_eq!(
-            Amount {
-                val: UnsignedIntType::MIN
-            } - Amount { val: 1 },
-            None
-        );
+        assert_eq!(Amount { val: UnsignedIntType::MIN } - Amount { val: 1 }, None);
     }
 
     #[test]
     fn mul_overflow() {
-        assert_eq!(
-            Amount {
-                val: UnsignedIntType::MAX / 2 + 1
-            } * 2,
-            None
-        );
+        assert_eq!(Amount { val: UnsignedIntType::MAX / 2 + 1 } * 2, None);
     }
 
     #[test]
@@ -445,11 +405,7 @@ mod tests {
         );
 
         assert_eq!(
-            amount_sum!(
-                Amount::from_atoms(1),
-                Amount::from_atoms(2),
-                Amount::from_atoms(3)
-            ),
+            amount_sum!(Amount::from_atoms(1), Amount::from_atoms(2), Amount::from_atoms(3)),
             Some(Amount::from_atoms(6))
         );
 
@@ -464,18 +420,12 @@ mod tests {
         );
 
         assert_eq!(
-            amount_sum!(
-                Amount::from_atoms(UnsignedIntType::MAX),
-                Amount::from_atoms(0)
-            ),
+            amount_sum!(Amount::from_atoms(UnsignedIntType::MAX), Amount::from_atoms(0)),
             Some(Amount::from_atoms(UnsignedIntType::MAX))
         );
 
         assert_eq!(
-            amount_sum!(
-                Amount::from_atoms(UnsignedIntType::MAX),
-                Amount::from_atoms(1)
-            ),
+            amount_sum!(Amount::from_atoms(UnsignedIntType::MAX), Amount::from_atoms(1)),
             None
         );
 
@@ -493,10 +443,7 @@ mod tests {
     fn signed_conversion_arbitrary() {
         let amount = Amount::from_atoms(10);
         let signed_amount_inner = 10 as SignedIntType;
-        assert_eq!(
-            amount.into_signed().unwrap(),
-            SignedAmount::from_atoms(signed_amount_inner)
-        )
+        assert_eq!(amount.into_signed().unwrap(), SignedAmount::from_atoms(signed_amount_inner))
     }
 
     #[test]
@@ -509,10 +456,7 @@ mod tests {
     fn signed_conversion_signed_max_before_threshold() {
         let amount = Amount::from_atoms(SignedIntType::MAX as UnsignedIntType);
         let signed_amount_inner = SignedIntType::MAX;
-        assert_eq!(
-            amount.into_signed().unwrap(),
-            SignedAmount::from_atoms(signed_amount_inner)
-        )
+        assert_eq!(amount.into_signed().unwrap(), SignedAmount::from_atoms(signed_amount_inner))
     }
 
     #[test]

--- a/common/src/primitives/encoding/tests.rs
+++ b/common/src/primitives/encoding/tests.rs
@@ -68,11 +68,7 @@ fn check_valid_addresses() {
             "a0d0c06640b95b78f965416ad6971b3b1609c3cd9b512aaa39439088211868b7",
         ),
         ("bc1zr4pq63udck", "5202", "1d42"),
-        (
-            "tb1ray6e8gxfx49ers6c4c70l3c8lsxtcmlx",
-            "5310",
-            "e93593a0c9354b91c358ae3cffc707fc",
-        ),
+        ("tb1ray6e8gxfx49ers6c4c70l3c8lsxtcmlx", "5310", "e93593a0c9354b91c358ae3cffc707fc"),
         (
             "tb1pxqf7d825wjtcftj7uep8w24jq3tz8vudfaqj20rns8ahqya56gcs92eqtu",
             "5120",
@@ -175,10 +171,7 @@ fn check_invalid_addresses() {
             "bc10rmfwl8nxdweeyc4sf89t0tn9fv9w6qpyzsnl2r4k48vjqh03qas9asdje0rlr0phru0wqw0p",
             "invalid length",
         ),
-        (
-            "bc1qxmf2d6aerjzam3rur0zufqxqnyqfts5u302s7x",
-            "invalid Bech32 encoding",
-        ),
+        ("bc1qxmf2d6aerjzam3rur0zufqxqnyqfts5u302s7x", "invalid Bech32 encoding"),
         ("bcrt1rhsveeudk", "invalid length"),
         (
             "tb13h83rtwq62udrhwpn87uely7cyxcjrj0azz6a4r3n9s87x5uj98ys6ufp83",
@@ -366,10 +359,7 @@ fn bech32m_empty_hrp_is_invalid() {
         .to_lowercase();
     let random_bytes: Vec<u8> = (0..data_length).map(|_| rng.gen::<u8>()).collect();
 
-    assert_eq!(
-        super::encode(test_hrp, random_bytes).unwrap_err(),
-        Bech32Error::InvalidLength
-    );
+    assert_eq!(super::encode(test_hrp, random_bytes).unwrap_err(), Bech32Error::InvalidLength);
 }
 
 #[test]

--- a/common/src/primitives/height.rs
+++ b/common/src/primitives/height.rs
@@ -230,22 +230,10 @@ mod tests {
         let d_m1 = BlockDistance::new(-1);
         let d_0 = BlockDistance::new(0);
         let d_p1 = BlockDistance::new(1);
-        assert_eq!(
-            (h_halfmax + d_m1).unwrap(),
-            BlockHeight::new(HeightIntType::MAX / 2 - 1)
-        );
-        assert_eq!(
-            (h_halfmax + d_0).unwrap(),
-            BlockHeight::new(HeightIntType::MAX / 2)
-        );
-        assert_eq!(
-            (d_max + d_m1).unwrap(),
-            BlockDistance::new(DistanceIntType::MAX - 1)
-        );
-        assert_eq!(
-            (d_max + d_0).unwrap(),
-            BlockDistance::new(DistanceIntType::MAX)
-        );
+        assert_eq!((h_halfmax + d_m1).unwrap(), BlockHeight::new(HeightIntType::MAX / 2 - 1));
+        assert_eq!((h_halfmax + d_0).unwrap(), BlockHeight::new(HeightIntType::MAX / 2));
+        assert_eq!((d_max + d_m1).unwrap(), BlockDistance::new(DistanceIntType::MAX - 1));
+        assert_eq!((d_max + d_0).unwrap(), BlockDistance::new(DistanceIntType::MAX));
         assert!((d_max + d_p1).is_none());
     }
 
@@ -265,20 +253,9 @@ mod tests {
                 Token::{NewtypeStruct, U64},
             };
             // Block height serializes to just a number, represented by a newtype struct
-            assert_tokens(
-                &height,
-                &[
-                    NewtypeStruct {
-                        name: "BlockHeight",
-                    },
-                    U64(height.0),
-                ],
-            );
+            assert_tokens(&height, &[NewtypeStruct { name: "BlockHeight" }, U64(height.0)]);
             assert_eq!(serde_json::to_value(height).ok(), Some(height.0.into()));
-            assert_eq!(
-                serde_json::to_string(&height).ok(),
-                Some(height.0.to_string())
-            );
+            assert_eq!(serde_json::to_string(&height).ok(), Some(height.0.to_string()));
         }
         check(BlockHeight::new(0));
         check(BlockHeight::new(1));

--- a/common/src/primitives/height.rs
+++ b/common/src/primitives/height.rs
@@ -70,9 +70,8 @@ impl Add<BlockDistance> for BlockHeight {
         //       We should clarify where the enforcement boundary for this is. Also nothing in the API prevents from adding
         //       a BlockDistance twice to a BlockHeight and that would trigger a panic here.
         let height: i64 = self.0.try_into().ok()?;
-        let result = height
-            .checked_add(other.0)
-            .expect("overflow when adding BlockHeight to instant");
+        let result =
+            height.checked_add(other.0).expect("overflow when adding BlockHeight to instant");
         let result: u64 = result.try_into().ok()?;
         Some(Self(result))
     }

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -144,10 +144,7 @@ impl<T> Id<T> {
     }
 
     pub const fn new(h: H256) -> Self {
-        Self {
-            id: h,
-            _shadow: std::marker::PhantomData,
-        }
+        Self { id: h, _shadow: std::marker::PhantomData }
     }
 }
 
@@ -293,10 +290,7 @@ mod tests {
             let hash: H256 = hex.parse().unwrap();
             // hash should serialize into its hex string
             serde_test::assert_tokens(&hash, &[serde_test::Token::Str(hex)]);
-            assert_eq!(
-                serde_json::to_value(hash).ok(),
-                Some(Value::String(format!("{hash:x}")))
-            );
+            assert_eq!(serde_json::to_value(hash).ok(), Some(Value::String(format!("{hash:x}"))));
         }
         SAMPLE_HASHES.iter().cloned().for_each(check)
     }
@@ -308,10 +302,7 @@ mod tests {
             let id: Id<()> = Id::new(hex.parse().unwrap());
             // ID should serialize into its hex string
             serde_test::assert_tokens(&id, &[serde_test::Token::Str(hex)]);
-            assert_eq!(
-                serde_json::to_value(id).ok(),
-                Some(Value::String(format!("{:x}", id.id)))
-            );
+            assert_eq!(serde_json::to_value(id).ok(), Some(Value::String(format!("{:x}", id.id))));
         }
         SAMPLE_HASHES.iter().cloned().for_each(check)
     }

--- a/common/src/primitives/id/with_id.rs
+++ b/common/src/primitives/id/with_id.rs
@@ -112,10 +112,7 @@ mod test {
 
     #[test]
     fn serialization() {
-        let data = TestStruct {
-            num: 1337,
-            blurb: "Hello!".into(),
-        };
+        let data = TestStruct { num: 1337, blurb: "Hello!".into() };
 
         let data_clone = data.clone();
         let encoded = WithId::new(data).encode();
@@ -127,10 +124,7 @@ mod test {
 
     #[test]
     fn owned() {
-        let data = TestStruct {
-            num: 1337,
-            blurb: "Hello!".into(),
-        };
+        let data = TestStruct { num: 1337, blurb: "Hello!".into() };
 
         let data_clone = data.clone();
         let wrapped = WithId::new(data);
@@ -140,10 +134,7 @@ mod test {
 
     #[test]
     fn borrowed() {
-        let data = TestStruct {
-            num: 42,
-            blurb: "Goodbye!".into(),
-        };
+        let data = TestStruct { num: 42, blurb: "Goodbye!".into() };
 
         // Check it works with references too so IDs can be pre-calculated for borrowed data.
         let data_id = data.get_id();

--- a/common/src/primitives/semver.rs
+++ b/common/src/primitives/semver.rs
@@ -24,11 +24,7 @@ pub struct SemVer {
 
 impl SemVer {
     pub const fn new(major: u8, minor: u8, patch: u16) -> Self {
-        Self {
-            major,
-            minor,
-            patch,
-        }
+        Self { major, minor, patch }
     }
 }
 
@@ -52,11 +48,7 @@ impl TryFrom<&str> for SemVer {
         let minor = split_version[1].parse::<u8>().map_err(|_| parse_err)?;
         let patch = split_version[2].parse::<u16>().map_err(|_| parse_err)?;
 
-        Ok(Self {
-            major,
-            minor,
-            patch,
-        })
+        Ok(Self { major, minor, patch })
     }
 }
 
@@ -94,25 +86,13 @@ mod tests {
         let version = SemVer::new(1, 2, 0x500);
         assert_eq!(String::from(version), "1.2.1280");
 
-        assert_eq!(
-            SemVer::try_from(" "),
-            Err("Invalid version. Number of components is wrong.")
-        );
+        assert_eq!(SemVer::try_from(" "), Err("Invalid version. Number of components is wrong."));
 
-        assert_eq!(
-            SemVer::try_from(""),
-            Err("Invalid version. Number of components is wrong.")
-        );
+        assert_eq!(SemVer::try_from(""), Err("Invalid version. Number of components is wrong."));
 
-        assert_eq!(
-            SemVer::try_from("1.2"),
-            Err("Invalid version. Number of components is wrong.")
-        );
+        assert_eq!(SemVer::try_from("1.2"), Err("Invalid version. Number of components is wrong."));
 
-        assert_eq!(
-            SemVer::try_from("1"),
-            Err("Invalid version. Number of components is wrong.")
-        );
+        assert_eq!(SemVer::try_from("1"), Err("Invalid version. Number of components is wrong."));
 
         let version = "hello";
         assert_eq!(
@@ -133,63 +113,36 @@ mod tests {
         assert_eq!(SemVer::try_from(version), Ok(SemVer::new(255, 255, 255)));
 
         let version = "255.255.65535".to_string();
-        assert_eq!(
-            SemVer::try_from(version.clone()),
-            Ok(SemVer::new(255, 255, 65535))
-        );
+        assert_eq!(SemVer::try_from(version.clone()), Ok(SemVer::new(255, 255, 65535)));
         assert_eq!(SemVer::try_from(version), Ok(SemVer::new(255, 255, 65535)));
 
         let version = "255.255.65536";
-        assert_eq!(
-            SemVer::try_from(version),
-            Err("Parsing SemVer component to integer failed")
-        );
+        assert_eq!(SemVer::try_from(version), Err("Parsing SemVer component to integer failed"));
         assert_eq!(
             SemVer::try_from(version.to_string()),
             Err("Parsing SemVer component to integer failed")
         );
 
-        assert_eq!(
-            SemVer::try_from("1.2.a"),
-            Err("Parsing SemVer component to integer failed")
-        );
+        assert_eq!(SemVer::try_from("1.2.a"), Err("Parsing SemVer component to integer failed"));
 
-        assert_eq!(
-            SemVer::try_from("1.2."),
-            Err("Parsing SemVer component to integer failed")
-        );
+        assert_eq!(SemVer::try_from("1.2."), Err("Parsing SemVer component to integer failed"));
 
-        assert_eq!(
-            SemVer::try_from("1..3"),
-            Err("Parsing SemVer component to integer failed")
-        );
+        assert_eq!(SemVer::try_from("1..3"), Err("Parsing SemVer component to integer failed"));
     }
 
     #[test]
     fn vertest_encode_decode() {
         let encoded = SemVer::new(1, 2, 3).encode();
-        assert_eq!(
-            DecodeAll::decode_all(&mut &encoded[..]),
-            Ok(SemVer::new(1, 2, 3))
-        );
+        assert_eq!(DecodeAll::decode_all(&mut &encoded[..]), Ok(SemVer::new(1, 2, 3)));
 
         let encoded = SemVer::new(0xff, 0xff, 0xff).encode();
-        assert_eq!(
-            DecodeAll::decode_all(&mut &encoded[..]),
-            Ok(SemVer::new(0xff, 0xff, 0xff))
-        );
+        assert_eq!(DecodeAll::decode_all(&mut &encoded[..]), Ok(SemVer::new(0xff, 0xff, 0xff)));
 
         let encoded = SemVer::new(0xff, 0xff, 0xffff).encode();
-        assert_eq!(
-            DecodeAll::decode_all(&mut &encoded[..]),
-            Ok(SemVer::new(0xff, 0xff, 0xffff))
-        );
+        assert_eq!(DecodeAll::decode_all(&mut &encoded[..]), Ok(SemVer::new(0xff, 0xff, 0xffff)));
 
         let encoded = SemVer::new(1, 2, 0x500).encode();
-        assert_eq!(
-            DecodeAll::decode_all(&mut &encoded[..]),
-            Ok(SemVer::new(1, 2, 0x500))
-        );
+        assert_eq!(DecodeAll::decode_all(&mut &encoded[..]), Ok(SemVer::new(1, 2, 0x500)));
     }
 
     #[test]

--- a/common/src/primitives/signed_amount.rs
+++ b/common/src/primitives/signed_amount.rs
@@ -76,9 +76,7 @@ impl SignedAmount {
 
         // cover the corner case: SignedAmount::MIN
         if negative && unsigned_amount.into_atoms() == UnsignedIntType::MAX / 2 + 1 {
-            return Some(SignedAmount {
-                val: SignedIntType::MIN,
-            });
+            return Some(SignedAmount { val: SignedIntType::MIN });
         }
 
         let signed_amount = unsigned_amount.into_signed()?;
@@ -215,12 +213,7 @@ mod tests {
 
     #[test]
     fn add_overflow() {
-        assert_eq!(
-            SignedAmount {
-                val: SignedIntType::MAX
-            } + SignedAmount { val: 1 },
-            None
-        );
+        assert_eq!(SignedAmount { val: SignedIntType::MAX } + SignedAmount { val: 1 }, None);
     }
 
     #[test]
@@ -238,9 +231,7 @@ mod tests {
         let amounts = vec![
             SignedAmount { val: 1 },
             SignedAmount { val: 2 },
-            SignedAmount {
-                val: SignedIntType::MAX - 2,
-            },
+            SignedAmount { val: SignedIntType::MAX - 2 },
         ];
         assert_eq!(amounts.into_iter().sum::<Option<SignedAmount>>(), None);
     }
@@ -255,22 +246,12 @@ mod tests {
 
     #[test]
     fn sub_underflow() {
-        assert_eq!(
-            SignedAmount {
-                val: SignedIntType::MIN
-            } - SignedAmount { val: 1 },
-            None
-        );
+        assert_eq!(SignedAmount { val: SignedIntType::MIN } - SignedAmount { val: 1 }, None);
     }
 
     #[test]
     fn mul_overflow() {
-        assert_eq!(
-            SignedAmount {
-                val: SignedIntType::MAX / 2 + 1
-            } * 2,
-            None
-        );
+        assert_eq!(SignedAmount { val: SignedIntType::MAX / 2 + 1 } * 2, None);
     }
 
     #[test]
@@ -322,18 +303,12 @@ mod tests {
         );
 
         assert_eq!(
-            amount_sum!(
-                SignedAmount::from_atoms(SignedIntType::MAX),
-                SignedAmount::from_atoms(0)
-            ),
+            amount_sum!(SignedAmount::from_atoms(SignedIntType::MAX), SignedAmount::from_atoms(0)),
             Some(SignedAmount::from_atoms(SignedIntType::MAX))
         );
 
         assert_eq!(
-            amount_sum!(
-                SignedAmount::from_atoms(SignedIntType::MAX),
-                SignedAmount::from_atoms(1)
-            ),
+            amount_sum!(SignedAmount::from_atoms(SignedIntType::MAX), SignedAmount::from_atoms(1)),
             None
         );
 
@@ -351,20 +326,14 @@ mod tests {
     fn unsigned_conversion_signed_arbitrary() {
         let amount = SignedAmount::from_atoms(10);
         let unsigned_amount_inner = 10 as UnsignedIntType;
-        assert_eq!(
-            amount.into_unsigned().unwrap(),
-            Amount::from_atoms(unsigned_amount_inner)
-        )
+        assert_eq!(amount.into_unsigned().unwrap(), Amount::from_atoms(unsigned_amount_inner))
     }
 
     #[test]
     fn unsigned_conversion_signed_max() {
         let amount = SignedAmount::MAX;
         let unsigned_amount_inner = SignedIntType::MAX as UnsignedIntType;
-        assert_eq!(
-            amount.into_unsigned().unwrap(),
-            Amount::from_atoms(unsigned_amount_inner)
-        )
+        assert_eq!(amount.into_unsigned().unwrap(), Amount::from_atoms(unsigned_amount_inner))
     }
 
     #[test]

--- a/common/src/primitives/signed_amount.rs
+++ b/common/src/primitives/signed_amount.rs
@@ -80,11 +80,8 @@ impl SignedAmount {
         }
 
         let signed_amount = unsigned_amount.into_signed()?;
-        let signed_atoms = if negative {
-            -signed_amount.into_atoms()
-        } else {
-            signed_amount.into_atoms()
-        };
+        let signed_atoms =
+            if negative { -signed_amount.into_atoms() } else { signed_amount.into_atoms() };
         Some(Self::from_atoms(signed_atoms))
     }
 }

--- a/common/src/primitives/time.rs
+++ b/common/src/primitives/time.rs
@@ -53,9 +53,9 @@ pub fn set(now: Duration) -> Result<(), std::num::TryFromIntError> {
 pub fn get_time() -> Duration {
     match get_mocked_time() {
         Some(mocked_time) => mocked_time,
-        None => SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time went backwards"),
+        None => {
+            SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).expect("Time went backwards")
+        }
     }
 }
 

--- a/common/src/primitives/user_agent.rs
+++ b/common/src/primitives/user_agent.rs
@@ -63,10 +63,7 @@ impl TryFrom<Vec<u8>> for UserAgent {
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         ensure!(!value.is_empty(), UserAgentError::Empty);
-        ensure!(
-            value.len() <= MAX_LENGTH,
-            UserAgentError::TooLong(value.len(), MAX_LENGTH)
-        );
+        ensure!(value.len() <= MAX_LENGTH, UserAgentError::TooLong(value.len(), MAX_LENGTH));
         ensure!(
             value
                 .iter()
@@ -98,22 +95,12 @@ mod tests {
 
     fn check(value: &str, valid: bool) {
         let convert_res = UserAgent::try_from(value.as_bytes().to_owned());
-        assert_eq!(
-            convert_res.is_ok(),
-            valid,
-            "convert check failed for {}",
-            value
-        );
+        assert_eq!(convert_res.is_ok(), valid, "convert check failed for {}", value);
 
         let encoded = value.encode();
         let decode_res =
             <UserAgent as serialization::DecodeAll>::decode_all(&mut encoded.as_slice());
-        assert_eq!(
-            decode_res.is_ok(),
-            valid,
-            "decode check failed for {}",
-            value
-        );
+        assert_eq!(decode_res.is_ok(), valid, "decode check failed for {}", value);
 
         if let Ok(decoded) = decode_res {
             assert_eq!(decoded.to_string(), value);

--- a/common/src/uint/impls.rs
+++ b/common/src/uint/impls.rs
@@ -131,10 +131,7 @@ macro_rules! construct_uint {
             /// big endian encoding
             pub fn from_be_slice(bytes: &[u8]) -> Result<$name, ParseLengthError> {
                 if bytes.len() != $n_words * 8 {
-                    Err(ParseLengthError {
-                        actual: bytes.len(),
-                        expected: $n_words * 8,
-                    })
+                    Err(ParseLengthError { actual: bytes.len(), expected: $n_words * 8 })
                 } else {
                     Ok(Self::_from_be_slice(bytes))
                 }
@@ -173,10 +170,7 @@ macro_rules! construct_uint {
             /// little endian encoding
             pub fn from_slice(bytes: &[u8]) -> Result<$name, ParseLengthError> {
                 if bytes.len() != $n_words * 8 {
-                    Err(ParseLengthError {
-                        actual: bytes.len(),
-                        expected: $n_words * 8,
-                    })
+                    Err(ParseLengthError { actual: bytes.len(), expected: $n_words * 8 })
                 } else {
                     Ok(Self::inner_from_slice(bytes))
                 }
@@ -567,11 +561,7 @@ pub struct ParseLengthError {
 
 impl core::fmt::Display for ParseLengthError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(
-            f,
-            "Invalid length: got {}, expected {}",
-            self.actual, self.expected
-        )
+        write!(f, "Invalid length: got {}, expected {}", self.actual, self.expected)
     }
 }
 
@@ -817,48 +807,24 @@ mod tests {
         let shl = add << 88;
         assert_eq!(shl, Uint256([0u64, 0xDFBD5B7DDE000000, 0x1BD5B7D, 0]));
         let shr = shl >> 40;
-        assert_eq!(
-            shr,
-            Uint256([0x7DDE000000000000u64, 0x0001BD5B7DDFBD5B, 0, 0])
-        );
+        assert_eq!(shr, Uint256([0x7DDE000000000000u64, 0x0001BD5B7DDFBD5B, 0, 0]));
         // Increment
         let mut incr = shr;
         incr.increment();
-        assert_eq!(
-            incr,
-            Uint256([0x7DDE000000000001u64, 0x0001BD5B7DDFBD5B, 0, 0])
-        );
+        assert_eq!(incr, Uint256([0x7DDE000000000001u64, 0x0001BD5B7DDFBD5B, 0, 0]));
         // Subtraction
         let sub = incr - init;
-        assert_eq!(
-            sub,
-            Uint256([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0])
-        );
+        assert_eq!(sub, Uint256([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0]));
         // Multiplication
         let mult = sub.mul_u32(300);
-        assert_eq!(
-            mult,
-            Uint256([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0])
-        );
+        assert_eq!(mult, Uint256([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]));
         // Division
-        assert_eq!(
-            Uint256::from_u64(105) / Uint256::from_u64(5),
-            Uint256::from_u64(21)
-        );
+        assert_eq!(Uint256::from_u64(105) / Uint256::from_u64(5), Uint256::from_u64(21));
         let div = mult / Uint256::from_u64(300);
-        assert_eq!(
-            div,
-            Uint256([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0])
-        );
+        assert_eq!(div, Uint256([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0]));
 
-        assert_eq!(
-            Uint256::from_u64(105) % Uint256::from_u64(5),
-            Uint256::from_u64(0)
-        );
-        assert_eq!(
-            Uint256::from_u64(35498456) % Uint256::from_u64(3435),
-            Uint256::from_u64(1166)
-        );
+        assert_eq!(Uint256::from_u64(105) % Uint256::from_u64(5), Uint256::from_u64(0));
+        assert_eq!(Uint256::from_u64(35498456) % Uint256::from_u64(3435), Uint256::from_u64(1166));
         let rem_src = mult * Uint256::from_u64(39842) + Uint256::from_u64(9054);
         assert_eq!(rem_src % Uint256::from_u64(39842), Uint256::from_u64(9054));
         // TODO: bit inversion
@@ -876,14 +842,8 @@ mod tests {
         let u256_res = u224_res.mul_u32(0xFFFFFFFF);
 
         assert_eq!(u96_res, Uint256([0xffffffff21524111u64, 0xDEADBEEE, 0, 0]));
-        assert_eq!(
-            u128_res,
-            Uint256([0x21524111DEADBEEFu64, 0xDEADBEEE21524110, 0, 0])
-        );
-        assert_eq!(
-            u160_res,
-            Uint256([0xBD5B7DDD21524111u64, 0x42A4822200000001, 0xDEADBEED, 0])
-        );
+        assert_eq!(u128_res, Uint256([0x21524111DEADBEEFu64, 0xDEADBEEE21524110, 0, 0]));
+        assert_eq!(u160_res, Uint256([0xBD5B7DDD21524111u64, 0x42A4822200000001, 0xDEADBEED, 0]));
         assert_eq!(
             u192_res,
             Uint256([0x63F6C333DEADBEEFu64, 0xBD5B7DDFBD5B7DDB, 0xDEADBEEC63F6C334, 0])
@@ -909,10 +869,7 @@ mod tests {
 
         let u128_res = u64_val * u64_val;
 
-        assert_eq!(
-            u128_res,
-            Uint256([0x048D1354216DA321u64, 0xC1B1CD13A4D13D46, 0, 0])
-        );
+        assert_eq!(u128_res, Uint256([0x048D1354216DA321u64, 0xC1B1CD13A4D13D46, 0, 0]));
 
         let u256_res = u128_res * u128_res;
 
@@ -1023,10 +980,7 @@ mod tests {
         let add = (init << 64) + init;
         assert_eq!(add, Uint256([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0]));
         assert_eq!(add >> 64, Uint256([0xDEADBEEFDEADBEEF, 0, 0, 0]));
-        assert_eq!(
-            add << 64,
-            Uint256([0, 0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0])
-        );
+        assert_eq!(add << 64, Uint256([0, 0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0]));
     }
 
     #[rstest]
@@ -1086,16 +1040,10 @@ mod tests {
         assert_eq!(Uint256::try_from(b).unwrap(), a);
 
         let a = Uint512::from(Uint256::MAX) + Uint512::ONE;
-        assert_eq!(
-            Uint256::try_from(a).unwrap_err(),
-            UintConversionError::ConversionOverflow
-        );
+        assert_eq!(Uint256::try_from(a).unwrap_err(), UintConversionError::ConversionOverflow);
 
         let a = Uint512::MAX;
-        assert_eq!(
-            Uint256::try_from(a).unwrap_err(),
-            UintConversionError::ConversionOverflow
-        );
+        assert_eq!(Uint256::try_from(a).unwrap_err(), UintConversionError::ConversionOverflow);
     }
 
     #[rstest]
@@ -1126,15 +1074,9 @@ mod tests {
         assert_eq!(u128::try_from(b).unwrap(), a);
 
         let a = Uint256::from(u128::MAX) + Uint256::ONE;
-        assert_eq!(
-            u128::try_from(a).unwrap_err(),
-            UintConversionError::ConversionOverflow
-        );
+        assert_eq!(u128::try_from(a).unwrap_err(), UintConversionError::ConversionOverflow);
 
         let a = Uint256::MAX;
-        assert_eq!(
-            u128::try_from(a).unwrap_err(),
-            UintConversionError::ConversionOverflow
-        );
+        assert_eq!(u128::try_from(a).unwrap_err(), UintConversionError::ConversionOverflow);
     }
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -165,12 +165,12 @@ where
                 block_height,
             )
             .map_err(ConsensusCreationError::MiningError),
-            GenerateBlockInputData::PoS(_) => Err(ConsensusCreationError::MiningError(
-                ConsensusPoWError::PoSInputDataProvided,
-            )),
-            GenerateBlockInputData::None => Err(ConsensusCreationError::MiningError(
-                ConsensusPoWError::NoInputDataProvided,
-            )),
+            GenerateBlockInputData::PoS(_) => {
+                Err(ConsensusCreationError::MiningError(ConsensusPoWError::PoSInputDataProvided))
+            }
+            GenerateBlockInputData::None => {
+                Err(ConsensusCreationError::MiningError(ConsensusPoWError::NoInputDataProvided))
+            }
         },
     }
 }
@@ -186,12 +186,12 @@ pub fn finalize_consensus_data(
     match chain_config.net_upgrade().consensus_status(block_height.next_height()) {
         RequiredConsensus::IgnoreConsensus => Ok(block_header.clone().with_no_signature()),
         RequiredConsensus::PoS(_) => match block_header.consensus_data() {
-            ConsensusData::None => Err(ConsensusCreationError::StakingError(
-                ConsensusPoSError::NoInputDataProvided,
-            )),
-            ConsensusData::PoW(_) => Err(ConsensusCreationError::StakingError(
-                ConsensusPoSError::PoWInputDataProvided,
-            )),
+            ConsensusData::None => {
+                Err(ConsensusCreationError::StakingError(ConsensusPoSError::NoInputDataProvided))
+            }
+            ConsensusData::PoW(_) => {
+                Err(ConsensusCreationError::StakingError(ConsensusPoSError::PoWInputDataProvided))
+            }
             ConsensusData::PoS(pos_data) => match finalize_data {
                 FinalizeBlockInputData::None => Err(ConsensusCreationError::StakingError(
                     ConsensusPoSError::NoInputDataProvided,
@@ -230,12 +230,12 @@ pub fn finalize_consensus_data(
             },
         },
         RequiredConsensus::PoW(_) => match block_header.consensus_data() {
-            ConsensusData::None => Err(ConsensusCreationError::MiningError(
-                ConsensusPoWError::NoInputDataProvided,
-            )),
-            ConsensusData::PoS(_) => Err(ConsensusCreationError::MiningError(
-                ConsensusPoWError::PoSInputDataProvided,
-            )),
+            ConsensusData::None => {
+                Err(ConsensusCreationError::MiningError(ConsensusPoWError::NoInputDataProvided))
+            }
+            ConsensusData::PoS(_) => {
+                Err(ConsensusCreationError::MiningError(ConsensusPoWError::PoSInputDataProvided))
+            }
             ConsensusData::PoW(pow_data) => {
                 let mine_result = mine(block_header, u128::MAX, pow_data.bits(), stop_flag)?;
 

--- a/consensus/src/pos/input_data.rs
+++ b/consensus/src/pos/input_data.rs
@@ -85,13 +85,7 @@ impl PoSGenerateBlockInputData {
         kernel_inputs: Vec<TxInput>,
         kernel_input_utxos: Vec<TxOutput>,
     ) -> Self {
-        Self {
-            stake_private_key,
-            vrf_private_key,
-            pool_id,
-            kernel_inputs,
-            kernel_input_utxos,
-        }
+        Self { stake_private_key, vrf_private_key, pool_id, kernel_inputs, kernel_input_utxos }
     }
 
     pub fn kernel_inputs(&self) -> &Vec<TxInput> {

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -82,10 +82,7 @@ pub fn check_pos_hash(
     let hash: Uint512 = hash.into();
     let pool_balance: Uint512 = pool_balance.into();
 
-    ensure!(
-        hash <= pool_balance * target.into(),
-        ConsensusPoSError::StakeKernelHashTooHigh
-    );
+    ensure!(hash <= pool_balance * target.into(), ConsensusPoSError::StakeKernelHashTooHigh);
 
     Ok(())
 }

--- a/consensus/src/pos/target.rs
+++ b/consensus/src/pos/target.rs
@@ -85,10 +85,7 @@ fn calculate_new_target(
     };
 
     let target_block_time = Uint512::from_u64(pos_config.target_block_time().get());
-    ensure!(
-        target_block_time > Uint512::ZERO,
-        ConsensusPoSError::InvalidTargetBlockTime
-    );
+    ensure!(target_block_time > Uint512::ZERO, ConsensusPoSError::InvalidTargetBlockTime);
     let prev_target: Uint512 = (*prev_target).into();
 
     // TODO: limiting factor (mintlayer/mintlayer-core#787)
@@ -115,10 +112,7 @@ where
     F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
 {
     let pos_config = match pos_status {
-        PoSStatus::Threshold {
-            initial_difficulty,
-            config: _,
-        } => return Ok(*initial_difficulty),
+        PoSStatus::Threshold { initial_difficulty, config: _ } => return Ok(*initial_difficulty),
         PoSStatus::Ongoing(config) => config,
     };
 
@@ -137,10 +131,7 @@ pub fn calculate_target_required(
     block_index_handle: &impl BlockIndexHandle,
 ) -> Result<Compact, ConsensusPoSError> {
     let pos_config = match pos_status {
-        PoSStatus::Threshold {
-            initial_difficulty,
-            config: _,
-        } => return Ok(*initial_difficulty),
+        PoSStatus::Threshold { initial_difficulty, config: _ } => return Ok(*initial_difficulty),
         PoSStatus::Ongoing(config) => config,
     };
 
@@ -172,10 +163,9 @@ where
     // check if prev block is a net upgrade threshold
     match chain_config.net_upgrade().consensus_status(prev_block_index.block_height()) {
         RequiredConsensus::PoS(status) => match status {
-            PoSStatus::Threshold {
-                initial_difficulty,
-                config: _,
-            } => return Ok(initial_difficulty),
+            PoSStatus::Threshold { initial_difficulty, config: _ } => {
+                return Ok(initial_difficulty)
+            }
             PoSStatus::Ongoing(_) => { /*do nothing*/ }
         },
         RequiredConsensus::PoW(_) | RequiredConsensus::IgnoreConsensus => {
@@ -258,10 +248,7 @@ mod tests {
 
     impl<'a> TestBlockIndexHandle<'a> {
         pub fn new(chain_config: &'a ChainConfig) -> Self {
-            Self {
-                blocks: Default::default(),
-                chain_config,
-            }
+            Self { blocks: Default::default(), chain_config }
         }
 
         pub fn new_with_blocks(
@@ -290,10 +277,7 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
 
-            Self {
-                blocks,
-                chain_config,
-            }
+            Self { blocks, chain_config }
         }
 
         pub fn get_block_index_by_height(&self, height: BlockHeight) -> Option<&BlockIndex> {
@@ -336,9 +320,7 @@ mod tests {
             }
 
             if ancestor_height == BlockHeight::new(0) {
-                Ok(GenBlockIndex::Genesis(Arc::clone(
-                    self.chain_config.genesis_block(),
-                )))
+                Ok(GenBlockIndex::Genesis(Arc::clone(self.chain_config.genesis_block())))
             } else {
                 Ok(self
                     .get_block_index_by_height(ancestor_height)

--- a/consensus/src/pos/target.rs
+++ b/consensus/src/pos/target.rs
@@ -56,17 +56,15 @@ where
     let timespan_start_height =
         std::cmp::max(net_version_range.start, block_height_to_stare_averaging);
 
-    let time_span_start = get_ancestor(block_index, timespan_start_height)?
-        .block_timestamp()
-        .as_int_seconds();
+    let time_span_start =
+        get_ancestor(block_index, timespan_start_height)?.block_timestamp().as_int_seconds();
     let current_block_time = block_index.block_timestamp().as_int_seconds();
 
     let timespan_difference = current_block_time
         .checked_sub(time_span_start)
         .ok_or(ConsensusPoSError::InvariantBrokenNotMonotonicBlockTime)?;
-    let blocks_in_timespan: i64 = (block_index.block_height() - timespan_start_height)
-        .expect("cannot be negative")
-        .into();
+    let blocks_in_timespan: i64 =
+        (block_index.block_height() - timespan_start_height).expect("cannot be negative").into();
 
     let average = timespan_difference / blocks_in_timespan as u64;
 
@@ -281,10 +279,7 @@ mod tests {
         }
 
         pub fn get_block_index_by_height(&self, height: BlockHeight) -> Option<&BlockIndex> {
-            self.blocks
-                .iter()
-                .find(|(block_height, _)| height == *block_height)
-                .map(|(_, b)| b)
+            self.blocks.iter().find(|(block_height, _)| height == *block_height).map(|(_, b)| b)
         }
     }
 

--- a/consensus/src/pos/target.rs
+++ b/consensus/src/pos/target.rs
@@ -76,11 +76,8 @@ fn calculate_new_target(
     prev_target: &Uint256,
     actual_block_time: u64,
 ) -> Result<Compact, ConsensusPoSError> {
-    let actual_block_time = if actual_block_time == 0 {
-        Uint512::ONE
-    } else {
-        Uint512::from_u64(actual_block_time)
-    };
+    let actual_block_time =
+        if actual_block_time == 0 { Uint512::ONE } else { Uint512::from_u64(actual_block_time) };
 
     let target_block_time = Uint512::from_u64(pos_config.target_block_time().get());
     ensure!(target_block_time > Uint512::ZERO, ConsensusPoSError::InvalidTargetBlockTime);

--- a/consensus/src/pow/helpers.rs
+++ b/consensus/src/pow/helpers.rs
@@ -78,11 +78,7 @@ pub fn calculate_new_target(
     let mut new_target = old_target * actual_timespan;
     new_target = new_target / target_timespan;
 
-    new_target = if new_target > difficulty_limit {
-        difficulty_limit
-    } else {
-        new_target
-    };
+    new_target = if new_target > difficulty_limit { difficulty_limit } else { new_target };
 
     Ok(Compact::from(new_target))
 }

--- a/consensus/src/pow/work.rs
+++ b/consensus/src/pow/work.rs
@@ -273,18 +273,9 @@ mod tests {
 
     #[rstest]
     #[case(0, "0000000000000000000000000000000000000000000000000000000000000000")]
-    #[case(
-        386_567_092,
-        "6c13667de68cb99b4ca3b8aaabe5513e68b90301a59f05000000000000000000"
-    )] // block 722731
-    #[case(
-        386_568_320,
-        "b33ea07931b531a42afbff7e2d474e905faafcb2385308000000000000000000"
-    )] // block 721311
-    #[case(
-        486_604_799,
-        "bdd99dc9fda39da1b108ce1a5d7030d0a9607bacb68b6b63605f626a00000000"
-    )] // block 2
+    #[case(386_567_092, "6c13667de68cb99b4ca3b8aaabe5513e68b90301a59f05000000000000000000")] // block 722731
+    #[case(386_568_320, "b33ea07931b531a42afbff7e2d474e905faafcb2385308000000000000000000")] // block 721311
+    #[case(486_604_799, "bdd99dc9fda39da1b108ce1a5d7030d0a9607bacb68b6b63605f626a00000000")] // block 2
     fn pow_ok(#[case] bits: u32, #[case] hash: H256) {
         assert!(check_proof_of_work(hash, Compact(bits)).unwrap());
     }

--- a/consensus/src/validator.rs
+++ b/consensus/src/validator.rs
@@ -59,12 +59,9 @@ where
     let block_height = prev_block_height.next_height();
     let consensus_status = chain_config.net_upgrade().consensus_status(block_height);
     match consensus_status {
-        RequiredConsensus::PoW(pow_status) => validate_pow_consensus(
-            chain_config,
-            header.header(),
-            &pow_status,
-            block_index_handle,
-        ),
+        RequiredConsensus::PoW(pow_status) => {
+            validate_pow_consensus(chain_config, header.header(), &pow_status, block_index_handle)
+        }
         RequiredConsensus::IgnoreConsensus => validate_ignore_consensus(header.header()),
         RequiredConsensus::PoS(pos_status) => validate_pos_consensus(
             chain_config,
@@ -90,14 +87,10 @@ fn validate_pow_consensus<H: BlockIndexHandle>(
                 "Chain configuration says we are PoW but block consensus data is not PoW.".into(),
             ))
         }
-        ConsensusData::PoW(pow_data) => check_pow_consensus(
-            chain_config,
-            header,
-            pow_data,
-            pow_status,
-            block_index_handle,
-        )
-        .map_err(Into::into),
+        ConsensusData::PoW(pow_data) => {
+            check_pow_consensus(chain_config, header, pow_data, pow_status, block_index_handle)
+                .map_err(Into::into)
+        }
     }
 }
 

--- a/crypto/src/kdf/argon2.rs
+++ b/crypto/src/kdf/argon2.rs
@@ -32,11 +32,7 @@ pub struct Argon2Config {
 
 impl Argon2Config {
     pub fn new(m_cost_memory_size: u32, t_cost_iterations: u32, p_cost_parallelism: u32) -> Self {
-        Self {
-            m_cost_memory_size,
-            t_cost_iterations,
-            p_cost_parallelism,
-        }
+        Self { m_cost_memory_size, t_cost_iterations, p_cost_parallelism }
     }
 }
 
@@ -77,10 +73,7 @@ pub mod test {
         );
         let hash = hash.unwrap();
         let hash_hex: String = hash.encode_hex();
-        assert_eq!(
-            hash_hex,
-            "0b549350ae93d48747c5b3a676589279a3cce4a7b9de79494e2f0b7193d0ae9b"
-        );
+        assert_eq!(hash_hex, "0b549350ae93d48747c5b3a676589279a3cce4a7b9de79494e2f0b7193d0ae9b");
     }
 
     #[test]
@@ -94,10 +87,7 @@ pub mod test {
         );
         let hash = hash.unwrap();
         let hash_hex: String = hash.encode_hex();
-        assert_eq!(
-            hash_hex,
-            "f6acd6dc507655ef500975881f6ba642eb03d04ce71d3b3a139e04b321daa88a"
-        );
+        assert_eq!(hash_hex, "f6acd6dc507655ef500975881f6ba642eb03d04ce71d3b3a139e04b321daa88a");
     }
 
     #[test]
@@ -111,10 +101,7 @@ pub mod test {
         );
         let hash = hash.unwrap();
         let hash_hex: String = hash.encode_hex();
-        assert_eq!(
-            hash_hex,
-            "e57d0a6482f160a9f9f6c23f480eb478fcf5b13e07445514a7d4d6e48c52c5e3"
-        );
+        assert_eq!(hash_hex, "e57d0a6482f160a9f9f6c23f480eb478fcf5b13e07445514a7d4d6e48c52c5e3");
     }
 
     #[test]
@@ -128,10 +115,7 @@ pub mod test {
         );
         let hash = hash.unwrap();
         let hash_hex: String = hash.encode_hex();
-        assert_eq!(
-            hash_hex,
-            "6e7833c72c1eaa5388b389f1cb657ee27858f062a164763d041c880fe7ced6d7"
-        );
+        assert_eq!(hash_hex, "6e7833c72c1eaa5388b389f1cb657ee27858f062a164763d041c880fe7ced6d7");
     }
 
     #[test]
@@ -145,10 +129,7 @@ pub mod test {
         );
         let hash = hash.unwrap();
         let hash_hex: String = hash.encode_hex();
-        assert_eq!(
-            hash_hex,
-            "8dd956b8a3d0e0a28905a70cff97a63ecc764af44b73daaef608de5a593e7ea7"
-        );
+        assert_eq!(hash_hex, "8dd956b8a3d0e0a28905a70cff97a63ecc764af44b73daaef608de5a593e7ea7");
     }
 
     #[test]
@@ -162,10 +143,7 @@ pub mod test {
         );
         let hash = hash.unwrap();
         let hash_hex: String = hash.encode_hex();
-        assert_eq!(
-            hash_hex,
-            "5aa54fa17129a5488e51a8c8ba6754921dfb0cbd88013942a4705ecb1789ab11"
-        );
+        assert_eq!(hash_hex, "5aa54fa17129a5488e51a8c8ba6754921dfb0cbd88013942a4705ecb1789ab11");
     }
 
     #[test]
@@ -179,10 +157,7 @@ pub mod test {
         );
         let hash = hash.unwrap();
         let hash_hex: String = hash.encode_hex();
-        assert_eq!(
-            hash_hex,
-            "d3fd0dc78bceed1c87d303aaead74177676157bed51b9e5479e09c905c5bf2b4"
-        );
+        assert_eq!(hash_hex, "d3fd0dc78bceed1c87d303aaead74177676157bed51b9e5479e09c905c5bf2b4");
     }
 
     #[test]
@@ -210,10 +185,7 @@ pub mod test {
         );
         let hash = hash.unwrap();
         let hash_hex: String = hash.encode_hex();
-        assert_eq!(
-            hash_hex,
-            "495205d26d5184c4b90e41c98cd067f85b67cc303d86391dfd16436f5d272e58"
-        );
+        assert_eq!(hash_hex, "495205d26d5184c4b90e41c98cd067f85b67cc303d86391dfd16436f5d272e58");
     }
 
     #[test]

--- a/crypto/src/key/extended.rs
+++ b/crypto/src/key/extended.rs
@@ -189,15 +189,12 @@ mod test {
     fn derive_secp256k1schnorr(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let (sk, _) = ExtendedPrivateKey::new_from_rng(&mut rng, ExtendedKeyKind::Secp256k1Schnorr);
-        let sk1 = sk
-            .clone()
-            .derive_child(ChildNumber::from_hardened(1.try_into().unwrap()))
-            .unwrap();
+        let sk1 =
+            sk.clone().derive_child(ChildNumber::from_hardened(1.try_into().unwrap())).unwrap();
         let sk2 = sk1.derive_child(ChildNumber::from_hardened(2.try_into().unwrap())).unwrap();
         let sk3 = sk2.derive_child(ChildNumber::from_hardened(3.try_into().unwrap())).unwrap();
-        let sk3_alt = sk
-            .derive_absolute_path(&DerivationPath::from_str("m/1h/2h/3h").unwrap())
-            .unwrap();
+        let sk3_alt =
+            sk.derive_absolute_path(&DerivationPath::from_str("m/1h/2h/3h").unwrap()).unwrap();
         assert_eq!(sk3, sk3_alt);
         let sk4 = sk3.derive_child(ChildNumber::from_normal(4.try_into().unwrap())).unwrap();
         let sk4_alt = sk3_alt

--- a/crypto/src/key/extended.rs
+++ b/crypto/src/key/extended.rs
@@ -50,9 +50,7 @@ impl ExtendedPrivateKey {
         match key_kind {
             ExtendedKeyKind::Secp256k1Schnorr => {
                 let secp_key = Secp256k1ExtendedPrivateKey::new_master(seed)?;
-                Ok(ExtendedPrivateKey {
-                    key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(secp_key),
-                })
+                Ok(ExtendedPrivateKey { key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(secp_key) })
             }
         }
     }
@@ -69,12 +67,8 @@ impl ExtendedPrivateKey {
             ExtendedKeyKind::Secp256k1Schnorr => {
                 let k = Secp256k1ExtendedPrivateKey::new(rng);
                 (
-                    ExtendedPrivateKey {
-                        key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(k.0),
-                    },
-                    ExtendedPublicKey {
-                        pub_key: ExtendedPublicKeyHolder::Secp256k1Schnorr(k.1),
-                    },
+                    ExtendedPrivateKey { key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(k.0) },
+                    ExtendedPublicKey { pub_key: ExtendedPublicKeyHolder::Secp256k1Schnorr(k.1) },
                 )
             }
         }
@@ -116,9 +110,7 @@ impl ExtendedPublicKey {
         match private_key.get_internal_key() {
             ExtendedPrivateKeyHolder::Secp256k1Schnorr(ref k) => {
                 let secp_key = Secp256k1ExtendedPublicKey::from_private_key(k);
-                ExtendedPublicKey {
-                    pub_key: ExtendedPublicKeyHolder::Secp256k1Schnorr(secp_key),
-                }
+                ExtendedPublicKey { pub_key: ExtendedPublicKeyHolder::Secp256k1Schnorr(secp_key) }
             }
         }
     }
@@ -135,9 +127,7 @@ impl Derivable for ExtendedPrivateKey {
         match self.key {
             ExtendedPrivateKeyHolder::Secp256k1Schnorr(key) => {
                 let secp_key = key.derive_child(num)?;
-                Ok(ExtendedPrivateKey {
-                    key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(secp_key),
-                })
+                Ok(ExtendedPrivateKey { key: ExtendedPrivateKeyHolder::Secp256k1Schnorr(secp_key) })
             }
         }
     }

--- a/crypto/src/key/hdkd/derivation_path.rs
+++ b/crypto/src/key/hdkd/derivation_path.rs
@@ -158,10 +158,7 @@ mod tests {
         let super_path = DerivationPath::from_str(super_path).unwrap();
         let result = result.map(|s| DerivationPath::from_str(s).unwrap().as_slice().to_vec());
 
-        assert_eq!(
-            super_path.get_super_path_diff(&sub_path).map(|a| a.to_vec()),
-            result
-        );
+        assert_eq!(super_path.get_super_path_diff(&sub_path).map(|a| a.to_vec()), result);
     }
 
     #[rstest]
@@ -192,26 +189,14 @@ mod tests {
         let sub_path = DerivationPath::try_from(sub_path_vec).unwrap();
         let super_path = DerivationPath::try_from(super_path_vec).unwrap();
 
-        assert_eq!(
-            super_path.get_super_path_diff(&sub_path).map(|a| a.to_vec()),
-            result
-        );
+        assert_eq!(super_path.get_super_path_diff(&sub_path).map(|a| a.to_vec()), result);
     }
 
     #[test]
     fn parse_derivation_path() {
-        assert_eq!(
-            DerivationPath::from_str(""),
-            Err(DerivationError::InvalidDerivationPathFormat)
-        );
-        assert_eq!(
-            DerivationPath::from_str("m/"),
-            Err(DerivationError::InvalidChildNumberFormat)
-        );
-        assert_eq!(
-            DerivationPath::from_str("m/h"),
-            Err(DerivationError::InvalidChildNumberFormat)
-        );
+        assert_eq!(DerivationPath::from_str(""), Err(DerivationError::InvalidDerivationPathFormat));
+        assert_eq!(DerivationPath::from_str("m/"), Err(DerivationError::InvalidChildNumberFormat));
+        assert_eq!(DerivationPath::from_str("m/h"), Err(DerivationError::InvalidChildNumberFormat));
         assert_eq!(
             DerivationPath::from_str("42"),
             Err(DerivationError::InvalidDerivationPathFormat)
@@ -277,10 +262,7 @@ mod tests {
             Err(DerivationError::InvalidChildNumberFormat)
         );
 
-        assert_eq!(
-            DerivationPath(vec![]),
-            DerivationPath::from_str("m").unwrap()
-        );
+        assert_eq!(DerivationPath(vec![]), DerivationPath::from_str("m").unwrap());
         assert_eq!(DerivationPath::from_str("m"), Ok(DerivationPath::empty()));
         assert_eq!(
             DerivationPath::from_str("m/0'"),
@@ -348,10 +330,7 @@ mod tests {
         let mut path = path_1_2.clone().into_vec();
         let index_3 = ChildNumber::from_hardened(3.try_into().unwrap());
         path.push(index_3);
-        assert_eq!(
-            path,
-            DerivationPath::from_str("m/1'/2'/3'").unwrap().into_vec()
-        );
+        assert_eq!(path, DerivationPath::from_str("m/1'/2'/3'").unwrap().into_vec());
         assert_eq!(path.pop(), Some(index_3));
         assert_eq!(path, path_1_2.into_vec());
         path.pop();

--- a/crypto/src/key/mod.rs
+++ b/crypto/src/key/mod.rs
@@ -93,9 +93,7 @@ impl PrivateKey {
 
 impl From<Secp256k1PrivateKey> for PrivateKey {
     fn from(sk: Secp256k1PrivateKey) -> Self {
-        Self {
-            key: PrivateKeyHolder::Secp256k1Schnorr(sk),
-        }
+        Self { key: PrivateKeyHolder::Secp256k1Schnorr(sk) }
     }
 }
 
@@ -132,9 +130,7 @@ impl PublicKey {
 
 impl From<Secp256k1PublicKey> for PublicKey {
     fn from(pk: Secp256k1PublicKey) -> Self {
-        Self {
-            pub_key: PublicKeyHolder::Secp256k1Schnorr(pk),
-        }
+        Self { pub_key: PublicKeyHolder::Secp256k1Schnorr(pk) }
     }
 }
 

--- a/crypto/src/key/secp256k1/extended_keys.rs
+++ b/crypto/src/key/secp256k1/extended_keys.rs
@@ -145,11 +145,7 @@ impl Derivable for Secp256k1ExtendedPrivateKey {
             child_path.try_into()?
         };
 
-        Ok(Secp256k1ExtendedPrivateKey {
-            derivation_path,
-            chain_code,
-            private_key,
-        })
+        Ok(Secp256k1ExtendedPrivateKey { derivation_path, chain_code, private_key })
     }
 
     fn get_derivation_path(&self) -> &DerivationPath {
@@ -231,11 +227,7 @@ impl Derivable for Secp256k1ExtendedPublicKey {
             child_path.try_into()?
         };
 
-        Ok(Secp256k1ExtendedPublicKey {
-            derivation_path,
-            chain_code,
-            public_key,
-        })
+        Ok(Secp256k1ExtendedPublicKey { derivation_path, chain_code, public_key })
     }
 
     fn get_derivation_path(&self) -> &DerivationPath {

--- a/crypto/src/key/secp256k1/mod.rs
+++ b/crypto/src/key/secp256k1/mod.rs
@@ -59,10 +59,7 @@ impl Secp256k1PrivateKey {
     pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> (Secp256k1PrivateKey, Secp256k1PublicKey) {
         let secret = secp256k1::SecretKey::new(rng);
         let public = secret.public_key(secp256k1::SECP256K1);
-        (
-            Secp256k1PrivateKey::from_native(secret),
-            Secp256k1PublicKey::from_native(public),
-        )
+        (Secp256k1PrivateKey::from_native(secret), Secp256k1PublicKey::from_native(public))
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -138,9 +135,7 @@ impl Secp256k1PublicKey {
     }
 
     pub fn from_native(native: secp256k1::PublicKey) -> Self {
-        Self {
-            pubkey_data: native,
-        }
+        Self { pubkey_data: native }
     }
 
     pub fn from_private_key(private_key: &Secp256k1PrivateKey) -> Self {
@@ -166,11 +161,7 @@ impl Secp256k1PublicKey {
         msg_hashed: &secp256k1::Message,
     ) -> bool {
         secp256k1::SECP256K1
-            .verify_schnorr(
-                signature,
-                msg_hashed,
-                &self.pubkey_data.x_only_public_key().0,
-            )
+            .verify_schnorr(signature, msg_hashed, &self.pubkey_data.x_only_public_key().0)
             .is_ok()
     }
 }

--- a/crypto/src/symkey/chacha20poly1305/mod.rs
+++ b/crypto/src/symkey/chacha20poly1305/mod.rs
@@ -38,15 +38,15 @@ impl Chacha20poly1305Key {
     }
 
     pub fn new_from_array(key_data: [u8; Self::KEY_LEN]) -> Self {
-        Self {
-            key_data: key_data.into(),
-        }
+        Self { key_data: key_data.into() }
     }
 
     pub fn new_from_bytes_slice(bytes_slice: &[u8]) -> Result<Self, Error> {
-        Ok(Self::new_from_array(bytes_slice.try_into().map_err(
-            |_| Error::WrongLenKeyBytes(bytes_slice.len(), Self::KEY_LEN),
-        )?))
+        Ok(Self::new_from_array(
+            bytes_slice
+                .try_into()
+                .map_err(|_| Error::WrongLenKeyBytes(bytes_slice.len(), Self::KEY_LEN))?,
+        ))
     }
 
     fn encrypt_with_nonce_and_aead<T: AsRef<[u8]>>(
@@ -97,10 +97,7 @@ impl Chacha20poly1305Key {
         associated_data: Option<&[u8]>,
     ) -> Result<Vec<u8>, Error> {
         if cipher_text_in.as_ref().len() < Self::NONCE_LEN {
-            return Err(Error::CipherTextTooShort(
-                cipher_text_in.as_ref().len(),
-                Self::NONCE_LEN,
-            ));
+            return Err(Error::CipherTextTooShort(cipher_text_in.as_ref().len(), Self::NONCE_LEN));
         }
         let nonce = &cipher_text_in.as_ref()[..Self::NONCE_LEN];
         let cipher_text = &cipher_text_in.as_ref()[Self::NONCE_LEN..];
@@ -239,10 +236,7 @@ mod test {
                 Some(&aead),
             )
             .unwrap();
-        assert_eq!(
-            nonce_with_encrypted[Chacha20poly1305Key::NONCE_LEN..],
-            expected_encrypted
-        );
+        assert_eq!(nonce_with_encrypted[Chacha20poly1305Key::NONCE_LEN..], expected_encrypted);
         assert_eq!(decrypted, message);
     }
 
@@ -319,10 +313,7 @@ mod test {
                 Some(&aead),
             )
             .unwrap();
-        assert_eq!(
-            nonce_with_encrypted[Chacha20poly1305Key::NONCE_LEN..],
-            cipher
-        );
+        assert_eq!(nonce_with_encrypted[Chacha20poly1305Key::NONCE_LEN..], cipher);
         assert_eq!(decrypted, message);
     }
 

--- a/crypto/src/symkey/mod.rs
+++ b/crypto/src/symkey/mod.rs
@@ -132,10 +132,7 @@ mod test {
         } else {
             assert_eq!(
                 result,
-                Err(Error::WrongLenKeyBytes(
-                    bytes.len(),
-                    Chacha20poly1305Key::KEY_LEN
-                ))
+                Err(Error::WrongLenKeyBytes(bytes.len(), Chacha20poly1305Key::KEY_LEN))
             );
         }
     }

--- a/crypto/src/vrf/mod.rs
+++ b/crypto/src/vrf/mod.rs
@@ -89,12 +89,8 @@ impl VRFPrivateKey {
             VRFKeyKind::Schnorrkel => {
                 let k = schnorrkel::SchnorrkelPrivateKey::new(rng);
                 (
-                    VRFPrivateKey {
-                        key: VRFPrivateKeyHolder::Schnorrkel(k.0),
-                    },
-                    VRFPublicKey {
-                        pub_key: VRFPublicKeyHolder::Schnorrkel(k.1),
-                    },
+                    VRFPrivateKey { key: VRFPrivateKeyHolder::Schnorrkel(k.0) },
+                    VRFPublicKey { pub_key: VRFPublicKeyHolder::Schnorrkel(k.1) },
                 )
             }
         }
@@ -110,12 +106,8 @@ impl VRFPrivateKey {
             VRFKeyKind::Schnorrkel => {
                 let k = schnorrkel::SchnorrkelPrivateKey::new_using_random_bytes(bytes)?;
                 Ok((
-                    VRFPrivateKey {
-                        key: VRFPrivateKeyHolder::Schnorrkel(k.0),
-                    },
-                    VRFPublicKey {
-                        pub_key: VRFPublicKeyHolder::Schnorrkel(k.1),
-                    },
+                    VRFPrivateKey { key: VRFPrivateKeyHolder::Schnorrkel(k.0) },
+                    VRFPublicKey { pub_key: VRFPublicKeyHolder::Schnorrkel(k.1) },
                 ))
             }
         }
@@ -288,10 +280,7 @@ mod tests {
 
     fn make_arbitrary_transcript() -> WrappedTranscript {
         TranscriptAssembler::new(b"some context")
-            .attach(
-                b"some label",
-                TranscriptComponent::RawData(b"Data to commit".to_vec()),
-            )
+            .attach(b"some label", TranscriptComponent::RawData(b"Data to commit".to_vec()))
             .attach(b"some other label", TranscriptComponent::U64(42))
             .attach(
                 b"some third label",

--- a/crypto/src/vrf/mod.rs
+++ b/crypto/src/vrf/mod.rs
@@ -314,8 +314,7 @@ mod tests {
             }
         }
 
-        pk.verify_vrf_data(transcript.into(), &vrf_data)
-            .expect("Valid VRF check failed");
+        pk.verify_vrf_data(transcript.into(), &vrf_data).expect("Valid VRF check failed");
     }
 
     #[rstest]
@@ -346,8 +345,7 @@ mod tests {
         let mut mutated_transcript: Transcript = transcript.into();
         mutated_transcript.append_u64(b"Forgery", 1337);
 
-        pk.verify_vrf_data(mutated_transcript, &vrf_data)
-            .expect_err("Invalid VRF check succeeded");
+        pk.verify_vrf_data(mutated_transcript, &vrf_data).expect_err("Invalid VRF check succeeded");
     }
 
     #[rstest]
@@ -377,8 +375,7 @@ mod tests {
 
         let (_sk2, pk2) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
 
-        pk2.verify_vrf_data(transcript.into(), &vrf_data)
-            .expect_err("Invalid VRF check succeeded");
+        pk2.verify_vrf_data(transcript.into(), &vrf_data).expect_err("Invalid VRF check succeeded");
     }
 
     #[test]
@@ -412,7 +409,6 @@ mod tests {
             }
         }
 
-        pk.verify_vrf_data(transcript.into(), &vrf_data)
-            .expect("Valid VRF check failed");
+        pk.verify_vrf_data(transcript.into(), &vrf_data).expect("Valid VRF check failed");
     }
 }

--- a/crypto/src/vrf/schnorrkel/data.rs
+++ b/crypto/src/vrf/schnorrkel/data.rs
@@ -175,11 +175,7 @@ mod tests {
 
         keypair
             .public
-            .vrf_verify(
-                ctx.bytes(&msg),
-                vrf_out_decoded.preout(),
-                vrf_out_decoded.proof(),
-            )
+            .vrf_verify(ctx.bytes(&msg), vrf_out_decoded.preout(), vrf_out_decoded.proof())
             .expect("Correct VRF verification failed");
     }
 
@@ -193,10 +189,7 @@ mod tests {
         assert_eq!(public_key_encoded.len(), 32);
         let secret_key = SecretKey::from_bytes(&secret_key_encoded).unwrap();
         let public_key = PublicKey::from_bytes(&public_key_encoded).unwrap();
-        let keypair = Keypair {
-            secret: secret_key,
-            public: public_key,
-        };
+        let keypair = Keypair { secret: secret_key, public: public_key };
 
         let label: Vec<u8> = FromHex::from_hex("b1d98117b0db617adbb95f2a7ac6c2ffd9c00972ce15a41ecd7ef629ab8082db74f7243da9a618e909a06c265185513dbc60f70d5dc7b8b1212af7718388d0adc944b7a20a4f939b2df418dacb21cfee2c3aa602e34384f729d05e88313b821f50754cb4b9946ddfe3dba6c728c842138e1ecf5fe69214bb73d2d2db42f0c82000749d619b2ac7302c35779d06729fcaa10d51f8992a78c547272351ef0d3f6b58837331c6d3d31612519bdee3f2774a37c3c5be47e0").unwrap();
 
@@ -212,11 +205,7 @@ mod tests {
 
         keypair
             .public
-            .vrf_verify(
-                ctx.bytes(&msg),
-                vrf_out_decoded.preout(),
-                vrf_out_decoded.proof(),
-            )
+            .vrf_verify(ctx.bytes(&msg), vrf_out_decoded.preout(), vrf_out_decoded.proof())
             .expect("Correct VRF verification failed");
 
         ///////////////////////////////////////

--- a/crypto/src/vrf/schnorrkel/mod.rs
+++ b/crypto/src/vrf/schnorrkel/mod.rs
@@ -38,9 +38,7 @@ pub struct SchnorrkelPublicKey {
 
 impl SchnorrkelPublicKey {
     pub fn from_private_key(private_key: &SchnorrkelPrivateKey) -> Self {
-        SchnorrkelPublicKey {
-            key: private_key.key.to_public(),
-        }
+        SchnorrkelPublicKey { key: private_key.key.to_public() }
     }
 
     pub fn verify_generic_vrf_data(
@@ -114,21 +112,14 @@ impl SchnorrkelPrivateKey {
             .map_err(|e| VRFError::GenerateKeyError(e.to_string()))?;
         let keypair = mini_secret.expand_to_keypair(schnorrkel::ExpansionMode::Uniform);
         Ok((
-            SchnorrkelPrivateKey {
-                key: keypair.secret.clone(),
-            },
-            SchnorrkelPublicKey {
-                key: keypair.public,
-            },
+            SchnorrkelPrivateKey { key: keypair.secret.clone() },
+            SchnorrkelPublicKey { key: keypair.public },
         ))
     }
 
     pub fn produce_vrf_data(&self, message: Transcript) -> SchnorrkelVRFReturn {
-        let (io, proof, _batchable_proof) = Keypair {
-            secret: self.key.clone(),
-            public: self.key.to_public(),
-        }
-        .vrf_sign(message);
+        let (io, proof, _batchable_proof) =
+            Keypair { secret: self.key.clone(), public: self.key.to_public() }.vrf_sign(message);
 
         SchnorrkelVRFReturn::new(io.to_preout(), proof)
     }
@@ -145,9 +136,7 @@ impl SchnorrkelPrivateKey {
             );
 
             (
-                Self {
-                    key: mini_secret.expand(schnorrkel::ExpansionMode::Uniform),
-                },
+                Self { key: mini_secret.expand(schnorrkel::ExpansionMode::Uniform) },
                 new_chain_code.0.into(),
             )
         } else {
@@ -230,10 +219,7 @@ mod tests {
         let decoded_sk = SchnorrkelPrivateKey::decode_all(&mut encoded_sk.as_slice()).unwrap();
         let decoded_pk = SchnorrkelPublicKey::decode_all(&mut encoded_pk.as_slice()).unwrap();
 
-        assert_eq!(
-            decoded_pk,
-            SchnorrkelPublicKey::from_private_key(&decoded_sk)
-        )
+        assert_eq!(decoded_pk, SchnorrkelPublicKey::from_private_key(&decoded_sk))
     }
 
     #[test]
@@ -255,19 +241,12 @@ mod tests {
             .public
             .vrf_verify(ctx.bytes(msg), out1, &proof1)
             .expect("Correct VRF verification failed!");
-        assert_eq!(
-            io1too, io1,
-            "Output differs between signing and verification!"
-        );
+        assert_eq!(io1too, io1, "Output differs between signing and verification!");
         assert_eq!(
             proof1batchable, proof1too,
             "VRF verification yielded incorrect batchable proof"
         );
-        assert_eq!(
-            keypair1.vrf_sign(ctx.bytes(msg)).0,
-            io1,
-            "Rerunning VRF gave different output"
-        );
+        assert_eq!(keypair1.vrf_sign(ctx.bytes(msg)).0, io1, "Rerunning VRF gave different output");
 
         assert!(
             keypair1.public.vrf_verify(ctx.bytes(b"not meow"), out1, &proof1).is_err(),

--- a/crypto/src/vrf/transcript.rs
+++ b/crypto/src/vrf/transcript.rs
@@ -92,10 +92,8 @@ mod tests {
 
         // build a random number generator using each transcript and ensure they both arrive to the same values
         let mut g1 = manual_transcript.build_rng().finalize(&mut ChaChaRng::from_seed([0u8; 32]));
-        let mut g2 = assembled_transcript
-            .0
-            .build_rng()
-            .finalize(&mut ChaChaRng::from_seed([0u8; 32]));
+        let mut g2 =
+            assembled_transcript.0.build_rng().finalize(&mut ChaChaRng::from_seed([0u8; 32]));
 
         for _ in 0..100 {
             assert_eq!(g1.gen::<u64>(), g2.gen::<u64>());

--- a/crypto/src/vrf/transcript.rs
+++ b/crypto/src/vrf/transcript.rs
@@ -46,10 +46,7 @@ impl From<WrappedTranscript> for Transcript {
 
 impl TranscriptAssembler {
     pub fn new(label: &'static [u8]) -> Self {
-        Self {
-            label,
-            components: Vec::new(),
-        }
+        Self { label, components: Vec::new() }
     }
 
     pub fn attach(self, label: &'static [u8], value: TranscriptComponent) -> Self {

--- a/dns_server/src/crawler_p2p/crawler/address_data.rs
+++ b/dns_server/src/crawler_p2p/crawler/address_data.rs
@@ -93,99 +93,55 @@ pub struct AddressData {
 impl AddressState {
     fn fail_count(&self) -> u32 {
         match self {
-            AddressState::Connecting {
-                fail_count,
-                was_reachable: _,
-            } => *fail_count,
+            AddressState::Connecting { fail_count, was_reachable: _ } => *fail_count,
             AddressState::Connected {} => 0,
-            AddressState::Disconnecting {
-                fail_count,
-                was_reachable: _,
-            } => *fail_count,
-            AddressState::Disconnected {
-                fail_count,
-                was_reachable: _,
-                disconnected_at: _,
-            } => *fail_count,
-            AddressState::Unreachable {
-                fail_count,
-                erase_after: _,
-                was_reachable: _,
-            } => *fail_count,
+            AddressState::Disconnecting { fail_count, was_reachable: _ } => *fail_count,
+            AddressState::Disconnected { fail_count, was_reachable: _, disconnected_at: _ } => {
+                *fail_count
+            }
+            AddressState::Unreachable { fail_count, erase_after: _, was_reachable: _ } => {
+                *fail_count
+            }
         }
     }
 
     fn was_reachable(&self) -> bool {
         match self {
-            AddressState::Connecting {
-                fail_count: _,
-                was_reachable,
-            } => *was_reachable,
+            AddressState::Connecting { fail_count: _, was_reachable } => *was_reachable,
             AddressState::Connected {} => true,
-            AddressState::Disconnecting {
-                fail_count: _,
-                was_reachable,
-            } => *was_reachable,
-            AddressState::Disconnected {
-                fail_count: _,
-                was_reachable,
-                disconnected_at: _,
-            } => *was_reachable,
-            AddressState::Unreachable {
-                erase_after: _,
-                was_reachable,
-                fail_count: _,
-            } => *was_reachable,
+            AddressState::Disconnecting { fail_count: _, was_reachable } => *was_reachable,
+            AddressState::Disconnected { fail_count: _, was_reachable, disconnected_at: _ } => {
+                *was_reachable
+            }
+            AddressState::Unreachable { erase_after: _, was_reachable, fail_count: _ } => {
+                *was_reachable
+            }
         }
     }
 
     /// Whether the address is currently recognized as reachable (available from DNS)
     pub fn is_reachable(&self) -> bool {
         match self {
-            AddressState::Connecting {
-                fail_count: _,
-                was_reachable: _,
-            } => false,
+            AddressState::Connecting { fail_count: _, was_reachable: _ } => false,
             AddressState::Connected {} => true,
-            AddressState::Disconnecting {
-                fail_count: _,
-                was_reachable: _,
-            } => false,
-            AddressState::Disconnected {
-                fail_count: _,
-                was_reachable: _,
-                disconnected_at: _,
-            } => false,
-            AddressState::Unreachable {
-                fail_count: _,
-                was_reachable: _,
-                erase_after: _,
-            } => false,
+            AddressState::Disconnecting { fail_count: _, was_reachable: _ } => false,
+            AddressState::Disconnected { fail_count: _, was_reachable: _, disconnected_at: _ } => {
+                false
+            }
+            AddressState::Unreachable { fail_count: _, was_reachable: _, erase_after: _ } => false,
         }
     }
 
     /// Whether to retain the address between node restarts (stored in DB).
     pub fn is_persistent(&self) -> bool {
         match self {
-            AddressState::Connecting {
-                fail_count: _,
-                was_reachable,
-            } => *was_reachable,
+            AddressState::Connecting { fail_count: _, was_reachable } => *was_reachable,
             AddressState::Connected {} => true,
-            AddressState::Disconnecting {
-                fail_count: _,
-                was_reachable,
-            } => *was_reachable,
-            AddressState::Disconnected {
-                fail_count: _,
-                was_reachable,
-                disconnected_at: _,
-            } => *was_reachable,
-            AddressState::Unreachable {
-                fail_count: _,
-                was_reachable: _,
-                erase_after: _,
-            } => false,
+            AddressState::Disconnecting { fail_count: _, was_reachable } => *was_reachable,
+            AddressState::Disconnected { fail_count: _, was_reachable, disconnected_at: _ } => {
+                *was_reachable
+            }
+            AddressState::Unreachable { fail_count: _, was_reachable: _, erase_after: _ } => false,
         }
     }
 }
@@ -195,25 +151,13 @@ impl AddressData {
     pub fn connect_now(&self, now: Duration) -> bool {
         match self.state {
             AddressState::Connected {}
-            | AddressState::Connecting {
-                fail_count: _,
-                was_reachable: _,
+            | AddressState::Connecting { fail_count: _, was_reachable: _ }
+            | AddressState::Disconnecting { fail_count: _, was_reachable: _ }
+            | AddressState::Unreachable { fail_count: _, was_reachable: _, erase_after: _ } => {
+                false
             }
-            | AddressState::Disconnecting {
-                fail_count: _,
-                was_reachable: _,
-            }
-            | AddressState::Unreachable {
-                fail_count: _,
-                was_reachable: _,
-                erase_after: _,
-            } => false,
 
-            AddressState::Disconnected {
-                fail_count,
-                was_reachable,
-                disconnected_at,
-            } => {
+            AddressState::Disconnected { fail_count, was_reachable, disconnected_at } => {
                 let age = now - disconnected_at;
                 if *self.reserved {
                     // Try to connect to the reserved nodes more often
@@ -247,11 +191,11 @@ impl AddressData {
     pub fn retain(&self, now: Duration) -> bool {
         match self.state {
             // Always keep user added addresses
-            AddressState::Unreachable {
-                erase_after,
-                fail_count: _,
-                was_reachable: _,
-            } if erase_after >= now => false,
+            AddressState::Unreachable { erase_after, fail_count: _, was_reachable: _ }
+                if erase_after >= now =>
+            {
+                false
+            }
             _ => true,
         }
     }

--- a/dns_server/src/crawler_p2p/crawler/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler/mod.rs
@@ -238,10 +238,8 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
             is_compatible
         );
 
-        let address_data = self
-            .addresses
-            .get_mut(&address)
-            .expect("address must be known (create_outbound_peer)");
+        let address_data =
+            self.addresses.get_mut(&address).expect("address must be known (create_outbound_peer)");
 
         if is_compatible {
             Self::change_address_state(

--- a/dns_server/src/crawler_p2p/crawler/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler/mod.rs
@@ -89,17 +89,9 @@ pub enum CrawlerEvent<A> {
 }
 
 pub enum CrawlerCommand<A> {
-    Connect {
-        address: A,
-    },
-    Disconnect {
-        peer_id: PeerId,
-    },
-    UpdateAddress {
-        address: A,
-        old_state: AddressState,
-        new_state: AddressState,
-    },
+    Connect { address: A },
+    Disconnect { peer_id: PeerId },
+    UpdateAddress { address: A, old_state: AddressState, new_state: AddressState },
 }
 
 impl<A: Ord + Clone + ToString> Crawler<A> {
@@ -127,12 +119,7 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
             })
             .collect::<BTreeMap<_, _>>();
 
-        Self {
-            now,
-            chain_config,
-            addresses,
-            outbound_peers: BTreeMap::new(),
-        }
+        Self { now, chain_config, addresses, outbound_peers: BTreeMap::new() }
     }
 
     fn handle_connected(
@@ -209,11 +196,7 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
         transition: AddressStateTransitionTo,
         callback: &mut impl FnMut(CrawlerCommand<A>),
     ) {
-        log::debug!(
-            "change address {} state to {:?}",
-            address.to_string(),
-            transition
-        );
+        log::debug!("change address {} state to {:?}", address.to_string(), transition);
 
         let old_state = address_data.state.clone();
 
@@ -241,10 +224,7 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
             ADDR_RATE_BUCKET_SIZE,
         );
 
-        let peer = Peer {
-            address: address.clone(),
-            address_rate_limiter,
-        };
+        let peer = Peer { address: address.clone(), address_rate_limiter };
 
         let old_peer = self.outbound_peers.insert(peer_id, peer);
         assert!(old_peer.is_none());
@@ -330,9 +310,7 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
                 callback,
             );
 
-            callback(CrawlerCommand::Connect {
-                address: address.clone(),
-            });
+            callback(CrawlerCommand::Connect { address: address.clone() });
         }
 
         self.addresses.retain(|_address, address_data| address_data.retain(self.now));
@@ -347,10 +325,7 @@ impl<A: Ord + Clone + ToString> Crawler<A> {
     ) {
         match event {
             CrawlerEvent::Timer { period } => {
-                assert!(
-                    period <= Duration::from_secs(24 * 3600),
-                    "time step is too big"
-                );
+                assert!(period <= Duration::from_secs(24 * 3600), "time step is too big");
 
                 self.now += period;
 

--- a/dns_server/src/crawler_p2p/crawler/tests/mock_crawler.rs
+++ b/dns_server/src/crawler_p2p/crawler/tests/mock_crawler.rs
@@ -61,11 +61,7 @@ pub fn test_crawler(
 ) -> MockCrawler {
     let chain_config = Arc::new(common::chain::config::create_mainnet());
 
-    let crawler = Crawler::new(
-        chain_config.clone(),
-        loaded_addresses.clone(),
-        added_addresses,
-    );
+    let crawler = Crawler::new(chain_config.clone(), loaded_addresses.clone(), added_addresses);
 
     MockCrawler {
         crawler,
@@ -89,10 +85,7 @@ impl MockCrawler {
     pub fn step(&mut self, event: CrawlerEvent<SocketAddr>, rng: &mut impl Rng) {
         match &event {
             CrawlerEvent::Timer { period: _ } => {}
-            CrawlerEvent::NewAddress {
-                address: _,
-                sender: _,
-            } => {}
+            CrawlerEvent::NewAddress { address: _, sender: _ } => {}
             CrawlerEvent::Connected { peer_info, address } => {
                 let removed = self.pending_connects.remove(address);
                 assert!(removed);
@@ -131,11 +124,7 @@ impl MockCrawler {
                 let inserted = self.pending_disconnects.insert(peer_id);
                 assert!(inserted);
             }
-            CrawlerCommand::UpdateAddress {
-                address,
-                old_state,
-                new_state,
-            } => {
+            CrawlerCommand::UpdateAddress { address, old_state, new_state } => {
                 match (old_state.is_reachable(), new_state.is_reachable()) {
                     (false, true) => {
                         let inserted = self.reachable.insert(address);
@@ -160,11 +149,7 @@ impl MockCrawler {
                     _ => {}
                 }
 
-                self.address_updates.push(AddressUpdate {
-                    address,
-                    old_state,
-                    new_state,
-                });
+                self.address_updates.push(AddressUpdate { address, old_state, new_state });
             }
         };
 

--- a/dns_server/src/crawler_p2p/crawler/tests/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler/tests/mod.rs
@@ -76,13 +76,7 @@ fn basic(#[case] seed: Seed) {
     let node2: SocketAddr = "4.3.2.1:12345".parse().unwrap();
     let peer2 = PeerId::new();
 
-    crawler.step(
-        CrawlerEvent::NewAddress {
-            address: node2,
-            sender: peer1,
-        },
-        &mut rng,
-    );
+    crawler.step(CrawlerEvent::NewAddress { address: node2, sender: peer1 }, &mut rng);
 
     crawler.timer(Duration::from_secs(100), &mut rng);
     assert!(crawler.pending_connects.contains(&node2));
@@ -262,10 +256,8 @@ fn long_offline(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let loaded_node: SocketAddr = "1.0.0.0:3031".parse().unwrap();
     let added_node: SocketAddr = "2.0.0.0:3031".parse().unwrap();
-    let mut crawler = test_crawler(
-        [loaded_node].into_iter().collect(),
-        [added_node].into_iter().collect(),
-    );
+    let mut crawler =
+        test_crawler([loaded_node].into_iter().collect(), [added_node].into_iter().collect());
     assert!(crawler.persistent.contains(&loaded_node));
 
     // Reachable and reserved nodes are offline for two month

--- a/dns_server/src/crawler_p2p/crawler_manager/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/mod.rs
@@ -164,24 +164,14 @@ where
                 // Ignored
             }
             PeerManagerMessage::AnnounceAddrRequest(AnnounceAddrRequest { address }) => {
-                log::debug!(
-                    "address announcement from peer {} ({})",
-                    peer_id,
-                    address.to_string()
-                );
+                log::debug!("address announcement from peer {} ({})", peer_id, address.to_string());
                 if let Some(address) = TransportAddress::from_peer_address(&address, false) {
-                    self.send_crawler_event(CrawlerEvent::NewAddress {
-                        address,
-                        sender: peer_id,
-                    });
+                    self.send_crawler_event(CrawlerEvent::NewAddress { address, sender: peer_id });
                 }
             }
             PeerManagerMessage::PingRequest(PingRequest { nonce }) => {
                 self.conn
-                    .send_message(
-                        peer_id,
-                        PeerManagerMessage::PingResponse(PingResponse { nonce }),
-                    )
+                    .send_message(peer_id, PeerManagerMessage::PingResponse(PingResponse { nonce }))
                     .expect("send_message must succeed");
             }
             PeerManagerMessage::AddrListResponse(_) => {}
@@ -194,11 +184,7 @@ where
             ConnectivityEvent::Message { peer, message } => {
                 self.handle_conn_message(peer, message);
             }
-            ConnectivityEvent::OutboundAccepted {
-                address,
-                peer_info,
-                receiver_address: _,
-            } => {
+            ConnectivityEvent::OutboundAccepted { address, peer_info, receiver_address: _ } => {
                 // Allow reading input messages from the connected peer
                 self.conn.accept(peer_info.peer_id).expect("accept must succeed");
 
@@ -217,10 +203,7 @@ where
             ConnectivityEvent::ConnectionClosed { peer_id } => {
                 self.send_crawler_event(CrawlerEvent::Disconnected { peer_id });
             }
-            ConnectivityEvent::Misbehaved {
-                peer_id: _,
-                error: _,
-            } => {
+            ConnectivityEvent::Misbehaved { peer_id: _, error: _ } => {
                 // Ignore all misbehave reports
                 // TODO: Should we ban peers when they send unexpected messages?
             }
@@ -272,11 +255,7 @@ where
             CrawlerCommand::Disconnect { peer_id } => {
                 conn.disconnect(peer_id).expect("disconnect must succeed");
             }
-            CrawlerCommand::UpdateAddress {
-                address,
-                old_state,
-                new_state,
-            } => {
+            CrawlerCommand::UpdateAddress { address, old_state, new_state } => {
                 match (
                     Self::get_dns_ip(&address, config.default_p2p_port),
                     old_state.is_reachable(),

--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
@@ -75,9 +75,7 @@ impl MockStateRef {
     pub fn node_online(&self, ip: SocketAddr) {
         let old = self.online.lock().unwrap().insert(
             ip,
-            TestNode {
-                chain_config: Arc::new(common::chain::config::create_mainnet()),
-            },
+            TestNode { chain_config: Arc::new(common::chain::config::create_mainnet()) },
         );
         assert!(old.is_none());
     }
@@ -225,10 +223,7 @@ pub fn test_crawler(
 ) {
     let (conn_tx, conn_rx) = mpsc::unbounded_channel();
     let reserved_nodes = reserved_nodes.iter().map(ToString::to_string).collect();
-    let crawler_config = CrawlerManagerConfig {
-        reserved_nodes,
-        default_p2p_port: 3031,
-    };
+    let crawler_config = CrawlerManagerConfig { reserved_nodes, default_p2p_port: 3031 };
 
     let state = MockStateRef {
         crawler_config: crawler_config.clone(),
@@ -238,10 +233,7 @@ pub fn test_crawler(
         conn_tx,
     };
 
-    let conn = MockConnectivityHandle {
-        state: state.clone(),
-        conn_rx,
-    };
+    let conn = MockConnectivityHandle { state: state.clone(), conn_rx };
     let sync = MockSyncingEventReceiver {};
 
     let storage = storage::inmemory::InMemory::new();

--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mod.rs
@@ -33,18 +33,12 @@ async fn basic() {
     // Node goes online, DNS record added
     state.node_online(node1);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node1.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node1.ip()));
 
     // Node goes offline, DNS record removed
     state.node_offline(node1);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::DelAddress(node1.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::DelAddress(node1.ip()));
 }
 
 #[tokio::test]
@@ -53,21 +47,12 @@ async fn long_offline() {
     let (mut crawler, state, mut command_rx, time_getter) = test_crawler(vec![node1]);
 
     // Two weeks passed
-    advance_time(
-        &mut crawler,
-        &time_getter,
-        Duration::from_secs(3600),
-        14 * 24,
-    )
-    .await;
+    advance_time(&mut crawler, &time_getter, Duration::from_secs(3600), 14 * 24).await;
 
     // Node goes online, DNS record is added in 24 hours
     state.node_online(node1);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 24 * 60).await;
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node1.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node1.ip()));
 }
 
 #[tokio::test]
@@ -82,30 +67,18 @@ async fn announced_online() {
     state.node_online(node3);
 
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node1.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node1.ip()));
 
     state.announce_address(node1, node2);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node2.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node2.ip()));
 
     state.announce_address(node2, node3);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node3.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node3.ip()));
 
     let addresses = crawler.storage.transaction_ro().unwrap().get_addresses().unwrap();
-    assert_eq!(
-        addresses,
-        vec![node1.to_string(), node2.to_string(), node3.to_string()]
-    );
+    assert_eq!(addresses, vec![node1.to_string(), node2.to_string(), node3.to_string()]);
 }
 
 #[tokio::test]
@@ -117,10 +90,7 @@ async fn announced_offline() {
     state.node_online(node1);
 
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node1.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node1.ip()));
     assert_eq!(state.connection_attempts.lock().unwrap().len(), 1);
 
     // Check that the crawler tries to connect to an offline node just once
@@ -132,10 +102,7 @@ async fn announced_offline() {
     state.node_online(node2);
     state.announce_address(node1, node2);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 24 * 60).await;
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node2.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node2.ip()));
     assert_eq!(state.connection_attempts.lock().unwrap().len(), 3);
 }
 
@@ -160,14 +127,8 @@ async fn private_ip() {
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 24 * 60).await;
 
     // Check that only nodes with public addresses and on the default port are added to DNS
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node1.ip())
-    );
-    assert_eq!(
-        command_rx.recv().await.unwrap(),
-        DnsServerCommand::AddAddress(node2.ip())
-    );
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node1.ip()));
+    assert_eq!(command_rx.recv().await.unwrap(), DnsServerCommand::AddAddress(node2.ip()));
     assert!(command_rx.try_recv().is_err());
 
     // Check that all reachable nodes are stored in the DB

--- a/dns_server/src/dns_server/mod.rs
+++ b/dns_server/src/dns_server/mod.rs
@@ -99,19 +99,11 @@ impl DnsServer {
             server.register_socket(udp_socket);
         }
 
-        Ok(Self {
-            auth,
-            server,
-            cmd_rx,
-        })
+        Ok(Self { auth, server, cmd_rx })
     }
 
     pub async fn run(self) -> Result<Never, DnsServerError> {
-        let DnsServer {
-            auth,
-            server,
-            mut cmd_rx,
-        } = self;
+        let DnsServer { auth, server, mut cmd_rx } = self;
 
         tokio::spawn(async move {
             while let Some(command) = cmd_rx.recv().await {
@@ -121,9 +113,7 @@ impl DnsServer {
 
         server.block_until_done().await?;
 
-        Err(DnsServerError::Other(
-            "trust_dns_server terminated unexpectedly",
-        ))
+        Err(DnsServerError::Other("trust_dns_server terminated unexpectedly"))
     }
 }
 

--- a/dns_server/src/dns_server/mod.rs
+++ b/dns_server/src/dns_server/mod.rs
@@ -264,16 +264,10 @@ fn handle_command(auth: &AuthorityImpl, command: DnsServerCommand) {
             auth.ip6.lock().expect("mutex must be valid (add ipv6)").push(ip);
         }
         DnsServerCommand::DelAddress(IpAddr::V4(ip)) => {
-            auth.ip4
-                .lock()
-                .expect("mutex must be valid (remove ipv4)")
-                .retain(|val| *val != ip);
+            auth.ip4.lock().expect("mutex must be valid (remove ipv4)").retain(|val| *val != ip);
         }
         DnsServerCommand::DelAddress(IpAddr::V6(ip)) => {
-            auth.ip6
-                .lock()
-                .expect("mutex must be valid (remove ipv6)")
-                .retain(|val| *val != ip);
+            auth.ip6.lock().expect("mutex must be valid (remove ipv6)").retain(|val| *val != ip);
         }
     };
 }

--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -93,11 +93,9 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<Never, error::DnsServerErro
     )
     .await?;
 
-    let data_dir = prepare_data_dir(
-        || default_data_dir_for_chain(chain_type.name()),
-        &config.datadir,
-    )
-    .expect("Failed to prepare data directory");
+    let data_dir =
+        prepare_data_dir(|| default_data_dir_for_chain(chain_type.name()), &config.datadir)
+            .expect("Failed to prepare data directory");
 
     let storage = DnsServerStorageImpl::new(storage_lmdb::Lmdb::new(
         data_dir.join(DNS_SERVER_DB_NAME),

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -238,10 +238,7 @@ impl MempoolBanScore for TxIndexError {
             // Invalid transactions
             TxIndexError::InvalidOutputCount => 100,
             TxIndexError::SerializationInvariantError(_) => 100,
-            TxIndexError::OutputIndexOutOfRange {
-                tx_id: _,
-                source_output_index: _,
-            } => 100,
+            TxIndexError::OutputIndexOutOfRange { tx_id: _, source_output_index: _ } => 100,
 
             // Double spend may happen if peers are out of sync.
             TxIndexError::DoubleSpendAttempt(_) => 0,

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -47,11 +47,7 @@ impl MempoolInit {
         chainstate_handle: subsystem::Handle<Box<dyn ChainstateInterface>>,
         time_getter: TimeGetter,
     ) -> Self {
-        Self {
-            chain_config,
-            chainstate_handle,
-            time_getter,
-        }
+        Self { chain_config, chainstate_handle, time_getter }
     }
 
     pub async fn subscribe_to_chainstate_events(

--- a/mempool/src/pool/entry.rs
+++ b/mempool/src/pool/entry.rs
@@ -32,10 +32,7 @@ pub struct TxAccountDependency {
 
 impl TxAccountDependency {
     pub fn new(delegation_id: DelegationId, nonce: AccountNonce) -> Self {
-        TxAccountDependency {
-            delegation_id,
-            nonce,
-        }
+        TxAccountDependency { delegation_id, nonce }
     }
 }
 
@@ -91,12 +88,7 @@ impl TxEntry {
     pub fn new(transaction: SignedTransaction, creation_time: Time) -> Self {
         let tx_id = transaction.transaction().get_id();
         let encoded_size = serialization::Encode::encoded_size(&transaction);
-        Self {
-            tx_id,
-            transaction,
-            creation_time,
-            encoded_size,
-        }
+        Self { tx_id, transaction, creation_time, encoded_size }
     }
 
     /// Underlying transaction

--- a/mempool/src/pool/feerate.rs
+++ b/mempool/src/pool/feerate.rs
@@ -74,9 +74,7 @@ mod tests {
         type Output = FeeRate;
         fn div(self, rhs: NonZeroUsize) -> Self::Output {
             let rhs = u128::try_from(usize::from(rhs)).expect("conversion");
-            FeeRate {
-                amount_per_kb: (self.amount_per_kb / rhs).expect("rhs is nonzero"),
-            }
+            FeeRate { amount_per_kb: (self.amount_per_kb / rhs).expect("rhs is nonzero") }
         }
     }
 
@@ -85,12 +83,7 @@ mod tests {
         let fee = Amount::from_atoms(7).into();
         let tx_size = usize::MAX;
         let rate = FeeRate::from_total_tx_fee(fee, NonZeroUsize::new(tx_size).unwrap()).unwrap();
-        assert_eq!(
-            rate,
-            FeeRate {
-                amount_per_kb: Amount::from_atoms(0)
-            }
-        );
+        assert_eq!(rate, FeeRate { amount_per_kb: Amount::from_atoms(0) });
 
         let fee = Amount::from_atoms(u128::MAX).into();
         let tx_size = 1;

--- a/mempool/src/pool/orphans/test.rs
+++ b/mempool/src/pool/orphans/test.rs
@@ -32,11 +32,7 @@ fn check_integrity(orphans: &TxOrphanPool) {
     assert_eq!(len, orphans.maps.by_insertion_time.len());
 
     orphans.maps.by_tx_id.iter().for_each(|(tx_id, iid)| {
-        assert_eq!(
-            orphans.get_at(*iid).tx_id(),
-            tx_id,
-            "Entry {iid:?} tx ID inconsistent",
-        );
+        assert_eq!(orphans.get_at(*iid).tx_id(), tx_id, "Entry {iid:?} tx ID inconsistent",);
     });
     orphans.maps.by_insertion_time.iter().for_each(|(time, iid)| {
         assert_eq!(
@@ -91,10 +87,7 @@ fn insert_and_delete(#[case] seed: Seed) {
 
     assert_eq!(orphans.len(), 1);
     assert_eq!(orphans.transactions.len(), 1);
-    assert_eq!(
-        orphans.maps.by_tx_id.keys().collect::<Vec<_>>(),
-        vec![&tx_id],
-    );
+    assert_eq!(orphans.maps.by_tx_id.keys().collect::<Vec<_>>(), vec![&tx_id],);
     assert_eq!(orphans.maps.by_deps.len(), n_deps);
     assert_eq!(orphans.maps.by_insertion_time.len(), 1);
     check_integrity(&orphans);
@@ -142,11 +135,7 @@ fn simulation(#[case] seed: Seed) {
             // Insert a random tx
             0..=1 => {
                 let entry = random_tx_entry(&mut rng);
-                assert_eq!(
-                    orphans.insert(entry.clone()),
-                    Ok(()),
-                    "Insertion of {entry:?} failed"
-                );
+                assert_eq!(orphans.insert(entry.clone()), Ok(()), "Insertion of {entry:?} failed");
                 assert_eq!(orphans.len(), len_before + 1);
             }
 
@@ -164,11 +153,7 @@ fn simulation(#[case] seed: Seed) {
             // Delete a non-existing tx
             3..=3 => {
                 let id: Id<Transaction> = H256(rng.gen::<[u8; 32]>()).into();
-                assert_eq!(
-                    orphans.remove(id),
-                    None,
-                    "Removal of non-existent {id:?} failed"
-                );
+                assert_eq!(orphans.remove(id), None, "Removal of non-existent {id:?} failed");
                 assert_eq!(orphans.len(), len_before);
             }
 

--- a/mempool/src/pool/rolling_fee_rate.rs
+++ b/mempool/src/pool/rolling_fee_rate.rs
@@ -52,10 +52,7 @@ impl RollingFeeRate {
             (self.rolling_minimum_fee_rate.atoms_per_kb() as f64 / divisor) as u128,
         ));
 
-        log::debug!(
-            "decay_fee: new fee rate:  {:?}",
-            self.rolling_minimum_fee_rate
-        );
+        log::debug!("decay_fee: new fee rate:  {:?}", self.rolling_minimum_fee_rate);
         self.last_rolling_fee_update = current_time;
         self
     }

--- a/mempool/src/pool/store/mem_usage.rs
+++ b/mempool/src/pool/store/mem_usage.rs
@@ -34,10 +34,7 @@ pub struct MemUsageTracker {
 
 impl MemUsageTracker {
     pub fn new() -> Self {
-        Self {
-            current_usage: 0,
-            peak_usage: 0,
-        }
+        Self { current_usage: 0, peak_usage: 0 }
     }
 
     pub fn get_usage(&self) -> usize {
@@ -411,15 +408,11 @@ mod test {
         let mut data: Tracked<Vec<u8>, NoOpDropPolicy> = Tracked::default();
 
         let len1 = rng.gen_range(0..=100);
-        tracker.modify(&mut data, |data, _| {
-            data.extend((0..len1).map(|_| rng.gen::<u8>()))
-        });
+        tracker.modify(&mut data, |data, _| data.extend((0..len1).map(|_| rng.gen::<u8>())));
         assert_eq!(tracker.get_usage(), len1);
 
         let len2 = rng.gen_range(0..=300);
-        tracker.modify(&mut data, |data, _| {
-            data.extend((0..len2).map(|_| rng.gen::<u8>()))
-        });
+        tracker.modify(&mut data, |data, _| data.extend((0..len2).map(|_| rng.gen::<u8>())));
         assert_eq!(tracker.get_usage(), len1 + len2);
     }
 

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -190,11 +190,8 @@ impl MempoolStore {
             + self.seq_nos_by_tx.indirect_memory_usage();
         assert_eq!(self.mem_tracker.get_usage(), expected_size, "Memory size tracker out of sync",);
 
-        let entries = self
-            .txs_by_descendant_score
-            .values()
-            .flat_map(|ids| ids.deref())
-            .collect::<Vec<_>>();
+        let entries =
+            self.txs_by_descendant_score.values().flat_map(|ids| ids.deref()).collect::<Vec<_>>();
 
         for id in self.txs_by_id.keys() {
             assert_eq!(entries.iter().filter(|entry_id| ***entry_id == *id).count(), 1)
@@ -324,13 +321,12 @@ impl MempoolStore {
 
         self.add_to_descendant_score_index(&entry);
         self.add_to_ancestor_score_index(&entry);
-        self.mem_tracker
-            .modify(&mut self.txs_by_creation_time, |txs_by_creation_time, tracker| {
-                tracker.modify(
-                    txs_by_creation_time.entry(entry.creation_time()).or_default(),
-                    |entry, _| entry.insert(tx_id),
-                );
-            });
+        self.mem_tracker.modify(&mut self.txs_by_creation_time, |txs_by_creation_time, tracker| {
+            tracker.modify(
+                txs_by_creation_time.entry(entry.creation_time()).or_default(),
+                |entry, _| entry.insert(tx_id),
+            );
+        });
 
         self.mem_tracker.modify(&mut self.txs_by_seq_no, |m, _| m.insert(seq_no, tx_id));
         self.mem_tracker.modify(&mut self.seq_nos_by_tx, |m, _| m.insert(tx_id, seq_no));
@@ -343,13 +339,12 @@ impl MempoolStore {
 
     fn add_to_descendant_score_index(&mut self, entry: &TxMempoolEntry) {
         self.refresh_ancestors(entry);
-        self.mem_tracker
-            .modify(&mut self.txs_by_descendant_score, |by_desc_score, tracker| {
-                tracker.modify(
-                    by_desc_score.entry(entry.descendant_score()).or_default(),
-                    |map_entry, _| map_entry.insert(*entry.tx_id()),
-                )
-            });
+        self.mem_tracker.modify(&mut self.txs_by_descendant_score, |by_desc_score, tracker| {
+            tracker.modify(
+                by_desc_score.entry(entry.descendant_score()).or_default(),
+                |map_entry, _| map_entry.insert(*entry.tx_id()),
+            )
+        });
     }
 
     fn add_to_ancestor_score_index(&mut self, entry: &TxMempoolEntry) {
@@ -728,10 +723,7 @@ impl TxMempoolEntry {
         // TODO: change this from recursive to iterative
         for parent in self.parents.iter() {
             if visited.insert(*parent) {
-                store
-                    .get_entry(parent)
-                    .expect("entry")
-                    .unconfirmed_ancestors_inner(visited, store);
+                store.get_entry(parent).expect("entry").unconfirmed_ancestors_inner(visited, store);
             }
         }
     }

--- a/mempool/src/pool/tests/expiry.rs
+++ b/mempool/src/pool/tests/expiry.rs
@@ -109,12 +109,8 @@ async fn only_expired_entries_removed(#[case] seed: Seed) -> anyhow::Result<()> 
     let config = Arc::clone(chainstate.get_chain_config());
     let chainstate_interface = start_chainstate(chainstate).await;
 
-    let mut mempool = Mempool::new(
-        config,
-        chainstate_interface,
-        mock_clock,
-        StoreMemoryUsageEstimator,
-    );
+    let mut mempool =
+        Mempool::new(config, chainstate_interface, mock_clock, StoreMemoryUsageEstimator);
 
     let parent_id = parent.transaction().get_id();
     mempool.add_transaction(parent.clone())?.assert_in_mempool();

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -848,10 +848,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     // Add first child
     mock_usage.expect_estimate_memory_usage().times(2).return_const(0usize);
     // Add second child, triggering the trimming process
-    mock_usage
-        .expect_estimate_memory_usage()
-        .times(1)
-        .return_const(MAX_MEMPOOL_SIZE_BYTES + 1);
+    mock_usage.expect_estimate_memory_usage().times(1).return_const(MAX_MEMPOOL_SIZE_BYTES + 1);
     // After removing one entry, cause the code to exit the loop by showing a small usage
     mock_usage.expect_estimate_memory_usage().return_const(0usize);
 
@@ -1286,12 +1283,8 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
 }
 
 fn check_txs_sorted_by_ancestor_score<E>(mempool: &Mempool<E>) {
-    let txs_by_ancestor_score = mempool
-        .store
-        .txs_by_descendant_score
-        .values()
-        .flat_map(Deref::deref)
-        .collect::<Vec<_>>();
+    let txs_by_ancestor_score =
+        mempool.store.txs_by_descendant_score.values().flat_map(Deref::deref).collect::<Vec<_>>();
     for i in 0..(txs_by_ancestor_score.len() - 1) {
         log::debug!("i =  {}", i);
         let tx_id = txs_by_ancestor_score.get(i).unwrap();
@@ -1403,12 +1396,8 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
 }
 
 fn check_txs_sorted_by_descendant_sore<M>(mempool: &Mempool<M>) {
-    let txs_by_descendant_score = mempool
-        .store
-        .txs_by_descendant_score
-        .values()
-        .flat_map(Deref::deref)
-        .collect::<Vec<_>>();
+    let txs_by_descendant_score =
+        mempool.store.txs_by_descendant_score.values().flat_map(Deref::deref).collect::<Vec<_>>();
     for i in 0..(txs_by_descendant_score.len() - 1) {
         log::debug!("i =  {}", i);
         let tx_id = txs_by_descendant_score.get(i).unwrap();
@@ -1433,10 +1422,7 @@ async fn mempool_full_mock(#[case] seed: Seed) -> anyhow::Result<()> {
     let genesis = tf.genesis();
 
     let mut mock_usage = MockMemoryUsageEstimator::new();
-    mock_usage
-        .expect_estimate_memory_usage()
-        .times(1)
-        .return_const(MAX_MEMPOOL_SIZE_BYTES + 1);
+    mock_usage.expect_estimate_memory_usage().times(1).return_const(MAX_MEMPOOL_SIZE_BYTES + 1);
 
     let chainstate = tf.chainstate();
     let config = Arc::clone(chainstate.get_chain_config());

--- a/mempool/src/pool/tests/orphans.rs
+++ b/mempool/src/pool/tests/orphans.rs
@@ -44,26 +44,14 @@ async fn two_transactions_in_sequence(
     let genesis_id = tf.genesis().get_id();
 
     let tx0 = TransactionBuilder::new()
-        .add_input(
-            TxInput::from_utxo(genesis_id.into(), 0),
-            empty_witness(&mut rng),
-        )
-        .add_output(TxOutput::Transfer(
-            OutputValue::Coin(amt0),
-            Destination::AnyoneCanSpend,
-        ))
+        .add_input(TxInput::from_utxo(genesis_id.into(), 0), empty_witness(&mut rng))
+        .add_output(TxOutput::Transfer(OutputValue::Coin(amt0), Destination::AnyoneCanSpend))
         .build();
     let tx0_id = tx0.transaction().get_id();
 
     let tx1 = TransactionBuilder::new()
-        .add_input(
-            TxInput::from_utxo(tx0_id.into(), 0),
-            empty_witness(&mut rng),
-        )
-        .add_output(TxOutput::Transfer(
-            OutputValue::Coin(amt1),
-            Destination::AnyoneCanSpend,
-        ))
+        .add_input(TxInput::from_utxo(tx0_id.into(), 0), empty_witness(&mut rng))
+        .add_output(TxOutput::Transfer(OutputValue::Coin(amt1), Destination::AnyoneCanSpend))
         .build();
     let tx1_id = tx1.transaction().get_id();
 
@@ -201,10 +189,7 @@ async fn orphan_conflicts_with_mempool_tx(#[case] seed: Seed) {
 
     // Check transaction that conflicts with one in mempool gets rejected instead of ending up in
     // the orphan pool.
-    assert_eq!(
-        mempool.add_transaction(tx1b),
-        Err(OrphanPoolError::MempoolConflict.into()),
-    );
+    assert_eq!(mempool.add_transaction(tx1b), Err(OrphanPoolError::MempoolConflict.into()),);
 }
 
 #[rstest]

--- a/mempool/src/pool/tests/replacement.rs
+++ b/mempool/src/pool/tests/replacement.rs
@@ -275,10 +275,8 @@ async fn pays_more_than_conflicts_with_descendants(#[case] seed: Seed) -> anyhow
     //Create a new incoming transaction that conflicts with `replaced_tx` because it spends
     //`input`. It will be rejected because its fee exactly equals (so is not greater than) the
     //sum of the fees of the conflict together with its descendants
-    let insufficient_rbf_fee = [replaced_tx_fee, descendant1_fee, descendant2_fee]
-        .into_iter()
-        .sum::<Option<_>>()
-        .unwrap();
+    let insufficient_rbf_fee =
+        [replaced_tx_fee, descendant1_fee, descendant2_fee].into_iter().sum::<Option<_>>().unwrap();
     let incoming_tx = tx_spend_input(
         &mempool,
         input.clone(),

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -198,10 +198,8 @@ pub fn generate_transaction_graph(
     time: Time,
 ) -> impl Iterator<Item = TxEntryWithFee> + '_ {
     let tf = TestFramework::builder(rng).build();
-    let mut utxos = vec![(
-        TxInput::from_utxo(tf.genesis().get_id().into(), 0),
-        100_000_000_000_000_u128,
-    )];
+    let mut utxos =
+        vec![(TxInput::from_utxo(tf.genesis().get_id().into(), 0), 100_000_000_000_000_u128)];
 
     std::iter::repeat_with(move || {
         let n_inputs = rng.gen_range(1..=std::cmp::min(3, utxos.len()));

--- a/mempool/src/tx_accumulator.rs
+++ b/mempool/src/tx_accumulator.rs
@@ -59,9 +59,8 @@ impl TransactionAccumulator for DefaultTxAccumulator {
     fn add_tx(&mut self, tx: SignedTransaction, tx_fee: Fee) -> Result<(), TxAccumulatorError> {
         if self.total_size + tx.encoded_size() <= self.target_size {
             self.total_size += tx.encoded_size();
-            self.total_fees = (self.total_fees + tx_fee).ok_or(
-                TxAccumulatorError::FeeAccumulationError(self.total_fees, tx_fee),
-            )?;
+            self.total_fees = (self.total_fees + tx_fee)
+                .ok_or(TxAccumulatorError::FeeAccumulationError(self.total_fees, tx_fee))?;
             self.txs.push(tx);
         } else {
             self.done = true

--- a/merkletree/src/merkle/pos/mod.rs
+++ b/merkletree/src/merkle/pos/mod.rs
@@ -76,9 +76,8 @@ impl NodePosition {
     pub fn position(&self) -> (u32, u32) {
         assert!(self.abs_index() < self.tree_size.get(), "Index must be within the tree size");
 
-        let level_from_top = (self.tree_size.get() - self.abs_index() + 1)
-            .next_power_of_two()
-            .trailing_zeros();
+        let level_from_top =
+            (self.tree_size.get() - self.abs_index() + 1).next_power_of_two().trailing_zeros();
 
         let level = self.tree_size.level_count().get() - level_from_top;
         let level_start = self.tree_size.level_start(level).expect("Abs index is valid");

--- a/merkletree/src/merkle/pos/mod.rs
+++ b/merkletree/src/merkle/pos/mod.rs
@@ -36,10 +36,7 @@ impl NodePosition {
             return None;
         }
 
-        Some(Self {
-            tree_size,
-            absolute_index,
-        })
+        Some(Self { tree_size, absolute_index })
     }
 
     pub fn from_position(
@@ -63,10 +60,7 @@ impl NodePosition {
             return None;
         }
 
-        Some(Self {
-            tree_size,
-            absolute_index,
-        })
+        Some(Self { tree_size, absolute_index })
     }
 
     pub fn tree_size(&self) -> TreeSize {
@@ -80,10 +74,7 @@ impl NodePosition {
     /// Returns the level and index in the level of the node, as in (level, index).
     /// Notice that the index value is capped by the number of nodes in the level.
     pub fn position(&self) -> (u32, u32) {
-        assert!(
-            self.abs_index() < self.tree_size.get(),
-            "Index must be within the tree size"
-        );
+        assert!(self.abs_index() < self.tree_size.get(), "Index must be within the tree size");
 
         let level_from_top = (self.tree_size.get() - self.abs_index() + 1)
             .next_power_of_two()
@@ -128,10 +119,7 @@ impl NodePosition {
             NodePosition::from_position(self.tree_size, parent_level, parent_node_index_in_level)
                 .expect("Parent index must be in range");
 
-        Some(Self {
-            tree_size: self.tree_size,
-            absolute_index: parent_position.abs_index(),
-        })
+        Some(Self { tree_size: self.tree_size, absolute_index: parent_position.abs_index() })
     }
 
     pub fn sibling(&self) -> Option<Self> {
@@ -143,10 +131,7 @@ impl NodePosition {
         // Practically we add one to the absolute index to get the sibling if it's a left, and subtract one if it's a right.
         let absolute_index = self.absolute_index ^ 1;
 
-        Some(Self {
-            tree_size: self.tree_size,
-            absolute_index,
-        })
+        Some(Self { tree_size: self.tree_size, absolute_index })
     }
 
     pub fn into_iter_parents(self) -> MerkleTreeNodePositionParentIterator {

--- a/merkletree/src/merkle/pos/tests.rs
+++ b/merkletree/src/merkle/pos/tests.rs
@@ -378,26 +378,11 @@ fn absolute_index_from_bottom() {
 
     assert_eq!(NodePosition::from_position(s, 1, 0).unwrap().abs_index(), 8);
     assert_eq!(NodePosition::from_position(s, 1, 1).unwrap().abs_index(), 9);
-    assert_eq!(
-        NodePosition::from_position(s, 1, 2).unwrap().abs_index(),
-        10
-    );
-    assert_eq!(
-        NodePosition::from_position(s, 1, 3).unwrap().abs_index(),
-        11
-    );
+    assert_eq!(NodePosition::from_position(s, 1, 2).unwrap().abs_index(), 10);
+    assert_eq!(NodePosition::from_position(s, 1, 3).unwrap().abs_index(), 11);
 
-    assert_eq!(
-        NodePosition::from_position(s, 2, 0).unwrap().abs_index(),
-        12
-    );
-    assert_eq!(
-        NodePosition::from_position(s, 2, 1).unwrap().abs_index(),
-        13
-    );
+    assert_eq!(NodePosition::from_position(s, 2, 0).unwrap().abs_index(), 12);
+    assert_eq!(NodePosition::from_position(s, 2, 1).unwrap().abs_index(), 13);
 
-    assert_eq!(
-        NodePosition::from_position(s, 3, 0).unwrap().abs_index(),
-        14
-    );
+    assert_eq!(NodePosition::from_position(s, 3, 0).unwrap().abs_index(), 14);
 }

--- a/merkletree/src/merkle/proof/multi/mod.rs
+++ b/merkletree/src/merkle/proof/multi/mod.rs
@@ -105,11 +105,9 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> MultiProofNodes<'a, T, H> {
         }
 
         if !is_sorted_and_unique(leaves_indices) {
-            return Err(
-                MerkleTreeProofExtractionError::UnsortedOrUniqueLeavesIndices(
-                    leaves_indices.to_vec(),
-                ),
-            );
+            return Err(MerkleTreeProofExtractionError::UnsortedOrUniqueLeavesIndices(
+                leaves_indices.to_vec(),
+            ));
         }
 
         {
@@ -206,10 +204,7 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> MultiProofNodes<'a, T, H> {
 /// This struct is supposed to be serialized and stored to be used later, unlike `MultiProofNodes`.
 #[must_use]
 #[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "scale-codec",
-    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
-)]
+#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode, parity_scale_codec::Decode))]
 pub struct MultiProofHashes<T, H> {
     /// The minimal set of nodes needed to recreate the root hash (in addition to the leaves)
     nodes: BTreeMap<u32, T>,

--- a/merkletree/src/merkle/proof/multi/mod.rs
+++ b/merkletree/src/merkle/proof/multi/mod.rs
@@ -129,17 +129,12 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> MultiProofNodes<'a, T, H> {
         let mut computed_from_prev_level = vec![];
         let mut proof = vec![];
 
-        let single_proofs_branches = single_proofs
-            .clone()
-            .into_iter()
-            .map(|sp| sp.branch().to_vec())
-            .collect::<Vec<_>>();
+        let single_proofs_branches =
+            single_proofs.clone().into_iter().map(|sp| sp.branch().to_vec()).collect::<Vec<_>>();
 
         // We expect all proofs to have the same branch lengths
         if !single_proofs_branches.is_empty()
-            && !single_proofs_branches
-                .iter()
-                .all(|v| v.len() == single_proofs_branches[0].len())
+            && !single_proofs_branches.iter().all(|v| v.len() == single_proofs_branches[0].len())
         {
             panic!("Proofs of the same tree are all expected to have the same length")
         }

--- a/merkletree/src/merkle/proof/multi/tests.rs
+++ b/merkletree/src/merkle/proof/multi/tests.rs
@@ -29,10 +29,7 @@ fn gen_leaves(n: u32) -> Vec<HashedData> {
 }
 
 fn indices_to_map(leaves_indices: &[u32], leaves: &[HashedData]) -> BTreeMap<u32, HashedData> {
-    leaves_indices
-        .iter()
-        .map(|i| (*i, leaves[*i as usize]))
-        .collect::<BTreeMap<_, _>>()
+    leaves_indices.iter().map(|i| (*i, leaves[*i as usize])).collect::<BTreeMap<_, _>>()
 }
 
 #[test]
@@ -120,11 +117,7 @@ fn multi_proof_two_leaves_with_proof_leaves(#[case] input: &[u32], #[case] nodes
     let multi_proof = MultiProofNodes::from_tree_leaves(&t, input).unwrap();
     assert_eq!(multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(), nodes);
     assert_eq!(
-        multi_proof
-            .proof_leaves()
-            .iter()
-            .map(|leaf| leaf.abs_index())
-            .collect::<Vec<_>>(),
+        multi_proof.proof_leaves().iter().map(|leaf| leaf.abs_index()).collect::<Vec<_>>(),
         input
     );
     assert_eq!(multi_proof.tree_leaf_count(), t.leaf_count().get());
@@ -154,11 +147,7 @@ fn multi_proof_four_leaves_with_proof_leaves(#[case] input: &[u32], #[case] node
     let multi_proof = MultiProofNodes::from_tree_leaves(&t, input).unwrap();
     assert_eq!(multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(), nodes);
     assert_eq!(
-        multi_proof
-            .proof_leaves()
-            .iter()
-            .map(|leaf| leaf.abs_index())
-            .collect::<Vec<_>>(),
+        multi_proof.proof_leaves().iter().map(|leaf| leaf.abs_index()).collect::<Vec<_>>(),
         input
     );
     assert_eq!(multi_proof.tree_leaf_count(), t.leaf_count().get());
@@ -446,11 +435,7 @@ fn multi_proof_eight_leaves_with_proof_leaves(#[case] input: &[u32], #[case] nod
     let multi_proof = MultiProofNodes::from_tree_leaves(&t, input).unwrap();
     assert_eq!(multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(), nodes);
     assert_eq!(
-        multi_proof
-            .proof_leaves()
-            .iter()
-            .map(|leaf| leaf.abs_index())
-            .collect::<Vec<_>>(),
+        multi_proof.proof_leaves().iter().map(|leaf| leaf.abs_index()).collect::<Vec<_>>(),
         input
     );
     assert_eq!(multi_proof.tree_leaf_count(), t.leaf_count().get());
@@ -496,10 +481,7 @@ fn multi_proof_verification_leaves_empty(#[case] leaf_count: u32) {
     // we provide something  in the creation because it doesn't work with empty leaves, yet we test verification with it
     let multi_proof = MultiProofNodes::from_tree_leaves(&t, &[0]).unwrap();
     assert_eq!(
-        multi_proof
-            .into_values()
-            .verify(indices_to_map(&[], &leaves), t.root())
-            .unwrap_err(),
+        multi_proof.into_values().verify(indices_to_map(&[], &leaves), t.root()).unwrap_err(),
         MerkleProofVerificationError::LeavesContainerProvidedIsEmpty,
         "Failed for indices: {:?}",
         &[0]
@@ -569,11 +551,7 @@ fn multi_proof_verification_one_leaf() {
     let leaves_hashes_map = indices_to_map(&leaves_indices, &leaves);
 
     assert!(
-        multi_proof
-            .into_values()
-            .verify(leaves_hashes_map, t.root())
-            .unwrap()
-            .passed_trivially(),
+        multi_proof.into_values().verify(leaves_hashes_map, t.root()).unwrap().passed_trivially(),
         "Failed for indices: {:?}",
         leaves_indices
     );
@@ -721,10 +699,7 @@ fn multi_proof_verification_tampered_tree_size_into_invalid_value(
     let t = MerkleTree::<HashedData, HashAlgo>::from_leaves(leaves.clone()).unwrap();
 
     let indices_to_map = |leaves_indices: &[u32]| {
-        leaves_indices
-            .iter()
-            .map(|i| (*i, leaves[*i as usize]))
-            .collect::<BTreeMap<_, _>>()
+        leaves_indices.iter().map(|i| (*i, leaves[*i as usize])).collect::<BTreeMap<_, _>>()
     };
 
     let mut cases = gen_leaves_indices_combinations(leaf_count)
@@ -782,10 +757,7 @@ fn multi_proof_verification_tampered_tree_size_into_wrong_value(
     let t = MerkleTree::<HashedData, HashAlgo>::from_leaves(leaves.clone()).unwrap();
 
     let indices_to_map = |leaves_indices: &[u32]| {
-        leaves_indices
-            .iter()
-            .map(|i| (*i, leaves[*i as usize]))
-            .collect::<BTreeMap<_, _>>()
+        leaves_indices.iter().map(|i| (*i, leaves[*i as usize])).collect::<BTreeMap<_, _>>()
     };
 
     let mut cases = gen_leaves_indices_combinations(leaf_count)

--- a/merkletree/src/merkle/proof/multi/tests.rs
+++ b/merkletree/src/merkle/proof/multi/tests.rs
@@ -56,10 +56,7 @@ fn empty_multi_proof() {
     let t = MerkleTree::<HashedData, HashAlgo>::from_leaves(leaves).unwrap();
 
     let multi_proof = MultiProofNodes::from_tree_leaves(&t, &[]);
-    assert_eq!(
-        multi_proof.unwrap_err(),
-        MerkleTreeProofExtractionError::NoLeavesToCreateProof
-    );
+    assert_eq!(multi_proof.unwrap_err(), MerkleTreeProofExtractionError::NoLeavesToCreateProof);
 }
 
 /// Proof of one leaf must be equivalent to single proof
@@ -121,10 +118,7 @@ fn multi_proof_two_leaves_with_proof_leaves(#[case] input: &[u32], #[case] nodes
     let t = MerkleTree::<HashedData, HashAlgo>::from_leaves(leaves).unwrap();
 
     let multi_proof = MultiProofNodes::from_tree_leaves(&t, input).unwrap();
-    assert_eq!(
-        multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(),
-        nodes
-    );
+    assert_eq!(multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(), nodes);
     assert_eq!(
         multi_proof
             .proof_leaves()
@@ -158,10 +152,7 @@ fn multi_proof_four_leaves_with_proof_leaves(#[case] input: &[u32], #[case] node
     let t = MerkleTree::<HashedData, HashAlgo>::from_leaves(leaves).unwrap();
 
     let multi_proof = MultiProofNodes::from_tree_leaves(&t, input).unwrap();
-    assert_eq!(
-        multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(),
-        nodes
-    );
+    assert_eq!(multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(), nodes);
     assert_eq!(
         multi_proof
             .proof_leaves()
@@ -453,10 +444,7 @@ fn multi_proof_eight_leaves_with_proof_leaves(#[case] input: &[u32], #[case] nod
     let t = MerkleTree::<HashedData, HashAlgo>::from_leaves(leaves).unwrap();
 
     let multi_proof = MultiProofNodes::from_tree_leaves(&t, input).unwrap();
-    assert_eq!(
-        multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(),
-        nodes
-    );
+    assert_eq!(multi_proof.nodes().iter().map(|n| n.abs_index()).collect::<Vec<_>>(), nodes);
     assert_eq!(
         multi_proof
             .proof_leaves()
@@ -469,10 +457,7 @@ fn multi_proof_eight_leaves_with_proof_leaves(#[case] input: &[u32], #[case] nod
 }
 
 fn gen_leaves_indices_combinations(leaf_count: u32) -> impl Iterator<Item = Vec<u32>> {
-    assert!(
-        leaf_count.is_power_of_two(),
-        "leaf_count must be a power of 2"
-    );
+    assert!(leaf_count.is_power_of_two(), "leaf_count must be a power of 2");
     let mut leaves_indices = vec![];
     for i in 0..leaf_count {
         leaves_indices.push(i);
@@ -486,10 +471,7 @@ fn gen_leaves_indices_combinations(leaf_count: u32) -> impl Iterator<Item = Vec<
 #[case(4)]
 #[case(8)]
 fn leaf_count_combinations_generator(#[case] leaf_count: u32) {
-    assert_eq!(
-        gen_leaves_indices_combinations(leaf_count).count(),
-        1 << leaf_count
-    );
+    assert_eq!(gen_leaves_indices_combinations(leaf_count).count(), 1 << leaf_count);
 }
 
 #[rstest]
@@ -555,10 +537,7 @@ fn multi_proof_verification(
     cases.shuffle(&mut rng);
 
     // ensure we're really going through all the test cases we expect
-    assert_eq!(
-        cases.len(),
-        max_test_cases.unwrap_or_else(|| 1 << leaf_count)
-    );
+    assert_eq!(cases.len(), max_test_cases.unwrap_or_else(|| 1 << leaf_count));
 
     for leaves_indices in cases {
         if leaves_indices.is_empty() {
@@ -631,10 +610,7 @@ fn multi_proof_verification_tampered_nodes(
     cases.shuffle(&mut rng);
 
     // ensure we're really going through all the test cases we expect
-    assert_eq!(
-        cases.len(),
-        max_test_cases.unwrap_or_else(|| 1 << leaf_count)
-    );
+    assert_eq!(cases.len(), max_test_cases.unwrap_or_else(|| 1 << leaf_count));
 
     for leaves_indices in cases {
         if leaves_indices.is_empty() {
@@ -692,10 +668,7 @@ fn multi_proof_verification_tampered_leaves(
     cases.shuffle(&mut rng);
 
     // ensure we're really going through all the test cases we expect
-    assert_eq!(
-        cases.len(),
-        max_test_cases.unwrap_or_else(|| 1 << leaf_count)
-    );
+    assert_eq!(cases.len(), max_test_cases.unwrap_or_else(|| 1 << leaf_count));
 
     for leaves_indices in cases {
         if leaves_indices.is_empty() {
@@ -760,10 +733,7 @@ fn multi_proof_verification_tampered_tree_size_into_invalid_value(
     cases.shuffle(&mut rng);
 
     // ensure we're really going through all the test cases we expect
-    assert_eq!(
-        cases.len(),
-        max_test_cases.unwrap_or_else(|| 1 << leaf_count)
-    );
+    assert_eq!(cases.len(), max_test_cases.unwrap_or_else(|| 1 << leaf_count));
 
     for leaves_indices in cases {
         if leaves_indices.is_empty() {
@@ -824,10 +794,7 @@ fn multi_proof_verification_tampered_tree_size_into_wrong_value(
     cases.shuffle(&mut rng);
 
     // ensure we're really going through all the test cases we expect
-    assert_eq!(
-        cases.len(),
-        max_test_cases.unwrap_or_else(|| 1 << leaf_count)
-    );
+    assert_eq!(cases.len(), max_test_cases.unwrap_or_else(|| 1 << leaf_count));
 
     for leaves_indices in cases {
         if leaves_indices.is_empty() {

--- a/merkletree/src/merkle/proof/single/mod.rs
+++ b/merkletree/src/merkle/proof/single/mod.rs
@@ -35,10 +35,7 @@ pub struct SingleProofNodes<'a, T, H> {
 
 impl<T, H> Clone for SingleProofNodes<'_, T, H> {
     fn clone(&self) -> Self {
-        Self {
-            leaf: self.leaf,
-            branch: self.branch.clone(),
-        }
+        Self { leaf: self.leaf, branch: self.branch.clone() }
     }
 }
 
@@ -87,10 +84,7 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> SingleProofNodes<'a, T, H> {
             "This happens only if the we fail to find a sibling, which is only for root. In the loop, this cannot happen, so siblings must exist"
         );
 
-        let result = Self {
-            leaf,
-            branch: proof,
-        };
+        let result = Self { leaf, branch: proof };
 
         Ok(result)
     }
@@ -111,10 +105,7 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> SingleProofNodes<'a, T, H> {
 /// This struct is supposed to be serialized, unlike `SingleProofNodes`.
 #[must_use]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "scale-codec",
-    derive(parity_scale_codec::Encode, parity_scale_codec::Decode)
-)]
+#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode, parity_scale_codec::Decode))]
 pub struct SingleProofHashes<T, H> {
     leaf_index_in_level: u32,
     branch: Vec<T>,

--- a/merkletree/src/merkle/proof/single/tests.rs
+++ b/merkletree/src/merkle/proof/single/tests.rs
@@ -37,10 +37,7 @@ fn single_proof_one_leaf() {
     let p0 = SingleProofNodes::from_tree_leaf(&t, leaf_index).unwrap();
     assert_eq!(p0.branch().len(), 0);
 
-    assert!(p0
-        .into_values()
-        .verify(leaves[leaf_index as usize], t.root())
-        .passed_trivially());
+    assert!(p0.into_values().verify(leaves[leaf_index as usize], t.root()).passed_trivially());
 }
 
 #[rstest]
@@ -86,10 +83,7 @@ fn single_proof_eight_leaves(
     let p = SingleProofNodes::from_tree_leaf(&t, leaf_index).unwrap();
     assert_eq!(p.branch().iter().map(|n| n.abs_index()).collect::<Vec<_>>(), branch);
 
-    assert!(p
-        .into_values()
-        .verify(leaves[leaf_index as usize], t.root())
-        .passed_decisively());
+    assert!(p.into_values().verify(leaves[leaf_index as usize], t.root()).passed_decisively());
 }
 
 #[rstest]

--- a/merkletree/src/merkle/proof/single/tests.rs
+++ b/merkletree/src/merkle/proof/single/tests.rs
@@ -84,10 +84,7 @@ fn single_proof_eight_leaves(
     let t = MerkleTree::<HashedData, HashAlgo>::from_leaves(leaves.clone()).unwrap();
 
     let p = SingleProofNodes::from_tree_leaf(&t, leaf_index).unwrap();
-    assert_eq!(
-        p.branch().iter().map(|n| n.abs_index()).collect::<Vec<_>>(),
-        branch
-    );
+    assert_eq!(p.branch().iter().map(|n| n.abs_index()).collect::<Vec<_>>(), branch);
 
     assert!(p
         .into_values()

--- a/merkletree/src/merkle/tree/mod.rs
+++ b/merkletree/src/merkle/tree/mod.rs
@@ -103,10 +103,7 @@ impl<T: Clone, H> MerkleTree<T, H> {
         )?
         .abs_index();
 
-        Some(Node {
-            tree_ref: self,
-            absolute_index,
-        })
+        Some(Node { tree_ref: self, absolute_index })
     }
 }
 
@@ -139,10 +136,7 @@ impl<T: Clone, H: PairHasher<Type = T>> MerkleTree<T, H> {
         let tree = Self::create_tree_from_padded_leaves(padded_leaves_iter)?;
 
         TreeSize::try_from(tree.len()).expect("Invalid tree size. Invariant broken.");
-        let res = Self {
-            tree,
-            _hasher: std::marker::PhantomData,
-        };
+        let res = Self { tree, _hasher: std::marker::PhantomData };
         Ok(res)
     }
 
@@ -161,10 +155,7 @@ impl<T: Clone, H: PairHasher<Type = T>> MerkleTree<T, H> {
         }
 
         let res = MerkleTreeNodeParentIterator {
-            node: Some(Node {
-                tree_ref: self,
-                absolute_index: start_leaf_index,
-            }),
+            node: Some(Node { tree_ref: self, absolute_index: start_leaf_index }),
         };
 
         Ok(res)
@@ -195,10 +186,7 @@ impl<T: Eq, H> Eq for Node<'_, T, H> {}
 
 impl<T, H> Clone for Node<'_, T, H> {
     fn clone(&self) -> Self {
-        Self {
-            tree_ref: self.tree_ref,
-            absolute_index: self.absolute_index,
-        }
+        Self { tree_ref: self.tree_ref, absolute_index: self.absolute_index }
     }
 }
 
@@ -227,10 +215,7 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> Node<'a, T, H> {
     pub fn parent(&self) -> Option<Node<'a, T, H>> {
         let pos = self.into_position().parent()?;
 
-        Some(Node {
-            tree_ref: self.tree_ref,
-            absolute_index: pos.abs_index(),
-        })
+        Some(Node { tree_ref: self.tree_ref, absolute_index: pos.abs_index() })
     }
 
     /// Return the node that combines with this node to create a hash at the parent level.
@@ -239,10 +224,7 @@ impl<'a, T: Clone, H: PairHasher<Type = T>> Node<'a, T, H> {
     /// This can only be None for the root node.
     pub fn sibling(&self) -> Option<Node<'a, T, H>> {
         let absolute_index = self.into_position().sibling()?;
-        Some(Node {
-            tree_ref: self.tree_ref,
-            absolute_index: absolute_index.abs_index(),
-        })
+        Some(Node { tree_ref: self.tree_ref, absolute_index: absolute_index.abs_index() })
     }
 
     pub fn is_root(&self) -> bool {

--- a/merkletree/src/merkle/tree/mod.rs
+++ b/merkletree/src/merkle/tree/mod.rs
@@ -64,10 +64,7 @@ impl<T: Clone, H> MerkleTree<T, H> {
     }
 
     pub fn total_node_count(&self) -> TreeSize {
-        self.tree
-            .len()
-            .try_into()
-            .expect("(total_node_count) By design, tree_size is always > 0")
+        self.tree.len().try_into().expect("(total_node_count) By design, tree_size is always > 0")
     }
 
     pub fn leaf_count(&self) -> NonZeroU32 {
@@ -244,9 +241,7 @@ pub struct MerkleTreeNodeParentIterator<'a, T, H> {
 
 impl<T: Debug, H> Debug for MerkleTreeNodeParentIterator<'_, T, H> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MerkleTreeNodeParentIterator")
-            .field("node", &self.node)
-            .finish()
+        f.debug_struct("MerkleTreeNodeParentIterator").field("node", &self.node).finish()
     }
 }
 

--- a/merkletree/src/merkle/tree/padding.rs
+++ b/merkletree/src/merkle/tree/padding.rs
@@ -28,12 +28,7 @@ pub struct IncrementalPaddingIterator<T, I: Iterator<Item = T> + FusedIterator, 
 
 impl<T, I: Iterator<Item = T> + FusedIterator, F: Fn(&T) -> T> IncrementalPaddingIterator<T, I, F> {
     pub fn new(leaves: I, padding_function: F) -> Self {
-        IncrementalPaddingIterator {
-            leaves,
-            padding_function,
-            last_value: None,
-            current_index: 0,
-        }
+        IncrementalPaddingIterator { leaves, padding_function, last_value: None, current_index: 0 }
     }
 }
 

--- a/merkletree/src/merkle/tree/tree_size.rs
+++ b/merkletree/src/merkle/tree/tree_size.rs
@@ -194,57 +194,21 @@ mod tests {
         assert_eq!(TreeSize::from_leaf_count(0), Err(TreeSizeError::ZeroSize));
         assert_eq!(TreeSize::from_leaf_count(1), Ok(TreeSize(1)));
         assert_eq!(TreeSize::from_leaf_count(2), Ok(TreeSize(3)));
-        assert_eq!(
-            TreeSize::from_leaf_count(3),
-            Err(TreeSizeError::InvalidSize(5))
-        );
+        assert_eq!(TreeSize::from_leaf_count(3), Err(TreeSizeError::InvalidSize(5)));
         assert_eq!(TreeSize::from_leaf_count(4), Ok(TreeSize(7)));
-        assert_eq!(
-            TreeSize::from_leaf_count(5),
-            Err(TreeSizeError::InvalidSize(9))
-        );
-        assert_eq!(
-            TreeSize::from_leaf_count(6),
-            Err(TreeSizeError::InvalidSize(11))
-        );
-        assert_eq!(
-            TreeSize::from_leaf_count(7),
-            Err(TreeSizeError::InvalidSize(13))
-        );
+        assert_eq!(TreeSize::from_leaf_count(5), Err(TreeSizeError::InvalidSize(9)));
+        assert_eq!(TreeSize::from_leaf_count(6), Err(TreeSizeError::InvalidSize(11)));
+        assert_eq!(TreeSize::from_leaf_count(7), Err(TreeSizeError::InvalidSize(13)));
         assert_eq!(TreeSize::from_leaf_count(8), Ok(TreeSize(15)));
-        assert_eq!(
-            TreeSize::from_leaf_count(9),
-            Err(TreeSizeError::InvalidSize(17))
-        );
-        assert_eq!(
-            TreeSize::from_leaf_count(10),
-            Err(TreeSizeError::InvalidSize(19))
-        );
-        assert_eq!(
-            TreeSize::from_leaf_count(11),
-            Err(TreeSizeError::InvalidSize(21))
-        );
-        assert_eq!(
-            TreeSize::from_leaf_count(12),
-            Err(TreeSizeError::InvalidSize(23))
-        );
-        assert_eq!(
-            TreeSize::from_leaf_count(13),
-            Err(TreeSizeError::InvalidSize(25))
-        );
-        assert_eq!(
-            TreeSize::from_leaf_count(14),
-            Err(TreeSizeError::InvalidSize(27))
-        );
-        assert_eq!(
-            TreeSize::from_leaf_count(15),
-            Err(TreeSizeError::InvalidSize(29))
-        );
+        assert_eq!(TreeSize::from_leaf_count(9), Err(TreeSizeError::InvalidSize(17)));
+        assert_eq!(TreeSize::from_leaf_count(10), Err(TreeSizeError::InvalidSize(19)));
+        assert_eq!(TreeSize::from_leaf_count(11), Err(TreeSizeError::InvalidSize(21)));
+        assert_eq!(TreeSize::from_leaf_count(12), Err(TreeSizeError::InvalidSize(23)));
+        assert_eq!(TreeSize::from_leaf_count(13), Err(TreeSizeError::InvalidSize(25)));
+        assert_eq!(TreeSize::from_leaf_count(14), Err(TreeSizeError::InvalidSize(27)));
+        assert_eq!(TreeSize::from_leaf_count(15), Err(TreeSizeError::InvalidSize(29)));
         assert_eq!(TreeSize::from_leaf_count(16), Ok(TreeSize(31)));
-        assert_eq!(
-            TreeSize::from_leaf_count(17),
-            Err(TreeSizeError::InvalidSize(33))
-        );
+        assert_eq!(TreeSize::from_leaf_count(17), Err(TreeSizeError::InvalidSize(33)));
     }
 
     #[test]
@@ -368,10 +332,7 @@ mod tests {
         assert_eq!(t3.iter_pairs_indices().collect::<Vec<_>>(), vec![(0, 1)]);
 
         let t7 = TreeSize::from_u32(7).unwrap();
-        assert_eq!(
-            t7.iter_pairs_indices().collect::<Vec<_>>(),
-            vec![(0, 1), (2, 3), (4, 5)]
-        );
+        assert_eq!(t7.iter_pairs_indices().collect::<Vec<_>>(), vec![(0, 1), (2, 3), (4, 5)]);
 
         let t15 = TreeSize::from_u32(15).unwrap();
         assert_eq!(
@@ -405,10 +366,7 @@ mod tests {
         for i in 1..10_u32 {
             let tree_size = TreeSize::from_u32((1 << i) - 1).unwrap();
             assert_eq!(TreeSize::from_u32((1 << i) - 1), Ok(TreeSize((1 << i) - 1)));
-            assert_eq!(
-                tree_size.iter_pairs_indices().count() as u32,
-                tree_size.get() / 2
-            );
+            assert_eq!(tree_size.iter_pairs_indices().count() as u32, tree_size.get() / 2);
             assert_eq!(
                 tree_size.iter_pairs_indices().collect::<Vec<_>>(),
                 (0..tree_size.get() / 2).map(|i| (i * 2, i * 2 + 1)).collect::<Vec<_>>()

--- a/node-gui/src/backend_controller.rs
+++ b/node-gui/src/backend_controller.rs
@@ -28,9 +28,7 @@ pub struct NodeBackendController {
 
 impl Debug for NodeBackendController {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("NodeInitializationData")
-            .field("chain_config", &self.chain_config)
-            .finish()
+        f.debug_struct("NodeInitializationData").field("chain_config", &self.chain_config).finish()
     }
 }
 

--- a/node-gui/src/main_window/main_menu.rs
+++ b/node-gui/src/main_window/main_menu.rs
@@ -35,9 +35,7 @@ pub struct MainMenu {
 
 impl MainMenu {
     pub fn new(backend_controller: NodeBackendController) -> Self {
-        Self {
-            _backend_controller: backend_controller,
-        }
+        Self { _backend_controller: backend_controller }
     }
 
     pub fn view(

--- a/node-gui/src/main_window/main_widget/mod.rs
+++ b/node-gui/src/main_window/main_widget/mod.rs
@@ -31,9 +31,7 @@ pub struct MainWidget {
 
 impl MainWidget {
     pub fn new(backend_controller: NodeBackendController) -> Self {
-        Self {
-            tabs: tabs::TabsWidget::new(backend_controller),
-        }
+        Self { tabs: tabs::TabsWidget::new(backend_controller) }
     }
 
     pub fn start() -> impl IntoIterator<Item = Command<MainWidgetMessage>> {

--- a/node-gui/src/main_window/main_widget/tabs/mod.rs
+++ b/node-gui/src/main_window/main_widget/tabs/mod.rs
@@ -32,10 +32,8 @@ pub mod summary;
 
 const TAB_PADDING: u16 = 16;
 
-const ICON_FONT: Font = iced::Font::External {
-    name: "Icons",
-    bytes: include_bytes!("../../../../fonts/icons.ttf"),
-};
+const ICON_FONT: Font =
+    iced::Font::External { name: "Icons", bytes: include_bytes!("../../../../fonts/icons.ttf") };
 
 enum Icon {
     User,

--- a/node-gui/src/main_window/main_widget/tabs/settings.rs
+++ b/node-gui/src/main_window/main_widget/tabs/settings.rs
@@ -46,9 +46,7 @@ pub struct TabSettings {
 
 impl TabSettings {
     pub fn new() -> Self {
-        TabSettings {
-            tab_bar_position: Some(TabBarPosition::Top),
-        }
+        TabSettings { tab_bar_position: Some(TabBarPosition::Top) }
     }
 }
 
@@ -64,9 +62,7 @@ pub struct SettingsTab {
 
 impl SettingsTab {
     pub fn new() -> Self {
-        SettingsTab {
-            settings: TabSettings::new(),
-        }
+        SettingsTab { settings: TabSettings::new() }
     }
 
     pub fn settings(&self) -> &TabSettings {
@@ -101,8 +97,8 @@ impl Tab for SettingsTab {
     }
 
     fn content(&self) -> Element<'_, Self::Message> {
-        let content: Element<'_, SettingsMessage> = Container::new(
-            Column::new().push(Text::new("Tabs position").size(20)).push(
+        let content: Element<'_, SettingsMessage> =
+            Container::new(Column::new().push(Text::new("Tabs position").size(20)).push(
                 TabBarPosition::ALL.iter().cloned().fold(
                     Column::new().padding(10).spacing(10),
                     |column, position| {
@@ -117,9 +113,8 @@ impl Tab for SettingsTab {
                         )
                     },
                 ),
-            ),
-        )
-        .into();
+            ))
+            .into();
 
         content.map(TabsMessage::Settings)
     }

--- a/node-gui/src/main_window/main_widget/tabs/summary.rs
+++ b/node-gui/src/main_window/main_widget/tabs/summary.rs
@@ -175,9 +175,8 @@ impl Tab for SummaryTab {
 
         let grid = Grid::with_columns(2);
         let grid = grid.push(Text::new("Best block id ")).push(Text::new(best_id.to_string()));
-        let grid = grid
-            .push(Text::new("Best block height "))
-            .push(Text::new(best_height.to_string()));
+        let grid =
+            grid.push(Text::new("Best block height ")).push(Text::new(best_height.to_string()));
 
         let main_widget: Element<'_, Self::Message> = Column::new()
             .spacing(15)

--- a/node-gui/src/main_window/main_widget/tabs/summary.rs
+++ b/node-gui/src/main_window/main_widget/tabs/summary.rs
@@ -71,10 +71,7 @@ pub struct SummaryTab {
 
 impl SummaryTab {
     pub fn new(controller: NodeBackendController) -> Self {
-        SummaryTab {
-            controller,
-            current_tip: None,
-        }
+        SummaryTab { controller, current_tip: None }
     }
 
     pub fn start(
@@ -113,15 +110,13 @@ impl SummaryTab {
         chainstate_handle
             .call_mut(|this| {
                 let subscribe_func =
-                    Arc::new(
-                        move |chainstate_event: ChainstateEvent| match chainstate_event {
-                            ChainstateEvent::NewTip(block_id, block_height) => {
-                                _ = chainstate_sender
-                                    .send((block_id.into(), block_height))
-                                    .log_err_pfx("Chainstate subscriber failed to send new tip");
-                            }
-                        },
-                    );
+                    Arc::new(move |chainstate_event: ChainstateEvent| match chainstate_event {
+                        ChainstateEvent::NewTip(block_id, block_height) => {
+                            _ = chainstate_sender
+                                .send((block_id.into(), block_height))
+                                .log_err_pfx("Chainstate subscriber failed to send new tip");
+                        }
+                    });
 
                 this.subscribe_to_events(subscribe_func);
             })

--- a/node-lib/src/config_files/mod.rs
+++ b/node-lib/src/config_files/mod.rs
@@ -174,18 +174,15 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
         cookie_file,
     } = config;
 
-    let http_bind_address = options
-        .http_rpc_addr
-        .unwrap_or_else(|| http_bind_address.unwrap_or(default_http_rpc_addr));
+    let http_bind_address =
+        options.http_rpc_addr.unwrap_or_else(|| http_bind_address.unwrap_or(default_http_rpc_addr));
     let http_enabled = options
         .http_rpc_enabled
         .unwrap_or_else(|| http_enabled.unwrap_or(DEFAULT_HTTP_RPC_ENABLED));
-    let ws_bind_address = options
-        .ws_rpc_addr
-        .unwrap_or_else(|| ws_bind_address.unwrap_or(default_ws_rpc_addr));
-    let ws_enabled = options
-        .ws_rpc_enabled
-        .unwrap_or_else(|| ws_enabled.unwrap_or(DEFAULT_WS_RPC_ENABLED));
+    let ws_bind_address =
+        options.ws_rpc_addr.unwrap_or_else(|| ws_bind_address.unwrap_or(default_ws_rpc_addr));
+    let ws_enabled =
+        options.ws_rpc_enabled.unwrap_or_else(|| ws_enabled.unwrap_or(DEFAULT_WS_RPC_ENABLED));
     let username = username.or(options.rpc_username.clone());
     let password = password.or(options.rpc_password.clone());
     let cookie_file = cookie_file.or(options.rpc_cookie_file.clone());

--- a/node-lib/src/config_files/mod.rs
+++ b/node-lib/src/config_files/mod.rs
@@ -46,11 +46,7 @@ pub struct NodeConfigFile {
 
 impl NodeConfigFile {
     pub fn new() -> Result<Self> {
-        Ok(Self {
-            chainstate: None,
-            p2p: None,
-            rpc: None,
-        })
+        Ok(Self { chainstate: None, p2p: None, rpc: None })
     }
 
     fn read_to_string_with_policy<P: AsRef<Path>>(config_path: P) -> Result<String> {
@@ -69,21 +65,14 @@ impl NodeConfigFile {
     pub fn read(config_path: &Path, options: &RunOptions) -> Result<Self> {
         let config_as_str = Self::read_to_string_with_policy(config_path)?;
 
-        let NodeConfigFile {
-            chainstate,
-            p2p,
-            rpc,
-        } = toml::from_str(&config_as_str).context("Failed to parse config")?;
+        let NodeConfigFile { chainstate, p2p, rpc } =
+            toml::from_str(&config_as_str).context("Failed to parse config")?;
 
         let chainstate = chainstate_config(chainstate.unwrap_or_default(), options);
         let p2p = p2p_config(p2p.unwrap_or_default(), options);
         let rpc = rpc_config(rpc.unwrap_or_default(), options);
 
-        Ok(Self {
-            chainstate: Some(chainstate),
-            p2p: Some(p2p),
-            rpc: Some(rpc),
-        })
+        Ok(Self { chainstate: Some(chainstate), p2p: Some(p2p), rpc: Some(rpc) })
     }
 }
 
@@ -91,10 +80,7 @@ fn chainstate_config(
     config: ChainstateLauncherConfigFile,
     options: &RunOptions,
 ) -> ChainstateLauncherConfigFile {
-    let ChainstateLauncherConfigFile {
-        storage_backend,
-        chainstate_config,
-    } = config;
+    let ChainstateLauncherConfigFile { storage_backend, chainstate_config } = config;
 
     let ChainstateConfigFile {
         max_db_commit_attempts,
@@ -117,10 +103,7 @@ fn chainstate_config(
         tx_index_enabled,
         max_tip_age,
     };
-    ChainstateLauncherConfigFile {
-        storage_backend,
-        chainstate_config,
-    }
+    ChainstateLauncherConfigFile { storage_backend, chainstate_config }
 }
 
 fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {

--- a/node-lib/src/mock_time.rs
+++ b/node-lib/src/mock_time.rs
@@ -20,10 +20,7 @@ use logging::log;
 
 /// Sets mock time (seconds since UNIX epoch)
 pub fn set_mock_time(chain_type: ChainType, time: u64) -> Result<(), crate::Error> {
-    anyhow::ensure!(
-        chain_type == ChainType::Regtest,
-        "Mock time allowed on regtest chain only"
-    );
+    anyhow::ensure!(chain_type == ChainType::Regtest, "Mock time allowed on regtest chain only");
     log::info!("set mock time to {time}");
     common::primitives::time::set(Duration::from_secs(time))?;
     Ok(())

--- a/node-lib/src/options.rs
+++ b/node-lib/src/options.rs
@@ -183,10 +183,7 @@ impl Options {
 
     /// Returns a path to the config file
     pub fn config_path(&self, chain_type: ChainType) -> PathBuf {
-        self.data_dir
-            .clone()
-            .unwrap_or_else(|| default_data_dir(chain_type))
-            .join(CONFIG_NAME)
+        self.data_dir.clone().unwrap_or_else(|| default_data_dir(chain_type)).join(CONFIG_NAME)
     }
 }
 

--- a/node-lib/src/rpc.rs
+++ b/node-lib/src/rpc.rs
@@ -42,10 +42,7 @@ struct NodeRpc {
 
 impl NodeRpc {
     fn new(shutdown_trigger: ShutdownTrigger, chain_config: Arc<ChainConfig>) -> Self {
-        Self {
-            shutdown_trigger,
-            chain_config,
-        }
+        Self { shutdown_trigger, chain_config }
     }
 }
 

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -155,10 +155,7 @@ async fn initialize(
         )?;
         // TODO: get rid of the unwrap_or() after fixing the issue in #446
         let rpc = rpc::Builder::new(rpc_config.into(), Some(rpc_creds))
-            .register(crate::rpc::init(
-                manager.make_shutdown_trigger(),
-                chain_config,
-            ))
+            .register(crate::rpc::init(manager.make_shutdown_trigger(), chain_config))
             .register(block_prod.clone().into_rpc())
             .register(chainstate.clone().into_rpc())
             .register(mempool.clone().into_rpc())
@@ -175,10 +172,8 @@ async fn initialize(
     };
 
     if let Some(sender) = node_controller {
-        let runtime_info = crate::node_controller::RuntimeInfo {
-            rpc_http_address,
-            rpc_websocket_address,
-        };
+        let runtime_info =
+            crate::node_controller::RuntimeInfo { rpc_http_address, rpc_websocket_address };
 
         let controller = NodeController {
             shutdown_trigger: manager.make_shutdown_trigger(),
@@ -261,11 +256,9 @@ async fn start(
     let node_config =
         NodeConfigFile::read(config_path, run_options).context("Failed to initialize config")?;
 
-    let data_dir = prepare_data_dir(
-        || default_data_dir(*chain_config.chain_type()),
-        datadir_path_opt,
-    )
-    .expect("Failed to prepare data directory");
+    let data_dir =
+        prepare_data_dir(|| default_data_dir(*chain_config.chain_type()), datadir_path_opt)
+            .expect("Failed to prepare data directory");
     let lock_file = lock_data_dir(&data_dir)?;
 
     log::info!("Starting with the following config:\n {node_config:#?}");

--- a/node-lib/tests/cli.rs
+++ b/node-lib/tests/cli.rs
@@ -39,23 +39,12 @@ fn create_default_config() {
     let config = NodeConfigFile::read(&config_path, &options).unwrap();
 
     assert_eq!(
-        config
-            .chainstate
-            .clone()
-            .unwrap_or_default()
-            .chainstate_config
-            .max_db_commit_attempts,
+        config.chainstate.clone().unwrap_or_default().chainstate_config.max_db_commit_attempts,
         None
     );
     assert_eq!(config.chainstate.unwrap_or_default().chainstate_config.max_orphan_blocks, None);
 
-    assert!(config
-        .p2p
-        .clone()
-        .unwrap_or_default()
-        .bind_addresses
-        .unwrap_or_default()
-        .is_empty());
+    assert!(config.p2p.clone().unwrap_or_default().bind_addresses.unwrap_or_default().is_empty());
     assert_eq!(config.p2p.clone().unwrap_or_default().ban_threshold, None);
     assert_eq!(config.p2p.clone().unwrap_or_default().outbound_connection_timeout, None);
 

--- a/node-lib/tests/cli.rs
+++ b/node-lib/tests/cli.rs
@@ -47,10 +47,7 @@ fn create_default_config() {
             .max_db_commit_attempts,
         None
     );
-    assert_eq!(
-        config.chainstate.unwrap_or_default().chainstate_config.max_orphan_blocks,
-        None
-    );
+    assert_eq!(config.chainstate.unwrap_or_default().chainstate_config.max_orphan_blocks, None);
 
     assert!(config
         .p2p
@@ -60,10 +57,7 @@ fn create_default_config() {
         .unwrap_or_default()
         .is_empty());
     assert_eq!(config.p2p.clone().unwrap_or_default().ban_threshold, None);
-    assert_eq!(
-        config.p2p.clone().unwrap_or_default().outbound_connection_timeout,
-        None
-    );
+    assert_eq!(config.p2p.clone().unwrap_or_default().outbound_connection_timeout, None);
 
     assert_eq!(
         config.rpc.unwrap_or_default().http_bind_address,
@@ -142,31 +136,13 @@ fn read_config_override_values() {
         config.chainstate.clone().unwrap().chainstate_config.max_orphan_blocks,
         Some(max_orphan_blocks)
     );
-    assert_eq!(
-        config.chainstate.clone().unwrap().chainstate_config.tx_index_enabled,
-        Some(false)
-    );
-    assert_eq!(
-        config.chainstate.clone().unwrap().chainstate_config.max_tip_age,
-        Some(max_tip_age)
-    );
+    assert_eq!(config.chainstate.clone().unwrap().chainstate_config.tx_index_enabled, Some(false));
+    assert_eq!(config.chainstate.clone().unwrap().chainstate_config.max_tip_age, Some(max_tip_age));
 
-    assert_eq!(
-        config.p2p.clone().unwrap().bind_addresses,
-        Some(vec!(p2p_addr.to_owned()))
-    );
-    assert_eq!(
-        config.p2p.clone().unwrap().socks5_proxy,
-        Some(p2p_socks5_proxy.to_owned())
-    );
-    assert_eq!(
-        config.p2p.clone().unwrap().disable_noise,
-        Some(p2p_disable_noise)
-    );
-    assert_eq!(
-        config.p2p.clone().unwrap().boot_nodes,
-        Some(vec!(p2p_boot_node.to_owned()))
-    );
+    assert_eq!(config.p2p.clone().unwrap().bind_addresses, Some(vec!(p2p_addr.to_owned())));
+    assert_eq!(config.p2p.clone().unwrap().socks5_proxy, Some(p2p_socks5_proxy.to_owned()));
+    assert_eq!(config.p2p.clone().unwrap().disable_noise, Some(p2p_disable_noise));
+    assert_eq!(config.p2p.clone().unwrap().boot_nodes, Some(vec!(p2p_boot_node.to_owned())));
     assert_eq!(
         config.p2p.clone().unwrap().reserved_nodes,
         Some(vec!(p2p_reserved_node.to_owned()))
@@ -175,56 +151,23 @@ fn read_config_override_values() {
         config.p2p.clone().unwrap().max_inbound_connections,
         Some(p2p_max_inbound_connections)
     );
-    assert_eq!(
-        config.p2p.clone().unwrap().ban_threshold,
-        Some(p2p_ban_threshold)
-    );
-    assert_eq!(
-        config.p2p.clone().unwrap().outbound_connection_timeout,
-        Some(p2p_timeout)
-    );
-    assert_eq!(
-        config.p2p.clone().unwrap().ping_check_period,
-        Some(p2p_ping_check_period)
-    );
-    assert_eq!(
-        config.p2p.clone().unwrap().ping_timeout,
-        Some(p2p_ping_timeout)
-    );
-    assert_eq!(
-        config.p2p.clone().unwrap().sync_stalling_timeout,
-        Some(p2p_sync_stalling_timeout)
-    );
-    assert_eq!(
-        config.p2p.clone().unwrap().max_clock_diff,
-        Some(p2p_max_clock_diff)
-    );
+    assert_eq!(config.p2p.clone().unwrap().ban_threshold, Some(p2p_ban_threshold));
+    assert_eq!(config.p2p.clone().unwrap().outbound_connection_timeout, Some(p2p_timeout));
+    assert_eq!(config.p2p.clone().unwrap().ping_check_period, Some(p2p_ping_check_period));
+    assert_eq!(config.p2p.clone().unwrap().ping_timeout, Some(p2p_ping_timeout));
+    assert_eq!(config.p2p.clone().unwrap().sync_stalling_timeout, Some(p2p_sync_stalling_timeout));
+    assert_eq!(config.p2p.clone().unwrap().max_clock_diff, Some(p2p_max_clock_diff));
     assert_eq!(config.p2p.clone().unwrap().node_type, Some(node_type));
 
-    assert_eq!(
-        config.rpc.clone().unwrap().http_bind_address,
-        Some(http_rpc_addr)
-    );
+    assert_eq!(config.rpc.clone().unwrap().http_bind_address, Some(http_rpc_addr));
     assert!(config.rpc.clone().unwrap().http_enabled.unwrap());
 
-    assert_eq!(
-        config.rpc.clone().unwrap().ws_bind_address,
-        Some(ws_rpc_addr)
-    );
+    assert_eq!(config.rpc.clone().unwrap().ws_bind_address, Some(ws_rpc_addr));
     assert!(!config.rpc.clone().unwrap().ws_enabled.unwrap());
 
-    assert_eq!(
-        config.rpc.as_ref().unwrap().username.as_deref(),
-        Some(rpc_username)
-    );
-    assert_eq!(
-        config.rpc.as_ref().unwrap().password.as_deref(),
-        Some(rpc_password)
-    );
-    assert_eq!(
-        config.rpc.as_ref().unwrap().cookie_file.as_deref(),
-        Some(rpc_cookie_file)
-    );
+    assert_eq!(config.rpc.as_ref().unwrap().username.as_deref(), Some(rpc_username));
+    assert_eq!(config.rpc.as_ref().unwrap().password.as_deref(), Some(rpc_password));
+    assert_eq!(config.rpc.as_ref().unwrap().cookie_file.as_deref(), Some(rpc_cookie_file));
 
     assert_eq!(config.chainstate.unwrap().storage_backend, backend_type);
 }

--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -118,11 +118,7 @@ where
     // spawn `sync2` into background and spam an orphan block on the network
     tokio::spawn(async move {
         let (peer, mut sync_rx) = match sync2.poll_next().await.unwrap() {
-            SyncingEvent::Connected {
-                peer_id,
-                services: _,
-                sync_rx,
-            } => (peer_id, sync_rx),
+            SyncingEvent::Connected { peer_id, services: _, sync_rx } => (peer_id, sync_rx),
             e => panic!("Unexpected event type: {e:?}"),
         };
         match sync_rx.recv().await.unwrap() {

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -89,17 +89,11 @@ where
     )
     .unwrap();
     messaging_handle1
-        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block
-            .header()
-            .clone()])))
+        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])))
         .unwrap();
 
     let mut sync_rx_2 = match sync2.poll_next().await.unwrap() {
-        SyncingEvent::Connected {
-            peer_id: _,
-            services: _,
-            sync_rx,
-        } => sync_rx,
+        SyncingEvent::Connected { peer_id: _, services: _, sync_rx } => sync_rx,
         event => panic!("Unexpected event: {event:?}"),
     };
 
@@ -123,17 +117,11 @@ where
     )
     .unwrap();
     messaging_handle2
-        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block
-            .header()
-            .clone()])))
+        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])))
         .unwrap();
 
     let mut sync_rx_1 = match sync1.poll_next().await.unwrap() {
-        SyncingEvent::Connected {
-            peer_id: _,
-            services: _,
-            sync_rx,
-        } => sync_rx,
+        SyncingEvent::Connected { peer_id: _, services: _, sync_rx } => sync_rx,
         event => panic!("Unexpected event: {event:?}"),
     };
 
@@ -229,9 +217,7 @@ where
     )
     .unwrap();
     messaging_handle1
-        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block
-            .header()
-            .clone()])))
+        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])))
         .unwrap();
 
     shutdown.store(true);

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -100,9 +100,7 @@ impl P2pBasicTestTimeGetter {
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap();
         let current_time_millis = Arc::new(SeqCstAtomicU64::new(current_time.as_millis() as u64));
-        Self {
-            current_time_millis,
-        }
+        Self { current_time_millis }
     }
 
     pub fn get_time_getter(&self) -> TimeGetter {

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -96,9 +96,8 @@ pub struct P2pBasicTestTimeGetter {
 
 impl P2pBasicTestTimeGetter {
     pub fn new() -> Self {
-        let current_time = std::time::SystemTime::now()
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .unwrap();
+        let current_time =
+            std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).unwrap();
         let current_time_millis = Arc::new(SeqCstAtomicU64::new(current_time.as_millis() as u64));
         Self { current_time_millis }
     }

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -55,9 +55,9 @@ pub enum NodeType {
 impl From<NodeType> for Services {
     fn from(t: NodeType) -> Self {
         match t {
-            NodeType::Full => [Service::Blocks, Service::Transactions, Service::PeerAddresses]
-                .as_slice()
-                .into(),
+            NodeType::Full => {
+                [Service::Blocks, Service::Transactions, Service::PeerAddresses].as_slice().into()
+            }
             NodeType::BlocksOnly => [Service::Blocks].as_slice().into(),
             NodeType::DnsServer => [Service::PeerAddresses].as_slice().into(),
             NodeType::Inactive => [].as_slice().into(),

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -126,9 +126,7 @@ pub struct BlockResponse {
 
 impl BlockResponse {
     pub fn new(block: Block) -> Self {
-        Self {
-            block: Box::new(block),
-        }
+        Self { block: Box::new(block) }
     }
 
     pub fn block(&self) -> &Block {

--- a/p2p/src/net/default_backend/backend.rs
+++ b/p2p/src/net/default_backend/backend.rs
@@ -199,10 +199,8 @@ where
 
     /// Allow peer to start reading network messages
     fn accept_peer(&mut self, peer_id: PeerId) -> crate::Result<()> {
-        let peer = self
-            .peers
-            .get_mut(&peer_id)
-            .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
+        let peer =
+            self.peers.get_mut(&peer_id).ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
 
         let (sync_tx, sync_rx) = mpsc::channel(SYNC_CHAN_BUF_SIZE);
         peer.tx.send(Event::Accepted { sync_tx })?;
@@ -223,19 +221,15 @@ where
 
     /// Disconnect remote peer by id. Might fail if the peer is already disconnected.
     fn disconnect_peer(&mut self, peer_id: PeerId) -> crate::Result<()> {
-        self.peers
-            .get(&peer_id)
-            .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
+        self.peers.get(&peer_id).ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
 
         self.destroy_peer(peer_id)
     }
 
     /// Sends a message the remote peer. Might fail if the peer is already disconnected.
     fn send_message(&mut self, peer: PeerId, message: Message) -> crate::Result<()> {
-        let peer = self
-            .peers
-            .get_mut(&peer)
-            .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
+        let peer =
+            self.peers.get_mut(&peer).ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
         Ok(peer.tx.send(Event::SendMessage(Box::new(message)))?)
     }
 
@@ -407,10 +401,8 @@ where
     /// Peer should not be in pending state.
     fn destroy_peer(&mut self, peer_id: PeerId) -> crate::Result<()> {
         // Make sure the peer exists so that `ConnectionClosed` is sent only once
-        let peer = self
-            .peers
-            .remove(&peer_id)
-            .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
+        let peer =
+            self.peers.remove(&peer_id).ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
 
         if peer.was_accepted.test() {
             Self::send_sync_event(

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -68,12 +68,7 @@ impl<S: NetworkingService, T: TransportSocket> ConnectivityHandle<S, T> {
         cmd_tx: mpsc::UnboundedSender<types::Command<T::Address>>,
         conn_rx: mpsc::UnboundedReceiver<ConnectivityEvent<T::Address>>,
     ) -> Self {
-        Self {
-            local_addresses,
-            cmd_tx,
-            conn_rx,
-            _marker: PhantomData,
-        }
+        Self { local_addresses, cmd_tx, conn_rx, _marker: PhantomData }
     }
 }
 
@@ -90,9 +85,7 @@ impl<T: TransportSocket> MessagingHandle<T> {
 
 impl<T: TransportSocket> Clone for MessagingHandle<T> {
     fn clone(&self) -> Self {
-        Self {
-            command_sender: self.command_sender.clone(),
-        }
+        Self { command_sender: self.command_sender.clone() }
     }
 }
 
@@ -173,10 +166,7 @@ where
     T: TransportSocket,
 {
     fn connect(&mut self, address: S::Address) -> crate::Result<()> {
-        log::debug!(
-            "try to establish outbound connection, address {:?}",
-            address
-        );
+        log::debug!("try to establish outbound connection, address {:?}", address);
 
         Ok(self.cmd_tx.send(types::Command::Connect { address })?)
     }
@@ -194,10 +184,9 @@ where
     }
 
     fn send_message(&mut self, peer: PeerId, message: PeerManagerMessage) -> crate::Result<()> {
-        Ok(self.cmd_tx.send(types::Command::SendMessage {
-            peer,
-            message: message.into(),
-        })?)
+        Ok(self
+            .cmd_tx
+            .send(types::Command::SendMessage { peer, message: message.into() })?)
     }
 
     fn local_addresses(&self) -> &[S::Address] {
@@ -211,10 +200,9 @@ where
 
 impl<T: TransportSocket> MessagingService for MessagingHandle<T> {
     fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()> {
-        Ok(self.command_sender.send(types::Command::SendMessage {
-            peer,
-            message: message.into(),
-        })?)
+        Ok(self
+            .command_sender
+            .send(types::Command::SendMessage { peer, message: message.into() })?)
     }
 
     fn broadcast_message(&mut self, message: SyncMessage) -> crate::Result<()> {
@@ -226,16 +214,15 @@ impl<T: TransportSocket> MessagingService for MessagingHandle<T> {
             | SyncMessage::BlockResponse(_)
             | SyncMessage::TransactionRequest(_)
             | SyncMessage::TransactionResponse(_) => {
-                return Err(P2pError::ProtocolError(ProtocolError::UnexpectedMessage(
-                    format!("Unable to broadcast message: {message:?}"),
-                )))
+                return Err(P2pError::ProtocolError(ProtocolError::UnexpectedMessage(format!(
+                    "Unable to broadcast message: {message:?}"
+                ))))
             }
         };
 
-        Ok(self.command_sender.send(types::Command::AnnounceData {
-            service,
-            message: message.into(),
-        })?)
+        Ok(self
+            .command_sender
+            .send(types::Command::AnnounceData { service, message: message.into() })?)
     }
 }
 

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -184,9 +184,7 @@ where
     }
 
     fn send_message(&mut self, peer: PeerId, message: PeerManagerMessage) -> crate::Result<()> {
-        Ok(self
-            .cmd_tx
-            .send(types::Command::SendMessage { peer, message: message.into() })?)
+        Ok(self.cmd_tx.send(types::Command::SendMessage { peer, message: message.into() })?)
     }
 
     fn local_addresses(&self) -> &[S::Address] {

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -102,16 +102,7 @@ where
     ) -> Self {
         let socket = BufferedTranscoder::new(socket, *p2p_config.max_message_size);
 
-        Self {
-            peer_id,
-            peer_role,
-            chain_config,
-            p2p_config,
-            socket,
-            receiver_address,
-            tx,
-            rx,
-        }
+        Self { peer_id, peer_role, chain_config, p2p_config, socket, receiver_address, tx, rx }
     }
 
     fn validate_peer_time(
@@ -172,17 +163,15 @@ where
                 ))?;
 
                 self.socket
-                    .send(types::Message::Handshake(
-                        types::HandshakeMessage::HelloAck {
-                            protocol: NETWORK_PROTOCOL_CURRENT,
-                            network: *self.chain_config.magic_bytes(),
-                            user_agent: self.p2p_config.user_agent.clone(),
-                            version: *self.chain_config.version(),
-                            services: (*self.p2p_config.node_type).into(),
-                            receiver_address: self.receiver_address.clone(),
-                            current_time: local_time,
-                        },
-                    ))
+                    .send(types::Message::Handshake(types::HandshakeMessage::HelloAck {
+                        protocol: NETWORK_PROTOCOL_CURRENT,
+                        network: *self.chain_config.magic_bytes(),
+                        user_agent: self.p2p_config.user_agent.clone(),
+                        version: *self.chain_config.version(),
+                        services: (*self.p2p_config.node_type).into(),
+                        receiver_address: self.receiver_address.clone(),
+                        current_time: local_time,
+                    }))
                     .await?;
             }
             PeerRole::Outbound { handshake_nonce } => {
@@ -250,33 +239,23 @@ where
 
             Message::PingRequest(r) => tx.send((
                 peer,
-                PeerEvent::MessageReceived {
-                    message: PeerManagerMessage::PingRequest(r),
-                },
+                PeerEvent::MessageReceived { message: PeerManagerMessage::PingRequest(r) },
             ))?,
             Message::PingResponse(r) => tx.send((
                 peer,
-                PeerEvent::MessageReceived {
-                    message: PeerManagerMessage::PingResponse(r),
-                },
+                PeerEvent::MessageReceived { message: PeerManagerMessage::PingResponse(r) },
             ))?,
             Message::AddrListRequest(r) => tx.send((
                 peer,
-                PeerEvent::MessageReceived {
-                    message: PeerManagerMessage::AddrListRequest(r),
-                },
+                PeerEvent::MessageReceived { message: PeerManagerMessage::AddrListRequest(r) },
             ))?,
             Message::AddrListResponse(r) => tx.send((
                 peer,
-                PeerEvent::MessageReceived {
-                    message: PeerManagerMessage::AddrListResponse(r),
-                },
+                PeerEvent::MessageReceived { message: PeerManagerMessage::AddrListResponse(r) },
             ))?,
             Message::AnnounceAddrRequest(r) => tx.send((
                 peer,
-                PeerEvent::MessageReceived {
-                    message: PeerManagerMessage::AnnounceAddrRequest(r),
-                },
+                PeerEvent::MessageReceived { message: PeerManagerMessage::AnnounceAddrRequest(r) },
             ))?,
 
             Message::HeaderListRequest(v) => {
@@ -471,17 +450,15 @@ mod tests {
         let mut socket2 = BufferedTranscoder::new(socket2, *p2p_config.max_message_size);
         socket2.recv().await.unwrap();
         assert!(socket2
-            .send(types::Message::Handshake(
-                types::HandshakeMessage::HelloAck {
-                    protocol: NETWORK_PROTOCOL_CURRENT,
-                    version: *chain_config.version(),
-                    network: *chain_config.magic_bytes(),
-                    user_agent: p2p_config.user_agent.clone(),
-                    services: [Service::Blocks, Service::Transactions].as_slice().into(),
-                    receiver_address: None,
-                    current_time: P2pTimestamp::from_int_seconds(123456),
-                }
-            ))
+            .send(types::Message::Handshake(types::HandshakeMessage::HelloAck {
+                protocol: NETWORK_PROTOCOL_CURRENT,
+                version: *chain_config.version(),
+                network: *chain_config.magic_bytes(),
+                user_agent: p2p_config.user_agent.clone(),
+                services: [Service::Blocks, Service::Transactions].as_slice().into(),
+                receiver_address: None,
+                current_time: P2pTimestamp::from_int_seconds(123456),
+            }))
             .await
             .is_ok());
 
@@ -607,9 +584,9 @@ mod tests {
         let mut socket2 = BufferedTranscoder::new(socket2, *p2p_config.max_message_size);
         assert!(socket2.recv().now_or_never().is_none());
         socket2
-            .send(types::Message::HeaderListRequest(
-                message::HeaderListRequest::new(Locator::new(vec![])),
-            ))
+            .send(types::Message::HeaderListRequest(message::HeaderListRequest::new(Locator::new(
+                vec![],
+            ))))
             .await
             .unwrap();
 

--- a/p2p/src/net/default_backend/tests.rs
+++ b/p2p/src/net/default_backend/tests.rs
@@ -72,11 +72,8 @@ where
     let addr = conn2.local_addresses();
     conn1.connect(addr[0].clone()).unwrap();
 
-    if let Ok(ConnectivityEvent::OutboundAccepted {
-        address,
-        peer_info,
-        receiver_address: _,
-    }) = conn1.poll_next().await
+    if let Ok(ConnectivityEvent::OutboundAccepted { address, peer_info, receiver_address: _ }) =
+        conn1.poll_next().await
     {
         assert_eq!(address, conn2.local_addresses()[0]);
         assert_eq!(peer_info.network, *config.magic_bytes());
@@ -147,11 +144,7 @@ where
     conn1.connect(bind_address[0].clone()).unwrap();
     let res2 = conn2.poll_next().await;
     match res2.unwrap() {
-        ConnectivityEvent::InboundAccepted {
-            address: _,
-            peer_info,
-            receiver_address: _,
-        } => {
+        ConnectivityEvent::InboundAccepted { address: _, peer_info, receiver_address: _ } => {
             assert_eq!(peer_info.network, *config.magic_bytes());
             assert_eq!(peer_info.version, *config.version());
             assert_eq!(peer_info.user_agent, p2p_config.user_agent);
@@ -219,11 +212,7 @@ where
     let res2 = conn2.poll_next().await;
 
     match res2.unwrap() {
-        ConnectivityEvent::InboundAccepted {
-            address: _,
-            peer_info,
-            receiver_address: _,
-        } => {
+        ConnectivityEvent::InboundAccepted { address: _, peer_info, receiver_address: _ } => {
             conn2.disconnect(peer_info.peer_id).unwrap();
         }
         _ => panic!("invalid event received, expected incoming connection"),
@@ -300,11 +289,8 @@ where
     // Check that we can still connect normally after
     let addr = conn2.local_addresses();
     conn1.connect(addr[0].clone()).unwrap();
-    if let Ok(ConnectivityEvent::OutboundAccepted {
-        address,
-        peer_info,
-        receiver_address: _,
-    }) = conn1.poll_next().await
+    if let Ok(ConnectivityEvent::OutboundAccepted { address, peer_info, receiver_address: _ }) =
+        conn1.poll_next().await
     {
         assert_eq!(address, conn2.local_addresses()[0]);
         assert_eq!(peer_info.protocol, NETWORK_PROTOCOL_CURRENT);

--- a/p2p/src/net/default_backend/transport/buffered_transcoder.rs
+++ b/p2p/src/net/default_backend/transport/buffered_transcoder.rs
@@ -33,11 +33,7 @@ pub struct BufferedTranscoder<S> {
 impl<S: AsyncWrite + AsyncRead + Unpin> BufferedTranscoder<S> {
     pub fn new(stream: S, max_message_size: usize) -> BufferedTranscoder<S> {
         let encoder_decoder = EncoderDecoder::new(max_message_size);
-        BufferedTranscoder {
-            stream,
-            buffer: BytesMut::new(),
-            encoder_decoder,
-        }
+        BufferedTranscoder { stream, buffer: BytesMut::new(), encoder_decoder }
     }
 
     pub async fn send(&mut self, msg: Message) -> Result<()> {

--- a/p2p/src/net/default_backend/transport/impls/channel.rs
+++ b/p2p/src/net/default_backend/transport/impls/channel.rs
@@ -68,10 +68,7 @@ pub struct MpscChannelTransport {
 impl MpscChannelTransport {
     pub fn new() -> Self {
         let local_address: Ipv4Addr = NEXT_IP_ADDRESS.fetch_add(1, Ordering::Relaxed).into();
-        MpscChannelTransport {
-            local_address: local_address.into(),
-            last_port: 1024.into(),
-        }
+        MpscChannelTransport { local_address: local_address.into(), last_port: 1024.into() }
     }
 
     fn new_port(&self) -> u16 {
@@ -109,9 +106,7 @@ impl TransportSocket for MpscChannelTransport {
 
             // It's not possible to bind to the used address
             if connections.contains_key(address) {
-                return Err(P2pError::DialError(DialError::IoError(
-                    std::io::ErrorKind::AddrInUse,
-                )));
+                return Err(P2pError::DialError(DialError::IoError(std::io::ErrorKind::AddrInUse)));
             }
         }
 
@@ -122,10 +117,7 @@ impl TransportSocket for MpscChannelTransport {
             assert!(old_entry.is_none());
         }
 
-        Ok(Self::Listener {
-            addresses,
-            receiver,
-        })
+        Ok(Self::Listener { addresses, receiver })
     }
 
     fn connect(&self, mut address: Self::Address) -> BoxFuture<'static, Result<Self::Stream>> {

--- a/p2p/src/net/default_backend/transport/impls/socks5.rs
+++ b/p2p/src/net/default_backend/transport/impls/socks5.rs
@@ -39,9 +39,7 @@ pub struct Socks5TransportSocket {
 
 impl Socks5TransportSocket {
     pub fn new(proxy: &str) -> Self {
-        Self {
-            proxy: Arc::new(proxy.to_owned()),
-        }
+        Self { proxy: Arc::new(proxy.to_owned()) }
     }
 }
 

--- a/p2p/src/net/default_backend/transport/impls/stream_adapter/noise.rs
+++ b/p2p/src/net/default_backend/transport/impls/stream_adapter/noise.rs
@@ -47,17 +47,11 @@ impl NoiseEncryptionAdapter {
                 .generate_keypair()
                 .expect("key generation must succeed"),
         );
-        Self {
-            local_key,
-            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
-        }
+        Self { local_key, handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT }
     }
 
     pub fn with_handshake_timeout(self, handshake_timeout: Duration) -> Self {
-        Self {
-            local_key: self.local_key,
-            handshake_timeout,
-        }
+        Self { local_key: self.local_key, handshake_timeout }
     }
 }
 

--- a/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/tests.rs
+++ b/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/tests.rs
@@ -131,10 +131,7 @@ pub struct TestListener {
 
 impl TestTransport {
     fn new() -> Self {
-        Self {
-            transport: MpscChannelTransport::new(),
-            port_open: Default::default(),
-        }
+        Self { transport: MpscChannelTransport::new(), port_open: Default::default() }
     }
 }
 
@@ -148,10 +145,7 @@ impl TransportSocket for TestTransport {
     async fn bind(&self, addresses: Vec<Self::Address>) -> crate::Result<Self::Listener> {
         let listener = self.transport.bind(addresses).await.unwrap();
         *self.port_open.lock().unwrap() = true;
-        Ok(TestListener {
-            listener,
-            port_open: Arc::clone(&self.port_open),
-        })
+        Ok(TestListener { listener, port_open: Arc::clone(&self.port_open) })
     }
 
     fn connect(&self, address: Self::Address) -> BoxFuture<'static, crate::Result<Self::Stream>> {
@@ -263,11 +257,7 @@ async fn pending_handshakes() {
     sockets.pop();
 
     // Noise connection should succeed now
-    let pending_fut = timeout(
-        Duration::from_millis(10000),
-        transport.connect(local_addr[0]),
-    )
-    .await;
+    let pending_fut = timeout(Duration::from_millis(10000), transport.connect(local_addr[0])).await;
     assert!(matches!(pending_fut, Ok(Ok(_))));
 
     join_handle.abort();

--- a/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/wrapped_listener.rs
+++ b/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/wrapped_listener.rs
@@ -44,11 +44,7 @@ pub struct AdaptedListener<S: StreamAdapter<T::Stream>, T: TransportSocket> {
 
 impl<S: StreamAdapter<T::Stream>, T: TransportSocket> AdaptedListener<S, T> {
     pub fn new(stream_adapter: S, listener: T::Listener) -> Self {
-        Self {
-            stream_adapter,
-            listener,
-            handshakes: FuturesUnordered::new(),
-        }
+        Self { stream_adapter, listener, handshakes: FuturesUnordered::new() }
     }
 }
 

--- a/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/wrapped_socket.rs
+++ b/p2p/src/net/default_backend/transport/impls/stream_adapter/wrapped_transport/wrapped_socket.rs
@@ -37,10 +37,7 @@ pub struct WrappedTransportSocket<S, T> {
 
 impl<S, T> WrappedTransportSocket<S, T> {
     pub fn new(stream_adapter: S, base_transport: T) -> Self {
-        Self {
-            stream_adapter,
-            base_transport,
-        }
+        Self { stream_adapter, base_transport }
     }
 }
 

--- a/p2p/src/net/default_backend/transport/message_codec.rs
+++ b/p2p/src/net/default_backend/transport/message_codec.rs
@@ -137,9 +137,7 @@ mod tests {
 
         let mut encoder = EncoderDecoder::new(rng.gen_range(0..message_length));
         assert_eq!(
-            Err(P2pError::DialError(DialError::IoError(
-                ErrorKind::InvalidData
-            ))),
+            Err(P2pError::DialError(DialError::IoError(ErrorKind::InvalidData))),
             encoder.encode(message, &mut buf)
         );
     }
@@ -164,9 +162,7 @@ mod tests {
 
         let mut decoder = EncoderDecoder::new(rng.gen_range(0..(encoded.len() - HEADER_LEN)));
         assert_eq!(
-            Err(P2pError::DialError(DialError::IoError(
-                ErrorKind::InvalidData
-            ))),
+            Err(P2pError::DialError(DialError::IoError(ErrorKind::InvalidData))),
             decoder.decode(&mut encoded)
         );
     }

--- a/p2p/src/net/default_backend/transport/message_codec.rs
+++ b/p2p/src/net/default_backend/transport/message_codec.rs
@@ -129,9 +129,7 @@ mod tests {
 
         let mut buf = BytesMut::new();
         // Encode to determine the serialized message length.
-        EncoderDecoder::new(rng.gen_range(64..128))
-            .encode(message.clone(), &mut buf)
-            .unwrap();
+        EncoderDecoder::new(rng.gen_range(64..128)).encode(message.clone(), &mut buf).unwrap();
         assert!(buf.len() > HEADER_LEN);
         let message_length = buf.len() - HEADER_LEN;
 
@@ -156,9 +154,7 @@ mod tests {
             .into(),
         });
         let mut encoded = BytesMut::new();
-        EncoderDecoder::new(rng.gen_range(126..512))
-            .encode(message, &mut encoded)
-            .unwrap();
+        EncoderDecoder::new(rng.gen_range(126..512)).encode(message, &mut encoded).unwrap();
 
         let mut decoder = EncoderDecoder::new(rng.gen_range(0..(encoded.len() - HEADER_LEN)));
         assert_eq!(

--- a/p2p/src/net/types/mod.rs
+++ b/p2p/src/net/types/mod.rs
@@ -147,11 +147,7 @@ pub enum ConnectivityEvent<A> {
 #[derive(Debug)]
 pub enum SyncingEvent {
     /// Peer connected
-    Connected {
-        peer_id: PeerId,
-        services: Services,
-        sync_rx: Receiver<SyncMessage>,
-    },
+    Connected { peer_id: PeerId, services: Services, sync_rx: Receiver<SyncMessage> },
 
     /// Peer disconnected
     Disconnected { peer_id: PeerId },

--- a/p2p/src/peer_manager/address_groups.rs
+++ b/p2p/src/peer_manager/address_groups.rs
@@ -83,9 +83,6 @@ mod tests {
         check_group("fe80::", AddressGroup::Private);
 
         check_group("1.2.3.4", AddressGroup::PublicV4([1, 2]));
-        check_group(
-            "2a00:1450:4017:815::200e",
-            AddressGroup::PublicV6([0x2a, 0x00, 0x14, 0x50]),
-        );
+        check_group("2a00:1450:4017:815::200e", AddressGroup::PublicV6([0x2a, 0x00, 0x14, 0x50]));
     }
 }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -867,10 +867,8 @@ where
         peer_id: PeerId,
         addresses: Vec<PeerAddress>,
     ) -> crate::Result<()> {
-        let peer = self
-            .peers
-            .get_mut(&peer_id)
-            .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
+        let peer =
+            self.peers.get_mut(&peer_id).ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
         ensure!(
             addresses.len() <= MAX_ADDRESS_COUNT,
             P2pError::ProtocolError(ProtocolError::AddressListLimitExceeded)

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -219,23 +219,15 @@ where
             .local_addresses()
             .iter()
             .map(TransportAddress::as_peer_address)
-            .filter_map(
-                |listening_address| match (&receiver_address, listening_address) {
-                    (PeerAddress::Ip4(receiver), PeerAddress::Ip4(listener)) => {
-                        Some(PeerAddress::Ip4(PeerAddressIp4 {
-                            ip: receiver.ip,
-                            port: listener.port,
-                        }))
-                    }
-                    (PeerAddress::Ip6(receiver), PeerAddress::Ip6(listener)) => {
-                        Some(PeerAddress::Ip6(PeerAddressIp6 {
-                            ip: receiver.ip,
-                            port: listener.port,
-                        }))
-                    }
-                    _ => None,
-                },
-            )
+            .filter_map(|listening_address| match (&receiver_address, listening_address) {
+                (PeerAddress::Ip4(receiver), PeerAddress::Ip4(listener)) => {
+                    Some(PeerAddress::Ip4(PeerAddressIp4 { ip: receiver.ip, port: listener.port }))
+                }
+                (PeerAddress::Ip6(receiver), PeerAddress::Ip6(listener)) => {
+                    Some(PeerAddress::Ip6(PeerAddressIp6 { ip: receiver.ip, port: listener.port }))
+                }
+                _ => None,
+            })
             .filter_map(|address| {
                 TransportAddress::from_peer_address(
                     &address,
@@ -1000,18 +992,10 @@ where
             ConnectivityEvent::Message { peer, message } => {
                 self.handle_incoming_message(peer, message);
             }
-            ConnectivityEvent::InboundAccepted {
-                address,
-                peer_info,
-                receiver_address,
-            } => {
+            ConnectivityEvent::InboundAccepted { address, peer_info, receiver_address } => {
                 self.accept_connection(address, Role::Inbound, peer_info, receiver_address);
             }
-            ConnectivityEvent::OutboundAccepted {
-                address,
-                peer_info,
-                receiver_address,
-            } => {
+            ConnectivityEvent::OutboundAccepted { address, peer_info, receiver_address } => {
                 self.accept_connection(address, Role::Outbound, peer_info, receiver_address);
             }
             ConnectivityEvent::ConnectionClosed { peer_id } => {
@@ -1098,10 +1082,7 @@ where
                         *peer_id,
                         PeerManagerMessage::PingRequest(PingRequest { nonce }),
                     );
-                    peer.sent_ping = Some(SentPing {
-                        nonce,
-                        timestamp: now,
-                    });
+                    peer.sent_ping = Some(SentPing { nonce, timestamp: now });
                 }
             }
         }

--- a/p2p/src/peer_manager/peerdb/address_data/mod.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/mod.rs
@@ -159,11 +159,7 @@ impl AddressData {
     }
 
     fn next_connect_delay(fail_count: u32, reserved: bool) -> Duration {
-        let max_delay = if reserved {
-            MAX_DELAY_RESERVED
-        } else {
-            MAX_DELAY_REACHABLE
-        };
+        let max_delay = if reserved { MAX_DELAY_RESERVED } else { MAX_DELAY_REACHABLE };
 
         // 10, 20, 40, 80... seconds
         std::cmp::min(

--- a/p2p/src/peer_manager/peerdb/address_data/mod.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/mod.rs
@@ -256,9 +256,7 @@ impl AddressData {
                             disconnected_by_user,
                         }
                     } else if !was_reachable {
-                        AddressState::Unreachable {
-                            erase_after: now + PURGE_UNREACHABLE_TIME,
-                        }
+                        AddressState::Unreachable { erase_after: now + PURGE_UNREACHABLE_TIME }
                     } else if fail_count + 1 >= PURGE_REACHABLE_FAIL_COUNT {
                         AddressState::Unreachable { erase_after: now }
                     } else {

--- a/p2p/src/peer_manager/peerdb/address_data/tests.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/tests.rs
@@ -91,11 +91,7 @@ fn reachable_reconnects(#[case] seed: Seed) {
 
 #[rstest]
 #[trace]
-#[case(
-    Seed::from_entropy(),
-    AddressStateTransitionTo::DisconnectedByUser,
-    false
-)]
+#[case(Seed::from_entropy(), AddressStateTransitionTo::DisconnectedByUser, false)]
 #[case(Seed::from_entropy(), AddressStateTransitionTo::Disconnected, true)]
 fn no_reconnects_after_manual_disconnect(
     #[case] seed: Seed,

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -219,10 +219,8 @@ where
             let banned = now <= *banned_till;
 
             if !banned {
-                storage::update_db(&self.storage, |tx| {
-                    tx.del_banned_address(&address.to_string())
-                })
-                .expect("removing banned address is expected to succeed");
+                storage::update_db(&self.storage, |tx| tx.del_banned_address(&address.to_string()))
+                    .expect("removing banned address is expected to succeed");
             }
 
             banned
@@ -275,11 +273,7 @@ where
 
         let is_persistent_old = address_data.is_persistent();
 
-        log::debug!(
-            "update address {} state to {:?}",
-            address.to_string(),
-            transition,
-        );
+        log::debug!("update address {} state to {:?}", address.to_string(), transition,);
 
         address_data.transition_to(transition, now, &mut make_pseudo_rng());
 
@@ -287,16 +281,12 @@ where
 
         match (is_persistent_old, is_persistent_new) {
             (false, true) => {
-                storage::update_db(&self.storage, |tx| {
-                    tx.add_known_address(&address.to_string())
-                })
-                .expect("adding address expected to succeed (peer_connected)");
+                storage::update_db(&self.storage, |tx| tx.add_known_address(&address.to_string()))
+                    .expect("adding address expected to succeed (peer_connected)");
             }
             (true, false) => {
-                storage::update_db(&self.storage, |tx| {
-                    tx.del_known_address(&address.to_string())
-                })
-                .expect("adding address expected to succeed (peer_connected)");
+                storage::update_db(&self.storage, |tx| tx.del_known_address(&address.to_string()))
+                    .expect("adding address expected to succeed (peer_connected)");
             }
             _ => {}
         }

--- a/p2p/src/peer_manager/peerdb/storage_load.rs
+++ b/p2p/src/peer_manager/peerdb/storage_load.rs
@@ -51,10 +51,7 @@ impl<A: Ord + FromStr, B: Ord + FromStr> LoadedStorage<A, B> {
         let mut tx = storage.transaction_rw()?;
         tx.set_version(STORAGE_VERSION)?;
         tx.commit()?;
-        Ok(LoadedStorage {
-            known_addresses: BTreeSet::new(),
-            banned_addresses: BTreeMap::new(),
-        })
+        Ok(LoadedStorage { known_addresses: BTreeSet::new(), banned_addresses: BTreeMap::new() })
     }
 
     fn load_storage_v1<S: PeerDbStorage>(storage: &S) -> crate::Result<LoadedStorage<A, B>> {
@@ -87,9 +84,6 @@ impl<A: Ord + FromStr, B: Ord + FromStr> LoadedStorage<A, B> {
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
-        Ok(LoadedStorage {
-            known_addresses,
-            banned_addresses,
-        })
+        Ok(LoadedStorage { known_addresses, banned_addresses })
     }
 }

--- a/p2p/src/peer_manager/peers_eviction/mod.rs
+++ b/p2p/src/peer_manager/peers_eviction/mod.rs
@@ -68,9 +68,10 @@ impl EvictionCandidate {
     pub fn new<A: TransportAddress>(peer: &PeerContext<A>, random_state: &RandomState) -> Self {
         EvictionCandidate {
             peer_id: peer.info.peer_id,
-            net_group_keyed: NetGroupKeyed(random_state.get_hash(
-                &AddressGroup::from_peer_address(&peer.address.as_peer_address()),
-            )),
+            net_group_keyed: NetGroupKeyed(
+                random_state
+                    .get_hash(&AddressGroup::from_peer_address(&peer.address.as_peer_address())),
+            ),
             ping_min: peer.ping_min.map_or(i64::MAX, |val| val.as_micros() as i64),
             role: peer.role,
         }

--- a/p2p/src/peer_manager/tests/addresses.rs
+++ b/p2p/src/peer_manager/tests/addresses.rs
@@ -166,10 +166,8 @@ fn test_addr_list_handling_inbound() {
     // Peer manager sends response normally to first address list request
     pm.handle_addr_list_request(peer_id_1);
     match cmd_rx.try_recv() {
-        Ok(Command::SendMessage {
-            peer,
-            message: Message::AddrListResponse(_),
-        }) if peer == peer_id_1 => {}
+        Ok(Command::SendMessage { peer, message: Message::AddrListResponse(_) })
+            if peer == peer_id_1 => {}
         v => panic!("unexpected command: {v:?}"),
     }
 
@@ -189,10 +187,7 @@ fn test_addr_list_handling_inbound() {
     assert_eq!(pm.peers.get(&peer_id_1).unwrap().score, 0);
 
     // Check that the peer is scored if it tries to send an unexpected address list response
-    pm.handle_addr_list_response(
-        peer_id_1,
-        vec![TestTcpAddressMaker::new().as_peer_address()],
-    );
+    pm.handle_addr_list_response(peer_id_1, vec![TestTcpAddressMaker::new().as_peer_address()]);
     assert_ne!(pm.peers.get(&peer_id_1).unwrap().score, 0);
 }
 
@@ -252,10 +247,8 @@ fn test_addr_list_handling_outbound() {
 
     // Address list is requested from the connected peer
     match cmd_rx.try_recv() {
-        Ok(Command::SendMessage {
-            peer,
-            message: Message::AddrListRequest(_),
-        }) if peer == peer_id_1 => {}
+        Ok(Command::SendMessage { peer, message: Message::AddrListRequest(_) })
+            if peer == peer_id_1 => {}
         v => panic!("unexpected command: {v:?}"),
     }
 
@@ -266,10 +259,7 @@ fn test_addr_list_handling_outbound() {
     }
 
     // Check that the address list response is processed normally and that the peer is not scored
-    pm.handle_addr_list_response(
-        peer_id_1,
-        vec![TestTcpAddressMaker::new().as_peer_address()],
-    );
+    pm.handle_addr_list_response(peer_id_1, vec![TestTcpAddressMaker::new().as_peer_address()]);
     assert_eq!(pm.peers.get(&peer_id_1).unwrap().score, 0);
 
     // No more messages
@@ -279,10 +269,7 @@ fn test_addr_list_handling_outbound() {
     }
 
     // Check that the peer is scored if it tries to send an unexpected address list response
-    pm.handle_addr_list_response(
-        peer_id_1,
-        vec![TestTcpAddressMaker::new().as_peer_address()],
-    );
+    pm.handle_addr_list_response(peer_id_1, vec![TestTcpAddressMaker::new().as_peer_address()]);
     assert_ne!(pm.peers.get(&peer_id_1).unwrap().score, 0);
 }
 

--- a/p2p/src/peer_manager/tests/addresses.rs
+++ b/p2p/src/peer_manager/tests/addresses.rs
@@ -348,10 +348,8 @@ async fn resend_own_addresses() {
     // PeerManager should resend own addresses
     let mut listening_addresses = listening_addresses.into_iter().collect::<BTreeSet<_>>();
     while !listening_addresses.is_empty() {
-        let event = tokio::time::timeout(Duration::from_secs(60), cmd_rx.recv())
-            .await
-            .unwrap()
-            .unwrap();
+        let event =
+            tokio::time::timeout(Duration::from_secs(60), cmd_rx.recv()).await.unwrap().unwrap();
 
         if let Command::SendMessage {
             peer: _,

--- a/p2p/src/peer_manager/tests/addresses.rs
+++ b/p2p/src/peer_manager/tests/addresses.rs
@@ -325,11 +325,7 @@ async fn resend_own_addresses() {
         // New peer connection is requested
         while !matches!(cmd_rx.try_recv().unwrap(), Command::Connect { address: _ }) {}
 
-        let own_ip = if peer_index % 2 == 0 {
-            outbound_address_1
-        } else {
-            outbound_address_2
-        };
+        let own_ip = if peer_index % 2 == 0 { outbound_address_1 } else { outbound_address_2 };
 
         pm.accept_connection(peer_address, Role::Outbound, peer_info, Some(own_ip.into()));
     }

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -60,11 +60,9 @@ where
     let (mut pm2, _shutdown_sender, _subscribers_sender) =
         make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
-    let (address, peer_info, _) = connect_services::<T>(
-        &mut pm1.peer_connectivity_handle,
-        &mut pm2.peer_connectivity_handle,
-    )
-    .await;
+    let (address, peer_info, _) =
+        connect_services::<T>(&mut pm1.peer_connectivity_handle, &mut pm2.peer_connectivity_handle)
+            .await;
     let peer_id = peer_info.peer_id;
     pm2.accept_connection(address, Role::Inbound, peer_info, None);
 
@@ -72,10 +70,7 @@ where
     let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
     let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
-    assert!(std::matches!(
-        event,
-        Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })
-    ));
+    assert!(std::matches!(event, Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })));
 }
 
 #[tokio::test]
@@ -109,11 +104,9 @@ where
     let (mut pm2, _shutdown_sender, _subscribers_sender) =
         make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
-    let (address, peer_info, _) = connect_services::<T>(
-        &mut pm1.peer_connectivity_handle,
-        &mut pm2.peer_connectivity_handle,
-    )
-    .await;
+    let (address, peer_info, _) =
+        connect_services::<T>(&mut pm1.peer_connectivity_handle, &mut pm2.peer_connectivity_handle)
+            .await;
     let peer_id = peer_info.peer_id;
     pm2.accept_connection(address, Role::Inbound, peer_info, None);
 
@@ -121,10 +114,7 @@ where
     let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
     assert!(pm2.peerdb.is_address_banned(&addr1));
     let event = get_connectivity_event::<T>(&mut pm2.peer_connectivity_handle).await;
-    assert!(std::matches!(
-        event,
-        Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })
-    ));
+    assert!(std::matches!(event, Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })));
 }
 
 #[tokio::test]
@@ -166,11 +156,9 @@ where
     let (mut pm2, _shutdown_sender, _subscribers_sender) =
         make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
-    let (address, peer_info1, _peer_info2) = connect_services::<T>(
-        &mut pm1.peer_connectivity_handle,
-        &mut pm2.peer_connectivity_handle,
-    )
-    .await;
+    let (address, peer_info1, _peer_info2) =
+        connect_services::<T>(&mut pm1.peer_connectivity_handle, &mut pm2.peer_connectivity_handle)
+            .await;
     let peer_id = peer_info1.peer_id;
     pm2.accept_connection(address, Role::Inbound, peer_info1, None);
 
@@ -330,12 +318,9 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let (mut pm1, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
-        A::make_transport(),
-        addr1,
-        Arc::new(config::create_mainnet()),
-    )
-    .await;
+    let (mut pm1, _shutdown_sender, _subscribers_sender) =
+        make_peer_manager::<T>(A::make_transport(), addr1, Arc::new(config::create_mainnet()))
+            .await;
     let (mut pm2, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
         A::make_transport(),
         addr2,

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -177,11 +177,8 @@ where
     let (mut pm2, _shutdown_sender, _subscribers_sender) =
         make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
-    connect_services::<T>(
-        &mut pm1.peer_connectivity_handle,
-        &mut pm2.peer_connectivity_handle,
-    )
-    .await;
+    connect_services::<T>(&mut pm1.peer_connectivity_handle, &mut pm2.peer_connectivity_handle)
+        .await;
 }
 
 #[tokio::test]
@@ -222,11 +219,9 @@ where
     )
     .await;
 
-    let (_address, peer_info, _) = connect_services::<T>(
-        &mut pm2.peer_connectivity_handle,
-        &mut pm1.peer_connectivity_handle,
-    )
-    .await;
+    let (_address, peer_info, _) =
+        connect_services::<T>(&mut pm2.peer_connectivity_handle, &mut pm1.peer_connectivity_handle)
+            .await;
     assert_ne!(peer_info.network, *config.magic_bytes());
 }
 
@@ -272,11 +267,9 @@ where
     let (mut pm2, _shutdown_sender, _subscribers_sender) =
         make_peer_manager::<T>(A::make_transport(), addr2, config).await;
 
-    let (address, peer_info, _) = connect_services::<T>(
-        &mut pm1.peer_connectivity_handle,
-        &mut pm2.peer_connectivity_handle,
-    )
-    .await;
+    let (address, peer_info, _) =
+        connect_services::<T>(&mut pm1.peer_connectivity_handle, &mut pm2.peer_connectivity_handle)
+            .await;
     pm2.try_accept_connection(address, Role::Inbound, peer_info, None).unwrap();
 }
 
@@ -310,12 +303,9 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let (mut pm1, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
-        A::make_transport(),
-        addr1,
-        Arc::new(config::create_mainnet()),
-    )
-    .await;
+    let (mut pm1, _shutdown_sender, _subscribers_sender) =
+        make_peer_manager::<T>(A::make_transport(), addr1, Arc::new(config::create_mainnet()))
+            .await;
     let (mut pm2, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
         A::make_transport(),
         addr2,
@@ -323,11 +313,9 @@ where
     )
     .await;
 
-    let (address, peer_info, _) = connect_services::<T>(
-        &mut pm1.peer_connectivity_handle,
-        &mut pm2.peer_connectivity_handle,
-    )
-    .await;
+    let (address, peer_info, _) =
+        connect_services::<T>(&mut pm1.peer_connectivity_handle, &mut pm2.peer_connectivity_handle)
+            .await;
 
     assert_eq!(
         pm2.try_accept_connection(address, Role::Inbound, peer_info, None),
@@ -374,18 +362,12 @@ where
     let addr1 = A::make_address();
     let addr2 = A::make_address();
 
-    let (mut pm1, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
-        A::make_transport(),
-        addr1,
-        Arc::new(config::create_mainnet()),
-    )
-    .await;
-    let (mut pm2, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
-        A::make_transport(),
-        addr2,
-        Arc::new(config::create_mainnet()),
-    )
-    .await;
+    let (mut pm1, _shutdown_sender, _subscribers_sender) =
+        make_peer_manager::<T>(A::make_transport(), addr1, Arc::new(config::create_mainnet()))
+            .await;
+    let (mut pm2, _shutdown_sender, _subscribers_sender) =
+        make_peer_manager::<T>(A::make_transport(), addr2, Arc::new(config::create_mainnet()))
+            .await;
 
     let (_address, peer_info, _) = connect_and_accept_services::<T>(
         &mut pm1.peer_connectivity_handle,
@@ -393,10 +375,7 @@ where
     )
     .await;
 
-    assert_eq!(
-        pm2.peer_connectivity_handle.disconnect(peer_info.peer_id),
-        Ok(())
-    );
+    assert_eq!(pm2.peer_connectivity_handle.disconnect(peer_info.peer_id), Ok(()));
     assert!(std::matches!(
         pm1.peer_connectivity_handle.poll_next().await,
         Ok(net::types::ConnectivityEvent::ConnectionClosed { .. })

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -98,11 +98,7 @@ async fn make_peer_manager<T>(
     transport: T::Transport,
     addr: T::Address,
     chain_config: Arc<common::chain::ChainConfig>,
-) -> (
-    PeerManager<T, impl PeerDbStorage>,
-    oneshot::Sender<()>,
-    UnboundedSender<P2pEventHandler>,
-)
+) -> (PeerManager<T, impl PeerDbStorage>, oneshot::Sender<()>, UnboundedSender<P2pEventHandler>)
 where
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -125,11 +121,7 @@ async fn run_peer_manager<T>(
     chain_config: Arc<common::chain::ChainConfig>,
     p2p_config: Arc<P2pConfig>,
     time_getter: TimeGetter,
-) -> (
-    UnboundedSender<PeerManagerEvent<T>>,
-    oneshot::Sender<()>,
-    UnboundedSender<P2pEventHandler>,
-)
+) -> (UnboundedSender<PeerManagerEvent<T>>, oneshot::Sender<()>, UnboundedSender<P2pEventHandler>)
 where
     T: NetworkingService + 'static,
     T::ConnectivityHandle: ConnectivityService<T>,
@@ -169,10 +161,7 @@ async fn send_and_sync<T: NetworkingService>(
 
     let event = expect_recv!(cmd_rx);
     match event {
-        Command::SendMessage {
-            peer,
-            message: Message::PingResponse(PingResponse { nonce }),
-        } => {
+        Command::SendMessage { peer, message: Message::PingResponse(PingResponse { nonce }) } => {
             conn_tx
                 .send(ConnectivityEvent::Message {
                     peer,

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -122,10 +122,7 @@ async fn ping_timeout() {
 
         let event = expect_recv!(&mut cmd_rx);
         match event {
-            Command::SendMessage {
-                peer,
-                message: Message::PingRequest(PingRequest { nonce }),
-            } => {
+            Command::SendMessage { peer, message: Message::PingRequest(PingRequest { nonce }) } => {
                 send_and_sync::<TestNetworkingService>(
                     peer,
                     PeerManagerMessage::PingResponse(PingResponse { nonce }),

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -211,11 +211,9 @@ where
     /// Sends an event to the corresponding peer.
     fn handle_peer_event(&mut self, event: SyncingEvent) {
         match event {
-            SyncingEvent::Connected {
-                peer_id,
-                services,
-                sync_rx,
-            } => self.register_peer(peer_id, services, sync_rx),
+            SyncingEvent::Connected { peer_id, services, sync_rx } => {
+                self.register_peer(peer_id, services, sync_rx)
+            }
             SyncingEvent::Disconnected { peer_id } => self.unregister_peer(peer_id),
         }
     }
@@ -228,13 +226,11 @@ pub async fn subscribe_to_new_tip(
     let (sender, receiver) = mpsc::unbounded_channel();
 
     let subscribe_func =
-        Arc::new(
-            move |chainstate_event: chainstate::ChainstateEvent| match chainstate_event {
-                chainstate::ChainstateEvent::NewTip(block_id, _) => {
-                    let _ = sender.send(block_id).log_err_pfx("The new tip receiver closed");
-                }
-            },
-        );
+        Arc::new(move |chainstate_event: chainstate::ChainstateEvent| match chainstate_event {
+            chainstate::ChainstateEvent::NewTip(block_id, _) => {
+                let _ = sender.send(block_id).log_err_pfx("The new tip receiver closed");
+            }
+        });
 
     chainstate_handle
         .call_mut(|this| this.subscribe_to_events(subscribe_func))

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -337,8 +337,7 @@ where
         log::debug!("Headers list from peer {}", self.id());
 
         if let Some(last_header) = headers.last() {
-            self.wait_for_clock_diff(last_header.timestamp().as_duration_since_epoch())
-                .await;
+            self.wait_for_clock_diff(last_header.timestamp().as_duration_since_epoch()).await;
         }
 
         if !self.known_headers.is_empty() {
@@ -387,12 +386,7 @@ where
             // This is OK because of the `headers.is_empty()` check above.
             .expect("Headers shouldn't be empty")
             .prev_block_id();
-        if self
-            .chainstate_handle
-            .call(move |c| c.get_gen_block_index(&prev_id))
-            .await??
-            .is_none()
-        {
+        if self.chainstate_handle.call(move |c| c.get_gen_block_index(&prev_id)).await??.is_none() {
             // It is possible to receive a new block announcement that isn't connected to our chain.
             if headers.len() == 1 {
                 // In order to prevent spam from malicious peers we have the `unconnected_headers`
@@ -413,10 +407,8 @@ where
         }
 
         let is_max_headers = headers.len() == *self.p2p_config.msg_header_count_limit;
-        let headers = self
-            .chainstate_handle
-            .call(|c| c.filter_already_existing_blocks(headers))
-            .await??;
+        let headers =
+            self.chainstate_handle.call(|c| c.filter_already_existing_blocks(headers)).await??;
         if headers.is_empty() {
             // A peer can have more headers if we have received the maximum amount of them.
             if is_max_headers {
@@ -435,9 +427,7 @@ where
             // This is OK because of the `headers.is_empty()` check above.
             .expect("Headers shouldn't be empty")
             .clone();
-        self.chainstate_handle
-            .call(|c| c.preliminary_header_check(first_header))
-            .await??;
+        self.chainstate_handle.call(|c| c.preliminary_header_check(first_header)).await??;
         self.unconnected_headers = 0;
 
         self.request_blocks(headers)
@@ -510,8 +500,7 @@ where
             None => TransactionResponse::NotFound(id),
         };
 
-        self.messaging_handle
-            .send_message(self.id(), SyncMessage::TransactionResponse(res))?;
+        self.messaging_handle.send_message(self.id(), SyncMessage::TransactionResponse(res))?;
 
         Ok(())
     }
@@ -573,8 +562,7 @@ where
         }
 
         if !(self.mempool_handle.call(move |m| m.contains_transaction(&tx)).await?) {
-            self.messaging_handle
-                .send_message(self.id(), SyncMessage::TransactionRequest(tx))?;
+            self.messaging_handle.send_message(self.id(), SyncMessage::TransactionRequest(tx))?;
             assert!(self.announced_transactions.insert(tx));
         }
 

--- a/p2p/src/sync/tests/ban_scores.rs
+++ b/p2p/src/sync/tests/ban_scores.rs
@@ -62,9 +62,7 @@ async fn peer_handle_result() {
         P2pError::ChainstateError(ChainstateError::ProcessBlockError(
             BlockError::BlockAlreadyProcessed(Id::new(H256::zero())),
         )),
-        P2pError::MempoolError(mempool::error::Error::Policy(
-            MempoolPolicyError::MempoolFull,
-        )),
+        P2pError::MempoolError(mempool::error::Error::Policy(MempoolPolicyError::MempoolFull)),
         P2pError::MempoolError(mempool::error::Error::Validity(TxValidationError::TipMoved)),
     ] {
         let handle_res = Peer::<DefaultNetworkingService<TcpTransportSocket>>::handle_result(

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -97,10 +97,7 @@ async fn invalid_timestamp() {
     )
     .unwrap();
     handle
-        .send_message(
-            peer,
-            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
-        )
+        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])))
         .await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
@@ -146,10 +143,7 @@ async fn invalid_consensus_data() {
     )
     .unwrap();
     handle
-        .send_message(
-            peer,
-            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
-        )
+        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])))
         .await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
@@ -240,10 +234,7 @@ async fn unconnected_headers(#[case] seed: Seed) {
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
-    assert_eq!(
-        score,
-        P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score()
-    );
+    assert_eq!(score, P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score());
     handle.assert_no_event().await;
 
     handle.join_subsystem_manager().await;
@@ -272,18 +263,12 @@ async fn valid_block(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     handle
-        .send_message(
-            peer,
-            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
-        )
+        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])))
         .await;
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(sent_to, peer);
-    assert_eq!(
-        message,
-        SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()]))
-    );
+    assert_eq!(message, SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()])));
     handle.assert_no_error().await;
 
     handle.join_subsystem_manager().await;

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -46,9 +46,8 @@ async fn unknown_prev_block(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let block_1 = tf.make_block_builder().build();
     let block_2 = tf.make_block_builder().with_parent(block_1.get_id().into()).build();
 
@@ -80,10 +79,8 @@ async fn unknown_prev_block(#[case] seed: Seed) {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn invalid_timestamp() {
     let chain_config = Arc::new(create_unit_test_config());
-    let mut handle = SyncManagerHandle::builder()
-        .with_chain_config(Arc::clone(&chain_config))
-        .build()
-        .await;
+    let mut handle =
+        SyncManagerHandle::builder().with_chain_config(Arc::clone(&chain_config)).build().await;
 
     let peer = PeerId::new();
     handle.connect_peer(peer).await;
@@ -126,10 +123,8 @@ async fn invalid_consensus_data() {
             .net_upgrades(NetUpgrades::new(ChainType::Mainnet))
             .build(),
     );
-    let mut handle = SyncManagerHandle::builder()
-        .with_chain_config(Arc::clone(&chain_config))
-        .build()
-        .await;
+    let mut handle =
+        SyncManagerHandle::builder().with_chain_config(Arc::clone(&chain_config)).build().await;
 
     let peer = PeerId::new();
     handle.connect_peer(peer).await;
@@ -171,9 +166,8 @@ async fn unconnected_headers(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let block = tf.make_block_builder().build();
     let orphan_block = tf.make_block_builder().with_parent(block.get_id().into()).build();
 
@@ -248,9 +242,8 @@ async fn valid_block(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let block = tf.make_block_builder().build();
 
     let mut handle = SyncManagerHandle::builder()

--- a/p2p/src/sync/tests/block_list_request.rs
+++ b/p2p/src/sync/tests/block_list_request.rs
@@ -64,10 +64,7 @@ async fn max_block_count_in_request_exceeded(#[case] seed: Seed) {
         .take(*p2p_config.max_request_blocks_count + 1)
         .collect();
     handle
-        .send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(blocks)),
-        )
+        .send_message(peer, SyncMessage::BlockListRequest(BlockListRequest::new(blocks)))
         .await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
@@ -110,10 +107,7 @@ async fn unknown_blocks(#[case] seed: Seed) {
         P2pError::ProtocolError(ProtocolError::UnknownBlockRequested(unknown_blocks[0]))
             .ban_score();
     handle
-        .send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(unknown_blocks)),
-        )
+        .send_message(peer, SyncMessage::BlockListRequest(BlockListRequest::new(unknown_blocks)))
         .await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
@@ -153,19 +147,13 @@ async fn valid_request(#[case] seed: Seed) {
 
     let ids = blocks.iter().map(|b| b.get_id()).collect();
     handle
-        .send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(ids)),
-        )
+        .send_message(peer, SyncMessage::BlockListRequest(BlockListRequest::new(ids)))
         .await;
 
     for block in blocks {
         let (sent_to, message) = handle.message().await;
         assert_eq!(peer, sent_to);
-        assert_eq!(
-            message,
-            SyncMessage::BlockResponse(BlockResponse::new(block))
-        );
+        assert_eq!(message, SyncMessage::BlockResponse(BlockResponse::new(block)));
     }
 
     handle.assert_no_error().await;
@@ -209,10 +197,7 @@ async fn request_same_block_twice(#[case] seed: Seed) {
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
-    assert_eq!(
-        message,
-        SyncMessage::BlockResponse(BlockResponse::new(block.clone()))
-    );
+    assert_eq!(message, SyncMessage::BlockResponse(BlockResponse::new(block.clone())));
 
     handle.assert_no_error().await;
     handle.assert_no_peer_manager_event().await;

--- a/p2p/src/sync/tests/block_list_request.rs
+++ b/p2p/src/sync/tests/block_list_request.rs
@@ -42,9 +42,8 @@ async fn max_block_count_in_request_exceeded(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     let block = tf.make_block_builder().build();
     tf.process_block(block.clone(), BlockSource::Local).unwrap().unwrap();
@@ -60,12 +59,9 @@ async fn max_block_count_in_request_exceeded(#[case] seed: Seed) {
     let peer = PeerId::new();
     handle.connect_peer(peer).await;
 
-    let blocks = iter::repeat(block.get_id())
-        .take(*p2p_config.max_request_blocks_count + 1)
-        .collect();
-    handle
-        .send_message(peer, SyncMessage::BlockListRequest(BlockListRequest::new(blocks)))
-        .await;
+    let blocks =
+        iter::repeat(block.get_id()).take(*p2p_config.max_request_blocks_count + 1).collect();
+    handle.send_message(peer, SyncMessage::BlockListRequest(BlockListRequest::new(blocks))).await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -86,9 +82,8 @@ async fn unknown_blocks(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     tf.make_block_builder().build_and_process().unwrap().unwrap();
     let unknown_blocks: Vec<Id<Block>> =
@@ -126,9 +121,8 @@ async fn valid_request(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Import several blocks.
     let num_blocks = rng.gen_range(2..10);
     let blocks = create_n_blocks(&mut tf, num_blocks);
@@ -146,9 +140,7 @@ async fn valid_request(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let ids = blocks.iter().map(|b| b.get_id()).collect();
-    handle
-        .send_message(peer, SyncMessage::BlockListRequest(BlockListRequest::new(ids)))
-        .await;
+    handle.send_message(peer, SyncMessage::BlockListRequest(BlockListRequest::new(ids))).await;
 
     for block in blocks {
         let (sent_to, message) = handle.message().await;
@@ -170,9 +162,8 @@ async fn request_same_block_twice(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     let block = tf.make_block_builder().build();
     tf.process_block(block.clone(), BlockSource::Local).unwrap().unwrap();

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -99,17 +99,11 @@ async fn valid_response(#[case] seed: Seed) {
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
     let ids = blocks.iter().map(|b| b.get_id()).collect();
-    assert_eq!(
-        message,
-        SyncMessage::BlockListRequest(BlockListRequest::new(ids))
-    );
+    assert_eq!(message, SyncMessage::BlockListRequest(BlockListRequest::new(ids)));
 
     for (i, block) in blocks.into_iter().enumerate() {
         handle
-            .send_message(
-                peer,
-                SyncMessage::BlockResponse(BlockResponse::new(block.clone())),
-            )
+            .send_message(peer, SyncMessage::BlockResponse(BlockResponse::new(block.clone())))
             .await;
 
         // A peer would request headers after the last block.
@@ -186,18 +180,12 @@ async fn disconnect(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     handle
-        .send_message(
-            peer,
-            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
-        )
+        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])))
         .await;
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
-    assert_eq!(
-        message,
-        SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()]))
-    );
+    assert_eq!(message, SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()])));
 
     tokio::time::sleep(Duration::from_millis(300)).await;
     handle.assert_disconnect_peer_event(peer).await;

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -39,9 +39,8 @@ async fn unrequested_block(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let block = tf.make_block_builder().build();
 
     let mut handle = SyncManagerHandle::builder()
@@ -53,9 +52,7 @@ async fn unrequested_block(#[case] seed: Seed) {
     let peer = PeerId::new();
     handle.connect_peer(peer).await;
 
-    handle
-        .send_message(peer, SyncMessage::BlockResponse(BlockResponse::new(block)))
-        .await;
+    handle.send_message(peer, SyncMessage::BlockResponse(BlockResponse::new(block))).await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -76,9 +73,8 @@ async fn valid_response(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let num_blocks = rng.gen_range(2..10);
     let blocks = create_n_blocks(&mut tf, num_blocks);
 
@@ -92,9 +88,7 @@ async fn valid_response(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let headers = blocks.iter().map(|b| b.header().clone()).collect();
-    handle
-        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers)))
-        .await;
+    handle.send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
@@ -140,9 +134,8 @@ async fn disconnect(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let block = tf.make_block_builder().build();
 
     let p2p_config = Arc::new(P2pConfig {

--- a/p2p/src/sync/tests/header_list_request.rs
+++ b/p2p/src/sync/tests/header_list_request.rs
@@ -36,9 +36,8 @@ async fn max_locator_size_exceeded(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let block = tf.make_block_builder().build();
 
     let mut handle = SyncManagerHandle::builder()
@@ -77,9 +76,8 @@ async fn valid_request(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     let block_index = tf.make_block_builder().build_and_process().unwrap().unwrap();
     let locator = tf

--- a/p2p/src/sync/tests/header_list_request.rs
+++ b/p2p/src/sync/tests/header_list_request.rs
@@ -97,10 +97,7 @@ async fn valid_request(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     handle
-        .send_message(
-            peer,
-            SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)),
-        )
+        .send_message(peer, SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)))
         .await;
 
     let (sent_to, message) = handle.message().await;

--- a/p2p/src/sync/tests/header_list_response.rs
+++ b/p2p/src/sync/tests/header_list_response.rs
@@ -39,9 +39,8 @@ async fn header_count_limit_exceeded(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let block = tf.make_block_builder().build();
 
     let p2p_config = Arc::new(test_p2p_config());
@@ -55,12 +54,9 @@ async fn header_count_limit_exceeded(#[case] seed: Seed) {
     let peer = PeerId::new();
     handle.connect_peer(peer).await;
 
-    let headers = iter::repeat(block.header().clone())
-        .take(*p2p_config.msg_header_count_limit + 1)
-        .collect();
-    handle
-        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers)))
-        .await;
+    let headers =
+        iter::repeat(block.header().clone()).take(*p2p_config.msg_header_count_limit + 1).collect();
+    handle.send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -81,9 +77,8 @@ async fn unordered_headers(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Skip the header in the middle.
     let headers = create_n_blocks(&mut tf, 3)
         .into_iter()
@@ -101,9 +96,7 @@ async fn unordered_headers(#[case] seed: Seed) {
     let peer = PeerId::new();
     handle.connect_peer(peer).await;
 
-    handle
-        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers)))
-        .await;
+    handle.send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -121,14 +114,10 @@ async fn disconnected_headers(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
-    let headers = create_n_blocks(&mut tf, 3)
-        .into_iter()
-        .skip(1)
-        .map(|b| b.header().clone())
-        .collect();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
+    let headers =
+        create_n_blocks(&mut tf, 3).into_iter().skip(1).map(|b| b.header().clone()).collect();
 
     let mut handle = SyncManagerHandle::builder()
         .with_chain_config(chain_config)
@@ -139,9 +128,7 @@ async fn disconnected_headers(#[case] seed: Seed) {
     let peer = PeerId::new();
     handle.connect_peer(peer).await;
 
-    handle
-        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers)))
-        .await;
+    handle.send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -159,9 +146,8 @@ async fn valid_headers(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     let blocks = create_n_blocks(&mut tf, 3);
 
     let mut handle = SyncManagerHandle::builder()
@@ -174,9 +160,7 @@ async fn valid_headers(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let headers = blocks.iter().map(|b| b.header().clone()).collect();
-    handle
-        .send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers)))
-        .await;
+    handle.send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
@@ -218,10 +202,8 @@ async fn disconnect() {
         max_unconnected_headers: Default::default(),
         sync_stalling_timeout: Duration::from_millis(100).into(),
     });
-    let mut handle = SyncManagerHandle::builder()
-        .with_p2p_config(Arc::clone(&p2p_config))
-        .build()
-        .await;
+    let mut handle =
+        SyncManagerHandle::builder().with_p2p_config(Arc::clone(&p2p_config)).build().await;
 
     let peer = PeerId::new();
     handle.connect_peer(peer).await;

--- a/p2p/src/sync/tests/header_list_response.rs
+++ b/p2p/src/sync/tests/header_list_response.rs
@@ -107,10 +107,7 @@ async fn unordered_headers(#[case] seed: Seed) {
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
-    assert_eq!(
-        score,
-        P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score()
-    );
+    assert_eq!(score, P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score());
     handle.assert_no_event().await;
 
     handle.join_subsystem_manager().await;
@@ -148,10 +145,7 @@ async fn disconnected_headers(#[case] seed: Seed) {
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
-    assert_eq!(
-        score,
-        P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score()
-    );
+    assert_eq!(score, P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score());
     handle.assert_no_event().await;
 
     handle.join_subsystem_manager().await;

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -179,9 +179,7 @@ impl SyncManagerHandle {
 
     /// Sends the `SyncControlEvent::Disconnected` event.
     pub fn disconnect_peer(&mut self, peer: PeerId) {
-        self.sync_event_sender
-            .send(SyncingEvent::Disconnected { peer_id: peer })
-            .unwrap();
+        self.sync_event_sender.send(SyncingEvent::Disconnected { peer_id: peer }).unwrap();
         self.connected_peers.lock().unwrap().remove(&peer);
     }
 
@@ -242,9 +240,7 @@ impl SyncManagerHandle {
 
     /// Panics if there is an event from the peer manager.
     pub async fn assert_no_peer_manager_event(&mut self) {
-        time::timeout(SHORT_TIMEOUT, self.peer_manager_receiver.recv())
-            .await
-            .unwrap_err();
+        time::timeout(SHORT_TIMEOUT, self.peer_manager_receiver.recv()).await.unwrap_err();
     }
 
     /// Panics if the sync manager sends an event (message or announcement).
@@ -278,11 +274,7 @@ impl SyncManagerHandle {
 
 pub async fn sync_managers_in_sync(managers: &[&mut SyncManagerHandle]) -> bool {
     let best_blocks = futures::future::join_all(managers.iter().map(|manager| async {
-        manager
-            .chainstate()
-            .call(|this| this.get_best_block_id().unwrap())
-            .await
-            .unwrap()
+        manager.chainstate().call(|this| this.get_best_block_id().unwrap()).await.unwrap()
     }))
     .await;
     best_blocks.iter().tuple_windows().all(|(l, r)| l == r)
@@ -300,9 +292,7 @@ pub async fn try_sync_managers_once(
         // Request a non-existent transaction to ensure that the event loop has a chance to process all pending requests
         let tx_peer_id = *peer_ids.iter().find(|peer_id| **peer_id != sender_peer_id).unwrap();
         let requested_txid = get_random_hash(rng).into();
-        manager
-            .send_message(tx_peer_id, SyncMessage::TransactionRequest(requested_txid))
-            .await;
+        manager.send_message(tx_peer_id, SyncMessage::TransactionRequest(requested_txid)).await;
 
         if let Ok(peer_event) = manager.peer_manager_receiver.try_recv() {
             // There should be no peer scoring or disconnections
@@ -346,9 +336,7 @@ pub async fn sync_managers(rng: &mut impl Rng, managers: &mut [&mut SyncManagerH
         }
     };
 
-    tokio::time::timeout(Duration::from_secs(60), sync_managers_helper)
-        .await
-        .unwrap();
+    tokio::time::timeout(Duration::from_secs(60), sync_managers_helper).await.unwrap();
 }
 
 pub struct SyncManagerHandleBuilder {

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -115,9 +115,7 @@ impl SyncManagerHandle {
             events_sender: messaging_sender,
             connected_peers: Arc::clone(&connected_peers),
         };
-        let sync_event_receiver = SyncingEventReceiverMock {
-            events_receiver: messaging_receiver,
-        };
+        let sync_event_receiver = SyncingEventReceiverMock { events_receiver: messaging_receiver };
 
         let sync = BlockSyncManager::new(
             chain_config,
@@ -398,13 +396,8 @@ impl SyncManagerHandleBuilder {
     }
 
     pub async fn build(self) -> SyncManagerHandle {
-        let SyncManagerHandleBuilder {
-            chain_config,
-            p2p_config,
-            chainstate,
-            time_getter,
-            blocks,
-        } = self;
+        let SyncManagerHandleBuilder { chain_config, p2p_config, chainstate, time_getter, blocks } =
+            self;
 
         let mut manager = subsystem::Manager::new("p2p-sync-test-manager");
         let shutdown_trigger = manager.make_shutdown_trigger();
@@ -541,9 +534,8 @@ pub fn new_block(
     let witness = InputWitness::NoSignature(Some(random_bytes));
     let signed_transaction = SignedTransaction::new(transaction, vec![witness]).unwrap();
 
-    let prev_block_id: Id<GenBlock> = prev_block.map_or(chain_config.genesis_block_id(), |block| {
-        block.header().block_id().into()
-    });
+    let prev_block_id: Id<GenBlock> = prev_block
+        .map_or(chain_config.genesis_block_id(), |block| block.header().block_id().into());
 
     Block::new(
         vec![signed_transaction],

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -70,16 +70,10 @@ async fn invalid_transaction(#[case] seed: Seed) {
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
-    assert_eq!(
-        message,
-        SyncMessage::TransactionRequest(tx.transaction().get_id())
-    );
+    assert_eq!(message, SyncMessage::TransactionRequest(tx.transaction().get_id()));
 
     handle
-        .send_message(
-            peer,
-            SyncMessage::TransactionResponse(TransactionResponse::Found(tx)),
-        )
+        .send_message(peer, SyncMessage::TransactionResponse(TransactionResponse::Found(tx)))
         .await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
@@ -278,10 +272,7 @@ async fn duplicated_announcement(#[case] seed: Seed) {
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
-    assert_eq!(
-        message,
-        SyncMessage::TransactionRequest(tx.transaction().get_id())
-    );
+    assert_eq!(message, SyncMessage::TransactionRequest(tx.transaction().get_id()));
 
     handle
         .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
@@ -333,10 +324,7 @@ async fn valid_transaction(#[case] seed: Seed) {
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
-    assert_eq!(
-        message,
-        SyncMessage::TransactionRequest(tx.transaction().get_id())
-    );
+    assert_eq!(message, SyncMessage::TransactionRequest(tx.transaction().get_id()));
 
     handle
         .send_message(
@@ -345,10 +333,7 @@ async fn valid_transaction(#[case] seed: Seed) {
         )
         .await;
 
-    assert_eq!(
-        SyncMessage::NewTransaction(tx.transaction().get_id()),
-        handle.message().await.1
-    );
+    assert_eq!(SyncMessage::NewTransaction(tx.transaction().get_id()), handle.message().await.1);
 
     handle.join_subsystem_manager().await;
 }

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -45,9 +45,8 @@ async fn invalid_transaction(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     tf.make_block_builder().build_and_process().unwrap().unwrap();
 
@@ -64,9 +63,7 @@ async fn invalid_transaction(#[case] seed: Seed) {
 
     let tx = Transaction::new(0x00, vec![], vec![]).unwrap();
     let tx = SignedTransaction::new(tx, vec![]).unwrap();
-    handle
-        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-        .await;
+    handle.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
@@ -92,18 +89,14 @@ async fn invalid_transaction(#[case] seed: Seed) {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn initial_block_download() {
     let chain_config = Arc::new(create_unit_test_config());
-    let mut handle = SyncManagerHandle::builder()
-        .with_chain_config(Arc::clone(&chain_config))
-        .build()
-        .await;
+    let mut handle =
+        SyncManagerHandle::builder().with_chain_config(Arc::clone(&chain_config)).build().await;
 
     let peer = PeerId::new();
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle
-        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-        .await;
+    handle.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
     handle.assert_no_event().await;
     handle.assert_no_peer_manager_event().await;
@@ -120,9 +113,8 @@ async fn no_transaction_service(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     tf.make_block_builder().build_and_process().unwrap().unwrap();
 
@@ -161,9 +153,7 @@ async fn no_transaction_service(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle
-        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-        .await;
+    handle.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -184,9 +174,8 @@ async fn too_many_announcements(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     tf.make_block_builder().build_and_process().unwrap().unwrap();
 
@@ -225,9 +214,7 @@ async fn too_many_announcements(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle
-        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-        .await;
+    handle.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -248,9 +235,8 @@ async fn duplicated_announcement(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     tf.make_block_builder().build_and_process().unwrap().unwrap();
 
@@ -266,17 +252,13 @@ async fn duplicated_announcement(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle
-        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-        .await;
+    handle.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);
     assert_eq!(message, SyncMessage::TransactionRequest(tx.transaction().get_id()));
 
-    handle
-        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-        .await;
+    handle.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
     let (adjusted_peer, score) = handle.adjust_peer_score_event().await;
     assert_eq!(peer, adjusted_peer);
@@ -300,9 +282,8 @@ async fn valid_transaction(#[case] seed: Seed) {
     let mut rng = test_utils::random::make_seedable_rng(seed);
 
     let chain_config = Arc::new(create_unit_test_config());
-    let mut tf = TestFramework::builder(&mut rng)
-        .with_chain_config(chain_config.as_ref().clone())
-        .build();
+    let mut tf =
+        TestFramework::builder(&mut rng).with_chain_config(chain_config.as_ref().clone()).build();
     // Process a block to finish the initial block download.
     tf.make_block_builder().build_and_process().unwrap().unwrap();
 
@@ -318,9 +299,7 @@ async fn valid_transaction(#[case] seed: Seed) {
     handle.connect_peer(peer).await;
 
     let tx = transaction(chain_config.genesis_block_id());
-    handle
-        .send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-        .await;
+    handle.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
     let (sent_to, message) = handle.message().await;
     assert_eq!(peer, sent_to);

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -161,11 +161,9 @@ where
 
     let (address, peer_info1) = match timeout(Duration::from_secs(5), conn2.poll_next()).await {
         Ok(event) => match event.unwrap() {
-            ConnectivityEvent::InboundAccepted {
-                address,
-                peer_info,
-                receiver_address: _,
-            } => (address, peer_info),
+            ConnectivityEvent::InboundAccepted { address, peer_info, receiver_address: _ } => {
+                (address, peer_info)
+            }
             event => panic!("expected `InboundAccepted`, got {event:?}"),
         },
         Err(_err) => panic!("did not receive `InboundAccepted` in time"),
@@ -173,11 +171,9 @@ where
 
     let peer_info2 = match timeout(Duration::from_secs(5), conn1.poll_next()).await {
         Ok(event) => match event.unwrap() {
-            ConnectivityEvent::OutboundAccepted {
-                address: _,
-                peer_info,
-                receiver_address: _,
-            } => peer_info,
+            ConnectivityEvent::OutboundAccepted { address: _, peer_info, receiver_address: _ } => {
+                peer_info
+            }
             event => panic!("expected `OutboundAccepted`, got {event:?}"),
         },
         Err(_err) => panic!("did not receive `OutboundAccepted` in time"),

--- a/p2p/src/utils/rate_limiter/mod.rs
+++ b/p2p/src/utils/rate_limiter/mod.rs
@@ -40,12 +40,7 @@ impl RateLimiter {
         assert!(rate >= 0.0);
         assert!(initial_tokens <= bucket);
         assert!(bucket >= 1);
-        RateLimiter {
-            rate,
-            tokens: initial_tokens.into(),
-            bucket,
-            last_time: now,
-        }
+        RateLimiter { rate, tokens: initial_tokens.into(), bucket, last_time: now }
     }
 
     /// Check if the new request is within the allowed rate at the current time (updating the state)

--- a/p2p/tests/shutdown.rs
+++ b/p2p/tests/shutdown.rs
@@ -48,11 +48,8 @@ async fn shutdown_timeout() {
     .unwrap();
     let chainstate = manager.add_subsystem("shutdown-test-chainstate", chainstate);
 
-    let mempool = mempool::make_mempool(
-        Arc::clone(&chain_config),
-        chainstate.clone(),
-        Default::default(),
-    );
+    let mempool =
+        mempool::make_mempool(Arc::clone(&chain_config), chainstate.clone(), Default::default());
     let mempool = manager.add_subsystem_with_custom_eventloop("shutdown-test-mempool", {
         move |call, shutdown| mempool.run(call, shutdown)
     });

--- a/p2p/types/src/global_ip.rs
+++ b/p2p/types/src/global_ip.rs
@@ -140,16 +140,10 @@ mod tests {
         ];
 
         for ip in global_unicast_ips {
-            assert!(
-                is_global_unicast(ip),
-                "{ip} is expected to be global unicast IP address"
-            );
+            assert!(is_global_unicast(ip), "{ip} is expected to be global unicast IP address");
         }
         for ip in non_global_unicast_ips {
-            assert!(
-                !is_global_unicast(ip),
-                "{ip} is expected to be not global unicast IP address"
-            );
+            assert!(!is_global_unicast(ip), "{ip} is expected to be not global unicast IP address");
         }
     }
 }

--- a/p2p/types/src/peer_address.rs
+++ b/p2p/types/src/peer_address.rs
@@ -66,14 +66,12 @@ impl Display for PeerAddress {
 impl From<std::net::SocketAddr> for PeerAddress {
     fn from(address: std::net::SocketAddr) -> Self {
         match address {
-            std::net::SocketAddr::V4(ip) => PeerAddress::Ip4(PeerAddressIp4 {
-                ip: (*ip.ip()).into(),
-                port: address.port(),
-            }),
-            std::net::SocketAddr::V6(ip) => PeerAddress::Ip6(PeerAddressIp6 {
-                ip: (*ip.ip()).into(),
-                port: address.port(),
-            }),
+            std::net::SocketAddr::V4(ip) => {
+                PeerAddress::Ip4(PeerAddressIp4 { ip: (*ip.ip()).into(), port: address.port() })
+            }
+            std::net::SocketAddr::V6(ip) => {
+                PeerAddress::Ip6(PeerAddressIp6 { ip: (*ip.ip()).into(), port: address.port() })
+            }
         }
     }
 }

--- a/pos_accounting/src/pool/block_undo.rs
+++ b/pos_accounting/src/pool/block_undo.rs
@@ -114,15 +114,12 @@ impl AccountingBlockUndo {
     }
 
     pub fn combine(&mut self, other: AccountingBlockUndo) -> Result<(), AccountingBlockUndoError> {
-        other
-            .tx_undos
-            .into_iter()
-            .try_for_each(|(id, u)| match self.tx_undos.entry(id) {
-                Entry::Vacant(e) => {
-                    e.insert(u);
-                    Ok(())
-                }
-                Entry::Occupied(_) => Err(AccountingBlockUndoError::UndoAlreadyExists(id)),
-            })
+        other.tx_undos.into_iter().try_for_each(|(id, u)| match self.tx_undos.entry(id) {
+            Entry::Vacant(e) => {
+                e.insert(u);
+                Ok(())
+            }
+            Entry::Occupied(_) => Err(AccountingBlockUndoError::UndoAlreadyExists(id)),
+        })
     }
 }

--- a/pos_accounting/src/pool/block_undo.rs
+++ b/pos_accounting/src/pool/block_undo.rs
@@ -72,10 +72,7 @@ impl AccountingBlockUndo {
         tx_undos: BTreeMap<Id<Transaction>, AccountingTxUndo>,
         reward_undos: Option<AccountingBlockRewardUndo>,
     ) -> Self {
-        Self {
-            reward_undos,
-            tx_undos,
-        }
+        Self { reward_undos, tx_undos }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/pos_accounting/src/pool/delegation.rs
+++ b/pos_accounting/src/pool/delegation.rs
@@ -24,10 +24,7 @@ pub struct DelegationData {
 
 impl DelegationData {
     pub fn new(source_pool: PoolId, spend_destination: Destination) -> Self {
-        Self {
-            spend_destination,
-            source_pool,
-        }
+        Self { spend_destination, source_pool }
     }
 
     pub fn spend_destination(&self) -> &Destination {

--- a/pos_accounting/src/pool/delta/data.rs
+++ b/pos_accounting/src/pool/delta/data.rs
@@ -74,8 +74,7 @@ impl PoSAccountingDeltaData {
         self.pool_delegation_shares
             .undo_merge_delta_amounts(undo_data.pool_delegation_shares_undo)?;
 
-        self.delegation_balances
-            .undo_merge_delta_amounts(undo_data.delegation_balances_undo)?;
+        self.delegation_balances.undo_merge_delta_amounts(undo_data.delegation_balances_undo)?;
 
         self.pool_data.undo_merge_delta_data(undo_data.pool_data_undo)?;
 

--- a/pos_accounting/src/pool/delta/mod.rs
+++ b/pos_accounting/src/pool/delta/mod.rs
@@ -125,10 +125,7 @@ impl<P: PoSAccountingView> PoSAccountingDelta<P> {
     }
 
     fn add_balance_to_pool(&mut self, pool_id: PoolId, amount_to_add: Amount) -> Result<(), Error> {
-        self.data
-            .pool_balances
-            .add_unsigned(pool_id, amount_to_add)
-            .map_err(Error::AccountingError)
+        self.data.pool_balances.add_unsigned(pool_id, amount_to_add).map_err(Error::AccountingError)
     }
 
     fn sub_balance_from_pool(
@@ -136,10 +133,7 @@ impl<P: PoSAccountingView> PoSAccountingDelta<P> {
         pool_id: PoolId,
         amount_to_add: Amount,
     ) -> Result<(), Error> {
-        self.data
-            .pool_balances
-            .sub_unsigned(pool_id, amount_to_add)
-            .map_err(Error::AccountingError)
+        self.data.pool_balances.sub_unsigned(pool_id, amount_to_add).map_err(Error::AccountingError)
     }
 
     fn add_delegation_to_pool_share(

--- a/pos_accounting/src/pool/delta/mod.rs
+++ b/pos_accounting/src/pool/delta/mod.rs
@@ -61,10 +61,7 @@ impl DeltaMergeUndo {
 
 impl<P: PoSAccountingView> PoSAccountingDelta<P> {
     pub fn new(parent: P) -> Self {
-        Self {
-            parent,
-            data: PoSAccountingDeltaData::new(),
-        }
+        Self { parent, data: PoSAccountingDeltaData::new() }
     }
 
     pub fn from_data(parent: P, data: PoSAccountingDeltaData) -> Self {

--- a/pos_accounting/src/pool/delta/operator_impls.rs
+++ b/pos_accounting/src/pool/delta/operator_impls.rs
@@ -113,13 +113,11 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
             DataDelta::new(Some(pool_data), Some(new_pool_data)),
         )?;
 
-        Ok(PoSAccountingUndo::IncreasePledgeAmount(
-            IncreasePledgeAmountUndo {
-                pool_id,
-                amount_added: amount_to_add,
-                data_undo: PoolDataUndo::DataDelta(Box::new(data_undo)),
-            },
-        ))
+        Ok(PoSAccountingUndo::IncreasePledgeAmount(IncreasePledgeAmountUndo {
+            pool_id,
+            amount_added: amount_to_add,
+            data_undo: PoolDataUndo::DataDelta(Box::new(data_undo)),
+        }))
     }
 
     fn create_delegation_id(
@@ -184,12 +182,10 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
             .delegation_data
             .merge_delta_data_element(delegation_id, DataDelta::new(Some(delegation_data), None))?;
 
-        Ok(PoSAccountingUndo::DeleteDelegationId(
-            DeleteDelegationIdUndo {
-                delegation_id,
-                data_undo: DelegationDataUndo::DataDelta(Box::new(data_undo)),
-            },
-        ))
+        Ok(PoSAccountingUndo::DeleteDelegationId(DeleteDelegationIdUndo {
+            delegation_id,
+            data_undo: DelegationDataUndo::DataDelta(Box::new(data_undo)),
+        }))
     }
 
     fn delegate_staking(
@@ -233,10 +229,7 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
 
         self.sub_from_delegation_balance(delegation_id, amount)?;
 
-        Ok(PoSAccountingUndo::SpendFromShare(SpendFromShareUndo {
-            delegation_id,
-            amount,
-        }))
+        Ok(PoSAccountingUndo::SpendFromShare(SpendFromShareUndo { delegation_id, amount }))
     }
 
     fn undo(&mut self, undo_data: PoSAccountingUndo) -> Result<(), Error> {

--- a/pos_accounting/src/pool/delta/operator_impls.rs
+++ b/pos_accounting/src/pool/delta/operator_impls.rs
@@ -69,9 +69,8 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
     }
 
     fn decommission_pool(&mut self, pool_id: PoolId) -> Result<PoSAccountingUndo, Error> {
-        let last_data = self
-            .get_pool_data(pool_id)?
-            .ok_or(Error::AttemptedDecommissionNonexistingPoolData)?;
+        let last_data =
+            self.get_pool_data(pool_id)?.ok_or(Error::AttemptedDecommissionNonexistingPoolData)?;
 
         let last_amount = self
             .get_pool_balance(pool_id)?
@@ -95,9 +94,8 @@ impl<P: PoSAccountingView> PoSAccountingOperations for PoSAccountingDelta<P> {
         pool_id: PoolId,
         amount_to_add: Amount,
     ) -> Result<PoSAccountingUndo, Error> {
-        let pool_data = self
-            .get_pool_data(pool_id)?
-            .ok_or(Error::IncreasePledgeAmountOfNonexistingPool)?;
+        let pool_data =
+            self.get_pool_data(pool_id)?.ok_or(Error::IncreasePledgeAmountOfNonexistingPool)?;
 
         self.add_balance_to_pool(pool_id, amount_to_add)?;
 
@@ -304,9 +302,7 @@ impl<P: PoSAccountingView> PoSAccountingDelta<P> {
         self.get_delegation_data(undo.delegation_id)?
             .ok_or(Error::InvariantErrorDelegationIdUndoFailedNotFound)?;
 
-        self.data
-            .delegation_data
-            .undo_merge_delta_data_element(undo.delegation_id, *undo_data)?;
+        self.data.delegation_data.undo_merge_delta_data_element(undo.delegation_id, *undo_data)?;
 
         Ok(())
     }
@@ -321,9 +317,7 @@ impl<P: PoSAccountingView> PoSAccountingDelta<P> {
             return Err(Error::DelegationDeletionFailedBalanceNonZero);
         }
 
-        self.data
-            .delegation_data
-            .undo_merge_delta_data_element(undo.delegation_id, undo_data)?;
+        self.data.delegation_data.undo_merge_delta_data_element(undo.delegation_id, undo_data)?;
 
         Ok(())
     }

--- a/pos_accounting/src/pool/delta/view_impl.rs
+++ b/pos_accounting/src/pool/delta/view_impl.rs
@@ -66,10 +66,7 @@ impl<P: PoSAccountingView> PoSAccountingView for PoSAccountingDelta<P> {
     type Error = Error;
 
     fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Self::Error> {
-        Ok(self
-            .get_pool_data(pool_id)?
-            .ok_or_else(|| self.parent.get_pool_data(pool_id))
-            .is_ok())
+        Ok(self.get_pool_data(pool_id)?.ok_or_else(|| self.parent.get_pool_data(pool_id)).is_ok())
     }
 
     fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {

--- a/pos_accounting/src/pool/delta/view_impl.rs
+++ b/pos_accounting/src/pool/delta/view_impl.rs
@@ -49,15 +49,14 @@ fn sum_maps<K: Ord + Copy>(
             Some(pv) => *pv,
             None => Amount::from_atoms(0),
         };
-        let base_amount = base_value.into_signed().ok_or(Error::AccountingError(
-            accounting::Error::ArithmeticErrorToUnsignedFailed,
-        ))?;
-        let new_amount = (base_amount + v).ok_or(Error::AccountingError(
-            accounting::Error::ArithmeticErrorSumToSignedFailed,
-        ))?;
-        let new_amount = new_amount.into_unsigned().ok_or(Error::AccountingError(
-            accounting::Error::ArithmeticErrorToUnsignedFailed,
-        ))?;
+        let base_amount = base_value
+            .into_signed()
+            .ok_or(Error::AccountingError(accounting::Error::ArithmeticErrorToUnsignedFailed))?;
+        let new_amount = (base_amount + v)
+            .ok_or(Error::AccountingError(accounting::Error::ArithmeticErrorSumToSignedFailed))?;
+        let new_amount = new_amount
+            .into_unsigned()
+            .ok_or(Error::AccountingError(accounting::Error::ArithmeticErrorToUnsignedFailed))?;
         m1.insert(k, new_amount);
     }
     Ok(m1)

--- a/pos_accounting/src/pool/storage/helpers.rs
+++ b/pos_accounting/src/pool/storage/helpers.rs
@@ -31,13 +31,7 @@ pub struct BorrowedStorageValue<'a, T, S, Getter, Setter, Deleter> {
 
 impl<'a, T, S, Getter, Setter, Deleter> BorrowedStorageValue<'a, T, S, Getter, Setter, Deleter> {
     pub fn new(store: &'a mut S, getter: Getter, setter: Setter, deleter: Deleter) -> Self {
-        Self {
-            store,
-            getter,
-            setter,
-            deleter,
-            _phantom: Default::default(),
-        }
+        Self { store, getter, setter, deleter, _phantom: Default::default() }
     }
 }
 

--- a/pos_accounting/src/pool/storage/mod.rs
+++ b/pos_accounting/src/pool/storage/mod.rs
@@ -43,10 +43,7 @@ pub struct PoSAccountingDB<S, T> {
 
 impl<S, T> PoSAccountingDB<S, T> {
     pub fn new(store: S) -> Self {
-        Self {
-            store,
-            _phantom: Default::default(),
-        }
+        Self { store, _phantom: Default::default() }
     }
 }
 

--- a/pos_accounting/src/pool/storage/mod.rs
+++ b/pos_accounting/src/pool/storage/mod.rs
@@ -287,10 +287,8 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingDB<S, T> {
         delegation_id: DelegationId,
         amount_to_add: Amount,
     ) -> Result<(), Error> {
-        let current_amount = self
-            .store
-            .get_pool_delegation_share(pool_id, delegation_id)?
-            .unwrap_or(Amount::ZERO);
+        let current_amount =
+            self.store.get_pool_delegation_share(pool_id, delegation_id)?.unwrap_or(Amount::ZERO);
         let new_amount =
             (current_amount + amount_to_add).ok_or(Error::DelegationSharesAdditionError)?;
         self.store.set_pool_delegation_share(pool_id, delegation_id, new_amount)?;

--- a/pos_accounting/src/pool/storage/operator_impls.rs
+++ b/pos_accounting/src/pool/storage/operator_impls.rs
@@ -104,13 +104,11 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingOperations
 
         self.add_balance_to_pool(pool_id, amount_to_add)?;
 
-        Ok(PoSAccountingUndo::IncreasePledgeAmount(
-            IncreasePledgeAmountUndo {
-                pool_id,
-                amount_added: amount_to_add,
-                data_undo: PoolDataUndo::Data(Box::new(pool_data)),
-            },
-        ))
+        Ok(PoSAccountingUndo::IncreasePledgeAmount(IncreasePledgeAmountUndo {
+            pool_id,
+            amount_added: amount_to_add,
+            data_undo: PoolDataUndo::Data(Box::new(pool_data)),
+        }))
     }
 
     fn create_delegation_id(
@@ -170,12 +168,10 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingOperations
 
         self.store.del_delegation_data(delegation_id)?;
 
-        Ok(PoSAccountingUndo::DeleteDelegationId(
-            DeleteDelegationIdUndo {
-                delegation_id,
-                data_undo: DelegationDataUndo::Data(Box::new(delegation_data)),
-            },
-        ))
+        Ok(PoSAccountingUndo::DeleteDelegationId(DeleteDelegationIdUndo {
+            delegation_id,
+            data_undo: DelegationDataUndo::Data(Box::new(delegation_data)),
+        }))
     }
 
     fn delegate_staking(
@@ -219,10 +215,7 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingOperations
 
         self.sub_from_delegation_balance(delegation_id, amount)?;
 
-        Ok(PoSAccountingUndo::SpendFromShare(SpendFromShareUndo {
-            delegation_id,
-            amount,
-        }))
+        Ok(PoSAccountingUndo::SpendFromShare(SpendFromShareUndo { delegation_id, amount }))
     }
 
     fn undo(&mut self, undo_data: PoSAccountingUndo) -> Result<(), Error> {

--- a/pos_accounting/src/pool/storage/view_impls.rs
+++ b/pos_accounting/src/pool/storage/view_impls.rs
@@ -70,9 +70,7 @@ impl<S: PoSAccountingStorageRead<T>, T: StorageTag> PoSAccountingView for PoSAcc
         pool_id: PoolId,
         delegation_id: DelegationId,
     ) -> Result<Option<Amount>, Error> {
-        self.store
-            .get_pool_delegation_share(pool_id, delegation_id)
-            .map_err(Error::from)
+        self.store.get_pool_delegation_share(pool_id, delegation_id).map_err(Error::from)
     }
 }
 

--- a/pos_accounting/src/pool/tests/delta_tests.rs
+++ b/pos_accounting/src/pool/tests/delta_tests.rs
@@ -43,11 +43,7 @@ fn merge_deltas_check_undo_check(#[case] seed: Seed) {
     let pool_data1 = create_pool_data(&mut rng, destination1.clone(), Amount::from_atoms(100));
     let data1 = PoSAccountingDeltaData {
         pool_data: DeltaDataCollection::from_iter(
-            [(
-                new_pool_id(1),
-                DataDelta::new(None, Some(pool_data1.clone())),
-            )]
-            .into_iter(),
+            [(new_pool_id(1), DataDelta::new(None, Some(pool_data1.clone())))].into_iter(),
         ),
         pool_balances: DeltaAmountCollection::from_iter(
             [
@@ -57,11 +53,7 @@ fn merge_deltas_check_undo_check(#[case] seed: Seed) {
             .into_iter(),
         ),
         pool_delegation_shares: DeltaAmountCollection::from_iter(
-            [(
-                (new_pool_id(5), new_delegation_id(6)),
-                SignedAmount::from_atoms(100),
-            )]
-            .into_iter(),
+            [((new_pool_id(5), new_delegation_id(6)), SignedAmount::from_atoms(100))].into_iter(),
         ),
         delegation_balances: DeltaAmountCollection::from_iter(
             [
@@ -94,10 +86,7 @@ fn merge_deltas_check_undo_check(#[case] seed: Seed) {
                     new_pool_id(1),
                     DataDelta::new(Some(pool_data1.clone()), Some(pool_data1_increased.clone())),
                 ),
-                (
-                    new_pool_id(10),
-                    DataDelta::new(None, Some(pool_data2.clone())),
-                ),
+                (new_pool_id(10), DataDelta::new(None, Some(pool_data2.clone()))),
             ]
             .into_iter(),
         ),
@@ -109,11 +98,7 @@ fn merge_deltas_check_undo_check(#[case] seed: Seed) {
             .into_iter(),
         ),
         pool_delegation_shares: DeltaAmountCollection::from_iter(
-            [(
-                (new_pool_id(5), new_delegation_id(6)),
-                SignedAmount::from_atoms(50),
-            )]
-            .into_iter(),
+            [((new_pool_id(5), new_delegation_id(6)), SignedAmount::from_atoms(50))].into_iter(),
         ),
         delegation_balances: DeltaAmountCollection::from_iter(
             [
@@ -138,10 +123,7 @@ fn merge_deltas_check_undo_check(#[case] seed: Seed) {
     let expected_data_after_merge = PoSAccountingDeltaData {
         pool_data: DeltaDataCollection::from_iter(
             [
-                (
-                    new_pool_id(1),
-                    DataDelta::new(None, Some(pool_data1_increased)),
-                ),
+                (new_pool_id(1), DataDelta::new(None, Some(pool_data1_increased))),
                 (new_pool_id(10), DataDelta::new(None, Some(pool_data2))),
             ]
             .into_iter(),
@@ -150,11 +132,7 @@ fn merge_deltas_check_undo_check(#[case] seed: Seed) {
             [(new_pool_id(4), SignedAmount::from_atoms(450))].into_iter(),
         ),
         pool_delegation_shares: DeltaAmountCollection::from_iter(
-            [(
-                (new_pool_id(5), new_delegation_id(6)),
-                SignedAmount::from_atoms(150),
-            )]
-            .into_iter(),
+            [((new_pool_id(5), new_delegation_id(6)), SignedAmount::from_atoms(150))].into_iter(),
         ),
         delegation_balances: DeltaAmountCollection::from_iter(
             [
@@ -189,11 +167,7 @@ fn merge_deltas_check_undo_check(#[case] seed: Seed) {
             .into_iter(),
         ),
         pool_delegation_shares: DeltaAmountCollection::from_iter(
-            [(
-                (new_pool_id(5), new_delegation_id(6)),
-                SignedAmount::from_atoms(100),
-            )]
-            .into_iter(),
+            [((new_pool_id(5), new_delegation_id(6)), SignedAmount::from_atoms(100))].into_iter(),
         ),
         delegation_balances: DeltaAmountCollection::from_iter(
             [
@@ -205,10 +179,7 @@ fn merge_deltas_check_undo_check(#[case] seed: Seed) {
         delegation_data: DeltaDataCollection::from_iter(
             [(
                 new_delegation_id(1),
-                DataDelta::new(
-                    None,
-                    Some(DelegationData::new(new_pool_id(1), destination1)),
-                ),
+                DataDelta::new(None, Some(DelegationData::new(new_pool_id(1), destination1))),
             )]
             .into_iter(),
         ),
@@ -236,10 +207,7 @@ fn merge_store_with_delta_check_undo_check(#[case] seed: Seed) {
             (new_pool_id(3), Amount::from_atoms(300)),
             (new_pool_id(4), Amount::from_atoms(400)),
         ]),
-        BTreeMap::from([(
-            (new_pool_id(5), new_delegation_id(6)),
-            Amount::from_atoms(100),
-        )]),
+        BTreeMap::from([((new_pool_id(5), new_delegation_id(6)), Amount::from_atoms(100))]),
         BTreeMap::from([
             (new_delegation_id(5), Amount::from_atoms(500)),
             (new_delegation_id(6), Amount::from_atoms(600)),
@@ -261,10 +229,7 @@ fn merge_store_with_delta_check_undo_check(#[case] seed: Seed) {
                         new_pool_id(1),
                         DataDelta::new(Some(pool_data1), Some(pool_data1_increased.clone())),
                     ),
-                    (
-                        new_pool_id(10),
-                        DataDelta::new(None, Some(pool_data2.clone())),
-                    ),
+                    (new_pool_id(10), DataDelta::new(None, Some(pool_data2.clone()))),
                 ]
                 .into_iter(),
             ),
@@ -276,11 +241,8 @@ fn merge_store_with_delta_check_undo_check(#[case] seed: Seed) {
                 .into_iter(),
             ),
             pool_delegation_shares: DeltaAmountCollection::from_iter(
-                [(
-                    (new_pool_id(5), new_delegation_id(6)),
-                    SignedAmount::from_atoms(50),
-                )]
-                .into_iter(),
+                [((new_pool_id(5), new_delegation_id(6)), SignedAmount::from_atoms(50))]
+                    .into_iter(),
             ),
             delegation_balances: DeltaAmountCollection::from_iter(
                 [
@@ -292,10 +254,7 @@ fn merge_store_with_delta_check_undo_check(#[case] seed: Seed) {
             delegation_data: DeltaDataCollection::from_iter(
                 [(
                     new_delegation_id(1),
-                    DataDelta::new(
-                        Some(DelegationData::new(new_pool_id(1), destination1)),
-                        None,
-                    ),
+                    DataDelta::new(Some(DelegationData::new(new_pool_id(1), destination1)), None),
                 )]
                 .into_iter(),
             ),
@@ -307,10 +266,7 @@ fn merge_store_with_delta_check_undo_check(#[case] seed: Seed) {
     let expected_storage = InMemoryPoSAccounting::from_values(
         BTreeMap::from([(new_pool_id(1), pool_data1_increased), (new_pool_id(10), pool_data2)]),
         BTreeMap::from([(new_pool_id(4), Amount::from_atoms(450))]),
-        BTreeMap::from([(
-            (new_pool_id(5), new_delegation_id(6)),
-            Amount::from_atoms(150),
-        )]),
+        BTreeMap::from([((new_pool_id(5), new_delegation_id(6)), Amount::from_atoms(150))]),
         BTreeMap::from([
             (new_delegation_id(5), Amount::from_atoms(500)),
             (new_delegation_id(6), Amount::from_atoms(600)),

--- a/pos_accounting/src/pool/tests/mod.rs
+++ b/pos_accounting/src/pool/tests/mod.rs
@@ -56,13 +56,7 @@ fn create_pool_data(
     let (_, vrf_pk) = VRFPrivateKey::new_from_rng(rng, VRFKeyKind::Schnorrkel);
     let margin_ratio = PerThousand::new(rng.gen_range(0..1000)).unwrap();
     let cost_per_block = Amount::from_atoms(rng.gen_range(0..1000));
-    PoolData::new(
-        decommission_destination,
-        pledged_amount,
-        vrf_pk,
-        margin_ratio,
-        cost_per_block,
-    )
+    PoolData::new(decommission_destination, pledged_amount, vrf_pk, margin_ratio, cost_per_block)
 }
 
 fn create_pool(
@@ -71,10 +65,8 @@ fn create_pool(
     pledged_amount: Amount,
 ) -> Result<(PoolId, PoolData, PoSAccountingUndo), Error> {
     let destination = new_pub_key_destination(rng);
-    let outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))),
-        0,
-    );
+    let outpoint =
+        UtxoOutPoint::new(OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))), 0);
     let pool_data = create_pool_data(rng, destination, pledged_amount);
     let pool_id = make_pool_id(&outpoint);
     op.create_pool(pool_id, pool_data.clone())
@@ -87,10 +79,8 @@ fn create_delegation_id(
     target_pool: PoolId,
 ) -> Result<(DelegationId, Destination, PoSAccountingUndo), Error> {
     let destination = new_pub_key_destination(rng);
-    let outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))),
-        0,
-    );
+    let outpoint =
+        UtxoOutPoint::new(OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))), 0);
     op.create_delegation_id(target_pool, destination.clone(), &outpoint)
         .map(|(id, undo)| (id, destination, undo))
 }
@@ -117,13 +107,7 @@ fn create_storage_with_pool_and_delegation(
     rng: &mut (impl Rng + CryptoRng),
     pledged_amount: Amount,
     delegated_amount: Amount,
-) -> (
-    PoolId,
-    PoolData,
-    DelegationId,
-    Destination,
-    InMemoryPoSAccounting,
-) {
+) -> (PoolId, PoolData, DelegationId, Destination, InMemoryPoSAccounting) {
     let pool_id = new_pool_id(rng.next_u64());
     let destination_pool = new_pub_key_destination(rng);
     let delegation_id = new_delegation_id(rng.next_u64());
@@ -135,10 +119,7 @@ fn create_storage_with_pool_and_delegation(
         BTreeMap::from([(pool_id, (pledged_amount + delegated_amount).unwrap())]),
         BTreeMap::from([((pool_id, delegation_id), delegated_amount)]),
         BTreeMap::from([(delegation_id, delegated_amount)]),
-        BTreeMap::from([(
-            delegation_id,
-            DelegationData::new(pool_id, destination_del.clone()),
-        )]),
+        BTreeMap::from([(delegation_id, DelegationData::new(pool_id, destination_del.clone()))]),
     );
     (pool_id, pool_data, delegation_id, destination_del, storage)
 }

--- a/pos_accounting/src/pool/tests/mod.rs
+++ b/pos_accounting/src/pool/tests/mod.rs
@@ -69,8 +69,7 @@ fn create_pool(
         UtxoOutPoint::new(OutPointSourceId::BlockReward(Id::new(H256::random_using(rng))), 0);
     let pool_data = create_pool_data(rng, destination, pledged_amount);
     let pool_id = make_pool_id(&outpoint);
-    op.create_pool(pool_id, pool_data.clone())
-        .map(|undo| (pool_id, pool_data, undo))
+    op.create_pool(pool_id, pool_data.clone()).map(|undo| (pool_id, pool_data, undo))
 }
 
 fn create_delegation_id(

--- a/pos_accounting/src/pool/tests/operations_tests.rs
+++ b/pos_accounting/src/pool/tests/operations_tests.rs
@@ -43,10 +43,8 @@ fn create_pool_twice(#[case] seed: Seed) {
     let mut storage = InMemoryPoSAccounting::new();
 
     let pledge_amount = Amount::from_atoms(100);
-    let outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))),
-        0,
-    );
+    let outpoint =
+        UtxoOutPoint::new(OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))), 0);
     let destination = new_pub_key_destination(&mut rng);
     let pool_data = create_pool_data(&mut rng, destination, pledge_amount);
     let pool_id = crate::make_pool_id(&outpoint);
@@ -191,10 +189,8 @@ fn create_delegation_twice(#[case] seed: Seed) {
     let pledge_amount = Amount::from_atoms(100);
     let (pool_id, _, mut storage) = create_storage_with_pool(&mut rng, pledge_amount);
 
-    let outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))),
-        0,
-    );
+    let outpoint =
+        UtxoOutPoint::new(OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))), 0);
     let destination = new_pub_key_destination(&mut rng);
 
     let mut db = PoSAccountingDB::new(&mut storage);
@@ -228,10 +224,8 @@ fn create_delegation_id_unknown_pool(#[case] seed: Seed) {
     let mut storage = InMemoryPoSAccounting::new();
 
     let destination = new_pub_key_destination(&mut rng);
-    let outpoint = UtxoOutPoint::new(
-        OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))),
-        0,
-    );
+    let outpoint =
+        UtxoOutPoint::new(OutPointSourceId::BlockReward(Id::new(H256::random_using(&mut rng))), 0);
     let pool_id = new_pool_id(rng.next_u64());
 
     {

--- a/pos_accounting/src/pool/tests/operations_tests.rs
+++ b/pos_accounting/src/pool/tests/operations_tests.rs
@@ -296,9 +296,7 @@ fn spend_share_unknown_id(#[case] seed: Seed) {
         let db = PoSAccountingDB::new(&mut storage);
         let mut delta = PoSAccountingDelta::new(&db);
         assert_eq!(
-            delta
-                .spend_share_from_delegation_id(delegation_id, delegated_amount)
-                .unwrap_err(),
+            delta.spend_share_from_delegation_id(delegation_id, delegated_amount).unwrap_err(),
             Error::InvariantErrorDelegationUndoFailedDataNotFound
         );
     }

--- a/pos_accounting/src/pool/tests/undo_tests.rs
+++ b/pos_accounting/src/pool/tests/undo_tests.rs
@@ -65,14 +65,8 @@ fn create_pool_check_undo_check(
     let pledged_amount = Amount::from_atoms(100);
     let (pool_id, pool_data, undo) = create_pool(rng, op, pledged_amount).unwrap();
 
-    assert_eq!(
-        op.get_pool_balance(pool_id).expect("ok").expect("some"),
-        pledged_amount
-    );
-    assert_eq!(
-        op.get_pool_data(pool_id).expect("ok").expect("some"),
-        pool_data
-    );
+    assert_eq!(op.get_pool_balance(pool_id).expect("ok").expect("some"), pledged_amount);
+    assert_eq!(op.get_pool_data(pool_id).expect("ok").expect("some"), pool_data);
     assert_eq!(op.get_pool_delegations_shares(pool_id).unwrap(), None);
 
     op.undo(undo).unwrap();
@@ -173,14 +167,8 @@ fn decommission_pool_check_undo_check(
 
     op.undo(undo).unwrap();
 
-    assert_eq!(
-        op.get_pool_balance(pool_id).expect("ok").expect("some"),
-        pledged_amount
-    );
-    assert_eq!(
-        op.get_pool_data(pool_id).expect("ok").expect("some"),
-        pool_data
-    );
+    assert_eq!(op.get_pool_balance(pool_id).expect("ok").expect("some"), pledged_amount);
+    assert_eq!(op.get_pool_data(pool_id).expect("ok").expect("some"), pool_data);
     assert_eq!(op.get_pool_delegations_shares(pool_id).expect("ok"), None);
 }
 
@@ -284,28 +272,16 @@ fn check_delegation_id(
         DelegationData::new(pool_id, del_pub_key)
     );
     assert_eq!(op.get_delegation_balance(delegation_id).expect("ok"), None);
-    assert_eq!(
-        op.get_pool_delegation_share(pool_id, delegation_id).expect("ok"),
-        None
-    );
+    assert_eq!(op.get_pool_delegation_share(pool_id, delegation_id).expect("ok"), None);
 
     op.undo(undo).unwrap();
 
     assert_eq!(op.get_delegation_data(delegation_id).expect("ok"), None);
 
-    assert_eq!(
-        op.get_pool_balance(pool_id).expect("ok").expect("some"),
-        pledged_amount
-    );
-    assert_eq!(
-        op.get_pool_data(pool_id).expect("ok").expect("some"),
-        pool_data
-    );
+    assert_eq!(op.get_pool_balance(pool_id).expect("ok").expect("some"), pledged_amount);
+    assert_eq!(op.get_pool_data(pool_id).expect("ok").expect("some"), pool_data);
     assert_eq!(op.get_delegation_balance(delegation_id).expect("ok"), None);
-    assert_eq!(
-        op.get_pool_delegation_share(pool_id, delegation_id).expect("ok"),
-        None
-    );
+    assert_eq!(op.get_pool_delegation_share(pool_id, delegation_id).expect("ok"), None);
 }
 
 #[rstest]
@@ -434,14 +410,8 @@ fn check_delegate_staking(
         op.get_delegation_data(delegation_id).expect("ok").expect("some"),
         DelegationData::new(pool_id, del_pub_key)
     );
-    assert_eq!(
-        op.get_pool_balance(pool_id).expect("ok").expect("some"),
-        pledged_amount
-    );
-    assert_eq!(
-        op.get_pool_data(pool_id).expect("ok").expect("some"),
-        pool_data
-    );
+    assert_eq!(op.get_pool_balance(pool_id).expect("ok").expect("some"), pledged_amount);
+    assert_eq!(op.get_pool_data(pool_id).expect("ok").expect("some"), pool_data);
     assert_eq!(op.get_delegation_balance(delegation_id).expect("ok"), None);
 }
 
@@ -468,10 +438,7 @@ fn delegate_staking_delta_flush_undo(#[case] seed: Seed) {
             BTreeMap::from([(pool_id, (pledged_amount + delegated_amount).unwrap())]),
             BTreeMap::from([((pool_id, delegation_id), delegated_amount)]),
             BTreeMap::from([(delegation_id, delegated_amount)]),
-            BTreeMap::from([(
-                delegation_id,
-                DelegationData::new(pool_id, del_pub_key.clone()),
-            )]),
+            BTreeMap::from([(delegation_id, DelegationData::new(pool_id, del_pub_key.clone()))]),
         );
         assert_eq!(storage, expected_storage);
         delta_undo
@@ -569,10 +536,7 @@ fn check_spend_share(
         op.get_pool_balance(pool_id).expect("ok").expect("some"),
         ((pledged_amount + delegated_amount).unwrap() - spent_amount).unwrap()
     );
-    assert_eq!(
-        op.get_pool_data(pool_id).expect("ok").expect("some"),
-        pool_data
-    );
+    assert_eq!(op.get_pool_data(pool_id).expect("ok").expect("some"), pool_data);
     assert_eq!(
         op.get_delegation_data(delegation_id).expect("ok").expect("some"),
         DelegationData::new(pool_id, del_pub_key.clone())
@@ -592,10 +556,7 @@ fn check_spend_share(
         op.get_pool_balance(pool_id).expect("ok").expect("some"),
         (pledged_amount + delegated_amount).unwrap()
     );
-    assert_eq!(
-        op.get_pool_data(pool_id).expect("ok").expect("some"),
-        pool_data
-    );
+    assert_eq!(op.get_pool_data(pool_id).expect("ok").expect("some"), pool_data);
     assert_eq!(
         op.get_delegation_data(delegation_id).expect("ok").expect("some"),
         DelegationData::new(pool_id, del_pub_key)
@@ -635,10 +596,7 @@ fn spend_share_delta_flush_undo(#[case] seed: Seed) {
                 (delegated_amount - spent_amount).unwrap(),
             )]),
             BTreeMap::from([(delegation_id, (delegated_amount - spent_amount).unwrap())]),
-            BTreeMap::from([(
-                delegation_id,
-                DelegationData::new(pool_id, del_pub_key.clone()),
-            )]),
+            BTreeMap::from([(delegation_id, DelegationData::new(pool_id, del_pub_key.clone()))]),
         );
         assert_eq!(storage, expected_storage);
         delta_undo

--- a/pos_accounting/src/storage/in_memory.rs
+++ b/pos_accounting/src/storage/in_memory.rs
@@ -80,11 +80,7 @@ impl InMemoryPoSAccounting {
         // pool_balance and pool_data must contain the same keys
         assert_eq!(self.pool_balances.len(), self.pool_data.len());
         self.pool_balances.keys().for_each(|key| {
-            assert!(
-                self.pool_data.contains_key(key),
-                "Pool data doesn't exist for {}",
-                key
-            )
+            assert!(self.pool_data.contains_key(key), "Pool data doesn't exist for {}", key)
         });
 
         // delegation_balance and delegation_data must contain the same keys
@@ -118,10 +114,7 @@ impl InMemoryPoSAccounting {
         });
 
         // delegation balances and delegation shares must contain the same amounts
-        assert_eq!(
-            self.delegation_balances.len(),
-            self.pool_delegation_shares.len()
-        );
+        assert_eq!(self.delegation_balances.len(), self.pool_delegation_shares.len());
         self.pool_delegation_shares.iter().for_each(|((_, key), balance)| {
             assert_eq!(
                 self.delegation_balances.get(key),

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -70,12 +70,7 @@ impl Builder {
         ws_bind_address: Option<SocketAddr>,
     ) -> Self {
         let methods = Methods::new();
-        Self {
-            http_bind_address,
-            ws_bind_address,
-            methods,
-            creds: None,
-        }
+        Self { http_bind_address, ws_bind_address, methods, creds: None }
     }
 
     /// New builder pre-populated with RPC info methods.
@@ -94,13 +89,8 @@ impl Builder {
             None
         };
 
-        Self {
-            http_bind_address,
-            ws_bind_address,
-            methods: Methods::new(),
-            creds,
-        }
-        .register(RpcInfo.into_rpc())
+        Self { http_bind_address, ws_bind_address, methods: Methods::new(), creds }
+            .register(RpcInfo.into_rpc())
     }
 
     /// Add methods handlers to the RPC server
@@ -173,11 +163,7 @@ impl Rpc {
             None => None,
         };
 
-        Ok(Self {
-            http,
-            websocket,
-            _creds: creds,
-        })
+        Ok(Self { http, websocket, _creds: creds })
     }
 
     pub fn http_address(&self) -> Option<&SocketAddr> {
@@ -250,10 +236,8 @@ pub type RpcHttpClient = HttpClient<SetRequestHeader<HttpBackend, RpcAuthData>>;
 pub type RpcWsClient = WsClient;
 
 pub fn new_http_client(host: String, rpc_auth: RpcAuthData) -> Result<RpcHttpClient> {
-    let middleware = tower::ServiceBuilder::new().layer(SetRequestHeaderLayer::overriding(
-        header::AUTHORIZATION,
-        rpc_auth,
-    ));
+    let middleware = tower::ServiceBuilder::new()
+        .layer(SetRequestHeaderLayer::overriding(header::AUTHORIZATION, rpc_auth));
 
     HttpClientBuilder::default().set_middleware(middleware).build(host)
 }
@@ -433,19 +417,13 @@ mod tests {
         // Valid requests
         http_request(
             &rpc,
-            RpcAuthData::Basic {
-                username: good_username.clone(),
-                password: good_password.clone(),
-            },
+            RpcAuthData::Basic { username: good_username.clone(), password: good_password.clone() },
         )
         .await
         .unwrap();
         ws_request(
             &rpc,
-            RpcAuthData::Basic {
-                username: good_username.clone(),
-                password: good_password.clone(),
-            },
+            RpcAuthData::Basic { username: good_username.clone(), password: good_password.clone() },
         )
         .await
         .unwrap();
@@ -456,37 +434,25 @@ mod tests {
 
         http_request(
             &rpc,
-            RpcAuthData::Basic {
-                username: good_username.clone(),
-                password: bad_password.clone(),
-            },
+            RpcAuthData::Basic { username: good_username.clone(), password: bad_password.clone() },
         )
         .await
         .unwrap_err();
         ws_request(
             &rpc,
-            RpcAuthData::Basic {
-                username: good_username.clone(),
-                password: bad_password.clone(),
-            },
+            RpcAuthData::Basic { username: good_username.clone(), password: bad_password.clone() },
         )
         .await
         .unwrap_err();
         http_request(
             &rpc,
-            RpcAuthData::Basic {
-                username: bad_username.clone(),
-                password: good_password.clone(),
-            },
+            RpcAuthData::Basic { username: bad_username.clone(), password: good_password.clone() },
         )
         .await
         .unwrap_err();
         ws_request(
             &rpc,
-            RpcAuthData::Basic {
-                username: bad_username.clone(),
-                password: good_password.clone(),
-            },
+            RpcAuthData::Basic { username: bad_username.clone(), password: good_password.clone() },
         )
         .await
         .unwrap_err();

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -77,17 +77,11 @@ impl Builder {
     ///
     /// If `creds` is set, basic HTTP authentication is required.
     pub fn new(rpc_config: RpcConfig, creds: Option<RpcCreds>) -> Self {
-        let http_bind_address = if *rpc_config.http_enabled {
-            Some(*rpc_config.http_bind_address)
-        } else {
-            None
-        };
+        let http_bind_address =
+            if *rpc_config.http_enabled { Some(*rpc_config.http_bind_address) } else { None };
 
-        let ws_bind_address = if *rpc_config.ws_enabled {
-            Some(*rpc_config.ws_bind_address)
-        } else {
-            None
-        };
+        let ws_bind_address =
+            if *rpc_config.ws_enabled { Some(*rpc_config.ws_bind_address) } else { None };
 
         Self { http_bind_address, ws_bind_address, methods: Methods::new(), creds }
             .register(RpcInfo.into_rpc())

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -308,10 +308,8 @@ mod tests {
             ws_enabled: ws.into(),
         };
 
-        let rpc = Builder::new(rpc_config, None)
-            .register(SubsystemRpcImpl.into_rpc())
-            .build()
-            .await?;
+        let rpc =
+            Builder::new(rpc_config, None).register(SubsystemRpcImpl.into_rpc()).build().await?;
 
         if http {
             let url = format!("http://{}", rpc.http_address().unwrap());

--- a/rpc/src/rpc_auth/mod.rs
+++ b/rpc/src/rpc_auth/mod.rs
@@ -37,11 +37,7 @@ pub struct RpcAuth {
 }
 
 const RPC_KDF_CONFIG: KdfConfig = KdfConfig::Argon2id {
-    config: Argon2Config {
-        m_cost_memory_size: 200,
-        t_cost_iterations: 10,
-        p_cost_parallelism: 2,
-    },
+    config: Argon2Config { m_cost_memory_size: 200, t_cost_iterations: 10, p_cost_parallelism: 2 },
     hash_length: match NonZeroUsize::new(32) {
         Some(v) => v,
         None => unreachable!(),
@@ -72,10 +68,7 @@ impl RpcAuth {
             hash_password(&mut make_true_rng(), RPC_KDF_CONFIG, password.as_bytes())
                 .expect("hash_password failed unexpectedly");
 
-        Self {
-            username: username.to_owned(),
-            password_hash,
-        }
+        Self { username: username.to_owned(), password_hash }
     }
 
     fn check_auth<B>(&self, request: &Request<B>) -> Result<bool, CheckError> {

--- a/rpc/src/rpc_creds.rs
+++ b/rpc/src/rpc_creds.rs
@@ -74,10 +74,7 @@ impl RpcCreds {
     ) -> Result<Self, RpcCredsError> {
         match (username, password) {
             (Some(username), Some(password)) => {
-                utils::ensure!(
-                    cookie_file.is_none(),
-                    RpcCredsError::InvalidCookieFileConfig
-                );
+                utils::ensure!(cookie_file.is_none(), RpcCredsError::InvalidCookieFileConfig);
                 Self::basic(username, password)
             }
 
@@ -93,11 +90,7 @@ impl RpcCreds {
                 write_file_atomically(&cookie_file, &cookie)
                     .map_err(|e| RpcCredsError::CookieFileIoError(cookie_file.clone(), e))?;
 
-                Ok(Self {
-                    username,
-                    password,
-                    cookie_file: Some(cookie_file),
-                })
+                Ok(Self { username, password, cookie_file: Some(cookie_file) })
             }
 
             _ => Err(RpcCredsError::InvalidUsernamePasswordConfig),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,6 +3,7 @@ hard_tabs = false
 tab_spaces = 4
 array_width = 80
 chain_width = 80
+use_small_heuristics = "Max"
 single_line_if_else_max_width = 50
 newline_style = "Unix"
 edition = "2021"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,6 @@ max_width = 100
 hard_tabs = false
 tab_spaces = 4
 use_small_heuristics = "Max"
-single_line_if_else_max_width = 50
 newline_style = "Unix"
 edition = "2021"
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,6 @@
 max_width = 100
 hard_tabs = false
 tab_spaces = 4
-array_width = 80
-chain_width = 80
 use_small_heuristics = "Max"
 single_line_if_else_max_width = 50
 newline_style = "Unix"

--- a/script/src/context.rs
+++ b/script/src/context.rs
@@ -127,18 +127,12 @@ pub mod testcontext {
     impl TestContext {
         /// New test context
         pub fn new(transaction: Vec<u8>) -> Self {
-            Self {
-                transaction,
-                block_height: 0,
-            }
+            Self { transaction, block_height: 0 }
         }
 
         /// New test context at particular block height
         pub fn new_at_height(transaction: Vec<u8>, block_height: u64) -> Self {
-            Self {
-                transaction,
-                block_height,
-            }
+            Self { transaction, block_height }
         }
     }
 

--- a/script/src/interpreter.rs
+++ b/script/src/interpreter.rs
@@ -295,10 +295,7 @@ pub fn run_script<'a, Ctx: Context>(
                             stack.push_bool(result);
                         }
                     }
-                    ensure!(
-                        !sig_opcode.is_verify() || stack.pop_bool()?,
-                        Error::VerifyFail
-                    );
+                    ensure!(!sig_opcode.is_verify() || stack.pop_bool()?, Error::VerifyFail);
                 }
                 opcodes::Class::ControlFlow(cf) => match cf {
                     opcodes::ControlFlow::OP_CODESEPARATOR => {
@@ -340,10 +337,7 @@ pub fn run_script<'a, Ctx: Context>(
             },
         }
 
-        ensure!(
-            (stack.len() + alt_stack.len()) <= Ctx::MAX_STACK_ELEMENTS,
-            Error::StackSize
-        );
+        ensure!((stack.len() + alt_stack.len()) <= Ctx::MAX_STACK_ELEMENTS, Error::StackSize);
         cur_instr_num = cur_instr_num.saturating_add(1);
     }
 

--- a/script/src/opcodes.rs
+++ b/script/src/opcodes.rs
@@ -894,10 +894,7 @@ impl PushData {
 impl Ordinary {
     /// Is this OP_*VERIFY?
     pub fn is_verify(self) -> bool {
-        matches!(
-            self,
-            Self::OP_VERIFY | Self::OP_EQUALVERIFY | Self::OP_NUMEQUALVERIFY
-        )
+        matches!(self, Self::OP_VERIFY | Self::OP_EQUALVERIFY | Self::OP_NUMEQUALVERIFY)
     }
 }
 

--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -195,10 +195,7 @@ impl Script {
 
     /// Generates P2PK-type of scriptPubkey
     pub fn new_p2pk(pubkey: &[u8]) -> Script {
-        Builder::new()
-            .push_slice(pubkey)
-            .push_opcode(opcodes::all::OP_CHECKSIG)
-            .into_script()
+        Builder::new().push_slice(pubkey).push_opcode(opcodes::all::OP_CHECKSIG).into_script()
     }
 
     /// Generates P2PKH-type of scriptPubkey
@@ -223,10 +220,7 @@ impl Script {
 
     /// Generates OP_RETURN-type of scriptPubkey for a given data
     pub fn new_op_return(data: &[u8]) -> Script {
-        Builder::new()
-            .push_opcode(opcodes::all::OP_RETURN)
-            .push_slice(data)
-            .into_script()
+        Builder::new().push_opcode(opcodes::all::OP_RETURN).push_slice(data).into_script()
     }
 
     /// The length in bytes of the script
@@ -851,26 +845,20 @@ mod test {
         let equal2 = Builder::from(vec![0x87]).push_verify().into_script();
         assert_eq!(format!("{equal2:x}"), "88");
 
-        let numequal = Builder::new()
-            .push_opcode(opcodes::all::OP_NUMEQUAL)
-            .push_verify()
-            .into_script();
+        let numequal =
+            Builder::new().push_opcode(opcodes::all::OP_NUMEQUAL).push_verify().into_script();
         assert_eq!(format!("{numequal:x}"), "9d");
         let numequal2 = Builder::from(vec![0x9c]).push_verify().into_script();
         assert_eq!(format!("{numequal2:x}"), "9d");
 
-        let checksig = Builder::new()
-            .push_opcode(opcodes::all::OP_CHECKSIG)
-            .push_verify()
-            .into_script();
+        let checksig =
+            Builder::new().push_opcode(opcodes::all::OP_CHECKSIG).push_verify().into_script();
         assert_eq!(format!("{checksig:x}"), "ad");
         let checksig2 = Builder::from(vec![0xac]).push_verify().into_script();
         assert_eq!(format!("{checksig2:x}"), "ad");
 
-        let checkmultisig = Builder::new()
-            .push_opcode(opcodes::all::OP_CHECKMULTISIG)
-            .push_verify()
-            .into_script();
+        let checkmultisig =
+            Builder::new().push_opcode(opcodes::all::OP_CHECKMULTISIG).push_verify().into_script();
         assert_eq!(format!("{checkmultisig:x}"), "af");
         let checkmultisig2 = Builder::from(vec![0xae]).push_verify().into_script();
         assert_eq!(format!("{checkmultisig2:x}"), "af");

--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -455,10 +455,7 @@ pub struct Instructions<'a> {
 
 impl<'a> Instructions<'a> {
     fn new(data: &'a [u8], enforce_minimal: bool) -> Self {
-        Instructions {
-            data,
-            enforce_minimal,
-        }
+        Instructions { data, enforce_minimal }
     }
 
     // Kill iterator so that it does not return an infinite stream of errors
@@ -834,10 +831,7 @@ mod test {
             .push_opcode(opcodes::all::OP_EQUALVERIFY)
             .push_opcode(opcodes::all::OP_CHECKSIG)
             .into_script();
-        assert_eq!(
-            &format!("{script:x}"),
-            "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac"
-        );
+        assert_eq!(&format!("{script:x}"), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
     }
 
     #[test]
@@ -933,14 +927,10 @@ mod test {
         assert!(!hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").is_provably_unspendable());
         assert!(!hex_script!("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").is_provably_unspendable());
         // p2pkhash
-        assert!(
-            !hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac")
-                .is_provably_unspendable(),
-        );
-        assert!(
-            hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
-                .is_provably_unspendable(),
-        );
+        assert!(!hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac")
+            .is_provably_unspendable(),);
+        assert!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
+            .is_provably_unspendable(),);
     }
 
     #[test]
@@ -957,10 +947,7 @@ mod test {
 
         let original = hex_script!("827651a0698faaa9a8a7a687");
         let json = serde_json::to_value(&original).unwrap();
-        assert_eq!(
-            json,
-            serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned())
-        );
+        assert_eq!(json, serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned()));
         let des = serde_json::from_value(json).unwrap();
         assert_eq!(original, des);
     }

--- a/serialization/core/tests/compatibility.rs
+++ b/serialization/core/tests/compatibility.rs
@@ -186,10 +186,8 @@ fn test_scale_version_compatibility_struct() {
     );
 
     let mut field_btree_map_string = BTreeMap::new();
-    field_btree_map_string.insert(
-        0xFF,
-        "The Adventure of Tom Sawyer is a novel by Mark Twain.".to_string(),
-    );
+    field_btree_map_string
+        .insert(0xFF, "The Adventure of Tom Sawyer is a novel by Mark Twain.".to_string());
 
     let mut field_btree_map_bytes = BTreeMap::new();
     field_btree_map_bytes.insert(0xFF, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/serialization/core/tests/complex_types.rs
+++ b/serialization/core/tests/complex_types.rs
@@ -263,10 +263,7 @@ fn test_scale_enums_with_single_variant() {
     dbg!(&enc);
     let dec = TestEnum6::decode_all(&mut &enc[..]).ok();
     assert!(&dec.is_some());
-    assert_eq!(
-        dec,
-        Some(TestEnum6::OnlyOneVariant("Hello, world!".to_string()))
-    );
+    assert_eq!(dec, Some(TestEnum6::OnlyOneVariant("Hello, world!".to_string())));
 
     #[derive(Encode, Decode, Debug, PartialEq, Eq)]
     enum TestEnum7 {

--- a/serialization/core/tests/containers.rs
+++ b/serialization/core/tests/containers.rs
@@ -100,14 +100,9 @@ fn test_scale_btree_map() {
             format!("Office Space {}", rng.gen::<u64>()),
             "Deals with real issues in the workplace.".to_string(),
         );
-        btree_map.insert(
-            format!("Pulp Fiction {}", rng.gen::<u64>()),
-            "Masterpiece.".to_string(),
-        );
-        btree_map.insert(
-            format!("The Godfather {}", rng.gen::<u64>()),
-            "Very enjoyable.".to_string(),
-        );
+        btree_map.insert(format!("Pulp Fiction {}", rng.gen::<u64>()), "Masterpiece.".to_string());
+        btree_map
+            .insert(format!("The Godfather {}", rng.gen::<u64>()), "Very enjoyable.".to_string());
         btree_map.insert(
             format!("The Blues Brothers {}", rng.gen::<u64>()),
             "Eye lyked it a lot.".to_string(),

--- a/serialization/core/tests/simple_types.rs
+++ b/serialization/core/tests/simple_types.rs
@@ -155,28 +155,19 @@ fn test_scale_numbers() {
     assert!(!enc.is_empty());
     let dec = SimpleWrapper::decode_all(&mut &enc[..]).ok();
     assert!(&dec.is_some());
-    assert_eq!(
-        dec,
-        Some(SimpleWrapper(-170141123460424235652481386091358552721i128))
-    );
+    assert_eq!(dec, Some(SimpleWrapper(-170141123460424235652481386091358552721i128)));
 
     let enc = SimpleWrapper::encode(&SimpleWrapper(10614612912676532892982561042679146832i128));
     assert!(!enc.is_empty());
     let dec = SimpleWrapper::decode_all(&mut &enc[..]).ok();
     assert!(&dec.is_some());
-    assert_eq!(
-        dec,
-        Some(SimpleWrapper(10614612912676532892982561042679146832i128))
-    );
+    assert_eq!(dec, Some(SimpleWrapper(10614612912676532892982561042679146832i128)));
 
     let enc = SimpleWrapper::encode(&SimpleWrapper(210614612912676532892982561042679146832u128));
     assert!(!enc.is_empty());
     let dec = SimpleWrapper::decode_all(&mut &enc[..]).ok();
     assert!(&dec.is_some());
-    assert_eq!(
-        dec,
-        Some(SimpleWrapper(210614612912676532892982561042679146832u128))
-    );
+    assert_eq!(dec, Some(SimpleWrapper(210614612912676532892982561042679146832u128)));
 
     let enc = SimpleWrapper::encode(&SimpleWrapper(0u128));
     assert!(!enc.is_empty());
@@ -345,12 +336,7 @@ fn test_scale_options() {
     assert!(!enc.is_empty());
     let dec = OptionWrapper::decode_all(&mut &enc[..]).ok();
     assert!(&dec.is_some());
-    assert_eq!(
-        dec,
-        Some(OptionWrapper::new(Some(
-            -170141123460424235652481386091358552721i128
-        )))
-    );
+    assert_eq!(dec, Some(OptionWrapper::new(Some(-170141123460424235652481386091358552721i128))));
 
     let enc = OptionWrapper::encode(&OptionWrapper::new(Some(
         170141123460424235652481386091358552721i128,
@@ -358,12 +344,7 @@ fn test_scale_options() {
     assert!(!enc.is_empty());
     let dec = OptionWrapper::decode_all(&mut &enc[..]).ok();
     assert!(&dec.is_some());
-    assert_eq!(
-        dec,
-        Some(OptionWrapper::new(Some(
-            170141123460424235652481386091358552721i128
-        )))
-    );
+    assert_eq!(dec, Some(OptionWrapper::new(Some(170141123460424235652481386091358552721i128))));
 
     let enc = OptionWrapper::encode(&OptionWrapper::new(Some(
         210614612912676532892982561042679146832u128,
@@ -371,12 +352,7 @@ fn test_scale_options() {
     assert!(!enc.is_empty());
     let dec = OptionWrapper::decode_all(&mut &enc[..]).ok();
     assert!(&dec.is_some());
-    assert_eq!(
-        dec,
-        Some(OptionWrapper::new(Some(
-            210614612912676532892982561042679146832u128
-        )))
-    );
+    assert_eq!(dec, Some(OptionWrapper::new(Some(210614612912676532892982561042679146832u128))));
 
     let enc = OptionWrapper::encode(&OptionWrapper::new(Some(0u128)));
     assert!(!enc.is_empty());
@@ -398,9 +374,7 @@ fn test_scale_options() {
     assert!(&dec.is_some());
     assert_eq!(
         dec,
-        Some(OptionWrapper::new(Some(TestEnum::TestField1(Some(
-            "any error message".to_string()
-        )))))
+        Some(OptionWrapper::new(Some(TestEnum::TestField1(Some("any error message".to_string())))))
     );
 
     let result = TestEnum::TestField2(Some(Box::new(Some("any error message".to_string()))));
@@ -410,9 +384,9 @@ fn test_scale_options() {
     assert!(&dec.is_some());
     assert_eq!(
         dec,
-        Some(OptionWrapper::new(Some(TestEnum::TestField2(Some(
-            Box::new(Some("any error message".to_string()))
-        )))))
+        Some(OptionWrapper::new(Some(TestEnum::TestField2(Some(Box::new(Some(
+            "any error message".to_string()
+        )))))))
     );
 }
 

--- a/serialization/src/extras/non_empty_vec.rs
+++ b/serialization/src/extras/non_empty_vec.rs
@@ -117,10 +117,7 @@ mod test {
     }
 
     fn test_back_and_forth(data: DataOrNoVec<u8>) {
-        assert_eq!(
-            DataOrNoVec::<u8>::decode_all(&mut data.encode().as_slice()),
-            Ok(data)
-        );
+        assert_eq!(DataOrNoVec::<u8>::decode_all(&mut data.encode().as_slice()), Ok(data));
     }
 
     #[test]

--- a/serialization/tagged/derive/src/direct.rs
+++ b/serialization/tagged/derive/src/direct.rs
@@ -61,13 +61,7 @@ impl<'a> VariantInfo<'a> {
     }
 
     fn first_ty(&self) -> &'_ syn::Type {
-        &self
-            .variant
-            .fields
-            .iter()
-            .next()
-            .expect("Each variant has to have at least 1 field")
-            .ty
+        &self.variant.fields.iter().next().expect("Each variant has to have at least 1 field").ty
     }
 }
 

--- a/serialization/tagged/derive/src/tagged.rs
+++ b/serialization/tagged/derive/src/tagged.rs
@@ -74,9 +74,8 @@ pub fn derive_tagged(ast: &syn::DeriveInput) -> TokenStream {
         }
     };
 
-    let where_clause = tag_type
-        .map(|ty| quote!(where #ty: ::serialization::tagged::Tagged))
-        .unwrap_or_default();
+    let where_clause =
+        tag_type.map(|ty| quote!(where #ty: ::serialization::tagged::Tagged)).unwrap_or_default();
 
     quote! {
         const _: () = {

--- a/serialization/tagged/src/derive_support.rs
+++ b/serialization/tagged/src/derive_support.rs
@@ -34,8 +34,7 @@ impl<'a, I: Input> Peekable<'a, I> {
 
     /// Peek the next byte
     pub fn peek(&mut self) -> Result<u8, crate::Error> {
-        self.init
-            .map_or_else(|| self.inner.read_byte().map(|b| *self.init.insert(b)), Ok)
+        self.init.map_or_else(|| self.inner.read_byte().map(|b| *self.init.insert(b)), Ok)
     }
 }
 

--- a/serialization/tagged/tests/derive.rs
+++ b/serialization/tagged/tests/derive.rs
@@ -96,10 +96,7 @@ fn gen_enum2() -> impl Strategy<Value = Enum2> {
     prop_oneof![
         Just(Enum2::X(Enum0::This)),
         gen_enum1().prop_map(Enum2::Y),
-        any::<[u8; 3]>().prop_map(|three_bytes| Enum2::Z {
-            tag: Tag,
-            three_bytes
-        }),
+        any::<[u8; 3]>().prop_map(|three_bytes| Enum2::Z { tag: Tag, three_bytes }),
     ]
 }
 
@@ -203,17 +200,8 @@ fn check_enum2_encoding() {
     }
     check(Enum2::X(Enum0::This), [55]);
     check(Enum2::Y(Enum1::The(258, String::new())), [42, 2, 1, 0]);
-    check(
-        Enum2::Y(Enum1::The(257, String::from("d"))),
-        [42, 1, 1, 4, 100],
-    );
-    check(
-        Enum2::Z {
-            tag: Tag,
-            three_bytes: [1, 2, 3],
-        },
-        [7, 1, 2, 3],
-    );
+    check(Enum2::Y(Enum1::The(257, String::from("d"))), [42, 1, 1, 4, 100]);
+    check(Enum2::Z { tag: Tag, three_bytes: [1, 2, 3] }, [7, 1, 2, 3]);
 }
 
 #[test]
@@ -226,17 +214,8 @@ fn check_enum2_decoding() {
     }
 
     check_ok([55], Enum2::X(Enum0::This));
-    check_ok(
-        [7, 8, 9, 10],
-        Enum2::Z {
-            tag: Tag,
-            three_bytes: [8, 9, 10],
-        },
-    );
-    check_ok(
-        [42, 1, 1, 4, 101],
-        Enum2::Y(Enum1::The(257, String::from("e"))),
-    );
+    check_ok([7, 8, 9, 10], Enum2::Z { tag: Tag, three_bytes: [8, 9, 10] });
+    check_ok([42, 1, 1, 4, 101], Enum2::Y(Enum1::The(257, String::from("e"))));
 
     check_err([]);
     check_err([0]);

--- a/storage/backend-test-suite/src/basic.rs
+++ b/storage/backend-test-suite/src/basic.rs
@@ -144,12 +144,7 @@ fn put_and_iterate_over_prefixes<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>
 
     // Check for a non-existent prefix
     assert_eq!(
-        store
-            .transaction_ro()
-            .unwrap()
-            .prefix_iter(MAPID.0, b"foo".to_vec())
-            .unwrap()
-            .next(),
+        store.transaction_ro().unwrap().prefix_iter(MAPID.0, b"foo".to_vec()).unwrap().next(),
         None,
     );
 
@@ -174,9 +169,8 @@ fn put_and_iterate_over_prefixes<B: Backend, F: BackendFn<B>>(backend_fn: Arc<F>
 // Check for items that are supposed to be present
 fn check_prefix<Tx: ReadOps>(dbtx: &Tx, prefix: Data, expected: &[(&str, &str)]) {
     let entries = dbtx.prefix_iter(MAPID.0, prefix).unwrap();
-    let expected = expected
-        .iter()
-        .map(|(x, y)| (Data::from(x.to_string()), Data::from(y.to_string())));
+    let expected =
+        expected.iter().map(|(x, y)| (Data::from(x.to_string()), Data::from(y.to_string())));
     assert!(entries.eq(expected));
 }
 

--- a/storage/core/src/adaptor/locking/mod.rs
+++ b/storage/core/src/adaptor/locking/mod.rs
@@ -64,10 +64,9 @@ impl<'tx, T: ReadOps> ReadOps for TxRw<'tx, T> {
     type PrefixIter<'i> = prefix_iter_rw::Iter<'i, T> where Self: 'i;
 
     fn get(&self, map_id: DbMapId, key: &[u8]) -> crate::Result<Option<Cow<[u8]>>> {
-        self.deltas[map_id].get(key).map_or_else(
-            || self.db.get(map_id, key),
-            |x| Ok(x.as_deref().map(|p| p.into())),
-        )
+        self.deltas[map_id]
+            .get(key)
+            .map_or_else(|| self.db.get(map_id, key), |x| Ok(x.as_deref().map(|p| p.into())))
     }
 
     fn prefix_iter(&self, map_id: DbMapId, prefix: Data) -> crate::Result<Self::PrefixIter<'_>> {
@@ -106,19 +105,13 @@ pub struct TransactionLockImpl<T> {
 
 impl<T> Clone for TransactionLockImpl<T> {
     fn clone(&self) -> Self {
-        Self {
-            db: sync::Arc::clone(&self.db),
-            num_maps: self.num_maps,
-        }
+        Self { db: sync::Arc::clone(&self.db), num_maps: self.num_maps }
     }
 }
 
 impl<T> utils::shallow_clone::ShallowClone for TransactionLockImpl<T> {
     fn shallow_clone(&self) -> Self {
-        Self {
-            db: self.db.shallow_clone(),
-            num_maps: self.num_maps.shallow_clone(),
-        }
+        Self { db: self.db.shallow_clone(), num_maps: self.num_maps.shallow_clone() }
     }
 }
 

--- a/storage/core/src/types.rs
+++ b/storage/core/src/types.rs
@@ -127,10 +127,7 @@ impl DbMapDesc {
 
     /// New DB map description with all details
     pub fn new_with_details(name: impl Into<String>, value_size_hint: Range<usize>) -> Self {
-        Self {
-            name: name.into(),
-            value_size_hint,
-        }
+        Self { name: name.into(), value_size_hint }
     }
 
     /// Get DB map name
@@ -176,10 +173,6 @@ pub mod construct {
 
     fn assert_names_unique(maps: &DbMapsData<DbMapDesc>) {
         let set: std::collections::BTreeSet<_> = maps.0.iter().map(|desc| &desc.name).collect();
-        assert_eq!(
-            set.len(),
-            maps.db_map_count().as_usize(),
-            "Duplicate map names found"
-        );
+        assert_eq!(set.len(), maps.db_map_count().as_usize(), "Duplicate map names found");
     }
 }

--- a/storage/lmdb/src/initial_map_size.rs
+++ b/storage/lmdb/src/initial_map_size.rs
@@ -28,9 +28,7 @@ impl InitialMapSize {
 
 impl From<MemSize> for InitialMapSize {
     fn from(initial_map_size: MemSize) -> Self {
-        Self {
-            initial_map_size: Some(initial_map_size),
-        }
+        Self { initial_map_size: Some(initial_map_size) }
     }
 }
 

--- a/storage/lmdb/src/lib.rs
+++ b/storage/lmdb/src/lib.rs
@@ -80,10 +80,8 @@ impl<Tx: lmdb::Transaction> backend::ReadOps for DbTx<'_, Tx> {
         map_id: DbMapId,
         prefix: Data,
     ) -> storage_core::Result<Self::PrefixIter<'_>> {
-        let cursor = self
-            .tx
-            .open_ro_cursor(self.backend.dbs[map_id])
-            .or_else(error::process_with_err)?;
+        let cursor =
+            self.tx.open_ro_cursor(self.backend.dbs[map_id]).or_else(error::process_with_err)?;
         let iter = if prefix.is_empty() {
             cursor.into_iter_start()
         } else {

--- a/storage/lmdb/src/lib.rs
+++ b/storage/lmdb/src/lib.rs
@@ -139,10 +139,7 @@ impl LmdbImpl {
         start_tx: impl FnOnce(&'a lmdb::Environment) -> Result<Tx, lmdb::Error>,
     ) -> storage_core::Result<DbTx<'a, Tx>> {
         // Make sure map token is acquired before starting the transaction below
-        Ok(DbTx {
-            tx: start_tx(&self.env).or_else(error::process_with_err)?,
-            backend: self,
-        })
+        Ok(DbTx { tx: start_tx(&self.env).or_else(error::process_with_err)?, backend: self })
     }
 
     fn schedule_map_resize(&self) {

--- a/storage/sqlite/src/lib.rs
+++ b/storage/sqlite/src/lib.rs
@@ -67,10 +67,7 @@ impl<'m> DbTx<'m> {
             .connection
             .lock()
             .map_err(|e| storage_core::error::Fatal::InternalError(e.to_string()))?;
-        let tx = DbTx {
-            connection,
-            queries: &sqlite.0.queries,
-        };
+        let tx = DbTx { connection, queries: &sqlite.0.queries };
         tx.connection.execute("BEGIN TRANSACTION", ()).map_err(process_sqlite_error)?;
         Ok(tx)
     }
@@ -227,9 +224,7 @@ pub struct Options {
 #[allow(clippy::derivable_impls)]
 impl Default for Options {
     fn default() -> Self {
-        Self {
-            disable_fsync: false,
-        }
+        Self { disable_fsync: false }
     }
 }
 
@@ -247,10 +242,7 @@ pub struct Sqlite {
 
 impl Sqlite {
     pub fn new_in_memory() -> Self {
-        Self {
-            backend: SqliteStorageMode::InMemory,
-            options: Default::default(),
-        }
+        Self { backend: SqliteStorageMode::InMemory, options: Default::default() }
     }
 
     /// New Sqlite database backend
@@ -262,10 +254,7 @@ impl Sqlite {
     }
 
     pub fn with_options(self, options: Options) -> Self {
-        Self {
-            backend: self.backend,
-            options,
-        }
+        Self { backend: self.backend, options }
     }
 
     fn open_db(self, desc: DbDesc) -> rusqlite::Result<Connection> {
@@ -345,9 +334,6 @@ impl backend::Backend for Sqlite {
 
         let connection = self.open_db(desc).map_err(process_sqlite_error)?;
 
-        Ok(SqliteImpl(Arc::new(SqliteConnection {
-            connection: Mutex::new(connection),
-            queries,
-        })))
+        Ok(SqliteImpl(Arc::new(SqliteConnection { connection: Mutex::new(connection), queries })))
     }
 }

--- a/storage/sqlite/src/lib.rs
+++ b/storage/sqlite/src/lib.rs
@@ -73,10 +73,8 @@ impl<'m> DbTx<'m> {
     }
 
     fn commit_transaction(&self) -> storage_core::Result<()> {
-        let _res = self
-            .connection
-            .execute("COMMIT TRANSACTION", ())
-            .map_err(process_sqlite_error)?;
+        let _res =
+            self.connection.execute("COMMIT TRANSACTION", ()).map_err(process_sqlite_error)?;
         Ok(())
     }
 }

--- a/storage/sqlite/tests/backend.rs
+++ b/storage/sqlite/tests/backend.rs
@@ -23,11 +23,8 @@ fn main() {
         let test_root = test_root.clone();
         move || {
             // Each test case gets its own subdirectory to avoid clashes
-            let db_file_path = test_root
-                .fresh_test_dir("unknown")
-                .as_ref()
-                .to_path_buf()
-                .join("database.sqlite");
+            let db_file_path =
+                test_root.fresh_test_dir("unknown").as_ref().to_path_buf().join("database.sqlite");
             Sqlite::new(db_file_path).with_options(storage_sqlite::Options { disable_fsync: true })
         }
     };

--- a/storage/sqlite/tests/backend.rs
+++ b/storage/sqlite/tests/backend.rs
@@ -28,9 +28,7 @@ fn main() {
                 .as_ref()
                 .to_path_buf()
                 .join("database.sqlite");
-            Sqlite::new(db_file_path).with_options(storage_sqlite::Options {
-                disable_fsync: true,
-            })
+            Sqlite::new(db_file_path).with_options(storage_sqlite::Options { disable_fsync: true })
         }
     };
 

--- a/storage/src/database/internal.rs
+++ b/storage/src/database/internal.rs
@@ -66,10 +66,7 @@ pub fn prefix_iter<DbMap: schema::DbMap, Tx: ReadOps>(
 ) -> crate::Result<impl '_ + EntryIterator<DbMap>> {
     dbtx.prefix_iter(map_id, prefix).map(|iter| {
         iter.map(|(k, v)| {
-            (
-                Encoded::from_bytes_unchecked(k).decode(),
-                Encoded::from_bytes_unchecked(v),
-            )
+            (Encoded::from_bytes_unchecked(k).decode(), Encoded::from_bytes_unchecked(v))
         })
     })
 }

--- a/storage/src/database/mod.rs
+++ b/storage/src/database/mod.rs
@@ -38,10 +38,7 @@ where
     B::Impl: ShallowClone,
 {
     fn clone(&self) -> Self {
-        Self {
-            backend: self.backend.clone(),
-            _schema: Default::default(),
-        }
+        Self { backend: self.backend.clone(), _schema: Default::default() }
     }
 }
 
@@ -50,10 +47,7 @@ where
     B::Impl: ShallowClone,
 {
     fn shallow_clone(&self) -> Self {
-        Self {
-            backend: self.backend.shallow_clone(),
-            _schema: self._schema.shallow_clone(),
-        }
+        Self { backend: self.backend.shallow_clone(), _schema: self._schema.shallow_clone() }
     }
 }
 
@@ -150,11 +144,7 @@ pub struct MapRef<'tx, Tx: TxImpl, DbMap: schema::DbMap> {
 impl<'tx, Tx: TxImpl, DbMap: schema::DbMap> MapRef<'tx, Tx, DbMap> {
     fn new(dbtx: &'tx Tx::Impl, map_id: DbMapId) -> Self {
         let _phantom = Default::default();
-        Self {
-            dbtx,
-            map_id,
-            _phantom,
-        }
+        Self { dbtx, map_id, _phantom }
     }
 }
 
@@ -203,11 +193,7 @@ pub struct MapMut<'tx, Tx: TxImpl, DbMap: schema::DbMap> {
 impl<'tx, Tx: TxImpl, DbMap: schema::DbMap> MapMut<'tx, Tx, DbMap> {
     fn new(dbtx: &'tx mut Tx::Impl, map_id: DbMapId) -> Self {
         let _phantom = Default::default();
-        Self {
-            dbtx,
-            map_id,
-            _phantom,
-        }
+        Self { dbtx, map_id, _phantom }
     }
 }
 

--- a/storage/src/database/raw.rs
+++ b/storage/src/database/raw.rs
@@ -72,9 +72,7 @@ impl<Sch: Schema> DbMapId<Sch> {
 
     /// Get index info
     pub fn info(&self) -> storage_core::DbMapDesc {
-        Sch::desc_iter()
-            .nth(self.idx.as_usize())
-            .expect("index to be in range due to schema")
+        Sch::desc_iter().nth(self.idx.as_usize()).expect("index to be in range due to schema")
     }
 
     /// Get map name at this index

--- a/storage/src/test.rs
+++ b/storage/src/test.rs
@@ -99,23 +99,15 @@ fn prefix_iteration() {
             values
         };
         let dbtx = store.transaction_ro().unwrap();
-        let items: Vec<_> = dbtx
-            .get::<Map2, _>()
-            .prefix_iter(&())
-            .unwrap()
-            .map(|(k, v)| (k, v.decode()))
-            .collect();
+        let items: Vec<_> =
+            dbtx.get::<Map2, _>().prefix_iter(&()).unwrap().map(|(k, v)| (k, v.decode())).collect();
         assert_eq!(items, test_values_sorted);
         dbtx.close();
 
         // Iterate over all decoded values
         let dbtx = store.transaction_ro().unwrap();
-        let items: Vec<_> = dbtx
-            .get::<Map2, _>()
-            .prefix_iter_decoded(&())
-            .unwrap()
-            .map(|(k, v)| (k, v))
-            .collect();
+        let items: Vec<_> =
+            dbtx.get::<Map2, _>().prefix_iter_decoded(&()).unwrap().map(|(k, v)| (k, v)).collect();
         assert_eq!(items, test_values_sorted);
         dbtx.close();
     });

--- a/subsystem/src/manager.rs
+++ b/subsystem/src/manager.rs
@@ -49,19 +49,13 @@ impl ManagerConfig {
     }
 
     pub fn new(name: &'static str, shutdown_timeout_per_subsystem: Option<Duration>) -> Self {
-        Self {
-            name,
-            shutdown_timeout_per_subsystem,
-        }
+        Self { name, shutdown_timeout_per_subsystem }
     }
 }
 
 impl Default for ManagerConfig {
     fn default() -> Self {
-        Self {
-            name: "<manager>",
-            shutdown_timeout_per_subsystem: Self::DEFAULT_SHUTDOWN_TIMEOUT,
-        }
+        Self { name: "<manager>", shutdown_timeout_per_subsystem: Self::DEFAULT_SHUTDOWN_TIMEOUT }
     }
 }
 
@@ -102,10 +96,7 @@ impl Manager {
 
     /// Initialize a new subsystem manager.
     pub fn new_with_config(config: ManagerConfig) -> Self {
-        let ManagerConfig {
-            name,
-            shutdown_timeout_per_subsystem,
-        } = config;
+        let ManagerConfig { name, shutdown_timeout_per_subsystem } = config;
         log::info!("Initializing subsystem manager {}", name);
 
         let (shutting_down_tx, shutting_down_rx) = mpsc::unbounded_channel();
@@ -185,11 +176,7 @@ impl Manager {
             // Perform the subsystem task.
             subsystem(call_rq, shutdown_rq).await;
         });
-        self.subsystems.push(SubsystemInfo {
-            name: subsys_name,
-            task,
-            shutdown_tx,
-        });
+        self.subsystems.push(SubsystemInfo { name: subsys_name, task, shutdown_tx });
 
         log::info!("Subsystem {}/{} initialized", manager_name, subsys_name);
 

--- a/subsystem/src/manager.rs
+++ b/subsystem/src/manager.rs
@@ -37,11 +37,8 @@ pub struct ManagerConfig {
 
 impl ManagerConfig {
     /// Default shutdown timeout.
-    const DEFAULT_SHUTDOWN_TIMEOUT: Option<Duration> = if cfg!(all(feature = "time", not(loom))) {
-        Some(Duration::from_secs(30))
-    } else {
-        None
-    };
+    const DEFAULT_SHUTDOWN_TIMEOUT: Option<Duration> =
+        if cfg!(all(feature = "time", not(loom))) { Some(Duration::from_secs(30)) } else { None };
 
     /// New config using given subsystem name. Other options are default.
     pub fn named(name: &'static str) -> Self {

--- a/subsystem/src/subsystem.rs
+++ b/subsystem/src/subsystem.rs
@@ -107,9 +107,7 @@ impl<T: ?Sized> Clone for Handle<T> {
 
 impl<T: ?Sized> ShallowClone for Handle<T> {
     fn shallow_clone(&self) -> Self {
-        Self {
-            action_tx: self.action_tx.clone(),
-        }
+        Self { action_tx: self.action_tx.clone() }
     }
 }
 
@@ -147,10 +145,9 @@ impl<T> std::future::Future for CallResult<T> {
     type Output = Result<T, CallError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        self.0.as_mut().map_or_else(
-            |err| task::Poll::Ready(Err(*err)),
-            |res| Pin::new(res).poll(cx),
-        )
+        self.0
+            .as_mut()
+            .map_or_else(|err| task::Poll::Ready(Err(*err)), |res| Pin::new(res).poll(cx))
     }
 }
 

--- a/subsystem/tests/async_calls.rs
+++ b/subsystem/tests/async_calls.rs
@@ -51,10 +51,7 @@ impl Counter {
     async fn bump(&mut self) -> Result<u64, CallError> {
         self.count += 1;
         let message = format!("Bumped counter to {}", self.count);
-        self.logger
-            .call(move |logger| logger.write(&message))
-            .await
-            .map(|()| self.count)
+        self.logger.call(move |logger| logger.write(&message)).await.map(|()| self.count)
     }
 }
 

--- a/subsystem/tests/blocking.rs
+++ b/subsystem/tests/blocking.rs
@@ -30,10 +30,7 @@ pub struct Tester {
 
 impl Tester {
     fn new(substringer: BlockingHandle<Substringer>, counter: BlockingHandle<Counter>) -> Self {
-        Self {
-            substringer,
-            counter,
-        }
+        Self { substringer, counter }
     }
 
     async fn run(self, _: CallRequest<()>, _shutdown: ShutdownRequest) {

--- a/subsystem/tests/passive.rs
+++ b/subsystem/tests/passive.rs
@@ -30,10 +30,7 @@ impl Tester {
         substringer: subsystem::Handle<Substringer>,
         counter: subsystem::Handle<Counter>,
     ) -> Self {
-        Self {
-            substringer,
-            counter,
-        }
+        Self { substringer, counter }
     }
 
     async fn run(&self, _: CallRequest<()>, _: ShutdownRequest) {

--- a/test-utils/src/test_dir.rs
+++ b/test-utils/src/test_dir.rs
@@ -104,10 +104,7 @@ impl TestRoot {
             }
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::AlreadyExists,
-            "All attempted directory names exist",
-        ))
+        Err(io::Error::new(io::ErrorKind::AlreadyExists, "All attempted directory names exist"))
     }
 
     /// Create the new test subdirectory

--- a/test-utils/tests/dir.rs
+++ b/test-utils/tests/dir.rs
@@ -19,8 +19,5 @@ use test_utils::test_dir::*;
 fn existing_dir_error() {
     pub const TARGET_TMPDIR: &str = env!("CARGO_TARGET_TMPDIR");
     // Target tmpdir should have been created by cargo, check we get the expected error code
-    assert_eq!(
-        try_create_dir(TARGET_TMPDIR).unwrap(),
-        DirCreationOutcome::AlreadyExists
-    );
+    assert_eq!(try_create_dir(TARGET_TMPDIR).unwrap(), DirCreationOutcome::AlreadyExists);
 }

--- a/test/runner/functional.rs
+++ b/test/runner/functional.rs
@@ -75,10 +75,7 @@ fn find_python_exe() -> PathBuf {
         .into_iter()
         .find_map(|exe| get_executable_path_from_path_env_var(format!("{exe}{file_suffix}")))
         .unwrap_or_else(|| {
-            panic!(
-                "Unable to find any of the executables {:?} in PATH",
-                possible_python_execs
-            )
+            panic!("Unable to find any of the executables {:?} in PATH", possible_python_execs)
         });
 
     println!("Found python executable in path: {}", python_exe.display());

--- a/utils/src/blockuntilzero.rs
+++ b/utils/src/blockuntilzero.rs
@@ -41,9 +41,7 @@ where
 {
     pub fn new() -> Self {
         let value: T = <T as Atomic>::Type::zero().into();
-        Self {
-            value: Arc::new(value),
-        }
+        Self { value: Arc::new(value) }
     }
 
     pub fn wait_for_zero(&self) {

--- a/utils/src/bloom_filters/bloom_filter.rs
+++ b/utils/src/bloom_filters/bloom_filter.rs
@@ -27,16 +27,14 @@ impl<T: Hash> BloomFilter<T> {
     pub fn new(size: usize, fpp: f64, rng: &mut impl Rng) -> Self {
         assert!(size > 0);
         assert!(fpp > 0.0 && fpp < 1.0);
-        Self(
-            probabilistic_collections::bloom::BloomFilter::<T>::with_hashers(
-                size,
-                fpp,
-                [
-                    SipHasherBuilder::from_seed(rng.gen(), rng.gen()),
-                    SipHasherBuilder::from_seed(rng.gen(), rng.gen()),
-                ],
-            ),
-        )
+        Self(probabilistic_collections::bloom::BloomFilter::<T>::with_hashers(
+            size,
+            fpp,
+            [
+                SipHasherBuilder::from_seed(rng.gen(), rng.gen()),
+                SipHasherBuilder::from_seed(rng.gen(), rng.gen()),
+            ],
+        ))
     }
 
     /// Inserts an element into the bloom filter

--- a/utils/src/bloom_filters/rolling_bloom_filter/cyclic_array.rs
+++ b/utils/src/bloom_filters/rolling_bloom_filter/cyclic_array.rs
@@ -21,10 +21,7 @@ pub struct CyclicArray<T, const SIZE: usize> {
 
 impl<T, const SIZE: usize> CyclicArray<T, SIZE> {
     pub fn new(list: [T; SIZE]) -> Self {
-        CyclicArray {
-            list,
-            current_index: SIZE - 1,
-        }
+        CyclicArray { list, current_index: SIZE - 1 }
     }
 
     /// Returns the latest inserted element

--- a/utils/src/const_value.rs
+++ b/utils/src/const_value.rs
@@ -44,9 +44,7 @@ impl<T> From<T> for ConstValue<T> {
 
 impl<T: Default> Default for ConstValue<T> {
     fn default() -> Self {
-        Self {
-            value: T::default(),
-        }
+        Self { value: T::default() }
     }
 }
 
@@ -66,9 +64,7 @@ impl<T: Copy> Copy for ConstValue<T> {}
 
 impl<T: Clone> Clone for ConstValue<T> {
     fn clone(&self) -> Self {
-        Self {
-            value: self.value.clone(),
-        }
+        Self { value: self.value.clone() }
     }
 }
 

--- a/utils/src/cookie.rs
+++ b/utils/src/cookie.rs
@@ -29,12 +29,10 @@ pub enum LoadCookieError {
 }
 
 pub fn load_cookie(path: impl AsRef<Path>) -> Result<(String, String), LoadCookieError> {
-    let content = std::fs::read_to_string(path.as_ref()).map_err(|e| LoadCookieError::Io {
-        source: e,
-        path: path.as_ref().to_owned(),
-    })?;
-    let (username, password) = content.split_once(':').ok_or_else(|| LoadCookieError::Format {
-        path: path.as_ref().to_owned(),
-    })?;
+    let content = std::fs::read_to_string(path.as_ref())
+        .map_err(|e| LoadCookieError::Io { source: e, path: path.as_ref().to_owned() })?;
+    let (username, password) = content
+        .split_once(':')
+        .ok_or_else(|| LoadCookieError::Format { path: path.as_ref().to_owned() })?;
     Ok((username.to_owned(), password.to_owned()))
 }

--- a/utils/src/counttracker.rs
+++ b/utils/src/counttracker.rs
@@ -33,10 +33,7 @@ where
     <T as Atomic>::Type: Zero,
 {
     pub fn new(source: Arc<T>) -> Self {
-        source.fetch_add(
-            <T as Atomic>::Type::one(),
-            std::sync::atomic::Ordering::Release,
-        );
+        source.fetch_add(<T as Atomic>::Type::one(), std::sync::atomic::Ordering::Release);
         Self { source }
     }
 
@@ -52,10 +49,8 @@ where
     <T as Atomic>::Type: Zero,
 {
     fn drop(&mut self) {
-        self.source.fetch_sub(
-            <T as Atomic>::Type::one(),
-            std::sync::atomic::Ordering::Release,
-        );
+        self.source
+            .fetch_sub(<T as Atomic>::Type::one(), std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/utils/src/counttracker.rs
+++ b/utils/src/counttracker.rs
@@ -49,8 +49,7 @@ where
     <T as Atomic>::Type: Zero,
 {
     fn drop(&mut self) {
-        self.source
-            .fetch_sub(<T as Atomic>::Type::one(), std::sync::atomic::Ordering::Release);
+        self.source.fetch_sub(<T as Atomic>::Type::one(), std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/utils/src/maybe_encrypted.rs
+++ b/utils/src/maybe_encrypted.rs
@@ -50,20 +50,13 @@ impl<T: Encode + DecodeAll> MaybeEncrypted<T> {
     }
 
     fn new_plain(value: &T) -> Self {
-        Self {
-            value: value.encode(),
-            _phantom: Default::default(),
-        }
+        Self { value: value.encode(), _phantom: Default::default() }
     }
 
     fn new_encrypted(value: &T, encryption_key: &SymmetricKey) -> Self {
         Self {
             value: encryption_key
-                .encrypt(
-                    Zeroizing::new(value.encode()).as_slice(),
-                    &mut make_true_rng(),
-                    None,
-                )
+                .encrypt(Zeroizing::new(value.encode()).as_slice(), &mut make_true_rng(), None)
                 .expect("should not fail"),
             _phantom: Default::default(),
         }
@@ -195,10 +188,7 @@ mod tests {
         let value = rng.gen::<u32>();
 
         let optional_key = if rng.gen::<bool>() {
-            Some(SymmetricKey::new(
-                SymmetricKeyKind::XChacha20Poly1305,
-                &mut rng,
-            ))
+            Some(SymmetricKey::new(SymmetricKeyKind::XChacha20Poly1305, &mut rng))
         } else {
             None
         };

--- a/utils/src/once_destructor.rs
+++ b/utils/src/once_destructor.rs
@@ -21,9 +21,7 @@ pub struct OnceDestructor<F: FnOnce()> {
 
 impl<F: FnOnce()> OnceDestructor<F> {
     pub fn new(call_on_drop: F) -> Self {
-        Self {
-            call_on_drop: Some(call_on_drop),
-        }
+        Self { call_on_drop: Some(call_on_drop) }
     }
 }
 

--- a/utils/src/qrcode.rs
+++ b/utils/src/qrcode.rs
@@ -202,10 +202,7 @@ mod tests {
             0, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0, 1,
             0, 1, 0, 0, 1, 0,
         ];
-        assert_eq!(
-            qr.as_vec().into_iter().map(|v| v as u32).collect::<Vec<_>>(),
-            expected
-        );
+        assert_eq!(qr.as_vec().into_iter().map(|v| v as u32).collect::<Vec<_>>(), expected);
 
         test_string_qrcode(&qr);
     }
@@ -238,10 +235,7 @@ mod tests {
             0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1,
             0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1,
         ];
-        assert_eq!(
-            qr.as_vec().into_iter().map(|v| v as u32).collect::<Vec<_>>(),
-            expected
-        );
+        assert_eq!(qr.as_vec().into_iter().map(|v| v as u32).collect::<Vec<_>>(), expected);
 
         test_string_qrcode(&qr);
     }

--- a/utils/typename-derive/src/lib.rs
+++ b/utils/typename-derive/src/lib.rs
@@ -20,13 +20,8 @@ use syn::{parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(TypeName)]
 pub fn derive(input: TokenStream) -> TokenStream {
-    let DeriveInput {
-        ident,
-        attrs: _attrs,
-        vis: _vis,
-        generics,
-        data: _data,
-    } = parse_macro_input!(input);
+    let DeriveInput { ident, attrs: _attrs, vis: _vis, generics, data: _data } =
+        parse_macro_input!(input);
     let output = if generics.params.is_empty() {
         let type_name = ident.to_string();
         quote! {

--- a/utils/typename/src/lib.rs
+++ b/utils/typename/src/lib.rs
@@ -69,10 +69,7 @@ mod tests {
 
     #[test]
     fn typename_with_custom_generic() {
-        assert_eq!(
-            TestType3::<TestType2>::typename_str(),
-            "TestType3<TestType2>"
-        );
+        assert_eq!(TestType3::<TestType2>::typename_str(), "TestType3<TestType2>");
     }
 
     #[derive(TypeName)]
@@ -82,10 +79,7 @@ mod tests {
 
     #[test]
     fn typename_with_derived_generic() {
-        assert_eq!(
-            TestType4::<TestType2>::typename_str(),
-            "TestType4<TestType2>"
-        );
+        assert_eq!(TestType4::<TestType2>::typename_str(), "TestType4<TestType2>");
     }
 
     #[test]
@@ -131,10 +125,7 @@ mod tests {
             B(String),
         }
 
-        assert_eq!(
-            TestType7::<TestType2>::typename_str(),
-            "TestType7<TestType2>"
-        );
+        assert_eq!(TestType7::<TestType2>::typename_str(), "TestType7<TestType2>");
     }
 
     #[test]

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -73,12 +73,7 @@ impl<P: UtxosView> UtxosCache<P> {
 
     pub fn new(parent: P) -> Result<Self, P::Error> {
         let current_block_hash = parent.best_block_hash()?;
-        Ok(UtxosCache {
-            parent,
-            current_block_hash,
-            utxos: BTreeMap::new(),
-            memory_usage: 0,
-        })
+        Ok(UtxosCache { parent, current_block_hash, utxos: BTreeMap::new(), memory_usage: 0 })
     }
 
     pub fn from_data(parent: P, utxos: ConsumedUtxoCache) -> Result<Self, P::Error> {
@@ -382,10 +377,7 @@ impl<P: UtxosView> UtxosCache<P> {
     }
 
     pub fn consume(self) -> ConsumedUtxoCache {
-        ConsumedUtxoCache {
-            container: self.utxos,
-            best_block: self.current_block_hash,
-        }
+        ConsumedUtxoCache { container: self.utxos, best_block: self.current_block_hash }
     }
 }
 

--- a/utxo/src/storage/in_memory.rs
+++ b/utxo/src/storage/in_memory.rs
@@ -31,11 +31,7 @@ pub struct UtxosDBInMemoryImpl {
 
 impl UtxosDBInMemoryImpl {
     pub fn new(best_block: Id<GenBlock>, initial_utxos: BTreeMap<UtxoOutPoint, Utxo>) -> Self {
-        Self {
-            store: initial_utxos,
-            undo_store: BTreeMap::new(),
-            best_block_id: best_block,
-        }
+        Self { store: initial_utxos, undo_store: BTreeMap::new(), best_block_id: best_block }
     }
 }
 

--- a/utxo/src/storage/mod.rs
+++ b/utxo/src/storage/mod.rs
@@ -75,9 +75,7 @@ impl<S: UtxosStorageWrite> UtxosDB<S> {
 
         let consumed_utxos_cache = utxos_cache.consume();
 
-        utxos_db
-            .batch_write(consumed_utxos_cache)
-            .expect("Writing genesis utxos failed");
+        utxos_db.batch_write(consumed_utxos_cache).expect("Writing genesis utxos failed");
     }
 }
 

--- a/utxo/src/storage/test.rs
+++ b/utxo/src/storage/test.rs
@@ -324,10 +324,7 @@ fn test_batch_write(#[case] seed: Seed) {
     let mut db_interface = UtxosDBInMemoryImpl::new(new_best_block_hash, Default::default());
     let mut utxo_db = UtxosDB::new(&mut db_interface);
 
-    let utxos = ConsumedUtxoCache {
-        container: utxos,
-        best_block: new_best_block_hash,
-    };
+    let utxos = ConsumedUtxoCache { container: utxos, best_block: new_best_block_hash };
 
     utxo_db.batch_write(utxos.clone()).unwrap();
 
@@ -363,10 +360,8 @@ fn try_flush_non_dirty_utxo(#[case] seed: Seed) {
     let entry = UtxoEntry::new(Some(utxo), IsFresh::No, IsDirty::No);
     map.insert(outpoint.clone(), entry);
 
-    let cache = ConsumedUtxoCache {
-        container: map,
-        best_block: Id::new(H256::random_using(&mut rng)),
-    };
+    let cache =
+        ConsumedUtxoCache { container: map, best_block: Id::new(H256::random_using(&mut rng)) };
 
     utxo_db.batch_write(cache).unwrap();
 
@@ -383,18 +378,14 @@ fn try_flush_spent_utxo(#[case] seed: Seed) {
         UtxosDBInMemoryImpl::new(Id::new(H256::random_using(&mut rng)), Default::default());
     let mut utxo_db = UtxosDB::new(&mut db_interface);
 
-    let outpoint = UtxoOutPoint::new(
-        OutPointSourceId::Transaction(Id::new(H256::random_using(&mut rng))),
-        0,
-    );
+    let outpoint =
+        UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::random_using(&mut rng))), 0);
     let mut map = BTreeMap::new();
     let entry = UtxoEntry::new(None, IsFresh::No, IsDirty::Yes);
     map.insert(outpoint.clone(), entry);
 
-    let cache = ConsumedUtxoCache {
-        container: map,
-        best_block: Id::new(H256::random_using(&mut rng)),
-    };
+    let cache =
+        ConsumedUtxoCache { container: map, best_block: Id::new(H256::random_using(&mut rng)) };
 
     utxo_db.batch_write(cache).unwrap();
 

--- a/utxo/src/storage/view_impls.rs
+++ b/utxo/src/storage/view_impls.rs
@@ -56,9 +56,7 @@ impl<S: UtxosStorageWrite> FlushableUtxoView for UtxosDB<S> {
                 };
             }
         }
-        self.0
-            .set_best_block_for_utxos(&utxos.best_block)
-            .map_err(|_| Error::StorageWrite)?;
+        self.0.set_best_block_for_utxos(&utxos.best_block).map_err(|_| Error::StorageWrite)?;
         Ok(())
     }
 }

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -531,9 +531,8 @@ fn multiple_update_utxos_test(#[case] seed: Seed) {
     // create a new transaction
     let new_tx = Transaction::new(0x00, to_spend.clone(), vec![]).expect("should succeed");
     // let's test `connect_transaction`
-    let tx_undo = cache
-        .connect_transaction(&new_tx, BlockHeight::new(2))
-        .expect("should return tx undo");
+    let tx_undo =
+        cache.connect_transaction(&new_tx, BlockHeight::new(2)).expect("should return tx undo");
 
     // check that these utxos came from the tx's output
     tx_undo.utxos().iter().for_each(|x| {
@@ -608,9 +607,7 @@ fn check_tx_spend_undo_spend(#[case] seed: Seed) {
     assert_eq!(undo1.utxos().len(), 1);
 
     //undo spending
-    cache
-        .disconnect_transaction(&tx, UtxosTxUndo::new(undo1.utxos().to_owned()))
-        .unwrap();
+    cache.disconnect_transaction(&tx, UtxosTxUndo::new(undo1.utxos().to_owned())).unwrap();
     assert!(cache.has_utxo_in_cache(&outpoint));
 
     //spend the transaction again
@@ -641,9 +638,7 @@ fn check_burn_spend_undo_spend(#[case] seed: Seed, #[case] output: TxOutput) {
     assert_eq!(undo1.utxos().len(), 1);
 
     //undo spending
-    cache
-        .disconnect_transaction(&tx, UtxosTxUndo::new(undo1.utxos().to_owned()))
-        .unwrap();
+    cache.disconnect_transaction(&tx, UtxosTxUndo::new(undo1.utxos().to_owned())).unwrap();
     assert!(cache.has_utxo_in_cache(&outpoint));
 
     //spend the transaction again
@@ -737,9 +732,7 @@ fn check_pow_reward_spend_undo_spend(#[case] seed: Seed) {
     assert!(undo1.is_none());
 
     //undo spending
-    cache
-        .disconnect_block_transactable(&reward, &block.get_id().into(), None)
-        .unwrap();
+    cache.disconnect_block_transactable(&reward, &block.get_id().into(), None).unwrap();
     assert!(!cache.has_utxo_in_cache(&outpoint));
 
     //spend the reward again
@@ -836,9 +829,7 @@ fn check_burn_output_in_block_reward(#[case] seed: Seed) {
     // spend the utxo in a block reward
     let block_id = block.get_id().into();
     assert_eq!(
-        cache
-            .connect_block_transactable(&reward, &block_id, BlockHeight::new(1))
-            .unwrap_err(),
+        cache.connect_block_transactable(&reward, &block_id, BlockHeight::new(1)).unwrap_err(),
         Error::InvalidBlockRewardOutputType(block_id)
     );
 }
@@ -869,9 +860,7 @@ fn check_burn_output_indexing(#[case] seed: Seed) {
     assert_eq!(undo1.utxos().len(), 1);
 
     //undo spending
-    cache
-        .disconnect_transaction(&tx, UtxosTxUndo::new(undo1.utxos().to_owned()))
-        .unwrap();
+    cache.disconnect_transaction(&tx, UtxosTxUndo::new(undo1.utxos().to_owned())).unwrap();
     assert!(cache.has_utxo_in_cache(&outpoint));
 
     //spend the transaction again
@@ -905,9 +894,7 @@ fn check_tx_spend_undo_spend_from_account(#[case] seed: Seed) {
     assert_eq!(cache.utxos.len(), 1);
 
     //undo spending
-    cache
-        .disconnect_transaction(&tx, UtxosTxUndo::new(undo1.utxos().to_owned()))
-        .unwrap();
+    cache.disconnect_transaction(&tx, UtxosTxUndo::new(undo1.utxos().to_owned())).unwrap();
     assert!(!cache.has_utxo_in_cache(&new_utxo_outpoint));
     assert!(cache.utxos.is_empty());
 

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -795,10 +795,7 @@ fn check_missing_reward_undo(#[case] seed: Seed) {
 
     // undo spending of block reward but miss reward_undo
     let res = cache.disconnect_block_transactable(&reward, &block.get_id().into(), None);
-    assert_eq!(
-        res,
-        Err(Error::MissingBlockRewardUndo(block.get_id().into()))
-    );
+    assert_eq!(res, Err(Error::MissingBlockRewardUndo(block.get_id().into())));
 }
 
 #[rstest]
@@ -863,10 +860,8 @@ fn check_burn_output_indexing(#[case] seed: Seed) {
     // create burn output at index 0
     let output1 = TxOutput::Burn(OutputValue::Coin(Amount::from_atoms(10)));
     // create transfer output at index 1
-    let output2 = TxOutput::Transfer(
-        OutputValue::Coin(Amount::from_atoms(10)),
-        Destination::AnyoneCanSpend,
-    );
+    let output2 =
+        TxOutput::Transfer(OutputValue::Coin(Amount::from_atoms(10)), Destination::AnyoneCanSpend);
     let input = TxInput::from_utxo(outpoint.tx_id(), outpoint.output_index());
     let tx = Transaction::new(0x00, vec![input], vec![output1, output2]).unwrap();
     let undo1 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();

--- a/utxo/src/tests/simulation.rs
+++ b/utxo/src/tests/simulation.rs
@@ -39,13 +39,8 @@ fn cache_simulation_test(
     let test_view = empty_test_utxos_view(common::primitives::H256::zero().into());
     let mut base = UtxosCache::new(test_view).unwrap_infallible();
 
-    let new_consumed_cache = simulation_step(
-        &mut rng,
-        &mut result,
-        &base,
-        iterations_per_cache,
-        nested_level,
-    );
+    let new_consumed_cache =
+        simulation_step(&mut rng, &mut result, &base, iterations_per_cache, nested_level);
     let new_consumed_cache = new_consumed_cache.unwrap();
     base.batch_write(new_consumed_cache).expect("batch write must succeed");
 
@@ -88,13 +83,8 @@ fn simulation_step<P: UtxosView<Error = Infallible>>(
     all_outputs.append(&mut current_cache_outputs);
 
     // create the child
-    let child_cache_op = simulation_step(
-        rng,
-        all_outputs,
-        &current_cache,
-        iterations_per_cache,
-        nested_level - 1,
-    );
+    let child_cache_op =
+        simulation_step(rng, all_outputs, &current_cache, iterations_per_cache, nested_level - 1);
 
     // flush child into current cache
     if let Some(child_cache) = child_cache_op {

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -97,9 +97,7 @@ fn simulation_step<P: UtxosView<Error = Infallible>>(
     let mut current_cache_outputs =
         populate_cache_with_undo(rng, &mut current_cache, iterations_per_cache, all_outputs);
     all_outputs.utxo_outpoints.append(&mut current_cache_outputs.utxo_outpoints);
-    all_outputs
-        .outpoints_with_undo
-        .append(&mut current_cache_outputs.outpoints_with_undo);
+    all_outputs.outpoints_with_undo.append(&mut current_cache_outputs.outpoints_with_undo);
 
     // create the child
     let child_cache_op =
@@ -141,9 +139,7 @@ fn populate_cache_with_undo<P: UtxosView<Error = Infallible>>(
                         false,
                     )
                     .unwrap();
-                result
-                    .utxo_outpoints
-                    .push(UtxoOutPoint::new(OutPointSourceId::from(block_id), 0));
+                result.utxo_outpoints.push(UtxoOutPoint::new(OutPointSourceId::from(block_id), 0));
             } else {
                 //spend random utxo in a transaction
 

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -55,13 +55,8 @@ fn cache_simulation_with_undo(
     let test_view = empty_test_utxos_view(H256::zero().into());
     let mut base = UtxosCache::new(test_view).unwrap_infallible();
 
-    let new_consumed_cache = simulation_step(
-        &mut rng,
-        &mut result,
-        &base,
-        iterations_per_cache,
-        nested_level,
-    );
+    let new_consumed_cache =
+        simulation_step(&mut rng, &mut result, &base, iterations_per_cache, nested_level);
     let new_consumed_cache = new_consumed_cache.unwrap();
     base.batch_write(new_consumed_cache).expect("batch write must succeed");
 
@@ -107,13 +102,8 @@ fn simulation_step<P: UtxosView<Error = Infallible>>(
         .append(&mut current_cache_outputs.outpoints_with_undo);
 
     // create the child
-    let child_cache_op = simulation_step(
-        rng,
-        all_outputs,
-        &current_cache,
-        iterations_per_cache,
-        nested_level - 1,
-    );
+    let child_cache_op =
+        simulation_step(rng, all_outputs, &current_cache, iterations_per_cache, nested_level - 1);
 
     // flush child into current cache
     if let Some(child_cache) = child_cache_op {
@@ -181,13 +171,9 @@ fn populate_cache_with_undo<P: UtxosView<Error = Infallible>>(
                 //keep result updated
                 let new_outpoint = UtxoOutPoint::new(OutPointSourceId::from(tx.get_id()), 0);
                 result.utxo_outpoints.push(new_outpoint.clone());
-                result.outpoints_with_undo.insert(
-                    new_outpoint,
-                    UndoInfo {
-                        prev_outpoint: outpoint,
-                        tx_undo: undo,
-                    },
-                );
+                result
+                    .outpoints_with_undo
+                    .insert(new_outpoint, UndoInfo { prev_outpoint: outpoint, tx_undo: undo });
             }
         } else if !result.outpoints_with_undo.is_empty() {
             //undo random transaction spending from current utxo set

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -165,10 +165,7 @@ impl UtxosBlockUndo {
     }
 
     fn get_parents_of(&self, tx_id: &Id<Transaction>) -> Vec<(Id<Transaction>, Id<Transaction>)> {
-        self.child_parent_dependencies
-            .range(Self::tx_children_range(tx_id))
-            .copied()
-            .collect()
+        self.child_parent_dependencies.range(Self::tx_children_range(tx_id)).copied().collect()
     }
 
     pub fn take_tx_undo(&mut self, tx_id: &Id<Transaction>) -> Option<UtxosTxUndo> {
@@ -213,16 +210,13 @@ impl UtxosBlockUndo {
         }
 
         // combine utxo
-        other
-            .tx_undos
-            .into_iter()
-            .try_for_each(|(id, u)| match self.tx_undos.entry(id) {
-                Entry::Vacant(e) => {
-                    e.insert(u);
-                    Ok(())
-                }
-                Entry::Occupied(_) => Err(UtxosBlockUndoError::UndoAlreadyExists(id)),
-            })?;
+        other.tx_undos.into_iter().try_for_each(|(id, u)| match self.tx_undos.entry(id) {
+            Entry::Vacant(e) => {
+                e.insert(u);
+                Ok(())
+            }
+            Entry::Occupied(_) => Err(UtxosBlockUndoError::UndoAlreadyExists(id)),
+        })?;
 
         // combine dependencies
         other.child_parent_dependencies.into_iter().try_for_each(|v| {

--- a/utxo/src/undo.rs
+++ b/utxo/src/undo.rs
@@ -77,10 +77,7 @@ pub struct UtxosTxUndoWithSources {
 
 impl UtxosTxUndoWithSources {
     pub fn new(utxos: Vec<Option<Utxo>>, sources: Vec<OutPointSourceId>) -> Self {
-        Self {
-            utxos: UtxosTxUndo::new(utxos),
-            sources,
-        }
+        Self { utxos: UtxosTxUndo::new(utxos), sources }
     }
 
     pub fn utxos(&self) -> &[Option<Utxo>] {

--- a/utxo/src/utxo.rs
+++ b/utxo/src/utxo.rs
@@ -56,17 +56,11 @@ impl Utxo {
     }
 
     pub fn new_for_blockchain(output: TxOutput, height: BlockHeight) -> Self {
-        Self {
-            output,
-            source: UtxoSource::Blockchain(height),
-        }
+        Self { output, source: UtxoSource::Blockchain(height) }
     }
 
     pub fn new_for_mempool(output: TxOutput) -> Self {
-        Self {
-            output,
-            source: UtxoSource::Mempool,
-        }
+        Self { output, source: UtxoSource::Mempool }
     }
 
     pub fn source(&self) -> &UtxoSource {

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -78,12 +78,7 @@ impl Account {
         let txs = db_tx.get_transactions(&key_chain.get_account_id())?;
         let output_cache = OutputCache::new(txs);
 
-        Ok(Account {
-            chain_config,
-            key_chain,
-            output_cache,
-            account_info,
-        })
+        Ok(Account { chain_config, key_chain, output_cache, account_info })
     }
 
     /// Create a new account by providing a key chain
@@ -107,12 +102,7 @@ impl Account {
 
         let output_cache = OutputCache::empty();
 
-        let mut account = Account {
-            chain_config,
-            key_chain,
-            output_cache,
-            account_info,
-        };
+        let mut account = Account { chain_config, key_chain, output_cache, account_info };
 
         account.scan_genesis(db_tx)?;
 
@@ -340,10 +330,8 @@ impl Account {
         db_tx: &impl WalletStorageReadUnlocked,
         median_time: BlockTimestamp,
     ) -> WalletResult<PoSGenerateBlockInputData> {
-        let utxos = self.get_utxos(
-            UtxoType::CreateStakePool | UtxoType::ProduceBlockFromStake,
-            median_time,
-        );
+        let utxos = self
+            .get_utxos(UtxoType::CreateStakePool | UtxoType::ProduceBlockFromStake, median_time);
         // TODO: Select by pool_id if there is more than one UTXO
         let (kernel_input_outpoint, (kernel_input_utxo, _token_id)) =
             utxos.into_iter().next().ok_or(WalletError::NoUtxos)?;
@@ -391,7 +379,7 @@ impl Account {
         let input_utxos = utxos.iter().map(Some).collect::<Vec<_>>();
         if utxos.len() != inputs.len() {
             return Err(
-                TransactionSigError::InvalidUtxoCountVsInputs(utxos.len(), inputs.len()).into(),
+                TransactionSigError::InvalidUtxoCountVsInputs(utxos.len(), inputs.len()).into()
             );
         }
 
@@ -548,10 +536,8 @@ impl Account {
         utxo_types: UtxoTypes,
         median_time: BlockTimestamp,
     ) -> BTreeMap<UtxoOutPoint, (&TxOutput, Option<TokenId>)> {
-        let current_block_info = BlockInfo {
-            height: self.account_info.best_block_height(),
-            timestamp: median_time,
-        };
+        let current_block_info =
+            BlockInfo { height: self.account_info.best_block_height(), timestamp: median_time };
         let mut all_outputs = self.output_cache.utxos_with_token_ids(current_block_info);
         all_outputs.retain(|_outpoint, (txo, _token_id)| {
             self.is_mine_or_watched(txo) && utxo_types.contains(get_utxo_type(txo))
@@ -642,10 +628,8 @@ impl Account {
             self.add_wallet_tx_if_relevant(db_tx, wallet_tx)?;
 
             for signed_tx in block.transactions() {
-                let wallet_tx = WalletTx::Tx(TxData::new(
-                    signed_tx.transaction().clone().into(),
-                    tx_state,
-                ));
+                let wallet_tx =
+                    WalletTx::Tx(TxData::new(signed_tx.transaction().clone().into(), tx_state));
                 self.add_wallet_tx_if_relevant(db_tx, wallet_tx)?;
             }
         }
@@ -661,10 +645,7 @@ impl Account {
     }
 
     pub fn best_block(&self) -> (Id<GenBlock>, BlockHeight) {
-        (
-            self.account_info.best_block_id(),
-            self.account_info.best_block_height(),
-        )
+        (self.account_info.best_block_id(), self.account_info.best_block_height())
     }
 
     pub fn has_transactions(&self) -> bool {

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -46,10 +46,7 @@ pub struct OutputCache {
 
 impl OutputCache {
     pub fn empty() -> Self {
-        Self {
-            txs: BTreeMap::new(),
-            consumed: BTreeSet::new(),
-        }
+        Self { txs: BTreeMap::new(), consumed: BTreeSet::new() }
     }
 
     pub fn new(txs: BTreeMap<AccountWalletTxId, WalletTx>) -> Self {

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -79,10 +79,7 @@ fn account_addresses_lookahead() {
         .unwrap();
     let mut account = Account::new(config, &mut db_tx, key_chain, None).unwrap();
 
-    assert_eq!(
-        account.key_chain.get_leaf_key_chain(ReceiveFunds).last_issued(),
-        None
-    );
+    assert_eq!(account.key_chain.get_leaf_key_chain(ReceiveFunds).last_issued(), None);
     let expected_last_derived =
         ChildNumber::from_index_with_hardened_bit(account.key_chain.lookahead_size() - 1);
     assert_eq!(
@@ -169,10 +166,7 @@ fn sign_transaction(#[case] seed: Seed) {
     let (_dest_prv, dest_pub) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
 
     let outputs = vec![
-        TxOutput::Transfer(
-            OutputValue::Coin(dest_amount),
-            Destination::PublicKey(dest_pub),
-        ),
+        TxOutput::Transfer(OutputValue::Coin(dest_amount), Destination::PublicKey(dest_pub)),
         TxOutput::LockThenTransfer(
             OutputValue::Coin(lock_amount),
             Destination::AnyoneCanSpend,

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -123,11 +123,7 @@ fn sign_transaction(#[case] seed: Seed) {
     let utxos: Vec<TxOutput> = amounts
         .iter()
         .map(|a| {
-            let purpose = if rng.gen_bool(0.5) {
-                ReceiveFunds
-            } else {
-                Change
-            };
+            let purpose = if rng.gen_bool(0.5) { ReceiveFunds } else { Change };
 
             TxOutput::Transfer(
                 OutputValue::Coin(*a),

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -45,9 +45,8 @@ fn account_addresses() {
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();
 
-    let key_chain = master_key_chain
-        .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
-        .unwrap();
+    let key_chain =
+        master_key_chain.create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX).unwrap();
 
     let mut account = Account::new(config, &mut db_tx, key_chain, None).unwrap();
     db_tx.commit().unwrap();
@@ -74,9 +73,8 @@ fn account_addresses_lookahead() {
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();
 
-    let key_chain = master_key_chain
-        .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
-        .unwrap();
+    let key_chain =
+        master_key_chain.create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX).unwrap();
     let mut account = Account::new(config, &mut db_tx, key_chain, None).unwrap();
 
     assert_eq!(account.key_chain.get_leaf_key_chain(ReceiveFunds).last_issued(), None);
@@ -112,9 +110,8 @@ fn sign_transaction(#[case] seed: Seed) {
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();
 
-    let key_chain = master_key_chain
-        .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
-        .unwrap();
+    let key_chain =
+        master_key_chain.create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX).unwrap();
     let mut account = Account::new(config.clone(), &mut db_tx, key_chain, None).unwrap();
 
     let amounts: Vec<Amount> = (0..(2 + rng.next_u32() % 5))

--- a/wallet/src/account/utxo_selector/mod.rs
+++ b/wallet/src/account/utxo_selector/mod.rs
@@ -474,10 +474,7 @@ fn select_coins_bnb(
         .ok_or(UtxoSelectorError::AmountArithmeticError)?;
 
     if curr_available_value < selection_target {
-        return Err(UtxoSelectorError::NotEnoughFunds(
-            curr_available_value,
-            selection_target,
-        ));
+        return Err(UtxoSelectorError::NotEnoughFunds(curr_available_value, selection_target));
     }
 
     // Sort the utxo_pool
@@ -644,10 +641,7 @@ pub fn select_coins(
         .ok_or(UtxoSelectorError::AmountArithmeticError)?;
 
     if total_available_value < selection_target {
-        return Err(UtxoSelectorError::NotEnoughFunds(
-            total_available_value,
-            selection_target,
-        ));
+        return Err(UtxoSelectorError::NotEnoughFunds(total_available_value, selection_target));
     }
 
     match select_coins_srd(
@@ -674,13 +668,7 @@ pub fn select_coins(
         Err(error) => errors.push(error),
     };
 
-    match select_coins_bnb(
-        utxo_pool,
-        selection_target,
-        cost_of_change,
-        max_weight,
-        pay_fees,
-    ) {
+    match select_coins_bnb(utxo_pool, selection_target, cost_of_change, max_weight, pay_fees) {
         Ok(result) => results.push(result),
         Err(error) => errors.push(error),
     };

--- a/wallet/src/account/utxo_selector/mod.rs
+++ b/wallet/src/account/utxo_selector/mod.rs
@@ -396,11 +396,8 @@ fn approximate_best_subset(
                 //that the rng is fast. We do not use a constant random sequence,
                 //because there may be some privacy improvement by making
                 //the selection random.
-                let rand_bool = if n_pass == 0 {
-                    rng.gen::<bool>()
-                } else {
-                    !current_solution_included[i]
-                };
+                let rand_bool =
+                    if n_pass == 0 { rng.gen::<bool>() } else { !current_solution_included[i] };
 
                 if rand_bool {
                     total = (total + group.get_effective_value(pay_fees))

--- a/wallet/src/account/utxo_selector/output_group.rs
+++ b/wallet/src/account/utxo_selector/output_group.rs
@@ -81,13 +81,7 @@ impl OutputGroup {
             }
         };
 
-        Ok(Self {
-            outputs: vec![output],
-            value,
-            fee,
-            long_term_fee,
-            weight,
-        })
+        Ok(Self { outputs: vec![output], value, fee, long_term_fee, weight })
     }
 
     pub fn get_effective_value(&self, pay_fees: PayFee) -> Amount {

--- a/wallet/src/key_chain/account_key_chain/mod.rs
+++ b/wallet/src/key_chain/account_key_chain/mod.rs
@@ -79,9 +79,7 @@ impl AccountKeyChain {
             chain_config.clone(),
             account_id,
             KeyPurpose::Change,
-            account_pubkey
-                .clone()
-                .derive_child(KeyPurpose::Change.get_deterministic_index())?,
+            account_pubkey.clone().derive_child(KeyPurpose::Change.get_deterministic_index())?,
         );
         change_key_chain.save_usage_state(db_tx)?;
 
@@ -250,9 +248,7 @@ impl AccountKeyChain {
 
     // Return true if the provided destination belongs to this key chain
     pub fn is_destination_mine(&self, destination: &Destination) -> bool {
-        KeyPurpose::ALL
-            .iter()
-            .any(|p| self.get_leaf_key_chain(*p).is_destination_mine(destination))
+        KeyPurpose::ALL.iter().any(|p| self.get_leaf_key_chain(*p).is_destination_mine(destination))
     }
 
     // Return true if the provided public key belongs to this key chain

--- a/wallet/src/key_chain/account_key_chain/tests.rs
+++ b/wallet/src/key_chain/account_key_chain/tests.rs
@@ -37,9 +37,8 @@ fn check_mine_methods(#[case] public: &str) {
 
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(chain_config, &mut db_tx, MNEMONIC, None).unwrap();
-    let mut key_chain = master_key_chain
-        .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
-        .unwrap();
+    let mut key_chain =
+        master_key_chain.create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX).unwrap();
     key_chain.top_up_all(&mut db_tx).unwrap();
     db_tx.commit().unwrap();
 

--- a/wallet/src/key_chain/leaf_key_chain/mod.rs
+++ b/wallet/src/key_chain/leaf_key_chain/mod.rs
@@ -164,9 +164,9 @@ impl LeafKeySoftChain {
                     .derive_child(KeyPurpose::ReceiveFunds.get_deterministic_index())?,
                 addresses.receive,
                 public_keys.receive,
-                usage_states.remove(&KeyPurpose::ReceiveFunds).ok_or(
-                    KeyChainError::MissingDatabaseProperty("ReceiveFunds usage state"),
-                )?,
+                usage_states
+                    .remove(&KeyPurpose::ReceiveFunds)
+                    .ok_or(KeyChainError::MissingDatabaseProperty("ReceiveFunds usage state"))?,
             )?,
             LeafKeySoftChain::new_from_parts(
                 chain_config,

--- a/wallet/src/key_chain/leaf_key_chain/mod.rs
+++ b/wallet/src/key_chain/leaf_key_chain/mod.rs
@@ -103,10 +103,8 @@ impl LeafKeySoftChain {
             .iter()
             .map(|(idx, xpub)| (xpub.clone().into_public_key(), *idx))
             .collect();
-        let public_key_hashes_to_index: BTreeMap<PublicKeyHash, ChildNumber> = public_keys_to_index
-            .iter()
-            .map(|(pk, idx)| (PublicKeyHash::from(pk), *idx))
-            .collect();
+        let public_key_hashes_to_index: BTreeMap<PublicKeyHash, ChildNumber> =
+            public_keys_to_index.iter().map(|(pk, idx)| (PublicKeyHash::from(pk), *idx)).collect();
 
         Ok(Self {
             chain_config,
@@ -267,11 +265,7 @@ impl LeafKeySoftChain {
         }
 
         // Derive the key
-        Ok(self
-            .parent_pubkey
-            .clone()
-            .take()
-            .derive_child(ChildNumber::from_normal(key_index))?)
+        Ok(self.parent_pubkey.clone().take().derive_child(ChildNumber::from_normal(key_index))?)
     }
 
     /// Derives and adds a key to his key chain. This does not affect the last used and issued state
@@ -304,12 +298,10 @@ impl LeafKeySoftChain {
         db_tx.set_address(&account_path_id, &address)?;
 
         // Add key and address the maps
-        self.derived_public_keys
-            .insert(ChildNumber::from_normal(key_index), derived_key.clone());
+        self.derived_public_keys.insert(ChildNumber::from_normal(key_index), derived_key.clone());
         self.addresses.insert(ChildNumber::from_normal(key_index), address);
         self.public_key_to_index.insert(public_key, ChildNumber::from_normal(key_index));
-        self.public_key_hash_to_index
-            .insert(public_key_hash, ChildNumber::from_normal(key_index));
+        self.public_key_hash_to_index.insert(public_key_hash, ChildNumber::from_normal(key_index));
 
         Ok(derived_key)
     }

--- a/wallet/src/key_chain/master_key_chain/mod.rs
+++ b/wallet/src/key_chain/master_key_chain/mod.rs
@@ -70,10 +70,7 @@ impl MasterKeyChain {
             return Err(KeyChainError::KeyNotRoot);
         }
 
-        let key_content = wallet_types::keys::RootKeys {
-            root_key,
-            root_vrf_key,
-        };
+        let key_content = wallet_types::keys::RootKeys { root_key, root_vrf_key };
 
         db_tx.set_root_key(&key_content)?;
 

--- a/wallet/src/key_chain/mod.rs
+++ b/wallet/src/key_chain/mod.rs
@@ -135,9 +135,7 @@ fn get_purpose_and_index(
 ) -> KeyChainResult<(KeyPurpose, ChildNumber)> {
     // Check that derivation path has the expected number of nodes
     if derivation_path.len() != BIP44_PATH_LENGTH {
-        return Err(KeyChainError::InvalidBip44DerivationPath(
-            derivation_path.clone(),
-        ));
+        return Err(KeyChainError::InvalidBip44DerivationPath(derivation_path.clone()));
     }
     let path = derivation_path.as_slice();
     // Calculate the key purpose and index

--- a/wallet/src/key_chain/mod.rs
+++ b/wallet/src/key_chain/mod.rs
@@ -104,11 +104,8 @@ type KeyChainResult<T> = Result<T, KeyChainError>;
 /// Create a deterministic path for an account identified by the `account_index`
 pub fn make_account_path(chain_config: &ChainConfig, account_index: U31) -> DerivationPath {
     // The path is m/44'/<coin_type>'/<account_index>'
-    let path = vec![
-        BIP44_PATH,
-        chain_config.bip44_coin_type(),
-        ChildNumber::from_hardened(account_index),
-    ];
+    let path =
+        vec![BIP44_PATH, chain_config.bip44_coin_type(), ChildNumber::from_hardened(account_index)];
     debug_assert!(path.iter().all(ChildNumber::is_hardened));
     path.try_into().expect("Path creation should not fail")
 }

--- a/wallet/src/key_chain/tests.rs
+++ b/wallet/src/key_chain/tests.rs
@@ -72,9 +72,8 @@ fn key_chain_creation(
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(chain_config, &mut db_tx, MNEMONIC, None).unwrap();
 
-    let mut key_chain = master_key_chain
-        .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
-        .unwrap();
+    let mut key_chain =
+        master_key_chain.create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX).unwrap();
     key_chain.top_up_all(&mut db_tx).unwrap();
     db_tx.commit().unwrap();
 
@@ -129,9 +128,8 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(chain_config.clone(), &mut db_tx, MNEMONIC, None)
             .unwrap();
-    let mut key_chain = master_key_chain
-        .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
-        .unwrap();
+    let mut key_chain =
+        master_key_chain.create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX).unwrap();
     db_tx.commit().unwrap();
 
     let id = key_chain.get_account_id();
@@ -199,9 +197,8 @@ fn top_up_and_lookahead(#[case] purpose: KeyPurpose) {
     let master_key_chain =
         MasterKeyChain::new_from_mnemonic(Arc::clone(&chain_config), &mut db_tx, MNEMONIC, None)
             .unwrap();
-    let key_chain = master_key_chain
-        .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
-        .unwrap();
+    let key_chain =
+        master_key_chain.create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX).unwrap();
     let id = key_chain.get_account_id();
     db_tx.commit().unwrap();
 
@@ -254,9 +251,7 @@ fn top_up_and_lookahead(#[case] purpose: KeyPurpose) {
     }
 
     // Mark the last key as used
-    assert!(key_chain
-        .mark_public_key_as_used(&mut db_tx, &issued_key.into_public_key())
-        .unwrap());
+    assert!(key_chain.mark_public_key_as_used(&mut db_tx, &issued_key.into_public_key()).unwrap());
 
     {
         let leaf_keys = key_chain.get_leaf_key_chain(purpose);

--- a/wallet/src/key_chain/tests.rs
+++ b/wallet/src/key_chain/tests.rs
@@ -144,10 +144,7 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
     for _ in 1..key_chain.lookahead_size() {
         last_address = key_chain.issue_address(&mut db_tx, purpose).unwrap();
     }
-    assert_eq!(
-        key_chain.issue_address(&mut db_tx, purpose),
-        Err(KeyChainError::LookAheadExceeded)
-    );
+    assert_eq!(key_chain.issue_address(&mut db_tx, purpose), Err(KeyChainError::LookAheadExceeded));
     db_tx.commit().unwrap();
 
     let account_info = AccountInfo::new(
@@ -176,10 +173,7 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
 
     let mut db_tx = db.transaction_rw(None).unwrap();
 
-    assert_eq!(
-        key_chain.issue_address(&mut db_tx, purpose),
-        Err(KeyChainError::LookAheadExceeded)
-    );
+    assert_eq!(key_chain.issue_address(&mut db_tx, purpose), Err(KeyChainError::LookAheadExceeded));
 
     key_chain
         .mark_public_key_hash_as_used(
@@ -192,10 +186,7 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
     for _ in 0..key_chain.lookahead_size() {
         key_chain.issue_address(&mut db_tx, purpose).unwrap();
     }
-    assert_eq!(
-        key_chain.issue_address(&mut db_tx, purpose),
-        Err(KeyChainError::LookAheadExceeded)
-    );
+    assert_eq!(key_chain.issue_address(&mut db_tx, purpose), Err(KeyChainError::LookAheadExceeded));
 }
 
 #[rstest]
@@ -253,14 +244,8 @@ fn top_up_and_lookahead(#[case] purpose: KeyPurpose) {
         let leaf_keys = key_chain.get_leaf_key_chain(purpose);
         let last_derived_idx = ChildNumber::from_index_with_hardened_bit(20);
         assert_eq!(leaf_keys.get_last_derived_index(), Some(last_derived_idx));
-        assert_eq!(
-            leaf_keys.usage_state().last_issued(),
-            Some(U31::from_u32(0).unwrap())
-        );
-        assert_eq!(
-            leaf_keys.usage_state().last_used(),
-            Some(U31::from_u32(0).unwrap())
-        );
+        assert_eq!(leaf_keys.usage_state().last_issued(), Some(U31::from_u32(0).unwrap()));
+        assert_eq!(leaf_keys.usage_state().last_used(), Some(U31::from_u32(0).unwrap()));
     }
 
     // Derive keys until lookahead
@@ -277,13 +262,7 @@ fn top_up_and_lookahead(#[case] purpose: KeyPurpose) {
         let leaf_keys = key_chain.get_leaf_key_chain(purpose);
         let last_derived_idx = ChildNumber::from_index_with_hardened_bit(40);
         assert_eq!(leaf_keys.get_last_derived_index(), Some(last_derived_idx));
-        assert_eq!(
-            leaf_keys.usage_state().last_issued(),
-            Some(U31::from_u32(20).unwrap())
-        );
-        assert_eq!(
-            leaf_keys.usage_state().last_used(),
-            Some(U31::from_u32(20).unwrap())
-        );
+        assert_eq!(leaf_keys.usage_state().last_issued(), Some(U31::from_u32(20).unwrap()));
+        assert_eq!(leaf_keys.usage_state().last_used(), Some(U31::from_u32(20).unwrap()));
     }
 }

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -61,10 +61,7 @@ pub fn make_address_output_token(
     let destination = Destination::Address(pub_key_hash);
 
     Ok(TxOutput::Transfer(
-        OutputValue::Token(Box::new(TokenData::TokenTransfer(TokenTransfer {
-            token_id,
-            amount,
-        }))),
+        OutputValue::Token(Box::new(TokenData::TokenTransfer(TokenTransfer { token_id, amount }))),
         destination,
     ))
 }
@@ -94,12 +91,7 @@ pub fn make_stake_output(
 
 impl SendRequest {
     pub fn new() -> Self {
-        Self {
-            flags: 0,
-            utxos: Vec::new(),
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-        }
+        Self { flags: 0, utxos: Vec::new(), inputs: Vec::new(), outputs: Vec::new() }
     }
 
     pub fn from_transaction(transaction: Transaction, utxos: Vec<TxOutput>) -> Self {

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -198,14 +198,7 @@ impl<B: storage::Backend> Wallet<B> {
             .map(|first_unsynced| accounts.split_off(&first_unsynced))
             .unwrap_or_default();
 
-        Ok(Wallet {
-            chain_config,
-            db,
-            key_chain,
-            accounts,
-            latest_median_time,
-            unsynced_accounts,
-        })
+        Ok(Wallet { chain_config, db, key_chain, accounts, latest_median_time, unsynced_accounts })
     }
 
     pub fn encrypt_wallet(&mut self, password: &Option<String>) -> WalletResult<()> {
@@ -237,10 +230,7 @@ impl<B: storage::Backend> Wallet<B> {
     }
 
     pub fn create_account(&mut self, name: Option<String>) -> WalletResult<(U31, Option<String>)> {
-        ensure!(
-            self.unsynced_accounts.is_empty(),
-            WalletError::LastAccountNotInSync
-        );
+        ensure!(self.unsynced_accounts.is_empty(), WalletError::LastAccountNotInSync);
 
         let next_account_index = self.accounts.last_key_value().map_or(
             Ok(U31::ZERO),
@@ -257,10 +247,7 @@ impl<B: storage::Backend> Wallet<B> {
             },
         )?;
 
-        ensure!(
-            name.as_ref().map_or(true, |name| !name.is_empty()),
-            WalletError::EmptyAccountName
-        );
+        ensure!(name.as_ref().map_or(true, |name| !name.is_empty()), WalletError::EmptyAccountName);
 
         let mut db_tx = self.db.transaction_rw_unlocked(None)?;
 

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -104,11 +104,8 @@ fn get_address(
     let address_priv_key = root_key
         .derive_absolute_path(&DerivationPath::try_from(address_path).unwrap())
         .unwrap();
-    Address::from_public_key(
-        chain_config,
-        &address_priv_key.to_public_key().into_public_key(),
-    )
-    .unwrap()
+    Address::from_public_key(chain_config, &address_priv_key.to_public_key().into_public_key())
+        .unwrap()
 }
 
 #[track_caller]
@@ -118,10 +115,7 @@ fn verify_wallet_balance(
     expected_balance: Amount,
 ) {
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -132,10 +126,7 @@ fn verify_wallet_balance(
     let db_copy = wallet.db.clone();
     let wallet = Wallet::load_wallet(Arc::clone(chain_config), db_copy).unwrap();
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -150,11 +141,7 @@ fn test_balance_from_genesis(
     utxos: Vec<TxOutput>,
     expected_balance: Amount,
 ) {
-    let genesis = Genesis::new(
-        String::new(),
-        BlockTimestamp::from_int_seconds(1639975460),
-        utxos,
-    );
+    let genesis = Genesis::new(String::new(), BlockTimestamp::from_int_seconds(1639975460), utxos);
     let chain_config = Arc::new(Builder::new(chain_type).genesis_custom(genesis).build());
 
     let db = create_wallet_in_memory().unwrap();
@@ -189,10 +176,8 @@ fn wallet_balance_genesis() {
     let chain_type = ChainType::Mainnet;
 
     let genesis_amount = Amount::from_atoms(12345);
-    let genesis_output = TxOutput::Transfer(
-        OutputValue::Coin(genesis_amount),
-        Destination::AnyoneCanSpend,
-    );
+    let genesis_output =
+        TxOutput::Transfer(OutputValue::Coin(genesis_amount), Destination::AnyoneCanSpend);
 
     test_balance_from_genesis(chain_type, vec![genesis_output.clone()], genesis_amount);
 
@@ -214,13 +199,8 @@ fn wallet_balance_genesis() {
     for purpose in KeyPurpose::ALL {
         for address_index in address_indexes {
             let address_index: U31 = address_index.try_into().unwrap();
-            let address = get_address(
-                &chain_config,
-                MNEMONIC,
-                DEFAULT_ACCOUNT_INDEX,
-                purpose,
-                address_index,
-            );
+            let address =
+                get_address(&chain_config, MNEMONIC, DEFAULT_ACCOUNT_INDEX, purpose, address_index);
 
             let genesis_amount = Amount::from_atoms(23456);
             let genesis_output = make_address_output(address, genesis_amount).unwrap();
@@ -241,10 +221,8 @@ fn locked_wallet_balance_works(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let chain_type = ChainType::Mainnet;
     let genesis_amount = Amount::from_atoms(rng.gen_range(1..10000));
-    let genesis_output = TxOutput::Transfer(
-        OutputValue::Coin(genesis_amount),
-        Destination::AnyoneCanSpend,
-    );
+    let genesis_output =
+        TxOutput::Transfer(OutputValue::Coin(genesis_amount), Destination::AnyoneCanSpend);
     let genesis = Genesis::new(
         String::new(),
         BlockTimestamp::from_int_seconds(1639975460),
@@ -256,10 +234,7 @@ fn locked_wallet_balance_works(#[case] seed: Seed) {
     let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -271,10 +246,7 @@ fn locked_wallet_balance_works(#[case] seed: Seed) {
     wallet.lock_wallet().unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -290,10 +262,7 @@ fn wallet_balance_block_reward() {
     let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -355,11 +324,7 @@ fn wallet_balance_block_reward() {
     let (best_block_id, best_block_height) = wallet.get_best_block().unwrap();
     assert_eq!(best_block_id, block2_id);
     assert_eq!(best_block_height, BlockHeight::new(2));
-    verify_wallet_balance(
-        &chain_config,
-        &wallet,
-        (block1_amount + block2_amount).unwrap(),
-    );
+    verify_wallet_balance(&chain_config, &wallet, (block1_amount + block2_amount).unwrap());
 
     // Create a new block to replace the second block
     let block2_amount_new = Amount::from_atoms(30000);
@@ -375,9 +340,7 @@ fn wallet_balance_block_reward() {
         block1_id.into(),
         chain_config.genesis_block().timestamp(),
         ConsensusData::None,
-        BlockReward::new(vec![
-            make_address_output(address, block2_amount_new).unwrap()
-        ]),
+        BlockReward::new(vec![make_address_output(address, block2_amount_new).unwrap()]),
     )
     .unwrap();
     let block2_new_id = block2_new.header().block_id();
@@ -387,11 +350,7 @@ fn wallet_balance_block_reward() {
     let (best_block_id, best_block_height) = wallet.get_best_block().unwrap();
     assert_eq!(best_block_id, block2_new_id);
     assert_eq!(best_block_height, BlockHeight::new(2));
-    verify_wallet_balance(
-        &chain_config,
-        &wallet,
-        (block1_amount + block2_amount_new).unwrap(),
-    );
+    verify_wallet_balance(&chain_config, &wallet, (block1_amount + block2_amount_new).unwrap());
 }
 
 #[test]
@@ -410,12 +369,9 @@ fn wallet_balance_block_transactions() {
         0.try_into().unwrap(),
     );
 
-    let transaction1 = Transaction::new(
-        0,
-        Vec::new(),
-        vec![make_address_output(address, tx_amount1).unwrap()],
-    )
-    .unwrap();
+    let transaction1 =
+        Transaction::new(0, Vec::new(), vec![make_address_output(address, tx_amount1).unwrap()])
+            .unwrap();
     let signed_transaction1 = SignedTransaction::new(transaction1, Vec::new()).unwrap();
     let block1 = Block::new(
         vec![signed_transaction1],
@@ -457,12 +413,9 @@ fn wallet_balance_parent_child_transactions() {
         1.try_into().unwrap(),
     );
 
-    let transaction1 = Transaction::new(
-        0,
-        Vec::new(),
-        vec![make_address_output(address1, tx_amount1).unwrap()],
-    )
-    .unwrap();
+    let transaction1 =
+        Transaction::new(0, Vec::new(), vec![make_address_output(address1, tx_amount1).unwrap()])
+            .unwrap();
     let transaction_id1 = transaction1.get_id();
     let signed_transaction1 = SignedTransaction::new(transaction1, Vec::new()).unwrap();
 
@@ -551,12 +504,7 @@ fn locked_wallet_accounts_creation_fail(#[case] seed: Seed) {
     wallet.lock_wallet().unwrap();
 
     let err = wallet.create_account(None);
-    assert_eq!(
-        err,
-        Err(WalletError::DatabaseError(
-            wallet_storage::Error::WalletLocked
-        ))
-    );
+    assert_eq!(err, Err(WalletError::DatabaseError(wallet_storage::Error::WalletLocked)));
 
     let name: String = (0..rng.gen_range(0..10)).map(|_| rng.gen::<char>()).collect();
 
@@ -584,10 +532,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
     let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -619,10 +564,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
     wallet.lock_wallet().unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -638,9 +580,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
 
     assert_eq!(
         wallet.create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output.clone()]),
-        Err(WalletError::DatabaseError(
-            wallet_storage::Error::WalletLocked
-        ))
+        Err(WalletError::DatabaseError(wallet_storage::Error::WalletLocked))
     );
 
     // success after unlock
@@ -683,9 +623,7 @@ fn lock_wallet_fail_empty_password() {
     let empty_password = Some(String::new());
     assert_eq!(
         wallet.encrypt_wallet(&empty_password),
-        Err(WalletError::DatabaseError(
-            wallet_storage::Error::WalletEmptyPassword
-        ))
+        Err(WalletError::DatabaseError(wallet_storage::Error::WalletEmptyPassword))
     );
 }
 
@@ -700,10 +638,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -724,9 +659,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         chain_config.genesis_block_id(),
         chain_config.genesis_block().timestamp(),
         ConsensusData::None,
-        BlockReward::new(vec![
-            make_address_output(address.clone(), block1_amount).unwrap()
-        ]),
+        BlockReward::new(vec![make_address_output(address.clone(), block1_amount).unwrap()]),
     )
     .unwrap();
 
@@ -736,10 +669,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     wallet.scan_new_blocks(BlockHeight::new(0), vec![block1]).unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -753,14 +683,12 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
 
     let token_amount_to_issue = Amount::from_atoms(rng.gen_range(1..amount_fraction));
     let new_output = TxOutput::Transfer(
-        OutputValue::Token(Box::new(TokenData::TokenIssuance(Box::new(
-            TokenIssuance {
-                token_ticker: "XXXX".as_bytes().to_vec(),
-                amount_to_issue: token_amount_to_issue,
-                number_of_decimals: rng.gen_range(1..18),
-                metadata_uri: "http://uri".as_bytes().to_vec(),
-            },
-        )))),
+        OutputValue::Token(Box::new(TokenData::TokenIssuance(Box::new(TokenIssuance {
+            token_ticker: "XXXX".as_bytes().to_vec(),
+            amount_to_issue: token_amount_to_issue,
+            number_of_decimals: rng.gen_range(1..18),
+            metadata_uri: "http://uri".as_bytes().to_vec(),
+        })))),
         Destination::Address(pkh),
     );
 
@@ -773,19 +701,14 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         block1_id.into(),
         block1_timestamp,
         ConsensusData::None,
-        BlockReward::new(vec![
-            make_address_output(address.clone(), block1_amount).unwrap()
-        ]),
+        BlockReward::new(vec![make_address_output(address.clone(), block1_amount).unwrap()]),
     )
     .unwrap();
 
     wallet.scan_new_blocks(BlockHeight::new(1), vec![block2]).unwrap();
 
     let currency_balances = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap();
     assert_eq!(
         currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
@@ -829,10 +752,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     wallet.scan_new_blocks(BlockHeight::new(2), vec![block3]).unwrap();
 
     let currency_balances = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap();
     assert_eq!(
         currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
@@ -849,10 +769,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let token_amount = token_balances
         .first()
         .map_or(Amount::ZERO, |(_token_id, token_amount)| *token_amount);
-    assert_eq!(
-        token_amount,
-        (token_amount_to_issue - tokens_to_transfer).expect("")
-    );
+    assert_eq!(token_amount, (token_amount_to_issue - tokens_to_transfer).expect(""));
 
     let not_enough_tokens_to_transfer =
         Amount::from_atoms(rng.gen_range(
@@ -893,10 +810,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
     let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -919,9 +833,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
         chain_config.genesis_block_id(),
         timestamp,
         ConsensusData::None,
-        BlockReward::new(vec![
-            make_address_output(address.clone(), block1_amount).unwrap()
-        ]),
+        BlockReward::new(vec![make_address_output(address.clone(), block1_amount).unwrap()]),
     )
     .unwrap();
 
@@ -933,10 +845,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
     wallet.scan_new_blocks(BlockHeight::new(0), vec![block1]).unwrap();
 
     let coin_balance = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()
@@ -979,10 +888,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
     wallet.scan_new_blocks(BlockHeight::new(1), vec![block2]).unwrap();
 
     let currency_balances = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap();
     let balance_without_locked_transer =
         (((block1_amount * 2).unwrap() - amount_to_lock_then_transfer).unwrap()
@@ -997,10 +903,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
     // check that for block_count_lock, the amount is not included
     for idx in 0..block_count_lock {
         let currency_balances = wallet
-            .get_balance(
-                DEFAULT_ACCOUNT_INDEX,
-                UtxoType::Transfer | UtxoType::LockThenTransfer,
-            )
+            .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
             .unwrap();
         assert_eq!(
             currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
@@ -1023,10 +926,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
 
     // check that after block_count_lock, the amount is included
     let currency_balances = wallet
-        .get_balance(
-            DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(DEFAULT_ACCOUNT_INDEX, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap();
     assert_eq!(
         currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
@@ -1090,20 +990,14 @@ fn wallet_sync_new_account(#[case] seed: Seed) {
     for block in blocks {
         // not yet synced
         let err = wallet.get_balance(new_account_index, UtxoType::Transfer.into()).err().unwrap();
-        assert_eq!(
-            err,
-            WalletError::AccountNotSyncedWithIndex(new_account_index)
-        );
+        assert_eq!(err, WalletError::AccountNotSyncedWithIndex(new_account_index));
 
         let (_, block_height) = wallet.get_best_block_for_unsynced_account().unwrap();
         wallet.scan_new_blocks_for_unsynced_account(block_height, vec![block]).unwrap();
     }
     // now both account are in sync and can be used
     let coin_balance = wallet
-        .get_balance(
-            new_account_index,
-            UtxoType::Transfer | UtxoType::LockThenTransfer,
-        )
+        .get_balance(new_account_index, UtxoType::Transfer | UtxoType::LockThenTransfer)
         .unwrap()
         .get(&Currency::Coin)
         .copied()

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -101,9 +101,8 @@ fn get_address(
     let mut address_path = make_account_path(chain_config, account_index).into_vec();
     address_path.push(purpose.get_deterministic_index());
     address_path.push(ChildNumber::from_normal(address_index));
-    let address_priv_key = root_key
-        .derive_absolute_path(&DerivationPath::try_from(address_path).unwrap())
-        .unwrap();
+    let address_priv_key =
+        root_key.derive_absolute_path(&DerivationPath::try_from(address_path).unwrap()).unwrap();
     Address::from_public_key(chain_config, &address_priv_key.to_public_key().into_public_key())
         .unwrap()
 }
@@ -586,9 +585,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
     // success after unlock
     wallet.unlock_wallet(&password.unwrap()).unwrap();
     if rng.gen::<bool>() {
-        wallet
-            .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
-            .unwrap();
+        wallet.create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output]).unwrap();
     } else {
         // check if we remove the password it should fail to lock
         wallet.encrypt_wallet(&None).unwrap();
@@ -608,9 +605,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
             .unwrap()
             .is_none());
 
-        wallet
-            .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
-            .unwrap();
+        wallet.create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output]).unwrap();
     }
 }
 
@@ -692,9 +687,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         Destination::Address(pkh),
     );
 
-    let token_issuance_transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
-        .unwrap();
+    let token_issuance_transaction =
+        wallet.create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output]).unwrap();
 
     let block2 = Block::new(
         vec![token_issuance_transaction],
@@ -737,9 +731,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         Destination::Address(some_other_address),
     );
 
-    let transfer_tokens_transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
-        .unwrap();
+    let transfer_tokens_transaction =
+        wallet.create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output]).unwrap();
 
     let block3 = Block::new(
         vec![transfer_tokens_transaction],
@@ -766,9 +759,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         })
         .collect_vec();
     assert!(token_balances.len() <= 1);
-    let token_amount = token_balances
-        .first()
-        .map_or(Amount::ZERO, |(_token_id, token_amount)| *token_amount);
+    let token_amount =
+        token_balances.first().map_or(Amount::ZERO, |(_token_id, token_amount)| *token_amount);
     assert_eq!(token_amount, (token_amount_to_issue - tokens_to_transfer).expect(""));
 
     let not_enough_tokens_to_transfer =
@@ -869,9 +861,8 @@ fn lock_then_transfer(#[case] seed: Seed) {
         timestamp,
     );
 
-    let lock_then_transfer_transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
-        .unwrap();
+    let lock_then_transfer_transaction =
+        wallet.create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output]).unwrap();
 
     let block2 = Block::new(
         vec![lock_then_transfer_transaction],

--- a/wallet/storage/src/internal/mod.rs
+++ b/wallet/storage/src/internal/mod.rs
@@ -141,10 +141,7 @@ impl<'tx, B: storage::Backend + 'tx> Transactional<'tx> for Store<B> {
     type TransactionRwUnlocked = StoreTxRwUnlocked<'tx, B>;
 
     fn transaction_ro<'st: 'tx>(&'st self) -> crate::Result<Self::TransactionRoLocked> {
-        self.storage
-            .transaction_ro()
-            .map_err(crate::Error::from)
-            .map(|tx| StoreTxRo::new(tx))
+        self.storage.transaction_ro().map_err(crate::Error::from).map(|tx| StoreTxRo::new(tx))
     }
 
     fn transaction_ro_unlocked<'st: 'tx>(&'st self) -> crate::Result<Self::TransactionRoUnlocked> {
@@ -162,10 +159,7 @@ impl<'tx, B: storage::Backend + 'tx> Transactional<'tx> for Store<B> {
         &'st self,
         size: Option<usize>,
     ) -> crate::Result<Self::TransactionRwLocked> {
-        self.storage
-            .transaction_rw(size)
-            .map_err(crate::Error::from)
-            .map(|tx| StoreTxRw::new(tx))
+        self.storage.transaction_rw(size).map_err(crate::Error::from).map(|tx| StoreTxRw::new(tx))
     }
 
     fn transaction_rw_unlocked<'st: 'tx>(

--- a/wallet/storage/src/internal/mod.rs
+++ b/wallet/storage/src/internal/mod.rs
@@ -48,10 +48,7 @@ impl<B: storage::Backend> Store<B> {
         let storage: storage::Storage<B, Schema> =
             storage::Storage::new(backend).map_err(crate::Error::from)?;
 
-        let mut storage = Self {
-            storage,
-            encryption_state: EncryptionState::Locked,
-        };
+        let mut storage = Self { storage, encryption_state: EncryptionState::Locked };
 
         let challenge = storage.transaction_ro()?.get_encryption_key_kdf_challenge()?;
         if challenge.is_none() {
@@ -133,10 +130,7 @@ where
     B::Impl: Clone,
 {
     fn clone(&self) -> Self {
-        Self {
-            storage: self.storage.clone(),
-            encryption_state: self.encryption_state.clone(),
-        }
+        Self { storage: self.storage.clone(), encryption_state: self.encryption_state.clone() }
     }
 }
 

--- a/wallet/storage/src/internal/password.rs
+++ b/wallet/storage/src/internal/password.rs
@@ -50,17 +50,11 @@ pub fn password_to_sym_key(password: &String) -> crate::Result<(SymmetricKey, Kd
     };
     let kdf_result = hash_password(&mut rng, config, password.as_bytes())
         .map_err(|_| crate::Error::WalletInvalidPassword)?;
-    let KdfResult::Argon2id {
-        hashed_password,
-        config: _,
-        salt: _,
-    } = &kdf_result;
+    let KdfResult::Argon2id { hashed_password, config: _, salt: _ } = &kdf_result;
 
-    let sym_key = SymmetricKey::from_raw_key(
-        SymmetricKeyKind::XChacha20Poly1305,
-        hashed_password.as_slice(),
-    )
-    .expect("must be correct size");
+    let sym_key =
+        SymmetricKey::from_raw_key(SymmetricKeyKind::XChacha20Poly1305, hashed_password.as_slice())
+            .expect("must be correct size");
 
     let challenge = kdf_result.into_challenge();
 
@@ -87,18 +81,13 @@ pub fn challenge_to_sym_key(
     password: &String,
     kdf_challenge: KdfChallenge,
 ) -> crate::Result<SymmetricKey> {
-    let KdfResult::Argon2id {
-        hashed_password,
-        salt: _,
-        config: _,
-    } = hash_from_challenge(kdf_challenge, password.as_bytes())
-        .map_err(|_| crate::Error::WalletInvalidPassword)?;
+    let KdfResult::Argon2id { hashed_password, salt: _, config: _ } =
+        hash_from_challenge(kdf_challenge, password.as_bytes())
+            .map_err(|_| crate::Error::WalletInvalidPassword)?;
 
-    let sym_key = SymmetricKey::from_raw_key(
-        SymmetricKeyKind::XChacha20Poly1305,
-        hashed_password.as_slice(),
-    )
-    .expect("must be correct size");
+    let sym_key =
+        SymmetricKey::from_raw_key(SymmetricKeyKind::XChacha20Poly1305, hashed_password.as_slice())
+            .expect("must be correct size");
 
     Ok(sym_key)
 }

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -371,10 +371,7 @@ macro_rules! impl_write_ops {
             }
 
             fn del_keychain_usage_state(&mut self, id: &AccountKeyPurposeId) -> crate::Result<()> {
-                self.storage
-                    .get_mut::<db::DBKeychainUsageStates, _>()
-                    .del(id)
-                    .map_err(Into::into)
+                self.storage.get_mut::<db::DBKeychainUsageStates, _>().del(id).map_err(Into::into)
             }
 
             fn set_public_key(
@@ -419,8 +416,7 @@ impl_write_ops!(StoreTxRwUnlocked);
 
 impl<'st, B: storage::Backend> WalletStorageEncryptionWrite for StoreTxRwUnlocked<'st, B> {
     fn set_encryption_kdf_challenge(&mut self, salt: &KdfChallenge) -> crate::Result<()> {
-        self.write_value::<well_known::EncryptionKeyKdfChallenge>(salt)
-            .map_err(Into::into)
+        self.write_value::<well_known::EncryptionKeyKdfChallenge>(salt).map_err(Into::into)
     }
     fn del_encryption_kdf_challenge(&mut self) -> crate::Result<()> {
         self.delete_value::<well_known::EncryptionKeyKdfChallenge>().map_err(Into::into)
@@ -455,10 +451,7 @@ impl<'st, B: storage::Backend> WalletStorageWriteUnlocked for StoreTxRwUnlocked<
     }
 
     fn del_root_key(&mut self) -> crate::Result<()> {
-        self.storage
-            .get_mut::<db::DBRootKeys, _>()
-            .del(&RootKeyConstant {})
-            .map_err(Into::into)
+        self.storage.get_mut::<db::DBRootKeys, _>().del(&RootKeyConstant {}).map_err(Into::into)
     }
 }
 

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -105,10 +105,7 @@ impl<'st, B: storage::Backend> StoreTxRoUnlocked<'st, B> {
         storage: storage::TransactionRo<'st, B, Schema>,
         encryption_key: &'st Option<SymmetricKey>,
     ) -> Self {
-        Self {
-            storage,
-            encryption_key,
-        }
+        Self { storage, encryption_key }
     }
 }
 
@@ -123,10 +120,7 @@ impl<'st, B: storage::Backend> StoreTxRwUnlocked<'st, B> {
         storage: storage::TransactionRw<'st, B, Schema>,
         encryption_key: &'st Option<SymmetricKey>,
     ) -> Self {
-        Self {
-            storage,
-            encryption_key,
-        }
+        Self { storage, encryption_key }
     }
 
     // Delete a value for a well-known entry
@@ -297,11 +291,9 @@ macro_rules! impl_read_unlocked_ops {
         /// Wallet data storage transaction
         impl<'st, B: storage::Backend> WalletStorageReadUnlocked for $TxType<'st, B> {
             fn get_root_key(&self) -> crate::Result<Option<RootKeys>> {
-                Ok(
-                    self.read::<db::DBRootKeys, _, _>(&RootKeyConstant {})?.map(|v| {
-                        v.try_take(self.encryption_key).expect("key was checked when unlocked")
-                    }),
-                )
+                Ok(self.read::<db::DBRootKeys, _, _>(&RootKeyConstant {})?.map(|v| {
+                    v.try_take(self.encryption_key).expect("key was checked when unlocked")
+                }))
             }
         }
     };

--- a/wallet/storage/src/internal/test.rs
+++ b/wallet/storage/src/internal/test.rs
@@ -57,10 +57,7 @@ fn compare_encrypt_and_decrypt_root_key(#[case] seed: Seed) {
             crypto::vrf::VRFKeyKind::Schnorrkel,
         )
         .unwrap();
-        let key_content = RootKeys {
-            root_key: xpriv_key,
-            root_vrf_key: vrf_key,
-        };
+        let key_content = RootKeys { root_key: xpriv_key, root_vrf_key: vrf_key };
         {
             let mut db_tx = store.transaction_rw_unlocked(None).unwrap();
             db_tx.set_root_key(&key_content).unwrap();

--- a/wallet/types/src/account_id.rs
+++ b/wallet/types/src/account_id.rs
@@ -46,10 +46,7 @@ pub struct AccountPrefixedId<Id> {
 
 impl<Id: Encode> AccountPrefixedId<Id> {
     pub fn new(account_id: AccountId, item_id: Id) -> AccountPrefixedId<Id> {
-        Self {
-            account_id,
-            item_id,
-        }
+        Self { account_id, item_id }
     }
 
     pub fn into_item_id(self) -> Id {

--- a/wallet/types/src/keys.rs
+++ b/wallet/types/src/keys.rs
@@ -83,10 +83,7 @@ pub struct KeychainUsageState {
 
 impl KeychainUsageState {
     pub fn new(last_used: Option<U31>, last_issued: Option<U31>) -> Self {
-        Self {
-            last_used,
-            last_issued,
-        }
+        Self { last_used, last_issued }
     }
 
     /// Get the last index used in the blockchain

--- a/wallet/wallet-cli-lib/src/lib.rs
+++ b/wallet/wallet-cli-lib/src/lib.rs
@@ -33,13 +33,9 @@ use tokio::sync::mpsc;
 use utils::{cookie::COOKIE_FILENAME, default_data_dir::default_data_dir_for_chain};
 
 enum Mode {
-    Interactive {
-        logger: repl::interactive::log::InteractiveLogger,
-    },
+    Interactive { logger: repl::interactive::log::InteractiveLogger },
     NonInteractive,
-    CommandsList {
-        file_input: console::FileInput,
-    },
+    CommandsList { file_input: console::FileInput },
 }
 
 pub async fn run(
@@ -87,9 +83,9 @@ pub async fn run(
                 default_data_dir_for_chain(chain_type.name()).join(COOKIE_FILENAME);
             RpcAuthData::Cookie { cookie_file_path }
         }
-        (Some(cookie_file_path), None, None) => RpcAuthData::Cookie {
-            cookie_file_path: cookie_file_path.into(),
-        },
+        (Some(cookie_file_path), None, None) => {
+            RpcAuthData::Cookie { cookie_file_path: cookie_file_path.into() }
+        }
         (None, Some(username), Some(password)) => RpcAuthData::Basic { username, password },
         _ => {
             return Err(WalletCliError::InvalidConfig(
@@ -121,10 +117,7 @@ pub async fn run(
     if start_staking {
         let (res_tx, res_rx) = tokio::sync::oneshot::channel();
         event_tx
-            .send(Event::HandleCommand {
-                command: WalletCommand::StartStaking,
-                res_tx,
-            })
+            .send(Event::HandleCommand { command: WalletCommand::StartStaking, res_tx })
             .expect("should not fail");
         startup_command_futures.push(res_rx);
     }

--- a/wallet/wallet-cli-lib/src/repl/interactive/key_bindings.rs
+++ b/wallet/wallet-cli-lib/src/repl/interactive/key_bindings.rs
@@ -40,9 +40,5 @@ pub fn add_menu_keybindings(keybindings: &mut Keybindings) {
         ]),
     );
 
-    keybindings.add_binding(
-        KeyModifiers::SHIFT,
-        KeyCode::BackTab,
-        ReedlineEvent::MenuPrevious,
-    );
+    keybindings.add_binding(KeyModifiers::SHIFT, KeyCode::BackTab, ReedlineEvent::MenuPrevious);
 }

--- a/wallet/wallet-cli-lib/src/repl/interactive/log.rs
+++ b/wallet/wallet-cli-lib/src/repl/interactive/log.rs
@@ -23,11 +23,7 @@ struct ReedlineLogWriter {
 
 impl ReedlineLogWriter {
     fn new(printer: reedline::ExternalPrinter<String>, print_directly: Arc<Mutex<bool>>) -> Self {
-        Self {
-            printer,
-            print_directly,
-            buf: Vec::new(),
-        }
+        Self { printer, print_directly, buf: Vec::new() }
     }
 }
 
@@ -76,10 +72,7 @@ impl InteractiveLogger {
 
         logging::init_logging_pipe(log_writer);
 
-        Self {
-            external_printer,
-            print_directly,
-        }
+        Self { external_printer, print_directly }
     }
 
     pub fn printer(&self) -> &reedline::ExternalPrinter<String> {

--- a/wallet/wallet-cli-lib/src/repl/interactive/mod.rs
+++ b/wallet/wallet-cli-lib/src/repl/interactive/mod.rs
@@ -136,25 +136,17 @@ pub fn run(
 ) -> Result<(), WalletCliError> {
     let repl_command = get_repl_command();
 
-    let mut line_editor = create_line_editor(
-        logger.printer().clone(),
-        repl_command.clone(),
-        history_file,
-        vi_mode,
-    )?;
+    let mut line_editor =
+        create_line_editor(logger.printer().clone(), repl_command.clone(), history_file, vi_mode)?;
 
     let mut prompt = wallet_prompt::WalletPrompt::new();
 
     // first wait for the results of any startup command before processing the rest
     for res_rx in startup_command_futures {
         let res = res_rx.blocking_recv().expect("Channel must be open");
-        if let Some(value) = handle_response(
-            res.map(Some),
-            &mut console,
-            &mut prompt,
-            &mut line_editor,
-            true,
-        ) {
+        if let Some(value) =
+            handle_response(res.map(Some), &mut console, &mut prompt, &mut line_editor, true)
+        {
             return value;
         }
     }
@@ -169,13 +161,9 @@ pub fn run(
 
         let res = process_line(&repl_command, &event_tx, sig);
 
-        if let Some(value) = handle_response(
-            res,
-            &mut console,
-            &mut prompt,
-            &mut line_editor,
-            exit_on_error,
-        ) {
+        if let Some(value) =
+            handle_response(res, &mut console, &mut prompt, &mut line_editor, exit_on_error)
+        {
             return value;
         }
     }
@@ -192,10 +180,7 @@ fn handle_response(
         Ok(Some(ConsoleCommand::Print(text))) => {
             console.print_line(&text);
         }
-        Ok(Some(ConsoleCommand::SetStatus {
-            status,
-            print_message,
-        })) => {
+        Ok(Some(ConsoleCommand::SetStatus { status, print_message })) => {
             prompt.set_status(status);
             console.print_line(&print_message);
         }

--- a/wallet/wallet-cli-lib/src/repl/interactive/wallet_prompt.rs
+++ b/wallet/wallet-cli-lib/src/repl/interactive/wallet_prompt.rs
@@ -26,9 +26,7 @@ pub struct WalletPrompt {
 
 impl WalletPrompt {
     pub fn new() -> Self {
-        WalletPrompt {
-            prompt_left: "Wallet".into(),
-        }
+        WalletPrompt { prompt_left: "Wallet".into() }
     }
     pub fn set_status(&mut self, status: String) {
         self.prompt_left = format!("Wallet{}", status);
@@ -61,9 +59,6 @@ impl Prompt for WalletPrompt {
             PromptHistorySearchStatus::Failing => "failing ",
         };
 
-        Cow::Owned(format!(
-            "({}reverse-search: {}) ",
-            prefix, history_search.term
-        ))
+        Cow::Owned(format!("({}reverse-search: {}) ", prefix, history_search.term))
     }
 }

--- a/wallet/wallet-cli-lib/src/repl/mod.rs
+++ b/wallet/wallet-cli-lib/src/repl/mod.rs
@@ -83,8 +83,6 @@ fn run_command_blocking(
     command: WalletCommand,
 ) -> Result<ConsoleCommand, WalletCliError> {
     let (res_tx, res_rx) = tokio::sync::oneshot::channel();
-    event_tx
-        .send(Event::HandleCommand { command, res_tx })
-        .expect("Channel must be open");
+    event_tx.send(Event::HandleCommand { command, res_tx }).expect("Channel must be open");
     res_rx.blocking_recv().expect("Channel must be open")
 }

--- a/wallet/wallet-cli-lib/src/repl/non_interactive/mod.rs
+++ b/wallet/wallet-cli-lib/src/repl/non_interactive/mod.rs
@@ -55,10 +55,9 @@ fn to_line_output(
 ) -> Result<LineOutput, WalletCliError> {
     match command_output {
         ConsoleCommand::Print(text) => Ok(LineOutput::Print(text)),
-        ConsoleCommand::SetStatus {
-            status: _,
-            print_message,
-        } => Ok(LineOutput::Print(print_message)),
+        ConsoleCommand::SetStatus { status: _, print_message } => {
+            Ok(LineOutput::Print(print_message))
+        }
         ConsoleCommand::ClearScreen
         | ConsoleCommand::PrintHistory
         | ConsoleCommand::ClearHistory => Err(WalletCliError::InvalidInput(format!(

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -61,10 +61,7 @@ struct MockConsole {
 impl MockConsole {
     fn new(input: &[&str]) -> Self {
         let input = input.iter().map(|&s| s.to_owned()).collect();
-        MockConsole {
-            input: Arc::new(Mutex::new(input)),
-            output: Default::default(),
-        }
+        MockConsole { input: Arc::new(Mutex::new(input)), output: Default::default() }
     }
 }
 
@@ -150,10 +147,7 @@ fn create_chain_config(rng: &mut impl Rng) -> ChainConfig {
     let genesis = create_custom_regtest_genesis(rng);
     let pos_config = create_unittest_pos_config();
     let upgrades = vec![
-        (
-            BlockHeight::new(0),
-            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
-        ),
+        (BlockHeight::new(0), UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus)),
         (
             BlockHeight::new(1),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
@@ -219,11 +213,8 @@ async fn start_node(chain_config: Arc<ChainConfig>) -> (subsystem::Manager, Sock
 
     let chainstate = manager.add_subsystem("wallet-cli-test-chainstate", chainstate);
 
-    let mempool = mempool::make_mempool(
-        Arc::clone(&chain_config),
-        chainstate.clone(),
-        Default::default(),
-    );
+    let mempool =
+        mempool::make_mempool(Arc::clone(&chain_config), chainstate.clone(), Default::default());
     let mempool = manager.add_subsystem_with_custom_eventloop("wallet-cli-test-mempool", {
         move |call, shutdn| mempool.run(call, shutdn)
     });
@@ -255,10 +246,7 @@ async fn start_node(chain_config: Arc<ChainConfig>) -> (subsystem::Manager, Sock
     );
 
     let rpc = rpc::Builder::new(rpc_config, Some(rpc_creds))
-        .register(node_lib::rpc::init(
-            manager.make_shutdown_trigger(),
-            chain_config,
-        ))
+        .register(node_lib::rpc::init(manager.make_shutdown_trigger(), chain_config))
         .register(block_prod.clone().into_rpc())
         .register(chainstate.clone().into_rpc())
         .register(mempool.clone().into_rpc())
@@ -294,13 +282,7 @@ impl CliTestFramework {
         let shutdown_trigger = manager.make_shutdown_trigger();
         let manager_task = manager.main_in_task();
 
-        Self {
-            chain_config,
-            manager_task,
-            shutdown_trigger,
-            rpc_address,
-            test_root,
-        }
+        Self { chain_config, manager_task, shutdown_trigger, rpc_address, test_root }
     }
 
     pub async fn run(&self, commands: &[&str]) -> Vec<String> {

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -78,12 +78,7 @@ pub type HandlesController = Controller<WalletHandlesClient>;
 
 impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
     pub fn new(chain_config: Arc<ChainConfig>, rpc_client: T, wallet: DefaultWallet) -> Self {
-        Self {
-            chain_config,
-            rpc_client,
-            wallet,
-            staking_started: None,
-        }
+        Self { chain_config, rpc_client, wallet, staking_started: None }
     }
 
     pub fn create_wallet(
@@ -173,10 +168,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         account_index: U31,
     ) -> Result<BTreeMap<Currency, Amount>, ControllerError<T>> {
         self.wallet
-            .get_balance(
-                account_index,
-                UtxoType::Transfer | UtxoType::LockThenTransfer,
-            )
+            .get_balance(account_index, UtxoType::Transfer | UtxoType::LockThenTransfer)
             .map_err(ControllerError::WalletError)
     }
 
@@ -253,10 +245,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
             .map_err(ControllerError::WalletError)?;
         let block = self
             .rpc_client
-            .generate_block(
-                GenerateBlockInputData::PoS(pos_data.into()),
-                transactions_opt,
-            )
+            .generate_block(GenerateBlockInputData::PoS(pos_data.into()), transactions_opt)
             .await
             .map_err(ControllerError::NodeCallError)?;
         Ok(block)
@@ -317,10 +306,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
                 let generate_res = self.generate_block(account_index, None).await;
 
                 if let Ok(block) = generate_res {
-                    log::info!(
-                        "New block generated successfully, block id: {}",
-                        block.get_id()
-                    );
+                    log::info!("New block generated successfully, block id: {}", block.get_id());
 
                     let submit_res = self.rpc_client.submit_block(block).await;
                     if let Err(e) = submit_res {

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -177,9 +177,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         account_index: U31,
         utxo_types: UtxoTypes,
     ) -> Result<BTreeMap<UtxoOutPoint, TxOutput>, ControllerError<T>> {
-        self.wallet
-            .get_utxos(account_index, utxo_types)
-            .map_err(ControllerError::WalletError)
+        self.wallet.get_utxos(account_index, utxo_types).map_err(ControllerError::WalletError)
     }
 
     pub fn new_address(&mut self, account_index: U31) -> Result<Address, ControllerError<T>> {
@@ -187,18 +185,14 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
     }
 
     pub fn new_public_key(&mut self, account_index: U31) -> Result<PublicKey, ControllerError<T>> {
-        self.wallet
-            .get_new_public_key(account_index)
-            .map_err(ControllerError::WalletError)
+        self.wallet.get_new_public_key(account_index).map_err(ControllerError::WalletError)
     }
 
     pub fn get_vrf_public_key(
         &mut self,
         account_index: U31,
     ) -> Result<VRFPublicKey, ControllerError<T>> {
-        self.wallet
-            .get_vrf_public_key(account_index)
-            .map_err(ControllerError::WalletError)
+        self.wallet.get_vrf_public_key(account_index).map_err(ControllerError::WalletError)
     }
 
     pub async fn send_to_address(
@@ -212,10 +206,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
             .wallet
             .create_transaction_to_addresses(account_index, [output])
             .map_err(ControllerError::WalletError)?;
-        self.rpc_client
-            .submit_transaction(tx)
-            .await
-            .map_err(ControllerError::NodeCallError)
+        self.rpc_client.submit_transaction(tx).await.map_err(ControllerError::NodeCallError)
     }
 
     pub async fn create_stake_pool_tx(
@@ -228,10 +219,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
             .wallet
             .create_stake_pool_tx(account_index, amount, decomission_key)
             .map_err(ControllerError::WalletError)?;
-        self.rpc_client
-            .submit_transaction(tx)
-            .await
-            .map_err(ControllerError::NodeCallError)
+        self.rpc_client.submit_transaction(tx).await.map_err(ControllerError::NodeCallError)
     }
 
     pub async fn generate_block(
@@ -259,10 +247,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         for _ in 0..count {
             self.sync_once().await?;
             let block = self.generate_block(account_index, None).await?;
-            self.rpc_client
-                .submit_block(block)
-                .await
-                .map_err(ControllerError::NodeCallError)?;
+            self.rpc_client.submit_block(block).await.map_err(ControllerError::NodeCallError)?;
         }
         self.sync_once().await
     }

--- a/wallet/wallet-controller/src/sync/mod.rs
+++ b/wallet/wallet-controller/src/sync/mod.rs
@@ -180,10 +180,7 @@ async fn fetch_and_sync<T: NodeInterface>(
         chain_info.best_block_height >= wallet_block_height,
         ControllerError::NotEnoughBlockHeight(wallet_block_height, chain_info.best_block_height,)
     );
-    let FetchedBlock {
-        block,
-        common_block_height,
-    } = fetch_new_block(
+    let FetchedBlock { block, common_block_height } = fetch_new_block(
         chain_config,
         rpc_client,
         chain_info.best_block_id,
@@ -242,11 +239,7 @@ async fn get_next_block_info<T: NodeInterface>(
         common::chain::GenBlockId::Block(id) => id,
     };
 
-    Ok(NextBlockInfo {
-        common_block_id,
-        common_block_height,
-        block_id,
-    })
+    Ok(NextBlockInfo { common_block_id, common_block_height, block_id })
 }
 
 // `node_block_height` can't be less than `wallet_block_height` and `node_block_height` can't be equal to `wallet_block_id`
@@ -258,11 +251,7 @@ async fn fetch_new_block<T: NodeInterface>(
     wallet_block_id: Id<GenBlock>,
     wallet_block_height: BlockHeight,
 ) -> Result<FetchedBlock, FetchBlockError<T>> {
-    let NextBlockInfo {
-        common_block_id,
-        common_block_height,
-        block_id,
-    } = get_next_block_info(
+    let NextBlockInfo { common_block_id, common_block_height, block_id } = get_next_block_info(
         chain_config,
         rpc_client,
         node_block_id,
@@ -282,10 +271,7 @@ async fn fetch_new_block<T: NodeInterface>(
         FetchBlockError::InvalidPrevBlockId(*block.header().prev_block_id(), common_block_id)
     );
 
-    Ok(FetchedBlock {
-        block,
-        common_block_height,
-    })
+    Ok(FetchedBlock { block, common_block_height })
 }
 
 #[cfg(test)]

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -96,10 +96,8 @@ impl NodeInterface for WalletHandlesClient {
         &self,
         height: BlockHeight,
     ) -> Result<Option<Id<GenBlock>>, Self::Error> {
-        let result = self
-            .chainstate
-            .call(move |this| this.get_block_id_from_height(&height))
-            .await??;
+        let result =
+            self.chainstate.call(move |this| this.get_block_id_from_height(&height)).await??;
         Ok(result)
     }
 
@@ -174,9 +172,7 @@ impl NodeInterface for WalletHandlesClient {
         Ok(())
     }
     async fn p2p_remove_reserved_node(&self, address: String) -> Result<(), Self::Error> {
-        self.p2p
-            .call_async_mut(move |this| this.remove_reserved_node(address))
-            .await??;
+        self.p2p.call_async_mut(move |this| this.remove_reserved_node(address)).await??;
         Ok(())
     }
 }

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -55,12 +55,7 @@ impl WalletHandlesClient {
         block_prod: BlockProductionHandle,
         p2p: P2pHandle,
     ) -> Result<Self, WalletHandlesClientError> {
-        let result = Self {
-            chainstate,
-            _mempool: mempool,
-            block_prod,
-            p2p,
-        };
+        let result = Self { chainstate, _mempool: mempool, block_prod, p2p };
         result.basic_start_test().await?;
         Ok(result)
     }

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -32,9 +32,7 @@ impl NodeInterface for NodeRpcClient {
     type Error = NodeRpcError;
 
     async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error> {
-        ChainstateRpcClient::info(&self.http_client)
-            .await
-            .map_err(NodeRpcError::ResponseError)
+        ChainstateRpcClient::info(&self.http_client).await.map_err(NodeRpcError::ResponseError)
     }
 
     async fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, Self::Error> {
@@ -120,9 +118,7 @@ impl NodeInterface for NodeRpcClient {
     }
 
     async fn p2p_connect(&self, address: String) -> Result<(), Self::Error> {
-        P2pRpcClient::connect(&self.http_client, address)
-            .await
-            .map_err(NodeRpcError::ResponseError)
+        P2pRpcClient::connect(&self.http_client, address).await.map_err(NodeRpcError::ResponseError)
     }
     async fn p2p_disconnect(&self, peer_id: PeerId) -> Result<(), Self::Error> {
         P2pRpcClient::disconnect(&self.http_client, peer_id)
@@ -130,9 +126,7 @@ impl NodeInterface for NodeRpcClient {
             .map_err(NodeRpcError::ResponseError)
     }
     async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error> {
-        P2pRpcClient::get_peer_count(&self.http_client)
-            .await
-            .map_err(NodeRpcError::ResponseError)
+        P2pRpcClient::get_peer_count(&self.http_client).await.map_err(NodeRpcError::ResponseError)
     }
     async fn p2p_get_connected_peers(&self) -> Result<Vec<ConnectedPeer>, Self::Error> {
         P2pRpcClient::get_connected_peers(&self.http_client)

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -202,15 +202,9 @@ async fn test_wallet_node_communication(
         chain_config.genesis_block_id()
     );
 
-    assert_eq!(
-        node_interface.get_block_id_at_height(1.into()).await.unwrap().unwrap(),
-        block_1_id
-    );
+    assert_eq!(node_interface.get_block_id_at_height(1.into()).await.unwrap().unwrap(), block_1_id);
 
-    assert_eq!(
-        node_interface.get_block_id_at_height(2.into()).await.unwrap(),
-        None
-    );
+    assert_eq!(node_interface.get_block_id_at_height(2.into()).await.unwrap(), None);
 
     let block_1 = node_interface.get_block(best_block_id.get().into()).await.unwrap().unwrap();
 


### PR DESCRIPTION
This is an example of how different the code formatting would be if we forced rustfmt to use the same width limit of 100 chars for all lines.
There are 3 commits here, which can be examined independently:
1) [Formatting changes after setting use_small_heuristics = "Max"](https://github.com/mintlayer/mintlayer-core/commit/b940cfdd05eb84b6659b1240487d9e39ba0f9bce); this forces full line width for all lines, except for those that correspond to the settings `array_width`, `chain_width` and `single_line_if_else_max_width`, which are currently explicitly set in `rustfmt.toml`.
2) [Also, array_width = 80 and chain_width = 80 were removed](https://github.com/mintlayer/mintlayer-core/commit/9c7f98e937fc860410e38a05bf690abc549270f6); here `array_width` and `chain_width` are removed, so the corresponding lines are also full width.
3) [Also, single_line_if_else_max_width = 50 was removed](https://github.com/mintlayer/mintlayer-core/commit/776cabe45f725a5fbd2b306f60151fa5f9ee315a) - single_line_if_else_max_width was removed.

Some notes:
1) I don't suggest to merge these changes or even start a discussion about applying any formatting changes right now. It's just something to think about and hopefully discuss at some point in the future.
2) The reason why IMO we should consider this is to reduce vertical space waste, which should improve code readability.
3) Sam expressed a concern about such formatting changes in general - they spoil the output of "git blame", making it harder to navigate the history. One solution to this is to create a file ".git-blame-ignore-revs", which would contain a list of revisions to be ignored by "blame", as explained [in this article](https://www.stefanjudis.com/today-i-learned/how-to-exclude-commits-from-git-blame/). GutHub is supposed to know about this file. The problem though is that everyone who will want to use this feature locally will have to add a configuration line to the local `.git/config` file, which is not very convenient.