### PR TITLE
Options add host resolution - remove websocket options

### DIFF
--- a/node-lib/src/config_files/mod.rs
+++ b/node-lib/src/config_files/mod.rs
@@ -210,7 +210,8 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
         cookie_file,
     } = config;
 
-    let http_bind_address = options.http_rpc_addr.clone().unwrap_or(default_http_rpc_addr.to_string());
+    let http_bind_address =
+        options.http_rpc_addr.clone().unwrap_or(default_http_rpc_addr.to_string());
     let http_enabled = options
         .http_rpc_enabled
         .unwrap_or_else(|| http_enabled.unwrap_or(DEFAULT_HTTP_RPC_ENABLED));

--- a/node-lib/src/config_files/mod.rs
+++ b/node-lib/src/config_files/mod.rs
@@ -214,14 +214,16 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
     } = config;
 
     let http_bind_address = options
-        .http_rpc_addr
-        .unwrap_or_else(|| http_bind_address.unwrap_or(default_http_rpc_addr));
+        .resolve_http_rpc_addr()
+        .or_else(|_| http_bind_address.ok_or("No address found"))
+        .unwrap_or(default_http_rpc_addr);
     let http_enabled = options
         .http_rpc_enabled
         .unwrap_or_else(|| http_enabled.unwrap_or(DEFAULT_HTTP_RPC_ENABLED));
     let ws_bind_address = options
-        .ws_rpc_addr
-        .unwrap_or_else(|| ws_bind_address.unwrap_or(default_ws_rpc_addr));
+        .resolve_ws_rpc_addr()
+        .or_else(|_| ws_bind_address.ok_or("No address found"))
+        .unwrap_or(default_ws_rpc_addr);
     let ws_enabled = options
         .ws_rpc_enabled
         .unwrap_or_else(|| ws_enabled.unwrap_or(DEFAULT_WS_RPC_ENABLED));

