### PR TITLE
Update some license headers for functional test files

### DIFF
--- a/test/functional/combine_logs.py
+++ b/test/functional/combine_logs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  Copyright (c) 2022-2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/combine_logs.py
+++ b/test/functional/combine_logs.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  Copyright (c) 2022-2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Combine logs from multiple bitcoin nodes as well as the test_framework log.
 
 This streams the combined log output to stdout. Use combine_logs.py > outputfile

--- a/test/functional/create_cache.py
+++ b/test/functional/create_cache.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2016-2019 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2016-2019 The Bitcoin Core developers
+#  Copyright (c) 2022-2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Create a blockchain cache.
 
 Creating a cache of the blockchain speeds up test execution when running

--- a/test/functional/create_cache.py
+++ b/test/functional/create_cache.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2016-2019 The Bitcoin Core developers
 #  Copyright (c) 2022-2023 RBB S.r.l
+#  Copyright (c) 2016-2019 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  Copyright (c) 2022-2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """An example functional test
 
 The module-level docstring should include a high-level description of

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  Copyright (c) 2022-2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/feature_lmdb_backend_test.py
+++ b/test/functional/feature_lmdb_backend_test.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
-# Copyright (c) 2022 RBB S.r.l
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  Copyright (c) 2022 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (

--- a/test/functional/feature_lmdb_backend_test.py
+++ b/test/functional/feature_lmdb_backend_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  Copyright (c) 2022 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/mempool_basic_reorg.py
+++ b/test/functional/mempool_basic_reorg.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Mempool reorg test
 
 Check that:

--- a/test/functional/mempool_eviction.py
+++ b/test/functional/mempool_eviction.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Mempool tx eviction test
 
 Check that:

--- a/test/functional/mempool_ibd.py
+++ b/test/functional/mempool_ibd.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Mempool initial block download test
 
 Check that:

--- a/test/functional/mempool_submit_orphan.py
+++ b/test/functional/mempool_submit_orphan.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/mempool_submit_orphan.py
+++ b/test/functional/mempool_submit_orphan.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Mempool orphan submission test
 
 Check that:

--- a/test/functional/mempool_submit_tx.py
+++ b/test/functional/mempool_submit_tx.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/mempool_submit_tx.py
+++ b/test/functional/mempool_submit_tx.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Mempool transaction submission test
 
 Check that:

--- a/test/functional/p2p_ping.py
+++ b/test/functional/p2p_ping.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2022 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2020-2022 The Bitcoin Core developers
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Test ping message
 """
 

--- a/test/functional/p2p_ping.py
+++ b/test/functional/p2p_ping.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2020-2022 The Bitcoin Core developers
 #  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2020-2022 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/p2p_relay_transactions.py
+++ b/test/functional/p2p_relay_transactions.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
-# Copyright (c) 2022 RBB S.r.l
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  Copyright (c) 2022 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 from test_framework.mintlayer import mintlayer_hash
 from test_framework.util import assert_raises_rpc_error

--- a/test/functional/p2p_relay_transactions.py
+++ b/test/functional/p2p_relay_transactions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  Copyright (c) 2022 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/p2p_submit_orphan.py
+++ b/test/functional/p2p_submit_orphan.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/p2p_submit_orphan.py
+++ b/test/functional/p2p_submit_orphan.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Mempool orphan submission test
 
 Check that:

--- a/test/functional/p2p_syncing_test.py
+++ b/test/functional/p2p_syncing_test.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2021 The Bitcoin Core developers
-# Copyright (c) 2022 RBB S.r.l
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  Copyright (c) 2022 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (

--- a/test/functional/p2p_syncing_test.py
+++ b/test/functional/p2p_syncing_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  Copyright (c) 2022 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
-# Copyright (c) 2014-2021 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#  Copyright (c) 2014-2021 The Bitcoin Core developers
+#  Copyright (c) 2022-2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 """Run regression test suite.
 
 This module calls down into individual test cases via subprocess. It will

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-#  Copyright (c) 2014-2021 The Bitcoin Core developers
 #  Copyright (c) 2022-2023 RBB S.r.l
+#  Copyright (c) 2014-2021 The Bitcoin Core developers
 #  opensource@mintlayer.org
 #  SPDX-License-Identifier: MIT
 #  Licensed under the MIT License;


### PR DESCRIPTION
I've added the Mintlayer (RBB) license header where it was missing in some files, essentially files that are heavily based on Bitcoin's functional tests but we have modified. I've retained the original Bitcoin copyright notice universally and perhaps in some cases superfluously but this is a quick fix that will suffice for now. 