### PR TITLE
Allow the mocked call expect to be called either 0 or 1 time

### DIFF
--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -208,7 +208,7 @@ mod produce_block {
 
         let chainstate_subsystem: ChainstateHandle = {
             let mut mock_chainstate = Box::new(MockChainstateInterfaceMock::new());
-            mock_chainstate.expect_subscribe_to_events().times(1).returning(|_| ());
+            mock_chainstate.expect_subscribe_to_events().times(..).returning(|_| ());
 
             mock_chainstate.expect_get_best_block_index().times(1).returning(|| {
                 Err(ChainstateError::FailedToReadProperty(


### PR DESCRIPTION
The following error occurred in CI:

```
--- STDERR:              blockprod detail::tests::produce_block::pull_best_block_index_error ---
thread 'tokio-runtime-worker' panicked at 'MockChainstateInterfaceMock::subscribe_to_events: Expectation(<anything>) called 0 time(s) which is fewer than expected 1', mocks/src/chainstate.rs:40:1
```

This was caused by a race between the following two tasks within Tokio:

  - `blockprod/src/detail/mod.rs` -> `pull_best_block_index()`'s -> `call().await`
  - `blockprod/src/detail/job_manager/mod.rs` -> `subscribe_to_chainstate()`'s -> `spawn()`

That `spawn()` is called during initialisation of `BlockProduction::new()`. Ideally, this setup would be complete before calling `blockprod.produce_block().await` which call `self.pull_best_block_index().await`. However, within this test, a lot of usual code is short-circuited so initialisation may not have a chance to finish.

Initially I made `spawn()` within `subscribe_to_chainstate()` block until setup was complete, which fixed this error, however it broke most of the other tests.

This simple fix sets the expected call count of `subscribe_to_events()` to either 0 or 1, which makes this test tolerant to this race. In reality, this isn't an error anyway given that the expectation is "testing the test" rather than testing a real-life scenario i.e if `chainstate_handle.get_best_block_index()` ever failed in production, `pull_best_block_index()` will return with an error, and knowing if `subscribe_to_chainstate()` doesn't help either way. 