### PR TITLE
Remove reward maturity setting for PoS

### DIFF
--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -1023,7 +1023,6 @@ mod produce_block {
                 NonZeroU64::new(2 * 60).expect("cannot be 0").into(),
                 2000.into(),
                 2000.into(),
-                2000.into(),
                 5,
                 PerThousand::new(1).expect("must be valid"),
             )

--- a/chainstate/test-suite/src/tests/mod.rs
+++ b/chainstate/test-suite/src/tests/mod.rs
@@ -45,6 +45,7 @@ mod nft_reorgs;
 mod nft_transfer;
 mod output_timelock;
 mod pos_accounting_reorg;
+mod pos_maturity_settings;
 mod pos_processing_tests;
 mod pos_retargeting_tests;
 mod processing_tests;

--- a/chainstate/test-suite/src/tests/pos_maturity_settings.rs
+++ b/chainstate/test-suite/src/tests/pos_maturity_settings.rs
@@ -1,0 +1,349 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::helpers::pos::create_custom_genesis_with_stake_pool;
+
+use chainstate::{BlockError, ChainstateError, ConnectTransactionError};
+use chainstate_test_framework::{empty_witness, TestFramework, TransactionBuilder};
+use common::{
+    chain::{
+        config::Builder as ConfigBuilder, stakelock::StakePoolData, timelock::OutputTimeLock,
+        tokens::OutputValue, AccountNonce, AccountOutPoint, AccountSpending, ConsensusUpgrade,
+        Destination, NetUpgrades, OutPointSourceId, PoSChainConfig, TxInput, TxOutput,
+        UpgradeVersion, UtxoOutPoint,
+    },
+    primitives::{per_thousand::PerThousand, Amount, BlockDistance, BlockHeight, Idable},
+    Uint256,
+};
+use crypto::{
+    key::{KeyKind, PrivateKey},
+    vrf::{VRFKeyKind, VRFPrivateKey},
+};
+use rstest::rstest;
+use test_utils::random::{make_seedable_rng, Seed};
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn decommission_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
+    let (staking_sk, staking_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+
+    let upgrades = vec![
+        (
+            BlockHeight::new(0),
+            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
+        ),
+        (
+            BlockHeight::new(1),
+            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
+                initial_difficulty: Uint256::MAX.into(),
+                config: PoSChainConfig::new(
+                    Uint256::MAX,
+                    1,
+                    100.into(),
+                    1.into(),
+                    5,
+                    PerThousand::new(100).unwrap(),
+                )
+                .unwrap(),
+            }),
+        ),
+        (
+            BlockHeight::new(3),
+            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
+                initial_difficulty: Uint256::MAX.into(),
+                config: PoSChainConfig::new(
+                    Uint256::MAX,
+                    1,
+                    50.into(), // decrease maturity setting
+                    1.into(),
+                    5,
+                    PerThousand::new(100).unwrap(),
+                )
+                .unwrap(),
+            }),
+        ),
+    ];
+    let net_upgrades = NetUpgrades::initialize(upgrades).expect("valid net-upgrades");
+    let genesis = create_custom_genesis_with_stake_pool(staking_pk, vrf_pk.clone());
+    let chain_config = ConfigBuilder::test_chain()
+        .net_upgrades(net_upgrades)
+        .genesis_custom(genesis)
+        .build();
+    let target_block_time =
+        chainstate_test_framework::get_target_block_time(&chain_config, BlockHeight::new(1));
+
+    let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
+    tf.progress_time_seconds_since_epoch(target_block_time.get());
+
+    //
+    // create a pool at height 1
+    //
+
+    let genesis_mint_outpoint = UtxoOutPoint::new(
+        OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+        0,
+    );
+
+    let pool_id = pos_accounting::make_pool_id(&genesis_mint_outpoint);
+    let stake_amount = Amount::from_atoms(40_000_000 * common::chain::Mlt::ATOMS_PER_MLT);
+
+    let tx = TransactionBuilder::new()
+        .add_input(genesis_mint_outpoint.into(), empty_witness(&mut rng))
+        .add_output(TxOutput::CreateStakePool(
+            pool_id,
+            Box::new(StakePoolData::new(
+                stake_amount,
+                Destination::AnyoneCanSpend,
+                vrf_pk,
+                Destination::AnyoneCanSpend,
+                PerThousand::new(0).unwrap(),
+                Amount::ZERO,
+            )),
+        ))
+        .build();
+    let create_pool_tx_id = tx.transaction().get_id();
+
+    tf.make_pos_block_builder(&mut rng)
+        .with_transactions(vec![tx])
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
+        .build_and_process()
+        .unwrap();
+
+    //
+    // try decommission pool at height 2 with wrong maturity setting
+    //
+    let decommission_tx = TransactionBuilder::new()
+        .add_input(
+            UtxoOutPoint::new(create_pool_tx_id.into(), 0).into(),
+            empty_witness(&mut rng),
+        )
+        .add_output(TxOutput::LockThenTransfer(
+            OutputValue::Coin(stake_amount),
+            Destination::AnyoneCanSpend,
+            OutputTimeLock::ForBlockCount(50),
+        ))
+        .build();
+    let decommission_tx_id = decommission_tx.transaction().get_id();
+    let decommission_outpoint = UtxoOutPoint::new(decommission_tx_id.into(), 0);
+
+    let result = tf
+        .make_pos_block_builder(&mut rng)
+        .with_transactions(vec![decommission_tx.clone()])
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
+        .build_and_process()
+        .unwrap_err();
+    assert_eq!(
+        result,
+        ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+            ConnectTransactionError::OutputTimelockError(
+                tx_verifier::timelock_check::OutputMaturityError::InvalidOutputMaturityDistance(
+                    decommission_outpoint,
+                    BlockDistance::new(50),
+                    BlockDistance::new(100)
+                )
+            )
+        ))
+    );
+
+    //
+    // produce some block at height 2 just to move to the next netupgrade
+    //
+    tf.make_pos_block_builder(&mut rng)
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
+        .build_and_process()
+        .unwrap();
+
+    //
+    // decommission pool again now it should pass
+    //
+    tf.make_pos_block_builder(&mut rng)
+        .with_transactions(vec![decommission_tx])
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk)
+        .with_vrf_key(vrf_sk)
+        .build_and_process()
+        .unwrap();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn spend_share_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
+    let (staking_sk, staking_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+
+    let upgrades = vec![
+        (
+            BlockHeight::new(0),
+            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::IgnoreConsensus),
+        ),
+        (
+            BlockHeight::new(1),
+            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
+                initial_difficulty: Uint256::MAX.into(),
+                config: PoSChainConfig::new(
+                    Uint256::MAX,
+                    1,
+                    1.into(),
+                    100.into(),
+                    5,
+                    PerThousand::new(100).unwrap(),
+                )
+                .unwrap(),
+            }),
+        ),
+        (
+            BlockHeight::new(3),
+            UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
+                initial_difficulty: Uint256::MAX.into(),
+                config: PoSChainConfig::new(
+                    Uint256::MAX,
+                    1,
+                    1.into(),
+                    50.into(), // decrease maturity setting
+                    5,
+                    PerThousand::new(100).unwrap(),
+                )
+                .unwrap(),
+            }),
+        ),
+    ];
+    let net_upgrades = NetUpgrades::initialize(upgrades).expect("valid net-upgrades");
+    let genesis = create_custom_genesis_with_stake_pool(staking_pk, vrf_pk);
+    let chain_config = ConfigBuilder::test_chain()
+        .net_upgrades(net_upgrades)
+        .genesis_custom(genesis)
+        .build();
+    let target_block_time =
+        chainstate_test_framework::get_target_block_time(&chain_config, BlockHeight::new(1));
+
+    let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
+    tf.progress_time_seconds_since_epoch(target_block_time.get());
+
+    //
+    // create delegation
+    //
+
+    let genesis_mint_outpoint = UtxoOutPoint::new(
+        OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+        0,
+    );
+
+    let amount_to_delegate = Amount::from_atoms(1000);
+    let pool_id = common::primitives::H256::zero().into();
+    let delegation_id = pos_accounting::make_delegation_id(&genesis_mint_outpoint);
+
+    let tx1 = TransactionBuilder::new()
+        .add_input(genesis_mint_outpoint.into(), empty_witness(&mut rng))
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(amount_to_delegate),
+            Destination::AnyoneCanSpend,
+        ))
+        .add_output(TxOutput::CreateDelegationId(
+            Destination::AnyoneCanSpend,
+            pool_id,
+        ))
+        .build();
+    let tx1_id = tx1.transaction().get_id();
+    let tx2 = TransactionBuilder::new()
+        .add_input(
+            UtxoOutPoint::new(tx1_id.into(), 0).into(),
+            empty_witness(&mut rng),
+        )
+        .add_output(TxOutput::DelegateStaking(amount_to_delegate, delegation_id))
+        .build();
+
+    tf.make_pos_block_builder(&mut rng)
+        .with_transactions(vec![tx1, tx2])
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
+        .build_and_process()
+        .unwrap();
+
+    //
+    // try spend share at height 2 with wrong maturity setting
+    //
+
+    let tx_input_spend_from_delegation = AccountOutPoint::new(
+        AccountNonce::new(0),
+        AccountSpending::Delegation(delegation_id, amount_to_delegate),
+    );
+    let spend_share_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::Account(tx_input_spend_from_delegation),
+            empty_witness(&mut rng),
+        )
+        .add_output(TxOutput::LockThenTransfer(
+            OutputValue::Coin(amount_to_delegate),
+            Destination::AnyoneCanSpend,
+            OutputTimeLock::ForBlockCount(50),
+        ))
+        .build();
+    let spend_share_tx_id = spend_share_tx.transaction().get_id();
+    let spend_share_tx_outpoint = UtxoOutPoint::new(spend_share_tx_id.into(), 0);
+
+    let result = tf
+        .make_pos_block_builder(&mut rng)
+        .with_transactions(vec![spend_share_tx.clone()])
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
+        .build_and_process()
+        .unwrap_err();
+    assert_eq!(
+        result,
+        ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+            ConnectTransactionError::OutputTimelockError(
+                tx_verifier::timelock_check::OutputMaturityError::InvalidOutputMaturityDistance(
+                    spend_share_tx_outpoint,
+                    BlockDistance::new(50),
+                    BlockDistance::new(100)
+                )
+            )
+        ))
+    );
+
+    //
+    // produce some block at height 2 just to move to the next netupgrade
+    //
+    tf.make_pos_block_builder(&mut rng)
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk.clone())
+        .with_vrf_key(vrf_sk.clone())
+        .build_and_process()
+        .unwrap();
+
+    //
+    // spend share again now it should pass
+    //
+    tf.make_pos_block_builder(&mut rng)
+        .with_transactions(vec![spend_share_tx])
+        .with_block_signing_key(staking_sk.clone())
+        .with_stake_spending_key(staking_sk)
+        .with_vrf_key(vrf_sk)
+        .build_and_process()
+        .unwrap();
+}

