### PR TITLE
Fix crash on disconnecting tx with pool decommissioning

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -124,7 +124,6 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::UtxoBlockUndoError(_) => 100,
             ConnectTransactionError::BurnAmountSumError(_) => 100,
             ConnectTransactionError::AttemptToSpendBurnedAmount => 100,
-            ConnectTransactionError::MissingPoSAccountingUndo(_) => 0,
             ConnectTransactionError::PoSAccountingError(err) => err.ban_score(),
             ConnectTransactionError::AccountingBlockUndoError(_) => 100,
             ConnectTransactionError::SpendStakeError(_) => 100,

--- a/chainstate/test-framework/src/pos_block_builder.rs
+++ b/chainstate/test-framework/src/pos_block_builder.rs
@@ -139,6 +139,16 @@ impl<'f> PoSBlockBuilder<'f> {
         self
     }
 
+    pub fn with_stake_pool(mut self, pool_id: PoolId) -> Self {
+        self.staking_pool = Some(pool_id);
+        self
+    }
+
+    pub fn with_kernel_input(mut self, outpoint: UtxoOutPoint) -> Self {
+        self.kernel_input_outpoint = Some(outpoint);
+        self
+    }
+
     fn build_impl(self) -> (Block, &'f mut TestFramework) {
         let (consensus_data, block_timestamp) = match self.consensus_data {
             Some(data) => (data, self.timestamp),

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -356,7 +356,8 @@ fn in_memory_reorg_disconnect_produce_pool(#[case] seed: Seed) {
         ))
         .build();
 
-    tf.make_pos_block_builder(&mut rng)
+    let block_b_index = tf
+        .make_pos_block_builder(&mut rng)
         .add_transaction(decommission_pool_tx)
         .with_stake_pool(pool_2_id)
         .with_kernel_input(UtxoOutPoint::new(stake_pool_2_tx_id.into(), 0))
@@ -364,7 +365,12 @@ fn in_memory_reorg_disconnect_produce_pool(#[case] seed: Seed) {
         .with_stake_spending_key(staking_sk_2.clone())
         .with_vrf_key(vrf_sk.clone())
         .build_and_process()
+        .unwrap()
         .unwrap();
+    assert_eq!(
+        Id::<GenBlock>::from(*block_b_index.block_id()),
+        tf.best_block_id()
+    );
 
     // produce block at height 2 that should trigger in memory reorg for block `b`
     tf.make_pos_block_builder(&mut rng)
@@ -376,6 +382,11 @@ fn in_memory_reorg_disconnect_produce_pool(#[case] seed: Seed) {
         .with_vrf_key(vrf_sk)
         .build_and_process()
         .unwrap();
+    // block_b is still the tip
+    assert_eq!(
+        Id::<GenBlock>::from(*block_b_index.block_id()),
+        tf.best_block_id()
+    );
 }
 
 // Produce `genesis -> a -> b` chain, where block `a` creates additional staking pool and
@@ -442,13 +453,19 @@ fn in_memory_reorg_disconnect_create_pool(#[case] seed: Seed) {
         ))
         .build();
 
-    tf.make_pos_block_builder(&mut rng)
+    let block_b_index = tf
+        .make_pos_block_builder(&mut rng)
         .add_transaction(decommission_pool_tx)
         .with_block_signing_key(staking_sk.clone())
         .with_stake_spending_key(staking_sk.clone())
         .with_vrf_key(vrf_sk.clone())
         .build_and_process()
+        .unwrap()
         .unwrap();
+    assert_eq!(
+        Id::<GenBlock>::from(*block_b_index.block_id()),
+        tf.best_block_id()
+    );
 
     // produce block at height 2 that should trigger in memory reorg for block `b`
     tf.make_pos_block_builder(&mut rng)
@@ -458,4 +475,9 @@ fn in_memory_reorg_disconnect_create_pool(#[case] seed: Seed) {
         .with_vrf_key(vrf_sk)
         .build_and_process()
         .unwrap();
+    // block_b is still the tip
+    assert_eq!(
+        Id::<GenBlock>::from(*block_b_index.block_id()),
+        tf.best_block_id()
+    );
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -100,8 +100,6 @@ pub enum ConnectTransactionError {
     AttemptToSpendBurnedAmount,
     #[error("PoS accounting error")]
     PoSAccountingError(#[from] pos_accounting::Error),
-    #[error("PoS accounting undo is missing for transaction {0}")]
-    MissingPoSAccountingUndo(Id<Transaction>),
     #[error("Error during stake spending: {0}")]
     SpendStakeError(#[from] SpendStakeError),
     #[error("Pool owner balance of pool {0} not found")]

--- a/chainstate/tx-verifier/src/transaction_verifier/flush.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/flush.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::TransactionSource;
+
 use super::{
     storage::{TransactionVerifierStorageMut, TransactionVerifierStorageRef},
     token_issuance_cache::{CachedAuxDataOp, CachedTokenIndexOp, ConsumedTokenIssuanceCache},
@@ -97,7 +99,14 @@ where
         } else if entry.undo.is_empty() {
             storage.del_utxo_undo_data(tx_source)?;
         } else {
-            panic!("BlockUndo was not used up completely")
+            match tx_source {
+                TransactionSource::Chain(block_id) => {
+                    panic!("BlockUndo utxo entries were not used up completely while disconnecting a block {}", block_id)
+                }
+                TransactionSource::Mempool => {
+                    /* it's ok for the mempool to use tx undos partially */
+                }
+            }
         }
     }
 
@@ -115,7 +124,14 @@ where
         } else if entry.undo.is_empty() {
             storage.del_accounting_undo_data(tx_source)?;
         } else {
-            panic!("BlockUndo was not used up completely")
+            match tx_source {
+                TransactionSource::Chain(block_id) => {
+                    panic!("BlockUndo accounting entries were not used up completely while disconnecting a block {}", block_id)
+                }
+                TransactionSource::Mempool => {
+                    /* it's ok for the mempool to use tx undos partially */
+                }
+            }
         }
     }
 

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -591,34 +591,10 @@ where
         tx_source: TransactionSource,
         tx: &Transaction,
     ) -> Result<(), ConnectTransactionError> {
-        // Note: it's not strictly required to check inputs/outputs to undo accounting operations
-        //       because `accounting_block_undo` is not empty in that case. But we do it anyway
-        //       to double check that the logic is consistent.
-        let mut apply_accounting_delta_undo = false;
-
+        // decrement nonce if disconnected input spent from account
         for input in tx.inputs() {
             match input {
-                // handle undo of pool decommissioning
-                TxInput::Utxo(input_outpoint) => {
-                    let input_utxo = self
-                        .utxo_cache
-                        .utxo(input_outpoint)
-                        .map_err(|_| utxo::Error::ViewRead)?
-                        .ok_or(ConnectTransactionError::MissingOutputOrSpent(
-                            input_outpoint.clone(),
-                        ))?;
-                    match input_utxo.output() {
-                        TxOutput::CreateStakePool(_, _) | TxOutput::ProduceBlockFromStake(_, _) => {
-                            apply_accounting_delta_undo = true;
-                        }
-                        TxOutput::Transfer(_, _)
-                        | TxOutput::LockThenTransfer(_, _, _)
-                        | TxOutput::Burn(_)
-                        | TxOutput::CreateDelegationId(_, _)
-                        | TxOutput::DelegateStaking(_, _) => { /* do nothing */ }
-                    }
-                }
-                // decrement nonce if disconnected input spent from account
+                TxInput::Utxo(_) => { /* do nothing */ }
                 TxInput::Account(account_input) => {
                     let account: AccountType = (*account_input.account()).into();
                     let new_nonce = self
@@ -633,32 +609,22 @@ where
         }
 
         // apply undos to accounting
-        tx.outputs().iter().for_each(|output| match output {
-            TxOutput::CreateStakePool(_, _)
-            | TxOutput::CreateDelegationId(_, _)
-            | TxOutput::DelegateStaking(_, _) => {
-                apply_accounting_delta_undo = true;
-            }
-            TxOutput::Transfer(_, _)
-            | TxOutput::LockThenTransfer(_, _, _)
-            | TxOutput::Burn(_)
-            | TxOutput::ProduceBlockFromStake(_, _) => { /* do nothing */ }
-        });
-
-        if apply_accounting_delta_undo {
-            let block_undo_fetcher = |id: Id<Block>| {
-                self.storage
-                    .get_accounting_undo(id)
-                    .map_err(|_| ConnectTransactionError::TxVerifierStorage)
-            };
-            self.accounting_block_undo
-                .take_tx_undo(&tx_source, &tx.get_id(), block_undo_fetcher)?
-                .into_inner()
-                .into_iter()
-                .try_for_each(|undo| {
-                    self.accounting_delta_adapter.operations(tx_source).undo(undo)
-                })?;
+        let block_undo_fetcher = |id: Id<Block>| {
+            self.storage
+                .get_accounting_undo(id)
+                .map_err(|_| ConnectTransactionError::TxVerifierStorage)
+        };
+        let undos = self.accounting_block_undo.take_tx_undo(
+            &tx_source,
+            &tx.get_id(),
+            block_undo_fetcher,
+        )?;
+        if let Some(undos) = undos {
+            undos.into_inner().into_iter().try_for_each(|undo| {
+                self.accounting_delta_adapter.operations(tx_source).undo(undo)
+            })?;
         }
+
         Ok(())
     }
 
@@ -938,9 +904,9 @@ where
             TransactionSource::Mempool => { /* do nothing */ }
         };
 
-        self.utxo_cache.disconnect_transaction(tx.transaction(), tx_undo)?;
-
         self.disconnect_pos_accounting_outputs(*tx_source, tx.transaction())?;
+
+        self.utxo_cache.disconnect_transaction(tx.transaction(), tx_undo)?;
 
         // pre-cache token ids before removing them
         self.token_issuance_cache.precache_token_issuance(

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -154,7 +154,6 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoaded(_) => 0,
             ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoadedFromHeight(_, _) => 0,
             ConnectTransactionError::TxUndoWithDependency(_) => 0,
-            ConnectTransactionError::MissingPoSAccountingUndo(_) => 0,
             ConnectTransactionError::UtxoBlockUndoError(_) => 0,
             ConnectTransactionError::AccountingBlockUndoError(_) => 0,
             ConnectTransactionError::PoolOwnerBalanceNotFound(_) => 0,

--- a/mempool/src/pool/orphans/detect.rs
+++ b/mempool/src/pool/orphans/detect.rs
@@ -66,7 +66,6 @@ impl OrphanType {
             | CTE::BurnAmountSumError(_)
             | CTE::AttemptToSpendBurnedAmount
             | CTE::PoSAccountingError(_)
-            | CTE::MissingPoSAccountingUndo(_)
             | CTE::SpendStakeError(_)
             | CTE::PoolOwnerBalanceNotFound(_)
             | CTE::PoolDataNotFound(_)


### PR DESCRIPTION
The problem was that while disconnecting the tx with pool decommissioning we try to detect if undo delta should be applied. So it happens that after we switched from dedicated DecommissionPool output type to just locked outputs I missed to change this check. So inputs for tx like ProduceBlock -> LockedOutput were skipped.

P.S. also I split panic condition to fire only for Chain. It looks like a proper thing to do even though current mempool should never trigger that.