### PR TITLE
mempool: Demote transaction rejection errors to warning

### DIFF
--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -889,7 +889,7 @@ impl<M: MemoryUsageEstimator> Mempool<M> {
         let tx_id = *tx.tx_id();
         let origin = tx.origin();
 
-        match self.validate_transaction(tx).log_err_pfx("Transaction rejected") {
+        match self.validate_transaction(tx).log_warn_pfx("Transaction rejected") {
             Ok(ValidationOutcome::Valid {
                 transaction,
                 conflicts,


### PR DESCRIPTION
Using an error here leads to a false impression that something is wrong wit the node. Change to a warning.

Vaguely related: #975