### PR TITLE
Set RUST_BACKTRACE by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,6 +3894,7 @@ dependencies = [
  "logging",
  "node-lib",
  "tokio",
+ "utils",
 ]
 
 [[package]]
@@ -6979,6 +6980,7 @@ version = "0.1.1"
 dependencies = [
  "clap",
  "tokio",
+ "utils",
  "wallet-cli-lib",
 ]
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ The logging of mintlayer-core is configured via the `RUST_LOG` environment varia
 Here are the commands as recommended for different scenarios:
 
 For normal operation
-- Node daemon: `RUST_BACKTRACE=full RUST_LOG=info cargo run --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
-- CLI Wallet:  `RUST_BACKTRACE=full RUST_LOG=info cargo run --bin wallet-cli -- --network testnet 2>&1 | tee ../wallet-cli.log`
-- GUI:         `RUST_BACKTRACE=full RUST_LOG=info cargo run --bin node-gui 2>&1 | tee ../node-gui.log`
+- Node daemon: `RUST_LOG=info cargo run --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
+- CLI Wallet:  `RUST_LOG=info cargo run --bin wallet-cli -- --network testnet 2>&1 | tee ../wallet-cli.log`
+- GUI:         `RUST_LOG=info cargo run --bin node-gui 2>&1 | tee ../node-gui.log`
 
 For heavy debugging operation
-- Node daemon: `RUST_BACKTRACE=full RUST_LOG=debug cargo run --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
-- CLI Wallet:  `RUST_BACKTRACE=full RUST_LOG=debug cargo run --bin wallet-cli -- --network testnet 2>&1 | tee ../wallet-cli.log`
-- GUI:         `RUST_BACKTRACE=full RUST_LOG=debug cargo run --bin node-gui 2>&1 | tee ../node-gui.log`
+- Node daemon: `RUST_LOG=debug cargo run --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
+- CLI Wallet:  `RUST_LOG=debug cargo run --bin wallet-cli -- --network testnet 2>&1 | tee ../wallet-cli.log`
+- GUI:         `RUST_LOG=debug cargo run --bin node-gui 2>&1 | tee ../node-gui.log`

--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -139,6 +139,8 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<Never, error::DnsServerErro
 
 #[tokio::main]
 async fn main() {
+    utils::rust_backtrace::enable();
+
     logging::init_logging::<std::path::PathBuf>(None);
 
     let config = Arc::new(DnsServerConfig::parse());

--- a/node-daemon/Cargo.toml
+++ b/node-daemon/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 [dependencies]
 logging = { path = "../logging" }
 node-lib = { path = "../node-lib/" }
+utils = { path = "../utils" }
 
 anyhow.workspace = true
 tokio = { workspace = true, default-features = false }

--- a/node-daemon/src/main.rs
+++ b/node-daemon/src/main.rs
@@ -24,6 +24,8 @@ pub async fn run() -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() {
+    utils::rust_backtrace::enable();
+
     run().await.unwrap_or_else(|err| {
         eprintln!("Mintlayer node launch failed: {err:?}");
         std::process::exit(1)

--- a/node-gui/src/main.rs
+++ b/node-gui/src/main.rs
@@ -30,6 +30,8 @@ use main_window::{MainWindow, MainWindowMessage};
 use tokio::sync::mpsc::UnboundedReceiver;
 
 pub fn main() -> iced::Result {
+    utils::rust_backtrace::enable();
+
     MintlayerNodeGUI::run(Settings {
         id: Some("mintlayer-gui".to_owned()),
         antialiasing: true,

--- a/utils/src/rust_backtrace.rs
+++ b/utils/src/rust_backtrace.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2023 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,26 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod atomics;
-pub mod blockuntilzero;
-pub mod bloom_filters;
-pub mod config_setting;
-pub mod const_value;
-pub mod cookie;
-pub mod counttracker;
-pub mod default_data_dir;
-pub mod ensure;
-pub mod eventhandler;
-pub mod exp_rand;
-pub mod graph_traversals;
-pub mod maybe_encrypted;
-pub mod newtype;
-pub mod once_destructor;
-pub mod qrcode;
-pub mod rust_backtrace;
-pub mod set_flag;
-pub mod shallow_clone;
-pub mod tap_error_log;
-
-mod concurrency_impl;
-pub use concurrency_impl::*;
+/// Set the `RUST_BACKTRACE` environment variable to `full` if it's not already set
+pub fn enable() {
+    if std::env::var("RUST_BACKTRACE").is_err() {
+        std::env::set_var("RUST_BACKTRACE", "full");
+    }
+}

--- a/wallet/wallet-cli/Cargo.toml
+++ b/wallet/wallet-cli/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+utils = { path = "../../utils" }
 wallet-cli-lib = { path = "../wallet-cli-lib" }
 
 clap = { version = "4", features = ["derive"] }

--- a/wallet/wallet-cli/src/main.rs
+++ b/wallet/wallet-cli/src/main.rs
@@ -21,6 +21,8 @@ use wallet_cli_lib::{
 
 #[tokio::main]
 async fn main() {
+    utils::rust_backtrace::enable();
+
     if std::env::var("RUST_LOG").is_err() {
         std::env::set_var("RUST_LOG", "info");
     }


### PR DESCRIPTION
I think it will be a little easier for everyone if we set `RUST_BACKTRACE` by default for our executables.
This can be useful for regular GUI users (but only if we also use file logging and log crashes).