### PR TITLE
Add ban/unban API

### DIFF
--- a/p2p/benches/benches.rs
+++ b/p2p/benches/benches.rs
@@ -22,6 +22,7 @@ use std::{
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use p2p::{
+    net::AsBannableAddress,
     peer_manager::peerdb::PeerDb,
     testing_utils::{
         peerdb_inmemory_store, test_p2p_config, RandomAddressMaker, TestTcpAddressMaker,
@@ -39,7 +40,7 @@ pub fn peer_db(c: &mut Criterion) {
     }
 
     for _ in 0..1000 {
-        peerdb.ban_peer(&TestTcpAddressMaker::new());
+        peerdb.ban(TestTcpAddressMaker::new().as_bannable());
     }
 
     let normal_outbound = (0..5).map(|_| TestTcpAddressMaker::new()).collect::<BTreeSet<_>>();

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -199,7 +199,7 @@ impl BanScore for ProtocolError {
     fn ban_score(&self) -> u32 {
         match self {
             ProtocolError::UnsupportedProtocol(_) => 0,
-            ProtocolError::DifferentNetwork(_, _) => 100,
+            ProtocolError::DifferentNetwork(_, _) => 0, // Do not ban peers if after deploying a new testnet
             ProtocolError::Unresponsive => 100,
             ProtocolError::LocatorSizeExceeded(_, _) => 20,
             ProtocolError::BlocksRequestLimitExceeded(_, _) => 20,

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -25,6 +25,10 @@ pub trait P2pInterface: Send + Sync {
     async fn connect(&mut self, addr: String) -> crate::Result<()>;
     async fn disconnect(&mut self, peer_id: PeerId) -> crate::Result<()>;
 
+    async fn list_banned(&mut self) -> crate::Result<Vec<String>>;
+    async fn ban(&mut self, addr: String) -> crate::Result<()>;
+    async fn unban(&mut self, addr: String) -> crate::Result<()>;
+
     async fn get_peer_count(&self) -> crate::Result<usize>;
     async fn get_bind_addresses(&self) -> crate::Result<Vec<String>>;
     async fn get_connected_peers(&self) -> crate::Result<Vec<ConnectedPeer>>;

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -36,6 +36,16 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
         self.deref_mut().disconnect(peer_id).await
     }
 
+    async fn list_banned(&mut self) -> crate::Result<Vec<String>> {
+        self.deref_mut().list_banned().await
+    }
+    async fn ban(&mut self, addr: String) -> crate::Result<()> {
+        self.deref_mut().ban(addr).await
+    }
+    async fn unban(&mut self, addr: String) -> crate::Result<()> {
+        self.deref_mut().unban(addr).await
+    }
+
     async fn get_peer_count(&self) -> crate::Result<usize> {
         self.deref().get_peer_count().await
     }

--- a/p2p/src/net/default_backend/transport/traits/socket.rs
+++ b/p2p/src/net/default_backend/transport/traits/socket.rs
@@ -42,7 +42,7 @@ pub trait TransportSocket: Send + Sync + 'static {
         + AsBannableAddress<BannableAddress = Self::BannableAddress>;
 
     /// A bannable address format.
-    type BannableAddress: Debug + Eq + Ord + Send + ToString + FromStr;
+    type BannableAddress: Clone + Debug + Eq + Ord + Send + ToString + FromStr;
 
     /// A listener type (or acceptor as per boost terminology).
     type Listener: TransportListener<Stream = Self::Stream, Address = Self::Address>;

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -69,7 +69,7 @@ pub trait NetworkingService {
     ///
     /// Usually it is part of the `NetworkingService::Address`. For example for a socket address
     /// that consists of an IP address and a port we want to ban the IP address.
-    type BannableAddress: Debug + Eq + Ord + Send + ToString + FromStr;
+    type BannableAddress: Clone + Debug + Eq + Ord + Send + ToString + FromStr;
 
     /// Handle for sending/receiving connectivity-related events
     type ConnectivityHandle: Send;

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -328,7 +328,7 @@ where
         );
 
         if peer.score >= *self.p2p_config.ban_threshold {
-            self.peerdb.ban_peer(&peer.address);
+            self.peerdb.ban(peer.address.as_bannable());
             self.disconnect(peer_id, None);
         }
     }
@@ -985,6 +985,17 @@ where
             }
             PeerManagerEvent::RemoveReserved(address) => {
                 self.peerdb.remove_reserved_node(address);
+            }
+            PeerManagerEvent::ListBanned(response) => {
+                response.send(self.peerdb.list_banned().cloned().collect())
+            }
+            PeerManagerEvent::Ban(address, response) => {
+                self.peerdb.ban(address);
+                response.send(Ok(()));
+            }
+            PeerManagerEvent::Unban(address, response) => {
+                self.peerdb.unban(&address);
+                response.send(Ok(()));
             }
         }
     }

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use common::primitives::user_agent::mintlayer_core_user_agent;
 use p2p_test_utils::P2pBasicTestTimeGetter;
@@ -34,7 +34,7 @@ use super::PeerDb;
 fn unban_peer() {
     let db_store = peerdb_inmemory_store();
     let time_getter = P2pBasicTestTimeGetter::new();
-    let mut peerdb = PeerDb::new(
+    let mut peerdb = PeerDb::<SocketAddr, _, _>::new(
         Arc::new(P2pConfig {
             bind_addresses: Default::default(),
             socks5_proxy: None,
@@ -65,7 +65,7 @@ fn unban_peer() {
     .unwrap();
 
     let address = TestTcpAddressMaker::new();
-    peerdb.ban_peer(&address);
+    peerdb.ban(address.as_bannable());
 
     assert!(peerdb.is_address_banned(&address.as_bannable()));
     let banned_addresses = peerdb.storage.transaction_ro().unwrap().get_banned_addresses().unwrap();

--- a/p2p/src/peer_manager_event.rs
+++ b/p2p/src/peer_manager_event.rs
@@ -43,4 +43,14 @@ pub enum PeerManagerEvent<T: NetworkingService> {
     AddReserved(T::Address),
 
     RemoveReserved(T::Address),
+
+    ListBanned(oneshot_nofail::Sender<Vec<T::BannableAddress>>),
+    Ban(
+        T::BannableAddress,
+        oneshot_nofail::Sender<crate::Result<()>>,
+    ),
+    Unban(
+        T::BannableAddress,
+        oneshot_nofail::Sender<crate::Result<()>>,
+    ),
 }

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -31,6 +31,15 @@ trait P2pRpc {
     #[method(name = "disconnect")]
     async fn disconnect(&self, peer_id: PeerId) -> RpcResult<()>;
 
+    #[method(name = "list_banned")]
+    async fn list_banned(&self) -> RpcResult<Vec<String>>;
+
+    #[method(name = "ban")]
+    async fn ban(&self, address: String) -> RpcResult<()>;
+
+    #[method(name = "unban")]
+    async fn unban(&self, address: String) -> RpcResult<()>;
+
     /// Get the number of peers
     #[method(name = "get_peer_count")]
     async fn get_peer_count(&self) -> RpcResult<usize>;
@@ -67,6 +76,21 @@ impl P2pRpcServer for super::P2pHandle {
 
     async fn disconnect(&self, peer_id: PeerId) -> RpcResult<()> {
         let res = self.call_async_mut(move |this| this.disconnect(peer_id)).await;
+        rpc::handle_result(res)
+    }
+
+    async fn list_banned(&self) -> RpcResult<Vec<String>> {
+        let res = self.call_async_mut(|this| this.list_banned()).await;
+        rpc::handle_result(res)
+    }
+
+    async fn ban(&self, address: String) -> RpcResult<()> {
+        let res = self.call_async_mut(|this| this.ban(address)).await;
+        rpc::handle_result(res)
+    }
+
+    async fn unban(&self, address: String) -> RpcResult<()> {
+        let res = self.call_async_mut(|this| this.unban(address)).await;
         rpc::handle_result(res)
     }
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -237,6 +237,19 @@ pub enum WalletCommand {
         peer_id: PeerId,
     },
 
+    /// List banned addresses
+    ListBanned,
+
+    /// Ban address
+    Ban {
+        address: String,
+    },
+
+    /// Unban address
+    Unban {
+        address: String,
+    },
+
     /// Get connected peer count
     PeerCount,
 
@@ -940,6 +953,20 @@ impl CommandHandler {
                 rpc_client.p2p_disconnect(peer_id).await.map_err(WalletCliError::RpcError)?;
                 Ok(ConsoleCommand::Print("Success".to_owned()))
             }
+
+            WalletCommand::ListBanned => {
+                let list = rpc_client.p2p_list_banned().await.map_err(WalletCliError::RpcError)?;
+                Ok(ConsoleCommand::Print(format!("{list:#?}")))
+            }
+            WalletCommand::Ban { address } => {
+                rpc_client.p2p_ban(address).await.map_err(WalletCliError::RpcError)?;
+                Ok(ConsoleCommand::Print("Success".to_owned()))
+            }
+            WalletCommand::Unban { address } => {
+                rpc_client.p2p_unban(address).await.map_err(WalletCliError::RpcError)?;
+                Ok(ConsoleCommand::Print("Success".to_owned()))
+            }
+
             WalletCommand::PeerCount => {
                 let peer_count =
                     rpc_client.p2p_get_peer_count().await.map_err(WalletCliError::RpcError)?;

--- a/wallet/wallet-cli-lib/src/config.rs
+++ b/wallet/wallet-cli-lib/src/config.rs
@@ -29,7 +29,7 @@ pub enum Network {
 #[derive(Parser, Debug)]
 pub struct WalletCliArgs {
     /// Network
-    #[arg(long, value_enum, default_value_t = Network::Mainnet)]
+    #[arg(long, value_enum, default_value_t = Network::Testnet)]
     pub network: Network,
 
     /// Optional path to the wallet file

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -204,6 +204,15 @@ impl NodeInterface for MockNode {
     async fn p2p_disconnect(&self, _peer_id: PeerId) -> Result<(), Self::Error> {
         unreachable!()
     }
+    async fn p2p_list_banned(&self) -> Result<Vec<String>, Self::Error> {
+        unreachable!()
+    }
+    async fn p2p_ban(&self, _address: String) -> Result<(), Self::Error> {
+        unreachable!()
+    }
+    async fn p2p_unban(&self, _address: String) -> Result<(), Self::Error> {
+        unreachable!()
+    }
     async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error> {
         unreachable!()
     }

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -192,6 +192,20 @@ impl NodeInterface for WalletHandlesClient {
         let count = self.p2p.call_async_mut(move |this| this.get_peer_count()).await??;
         Ok(count)
     }
+
+    async fn p2p_list_banned(&self) -> Result<Vec<String>, Self::Error> {
+        let list = self.p2p.call_async_mut(move |this| this.list_banned()).await??;
+        Ok(list)
+    }
+    async fn p2p_ban(&self, address: String) -> Result<(), Self::Error> {
+        self.p2p.call_async_mut(move |this| this.ban(address)).await??;
+        Ok(())
+    }
+    async fn p2p_unban(&self, address: String) -> Result<(), Self::Error> {
+        self.p2p.call_async_mut(move |this| this.unban(address)).await??;
+        Ok(())
+    }
+
     async fn p2p_get_connected_peers(&self) -> Result<Vec<ConnectedPeer>, Self::Error> {
         let peers = self.p2p.call_async_mut(move |this| this.get_connected_peers()).await??;
         Ok(peers)

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -62,6 +62,9 @@ pub trait NodeInterface {
 
     async fn p2p_connect(&self, address: String) -> Result<(), Self::Error>;
     async fn p2p_disconnect(&self, peer_id: PeerId) -> Result<(), Self::Error>;
+    async fn p2p_list_banned(&self) -> Result<Vec<String>, Self::Error>;
+    async fn p2p_ban(&self, address: String) -> Result<(), Self::Error>;
+    async fn p2p_unban(&self, address: String) -> Result<(), Self::Error>;
     async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error>;
     async fn p2p_get_connected_peers(&self) -> Result<Vec<ConnectedPeer>, Self::Error>;
     async fn p2p_add_reserved_node(&self, address: String) -> Result<(), Self::Error>;

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -143,6 +143,23 @@ impl NodeInterface for NodeRpcClient {
             .await
             .map_err(NodeRpcError::ResponseError)
     }
+
+    async fn p2p_list_banned(&self) -> Result<Vec<String>, Self::Error> {
+        P2pRpcClient::list_banned(&self.http_client)
+            .await
+            .map_err(NodeRpcError::ResponseError)
+    }
+    async fn p2p_ban(&self, address: String) -> Result<(), Self::Error> {
+        P2pRpcClient::ban(&self.http_client, address)
+            .await
+            .map_err(NodeRpcError::ResponseError)
+    }
+    async fn p2p_unban(&self, address: String) -> Result<(), Self::Error> {
+        P2pRpcClient::unban(&self.http_client, address)
+            .await
+            .map_err(NodeRpcError::ResponseError)
+    }
+
     async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error> {
         P2pRpcClient::get_peer_count(&self.http_client)
             .await


### PR DESCRIPTION
I think we should not ban peers after the `DifferentNetwork` error, because it makes deploying a new testnet network annoying. Once a node is upgraded, it will ban all old peers and be banned by them.