### PR TITLE
Try to fix the failing reorg test (p2p)

### DIFF
--- a/p2p/src/sync/tests/network_sync.rs
+++ b/p2p/src/sync/tests/network_sync.rs
@@ -19,6 +19,7 @@ use common::{
     chain::block::timestamp::BlockTimestamp, primitives::user_agent::mintlayer_core_user_agent,
 };
 use crypto::random::Rng;
+use logging::log;
 use p2p_test_utils::P2pBasicTestTimeGetter;
 use test_utils::random::Seed;
 
@@ -303,6 +304,12 @@ async fn reorg(#[case] seed: Seed) {
 
     sync_managers(&mut rng, vec![&mut manager1, &mut manager2].as_mut_slice()).await;
 
+    log::debug!("Disconnect peers");
+    manager1.disconnect_peer(manager2.peer_id);
+    manager2.disconnect_peer(manager1.peer_id);
+    sync_managers(&mut rng, vec![&mut manager1, &mut manager2].as_mut_slice()).await;
+
+    log::debug!("Shutdown");
     manager1.join_subsystem_manager().await;
     manager2.join_subsystem_manager().await;
 }


### PR DESCRIPTION
I think the problem is with shutdown. There are two managers, and once one is stopped, the other is still running (at least its peer tasks), and it sometimes tries to send messages to the other destroyed manager, which fails:
```
2023-08-02T17:16:06.5338022Z [2023-08-02T17:16:03Z INFO  chainstate::detail] New tip in chainstate 0xf12d…e7e0 with height 12, timestamp: 1690997163
2023-08-02T17:16:06.5344751Z [2023-08-02T17:16:03Z INFO  mempool::pool] mempool: Processing chainstate event NewTip(Id<Block>{0xf12dd87ac1954a30362d8c61bd765fdb48889da832ad8630b08ff3a7decce7e0}, BlockHeight(12))
2023-08-02T17:16:06.5351053Z [2023-08-02T17:16:03Z INFO  mempool::pool] new tip: block Id<Block>{0xf12dd87ac1954a30362d8c61bd765fdb48889da832ad8630b08ff3a7decce7e0} height BlockHeight(12)
2023-08-02T17:16:06.5356722Z [2023-08-02T17:16:03Z DEBUG p2p::sync] Broadcasting a new tip header 0xf12d…e7e0
2023-08-02T17:16:06.5357341Z [2023-08-02T17:16:03Z DEBUG p2p::sync::peer] Headers request from peer 2
2023-08-02T17:16:06.5359735Z [2023-08-02T17:16:03Z DEBUG p2p::sync::peer] Headers list from peer 1
2023-08-02T17:16:06.5364123Z [2023-08-02T17:16:03Z INFO  subsystem::manager] Manager p2p-sync-test-manager shutting down
2023-08-02T17:16:06.5367590Z [2023-08-02T17:16:03Z INFO  subsystem::manager] Subsystem p2p-sync-test-manager/p2p-sync-test-mempool terminated
2023-08-02T17:16:06.5370428Z [2023-08-02T17:16:03Z INFO  subsystem::manager] Subsystem p2p-sync-test-manager/p2p-sync-test-chainstate terminated
2023-08-02T17:16:06.5373363Z [2023-08-02T17:16:03Z INFO  subsystem::manager] Manager p2p-sync-test-manager terminated
2023-08-02T17:16:06.5377732Z [2023-08-02T17:16:03Z INFO  subsystem::manager] Manager p2p-sync-test-manager shutting down
2023-08-02T17:16:06.5381917Z [2023-08-02T17:16:03Z INFO  subsystem::manager] Subsystem p2p-sync-test-manager/p2p-sync-test-mempool terminated
2023-08-02T17:16:06.5384469Z [2023-08-02T17:16:03Z INFO  subsystem::manager] Subsystem p2p-sync-test-manager/p2p-sync-test-chainstate terminated
2023-08-02T17:16:06.5388093Z [2023-08-02T17:16:03Z INFO  subsystem::manager] Manager p2p-sync-test-manager terminated
2023-08-02T17:16:06.5392213Z thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: SendError((PeerId(1), HeaderList(HeaderList { headers: [SignedBlockHeader { block_header: BlockHeader { version: VersionTag(Tag), prev_block_id: Id<GenBlock>{0x5f81798d7a53113bae4812fe61f734d0a5cd837cfeaa6b9b7f83f71bdc2f275c}, tx_merkle_root: 0xb6dcf20cb14d31e15ed2404f9fe9cd6e1fdbf0e6198c7fea7571511b3700ea35, witness_merkle_root: 0x5641f39df26372ed576af7da2330289796d8575e6cb8b6172d88aa80a7cfdae0, timestamp: BlockTimestamp { timestamp: 1690997163 }, consensus_data: None }, signature_data: None }] })))', p2p/src/sync/tests/helpers.rs:499:50
```