### PR TITLE
Calculate transaction fees based on fee rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6432,6 +6432,7 @@ dependencies = [
  "hex",
  "itertools",
  "logging",
+ "mempool",
  "parity-scale-codec",
  "pos_accounting",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6506,6 +6506,7 @@ dependencies = [
  "crypto",
  "futures",
  "logging",
+ "mempool",
  "mempool-types",
  "node-comm",
  "rstest",

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 use crate::{
-    error::Error, event::MempoolEvent, tx_accumulator::TransactionAccumulator, MempoolMaxSize,
-    TxOrigin, TxStatus,
+    error::Error, event::MempoolEvent, tx_accumulator::TransactionAccumulator, FeeRate,
+    MempoolMaxSize, TxOrigin, TxStatus,
 };
 use common::{
     chain::{GenBlock, SignedTransaction, Transaction},
@@ -70,7 +70,7 @@ pub trait MempoolInterface: Send + Sync {
     fn set_max_size(&mut self, max_size: MempoolMaxSize) -> Result<(), Error>;
 
     /// Get current fee rate
-    fn get_fee_rate(&self) -> u128;
+    fn get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, Error>;
 }
 
 #[async_trait::async_trait]

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -68,6 +68,9 @@ pub trait MempoolInterface: Send + Sync {
 
     /// Set the maximum mempool size
     fn set_max_size(&mut self, max_size: MempoolMaxSize) -> Result<(), Error>;
+
+    /// Get current fee rate
+    fn get_fee_rate(&self) -> u128;
 }
 
 #[async_trait::async_trait]

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -69,7 +69,8 @@ pub trait MempoolInterface: Send + Sync {
     /// Set the maximum mempool size
     fn set_max_size(&mut self, max_size: MempoolMaxSize) -> Result<(), Error>;
 
-    /// Get current fee rate
+    /// Get the fee rate such that it would put the new transaction in the top X MB of the mempool
+    /// making it less likely to get rejected or trimmed in the case the mempool is full
     fn get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, Error>;
 }
 

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -158,6 +158,10 @@ impl MempoolInterface for Mempool {
     fn set_max_size(&mut self, max_size: MempoolMaxSize) -> Result<(), Error> {
         self.set_max_size(max_size)
     }
+
+    fn get_fee_rate(&self) -> u128 {
+        self.current_fee_rate()
+    }
 }
 
 /// Mempool constructor

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -160,7 +160,7 @@ impl MempoolInterface for Mempool {
     }
 
     fn get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, Error> {
-        self.current_fee_rate(in_top_x_mb).map_err(Error::Policy)
+        self.get_fee_rate(in_top_x_mb).map_err(Error::Policy)
     }
 }
 

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     error::Error, event::MempoolEvent, pool::memory_usage_estimator::StoreMemoryUsageEstimator,
-    tx_accumulator::TransactionAccumulator, MempoolInterface, MempoolMaxSize,
+    tx_accumulator::TransactionAccumulator, FeeRate, MempoolInterface, MempoolMaxSize,
     MempoolSubsystemInterface, TxOrigin, TxStatus,
 };
 use chainstate::chainstate_interface::ChainstateInterface;
@@ -159,8 +159,8 @@ impl MempoolInterface for Mempool {
         self.set_max_size(max_size)
     }
 
-    fn get_fee_rate(&self) -> u128 {
-        self.current_fee_rate()
+    fn get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, Error> {
+        self.current_fee_rate(in_top_x_mb).map_err(Error::Policy)
     }
 }
 

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -27,6 +27,8 @@ mod pool;
 pub mod rpc;
 pub mod tx_accumulator;
 
+pub use pool::FeeRate;
+
 pub type MempoolHandle = subsystem::Handle<dyn MempoolInterface>;
 
 pub type Result<T> = core::result::Result<T, error::Error>;

--- a/mempool/src/pool/feerate.rs
+++ b/mempool/src/pool/feerate.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 
 use common::primitives::amount::Amount;
@@ -24,7 +25,7 @@ use super::fee::Fee;
 pub const INCREMENTAL_RELAY_FEE_RATE: FeeRate = FeeRate::new(Amount::from_atoms(1000));
 pub const INCREMENTAL_RELAY_THRESHOLD: FeeRate = FeeRate::new(Amount::from_atoms(500));
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct FeeRate {
     amount_per_kb: Amount,
 }

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -1043,7 +1043,7 @@ impl<M: MemoryUsageEstimator> Mempool<M> {
                     .iter()
                     .map(|tx_id| self.store.txs_by_id.get(tx_id).map_or(0, |tx| tx.size()))
                     .sum::<usize>();
-                (total_size / 1000000) < in_top_x_mb
+                (total_size / 1000000) >= in_top_x_mb
             })
             .map_or_else(
                 || Ok(self.rolling_fee_rate.read().rolling_minimum_fee_rate()),

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -44,11 +44,12 @@ use utils::{
     ensure, eventhandler::EventsController, shallow_clone::ShallowClone, tap_error_log::LogError,
 };
 
+pub use self::feerate::FeeRate;
 pub use self::memory_usage_estimator::MemoryUsageEstimator;
 use self::{
     entry::{TxDependency, TxEntry, TxEntryWithFee},
     fee::Fee,
-    feerate::{FeeRate, INCREMENTAL_RELAY_FEE_RATE, INCREMENTAL_RELAY_THRESHOLD},
+    feerate::{INCREMENTAL_RELAY_FEE_RATE, INCREMENTAL_RELAY_THRESHOLD},
     orphans::{OrphanType, TxOrphanPool},
     rolling_fee_rate::RollingFeeRate,
     spends_unconfirmed::SpendsUnconfirmed,

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -1031,6 +1031,10 @@ impl<M: MemoryUsageEstimator> Mempool<M> {
         let event = event::NewTip::new(block_id, block_height);
         self.events_controller.broadcast(event.into());
     }
+
+    pub fn current_fee_rate(&self) -> u128 {
+        self.rolling_fee_rate.read().rolling_minimum_fee_rate().atoms_per_kb()
+    }
 }
 
 #[cfg(test)]

--- a/mempool/src/rpc.rs
+++ b/mempool/src/rpc.rs
@@ -22,7 +22,7 @@ use common::{
 use serialization::hex_encoded::HexEncoded;
 use utils::tap_error_log::LogError;
 
-use crate::{MempoolMaxSize, TxOrigin, TxStatus};
+use crate::{FeeRate, MempoolMaxSize, TxOrigin, TxStatus};
 
 use rpc::Result as RpcResult;
 
@@ -66,7 +66,7 @@ trait MempoolRpc {
     async fn set_max_size(&self, max_size: usize) -> RpcResult<()>;
 
     #[method(name = "get_fee_rate")]
-    async fn get_fee_rate(&self) -> RpcResult<u128>;
+    async fn get_fee_rate(&self, in_top_x_mb: usize) -> RpcResult<FeeRate>;
 }
 
 #[async_trait::async_trait]
@@ -130,7 +130,7 @@ impl MempoolRpcServer for super::MempoolHandle {
         rpc::handle_result(self.call_mut(move |this| this.set_max_size(max_size)).await)
     }
 
-    async fn get_fee_rate(&self) -> rpc::Result<u128> {
-        rpc::handle_result(self.call(move |this| this.get_fee_rate()).await)
+    async fn get_fee_rate(&self, in_top_x_mb: usize) -> rpc::Result<FeeRate> {
+        rpc::handle_result(self.call(move |this| this.get_fee_rate(in_top_x_mb)).await)
     }
 }

--- a/mempool/src/rpc.rs
+++ b/mempool/src/rpc.rs
@@ -64,6 +64,9 @@ trait MempoolRpc {
     // count, e.g. "200MB" instead of 200000000
     #[method(name = "set_max_size")]
     async fn set_max_size(&self, max_size: usize) -> RpcResult<()>;
+
+    #[method(name = "get_fee_rate")]
+    async fn get_fee_rate(&self) -> RpcResult<u128>;
 }
 
 #[async_trait::async_trait]
@@ -125,5 +128,9 @@ impl MempoolRpcServer for super::MempoolHandle {
     async fn set_max_size(&self, max_size: usize) -> rpc::Result<()> {
         let max_size = MempoolMaxSize::from_bytes(max_size);
         rpc::handle_result(self.call_mut(move |this| this.set_max_size(max_size)).await)
+    }
+
+    async fn get_fee_rate(&self) -> rpc::Result<u128> {
+        rpc::handle_result(self.call(move |this| this.get_fee_rate()).await)
     }
 }

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -19,13 +19,13 @@ use std::sync::Arc;
 
 use common::{
     chain::{GenBlock, SignedTransaction, Transaction},
-    primitives::Id,
+    primitives::{Amount, Id},
 };
 use mempool::{
     error::{Error, TxValidationError},
     event::MempoolEvent,
     tx_accumulator::TransactionAccumulator,
-    MempoolInterface, MempoolMaxSize, MempoolSubsystemInterface, TxOrigin, TxStatus,
+    FeeRate, MempoolInterface, MempoolMaxSize, MempoolSubsystemInterface, TxOrigin, TxStatus,
 };
 use subsystem::{subsystem::CallError, CallRequest, ShutdownRequest};
 use utils::atomics::AcqRelAtomicBool;
@@ -139,8 +139,8 @@ impl MempoolInterface for MempoolInterfaceMock {
         unimplemented!()
     }
 
-    fn get_fee_rate(&self) -> u128 {
-        0
+    fn get_fee_rate(&self, _in_top_x_mb: usize) -> Result<FeeRate, Error> {
+        Ok(FeeRate::new(Amount::ZERO))
     }
 }
 

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -138,6 +138,10 @@ impl MempoolInterface for MempoolInterfaceMock {
     fn set_max_size(&mut self, _max_size: MempoolMaxSize) -> Result<(), Error> {
         unimplemented!()
     }
+
+    fn get_fee_rate(&self) -> u128 {
+        0
+    }
 }
 
 #[async_trait::async_trait]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -14,6 +14,7 @@ crypto = { path = "../crypto/" }
 logging = { path = "../logging" }
 pos_accounting = { path = "../pos_accounting" }
 serialization = { path = "../serialization" }
+mempool = { path = "../mempool" }
 storage = { path = "../storage", features = ["inmemory"] }
 tx-verifier = { path = "../chainstate/tx-verifier" }
 utils = { path = "../utils" }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -23,6 +23,7 @@ wallet-storage = { path = "./storage" }
 wallet-types = { path = "./types" }
 
 bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
+hex.workspace = true
 itertools.workspace = true
 parity-scale-codec.workspace = true
 thiserror.workspace = true
@@ -31,6 +32,5 @@ zeroize.workspace = true
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
 
-hex.workspace = true
 rstest.workspace = true
 tempfile.workspace = true

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -971,9 +971,11 @@ fn input_signature_size(destination: &Destination) -> usize {
         )
         .encode(),
         Destination::PublicKey(_) => AuthorizedPublicKeySpend::new(signature).encode(),
-        Destination::AnyoneCanSpend
-        | Destination::ScriptHash(_)
-        | Destination::ClassicMultisig(_) => unimplemented!(),
+        Destination::AnyoneCanSpend => {
+            let input_sig = InputWitness::NoSignature(None);
+            return serialization::Encode::encoded_size(&input_sig);
+        }
+        Destination::ScriptHash(_) | Destination::ClassicMultisig(_) => unimplemented!(),
     };
 
     let input_sig = InputWitness::Standard(StandardInputSignature::new(

--- a/wallet/src/account/utxo_selector/mod.rs
+++ b/wallet/src/account/utxo_selector/mod.rs
@@ -33,6 +33,7 @@ pub struct SelectionResult {
     waste: SignedAmount,
     weight: u32,
     fees: Amount,
+    change: Amount,
 }
 
 impl SelectionResult {
@@ -44,6 +45,7 @@ impl SelectionResult {
             waste: SignedAmount::ZERO,
             weight: 0,
             fees: Amount::ZERO,
+            change: Amount::ZERO,
         }
     }
 
@@ -51,8 +53,8 @@ impl SelectionResult {
         self.fees
     }
 
-    pub fn get_total_value(&self) -> Amount {
-        self.effective_value
+    pub fn get_change(&self) -> Amount {
+        self.change
     }
 
     pub fn into_output_pairs(self) -> Vec<(TxInput, TxOutput)> {
@@ -88,9 +90,9 @@ impl SelectionResult {
         change_cost: Amount,
         change_fee: Amount,
     ) -> Result<(), UtxoSelectorError> {
-        let change = self.get_change(min_viable_change, change_fee);
+        self.change = self.calculate_change(min_viable_change, change_fee);
 
-        if change != Amount::ZERO {
+        if self.change != Amount::ZERO {
             // Consider the cost of making change and spending it in the future
             // If we aren't making change, the caller should've set change_cost to 0
             self.waste = change_cost
@@ -109,7 +111,7 @@ impl SelectionResult {
         Ok(())
     }
 
-    fn get_change(&self, min_viable_change: Amount, change_fee: Amount) -> Amount {
+    fn calculate_change(&self, min_viable_change: Amount, change_fee: Amount) -> Amount {
         // change = SUM(inputs) - SUM(outputs) - fees
         // 1) With SFFO we don't pay any fees
         // 2) Otherwise we pay all the fees:
@@ -618,7 +620,7 @@ fn select_coins_bnb(
         result.add_input(&utxo_pool[i], pay_fees)?;
     }
 
-    result.compute_and_set_waste(cost_of_change, cost_of_change, Amount::ZERO)?;
+    result.compute_and_set_waste(cost_of_change, cost_of_change, cost_of_change)?;
     assert_eq!(best_waste, result.waste);
     Ok(result)
 }
@@ -627,9 +629,8 @@ pub fn select_coins(
     mut utxo_pool: Vec<OutputGroup>,
     selection_target: Amount,
     pay_fees: PayFee,
+    cost_of_change: Amount,
 ) -> Result<SelectionResult, UtxoSelectorError> {
-    // TODO: set some cost of change
-    let cost_of_change = Amount::ZERO;
     // TODO: set some max weight
     let max_weight = 999;
     let mut rng = make_pseudo_rng();
@@ -658,7 +659,10 @@ pub fn select_coins(
         max_weight,
         pay_fees,
     ) {
-        Ok(result) => results.push(result),
+        Ok(mut result) => {
+            result.compute_and_set_waste(cost_of_change, cost_of_change, cost_of_change)?;
+            results.push(result)
+        }
         Err(error) => errors.push(error),
     };
 
@@ -670,7 +674,10 @@ pub fn select_coins(
         max_weight,
         pay_fees,
     ) {
-        Ok(result) => results.push(result),
+        Ok(mut result) => {
+            result.compute_and_set_waste(cost_of_change, cost_of_change, cost_of_change)?;
+            results.push(result)
+        }
         Err(error) => errors.push(error),
     };
 

--- a/wallet/src/account/utxo_selector/mod.rs
+++ b/wallet/src/account/utxo_selector/mod.rs
@@ -19,7 +19,7 @@ pub mod output_group;
 pub use output_group::{OutputGroup, PayFee};
 
 use common::{
-    chain::{TxOutput, UtxoOutPoint},
+    chain::{TxInput, TxOutput},
     primitives::{signed_amount::SignedAmount, Amount},
 };
 use crypto::random::{make_pseudo_rng, Rng, SliceRandom};
@@ -27,7 +27,7 @@ use crypto::random::{make_pseudo_rng, Rng, SliceRandom};
 const TOTAL_TRIES: u32 = 100_000;
 
 pub struct SelectionResult {
-    outputs: Vec<(UtxoOutPoint, TxOutput)>,
+    outputs: Vec<(TxInput, TxOutput)>,
     effective_value: Amount,
     target: Amount,
     waste: SignedAmount,
@@ -55,7 +55,7 @@ impl SelectionResult {
         self.effective_value
     }
 
-    pub fn into_output_pairs(self) -> Vec<(UtxoOutPoint, TxOutput)> {
+    pub fn into_output_pairs(self) -> Vec<(TxInput, TxOutput)> {
         self.outputs
     }
 

--- a/wallet/src/account/utxo_selector/output_group.rs
+++ b/wallet/src/account/utxo_selector/output_group.rs
@@ -16,7 +16,7 @@
 use common::{
     chain::{
         tokens::{OutputValue, TokenData},
-        TxOutput, UtxoOutPoint,
+        TxInput, TxOutput,
     },
     primitives::Amount,
 };
@@ -28,7 +28,7 @@ use super::UtxoSelectorError;
 #[derive(Clone)]
 pub struct OutputGroup {
     /// The list of UTXOs contained in this output group.
-    pub outputs: Vec<(UtxoOutPoint, TxOutput)>,
+    pub outputs: Vec<(TxInput, TxOutput)>,
     /// the total amount of the outputs in this group
     pub value: Amount,
     /// The fee cost of these UTXOs at the effective feerate.
@@ -52,7 +52,7 @@ pub enum PayFee {
 
 impl OutputGroup {
     pub fn new(
-        output: (UtxoOutPoint, TxOutput),
+        output: (TxInput, TxOutput),
         fee: Amount,
         long_term_fee: Amount,
         weight: u32,

--- a/wallet/src/account/utxo_selector/tests.rs
+++ b/wallet/src/account/utxo_selector/tests.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{tokens::OutputValue, Destination, GenBlock, OutPointSourceId},
+    chain::{tokens::OutputValue, Destination, GenBlock, OutPointSourceId, UtxoOutPoint},
     primitives::Id,
     Uint256,
 };
@@ -30,7 +30,7 @@ fn add_output(value: Amount, groups: &mut Vec<OutputGroup>) {
     );
     let tx_output = TxOutput::Transfer(OutputValue::Coin(value), Destination::AnyoneCanSpend);
 
-    let outputs = vec![(outpoint, tx_output)];
+    let outputs = vec![(outpoint.into(), tx_output)];
 
     groups.push(OutputGroup {
         outputs,

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -18,7 +18,6 @@ use common::chain::stakelock::StakePoolData;
 use common::chain::tokens::{OutputValue, TokenData, TokenId, TokenTransfer};
 use common::chain::{
     ChainConfig, Destination, PoolId, Transaction, TransactionCreationError, TxInput, TxOutput,
-    UtxoOutPoint,
 };
 use common::primitives::per_thousand::PerThousand;
 use common::primitives::Amount;
@@ -122,12 +121,9 @@ impl SendRequest {
         &self.utxos
     }
 
-    pub fn with_inputs(
-        mut self,
-        utxos: impl IntoIterator<Item = (UtxoOutPoint, TxOutput)>,
-    ) -> Self {
+    pub fn with_inputs(mut self, utxos: impl IntoIterator<Item = (TxInput, TxOutput)>) -> Self {
         for (outpoint, txo) in utxos {
-            self.inputs.push(outpoint.into());
+            self.inputs.push(outpoint);
             self.utxos.push(txo);
         }
         self

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -36,6 +36,7 @@ use crypto::key::hdkd::u31::U31;
 use crypto::key::PublicKey;
 use crypto::vrf::VRFPublicKey;
 use itertools::Itertools;
+use mempool::FeeRate;
 use utils::ensure;
 use wallet_storage::{
     DefaultBackend, Store, StoreTxRw, TransactionRoLocked, TransactionRwLocked, Transactional,
@@ -427,8 +428,8 @@ impl<B: storage::Backend> Wallet<B> {
         &mut self,
         account_index: U31,
         outputs: impl IntoIterator<Item = TxOutput>,
-        current_fee_rate: Amount,
-        long_term_fee_rate: Amount,
+        current_fee_rate: FeeRate,
+        long_term_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let request = SendRequest::new().with_outputs(outputs);
         let latest_median_time = self.latest_median_time;
@@ -453,8 +454,8 @@ impl<B: storage::Backend> Wallet<B> {
         account_index: U31,
         amount: Amount,
         decomission_key: Option<PublicKey>,
-        current_fee_rate: Amount,
-        long_term_fee_rate: Amount,
+        current_fee_rate: FeeRate,
+        long_term_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked(account_index, |account, db_tx| {

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -427,11 +427,19 @@ impl<B: storage::Backend> Wallet<B> {
         &mut self,
         account_index: U31,
         outputs: impl IntoIterator<Item = TxOutput>,
+        current_fee_rate: Amount,
+        long_term_fee_rate: Amount,
     ) -> WalletResult<SignedTransaction> {
         let request = SendRequest::new().with_outputs(outputs);
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
-            let tx = account.process_send_request(db_tx, request, latest_median_time)?;
+            let tx = account.process_send_request(
+                db_tx,
+                request,
+                latest_median_time,
+                current_fee_rate,
+                long_term_fee_rate,
+            )?;
             let txs = [tx];
             account.scan_new_unconfirmed_transactions(&txs, TxState::Inactive, db_tx)?;
 
@@ -445,11 +453,19 @@ impl<B: storage::Backend> Wallet<B> {
         account_index: U31,
         amount: Amount,
         decomission_key: Option<PublicKey>,
+        current_fee_rate: Amount,
+        long_term_fee_rate: Amount,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
-            let tx =
-                account.create_stake_pool_tx(db_tx, amount, decomission_key, latest_median_time)?;
+            let tx = account.create_stake_pool_tx(
+                db_tx,
+                amount,
+                decomission_key,
+                latest_median_time,
+                current_fee_rate,
+                long_term_fee_rate,
+            )?;
 
             let txs = [tx];
             account.scan_new_unconfirmed_transactions(&txs, TxState::Inactive, db_tx)?;

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -699,8 +699,8 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
         wallet.create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             vec![new_output.clone()],
-            Amount::ZERO,
-            Amount::ZERO
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         ),
         Err(WalletError::DatabaseError(
             wallet_storage::Error::WalletLocked
@@ -714,8 +714,8 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 vec![new_output],
-                Amount::ZERO,
-                Amount::ZERO,
+                FeeRate::new(Amount::ZERO),
+                FeeRate::new(Amount::ZERO),
             )
             .unwrap();
     } else {
@@ -741,8 +741,8 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 vec![new_output],
-                Amount::ZERO,
-                Amount::ZERO,
+                FeeRate::new(Amount::ZERO),
+                FeeRate::new(Amount::ZERO),
             )
             .unwrap();
     }
@@ -816,17 +816,11 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
         .map(|_| gen_random_transfer(&mut rng, amount_to_transfer))
         .collect();
 
-    let amount_fee_per_kb = Amount::from_atoms(1000);
+    let feerate = FeeRate::new(Amount::from_atoms(1000));
     let transaction = wallet
-        .create_transaction_to_addresses(
-            DEFAULT_ACCOUNT_INDEX,
-            outputs,
-            amount_fee_per_kb,
-            amount_fee_per_kb,
-        )
+        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, outputs, feerate, feerate)
         .unwrap();
 
-    let feerate = mempool::FeeRate::new(amount_fee_per_kb);
     let tx_size = serialization::Encode::encoded_size(&transaction);
     let fee = feerate.compute_fee(tx_size).unwrap();
 
@@ -930,8 +924,8 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
             DEFAULT_ACCOUNT_INDEX,
             pool_amount,
             None,
-            Amount::ZERO,
-            Amount::ZERO,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         )
         .unwrap();
     let block2 = Block::new(
@@ -1045,8 +1039,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             vec![new_output],
-            Amount::ZERO,
-            Amount::ZERO,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         )
         .unwrap();
 
@@ -1104,8 +1098,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             vec![new_output],
-            Amount::ZERO,
-            Amount::ZERO,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         )
         .unwrap();
 
@@ -1169,8 +1163,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             vec![new_output],
-            Amount::ZERO,
-            Amount::ZERO,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         )
         .err()
         .unwrap();
@@ -1272,8 +1266,8 @@ fn lock_then_transfer(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             vec![new_output],
-            Amount::ZERO,
-            Amount::ZERO,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         )
         .unwrap();
 
@@ -1520,8 +1514,8 @@ fn wallet_multiple_transactions_in_single_block(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 vec![new_output],
-                Amount::ZERO,
-                Amount::ZERO,
+                FeeRate::new(Amount::ZERO),
+                FeeRate::new(Amount::ZERO),
             )
             .unwrap();
 
@@ -1662,8 +1656,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 vec![new_output, change_output],
-                Amount::ZERO,
-                Amount::ZERO,
+                FeeRate::new(Amount::ZERO),
+                FeeRate::new(Amount::ZERO),
             )
             .unwrap();
 
@@ -1693,8 +1687,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             vec![new_output],
-            Amount::ZERO,
-            Amount::ZERO,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         )
         .unwrap();
 
@@ -1730,8 +1724,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             vec![new_output],
-            Amount::ZERO,
-            Amount::ZERO,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         )
         .unwrap_err();
     assert_eq!(
@@ -1754,8 +1748,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             vec![new_output],
-            Amount::ZERO,
-            Amount::ZERO,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
         )
         .unwrap();
 
@@ -1902,8 +1896,8 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 vec![new_output, change_output],
-                Amount::ZERO,
-                Amount::ZERO,
+                FeeRate::new(Amount::ZERO),
+                FeeRate::new(Amount::ZERO),
             )
             .unwrap();
 

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -64,10 +64,10 @@ fn gen_random_transfer(rng: &mut (impl Rng + CryptoRng), amount: Amount) -> TxOu
     match rng.gen::<bool>() {
         true => TxOutput::Transfer(OutputValue::Coin(amount), destination),
         false => {
-            let lock_for_blocks = rng.gen::<u32>() as u64;
-            let current_block_height = BlockHeight::new(rng.gen::<u32>() as u64);
-            let seconds_between_blocks = rng.gen::<u32>() as u64;
-            let current_timestamp = BlockTimestamp::from_int_seconds(rng.gen::<u32>() as u64);
+            let lock_for_blocks = rng.gen_range(0..1000);
+            let current_block_height = BlockHeight::new(rng.gen_range(0..1000));
+            let seconds_between_blocks = rng.gen_range(1..1000);
+            let current_timestamp = BlockTimestamp::from_int_seconds(rng.gen_range(0..1000));
             gen_random_lock_then_transfer(
                 rng,
                 amount,

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -672,7 +672,12 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
     );
 
     assert_eq!(
-        wallet.create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output.clone()]),
+        wallet.create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            vec![new_output.clone()],
+            Amount::ZERO,
+            Amount::ZERO
+        ),
         Err(WalletError::DatabaseError(
             wallet_storage::Error::WalletLocked
         ))
@@ -682,7 +687,12 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
     wallet.unlock_wallet(&password.unwrap()).unwrap();
     if rng.gen::<bool>() {
         wallet
-            .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+            .create_transaction_to_addresses(
+                DEFAULT_ACCOUNT_INDEX,
+                vec![new_output],
+                Amount::ZERO,
+                Amount::ZERO,
+            )
             .unwrap();
     } else {
         // check if we remove the password it should fail to lock
@@ -704,7 +714,12 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
             .is_none());
 
         wallet
-            .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+            .create_transaction_to_addresses(
+                DEFAULT_ACCOUNT_INDEX,
+                vec![new_output],
+                Amount::ZERO,
+                Amount::ZERO,
+            )
             .unwrap();
     }
 }
@@ -791,8 +806,15 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
 
     let pool_amount = (block1_amount - Amount::from_atoms(NETWORK_FEE)).unwrap();
 
-    let stake_pool_transaction =
-        wallet.create_stake_pool_tx(DEFAULT_ACCOUNT_INDEX, pool_amount, None).unwrap();
+    let stake_pool_transaction = wallet
+        .create_stake_pool_tx(
+            DEFAULT_ACCOUNT_INDEX,
+            pool_amount,
+            None,
+            Amount::ZERO,
+            Amount::ZERO,
+        )
+        .unwrap();
     let block2 = Block::new(
         vec![stake_pool_transaction],
         block1_id.into(),
@@ -901,7 +923,12 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     );
 
     let token_issuance_transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+        .create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            vec![new_output],
+            Amount::ZERO,
+            Amount::ZERO,
+        )
         .unwrap();
 
     let block2 = Block::new(
@@ -955,7 +982,12 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     );
 
     let transfer_tokens_transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+        .create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            vec![new_output],
+            Amount::ZERO,
+            Amount::ZERO,
+        )
         .unwrap();
 
     let block3 = Block::new(
@@ -1015,7 +1047,12 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     );
 
     let transfer_tokens_error = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+        .create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            vec![new_output],
+            Amount::ZERO,
+            Amount::ZERO,
+        )
         .err()
         .unwrap();
 
@@ -1113,7 +1150,12 @@ fn lock_then_transfer(#[case] seed: Seed) {
     );
 
     let lock_then_transfer_transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+        .create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            vec![new_output],
+            Amount::ZERO,
+            Amount::ZERO,
+        )
         .unwrap();
 
     let block2 = Block::new(
@@ -1360,7 +1402,12 @@ fn wallet_multiple_transactions_in_single_block(#[case] seed: Seed) {
         );
 
         let transaction = wallet
-            .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+            .create_transaction_to_addresses(
+                DEFAULT_ACCOUNT_INDEX,
+                vec![new_output],
+                Amount::ZERO,
+                Amount::ZERO,
+            )
             .unwrap();
 
         for utxo in transaction.inputs().iter().map(|inp| inp.utxo_outpoint().unwrap()) {
@@ -1484,7 +1531,12 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             make_address_output(chain_config.as_ref(), address, amount_to_transfer).unwrap();
 
         let transaction = wallet
-            .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+            .create_transaction_to_addresses(
+                DEFAULT_ACCOUNT_INDEX,
+                vec![new_output],
+                Amount::ZERO,
+                Amount::ZERO,
+            )
             .unwrap();
 
         for utxo in transaction.inputs().iter().map(|inp| inp.utxo_outpoint().unwrap()) {
@@ -1512,7 +1564,12 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
         ),
     );
     let transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+        .create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            vec![new_output],
+            Amount::ZERO,
+            Amount::ZERO,
+        )
         .unwrap();
 
     for utxo in transaction.inputs().iter().map(|inp| inp.utxo_outpoint().unwrap()) {
@@ -1547,7 +1604,12 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
         ),
     );
     let err = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+        .create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            vec![new_output],
+            Amount::ZERO,
+            Amount::ZERO,
+        )
         .unwrap_err();
     assert_eq!(
         err,
@@ -1566,7 +1628,12 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
     );
 
     let transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+        .create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            vec![new_output],
+            Amount::ZERO,
+            Amount::ZERO,
+        )
         .unwrap();
 
     let transaction_id = transaction.transaction().get_id();
@@ -1696,7 +1763,12 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
             make_address_output(chain_config.as_ref(), address, amount_to_transfer).unwrap();
 
         let transaction = wallet
-            .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, vec![new_output])
+            .create_transaction_to_addresses(
+                DEFAULT_ACCOUNT_INDEX,
+                vec![new_output],
+                Amount::ZERO,
+                Amount::ZERO,
+            )
             .unwrap();
 
         for utxo in transaction.inputs().iter().map(|inp| inp.utxo_outpoint().unwrap()) {

--- a/wallet/wallet-controller/Cargo.toml
+++ b/wallet/wallet-controller/Cargo.toml
@@ -12,6 +12,7 @@ consensus = { path = "../../consensus" }
 crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
 mempool-types = { path = "../../mempool/types" }
+mempool = { path = "../../mempool" }
 node-comm = { path = "../wallet-node-client" }
 serialization = { path = "../../serialization" }
 utils = { path = "../../utils" }

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -285,7 +285,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
             .await
             .map_err(ControllerError::NodeCallError)?;
 
-        let long_term_fee_rate = current_fee_rate;
+        let consolidate_fee_rate = current_fee_rate;
 
         let tx = self
             .wallet
@@ -293,7 +293,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
                 account_index,
                 [output],
                 current_fee_rate,
-                long_term_fee_rate,
+                consolidate_fee_rate,
             )
             .map_err(ControllerError::WalletError)?;
         self.rpc_client
@@ -314,7 +314,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
             .await
             .map_err(ControllerError::NodeCallError)?;
 
-        let long_term_fee_rate = current_fee_rate;
+        let consolidate_fee_rate = current_fee_rate;
         let tx = self
             .wallet
             .create_stake_pool_tx(
@@ -322,7 +322,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
                 amount,
                 decomission_key,
                 current_fee_rate,
-                long_term_fee_rate,
+                consolidate_fee_rate,
             )
             .map_err(ControllerError::WalletError)?;
         self.rpc_client

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -279,9 +279,17 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
     ) -> Result<TxStatus, ControllerError<T>> {
         let output = make_address_output(self.chain_config.as_ref(), address, amount)
             .map_err(ControllerError::WalletError)?;
+        //TODO: get feerate from mempool
+        let current_fee_rate = Amount::ZERO;
+        let long_term_fee_rate = Amount::ZERO;
         let tx = self
             .wallet
-            .create_transaction_to_addresses(account_index, [output])
+            .create_transaction_to_addresses(
+                account_index,
+                [output],
+                current_fee_rate,
+                long_term_fee_rate,
+            )
             .map_err(ControllerError::WalletError)?;
         self.rpc_client
             .submit_transaction(tx.clone())
@@ -295,9 +303,18 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         amount: Amount,
         decomission_key: Option<PublicKey>,
     ) -> Result<TxStatus, ControllerError<T>> {
+        //TODO: get feerate from mempool
+        let current_fee_rate = Amount::ZERO;
+        let long_term_fee_rate = Amount::ZERO;
         let tx = self
             .wallet
-            .create_stake_pool_tx(account_index, amount, decomission_key)
+            .create_stake_pool_tx(
+                account_index,
+                amount,
+                decomission_key,
+                current_fee_rate,
+                long_term_fee_rate,
+            )
             .map_err(ControllerError::WalletError)?;
         self.rpc_client
             .submit_transaction(tx.clone())

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -279,14 +279,14 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
     ) -> Result<TxStatus, ControllerError<T>> {
         let output = make_address_output(self.chain_config.as_ref(), address, amount)
             .map_err(ControllerError::WalletError)?;
-        let amount_fee_per_kb = self
+        let current_fee_rate = self
             .rpc_client
-            .mempool_get_fee_rate()
+            .mempool_get_fee_rate(5)
             .await
             .map_err(ControllerError::NodeCallError)?;
 
-        let current_fee_rate = Amount::from_atoms(amount_fee_per_kb);
-        let long_term_fee_rate = Amount::from_atoms(amount_fee_per_kb);
+        let long_term_fee_rate = current_fee_rate;
+
         let tx = self
             .wallet
             .create_transaction_to_addresses(
@@ -308,14 +308,13 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         amount: Amount,
         decomission_key: Option<PublicKey>,
     ) -> Result<TxStatus, ControllerError<T>> {
-        let amount_fee_per_kb = self
+        let current_fee_rate = self
             .rpc_client
-            .mempool_get_fee_rate()
+            .mempool_get_fee_rate(5)
             .await
             .map_err(ControllerError::NodeCallError)?;
 
-        let current_fee_rate = Amount::from_atoms(amount_fee_per_kb);
-        let long_term_fee_rate = Amount::from_atoms(amount_fee_per_kb);
+        let long_term_fee_rate = current_fee_rate;
         let tx = self
             .wallet
             .create_stake_pool_tx(

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -279,9 +279,14 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
     ) -> Result<TxStatus, ControllerError<T>> {
         let output = make_address_output(self.chain_config.as_ref(), address, amount)
             .map_err(ControllerError::WalletError)?;
-        //TODO: get feerate from mempool
-        let current_fee_rate = Amount::ZERO;
-        let long_term_fee_rate = Amount::ZERO;
+        let amount_fee_per_kb = self
+            .rpc_client
+            .mempool_get_fee_rate()
+            .await
+            .map_err(ControllerError::NodeCallError)?;
+
+        let current_fee_rate = Amount::from_atoms(amount_fee_per_kb);
+        let long_term_fee_rate = Amount::from_atoms(amount_fee_per_kb);
         let tx = self
             .wallet
             .create_transaction_to_addresses(
@@ -303,9 +308,14 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static> Controller<T> {
         amount: Amount,
         decomission_key: Option<PublicKey>,
     ) -> Result<TxStatus, ControllerError<T>> {
-        //TODO: get feerate from mempool
-        let current_fee_rate = Amount::ZERO;
-        let long_term_fee_rate = Amount::ZERO;
+        let amount_fee_per_kb = self
+            .rpc_client
+            .mempool_get_fee_rate()
+            .await
+            .map_err(ControllerError::NodeCallError)?;
+
+        let current_fee_rate = Amount::from_atoms(amount_fee_per_kb);
+        let long_term_fee_rate = Amount::from_atoms(amount_fee_per_kb);
         let tx = self
             .wallet
             .create_stake_pool_tx(

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -208,6 +208,10 @@ impl NodeInterface for MockNode {
     async fn p2p_remove_reserved_node(&self, _address: String) -> Result<(), Self::Error> {
         unreachable!()
     }
+
+    async fn mempool_get_fee_rate(&self) -> Result<u128, Self::Error> {
+        Ok(0)
+    }
 }
 
 fn create_chain(node: &MockNode, rng: &mut (impl Rng + CryptoRng), parent: u64, count: usize) {

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -27,6 +27,7 @@ use common::{
 use consensus::GenerateBlockInputData;
 use crypto::random::{seq::IteratorRandom, CryptoRng, Rng};
 use logging::log;
+use mempool::FeeRate;
 use mempool_types::TxStatus;
 use node_comm::{
     node_traits::{ConnectedPeer, PeerId},
@@ -209,8 +210,8 @@ impl NodeInterface for MockNode {
         unreachable!()
     }
 
-    async fn mempool_get_fee_rate(&self) -> Result<u128, Self::Error> {
-        Ok(0)
+    async fn mempool_get_fee_rate(&self, _in_top_x_mb: usize) -> Result<FeeRate, Self::Error> {
+        Ok(FeeRate::new(Amount::ZERO))
     }
 }
 

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -20,7 +20,7 @@ use common::{
     primitives::{Amount, BlockHeight, Id},
 };
 use consensus::GenerateBlockInputData;
-use mempool::MempoolHandle;
+use mempool::{FeeRate, MempoolHandle};
 use p2p::{error::P2pError, interface::types::ConnectedPeer, types::peer_id::PeerId, P2pHandle};
 use serialization::hex::HexError;
 
@@ -189,8 +189,8 @@ impl NodeInterface for WalletHandlesClient {
         Ok(())
     }
 
-    async fn mempool_get_fee_rate(&self) -> Result<u128, Self::Error> {
-        let res = self.mempool.call(|this| this.get_fee_rate()).await?;
+    async fn mempool_get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, Self::Error> {
+        let res = self.mempool.call(move |this| this.get_fee_rate(in_top_x_mb)).await??;
         Ok(res)
     }
 }

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -29,7 +29,7 @@ use crate::node_traits::NodeInterface;
 #[derive(Clone)]
 pub struct WalletHandlesClient {
     chainstate: ChainstateHandle,
-    _mempool: MempoolHandle,
+    mempool: MempoolHandle,
     block_prod: BlockProductionHandle,
     p2p: P2pHandle,
 }
@@ -59,7 +59,7 @@ impl WalletHandlesClient {
     ) -> Result<Self, WalletHandlesClientError> {
         let result = Self {
             chainstate,
-            _mempool: mempool,
+            mempool,
             block_prod,
             p2p,
         };
@@ -187,5 +187,10 @@ impl NodeInterface for WalletHandlesClient {
             .call_async_mut(move |this| this.remove_reserved_node(address))
             .await??;
         Ok(())
+    }
+
+    async fn mempool_get_fee_rate(&self) -> Result<u128, Self::Error> {
+        let res = self.mempool.call(|this| this.get_fee_rate()).await?;
+        Ok(res)
     }
 }

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -60,4 +60,6 @@ pub trait NodeInterface {
     async fn p2p_get_connected_peers(&self) -> Result<Vec<ConnectedPeer>, Self::Error>;
     async fn p2p_add_reserved_node(&self, address: String) -> Result<(), Self::Error>;
     async fn p2p_remove_reserved_node(&self, address: String) -> Result<(), Self::Error>;
+
+    async fn mempool_get_fee_rate(&self) -> Result<u128, Self::Error>;
 }

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -20,6 +20,7 @@ use common::{
 };
 
 use consensus::GenerateBlockInputData;
+use mempool::FeeRate;
 pub use p2p::{interface::types::ConnectedPeer, types::peer_id::PeerId};
 
 #[async_trait::async_trait]
@@ -61,5 +62,5 @@ pub trait NodeInterface {
     async fn p2p_add_reserved_node(&self, address: String) -> Result<(), Self::Error>;
     async fn p2p_remove_reserved_node(&self, address: String) -> Result<(), Self::Error>;
 
-    async fn mempool_get_fee_rate(&self) -> Result<u128, Self::Error>;
+    async fn mempool_get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, Self::Error>;
 }

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -20,8 +20,8 @@ use common::{
     primitives::{Amount, BlockHeight, Id},
 };
 use consensus::GenerateBlockInputData;
-use mempool::rpc::MempoolRpcClient;
 use mempool::TxStatus;
+use mempool::{rpc::MempoolRpcClient, FeeRate};
 use p2p::{interface::types::ConnectedPeer, rpc::P2pRpcClient, types::peer_id::PeerId};
 use serialization::hex_encoded::HexEncoded;
 
@@ -153,8 +153,8 @@ impl NodeInterface for NodeRpcClient {
             .map_err(NodeRpcError::ResponseError)
     }
 
-    async fn mempool_get_fee_rate(&self) -> Result<u128, Self::Error> {
-        MempoolRpcClient::get_fee_rate(&self.http_client)
+    async fn mempool_get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, Self::Error> {
+        MempoolRpcClient::get_fee_rate(&self.http_client, in_top_x_mb)
             .await
             .map_err(NodeRpcError::ResponseError)
     }

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -20,6 +20,7 @@ use common::{
     primitives::{Amount, BlockHeight, Id},
 };
 use consensus::GenerateBlockInputData;
+use mempool::rpc::MempoolRpcClient;
 use mempool::TxStatus;
 use p2p::{interface::types::ConnectedPeer, rpc::P2pRpcClient, types::peer_id::PeerId};
 use serialization::hex_encoded::HexEncoded;
@@ -148,6 +149,12 @@ impl NodeInterface for NodeRpcClient {
     }
     async fn p2p_remove_reserved_node(&self, address: String) -> Result<(), Self::Error> {
         P2pRpcClient::remove_reserved_node(&self.http_client, address)
+            .await
+            .map_err(NodeRpcError::ResponseError)
+    }
+
+    async fn mempool_get_fee_rate(&self) -> Result<u128, Self::Error> {
+        MempoolRpcClient::get_fee_rate(&self.http_client)
             .await
             .map_err(NodeRpcError::ResponseError)
     }


### PR DESCRIPTION
Take current fee rate from mempool
Calculate fee based on the current fee rate and expected transaction size.

The fee can get overestimated by couple of bytes per change output because of the non-fixed size encoded numbers in them.