### PR TITLE
mempool: Disable during initial block download

### DIFF
--- a/chainstate/src/config.rs
+++ b/chainstate/src/config.rs
@@ -33,13 +33,6 @@ make_config_setting!(
 make_config_setting!(TxIndexEnabled, bool, false);
 make_config_setting!(MaxTipAge, Duration, Duration::from_secs(60 * 60 * 24));
 
-impl MaxTipAge {
-    /// Max tip age of 100 years, useful to avoid the IBD state during testing
-    pub const CENTURY: Self = Self {
-        value: Duration::from_secs(100 * 365 * 24 * 60 * 60),
-    };
-}
-
 /// The chainstate subsystem configuration.
 #[derive(Debug, Clone, Default)]
 pub struct ChainstateConfig {

--- a/chainstate/src/config.rs
+++ b/chainstate/src/config.rs
@@ -33,6 +33,13 @@ make_config_setting!(
 make_config_setting!(TxIndexEnabled, bool, false);
 make_config_setting!(MaxTipAge, Duration, Duration::from_secs(60 * 60 * 24));
 
+impl MaxTipAge {
+    /// Max tip age of 100 years, useful to avoid the IBD state during testing
+    pub const CENTURY: Self = Self {
+        value: Duration::from_secs(100 * 365 * 24 * 60 * 60),
+    };
+}
+
 /// The chainstate subsystem configuration.
 #[derive(Debug, Clone, Default)]
 pub struct ChainstateConfig {

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -24,7 +24,7 @@ use tx_verifier::transaction_verifier::storage::HasTxIndexDisabledError;
 pub mod rpc;
 
 pub use crate::{
-    config::ChainstateConfig,
+    config::{ChainstateConfig, MaxTipAge},
     detail::{
         ban_score, calculate_median_time_past, check_nft_issuance_data, check_tokens_issuance_data,
         is_rfc3986_valid_symbol, BlockError, BlockSource, ChainInfo, CheckBlockError,

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -97,6 +97,7 @@ impl TestFrameworkBuilder {
         self
     }
 
+    /// Set max tip age in [ChainstateConfig] to given value.
     pub fn with_max_tip_age(mut self, max_tip_age: chainstate::MaxTipAge) -> Self {
         self.chainstate_config.max_tip_age = max_tip_age;
         self
@@ -117,6 +118,7 @@ impl TestFrameworkBuilder {
         self
     }
 
+    /// Set initial mock time to given number of seconds after the genesis timestamp.
     pub fn with_initial_time_since_genesis(mut self, initial_time_since_genesis: u64) -> Self {
         self.initial_time_since_genesis = initial_time_since_genesis;
         self

--- a/chainstate/test-suite/src/tests/syncing_tests.rs
+++ b/chainstate/test-suite/src/tests/syncing_tests.rs
@@ -467,9 +467,10 @@ fn initial_block_download(#[case] seed: Seed) {
                 tx_index_enabled: Default::default(),
                 max_tip_age: Duration::from_secs(1).into(),
             })
+            .with_initial_time_since_genesis(2)
             .build();
 
-        // Only genesis block, so is_initial_block_download should return true.
+        // We are two seconds after genesis timestamp, so in the IBD state
         assert!(tf.chainstate.is_initial_block_download());
 
         // Create a block with an "old" timestamp.

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -84,6 +84,9 @@ impl MempoolBanScore for TxValidationError {
             TxValidationError::ChainstateError(err) => err.mempool_ban_score(),
             TxValidationError::TxValidation(err) => err.mempool_ban_score(),
 
+            // Unsolicited transaction sent during IBD
+            TxValidationError::AddedDuringIBD => 0,
+
             // Internal errors
             TxValidationError::CallError(_) => 0,
             TxValidationError::TipMoved => 0,

--- a/mempool/src/error/mod.rs
+++ b/mempool/src/error/mod.rs
@@ -85,7 +85,7 @@ pub enum MempoolPolicyError {
 pub enum TxValidationError {
     #[error("Chainstate error")]
     ChainstateError(#[from] ChainstateError),
-    #[error("Not accepting transactions during initial block download")]
+    #[error("Transaction added during initial block download")]
     AddedDuringIBD,
     #[error(transparent)]
     TxValidation(#[from] ConnectTransactionError),

--- a/mempool/src/error/mod.rs
+++ b/mempool/src/error/mod.rs
@@ -85,6 +85,8 @@ pub enum MempoolPolicyError {
 pub enum TxValidationError {
     #[error("Chainstate error")]
     ChainstateError(#[from] ChainstateError),
+    #[error("Not accepting transactions during initial block download")]
+    AddedDuringIBD,
     #[error(transparent)]
     TxValidation(#[from] ConnectTransactionError),
     #[error("Subsystem call error")]

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -97,7 +97,11 @@ impl MempoolSubsystemInterface for MempoolInit {
             tokio::select! {
                 () = shut_rq.recv() => break,
                 call = call_rq.recv() => call(&mut mempool).await,
-                Some(evt) = chainstate_events_rx.recv() => mempool.process_chainstate_event(evt),
+                Some(evt) = chainstate_events_rx.recv() => {
+                    let _ = mempool
+                        .process_chainstate_event(evt)
+                        .log_err_pfx("Error while handling a mempool event");
+                }
             }
         }
     }

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -355,6 +355,9 @@ impl<M: MemoryUsageEstimator> Mempool<M> {
     ) -> Result<VerificationOutcome, TxValidationError> {
         let chainstate_handle = self.blocking_chainstate_handle();
 
+        let is_ibd = chainstate_handle.call(|chainstate| chainstate.is_initial_block_download())?;
+        ensure!(!is_ibd, TxValidationError::AddedDuringIBD);
+
         for _ in 0..MAX_TX_ADDITION_ATTEMPTS {
             let (tip, current_best) = chainstate_handle.call(|chainstate| {
                 let tip = chainstate.get_best_block_id()?;

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -1083,20 +1083,29 @@ impl<M: MemoryUsageEstimator> Mempool<M> {
         self.events_controller.subscribe_to_events(handler)
     }
 
-    pub fn process_chainstate_event(&mut self, evt: chainstate::ChainstateEvent) {
+    pub fn process_chainstate_event(
+        &mut self,
+        evt: chainstate::ChainstateEvent,
+    ) -> Result<(), reorg::ReorgError> {
         log::info!("mempool: Processing chainstate event {evt:?}");
         match evt {
             chainstate::ChainstateEvent::NewTip(block_id, block_height) => {
-                self.on_new_tip(block_id, block_height);
+                self.on_new_tip(block_id, block_height)?;
             }
         }
+        Ok(())
     }
 
-    pub fn on_new_tip(&mut self, block_id: Id<Block>, block_height: BlockHeight) {
+    pub fn on_new_tip(
+        &mut self,
+        block_id: Id<Block>,
+        block_height: BlockHeight,
+    ) -> Result<(), reorg::ReorgError> {
         log::info!("new tip: block {block_id:?} height {block_height:?}");
-        reorg::handle_new_tip(self, block_id);
+        reorg::handle_new_tip(self, block_id)?;
         let event = event::NewTip::new(block_id, block_height);
         self.events_controller.broadcast(event.into());
+        Ok(())
     }
 
     pub fn get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, MempoolPolicyError> {

--- a/mempool/src/pool/tests/accumulator.rs
+++ b/mempool/src/pool/tests/accumulator.rs
@@ -292,7 +292,7 @@ async fn timelocked(#[case] seed: Seed, #[case] timelock: OutputTimeLock, #[case
         .await
         .unwrap()
         .expect("block1");
-    mempool.on_new_tip(block1_id, BlockHeight::new(1));
+    mempool.on_new_tip(block1_id, BlockHeight::new(1)).unwrap();
 
     let in_mempool = if !in_mempool_at0 {
         mempool.add_transaction(tx1.clone(), TxOrigin::TEST).is_ok()

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -1069,7 +1069,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
         .chainstate_handle
         .call_mut(|this| this.process_block(block, BlockSource::Local))
         .await??;
-    mempool.on_new_tip(Id::new(H256::zero()), BlockHeight::new(1));
+    mempool.on_new_tip(Id::new(H256::zero()), BlockHeight::new(1)).unwrap();
 
     assert!(!mempool.contains_transaction(&child_2_high_fee_id));
     assert!(mempool

--- a/mempool/src/pool/tests/reorg.rs
+++ b/mempool/src/pool/tests/reorg.rs
@@ -179,3 +179,64 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
     assert!(mempool.contains_transaction(&tx1_id));
     assert!(mempool.contains_transaction(&tx2_id));
 }
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reject_txs_during_ibd(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    // Set up chainstate, mempool, and mock time
+    let tf = TestFramework::builder(&mut rng)
+        .with_max_tip_age(Duration::from_secs(10).into())
+        .with_initial_time_since_genesis(200)
+        .build();
+    let genesis_id = tf.genesis().get_id();
+    let mock_time = tf.time_value.unwrap().shallow_clone();
+    let mock_clock = tf.time_getter.clone();
+    let mut mempool = setup_with_chainstate(tf.chainstate).await;
+    mempool.clock = mock_clock;
+    let chainstate = mempool.chainstate_handle().shallow_clone();
+
+    // A test transaction
+    let tx1 = make_tx(&mut rng, &[(genesis_id.into(), 0)], &[1_000_000_000]);
+    let tx1_id = tx1.transaction().get_id();
+
+    // We should not be able to add the transaction yet
+    let res = mempool.add_transaction(tx1.clone(), TxOrigin::TEST);
+    assert_eq!(res, Err(TxValidationError::AddedDuringIBD.into()));
+    assert!(!mempool.contains_transaction(&tx1_id));
+
+    // Submit an "old" block
+    let block1_time = BlockTimestamp::from_int_seconds(mock_time.fetch_add(15));
+    let block1 = make_test_block(vec![], genesis_id, block1_time);
+    let block1_id = block1.get_id();
+    chainstate
+        .call_mut(move |c| c.process_block(block1, BlockSource::Local))
+        .await
+        .unwrap()
+        .expect("block1");
+    mempool.on_new_tip(block1_id, BlockHeight::new(1));
+
+    // We should not be able to add the transaction yet
+    let res = mempool.add_transaction(tx1.clone(), TxOrigin::TEST);
+    assert_eq!(res, Err(TxValidationError::AddedDuringIBD.into()));
+    assert!(!mempool.contains_transaction(&tx1_id));
+
+    // Submit a "fresh" block
+    let block2_time = BlockTimestamp::from_int_seconds(mock_time.fetch_add(3));
+    let block2 = make_test_block(vec![], block1_id, block2_time);
+    let block2_id = block2.get_id();
+    chainstate
+        .call_mut(move |c| c.process_block(block2, BlockSource::Local))
+        .await
+        .unwrap()
+        .expect("block2");
+    mempool.on_new_tip(block2_id, BlockHeight::new(2));
+
+    // We should be able to add the transaction now
+    let res = mempool.add_transaction(tx1, TxOrigin::TEST);
+    assert_eq!(res, Ok(TxStatus::InMempool));
+    assert!(mempool.contains_transaction(&tx1_id));
+}

--- a/mempool/src/pool/tests/reorg.rs
+++ b/mempool/src/pool/tests/reorg.rs
@@ -74,7 +74,7 @@ async fn basic_reorg(#[case] seed: Seed) {
         .await
         .unwrap()
         .expect("block1");
-    mempool.on_new_tip(block1_id, BlockHeight::new(1));
+    mempool.on_new_tip(block1_id, BlockHeight::new(1)).unwrap();
     assert!(!mempool.contains_transaction(&tx1_id));
     assert!(mempool.contains_transaction(&tx2_id));
 
@@ -89,7 +89,7 @@ async fn basic_reorg(#[case] seed: Seed) {
         .await
         .unwrap()
         .expect("block2");
-    mempool.on_new_tip(block2_id, BlockHeight::new(2));
+    mempool.on_new_tip(block2_id, BlockHeight::new(2)).unwrap();
     assert!(!mempool.contains_transaction(&tx1_id));
     assert!(!mempool.contains_transaction(&tx2_id));
 
@@ -104,7 +104,7 @@ async fn basic_reorg(#[case] seed: Seed) {
             .unwrap()
             .expect(name);
     }
-    mempool.on_new_tip(block4_id, BlockHeight::new(3));
+    mempool.on_new_tip(block4_id, BlockHeight::new(3)).unwrap();
     assert!(!mempool.contains_transaction(&tx1_id));
     assert!(mempool.contains_transaction(&tx2_id));
 }
@@ -160,7 +160,7 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
         .await
         .unwrap()
         .expect("block1");
-    mempool.on_new_tip(block1_id, BlockHeight::new(1));
+    mempool.on_new_tip(block1_id, BlockHeight::new(1)).unwrap();
     assert!(!mempool.contains_transaction(&tx1_id));
     assert!(!mempool.contains_transaction(&tx2_id));
 
@@ -175,7 +175,7 @@ async fn tx_chain_in_block(#[case] seed: Seed) {
             .unwrap()
             .expect(name);
     }
-    mempool.on_new_tip(block3_id, BlockHeight::new(2));
+    mempool.on_new_tip(block3_id, BlockHeight::new(2)).unwrap();
     assert!(mempool.contains_transaction(&tx1_id));
     assert!(mempool.contains_transaction(&tx2_id));
 }
@@ -217,7 +217,7 @@ async fn reject_txs_during_ibd(#[case] seed: Seed) {
         .await
         .unwrap()
         .expect("block1");
-    mempool.on_new_tip(block1_id, BlockHeight::new(1));
+    mempool.on_new_tip(block1_id, BlockHeight::new(1)).unwrap();
 
     // We should not be able to add the transaction yet
     let res = mempool.add_transaction(tx1.clone(), TxOrigin::TEST);
@@ -233,7 +233,7 @@ async fn reject_txs_during_ibd(#[case] seed: Seed) {
         .await
         .unwrap()
         .expect("block2");
-    mempool.on_new_tip(block2_id, BlockHeight::new(2));
+    mempool.on_new_tip(block2_id, BlockHeight::new(2)).unwrap();
 
     // We should be able to add the transaction now
     let res = mempool.add_transaction(tx1, TxOrigin::TEST);

--- a/node-lib/src/options.rs
+++ b/node-lib/src/options.rs
@@ -141,7 +141,7 @@ pub struct RunOptions {
     ///
     /// The initial block download is finished if the difference between the current time and the
     /// tip time is less than this value.
-    #[clap(long)]
+    #[clap(long, overrides_with("max_tip_age"))]
     pub max_tip_age: Option<u64>,
 
     /// Address to bind http RPC to.

--- a/test/functional/mempool_basic_reorg.py
+++ b/test/functional/mempool_basic_reorg.py
@@ -77,8 +77,8 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         assert not node.mempool_contains_tx(tx3_id)
 
         # Create two new blocks on top of block1
-        (block2a, block2a_id) = mine_empty_block(block1_id)
-        (block3a, block3a_id) = mine_empty_block(block2a_id)
+        (block2a, block2a_id) = mine_pow_block(block1_id)
+        (block3a, block3a_id) = mine_pow_block(block2a_id)
         self.log.debug("Encoded block2a {}: {}".format(block2a_id, block2a))
         self.log.debug("Encoded block3a {}: {}".format(block3a_id, block3a))
 

--- a/test/functional/mempool_ibd.py
+++ b/test/functional/mempool_ibd.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Mempool initial block download test
+
+Check that:
+* Transactions are rejected during IBD
+* Transactions are accepted after IBD is finished
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+from test_framework.mintlayer import *
+import time
+
+# Default max tip age of 24hrs
+MAX_TIP_AGE = 24 * 60 * 60
+IBD_ERR = "Transaction added during initial block download"
+
+class MempoolTxSubmissionTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[
+            "--blockprod-min-peers-to-produce-blocks=0",
+            "--max-tip-age={}".format(MAX_TIP_AGE),
+        ]]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.sync_all(self.nodes[0:1])
+
+    def advance_mock_time(self, delta):
+        self.mock_time += delta
+        self.nodes[0].node_set_mock_time(self.mock_time)
+
+    def submit_block(self, block):
+        node = self.nodes[0]
+        node.chainstate_submit_block(block)
+        block_id = node.chainstate_best_block_id()
+        self.wait_until(lambda: node.mempool_local_best_block_id() == block_id, timeout = 5)
+        return block_id
+
+    def run_test(self):
+        self.mock_time = int(time.time())
+        self.advance_mock_time(0)
+
+        node = self.nodes[0]
+
+        # Get chain tip
+        genesis_id = node.chainstate_best_block_id()
+        self.log.debug('Initial tip: {}'.format(genesis_id))
+
+        # Prepare three transactions, each spending the previous one in sequence
+        (tx1, tx1_id) = make_tx([ reward_input(genesis_id) ], [ 1_000_000 ] )
+        self.log.debug("Encoded tx1 {}: {}".format(tx1_id, tx1))
+
+        # The transaction should be rejected because of IBD
+        assert_raises_rpc_error(None, IBD_ERR, node.mempool_submit_transaction, tx1)
+        assert not node.mempool_contains_tx(tx1_id)
+
+        # Produce a block but wait over a day to submit it
+        (block1, block1_id) = mine_pow_block(genesis_id, timestamp = self.mock_time)
+        self.advance_mock_time(MAX_TIP_AGE + 5)
+        self.submit_block(block1)
+
+        # The transaction should still be rejected because of IBD
+        assert_raises_rpc_error(None, IBD_ERR, node.mempool_submit_transaction, tx1)
+        assert not node.mempool_contains_tx(tx1_id)
+
+        # Produce a block but don't wait too long before submission
+        (block2, block2_id) = mine_pow_block(block1_id, timestamp = self.mock_time)
+        self.advance_mock_time(MAX_TIP_AGE - 15)
+        self.log.debug("Chain info 1: {}".format(node.chainstate_info()))
+        self.submit_block(block2)
+        self.log.debug("Chain info 2: {}".format(node.chainstate_info()))
+
+        # The transaction should now be accepted
+        node.mempool_submit_transaction(tx1)
+        assert node.mempool_contains_tx(tx1_id)
+
+if __name__ == '__main__':
+    MempoolTxSubmissionTest().main()
+

--- a/test/functional/test_framework/mintlayer.py
+++ b/test/functional/test_framework/mintlayer.py
@@ -75,7 +75,7 @@ def make_tx(inputs, outputs, flags = 0):
     encoded_tx = signed_tx_obj.encode(signed_tx).to_hex()[2:]
     return (encoded_tx, tx_id)
 
-def make_empty_block(parent_id, nonce, transactions = []):
+def make_pow_block(parent_id, nonce, transactions = [], timestamp = None):
     empty_merkle_root = "0x" + hash_object(vec_output_obj, [])
     pow_data = {
         'bits': 0x207fffff,
@@ -86,7 +86,7 @@ def make_empty_block(parent_id, nonce, transactions = []):
         'prev_block_id': "0x{}".format(parent_id),
         'tx_merkle_root': empty_merkle_root,
         'witness_merkle_root': empty_merkle_root,
-        'timestamp': int(time.time()),
+        'timestamp': int(timestamp or time.time()),
         'consensus_data': { 'PoW': pow_data },
     }
     signed_header = {
@@ -107,9 +107,9 @@ def make_empty_block(parent_id, nonce, transactions = []):
     encoded_block = block_obj.encode(block).to_hex()[2:]
     return (encoded_block, block_id)
 
-def mine_empty_block(parent_id):
+def mine_pow_block(parent_id, transactions = [], timestamp = None):
     for nonce in range(1000):
-        (block, block_id) = make_empty_block(parent_id, nonce)
+        (block, block_id) = make_pow_block(parent_id, nonce, transactions, timestamp)
         if block_id[-2] in "0123456":
             return (block, block_id)
     assert False, "Cannot mine block"

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -112,8 +112,9 @@ BASE_SCRIPTS = [
     'feature_lmdb_backend_test.py',
     'mempool_basic_reorg.py',
     'mempool_eviction.py',
-    'mempool_submit_tx.py',
+    'mempool_ibd.py',
     'mempool_submit_orphan.py',
+    'mempool_submit_tx.py',
     'mempool_timelocked_tx.py',
 
     # Don't append tests at the end to avoid merge conflicts

--- a/utils/src/config_setting.rs
+++ b/utils/src/config_setting.rs
@@ -22,6 +22,12 @@ macro_rules! make_config_setting {
             value: $tp,
         }
 
+        impl $name {
+            pub const fn new(value: $tp) -> Self {
+                Self { value }
+            }
+        }
+
         impl From<$tp> for $name {
             fn from(v: $tp) -> Self {
                 Self { value: v }


### PR DESCRIPTION
This also changes slightly how IBD is detected, where block timestamp is taken into account even for genesis.