--- a/common/src/chain/block/consensus_data.rs
+++ b/common/src/chain/block/consensus_data.rs
@@ -13,11 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::chain::signature::inputsig::InputWitness;
-use crate::chain::{chaintrust, ChainConfig, PoolId};
 use crate::{
-    chain::TxInput,
-    primitives::{BlockDistance, Compact},
+    chain::{chaintrust, signature::inputsig::InputWitness, PoolId, TxInput},
+    primitives::Compact,
     Uint256,
 };
 use crypto::vrf::VRFReturn;
@@ -56,16 +54,6 @@ impl ConsensusData {
                 let block_proof = chaintrust::asymptote::calculate_block_proof(timestamp_diff);
                 Some(block_proof)
             }
-        }
-    }
-
-    pub fn reward_maturity_distance(&self, chain_config: &ChainConfig) -> BlockDistance {
-        match self {
-            ConsensusData::None => chain_config.empty_consensus_reward_maturity_distance(),
-            ConsensusData::PoW(_) => {
-                chain_config.get_proof_of_work_config().reward_maturity_distance()
-            }
-            ConsensusData::PoS(_) => BlockDistance::new(2000),
         }
     }
 }

--- a/common/src/chain/pos.rs
+++ b/common/src/chain/pos.rs
@@ -38,8 +38,6 @@ pub struct PoSChainConfig {
     target_limit: Uint256,
     /// Time interval in secs between the blocks targeted by the difficulty adjustment algorithm
     target_block_time: NonZeroU64,
-    /// The distance required to pass to allow spending the block reward
-    reward_maturity_distance: BlockDistance,
     /// The distance required to pass to allow spending the decommission pool
     decommission_maturity_distance: BlockDistance,
     /// The distance required to pass to allow spending delegation share
@@ -54,7 +52,6 @@ impl PoSChainConfig {
     pub fn new(
         target_limit: Uint256,
         target_block_time: u64,
-        reward_maturity_distance: BlockDistance,
         decommission_maturity_distance: BlockDistance,
         spend_share_maturity_distance: BlockDistance,
         block_count_to_average_for_blocktime: usize,
@@ -68,7 +65,6 @@ impl PoSChainConfig {
         Some(Self {
             target_limit,
             target_block_time,
-            reward_maturity_distance,
             decommission_maturity_distance,
             spend_share_maturity_distance,
             block_count_to_average_for_blocktime,
@@ -82,10 +78,6 @@ impl PoSChainConfig {
 
     pub fn target_block_time(&self) -> NonZeroU64 {
         self.target_block_time
-    }
-
-    pub fn reward_maturity_distance(&self) -> BlockDistance {
-        self.reward_maturity_distance
     }
 
     pub fn decommission_maturity_distance(&self) -> BlockDistance {
@@ -115,7 +107,6 @@ pub fn create_testnet_pos_config() -> PoSChainConfig {
     PoSChainConfig {
         target_limit,
         target_block_time,
-        reward_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,
@@ -127,7 +118,6 @@ pub fn create_unittest_pos_config() -> PoSChainConfig {
     PoSChainConfig {
         target_limit: Uint256::MAX,
         target_block_time: NonZeroU64::new(2 * 60).expect("cannot be 0"),
-        reward_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,
@@ -142,7 +132,6 @@ pub fn create_regtest_pos_config() -> PoSChainConfig {
     PoSChainConfig {
         target_limit,
         target_block_time,
-        reward_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
         block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -117,7 +117,7 @@ where
             let consensus_data = ConsensusData::None;
 
             let time_lock = {
-                let block_distance = consensus_data.reward_maturity_distance(chain_config);
+                let block_distance = chain_config.empty_consensus_reward_maturity_distance();
 
                 let reward_maturity_distance_i64: i64 =
                     block_distance.try_into().map_err(|_| {

--- a/consensus/src/pos/target.rs
+++ b/consensus/src/pos/target.rs
@@ -405,7 +405,6 @@ mod tests {
                 target_block_time,
                 1.into(),
                 1.into(),
-                1.into(),
                 2,
                 PerThousand::new(100).unwrap(),
             )
@@ -425,7 +424,6 @@ mod tests {
             let config = PoSChainConfig::new(
                 Uint256::MAX,
                 target_block_time,
-                1.into(),
                 1.into(),
                 1.into(),
                 2,
@@ -448,7 +446,6 @@ mod tests {
             1,
             1.into(),
             1.into(),
-            1.into(),
             2,
             PerThousand::new(100).unwrap(),
         )
@@ -465,7 +462,6 @@ mod tests {
         let config = PoSChainConfig::new(
             Uint256::ONE,
             1,
-            1.into(),
             1.into(),
             1.into(),
             2,
@@ -486,7 +482,6 @@ mod tests {
         let pos_config = PoSChainConfig::new(
             Uint256::MAX,
             2 * 60,
-            2000.into(),
             2000.into(),
             2000.into(),
             5,
@@ -619,7 +614,6 @@ mod tests {
             10,
             1.into(),
             1.into(),
-            1.into(),
             2,
             PerThousand::new(100).unwrap(),
         )
@@ -627,7 +621,6 @@ mod tests {
         let pos_config_2 = PoSChainConfig::new(
             target_limit_2,
             20,
-            1.into(),
             1.into(),
             1.into(),
             5,

--- a/consensus/src/pow/input_data.rs
+++ b/consensus/src/pow/input_data.rs
@@ -16,12 +16,11 @@
 use crate::pow::{calculate_work_required, error::ConsensusPoWError};
 use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
 use common::{
-    chain::block::{
-        consensus_data::PoWData, timestamp::BlockTimestamp, BlockReward, ConsensusData,
-    },
     chain::{
-        timelock::OutputTimeLock, tokens::OutputValue, ChainConfig, Destination, PoWStatus,
-        TxOutput,
+        block::{consensus_data::PoWData, timestamp::BlockTimestamp, BlockReward, ConsensusData},
+        timelock::OutputTimeLock,
+        tokens::OutputValue,
+        ChainConfig, Destination, PoWStatus, TxOutput,
     },
     primitives::BlockHeight,
 };
@@ -66,7 +65,7 @@ where
     let consensus_data = ConsensusData::PoW(Box::new(PoWData::new(work_required, 0)));
 
     let time_lock = {
-        let block_distance = consensus_data.reward_maturity_distance(chain_config);
+        let block_distance = chain_config.get_proof_of_work_config().reward_maturity_distance();
 
         let reward_maturity_distance_i64: i64 = block_distance
             .try_into()


### PR DESCRIPTION
Reward maturity setting doesn't make sense for PoS because it cannot be spent.

Also added tests to ensure that decommission_maturity and spend_share_maturity follows `NetUpgrade` setting