### PR TITLE
Mempool rejects transaction accumulators with wrong tips

### DIFF
--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -76,6 +76,8 @@ mod collect_transactions {
             }
         });
 
+        let current_tip = Id::new(H256::zero());
+
         manager.add_subsystem_with_custom_eventloop(
             "test-call",
             move |_: CallRequest<()>, _| async move {
@@ -88,7 +90,7 @@ mod collect_transactions {
                 )
                 .expect("Error initializing blockprod");
 
-                let accumulator = block_production.collect_transactions().await;
+                let accumulator = block_production.collect_transactions(current_tip).await;
 
                 let collected_transactions = mock_mempool.collect_txs_called.load();
                 assert!(collected_transactions, "Expected collect_tx() to be called");
@@ -124,6 +126,8 @@ mod collect_transactions {
         // shutdown straight after startup, *then* call collect_transactions()
         manager.main().await;
 
+        let current_tip = Id::new(H256::zero());
+
         // spawn rather than adding a subsystem as manager is moved into main() above
         tokio::spawn(async move {
             let block_production = BlockProduction::new(
@@ -135,7 +139,7 @@ mod collect_transactions {
             )
             .expect("Error initializing blockprod");
 
-            let accumulator = block_production.collect_transactions().await;
+            let accumulator = block_production.collect_transactions(current_tip).await;
 
             let collected_transactions = mock_mempool.collect_txs_called.load();
             assert!(
@@ -165,6 +169,8 @@ mod collect_transactions {
             }
         });
 
+        let current_tip = Id::new(H256::zero());
+
         let block_production = BlockProduction::new(
             chain_config,
             chainstate,
@@ -182,7 +188,7 @@ mod collect_transactions {
                     shutdown_trigger.initiate();
                 });
 
-                let accumulator = block_production.collect_transactions().await;
+                let accumulator = block_production.collect_transactions(current_tip).await;
 
                 let collected_transactions = mock_mempool.collect_txs_called.load();
                 assert!(collected_transactions, "Expected collect_tx() to be called");

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -51,10 +51,11 @@ pub trait MempoolInterface: Send + Sync {
     fn best_block_id(&self) -> Id<GenBlock>;
 
     /// Collect transactions by putting them in given accumulator
+    /// Ok(None) is returned if mempool rejects the accumulator due configuration mismatch (e.g., tip mismatch)
     fn collect_txs(
         &self,
         tx_accumulator: Box<dyn TransactionAccumulator + Send>,
-    ) -> Result<Box<dyn TransactionAccumulator>, Error>;
+    ) -> Result<Option<Box<dyn TransactionAccumulator>>, Error>;
 
     /// Subscribe to events emitted by mempool
     fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>);

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -139,7 +139,7 @@ impl MempoolInterface for Mempool {
     fn collect_txs(
         &self,
         tx_accumulator: Box<dyn TransactionAccumulator + Send>,
-    ) -> Result<Box<dyn TransactionAccumulator>, Error> {
+    ) -> Result<Option<Box<dyn TransactionAccumulator>>, Error> {
         Ok(self.collect_txs(tx_accumulator))
     }
 

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -1694,9 +1694,9 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
 
     let size_limit: usize = 1_000;
-    let tx_accumulator = DefaultTxAccumulator::new(size_limit);
+    let tx_accumulator = DefaultTxAccumulator::new(size_limit, genesis.get_id().into());
     let returned_accumulator = mempool.collect_txs(Box::new(tx_accumulator));
-    let collected_txs = returned_accumulator.transactions();
+    let collected_txs = returned_accumulator.unwrap().transactions().clone();
     let expected_num_txs_collected: usize = 0;
     assert_eq!(collected_txs.len(), expected_num_txs_collected);
 
@@ -1730,23 +1730,23 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
     }
 
     let size_limit = 1_000;
-    let tx_accumulator = DefaultTxAccumulator::new(size_limit);
+    let tx_accumulator = DefaultTxAccumulator::new(size_limit, genesis.get_id().into());
     let returned_accumulator = mempool.collect_txs(Box::new(tx_accumulator));
-    let collected_txs = returned_accumulator.transactions();
+    let collected_txs = returned_accumulator.unwrap().transactions().clone();
     log::debug!("ancestor index: {:?}", mempool.store.txs_by_ancestor_score);
     let expected_num_txs_collected = 6;
     assert_eq!(collected_txs.len(), expected_num_txs_collected);
     let total_tx_size: usize = collected_txs.iter().map(|tx| tx.encoded_size()).sum();
     assert!(total_tx_size <= size_limit);
 
-    let tx_accumulator = DefaultTxAccumulator::new(0);
+    let tx_accumulator = DefaultTxAccumulator::new(0, genesis.get_id().into());
     let returned_accumulator = mempool.collect_txs(Box::new(tx_accumulator));
-    let collected_txs = returned_accumulator.transactions();
+    let collected_txs = returned_accumulator.unwrap().transactions().clone();
     assert_eq!(collected_txs.len(), 0);
 
-    let tx_accumulator = DefaultTxAccumulator::new(1);
+    let tx_accumulator = DefaultTxAccumulator::new(1, genesis.get_id().into());
     let returned_accumulator = mempool.collect_txs(Box::new(tx_accumulator));
-    let collected_txs = returned_accumulator.transactions();
+    let collected_txs = returned_accumulator.unwrap().transactions().clone();
     assert_eq!(collected_txs.len(), 0);
     Ok(())
 }

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -113,13 +113,13 @@ impl MempoolInterface for MempoolInterfaceMock {
     fn collect_txs(
         &self,
         tx_accumulator: Box<dyn TransactionAccumulator + Send>,
-    ) -> Result<Box<dyn TransactionAccumulator>, Error> {
+    ) -> Result<Option<Box<dyn TransactionAccumulator>>, Error> {
         self.collect_txs_called.store(true);
 
         if self.collect_txs_should_error.load() {
             Err(SUBSYSTEM_ERROR)
         } else {
-            Ok(tx_accumulator)
+            Ok(Some(tx_accumulator))
         }
     }
 


### PR DESCRIPTION
It's possible that there's a race between the mempool updating its tip and the block production. Hence, in this PR, we enforce having both the mempool and block production having the same tip as a condition for the mempool to provide transactions.

In addition, we establish the concept of "rejecting the transaction accumulator" as basis for any other disagreements between the accumulator and the mempool.