### PR TITLE
Fix failing functional tests (p2p)

### DIFF
--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -23,6 +23,7 @@ use crate::{
     error::P2pError,
     interface::{p2p_interface::P2pInterface, types::ConnectedPeer},
     net::NetworkingService,
+    peer_manager_event::PeerDisconnectionDbAction,
     types::peer_id::PeerId,
     utils::oneshot_nofail,
     MessagingService, P2p, P2pEvent, PeerManagerEvent,
@@ -45,7 +46,11 @@ where
     async fn disconnect(&mut self, peer_id: PeerId) -> crate::Result<()> {
         let (tx, rx) = oneshot_nofail::channel();
         self.tx_peer_manager
-            .send(PeerManagerEvent::Disconnect(peer_id, tx))
+            .send(PeerManagerEvent::Disconnect(
+                peer_id,
+                PeerDisconnectionDbAction::RemoveIfOutbound,
+                tx,
+            ))
             .map_err(|_| P2pError::ChannelClosed)?;
         rx.await?
     }

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -253,6 +253,10 @@ where
         self.change_address_state(address, AddressStateTransitionTo::Disconnected);
     }
 
+    pub fn remove_outbound_address(&mut self, address: &A) {
+        self.addresses.remove(address);
+    }
+
     pub fn change_address_state(&mut self, address: A, transition: AddressStateTransitionTo) {
         let now = self.time_getter.get_time();
 

--- a/p2p/src/peer_manager_event.rs
+++ b/p2p/src/peer_manager_event.rs
@@ -18,12 +18,26 @@ use p2p_types::{bannable_address::BannableAddress, ip_or_socket_address::IpOrSoc
 use crate::{interface::types::ConnectedPeer, types::peer_id::PeerId, utils::oneshot_nofail};
 
 #[derive(Debug)]
+pub enum PeerDisconnectionDbAction {
+    /// The address is kept in the PeerDb and there can be automatic reconnects
+    Keep,
+    /// The address will be removed from the PeerDb and there will be no reconnect attempts
+    /// (at least until the peer address is rediscovered).
+    /// It only affects outbound addresses.
+    RemoveIfOutbound,
+}
+
+#[derive(Debug)]
 pub enum PeerManagerEvent {
     /// Try to establish connection with a remote peer
     Connect(IpOrSocketAddress, oneshot_nofail::Sender<crate::Result<()>>),
 
     /// Disconnect node using peer ID
-    Disconnect(PeerId, oneshot_nofail::Sender<crate::Result<()>>),
+    Disconnect(
+        PeerId,
+        PeerDisconnectionDbAction,
+        oneshot_nofail::Sender<crate::Result<()>>,
+    ),
 
     /// Get the total number of peers local node has a connection with
     GetPeerCount(oneshot_nofail::Sender<usize>),

--- a/p2p/src/sync/peer.rs
+++ b/p2p/src/sync/peer.rs
@@ -55,6 +55,7 @@ use crate::{
         types::services::{Service, Services},
         NetworkingService,
     },
+    peer_manager_event::PeerDisconnectionDbAction,
     sync::types::PeerActivity,
     types::peer_id::PeerId,
     utils::oneshot_nofail,
@@ -806,7 +807,11 @@ where
         // but this should never occur in a normal network and can be worked around in the tests.
         let (sender, receiver) = oneshot_nofail::channel();
         log::warn!("Disconnecting peer {} for ignoring requests", self.id());
-        self.peer_manager_sender.send(PeerManagerEvent::Disconnect(self.id(), sender))?;
+        self.peer_manager_sender.send(PeerManagerEvent::Disconnect(
+            self.id(),
+            PeerDisconnectionDbAction::Keep,
+            sender,
+        ))?;
         receiver.await?.or_else(|e| match e {
             P2pError::PeerError(PeerError::PeerDoesntExist) => Ok(()),
             e => Err(e),

--- a/p2p/src/sync/tests/helpers.rs
+++ b/p2p/src/sync/tests/helpers.rs
@@ -227,7 +227,7 @@ impl SyncManagerHandle {
 
     pub async fn assert_disconnect_peer_event(&mut self, id: PeerId) {
         match self.peer_manager_receiver.recv().await.unwrap() {
-            PeerManagerEvent::Disconnect(peer_id, sender) => {
+            PeerManagerEvent::Disconnect(peer_id, _peerdb_action, sender) => {
                 assert_eq!(id, peer_id);
                 sender.send(Ok(()));
             }
@@ -239,7 +239,7 @@ impl SyncManagerHandle {
         time::timeout(SHORT_TIMEOUT, async {
             loop {
                 match self.peer_manager_receiver.recv().await.unwrap() {
-                    PeerManagerEvent::Disconnect(peer_id, _) if id == peer_id => {
+                    PeerManagerEvent::Disconnect(peer_id, _peerdb_action, _) if id == peer_id => {
                         break;
                     }
                     _ => {}


### PR DESCRIPTION
Do not attempt to reconnect to outbound peers after the RPC disconnect request.