### PR TITLE
mempool: Time lock handling

### DIFF
--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -62,6 +62,9 @@ use crate::{
 mod collect_transactions {
     use super::*;
 
+    // A dummy timestamp for tests where the block timestamp is irrelevant
+    const DUMMY_TIMESTAMP: BlockTimestamp = BlockTimestamp::from_int_seconds(0u64);
+
     // TODO: add tests for mempool rejecting transaction accumulator
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -94,7 +97,8 @@ mod collect_transactions {
                 )
                 .expect("Error initializing blockprod");
 
-                let accumulator = block_production.collect_transactions(current_tip).await;
+                let accumulator =
+                    block_production.collect_transactions(current_tip, DUMMY_TIMESTAMP).await;
 
                 let collected_transactions = mock_mempool.collect_txs_called.load();
                 assert!(collected_transactions, "Expected collect_tx() to be called");
@@ -145,7 +149,8 @@ mod collect_transactions {
             )
             .expect("Error initializing blockprod");
 
-            let accumulator = block_production.collect_transactions(current_tip).await;
+            let accumulator =
+                block_production.collect_transactions(current_tip, DUMMY_TIMESTAMP).await;
 
             let collected_transactions = mock_mempool.collect_txs_called.load();
             assert!(
@@ -196,7 +201,8 @@ mod collect_transactions {
                     shutdown_trigger.initiate();
                 });
 
-                let accumulator = block_production.collect_transactions(current_tip).await;
+                let accumulator =
+                    block_production.collect_transactions(current_tip, DUMMY_TIMESTAMP).await;
 
                 let collected_transactions = mock_mempool.collect_txs_called.load();
                 assert!(collected_transactions, "Expected collect_tx() to be called");

--- a/chainstate/test-suite/src/tests/mempool_output_timelock.rs
+++ b/chainstate/test-suite/src/tests/mempool_output_timelock.rs
@@ -75,9 +75,7 @@ fn output_lock_until_height(#[case] seed: Seed) {
             let best_block_index = tf.best_block_index();
             assert!(matches!(
                 verifier.connect_transaction(
-                    &TransactionSourceForConnect::Mempool {
-                        current_best: &best_block_index,
-                    },
+                    &TransactionSourceForConnect::for_mempool(&best_block_index),
                     &spend_locked_tx,
                     &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                     None
@@ -96,9 +94,7 @@ fn output_lock_until_height(#[case] seed: Seed) {
         let best_block_index = tf.best_block_index();
         verifier
             .connect_transaction(
-                &TransactionSourceForConnect::Mempool {
-                    current_best: &best_block_index,
-                },
+                &TransactionSourceForConnect::for_mempool(&best_block_index),
                 &spend_locked_tx,
                 &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                 None,
@@ -142,9 +138,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
             let best_block_index = tf.best_block_index();
             assert!(matches!(
                 verifier.connect_transaction(
-                    &TransactionSourceForConnect::Mempool {
-                        current_best: &best_block_index,
-                    },
+                    &TransactionSourceForConnect::for_mempool(&best_block_index),
                     &spend_locked_tx,
                     &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                     None,
@@ -166,9 +160,7 @@ fn output_lock_for_block_count(#[case] seed: Seed) {
         let best_block_index = tf.best_block_index();
         verifier
             .connect_transaction(
-                &TransactionSourceForConnect::Mempool {
-                    current_best: &best_block_index,
-                },
+                &TransactionSourceForConnect::for_mempool(&best_block_index),
                 &spend_locked_tx,
                 &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                 None,
@@ -233,9 +225,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
             let best_block_index = tf.best_block_index();
             assert!(matches!(
                 verifier.connect_transaction(
-                    &TransactionSourceForConnect::Mempool {
-                        current_best: &best_block_index,
-                    },
+                    &TransactionSourceForConnect::for_mempool(&best_block_index),
                     &spend_locked_tx,
                     &mtp,
                     None,
@@ -258,9 +248,7 @@ fn output_lock_until_time(#[case] seed: Seed) {
         let best_block_index = tf.best_block_index();
         verifier
             .connect_transaction(
-                &TransactionSourceForConnect::Mempool {
-                    current_best: &best_block_index,
-                },
+                &TransactionSourceForConnect::for_mempool(&best_block_index),
                 &spend_locked_tx,
                 &BlockTimestamp::from_duration_since_epoch(tf.current_time()),
                 None,
@@ -326,9 +314,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
             let best_block_index = tf.best_block_index();
             assert!(matches!(
                 verifier.connect_transaction(
-                    &TransactionSourceForConnect::Mempool {
-                        current_best: &best_block_index,
-                    },
+                    &TransactionSourceForConnect::for_mempool(&best_block_index),
                     &spend_locked_tx,
                     &mtp,
                     None
@@ -356,9 +342,7 @@ fn output_lock_for_seconds(#[case] seed: Seed) {
         let best_block_index = tf.best_block_index();
         verifier
             .connect_transaction(
-                &TransactionSourceForConnect::Mempool {
-                    current_best: &best_block_index,
-                },
+                &TransactionSourceForConnect::for_mempool(&best_block_index),
                 &spend_locked_tx,
                 &BlockTimestamp::from_duration_since_epoch(time::get_time()),
                 None,

--- a/chainstate/test-suite/src/tests/tx_verifier_disconnect.rs
+++ b/chainstate/test-suite/src/tests/tx_verifier_disconnect.rs
@@ -137,9 +137,8 @@ fn connect_disconnect_tx_mempool(#[case] seed: Seed) {
             &chain_config,
             TransactionVerifierConfig::new(true),
         );
-        let tx_source = TransactionSourceForConnect::Mempool {
-            current_best: &best_block.into(),
-        };
+        let best_block_idx = best_block.into();
+        let tx_source = TransactionSourceForConnect::for_mempool(&best_block_idx);
 
         // create and connect a tx from mempool based on best block
         let tx1 = TransactionBuilder::new()

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -708,7 +708,7 @@ where
         // spend utxos
         let tx_undo = self
             .utxo_cache
-            .connect_transaction(tx.transaction(), tx_source.expected_block_height())
+            .connect_transaction(tx.transaction(), tx_source.to_utxo_source())
             .map_err(ConnectTransactionError::from)?;
 
         // save spent utxos for undo
@@ -737,7 +737,7 @@ where
                     )?;
                 }
             }
-            TransactionSourceForConnect::Mempool { current_best: _ } => { /* do nothing */ }
+            TransactionSourceForConnect::Mempool { .. } => { /* do nothing */ }
         };
 
         Ok(fee)

--- a/chainstate/tx-verifier/src/transaction_verifier/tx_source.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tx_source.rs
@@ -18,6 +18,7 @@ use common::{
     chain::Block,
     primitives::{BlockHeight, Id},
 };
+use utxo::UtxoSource;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum TransactionSource {
@@ -31,35 +32,85 @@ impl<'a> From<&TransactionSourceForConnect<'a>> for TransactionSource {
             TransactionSourceForConnect::Chain { new_block_index } => {
                 TransactionSource::Chain(*new_block_index.block_id())
             }
-            TransactionSourceForConnect::Mempool { current_best: _ } => TransactionSource::Mempool,
+            TransactionSourceForConnect::Mempool {
+                current_best: _,
+                effective_height: _,
+            } => TransactionSource::Mempool,
         }
     }
 }
 
 pub enum TransactionSourceForConnect<'a> {
-    Chain { new_block_index: &'a BlockIndex },
-    Mempool { current_best: &'a GenBlockIndex },
+    Chain {
+        new_block_index: &'a BlockIndex,
+    },
+    Mempool {
+        // Blockchain tip according to mempool
+        current_best: &'a GenBlockIndex,
+        // Effective block height used for mempool transaction validation (e.g. timelocks)
+        effective_height: BlockHeight,
+    },
 }
 
 impl<'a> TransactionSourceForConnect<'a> {
+    pub fn for_chain(new_block_index: &'a BlockIndex) -> Self {
+        Self::Chain { new_block_index }
+    }
+
+    pub fn for_mempool(current_best: &'a GenBlockIndex) -> Self {
+        let effective_height = current_best.block_height().next_height();
+        Self::for_mempool_with_height(current_best, effective_height)
+    }
+
+    /// Source is mempool with given declared block height
+    ///
+    /// The height has to be strictly greater than the height of chain tip
+    pub fn for_mempool_with_height(
+        current_best: &'a GenBlockIndex,
+        effective_height: BlockHeight,
+    ) -> Self {
+        assert!(current_best.block_height() < effective_height);
+        Self::Mempool {
+            current_best,
+            effective_height,
+        }
+    }
+
     /// The block height of the transaction to be connected
-    /// For the mempool, it's the height of the next-to-be block
-    /// For the chain, it's for the block being connected
+    ///
+    /// * For the mempool, it's the height greater than tip, as specified by mempool
+    /// * For the chain, it's for the block being connected
     pub fn expected_block_height(&self) -> BlockHeight {
         match self {
             TransactionSourceForConnect::Chain { new_block_index } => {
                 new_block_index.block_height()
             }
             TransactionSourceForConnect::Mempool {
-                current_best: best_block_index,
-            } => best_block_index.block_height().next_height(),
+                current_best: _,
+                effective_height,
+            } => *effective_height,
         }
     }
 
     pub fn chain_block_index(&self) -> Option<&BlockIndex> {
         match self {
             TransactionSourceForConnect::Chain { new_block_index } => Some(new_block_index),
-            TransactionSourceForConnect::Mempool { current_best: _ } => None,
+            TransactionSourceForConnect::Mempool {
+                current_best: _,
+                effective_height: _,
+            } => None,
+        }
+    }
+
+    pub fn to_utxo_source(&self) -> UtxoSource {
+        match self {
+            Self::Chain {
+                new_block_index: idx,
+            } => UtxoSource::Blockchain(idx.block_height()),
+            Self::Mempool {
+                current_best: _,
+                effective_height: _,
+            } => UtxoSource::Mempool,
         }
     }
 }

--- a/common/src/chain/block/timestamp.rs
+++ b/common/src/chain/block/timestamp.rs
@@ -36,21 +36,21 @@ impl std::fmt::Display for BlockTimestamp {
 }
 
 impl BlockTimestamp {
-    pub fn from_int_seconds(timestamp: BlockTimestampInternalType) -> Self {
+    pub const fn from_int_seconds(timestamp: BlockTimestampInternalType) -> Self {
         Self { timestamp }
     }
 
-    pub fn from_duration_since_epoch(duration: Duration) -> Self {
+    pub const fn from_duration_since_epoch(duration: Duration) -> Self {
         Self {
             timestamp: duration.as_secs(),
         }
     }
 
-    pub fn as_duration_since_epoch(&self) -> Duration {
+    pub const fn as_duration_since_epoch(&self) -> Duration {
         Duration::from_secs(self.timestamp)
     }
 
-    pub fn as_int_seconds(&self) -> BlockTimestampInternalType {
+    pub const fn as_int_seconds(&self) -> BlockTimestampInternalType {
         self.timestamp
     }
 

--- a/mempool/src/config.rs
+++ b/mempool/src/config.rs
@@ -15,6 +15,8 @@
 
 use std::time::Duration;
 
+use common::primitives::BlockDistance;
+
 pub type Time = Duration;
 
 /// Mempool size configuration
@@ -68,3 +70,7 @@ pub const DEFAULT_ORPHAN_TX_EXPIRY_INTERVAL: Time = Duration::from_secs(5 * 10);
 pub const MAX_ORPHAN_TX_SIZE: usize = 20_000;
 
 pub const MAX_ORPHAN_ACCOUNT_GAP: u64 = 2;
+
+pub const FUTURE_TIMELOCK_TOLERANCE_SECS: Time = Duration::from_secs(5 * 60);
+
+pub const FUTURE_TIMELOCK_TOLERANCE_BLOCKS: BlockDistance = BlockDistance::new(5);

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -831,8 +831,6 @@ impl<T: std::borrow::Borrow<TxMempoolEntry> + Eq> PartialOrd for TxMempoolEntryB
 
 impl<T: std::borrow::Borrow<TxMempoolEntry> + Eq> Ord for TxMempoolEntryByScore<T> {
     fn cmp(&self, rhs: &Self) -> Ordering {
-        rhs.ancestor_score()
-            .cmp(&self.ancestor_score())
-            .then_with(|| self.tx_id().cmp(rhs.tx_id()))
+        (rhs.ancestor_score(), self.tx_id()).cmp(&(self.ancestor_score(), rhs.tx_id()))
     }
 }

--- a/mempool/src/pool/tests/accumulator.rs
+++ b/mempool/src/pool/tests/accumulator.rs
@@ -13,8 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common::chain::timelock::OutputTimeLock;
+
 use super::*;
 use crate::tx_accumulator::DefaultTxAccumulator;
+
+// Useful for testing cases where timestamp is irrelevant.
+const DUMMY_TIMESTAMP: BlockTimestamp = BlockTimestamp::from_int_seconds(0u64);
 
 #[rstest]
 #[trace]
@@ -49,7 +54,11 @@ async fn transaction_order_respects_deps(#[case] seed: Seed) {
     );
     assert!(mempool.contains_transaction(&tx2_id));
 
-    let accumulator = Box::new(DefaultTxAccumulator::new(1_000_000, genesis_id.into()));
+    let accumulator = Box::new(DefaultTxAccumulator::new(
+        1_000_000,
+        genesis_id.into(),
+        DUMMY_TIMESTAMP,
+    ));
     let accumulator = mempool.collect_txs(accumulator).unwrap();
     let tx_ids: Vec<_> =
         accumulator.transactions().iter().map(|tx| tx.transaction().get_id()).collect();
@@ -80,7 +89,11 @@ async fn transaction_graph_respects_deps(#[case] seed: Seed) {
 
     let txs_by_id: BTreeMap<_, _> = txs.into_iter().map(|tx| (*tx.tx_id(), tx)).collect();
 
-    let accumulator = Box::new(DefaultTxAccumulator::new(10_000_000, genesis_id.into()));
+    let accumulator = Box::new(DefaultTxAccumulator::new(
+        10_000_000,
+        genesis_id.into(),
+        DUMMY_TIMESTAMP,
+    ));
     let accumulator = mempool.collect_txs(accumulator).unwrap();
     let position_map: BTreeMap<Id<Transaction>, usize> = accumulator
         .transactions()
@@ -109,7 +122,8 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
     let mut mempool = setup_with_chainstate(tf.chainstate()).await;
 
     let size_limit: usize = 1_000;
-    let tx_accumulator = DefaultTxAccumulator::new(size_limit, mempool.best_block_id());
+    let tx_accumulator =
+        DefaultTxAccumulator::new(size_limit, mempool.best_block_id(), DUMMY_TIMESTAMP);
     let returned_accumulator = mempool.collect_txs(Box::new(tx_accumulator)).unwrap();
     let collected_txs = returned_accumulator.transactions();
     let expected_num_txs_collected: usize = 0;
@@ -145,7 +159,8 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
     }
 
     let size_limit = 1_000;
-    let tx_accumulator = DefaultTxAccumulator::new(size_limit, mempool.best_block_id());
+    let tx_accumulator =
+        DefaultTxAccumulator::new(size_limit, mempool.best_block_id(), DUMMY_TIMESTAMP);
     let returned_accumulator = mempool.collect_txs(Box::new(tx_accumulator)).unwrap();
     let collected_txs = returned_accumulator.transactions();
     log::debug!("ancestor index: {:?}", mempool.store.txs_by_ancestor_score);
@@ -154,14 +169,148 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
     let total_tx_size: usize = collected_txs.iter().map(|tx| tx.encoded_size()).sum();
     assert!(total_tx_size <= size_limit);
 
-    let tx_accumulator = DefaultTxAccumulator::new(0, mempool.best_block_id());
+    let tx_accumulator = DefaultTxAccumulator::new(0, mempool.best_block_id(), DUMMY_TIMESTAMP);
     let returned_accumulator = mempool.collect_txs(Box::new(tx_accumulator)).unwrap();
     let collected_txs = returned_accumulator.transactions();
     assert_eq!(collected_txs.len(), 0);
 
-    let tx_accumulator = DefaultTxAccumulator::new(1, mempool.best_block_id());
+    let tx_accumulator = DefaultTxAccumulator::new(1, mempool.best_block_id(), DUMMY_TIMESTAMP);
     let returned_accumulator = mempool.collect_txs(Box::new(tx_accumulator)).unwrap();
     let collected_txs = returned_accumulator.transactions();
     assert_eq!(collected_txs.len(), 0);
     Ok(())
+}
+
+fn timelock_secs_after_genesis(n: u64) -> OutputTimeLock {
+    let mut rng = make_seedable_rng(Seed::from_u64(0));
+    let t0 = TestFramework::builder(&mut rng).build().genesis().timestamp();
+    OutputTimeLock::UntilTime(t0.add_int_seconds(n).unwrap())
+}
+
+#[rstest]
+#[trace]
+#[case::until_blk1(Seed::from_entropy(), OutputTimeLock::UntilHeight(1.into()), 0b1111)]
+#[trace]
+#[case::until_blk2(Seed::from_entropy(), OutputTimeLock::UntilHeight(2.into()), 0b1011)]
+#[trace]
+#[case::until_blk4(Seed::from_entropy(), OutputTimeLock::UntilHeight(4.into()), 0b1010)]
+#[trace]
+#[case::until_blk20(Seed::from_entropy(), OutputTimeLock::UntilHeight(20.into()), 0b0000)]
+#[trace]
+#[case::for_1blk(Seed::from_entropy(), OutputTimeLock::ForBlockCount(1), 0b0011)]
+#[trace]
+#[case::for_2blk(Seed::from_entropy(), OutputTimeLock::ForBlockCount(2), 0b0010)]
+#[trace]
+#[case::for_20blk(Seed::from_entropy(), OutputTimeLock::ForBlockCount(20), 0b0000)]
+#[trace]
+#[case::until_5s(Seed::from_entropy(), timelock_secs_after_genesis(5), 0b1111)]
+#[trace]
+#[case::until_10s(Seed::from_entropy(), timelock_secs_after_genesis(10), 0b1111)]
+#[trace]
+#[case::until_11s(Seed::from_entropy(), timelock_secs_after_genesis(11), 0b1011)]
+#[trace]
+#[case::until_30s(Seed::from_entropy(), timelock_secs_after_genesis(30), 0b1011)]
+#[trace]
+#[case::until_31s(Seed::from_entropy(), timelock_secs_after_genesis(31), 0b1010)]
+#[trace]
+#[case::until_500s(Seed::from_entropy(), timelock_secs_after_genesis(500), 0b0000)]
+#[trace]
+#[case::for_1s(Seed::from_entropy(), OutputTimeLock::ForSeconds(1), 0b0011)]
+#[trace]
+#[case::for_10s(Seed::from_entropy(), OutputTimeLock::ForSeconds(10), 0b0011)]
+#[trace]
+#[case::for_20s(Seed::from_entropy(), OutputTimeLock::ForSeconds(20), 0b0011)]
+#[trace]
+#[case::for_21s(Seed::from_entropy(), OutputTimeLock::ForSeconds(21), 0b0010)]
+#[trace]
+#[case::for_500s(Seed::from_entropy(), OutputTimeLock::ForSeconds(500), 0b0000)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn timelocked(#[case] seed: Seed, #[case] timelock: OutputTimeLock, #[case] expected: u32) {
+    // Unpack expected results:
+    let in_mempool_at0 = (expected & 0b1000) != 0;
+    let in_accumulator_at0 = (expected & 0b0100) != 0;
+    let in_mempool_at1 = (expected & 0b0010) != 0;
+    let in_accumulator_at1 = (expected & 0b0001) != 0;
+
+    let mut rng = make_seedable_rng(seed);
+    let tf = TestFramework::builder(&mut rng).build();
+    let genesis_id = tf.genesis().get_id();
+
+    let genesis_time = tf.genesis().timestamp();
+    let block1_time = genesis_time.add_int_seconds(10).unwrap();
+    let block2_time = genesis_time.add_int_seconds(30).unwrap();
+
+    let tx0 = {
+        TransactionBuilder::new()
+            .add_input(
+                TxInput::from_utxo(genesis_id.into(), 0),
+                empty_witness(&mut rng),
+            )
+            .add_output(TxOutput::LockThenTransfer(
+                OutputValue::Coin(Amount::from_atoms(900_000_000)),
+                Destination::AnyoneCanSpend,
+                timelock.clone(),
+            ))
+            .build()
+    };
+    let tx0_id = tx0.transaction().get_id();
+
+    let mut mempool = setup_with_chainstate(tf.chainstate()).await;
+    mempool.clock = mocked_time_getter_seconds(Arc::new(block1_time.as_int_seconds().into()));
+    let chainstate = mempool.chainstate_handle().shallow_clone();
+
+    let res = mempool.add_transaction(tx0.clone(), TxOrigin::TEST);
+    assert_eq!(res, Ok(TxStatus::InMempool));
+
+    let tx1 = make_tx(&mut rng, &[(tx0_id.into(), 0)], &[800_000_000]);
+    let tx1_id = tx1.transaction().get_id();
+
+    let res = mempool.add_transaction(tx1.clone(), TxOrigin::TEST);
+    assert_eq!(
+        res.is_ok(),
+        in_mempool_at0,
+        "Unexpected mempool acceptance {res:?}"
+    );
+
+    let accumulator = Box::new(DefaultTxAccumulator::new(
+        1_000_000,
+        genesis_id.into(),
+        block1_time,
+    ));
+    let accumulator = mempool.collect_txs(accumulator).unwrap();
+    let accumulated_ids: BTreeSet<_> =
+        accumulator.transactions().iter().map(|tx| tx.transaction().get_id()).collect();
+
+    assert!(accumulated_ids.contains(&tx0_id));
+    assert_eq!(accumulated_ids.contains(&tx1_id), in_accumulator_at0);
+
+    // Submit a block with the transaction that defines the time-locked output
+    let block1 = make_test_block(vec![tx0], genesis_id, block1_time);
+    let block1_id = block1.get_id();
+    chainstate
+        .call_mut(move |c| c.process_block(block1, BlockSource::Local))
+        .await
+        .unwrap()
+        .expect("block1");
+    mempool.on_new_tip(block1_id, BlockHeight::new(1));
+
+    let in_mempool = if !in_mempool_at0 {
+        mempool.add_transaction(tx1.clone(), TxOrigin::TEST).is_ok()
+    } else {
+        mempool.contains_transaction(&tx1_id)
+    };
+
+    assert_eq!(in_mempool, in_mempool_at1);
+
+    // Check if the transaction spending time locked output is in the accumulator now
+    let accumulator = Box::new(DefaultTxAccumulator::new(
+        1_000_000,
+        block1_id.into(),
+        block2_time,
+    ));
+    let accumulator = mempool.collect_txs(accumulator).unwrap();
+    let has_tx1 = accumulator.transactions().iter().any(|tx| tx.transaction().get_id() == tx1_id);
+
+    assert_eq!(has_tx1, in_accumulator_at1);
+    assert!(accumulator.transactions().len() <= 1);
 }

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -257,3 +257,18 @@ pub fn generate_transaction_graph(
         TxEntryWithFee::new(entry, Fee::new(Amount::from_atoms(total)))
     })
 }
+
+pub fn make_test_block(
+    txs: Vec<SignedTransaction>,
+    parent: impl Into<Id<GenBlock>>,
+    time: BlockTimestamp,
+) -> Block {
+    Block::new(
+        txs,
+        parent.into(),
+        time,
+        ConsensusData::None,
+        BlockReward::new(vec![]),
+    )
+    .unwrap()
+}

--- a/mempool/src/pool/tx_verifier/mod.rs
+++ b/mempool/src/pool/tx_verifier/mod.rs
@@ -16,6 +16,7 @@
 //! Transaction verifier adapted to mempool
 
 mod chainstate_handle;
+mod utxo_view;
 
 use std::sync::Arc;
 
@@ -23,7 +24,9 @@ pub use chainstate::tx_verifier::flush_to_storage;
 use common::chain::ChainConfig;
 use utils::shallow_clone::ShallowClone;
 
-use chainstate_handle::{Chainstate, ChainstateHandle};
+use chainstate_handle::Chainstate;
+pub use chainstate_handle::ChainstateHandle;
+pub use utxo_view::MempoolUtxoView;
 
 /// Mempool instantiation of [chainstate::tx_verifier::TransactionVerifier]
 pub type TransactionVerifier = chainstate::tx_verifier::TransactionVerifier<

--- a/mempool/src/pool/tx_verifier/utxo_view.rs
+++ b/mempool/src/pool/tx_verifier/utxo_view.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::chain::UtxoOutPoint;
+use utxo::{Utxo, UtxosView};
+
+use crate::pool::Mempool;
+
+#[derive(Eq, PartialEq, Debug, thiserror::Error)]
+pub enum Error<P> {
+    #[error("Transaction output index out of range")]
+    OutputOutOfRange,
+    #[error(transparent)]
+    ParentError(#[from] P),
+}
+
+/// Utxo view sourcing UTXOs from chainstate and mempool
+///
+/// This sources the UTXOs from mempool and chainstate if not available in mempool. All mempool
+/// UTXOs are considered available, double spending is not checked by this view. This is useful for
+/// checking transactions that connect anywhere, not just the unspent boundary of mempool. That may
+/// be used to check RBF transactions without having to disconnect conflicting transactions or to
+/// check transactions to be included in the next block for time locks.
+/// However, it also means double spending has to be checked separately.
+pub struct MempoolUtxoView<'m, M, P> {
+    mempool: &'m Mempool<M>,
+    parent: P,
+}
+
+impl<'m, M, P> MempoolUtxoView<'m, M, P> {
+    pub fn new(mempool: &'m Mempool<M>, parent: P) -> Self {
+        Self { mempool, parent }
+    }
+}
+
+impl<'m, M, P: UtxosView> UtxosView for MempoolUtxoView<'m, M, P> {
+    type Error = Error<P::Error>;
+
+    fn utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<Utxo>, Self::Error> {
+        let tx_id = match outpoint.tx_id().get_tx_id() {
+            Some(tx_id) => *tx_id,
+            None => return Ok(self.parent.utxo(outpoint)?),
+        };
+
+        self.mempool.store.txs_by_id.get(&tx_id).map_or_else(
+            || Ok(self.parent.utxo(outpoint)?),
+            |tx_entry| {
+                let tx = tx_entry.transaction();
+                let output = tx
+                    .outputs()
+                    .get(outpoint.output_index() as usize)
+                    .ok_or(Error::OutputOutOfRange)?;
+                Ok(Some(Utxo::new_for_mempool(output.clone())))
+            },
+        )
+    }
+
+    fn has_utxo(&self, outpoint: &UtxoOutPoint) -> Result<bool, Self::Error> {
+        // TODO: A more efficient implementation is possible here
+        self.utxo(outpoint).map(|u| u.is_some())
+    }
+
+    fn best_block_hash(
+        &self,
+    ) -> Result<common::primitives::Id<common::chain::GenBlock>, Self::Error> {
+        Ok(self.mempool.best_block_id())
+    }
+
+    fn estimated_size(&self) -> Option<usize> {
+        None
+    }
+}

--- a/mempool/src/tx_accumulator.rs
+++ b/mempool/src/tx_accumulator.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{GenBlock, SignedTransaction},
+    chain::{block::timestamp::BlockTimestamp, GenBlock, SignedTransaction},
     primitives::{Amount, Id},
 };
 use serialization::Encode;
@@ -40,6 +40,9 @@ pub trait TransactionAccumulator: Send {
     /// The tip that the accumulator expects. This is used so that the mempool remains in sync with block production,
     /// and to prevent having transactions pulled for a different state than the one the block producer is working on.
     fn expected_tip(&self) -> Id<GenBlock>;
+
+    /// Candidate block timestamp to verify time locks against
+    fn block_timestamp(&self) -> BlockTimestamp;
 }
 
 pub struct DefaultTxAccumulator {
@@ -49,10 +52,11 @@ pub struct DefaultTxAccumulator {
     done: bool,
     total_fees: Fee,
     expected_tip: Id<GenBlock>,
+    timestamp: BlockTimestamp,
 }
 
 impl DefaultTxAccumulator {
-    pub fn new(target_size: usize, expected_tip: Id<GenBlock>) -> Self {
+    pub fn new(target_size: usize, expected_tip: Id<GenBlock>, timestamp: BlockTimestamp) -> Self {
         Self {
             txs: Vec::new(),
             total_size: 0,
@@ -60,6 +64,7 @@ impl DefaultTxAccumulator {
             done: false,
             total_fees: Amount::ZERO.into(),
             expected_tip,
+            timestamp,
         }
     }
 }
@@ -92,5 +97,9 @@ impl TransactionAccumulator for DefaultTxAccumulator {
 
     fn expected_tip(&self) -> Id<GenBlock> {
         self.expected_tip
+    }
+
+    fn block_timestamp(&self) -> BlockTimestamp {
+        self.timestamp
     }
 }

--- a/test/functional/mempool_timelocked_tx.py
+++ b/test/functional/mempool_timelocked_tx.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+""" Time-locked transaction handling test """
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.mintlayer import *
+from test_framework.util import (assert_raises_rpc_error)
+
+class MempoolTimelockedTxTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[
+            "--blockprod-min-peers-to-produce-blocks=0",
+        ]]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.sync_all(self.nodes[0:1])
+
+    def generate_block(self):
+        node = self.nodes[0]
+
+        block_input_data = { "PoW": { "reward_destination": "AnyoneCanSpend" } }
+        block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
+
+        # create a new block, taking transactions from mempool
+        block = node.blockprod_generate_block(block_input_data, None)
+        node.chainstate_submit_block(block)
+        block_id = node.chainstate_best_block_id()
+
+        # Wait for mempool to sync
+        self.wait_until(lambda: node.mempool_local_best_block_id() == block_id, timeout = 5)
+
+        return block_id
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Get chain tip
+        genesis_id = node.chainstate_best_block_id()
+
+        # Prepare a transaction with a bunch of time locked outputs
+        (tx0, tx0_id) = make_tx(
+                [ reward_input(genesis_id) ],
+                [
+                    tx_output(1_000_000, timelock = { 'UntilHeight': 3 }),
+                    tx_output(1_000_000, timelock = { 'ForBlockCount': 4 }),
+                    1_000_000,
+                ],
+            )
+        self.log.debug("Encoded tx0 {}: {}".format(tx0_id, tx0))
+
+        # Prepare transactions spending the outputs
+        (tx1, tx1_id) = make_tx([ tx_input(tx0_id, 0) ], [ 900_000 ] )
+        self.log.debug("Encoded tx1 {}: {}".format(tx1_id, tx1))
+
+        (tx2, tx2_id) = make_tx([ tx_input(tx0_id, 1) ], [ 900_000 ] )
+        self.log.debug("Encoded tx2 {}: {}".format(tx2_id, tx2))
+
+        (tx3, tx3_id) = make_tx([ tx_input(tx0_id, 2) ], [ 900_000 ] )
+        self.log.debug("Encoded tx3 {}: {}".format(tx3_id, tx3))
+
+        # Submit the transactions
+        node.mempool_submit_transaction(tx0)
+        node.mempool_submit_transaction(tx1)
+        node.mempool_submit_transaction(tx3)
+        # Cannot submit tx2 yet, it spends and unconfirmed time-locked output
+        assert_raises_rpc_error(None, "Timelock rules violated", node.mempool_submit_transaction, tx2)
+
+        assert node.mempool_contains_tx(tx0_id)
+        assert node.mempool_contains_tx(tx1_id)
+        assert not node.mempool_contains_tx(tx2_id)
+        assert node.mempool_contains_tx(tx3_id)
+
+        # tx0 should make it into a block now, and also tx3 that spends the unconstrained output
+        self.generate_block() # Block 1
+        assert not node.mempool_contains_tx(tx0_id)
+        assert node.mempool_contains_tx(tx1_id)
+        assert not node.mempool_contains_tx(tx2_id)
+        assert not node.mempool_contains_tx(tx3_id)
+
+        # We can now submit tx2
+        node.mempool_submit_transaction(tx2)
+        assert not node.mempool_contains_tx(tx0_id)
+        assert node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2_id)
+        assert not node.mempool_contains_tx(tx3_id)
+
+        self.generate_block() # Block 2
+        assert not node.mempool_contains_tx(tx0_id)
+        assert node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2_id)
+        assert not node.mempool_contains_tx(tx3_id)
+
+        # tx1 now should be included in the block as time lock is now ready
+        self.generate_block() # Block 3
+        assert not node.mempool_contains_tx(tx0_id)
+        assert not node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2_id)
+        assert not node.mempool_contains_tx(tx3_id)
+
+        self.generate_block() # Block 4
+        assert not node.mempool_contains_tx(tx0_id)
+        assert not node.mempool_contains_tx(tx1_id)
+        assert node.mempool_contains_tx(tx2_id)
+        assert not node.mempool_contains_tx(tx3_id)
+
+        # tx2 time lock is now released
+        self.generate_block() # Block 5
+        assert not node.mempool_contains_tx(tx0_id)
+        assert not node.mempool_contains_tx(tx1_id)
+        assert not node.mempool_contains_tx(tx2_id)
+        assert not node.mempool_contains_tx(tx3_id)
+
+        # Check each transaction is included in appropriate block
+        for ht in range(1, 6):
+            block = node.chainstate_get_block(node.chainstate_block_id_at_height(ht))
+            for (tx, where) in [ (tx0, 1), (tx1, 3), (tx2, 5), (tx3, 1) ]:
+                should_be_here = where == ht
+                is_here = tx in block
+                assert should_be_here == is_here
+
+if __name__ == '__main__':
+    MempoolTimelockedTxTest().main()

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -22,6 +22,8 @@ def init_mintlayer_types():
 
             "H256": "[u8; 32]",
 
+            "BlockHeight": "Compact<u64>",
+
             "OutputValue": {
                 "type": "enum",
                 "type_mapping": [

--- a/test/functional/test_framework/mintlayer.py
+++ b/test/functional/test_framework/mintlayer.py
@@ -46,9 +46,17 @@ def tx_input(tx_id, index = 0):
         }
     }
 
-def make_tx(inputs, output_amounts, flags = 0):
-    outputs = [ {'Transfer': [ { 'Coin': amt }, { 'AnyoneCanSpend': None } ]}
-               for amt in output_amounts ]
+def tx_output(amount, timelock = None):
+    if isinstance(amount, dict):
+        return amount
+    if timelock is None:
+        return {'Transfer': [ { 'Coin': amount }, { 'AnyoneCanSpend': None } ]}
+    else:
+        return {'LockThenTransfer': [ { 'Coin': amount }, { 'AnyoneCanSpend': None }, timelock ]}
+
+
+def make_tx(inputs, outputs, flags = 0):
+    outputs = [ tx_output(amt) for amt in outputs ]
     witness = { 'NoSignature': None }
     tx = {
         'version': 1,

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -113,6 +113,7 @@ BASE_SCRIPTS = [
     'mempool_eviction.py',
     'mempool_submit_tx.py',
     'mempool_submit_orphan.py',
+    'mempool_timelocked_tx.py',
 
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time

--- a/utxo/src/cache.rs
+++ b/utxo/src/cache.rs
@@ -147,7 +147,7 @@ impl<P: UtxosView> UtxosCache<P> {
     pub fn connect_transaction(
         &mut self,
         tx: &Transaction,
-        height: BlockHeight,
+        source: UtxoSource,
     ) -> Result<UtxosTxUndoWithSources, Error> {
         let sources = tx
             .inputs()
@@ -167,7 +167,7 @@ impl<P: UtxosView> UtxosCache<P> {
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
-        self.add_utxos_from_tx(tx, UtxoSource::Blockchain(height), false)?;
+        self.add_utxos_from_tx(tx, source, false)?;
 
         Ok(UtxosTxUndoWithSources::new(utxos, sources))
     }

--- a/utxo/src/tests/mod.rs
+++ b/utxo/src/tests/mod.rs
@@ -532,7 +532,7 @@ fn multiple_update_utxos_test(#[case] seed: Seed) {
     let new_tx = Transaction::new(0x00, to_spend.clone(), vec![]).expect("should succeed");
     // let's test `connect_transaction`
     let tx_undo = cache
-        .connect_transaction(&new_tx, BlockHeight::new(2))
+        .connect_transaction(&new_tx, UtxoSource::Blockchain(BlockHeight::new(2)))
         .expect("should return tx undo");
 
     // check that these utxos came from the tx's output
@@ -603,7 +603,9 @@ fn check_tx_spend_undo_spend(#[case] seed: Seed) {
     // spend the utxo in a transaction
     let input = TxInput::from_utxo(outpoint.tx_id(), outpoint.output_index());
     let tx = Transaction::new(0x00, vec![input], create_tx_outputs(&mut rng, 1)).unwrap();
-    let undo1 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    let undo1 = cache
+        .connect_transaction(&tx, UtxoSource::Blockchain(BlockHeight::new(1)))
+        .unwrap();
     assert!(!cache.has_utxo_in_cache(&outpoint));
     assert_eq!(undo1.utxos().len(), 1);
 
@@ -614,7 +616,9 @@ fn check_tx_spend_undo_spend(#[case] seed: Seed) {
     assert!(cache.has_utxo_in_cache(&outpoint));
 
     //spend the transaction again
-    let undo2 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    let undo2 = cache
+        .connect_transaction(&tx, UtxoSource::Blockchain(BlockHeight::new(1)))
+        .unwrap();
     assert!(!cache.has_utxo_in_cache(&outpoint));
     assert_eq!(undo1, undo2);
 }
@@ -636,7 +640,9 @@ fn check_burn_spend_undo_spend(#[case] seed: Seed, #[case] output: TxOutput) {
     // burn output in a tx
     let input = TxInput::from_utxo(outpoint.tx_id(), outpoint.output_index());
     let tx = Transaction::new(0x00, vec![input], vec![output]).unwrap();
-    let undo1 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    let undo1 = cache
+        .connect_transaction(&tx, UtxoSource::Blockchain(BlockHeight::new(1)))
+        .unwrap();
     assert!(!cache.has_utxo_in_cache(&outpoint));
     assert_eq!(undo1.utxos().len(), 1);
 
@@ -647,7 +653,9 @@ fn check_burn_spend_undo_spend(#[case] seed: Seed, #[case] output: TxOutput) {
     assert!(cache.has_utxo_in_cache(&outpoint));
 
     //spend the transaction again
-    let undo2 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    let undo2 = cache
+        .connect_transaction(&tx, UtxoSource::Blockchain(BlockHeight::new(1)))
+        .unwrap();
     assert!(!cache.has_utxo_in_cache(&outpoint));
     assert_eq!(undo1, undo2);
 }
@@ -869,7 +877,9 @@ fn check_burn_output_indexing(#[case] seed: Seed) {
     );
     let input = TxInput::from_utxo(outpoint.tx_id(), outpoint.output_index());
     let tx = Transaction::new(0x00, vec![input], vec![output1, output2]).unwrap();
-    let undo1 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    let undo1 = cache
+        .connect_transaction(&tx, UtxoSource::Blockchain(BlockHeight::new(1)))
+        .unwrap();
     assert!(!cache.has_utxo_in_cache(&outpoint));
     assert_eq!(undo1.utxos().len(), 1);
 
@@ -880,7 +890,9 @@ fn check_burn_output_indexing(#[case] seed: Seed) {
     assert!(cache.has_utxo_in_cache(&outpoint));
 
     //spend the transaction again
-    let undo2 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    let undo2 = cache
+        .connect_transaction(&tx, UtxoSource::Blockchain(BlockHeight::new(1)))
+        .unwrap();
     assert!(!cache.has_utxo_in_cache(&outpoint));
     assert_eq!(undo1, undo2);
 }
@@ -904,7 +916,9 @@ fn check_tx_spend_undo_spend_from_account(#[case] seed: Seed) {
     let tx = Transaction::new(0x00, vec![input], create_tx_outputs(&mut rng, 1)).unwrap();
     let new_utxo_outpoint = UtxoOutPoint::new(tx.get_id().into(), 0);
 
-    let undo1 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    let undo1 = cache
+        .connect_transaction(&tx, UtxoSource::Blockchain(BlockHeight::new(1)))
+        .unwrap();
     assert!(cache.has_utxo_in_cache(&new_utxo_outpoint));
     assert_eq!(undo1.utxos(), vec![None]);
     assert_eq!(cache.utxos.len(), 1);
@@ -917,7 +931,9 @@ fn check_tx_spend_undo_spend_from_account(#[case] seed: Seed) {
     assert!(cache.utxos.is_empty());
 
     //spend the transaction again
-    let undo2 = cache.connect_transaction(&tx, BlockHeight::new(1)).unwrap();
+    let undo2 = cache
+        .connect_transaction(&tx, UtxoSource::Blockchain(BlockHeight::new(1)))
+        .unwrap();
     assert_eq!(undo2.utxos(), vec![None]);
 
     let consumed_cache = cache.consume();

--- a/utxo/src/tests/simulation_with_undo.rs
+++ b/utxo/src/tests/simulation_with_undo.rs
@@ -176,7 +176,8 @@ fn populate_cache_with_undo<P: UtxosView<Error = Infallible>>(
 
                 //spent the transaction
                 let block_height = BlockHeight::new(rng.gen_range(0..iterations_count as u64));
-                let undo = cache.connect_transaction(&tx, block_height).unwrap();
+                let undo =
+                    cache.connect_transaction(&tx, UtxoSource::Blockchain(block_height)).unwrap();
 
                 //keep result updated
                 let new_outpoint = UtxoOutPoint::new(OutPointSourceId::from(tx.get_id()), 0);


### PR DESCRIPTION
* Allow time locked transactions in mempool (within certain limit).
* Modifications to tx verifier to support time locked instructions in mempool.
* Transaction accumulator to only allow transactions where time lock constraints are satisfied.