### PR TITLE
Fix transaction broadcasting in wallet commands to be consistent

### DIFF
--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -494,7 +494,6 @@ impl<B: storage::Backend> Wallet<B> {
 
     pub fn create_transaction_to_addresses_from_delegation(
         &mut self,
-        wallet_events: &mut impl WalletEvents,
         account_index: U31,
         address: Address<Destination>,
         amount: Amount,
@@ -502,23 +501,7 @@ impl<B: storage::Backend> Wallet<B> {
         current_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
-            let tx = account.spend_from_delegation(
-                db_tx,
-                address,
-                amount,
-                delegation_id,
-                current_fee_rate,
-            )?;
-            let txs = [tx];
-            account.scan_new_unconfirmed_transactions(
-                &txs,
-                TxState::Inactive,
-                db_tx,
-                wallet_events,
-            )?;
-
-            let [tx] = txs;
-            Ok(tx)
+            account.spend_from_delegation(db_tx, address, amount, delegation_id, current_fee_rate)
         })
     }
 
@@ -610,25 +593,13 @@ impl<B: storage::Backend> Wallet<B> {
 
     pub fn decommission_stake_pool(
         &mut self,
-        wallet_events: &mut impl WalletEvents,
         account_index: U31,
         pool_id: PoolId,
         pool_balance: Amount,
         current_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
-            let tx =
-                account.decommission_stake_pool(db_tx, pool_id, pool_balance, current_fee_rate)?;
-            let txs = [tx];
-            account.scan_new_unconfirmed_transactions(
-                &txs,
-                TxState::Inactive,
-                db_tx,
-                wallet_events,
-            )?;
-
-            let [tx] = txs;
-            Ok(tx)
+            account.decommission_stake_pool(db_tx, pool_id, pool_balance, current_fee_rate)
         })
     }
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -968,7 +968,7 @@ impl CommandHandler {
                     parse_token_amount(token_number_of_decimals, &amount)?
                 };
 
-                let tx = controller_opt
+                let status = controller_opt
                     .as_mut()
                     .ok_or(WalletCliError::NoWallet)?
                     .send_tokens_to_address(
@@ -979,7 +979,7 @@ impl CommandHandler {
                     )
                     .await
                     .map_err(WalletCliError::Controller)?;
-                Self::broadcast_transaction(rpc_client, tx).await
+                Ok(Self::handle_mempool_tx_status(status))
             }
 
             WalletCommand::CreateDelegation { address, pool_id } => {
@@ -1080,7 +1080,7 @@ impl CommandHandler {
 
             WalletCommand::DecommissionStakePool { pool_id } => {
                 let pool_id = parse_pool_id(chain_config, pool_id.as_str())?;
-                let tx = controller_opt
+                let status = controller_opt
                     .as_mut()
                     .ok_or(WalletCliError::NoWallet)?
                     .decommission_stake_pool(
@@ -1089,7 +1089,7 @@ impl CommandHandler {
                     )
                     .await
                     .map_err(WalletCliError::Controller)?;
-                Self::broadcast_transaction(rpc_client, tx).await
+                Ok(Self::handle_mempool_tx_status(status))
             }
 
             WalletCommand::NodeVersion => {

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -297,11 +297,8 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 consolidate_fee_rate,
             )
             .map_err(ControllerError::WalletError)?;
-        self.rpc_client
-            .submit_transaction(tx.clone())
-            .await
-            .map_err(ControllerError::NodeCallError)
-            .map(|status| (token_id, status))
+
+        self.broadcast_to_mempool(tx).await.map(|status| (token_id, status))
     }
 
     pub async fn issue_new_nft(
@@ -327,11 +324,8 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 consolidate_fee_rate,
             )
             .map_err(ControllerError::WalletError)?;
-        self.rpc_client
-            .submit_transaction(tx.clone())
-            .await
-            .map_err(ControllerError::NodeCallError)
-            .map(|status| (token_id, status))
+
+        self.broadcast_to_mempool(tx).await.map(|status| (token_id, status))
     }
 
     pub fn new_address(
@@ -481,11 +475,8 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 consolidate_fee_rate,
             )
             .map_err(ControllerError::WalletError)?;
-        self.rpc_client
-            .submit_transaction(tx.clone())
-            .await
-            .map_err(ControllerError::NodeCallError)
-            .map(|status| (delegation_id, status))
+
+        self.broadcast_to_mempool(tx).await.map(|status| (delegation_id, status))
     }
 
     pub async fn delegate_staking(
@@ -512,10 +503,8 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 consolidate_fee_rate,
             )
             .map_err(ControllerError::WalletError)?;
-        self.rpc_client
-            .submit_transaction(tx.clone())
-            .await
-            .map_err(ControllerError::NodeCallError)
+
+        self.broadcast_to_mempool(tx).await
     }
 
     pub async fn send_to_address_from_delegation(
@@ -534,7 +523,6 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         let tx = self
             .wallet
             .create_transaction_to_addresses_from_delegation(
-                &mut self.wallet_events,
                 account_index,
                 address,
                 amount,
@@ -542,10 +530,8 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 current_fee_rate,
             )
             .map_err(ControllerError::WalletError)?;
-        self.rpc_client
-            .submit_transaction(tx.clone())
-            .await
-            .map_err(ControllerError::NodeCallError)
+
+        self.broadcast_to_mempool(tx).await
     }
 
     pub async fn send_tokens_to_address(
@@ -554,7 +540,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         token_id: TokenId,
         address: Address<Destination>,
         amount: Amount,
-    ) -> Result<SignedTransaction, ControllerError<T>> {
+    ) -> Result<TxStatus, ControllerError<T>> {
         let current_fee_rate = self
             .rpc_client
             .mempool_get_fee_rate(IN_TOP_N_MB)
@@ -565,14 +551,17 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         let output =
             make_address_output_token(self.chain_config.as_ref(), address, amount, token_id)
                 .map_err(ControllerError::WalletError)?;
-        self.wallet
+        let tx = self
+            .wallet
             .create_transaction_to_addresses(
                 account_index,
                 [output],
                 current_fee_rate,
                 consolidate_fee_rate,
             )
-            .map_err(ControllerError::WalletError)
+            .map_err(ControllerError::WalletError)?;
+
+        self.broadcast_to_mempool(tx).await
     }
 
     pub async fn get_token_number_of_decimals(
@@ -634,7 +623,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         &mut self,
         account_index: U31,
         pool_id: PoolId,
-    ) -> Result<SignedTransaction, ControllerError<T>> {
+    ) -> Result<TxStatus, ControllerError<T>> {
         let current_fee_rate = self
             .rpc_client
             .mempool_get_fee_rate(IN_TOP_N_MB)
@@ -650,15 +639,12 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 pool_id,
             )))?;
 
-        self.wallet
-            .decommission_stake_pool(
-                &mut self.wallet_events,
-                account_index,
-                pool_id,
-                staker_balance,
-                current_fee_rate,
-            )
-            .map_err(ControllerError::WalletError)
+        let tx = self
+            .wallet
+            .decommission_stake_pool(account_index, pool_id, staker_balance, current_fee_rate)
+            .map_err(ControllerError::WalletError)?;
+
+        self.broadcast_to_mempool(tx).await
     }
 
     pub async fn generate_block(


### PR DESCRIPTION
Reuse the broadcasting functionality in all commands to be the same