### PR TITLE
Speed up wallet scan

### DIFF
--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -89,7 +89,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     ) -> Result<Vec<Block>, PropertyQueryError> {
         utils::ensure!(
             from != BlockHeight::zero(),
-            PropertyQueryError::InvalidParameter("from", "cannot be zero")
+            PropertyQueryError::InvalidStartingBlockHeightForMainchainBlocks(from)
         );
 
         let mut res = Vec::new();

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -82,6 +82,40 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         self.chainstate_ref.get_block(id)
     }
 
+    pub fn get_mainchain_blocks(
+        &self,
+        mut from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, PropertyQueryError> {
+        utils::ensure!(
+            from != BlockHeight::zero(),
+            PropertyQueryError::InvalidParameter("from", "cannot be zero")
+        );
+
+        let mut res = Vec::new();
+        for _ in 0..max_count {
+            match self.get_block_id_from_height(&from)? {
+                Some(get_block_id) => {
+                    match get_block_id.classify(self.chainstate_ref.chain_config()) {
+                        common::chain::GenBlockId::Genesis(_) => {
+                            panic!("genesis block received at non-zero height {from}")
+                        }
+                        common::chain::GenBlockId::Block(block_id) => {
+                            let block = self.get_block(block_id)?.unwrap_or_else(|| {
+                                panic!("can't find block {block_id} at height {from}")
+                            });
+                            res.push(block);
+                        }
+                    }
+                }
+                None => break,
+            }
+            from = from.next_height();
+        }
+
+        Ok(res)
+    }
+
     pub fn get_block_index(
         &self,
         id: &Id<Block>,

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -59,6 +59,11 @@ pub trait ChainstateInterface: Send {
         height: &BlockHeight,
     ) -> Result<Option<Id<GenBlock>>, ChainstateError>;
     fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, ChainstateError>;
+    fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, ChainstateError>;
     fn get_block_header(
         &self,
         block_id: Id<Block>,

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -128,6 +128,18 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterfa
             .map_err(ChainstateError::FailedToReadProperty)
     }
 
+    fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, ChainstateError> {
+        self.chainstate
+            .query()
+            .map_err(ChainstateError::from)?
+            .get_mainchain_blocks(from, max_count)
+            .map_err(ChainstateError::FailedToReadProperty)
+    }
+
     fn get_block_header(
         &self,
         block_id: Id<Block>,

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -106,6 +106,14 @@ where
         self.deref().get_block(block_id)
     }
 
+    fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, ChainstateError> {
+        self.deref().get_mainchain_blocks(from, max_count)
+    }
+
     fn get_locator(&self) -> Result<Locator, ChainstateError> {
         self.deref().get_locator()
     }

--- a/chainstate/src/rpc.rs
+++ b/chainstate/src/rpc.rs
@@ -42,7 +42,7 @@ trait ChainstateRpc {
     #[method(name = "get_block")]
     async fn get_block(&self, id: Id<Block>) -> RpcResult<Option<HexEncoded<Block>>>;
 
-    /// Returns a hex-encoded serialized block with the given id.
+    /// Returns a hex-encoded serialized blocks from the mainchain starting from a given block height.
     #[method(name = "get_mainchain_blocks")]
     async fn get_mainchain_blocks(
         &self,

--- a/chainstate/src/rpc.rs
+++ b/chainstate/src/rpc.rs
@@ -42,6 +42,14 @@ trait ChainstateRpc {
     #[method(name = "get_block")]
     async fn get_block(&self, id: Id<Block>) -> RpcResult<Option<HexEncoded<Block>>>;
 
+    /// Returns a hex-encoded serialized block with the given id.
+    #[method(name = "get_mainchain_blocks")]
+    async fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> RpcResult<Vec<HexEncoded<Block>>>;
+
     /// Submit a block to be included in the chain
     #[method(name = "submit_block")]
     async fn submit_block(&self, block_hex: HexEncoded<Block>) -> RpcResult<()>;
@@ -104,6 +112,17 @@ impl ChainstateRpcServer for super::ChainstateHandle {
         let block: Option<Block> =
             rpc::handle_result(self.call(move |this| this.get_block(id)).await)?;
         Ok(block.map(HexEncoded::new))
+    }
+
+    async fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> RpcResult<Vec<HexEncoded<Block>>> {
+        let blocks: Vec<Block> = rpc::handle_result(
+            self.call(move |this| this.get_mainchain_blocks(from, max_count)).await,
+        )?;
+        Ok(blocks.into_iter().map(HexEncoded::new).collect())
     }
 
     async fn submit_block(&self, block: HexEncoded<Block>) -> RpcResult<()> {

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -58,8 +58,8 @@ pub enum PropertyQueryError {
     PoolBalanceNotFound(PoolId),
     #[error("Failed to read balance of pool {0}")]
     PoolBalanceReadError(PoolId),
-    #[error("Invalid parameter: {0}: {1}")]
-    InvalidParameter(&'static str, &'static str),
+    #[error("Invalid starting block height: {0}")]
+    InvalidStartingBlockHeightForMainchainBlocks(BlockHeight),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -58,6 +58,8 @@ pub enum PropertyQueryError {
     PoolBalanceNotFound(PoolId),
     #[error("Failed to read balance of pool {0}")]
     PoolBalanceReadError(PoolId),
+    #[error("Invalid parameter: {0}: {1}")]
+    InvalidParameter(&'static str, &'static str),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/common/src/primitives/height.rs
+++ b/common/src/primitives/height.rs
@@ -135,15 +135,15 @@ impl BlockHeight {
         Self(height)
     }
 
-    pub fn zero() -> BlockHeight {
+    pub const fn zero() -> BlockHeight {
         BlockHeight::ZERO
     }
 
-    pub fn one() -> BlockHeight {
+    pub const fn one() -> BlockHeight {
         BlockHeight::ONE
     }
 
-    pub fn max() -> BlockHeight {
+    pub const fn max() -> BlockHeight {
         BlockHeight::MAX
     }
 
@@ -159,7 +159,7 @@ impl BlockHeight {
         self.0.checked_sub(1).map(Self)
     }
 
-    pub fn into_int(self) -> HeightIntType {
+    pub const fn into_int(self) -> HeightIntType {
         self.0
     }
 }

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -58,6 +58,11 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> Result<Option<Id<GenBlock>>, ChainstateError>;
         fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, ChainstateError>;
+        fn get_mainchain_blocks(
+            &self,
+            start_block_height: BlockHeight,
+            max_count: usize,
+        ) -> Result<Vec<Block>, ChainstateError>;
         fn get_block_header(&self, block_id: Id<Block>) -> Result<Option<SignedBlockHeader>, ChainstateError>;
         fn get_locator(&self) -> Result<Locator, ChainstateError>;
         fn get_locator_from_height(&self, height: BlockHeight) -> Result<Locator, ChainstateError>;

--- a/node-gui/src/backend/mod.rs
+++ b/node-gui/src/backend/mod.rs
@@ -29,7 +29,7 @@ use common::primitives::Amount;
 use common::time_getter::TimeGetter;
 use std::fmt::Debug;
 use std::sync::Arc;
-use tokio::sync::mpsc::{channel, unbounded_channel, Receiver, UnboundedSender};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use crate::backend::chainstate_event_handler::ChainstateEventHandler;
 use crate::backend::p2p_event_handler::P2pEventHandler;
@@ -37,13 +37,11 @@ use crate::backend::p2p_event_handler::P2pEventHandler;
 use self::error::BackendError;
 use self::messages::{BackendEvent, BackendRequest};
 
-const UI_CHANNEL_BUF: usize = 10;
-
 #[derive(Debug)]
 pub struct BackendControls {
     pub initialized_node: InitializedNode,
     pub backend_sender: BackendSender,
-    pub backend_receiver: Receiver<BackendEvent>,
+    pub backend_receiver: UnboundedReceiver<BackendEvent>,
 }
 
 /// `UnboundedSender` wrapper, used to make sure there is only one instance and it doesn't get cloned
@@ -92,7 +90,7 @@ pub async fn node_initialize(_time_getter: TimeGetter) -> anyhow::Result<Backend
     let manager_join_handle = tokio::spawn(async move { node.main().await });
 
     let (request_tx, request_rx) = unbounded_channel();
-    let (event_tx, event_rx) = channel(UI_CHANNEL_BUF);
+    let (event_tx, event_rx) = unbounded_channel();
     let (wallet_updated_tx, wallet_updated_rx) = unbounded_channel();
 
     // Subscribe to chainstate before getting the current chain_info!

--- a/node-gui/src/backend/p2p_event_handler.rs
+++ b/node-gui/src/backend/p2p_event_handler.rs
@@ -17,18 +17,21 @@ use std::sync::Arc;
 
 use p2p::{interface::p2p_interface::P2pInterface, P2pEvent};
 use subsystem::Handle;
-use tokio::sync::mpsc::{unbounded_channel, Sender, UnboundedReceiver};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use utils::tap_error_log::LogError;
 
 use super::{backend_impl::Backend, messages::BackendEvent};
 
 pub struct P2pEventHandler {
     p2p_event_rx: UnboundedReceiver<P2pEvent>,
-    event_tx: Sender<BackendEvent>,
+    event_tx: UnboundedSender<BackendEvent>,
 }
 
 impl P2pEventHandler {
-    pub async fn new(p2p: &Handle<dyn P2pInterface>, event_tx: Sender<BackendEvent>) -> Self {
+    pub async fn new(
+        p2p: &Handle<dyn P2pInterface>,
+        event_tx: UnboundedSender<BackendEvent>,
+    ) -> Self {
         // TODO: Fix race in p2p events subscribe (if some peers are connected before the subscription is complete)
 
         let (p2p_event_tx, p2p_event_rx) = unbounded_channel();
@@ -55,7 +58,7 @@ impl P2pEventHandler {
             let p2p_event_opt = self.p2p_event_rx.recv().await;
             match p2p_event_opt {
                 Some(event) => {
-                    Backend::send_event(&self.event_tx, BackendEvent::P2p(event)).await;
+                    Backend::send_event(&self.event_tx, BackendEvent::P2p(event));
                 }
                 None => {
                     // Node is stopped

--- a/node-gui/src/main.rs
+++ b/node-gui/src/main.rs
@@ -27,7 +27,7 @@ use iced::Subscription;
 use iced::{executor, Application, Command, Element, Length, Settings, Theme};
 use iced_aw::native::cupertino::cupertino_spinner::CupertinoSpinner;
 use main_window::{MainWindow, MainWindowMessage};
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 pub fn main() -> iced::Result {
     MintlayerNodeGUI::run(Settings {
@@ -47,7 +47,7 @@ enum MintlayerNodeGUI {
 
 #[derive(Debug)]
 pub enum Message {
-    FromBackend(Receiver<BackendEvent>, BackendEvent),
+    FromBackend(UnboundedReceiver<BackendEvent>, BackendEvent),
     Loaded(anyhow::Result<BackendControls>),
     EventOccurred(iced::Event),
     ShuttingDownFinished,
@@ -190,7 +190,7 @@ impl Application for MintlayerNodeGUI {
     }
 }
 
-fn recv_backend_command(mut backend_receiver: Receiver<BackendEvent>) -> Command<Message> {
+fn recv_backend_command(mut backend_receiver: UnboundedReceiver<BackendEvent>) -> Command<Message> {
     Command::perform(
         async move {
             match backend_receiver.recv().await {

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -211,7 +211,7 @@ where
 
                 event = self.local_event_rx.recv() => {
                     let event = event.ok_or(P2pError::ChannelClosed)?;
-                    self.handle_new_event(event)?;
+                    self.handle_local_event(event)?;
                 }
 
                 _ = stalling_interval.tick(), if !matches!(self.last_activity, PeerActivity::Pending) => {}
@@ -226,7 +226,7 @@ where
         }
     }
 
-    fn handle_new_event(&mut self, event: LocalEvent) -> Result<()> {
+    fn handle_local_event(&mut self, event: LocalEvent) -> Result<()> {
         match event {
             LocalEvent::ChainstateNewTip(header) => {
                 if self.send_tip_updates && self.common_services.has_service(Service::Blocks) {

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -523,9 +523,12 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
 
     /// Wallet sync progress
     pub fn best_block(&self) -> (Id<GenBlock>, BlockHeight) {
-        self.wallet
-            .get_best_block_for_unsynced_account()
-            .unwrap_or_else(|| self.wallet.get_best_block())
+        *self
+            .wallet
+            .get_best_block()
+            .values()
+            .min_by_key(|(_block_id, block_height)| block_height)
+            .expect("there must be at least one account")
     }
 
     pub async fn get_stake_pool_balances(

--- a/wallet/wallet-controller/src/sync/mod.rs
+++ b/wallet/wallet-controller/src/sync/mod.rs
@@ -26,7 +26,7 @@ use wallet::{wallet_events::WalletEvents, DefaultWallet, WalletResult};
 
 use crate::ControllerError;
 
-const MAX_FETCH_BLOCK_COUNT: usize = 1000;
+const MAX_FETCH_BLOCK_COUNT: usize = 100;
 
 pub trait SyncingWallet {
     fn best_block(&self) -> BTreeMap<U31, (Id<GenBlock>, BlockHeight)>;

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -144,6 +144,19 @@ impl NodeInterface for MockNode {
     async fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, Self::Error> {
         Ok(self.tf.lock().unwrap().chainstate.get_block(block_id).unwrap())
     }
+    async fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, Self::Error> {
+        Ok(self
+            .tf
+            .lock()
+            .unwrap()
+            .chainstate
+            .get_mainchain_blocks(from, max_count)
+            .unwrap())
+    }
     async fn get_best_block_height(&self) -> Result<BlockHeight, Self::Error> {
         unreachable!()
     }

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -67,12 +67,16 @@ impl MockWallet {
 }
 
 impl SyncingWallet for MockWallet {
-    fn best_block(&self) -> (Id<GenBlock>, BlockHeight) {
-        (self.get_best_block_id(), self.get_block_height())
+    fn best_block(&self) -> BTreeMap<U31, (Id<GenBlock>, BlockHeight)> {
+        BTreeMap::from([(
+            U31::ZERO,
+            (self.get_best_block_id(), self.get_block_height()),
+        )])
     }
 
     fn scan_blocks(
         &mut self,
+        _account: U31,
         common_block_height: BlockHeight,
         blocks: Vec<Block>,
         _wallet_events: &mut impl WalletEvents,
@@ -103,19 +107,6 @@ impl SyncingWallet for MockWallet {
     fn update_median_time(&mut self, median_time: BlockTimestamp) -> WalletResult<()> {
         self.latest_median_time = median_time;
         Ok(())
-    }
-
-    fn best_block_unsynced_acc(&self) -> Option<(Id<GenBlock>, BlockHeight)> {
-        None
-    }
-
-    fn scan_blocks_unsynced_acc(
-        &mut self,
-        _common_block_height: BlockHeight,
-        _blocks: Vec<Block>,
-        _wallet_events: &mut impl WalletEvents,
-    ) -> WalletResult<()> {
-        Err(wallet::WalletError::NoUnsyncedAccount)
     }
 }
 

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -100,6 +100,18 @@ impl NodeInterface for WalletHandlesClient {
         Ok(result)
     }
 
+    async fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, Self::Error> {
+        let blocks = self
+            .chainstate
+            .call(move |this| this.get_mainchain_blocks(from, max_count))
+            .await??;
+        Ok(blocks)
+    }
+
     async fn get_best_block_height(&self) -> Result<BlockHeight, Self::Error> {
         let result = self.chainstate.call(move |this| this.get_best_block_height()).await??;
         Ok(result)

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -30,6 +30,11 @@ pub trait NodeInterface {
     async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error>;
     async fn get_best_block_id(&self) -> Result<Id<GenBlock>, Self::Error>;
     async fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, Self::Error>;
+    async fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, Self::Error>;
     async fn get_best_block_height(&self) -> Result<BlockHeight, Self::Error>;
     async fn get_block_id_at_height(
         &self,

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -46,6 +46,17 @@ impl NodeInterface for NodeRpcClient {
             .map(|block_opt| block_opt.map(HexEncoded::take))
     }
 
+    async fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, Self::Error> {
+        ChainstateRpcClient::get_mainchain_blocks(&self.http_client, from, max_count)
+            .await
+            .map_err(NodeRpcError::ResponseError)
+            .map(|blocks| blocks.into_iter().map(HexEncoded::take).collect())
+    }
+
     async fn get_best_block_id(&self) -> Result<Id<GenBlock>, Self::Error> {
         ChainstateRpcClient::best_block_id(&self.http_client)
             .await


### PR DESCRIPTION
The problem with the slow wallet scan is that we download one block at a time and it takes many minutes to scan a new wallet. I added a new chainstate RPC function that returns a vector of mainchain blocks. With this change, the full wallet scan takes about 5 seconds for me. This should fix https://github.com/mintlayer/mintlayer-core/issues/1084

After this change, I got a problem with unsyncing accounts where the wallet would not correctly move an unsynced account to regular accounts. I decided not to spend time fixing it and removed the unsyncing accounts. Now all accounts are treated the same, which simplified the code.