### PR TITLE
Fix duplicated transaction bans (p2p)

### DIFF
--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -133,9 +133,10 @@ where
             .send_message(peer, SyncMessage::HeaderList(HeaderList::new(Vec::new())))
             .unwrap();
         messaging_handle_2
-            .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block
-                .header()
-                .clone()])))
+            .send_message(
+                peer,
+                SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
+            )
             .unwrap();
     });
 

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -78,7 +78,7 @@ where
     .await
     .unwrap();
 
-    connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;
+    let (_, peer1, peer2) = connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;
 
     let block = Block::new(
         vec![],
@@ -89,9 +89,10 @@ where
     )
     .unwrap();
     messaging_handle1
-        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block
-            .header()
-            .clone()])))
+        .send_message(
+            peer2.peer_id,
+            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
+        )
         .unwrap();
 
     let mut sync_rx_2 = match sync2.poll_next().await.unwrap() {
@@ -123,9 +124,10 @@ where
     )
     .unwrap();
     messaging_handle2
-        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block
-            .header()
-            .clone()])))
+        .send_message(
+            peer1.peer_id,
+            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
+        )
         .unwrap();
 
     let mut sync_rx_1 = match sync1.poll_next().await.unwrap() {
@@ -218,7 +220,7 @@ where
     .await
     .unwrap();
 
-    connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;
+    let (_, _peer1, peer2) = connect_and_accept_services::<N>(&mut conn1, &mut conn2).await;
 
     let block = Block::new(
         vec![],
@@ -229,9 +231,10 @@ where
     )
     .unwrap();
     messaging_handle1
-        .broadcast_message(SyncMessage::HeaderList(HeaderList::new(vec![block
-            .header()
-            .clone()])))
+        .send_message(
+            peer2.peer_id,
+            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
+        )
         .unwrap();
 
     shutdown.store(true);

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -28,7 +28,7 @@ use crate::{
         HeaderList, HeaderListRequest, PeerManagerMessage, PingRequest, PingResponse, SyncMessage,
         TransactionResponse,
     },
-    net::types::services::{Service, Services},
+    net::types::services::Services,
     protocol::NetworkProtocol,
     types::{peer_address::PeerAddress, peer_id::PeerId},
 };
@@ -39,7 +39,6 @@ pub enum Command<A> {
     Accept { peer_id: PeerId },
     Disconnect { peer_id: PeerId },
     SendMessage { peer: PeerId, message: Message },
-    AnnounceData { service: Service, message: Message },
 }
 
 /// Random nonce sent in outbound handshake.

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -144,9 +144,6 @@ where
 pub trait MessagingService: Clone {
     /// Sends a message to the peer.
     fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()>;
-
-    /// Broadcasts a message to all peers.
-    fn broadcast_message(&mut self, message: SyncMessage) -> crate::Result<()>;
 }
 
 #[async_trait]

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -348,10 +348,8 @@ async fn valid_transaction(#[case] seed: Seed) {
         )
         .await;
 
-    assert_eq!(
-        SyncMessage::NewTransaction(tx.transaction().get_id()),
-        handle.message().await.1
-    );
+    // There should be no `NewTransaction` message because the transaction is already known
+    handle.assert_no_event().await;
 
     handle.join_subsystem_manager().await;
 }


### PR DESCRIPTION
Add a `RollingBloomFilter` for transaction announcements, similar to what's done in Bitcoin Core. This should fix the problem with unexpected bans after duplicate transaction announcements.

I have removed `announce_data` from `MessagingService` because it's not used anymore.