--- a/node-lib/src/config_files/mod.rs
+++ b/node-lib/src/config_files/mod.rs
@@ -199,19 +199,17 @@ fn p2p_config(config: P2pConfigFile, options: &RunOptions) -> P2pConfigFile {
 fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
     const DEFAULT_HTTP_RPC_ENABLED: bool = true;
     // TODO: Disabled by default because it causes port bind issues in functional tests; to be fixed after #446 is resolved
-    const DEFAULT_WS_RPC_ENABLED: bool = false;
     let default_http_rpc_addr = "127.0.0.1:3030";
 
     let RpcConfigFile {
-        http_bind_address,
+        http_rpc_addr: _,
         http_enabled,
         username,
         password,
         cookie_file,
     } = config;
 
-    let http_bind_address =
-        options.http_rpc_addr.clone().unwrap_or(default_http_rpc_addr.to_string());
+    let http_rpc_addr = options.http_rpc_addr.clone().unwrap_or(default_http_rpc_addr.to_string());
     let http_enabled = options
         .http_rpc_enabled
         .unwrap_or_else(|| http_enabled.unwrap_or(DEFAULT_HTTP_RPC_ENABLED));
@@ -220,7 +218,7 @@ fn rpc_config(config: RpcConfigFile, options: &RunOptions) -> RpcConfigFile {
     let cookie_file = cookie_file.or(options.rpc_cookie_file.clone());
 
     RpcConfigFile {
-        http_bind_address: Some(http_bind_address),
+        http_rpc_addr: Some(http_rpc_addr),
         http_enabled: Some(http_enabled),
         username,
         password,

--- a/node-lib/src/config_files/rpc.rs
+++ b/node-lib/src/config_files/rpc.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct RpcConfigFile {
     /// Address to bind http RPC to
-    pub http_bind_address: Option<String>,
+    pub http_rpc_addr: Option<String>,
 
     /// Whether http RPC is enabled
     pub http_enabled: Option<bool>,
@@ -39,7 +39,7 @@ pub struct RpcConfigFile {
 impl From<RpcConfigFile> for RpcConfig {
     fn from(c: RpcConfigFile) -> Self {
         RpcConfig {
-            http_rpc_addr: c.http_bind_address,
+            http_rpc_addr: c.http_rpc_addr,
             http_enabled: c.http_enabled.into(),
         }
     }

--- a/node-lib/src/config_files/rpc.rs
+++ b/node-lib/src/config_files/rpc.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::SocketAddr;
-
 use rpc::RpcConfig;
 use serde::{Deserialize, Serialize};
 
@@ -23,16 +21,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct RpcConfigFile {
     /// Address to bind http RPC to
-    pub http_bind_address: Option<SocketAddr>,
+    pub http_bind_address: Option<String>,
 
     /// Whether http RPC is enabled
     pub http_enabled: Option<bool>,
-
-    /// Address to bind websocket RPC to
-    pub ws_bind_address: Option<SocketAddr>,
-
-    /// Whether websocket RPC is enabled
-    pub ws_enabled: Option<bool>,
 
     /// Username for RPC HTTP and WebSocket server basic authorization
     pub username: Option<String>,
@@ -47,10 +39,8 @@ pub struct RpcConfigFile {
 impl From<RpcConfigFile> for RpcConfig {
     fn from(c: RpcConfigFile) -> Self {
         RpcConfig {
-            http_bind_address: c.http_bind_address.into(),
+            http_rpc_addr: c.http_bind_address,
             http_enabled: c.http_enabled.into(),
-            ws_bind_address: c.ws_bind_address.into(),
-            ws_enabled: c.ws_enabled.into(),
         }
     }
 }

--- a/node-lib/src/options.rs
+++ b/node-lib/src/options.rs
@@ -15,13 +15,11 @@
 
 //! The node command line options.
 
-use std::{ffi::OsString, net::SocketAddr, num::NonZeroU64, path::PathBuf};
+use std::{ffi::OsString, num::NonZeroU64, path::PathBuf};
 
 use clap::{Args, Parser, Subcommand};
 use common::chain::config::ChainType;
 use p2p::types::ip_or_socket_address::IpOrSocketAddress;
-use std::io::{Error, ErrorKind};
-use std::net::ToSocketAddrs;
 use utils::default_data_dir::default_data_dir_common;
 
 use crate::{
@@ -154,14 +152,6 @@ pub struct RunOptions {
     #[clap(long)]
     pub http_rpc_enabled: Option<bool>,
 
-    /// Address to bind websocket RPC to.
-    #[clap(long, value_name = "ADDR")]
-    pub ws_rpc_addr: Option<String>,
-
-    /// Enable/Disable websocket RPC.
-    #[clap(long)]
-    pub ws_rpc_enabled: Option<bool>,
-
     /// Username for RPC HTTP and WebSocket server basic authorization.
     /// If not set, the cookie file is created.
     #[clap(long)]
@@ -176,48 +166,6 @@ pub struct RunOptions {
     /// If not set, the cookie file is created in the data dir.
     #[clap(long)]
     pub rpc_cookie_file: Option<String>,
-}
-
-impl RunOptions {
-    /// Resolve the hostname and return a <SocketAddr>
-    pub fn resolve_http_rpc_addr(&self) -> std::io::Result<SocketAddr> {
-        let mut addrs = match self.http_rpc_addr.as_ref().unwrap().to_socket_addrs() {
-            Ok(addrs) => addrs,
-            Err(_) => panic!(
-                "could not resolve address: {}",
-                self.http_rpc_addr.as_ref().unwrap()
-            ),
-        };
-        addrs.next().ok_or_else(|| {
-            Error::new(
-                ErrorKind::Other,
-                format!(
-                    "couldn't resolve address: {}",
-                    self.http_rpc_addr.as_ref().unwrap()
-                ),
-            )
-        })
-    }
-
-    /// Resolve the hostname and return a <SocketAddr>
-    pub fn resolve_ws_rpc_addr(&self) -> std::io::Result<SocketAddr> {
-        let mut addrs = match self.ws_rpc_addr.as_ref().unwrap().to_socket_addrs() {
-            Ok(addrs) => addrs,
-            Err(_) => panic!(
-                "could not resolve address: {}",
-                self.ws_rpc_addr.as_ref().unwrap()
-            ),
-        };
-        addrs.next().ok_or_else(|| {
-            Error::new(
-                ErrorKind::Other,
-                format!(
-                    "couldn't resolve address: {}",
-                    self.ws_rpc_addr.as_ref().unwrap()
-                ),
-            )
-        })
-    }
 }
 
 impl Options {

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -155,7 +155,7 @@ async fn initialize(
 
     // RPC subsystem
     let rpc_config = node_config.rpc.unwrap_or_default();
-    if rpc_config.http_enabled.unwrap_or(true) || rpc_config.ws_enabled.unwrap_or(true) {
+    if rpc_config.http_enabled.unwrap_or(true) {
         let rpc_creds = RpcCreds::new(
             &data_dir,
             rpc_config.username.as_deref(),

--- a/node-lib/tests/cli.rs
+++ b/node-lib/tests/cli.rs
@@ -97,7 +97,7 @@ fn read_config_override_values() {
     let p2p_ping_timeout = NonZeroU64::new(60).unwrap();
     let p2p_sync_stalling_timeout = NonZeroU64::new(37).unwrap();
     let p2p_max_clock_diff = 15;
-    let http_rpc_addr = SocketAddr::from_str("127.0.0.1:5432").unwrap();
+    let http_rpc_addr = "localhost:5432";
     let ws_rpc_addr = SocketAddr::from_str("127.0.0.1:5433").unwrap();
     let backend_type = StorageBackendConfigFile::InMemory;
     let node_type = NodeTypeConfigFile::FullNode;
@@ -127,9 +127,9 @@ fn read_config_override_values() {
         p2p_sync_stalling_timeout: Some(p2p_sync_stalling_timeout),
         p2p_max_clock_diff: Some(p2p_max_clock_diff),
         max_tip_age: Some(max_tip_age),
-        http_rpc_addr: Some(http_rpc_addr),
+        http_rpc_addr: Some(http_rpc_addr.to_string()),
         http_rpc_enabled: Some(true),
-        ws_rpc_addr: Some(ws_rpc_addr),
+        ws_rpc_addr: Some(ws_rpc_addr.to_string()),
         ws_rpc_enabled: Some(false),
         rpc_username: Some(rpc_username.to_owned()),
         rpc_password: Some(rpc_password.to_owned()),
@@ -211,9 +211,10 @@ fn read_config_override_values() {
     assert_eq!(config.p2p.clone().unwrap().node_type, Some(node_type));
 
     assert_eq!(
-        config.rpc.clone().unwrap().http_bind_address,
-        Some(http_rpc_addr)
+        config.rpc.clone().unwrap().http_bind_address.map(|addr| addr.to_string()),
+        Some(http_rpc_addr.to_string())
     );
+
     assert!(config.rpc.clone().unwrap().http_enabled.unwrap());
 
     assert_eq!(

--- a/node-lib/tests/cli.rs
+++ b/node-lib/tests/cli.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{net::SocketAddr, num::NonZeroU64, path::Path, str::FromStr};
+use std::{num::NonZeroU64, path::Path};
 
 use p2p::types::ip_or_socket_address::IpOrSocketAddress;
 use tempfile::TempDir;
@@ -67,7 +67,7 @@ fn create_default_config() {
     );
 
     assert_eq!(
-        config.rpc.unwrap_or_default().http_bind_address,
+        config.rpc.unwrap_or_default().http_rpc_addr,
         Some("127.0.0.1:3030".to_string())
     );
 }
@@ -98,7 +98,6 @@ fn read_config_override_values() {
     let p2p_sync_stalling_timeout = NonZeroU64::new(37).unwrap();
     let p2p_max_clock_diff = 15;
     let http_rpc_addr = "localhost:5432";
-    let ws_rpc_addr = SocketAddr::from_str("127.0.0.1:5433").unwrap();
     let backend_type = StorageBackendConfigFile::InMemory;
     let node_type = NodeTypeConfigFile::FullNode;
     let max_tip_age = 1000;
@@ -209,7 +208,7 @@ fn read_config_override_values() {
     assert_eq!(config.p2p.clone().unwrap().node_type, Some(node_type));
 
     assert_eq!(
-        config.rpc.clone().unwrap().http_bind_address.map(|addr| addr.to_string()),
+        config.rpc.clone().unwrap().http_rpc_addr.map(|addr| addr.to_string()),
         Some(http_rpc_addr.to_string())
     );
 

--- a/node-lib/tests/cli.rs
+++ b/node-lib/tests/cli.rs
@@ -68,7 +68,7 @@ fn create_default_config() {
 
     assert_eq!(
         config.rpc.unwrap_or_default().http_bind_address,
-        Some(SocketAddr::from_str("127.0.0.1:3030").unwrap())
+        Some("127.0.0.1:3030".to_string())
     );
 }
 
@@ -129,8 +129,6 @@ fn read_config_override_values() {
         max_tip_age: Some(max_tip_age),
         http_rpc_addr: Some(http_rpc_addr.to_string()),
         http_rpc_enabled: Some(true),
-        ws_rpc_addr: Some(ws_rpc_addr.to_string()),
-        ws_rpc_enabled: Some(false),
         rpc_username: Some(rpc_username.to_owned()),
         rpc_password: Some(rpc_password.to_owned()),
         rpc_cookie_file: Some(rpc_cookie_file.to_owned()),
@@ -216,12 +214,6 @@ fn read_config_override_values() {
     );
 
     assert!(config.rpc.clone().unwrap().http_enabled.unwrap());
-
-    assert_eq!(
-        config.rpc.clone().unwrap().ws_bind_address,
-        Some(ws_rpc_addr)
-    );
-    assert!(!config.rpc.clone().unwrap().ws_enabled.unwrap());
 
     assert_eq!(
         config.rpc.as_ref().unwrap().username.as_deref(),

--- a/rpc/src/config.rs
+++ b/rpc/src/config.rs
@@ -13,38 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fmt::Debug, net::SocketAddr, str::FromStr};
+use std::fmt::Debug;
 
 use utils::make_config_setting;
 
 make_config_setting!(
     HttpBindAddress,
-    SocketAddr,
-    SocketAddr::from_str("127.0.0.1:3030").expect("Address must be correct")
+    Option<String>,
+    Some("127.0.0.1:3030".to_string())
 );
 
 make_config_setting!(HttpRpcEnabled, bool, true);
-
-make_config_setting!(
-    WebsocketBindAddress,
-    SocketAddr,
-    SocketAddr::from_str("127.0.0.1:3032").expect("Address must be correct")
-);
-
-make_config_setting!(WebsocketRpcEnabled, bool, true);
 
 /// The rpc subsystem configuration.
 #[derive(Debug, Default)]
 pub struct RpcConfig {
     /// Address to bind http RPC to.
-    pub http_bind_address: HttpBindAddress,
+    pub http_rpc_addr: Option<String>,
 
     /// Whether http RPC is enabled
     pub http_enabled: HttpRpcEnabled,
-
-    /// Address to bind websocket RPC to.
-    pub ws_bind_address: WebsocketBindAddress,
-
-    /// Whether websocket RPC is enabled
-    pub ws_enabled: WebsocketRpcEnabled,
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -18,14 +18,13 @@ mod error;
 mod rpc_auth;
 pub mod rpc_creds;
 
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, net::ToSocketAddrs, path::PathBuf};
 
 use base64::Engine;
 use http::{header, HeaderValue};
 use jsonrpsee::{
     http_client::{transport::HttpBackend, HttpClient, HttpClientBuilder},
     server::{ServerBuilder, ServerHandle},
-    ws_client::{WsClient, WsClientBuilder},
 };
 
 use logging::log;
@@ -58,21 +57,20 @@ impl RpcInfoServer for RpcInfo {
 /// The RPC subsystem builder. Used to populate the RPC server with method handlers.
 pub struct Builder {
     http_bind_address: Option<SocketAddr>,
-    ws_bind_address: Option<SocketAddr>,
     methods: Methods,
     creds: Option<RpcCreds>,
 }
 
 impl Builder {
-    /// New builder with no methods. None Option disables http or websocket.
-    pub fn new_empty(
-        http_bind_address: Option<SocketAddr>,
-        ws_bind_address: Option<SocketAddr>,
-    ) -> Self {
+    /// New builder with no methods. None Option disables http.
+    pub fn new_empty(http_rpc_addr: Option<String>) -> Self {
         let methods = Methods::new();
+        // Convert the http_rpc_addr to SocketAddr
+        let http_bind_address = http_rpc_addr
+            .and_then(|addr| addr.to_socket_addrs().ok().and_then(|mut addrs| addrs.next()));
+
         Self {
             http_bind_address,
-            ws_bind_address,
             methods,
             creds: None,
         }
@@ -82,21 +80,17 @@ impl Builder {
     ///
     /// If `creds` is set, basic HTTP authentication is required.
     pub fn new(rpc_config: RpcConfig, creds: Option<RpcCreds>) -> Self {
+        // Convert the http_rpc_addr to SocketAddr
         let http_bind_address = if *rpc_config.http_enabled {
-            Some(*rpc_config.http_bind_address)
-        } else {
-            None
-        };
-
-        let ws_bind_address = if *rpc_config.ws_enabled {
-            Some(*rpc_config.ws_bind_address)
+            rpc_config
+                .http_rpc_addr
+                .and_then(|addr| addr.to_socket_addrs().ok().and_then(|mut addrs| addrs.next()))
         } else {
             None
         };
 
         Self {
             http_bind_address,
-            ws_bind_address,
             methods: Methods::new(),
             creds,
         }
@@ -111,20 +105,13 @@ impl Builder {
 
     /// Build the RPC server and get the RPC object
     pub async fn build(self) -> anyhow::Result<Rpc> {
-        Rpc::new(
-            self.http_bind_address.as_ref(),
-            self.ws_bind_address.as_ref(),
-            self.methods,
-            self.creds,
-        )
-        .await
+        Rpc::new(self.http_bind_address.as_ref(), self.methods, self.creds).await
     }
 }
 
 /// The RPC subsystem
 pub struct Rpc {
     http: Option<(SocketAddr, ServerHandle)>,
-    websocket: Option<(SocketAddr, ServerHandle)>,
     // Stored here to remove the cookie file when the node is stopped
     _creds: Option<RpcCreds>,
 }
@@ -135,7 +122,6 @@ impl Rpc {
     /// If `creds` is set, basic HTTP authentication is required.
     async fn new(
         http_bind_addr: Option<&SocketAddr>,
-        ws_bind_addr: Option<&SocketAddr>,
         methods: Methods,
         creds: Option<RpcCreds>,
     ) -> anyhow::Result<Self> {
@@ -159,33 +145,14 @@ impl Rpc {
             None => None,
         };
 
-        let websocket = match ws_bind_addr {
-            Some(bind_addr) => {
-                let ws_server = ServerBuilder::new()
-                    .set_middleware(middleware)
-                    .ws_only()
-                    .build(bind_addr)
-                    .await?;
-                let ws_address = ws_server.local_addr()?;
-                let ws_handle = ws_server.start(methods)?;
-                Some((ws_address, ws_handle))
-            }
-            None => None,
-        };
-
         Ok(Self {
             http,
-            websocket,
             _creds: creds,
         })
     }
 
     pub fn http_address(&self) -> Option<&SocketAddr> {
         self.http.as_ref().map(|v| &v.0)
-    }
-
-    pub fn websocket_address(&self) -> Option<&SocketAddr> {
-        self.websocket.as_ref().map(|v| &v.0)
     }
 }
 
@@ -196,12 +163,6 @@ impl subsystem::Subsystem for Rpc {
             match obj.1.stop() {
                 Ok(()) => obj.1.stopped().await,
                 Err(e) => log::error!("Http RPC stop handle acquisition failed: {}", e),
-            }
-        }
-        if let Some(obj) = self.websocket {
-            match obj.1.stop() {
-                Ok(()) => obj.1.stopped().await,
-                Err(e) => log::error!("Websocket RPC stop handle acquisition failed: {}", e),
             }
         }
     }
@@ -247,7 +208,6 @@ impl<T> MakeHeaderValue<T> for RpcAuthData {
 }
 
 pub type RpcHttpClient = HttpClient<SetRequestHeader<HttpBackend, RpcAuthData>>;
-pub type RpcWsClient = WsClient;
 
 pub fn new_http_client(host: String, rpc_auth: RpcAuthData) -> Result<RpcHttpClient> {
     let middleware = tower::ServiceBuilder::new().layer(SetRequestHeaderLayer::overriding(
@@ -256,15 +216,6 @@ pub fn new_http_client(host: String, rpc_auth: RpcAuthData) -> Result<RpcHttpCli
     ));
 
     HttpClientBuilder::default().set_middleware(middleware).build(host)
-}
-
-pub async fn new_ws_client(host: String, rpc_auth: RpcAuthData) -> Result<RpcWsClient> {
-    let mut headers = http::HeaderMap::new();
-    if let Some(header) = rpc_auth.get_header() {
-        headers.append(http::header::AUTHORIZATION, header);
-    }
-
-    WsClientBuilder::default().set_headers(headers).build(host).await
 }
 
 fn make_http_header_value(username: &str, password: &str) -> http::HeaderValue {
@@ -312,16 +263,13 @@ mod tests {
 
     #[rstest]
     #[trace]
-    #[case(true, false)]
-    #[case(false, true)]
-    #[case(true, true)]
+    #[case(true)]
+    #[case(false)]
     #[tokio::test]
-    async fn rpc_server(#[case] http: bool, #[case] ws: bool) -> anyhow::Result<()> {
+    async fn rpc_server(#[case] http: bool) -> anyhow::Result<()> {
         let rpc_config = RpcConfig {
-            http_bind_address: "127.0.0.1:0".parse::<SocketAddr>().unwrap().into(),
+            http_rpc_addr: Some("127.0.0.1:0".to_string()),
             http_enabled: http.into(),
-            ws_bind_address: "127.0.0.1:0".parse::<SocketAddr>().unwrap().into(),
-            ws_enabled: ws.into(),
         };
 
         let rpc = Builder::new(rpc_config, None)
@@ -345,22 +293,6 @@ mod tests {
             assert_eq!(response.unwrap(), 7);
         }
 
-        if ws {
-            let url = format!("ws://{}", rpc.websocket_address().unwrap());
-            let client = new_ws_client(url, RpcAuthData::None).await.unwrap();
-            let response: Result<String> =
-                client.request("example_server_protocol_version", rpc_params!()).await;
-            assert_eq!(response.unwrap(), "version1");
-
-            let response: Result<String> =
-                client.request("some_subsystem_name", rpc_params!()).await;
-            assert_eq!(response.unwrap(), "sub1");
-
-            let response: Result<u64> =
-                client.request("some_subsystem_add", rpc_params!(2, 5)).await;
-            assert_eq!(response.unwrap(), 7);
-        }
-
         subsystem::Subsystem::shutdown(rpc).await;
         Ok(())
     }
@@ -368,15 +300,6 @@ mod tests {
     async fn http_request(rpc: &Rpc, rpc_auth: RpcAuthData) -> anyhow::Result<()> {
         let url = format!("http://{}", rpc.http_address().unwrap());
         let client = new_http_client(url, rpc_auth)?;
-        let response: String =
-            client.request("example_server_protocol_version", rpc_params!()).await?;
-        anyhow::ensure!(response == "version1");
-        Ok(())
-    }
-
-    async fn ws_request(rpc: &Rpc, rpc_auth: RpcAuthData) -> anyhow::Result<()> {
-        let url = format!("ws://{}", rpc.websocket_address().unwrap());
-        let client = new_ws_client(url, rpc_auth).await?;
         let response: String =
             client.request("example_server_protocol_version", rpc_params!()).await?;
         anyhow::ensure!(response == "version1");
@@ -406,10 +329,8 @@ mod tests {
         let bad_password = gen_random_string(&mut rng, &good_password);
 
         let rpc_config = RpcConfig {
-            http_bind_address: "127.0.0.1:0".parse::<SocketAddr>().unwrap().into(),
+            http_rpc_addr: Some("127.0.0.1:0".to_string()),
             http_enabled: true.into(),
-            ws_bind_address: "127.0.0.1:0".parse::<SocketAddr>().unwrap().into(),
-            ws_enabled: true.into(),
         };
 
         let data_dir: PathBuf = ".".into();
@@ -440,19 +361,9 @@ mod tests {
         )
         .await
         .unwrap();
-        ws_request(
-            &rpc,
-            RpcAuthData::Basic {
-                username: good_username.clone(),
-                password: good_password.clone(),
-            },
-        )
-        .await
-        .unwrap();
 
         // Invalid requests
         http_request(&rpc, RpcAuthData::None).await.unwrap_err();
-        ws_request(&rpc, RpcAuthData::None).await.unwrap_err();
 
         http_request(
             &rpc,
@@ -463,25 +374,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        ws_request(
-            &rpc,
-            RpcAuthData::Basic {
-                username: good_username.clone(),
-                password: bad_password.clone(),
-            },
-        )
-        .await
-        .unwrap_err();
         http_request(
-            &rpc,
-            RpcAuthData::Basic {
-                username: bad_username.clone(),
-                password: good_password.clone(),
-            },
-        )
-        .await
-        .unwrap_err();
-        ws_request(
             &rpc,
             RpcAuthData::Basic {
                 username: bad_username.clone(),

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -199,10 +199,8 @@ async fn start_node(chain_config: Arc<ChainConfig>) -> (subsystem::Manager, Sock
     let rpc_creds = RpcCreds::basic(RPC_USERNAME, RPC_PASSWORD).unwrap();
 
     let rpc_config = RpcConfig {
-        http_bind_address: "127.0.0.1:0".parse::<SocketAddr>().unwrap().into(),
+        http_rpc_addr: Some("127.0.0.1:0".to_string()),
         http_enabled: true.into(),
-        ws_bind_address: Default::default(),
-        ws_enabled: false.into(),
     };
 
     let mut manager = subsystem::Manager::new("wallet-cli-test-manager");

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
 use blockprod::{test_blockprod_config, BlockProductionHandle};
 use chainstate::{
@@ -123,14 +123,8 @@ pub async fn start_subsystems(
     );
 
     let rpc_config = RpcConfig {
-        http_bind_address: SocketAddr::from_str(&rpc_bind_address)
-            .expect("Address must be correct")
-            .into(),
+        http_rpc_addr: Some(rpc_bind_address.to_string()),
         http_enabled: true.into(),
-        ws_bind_address: SocketAddr::from_str("127.0.0.1:3030")
-            .expect("Address must be correct")
-            .into(),
-        ws_enabled: false.into(),
     };
 
     let rpc_subsys = rpc::Builder::new(rpc_config, None)


### PR DESCRIPTION
The objective is to leverage `std::net::ToSocketAddrs` instead of `SocketAddr`. This approach enables the use of a hostname for the RPC, which is particularly beneficial for docker container networking. With this method, one container can connect to another without the necessity of knowing the assigned IP.

NOTE: This PR also remove the unnecessary `ws` option settings. 

