### PR TITLE
Remove the disconnected by user flag (p2p)

### DIFF
--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -661,12 +661,7 @@ where
             let resp_ch = self.pending_disconnects.remove(&peer_id).flatten();
 
             if peer.role == Role::Outbound {
-                // If `resp_ch` is some, the peer is disconnected after the RPC command
-                if resp_ch.is_some() {
-                    self.peerdb.outbound_peer_disconnected_by_user(peer.address);
-                } else {
-                    self.peerdb.outbound_peer_disconnected(peer.address);
-                }
+                self.peerdb.outbound_peer_disconnected(peer.address);
             }
 
             if let Some(response) = resp_ch {

--- a/p2p/src/peer_manager/peerdb/address_data/tests.rs
+++ b/p2p/src/peer_manager/peerdb/address_data/tests.rs
@@ -29,7 +29,7 @@ fn randomized(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let started_at = Duration::ZERO;
 
-    let weights = [100, 100, 100, 100, 10, 10];
+    let weights = [100, 100, 100, 10, 10];
     assert_eq!(weights.len(), ALL_TRANSITIONS.len());
     let weights = WeightedIndex::new(weights).unwrap();
 
@@ -45,7 +45,6 @@ fn randomized(#[case] seed: Seed) {
             let is_valid_transition = match transition {
                 AddressStateTransitionTo::Connected => !address_data.is_connected(),
                 AddressStateTransitionTo::Disconnected => address_data.is_connected(),
-                AddressStateTransitionTo::DisconnectedByUser => address_data.is_connected(),
                 AddressStateTransitionTo::ConnectionFailed => !address_data.is_connected(),
                 AddressStateTransitionTo::SetReserved => true,
                 AddressStateTransitionTo::UnsetReserved => true,
@@ -87,28 +86,4 @@ fn reachable_reconnects(#[case] seed: Seed) {
         time_until_removed >= 2 * week && time_until_removed <= 6 * week,
         "invalid time until removed: {time_until_removed:?}"
     );
-}
-
-#[rstest]
-#[trace]
-#[case(
-    Seed::from_entropy(),
-    AddressStateTransitionTo::DisconnectedByUser,
-    false
-)]
-#[case(Seed::from_entropy(), AddressStateTransitionTo::Disconnected, true)]
-fn no_reconnects_after_manual_disconnect(
-    #[case] seed: Seed,
-    #[case] reason: AddressStateTransitionTo,
-    #[case] expected_reconnect: bool,
-) {
-    let mut rng = make_seedable_rng(seed);
-    let now = Duration::from_secs(1600000000);
-
-    let mut address = AddressData::new(true, false, now);
-    address.transition_to(AddressStateTransitionTo::Connected, now, &mut rng);
-    address.transition_to(reason, now, &mut rng);
-    let reconnect = address.connect_now(now + Duration::from_secs(100 * 24 * 3600));
-    // Test that there are no reconnection attempts to peers that were disconnected by RPC
-    assert_eq!(reconnect, expected_reconnect);
 }

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -258,11 +258,6 @@ where
         self.change_address_state(address, AddressStateTransitionTo::Disconnected);
     }
 
-    /// Handle peer disconnect event after RPC command
-    pub fn outbound_peer_disconnected_by_user(&mut self, address: A) {
-        self.change_address_state(address, AddressStateTransitionTo::DisconnectedByUser);
-    }
-
     pub fn change_address_state(&mut self, address: A, transition: AddressStateTransitionTo) {
         let now = self.time_getter.get_time();
 

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -805,7 +805,7 @@ where
         // Nodes can disconnect each other if all of them are in the initial block download state,
         // but this should never occur in a normal network and can be worked around in the tests.
         let (sender, receiver) = oneshot_nofail::channel();
-        log::warn!("Disconnecting peer for ignoring requests");
+        log::warn!("Disconnecting peer {} for ignoring requests", self.id());
         self.peer_manager_sender.send(PeerManagerEvent::Disconnect(self.id(), sender))?;
         receiver.await?.or_else(|e| match e {
             P2pError::PeerError(PeerError::PeerDoesntExist) => Ok(()),


### PR DESCRIPTION
There is another reason why the node might get isolated. We use a fairly small timeout before disconnecting peers for ignoring header/block requests (5 seconds). Sometimes busy nodes get disconnected for this reason. This is not a big problem in itself, but there is another bug when such disconnected nodes are flagged as "disconnected by user". This flag prevents reconnects and may look like the node is banned. Let's remove this flag completely, as it duplicates the functionality provided by the ban API.