### PR TITLE
Add option to save seed phrase in the wallet DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7058,6 +7058,7 @@ dependencies = [
 name = "wallet-storage"
 version = "0.1.1"
 dependencies = [
+ "bip39",
  "common",
  "crypto",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
  "zeroize",
@@ -7079,6 +7081,7 @@ dependencies = [
  "bip39",
  "common",
  "crypto",
+ "itertools 0.11.0",
  "parity-scale-codec",
  "rstest",
  "serialization",

--- a/node-gui/src/backend/backend_impl.rs
+++ b/node-gui/src/backend/backend_impl.rs
@@ -127,7 +127,7 @@ impl Backend {
             file_path.clone(),
             mnemonic,
             None,
-            false,
+            true,
         )
         .map_err(|e| BackendError::WalletError(e.to_string()))?;
 

--- a/node-gui/src/backend/backend_impl.rs
+++ b/node-gui/src/backend/backend_impl.rs
@@ -121,11 +121,13 @@ impl Backend {
                 .map_err(|err| BackendError::WalletError(err.to_string()))?;
         }
 
+        // TODO: add support for passphrase and saving of seed phrase
         let wallet = GuiController::create_wallet(
             Arc::clone(&self.chain_config),
             file_path.clone(),
             mnemonic,
             None,
+            false,
         )
         .map_err(|e| BackendError::WalletError(e.to_string()))?;
 

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -42,7 +42,8 @@ fn account_addresses() {
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 
     let master_key_chain =
-        MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();
+        MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None, false)
+            .unwrap();
 
     let key_chain = master_key_chain
         .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
@@ -71,7 +72,8 @@ fn account_addresses_lookahead() {
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 
     let master_key_chain =
-        MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();
+        MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None, false)
+            .unwrap();
 
     let key_chain = master_key_chain
         .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
@@ -112,7 +114,8 @@ fn sign_transaction(#[case] seed: Seed) {
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 
     let master_key_chain =
-        MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None).unwrap();
+        MasterKeyChain::new_from_mnemonic(config.clone(), &mut db_tx, MNEMONIC, None, false)
+            .unwrap();
 
     let key_chain = master_key_chain
         .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)

--- a/wallet/src/key_chain/account_key_chain/tests.rs
+++ b/wallet/src/key_chain/account_key_chain/tests.rs
@@ -36,7 +36,7 @@ fn check_mine_methods(#[case] public: &str) {
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 
     let master_key_chain =
-        MasterKeyChain::new_from_mnemonic(chain_config, &mut db_tx, MNEMONIC, None).unwrap();
+        MasterKeyChain::new_from_mnemonic(chain_config, &mut db_tx, MNEMONIC, None, false).unwrap();
     let mut key_chain = master_key_chain
         .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
         .unwrap();

--- a/wallet/src/key_chain/master_key_chain/mod.rs
+++ b/wallet/src/key_chain/master_key_chain/mod.rs
@@ -69,7 +69,7 @@ impl MasterKeyChain {
         )
     }
 
-    pub fn new_from_root_key<B: storage::Backend>(
+    fn new_from_root_key<B: storage::Backend>(
         chain_config: Arc<ChainConfig>,
         db_tx: &mut StoreTxRwUnlocked<B>,
         root_key: ExtendedPrivateKey,

--- a/wallet/src/key_chain/master_key_chain/mod.rs
+++ b/wallet/src/key_chain/master_key_chain/mod.rs
@@ -25,6 +25,7 @@ use wallet_storage::{
     StoreTxRwUnlocked, WalletStorageReadLocked, WalletStorageReadUnlocked,
     WalletStorageWriteUnlocked,
 };
+use wallet_types::keys::SeedPhrase;
 
 use super::DEFAULT_VRF_KEY_KIND;
 
@@ -37,14 +38,14 @@ impl MasterKeyChain {
     pub fn mnemonic_to_root_key(
         mnemonic_str: &str,
         passphrase: Option<&str>,
-    ) -> KeyChainResult<(ExtendedPrivateKey, ExtendedVRFPrivateKey)> {
+    ) -> KeyChainResult<(ExtendedPrivateKey, ExtendedVRFPrivateKey, SeedPhrase)> {
         let mnemonic = zeroize::Zeroizing::new(
             bip39::Mnemonic::parse(mnemonic_str).map_err(KeyChainError::Bip39)?,
         );
         let seed = zeroize::Zeroizing::new(mnemonic.to_seed(passphrase.unwrap_or("")));
         let root_key = ExtendedPrivateKey::new_master(seed.as_ref(), DEFAULT_KEY_KIND)?;
         let root_vrf_key = ExtendedVRFPrivateKey::new_master(seed.as_ref(), DEFAULT_VRF_KEY_KIND)?;
-        Ok((root_key, root_vrf_key))
+        Ok((root_key, root_vrf_key, SeedPhrase { mnemonic }))
     }
 
     pub fn new_from_mnemonic<B: storage::Backend>(
@@ -52,12 +53,20 @@ impl MasterKeyChain {
         db_tx: &mut StoreTxRwUnlocked<B>,
         mnemonic_str: &str,
         passphrase: Option<&str>,
+        save_seed_phrase: bool,
     ) -> KeyChainResult<Self> {
         // TODO: Do not store the master key here, store only the key relevant to the mintlayer
         // (see make_account_path)
 
-        let (root_key, root_vrf_key) = Self::mnemonic_to_root_key(mnemonic_str, passphrase)?;
-        Self::new_from_root_key(chain_config, db_tx, root_key, root_vrf_key)
+        let (root_key, root_vrf_key, seed_phrase) =
+            Self::mnemonic_to_root_key(mnemonic_str, passphrase)?;
+        Self::new_from_root_key(
+            chain_config,
+            db_tx,
+            root_key,
+            root_vrf_key,
+            save_seed_phrase.then_some(seed_phrase),
+        )
     }
 
     pub fn new_from_root_key<B: storage::Backend>(
@@ -65,6 +74,7 @@ impl MasterKeyChain {
         db_tx: &mut StoreTxRwUnlocked<B>,
         root_key: ExtendedPrivateKey,
         root_vrf_key: ExtendedVRFPrivateKey,
+        seed_phrase: Option<SeedPhrase>,
     ) -> KeyChainResult<Self> {
         if !root_key.get_derivation_path().is_root() {
             return Err(KeyChainError::KeyNotRoot);
@@ -76,6 +86,9 @@ impl MasterKeyChain {
         };
 
         db_tx.set_root_key(&key_content)?;
+        if let Some(seed_phrase) = seed_phrase {
+            db_tx.set_seed_phrase(seed_phrase)?;
+        }
 
         Ok(MasterKeyChain { chain_config })
     }

--- a/wallet/src/key_chain/tests.rs
+++ b/wallet/src/key_chain/tests.rs
@@ -70,7 +70,7 @@ fn key_chain_creation(
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
     let master_key_chain =
-        MasterKeyChain::new_from_mnemonic(chain_config, &mut db_tx, MNEMONIC, None).unwrap();
+        MasterKeyChain::new_from_mnemonic(chain_config, &mut db_tx, MNEMONIC, None, false).unwrap();
 
     let mut key_chain = master_key_chain
         .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
@@ -127,7 +127,7 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
     let master_key_chain =
-        MasterKeyChain::new_from_mnemonic(chain_config.clone(), &mut db_tx, MNEMONIC, None)
+        MasterKeyChain::new_from_mnemonic(chain_config.clone(), &mut db_tx, MNEMONIC, None, false)
             .unwrap();
     let mut key_chain = master_key_chain
         .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)
@@ -205,7 +205,7 @@ fn top_up_and_lookahead(#[case] purpose: KeyPurpose) {
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
     let master_key_chain =
-        MasterKeyChain::new_from_mnemonic(Arc::clone(&chain_config), &mut db_tx, MNEMONIC, None)
+        MasterKeyChain::new_from_mnemonic(chain_config.clone(), &mut db_tx, MNEMONIC, None, false)
             .unwrap();
     let key_chain = master_key_chain
         .create_account_key_chain(&mut db_tx, DEFAULT_ACCOUNT_INDEX)

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -48,9 +48,10 @@ use tx_verifier::error::TokenIssuanceError;
 use utils::ensure;
 use wallet_storage::{
     DefaultBackend, Store, StoreTxRw, TransactionRoLocked, TransactionRwLocked, Transactional,
-    WalletStorageReadLocked, WalletStorageWriteLocked,
+    WalletStorageReadLocked, WalletStorageReadUnlocked, WalletStorageWriteLocked,
 };
 use wallet_storage::{StoreTxRwUnlocked, TransactionRwUnlocked};
+use wallet_types::keys::SeedPhrase;
 use wallet_types::utxo_types::{UtxoStates, UtxoTypes};
 use wallet_types::wallet_tx::TxState;
 use wallet_types::with_locked::WithLocked;
@@ -168,6 +169,7 @@ impl<B: storage::Backend> Wallet<B> {
         db: Store<B>,
         mnemonic: &str,
         passphrase: Option<&str>,
+        save_seed_phrase: bool,
     ) -> WalletResult<Self> {
         let mut db_tx = db.transaction_rw_unlocked(None)?;
 
@@ -178,6 +180,7 @@ impl<B: storage::Backend> Wallet<B> {
             &mut db_tx,
             mnemonic,
             passphrase,
+            save_seed_phrase,
         )?;
 
         db_tx.set_storage_version(CURRENT_WALLET_VERSION)?;
@@ -234,6 +237,10 @@ impl<B: storage::Backend> Wallet<B> {
             accounts,
             latest_median_time,
         })
+    }
+
+    pub fn seed_phrase(&self) -> WalletResult<Option<SeedPhrase>> {
+        self.db.transaction_ro_unlocked()?.get_seed_phrase().map_err(WalletError::from)
     }
 
     pub fn is_encrypted(&self) -> bool {

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -47,10 +47,10 @@ use pos_accounting::make_delegation_id;
 use tx_verifier::error::TokenIssuanceError;
 use utils::ensure;
 use wallet_storage::{
-    DefaultBackend, Store, StoreTxRw, TransactionRoLocked, TransactionRwLocked, Transactional,
-    WalletStorageReadLocked, WalletStorageReadUnlocked, WalletStorageWriteLocked,
+    DefaultBackend, Store, StoreTxRw, StoreTxRwUnlocked, TransactionRoLocked, TransactionRwLocked,
+    TransactionRwUnlocked, Transactional, WalletStorageReadLocked, WalletStorageReadUnlocked,
+    WalletStorageWriteLocked, WalletStorageWriteUnlocked,
 };
-use wallet_storage::{StoreTxRwUnlocked, TransactionRwUnlocked};
 use wallet_types::keys::SeedPhrase;
 use wallet_types::utxo_types::{UtxoStates, UtxoTypes};
 use wallet_types::wallet_tx::TxState;
@@ -241,6 +241,14 @@ impl<B: storage::Backend> Wallet<B> {
 
     pub fn seed_phrase(&self) -> WalletResult<Option<SeedPhrase>> {
         self.db.transaction_ro_unlocked()?.get_seed_phrase().map_err(WalletError::from)
+    }
+
+    pub fn delete_seed_phrase(&self) -> WalletResult<Option<SeedPhrase>> {
+        let mut tx = self.db.transaction_rw_unlocked(None)?;
+        let seed_phrase = tx.del_seed_phrase().map_err(WalletError::from)?;
+        tx.commit()?;
+
+        Ok(seed_phrase)
     }
 
     pub fn is_encrypted(&self) -> bool {

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -271,6 +271,12 @@ fn wallet_seed_phrase_retrieval(#[case] seed: Seed) {
     wallet.unlock_wallet(&password).unwrap();
     let seed_phrase = wallet.seed_phrase().unwrap().unwrap();
     assert_eq!(seed_phrase.mnemonic.to_string(), MNEMONIC);
+
+    let seed_phrase = wallet.delete_seed_phrase().unwrap().unwrap();
+    assert_eq!(seed_phrase.mnemonic.to_string(), MNEMONIC);
+
+    let seed_phrase = wallet.seed_phrase().unwrap();
+    assert!(seed_phrase.is_none());
 }
 
 #[test]
@@ -1081,7 +1087,8 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -141,7 +141,8 @@ fn get_address(
     purpose: KeyPurpose,
     address_index: U31,
 ) -> Address<Destination> {
-    let (root_key, _root_vrf_key) = MasterKeyChain::mnemonic_to_root_key(mnemonic, None).unwrap();
+    let (root_key, _root_vrf_key, _) =
+        MasterKeyChain::mnemonic_to_root_key(mnemonic, None).unwrap();
     let mut address_path = make_account_path(chain_config, account_index).into_vec();
     address_path.push(purpose.get_deterministic_index());
     address_path.push(ChildNumber::from_normal(address_index));
@@ -207,7 +208,7 @@ fn test_balance_from_genesis(
 
     let db = create_wallet_in_memory().unwrap();
 
-    let wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     verify_wallet_balance(&chain_config, &wallet, expected_balance);
 }
@@ -225,11 +226,51 @@ fn wallet_creation_in_memory() {
 
     let empty_db = create_wallet_in_memory().unwrap();
     // initialize a new wallet with mnemonic
-    let wallet = Wallet::new_wallet(Arc::clone(&chain_config), empty_db, MNEMONIC, None).unwrap();
+    let wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), empty_db, MNEMONIC, None, false).unwrap();
     let initialized_db = wallet.db;
 
     // successfully load a wallet from initialized db
     let _wallet = Wallet::load_wallet(chain_config, initialized_db).unwrap();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn wallet_seed_phrase_retrieval(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    // create wallet without saving the seed phrase
+    {
+        let db = create_wallet_in_memory().unwrap();
+        let wallet =
+            Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
+        let seed_phrase = wallet.seed_phrase().unwrap();
+        assert!(seed_phrase.is_none());
+    }
+
+    // create wallet with saving the seed phrase
+    let db = create_wallet_in_memory().unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, true).unwrap();
+
+    let seed_phrase = wallet.seed_phrase().unwrap().unwrap();
+    assert_eq!(seed_phrase.mnemonic.to_string(), MNEMONIC);
+
+    let password = gen_random_password(&mut rng);
+    wallet.encrypt_wallet(&Some(password.clone())).unwrap();
+    wallet.lock_wallet().unwrap();
+
+    let err = wallet.seed_phrase().unwrap_err();
+    assert_eq!(
+        err,
+        WalletError::DatabaseError(wallet_storage::Error::WalletLocked)
+    );
+
+    wallet.unlock_wallet(&password).unwrap();
+    let seed_phrase = wallet.seed_phrase().unwrap().unwrap();
+    assert_eq!(seed_phrase.mnemonic.to_string(), MNEMONIC);
 }
 
 #[test]
@@ -302,7 +343,8 @@ fn locked_wallet_balance_works(#[case] seed: Seed) {
     let chain_config = Arc::new(Builder::new(chain_type).genesis_custom(genesis).build());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(
@@ -340,7 +382,8 @@ fn wallet_balance_block_reward() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(
@@ -467,7 +510,8 @@ fn wallet_balance_block_transactions() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let tx_amount1 = Amount::from_atoms(10000);
     let address = get_address(
@@ -505,7 +549,8 @@ fn wallet_balance_parent_child_transactions() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let tx_amount1 = Amount::from_atoms(20000);
     let tx_amount2 = Amount::from_atoms(10000);
@@ -577,7 +622,8 @@ fn wallet_accounts_creation() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
     test_wallet_accounts(&chain_config, &wallet, vec![DEFAULT_ACCOUNT_INDEX]);
 
     let error = wallet.create_account(None).err().unwrap();
@@ -592,7 +638,8 @@ fn locked_wallet_accounts_creation_fail(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     // Need at least one address used from the previous account in order to create a new account
     // Generate a new block which sends reward to the wallet
@@ -654,7 +701,8 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(
@@ -779,7 +827,8 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(
@@ -869,7 +918,8 @@ fn lock_wallet_fail_empty_password() {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
     let empty_password = Some(String::new());
     assert_eq!(
         wallet.encrypt_wallet(&empty_password),
@@ -887,7 +937,8 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(
@@ -1249,7 +1300,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(
@@ -1497,7 +1549,8 @@ fn lock_then_transfer(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(
@@ -1693,7 +1746,8 @@ fn wallet_sync_new_account(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let err = wallet.create_account(None).err().unwrap();
     assert_eq!(err, WalletError::EmptyLastAccount);
@@ -1783,7 +1837,8 @@ fn wallet_multiple_transactions_in_single_block(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let blocks_to_add = rng.gen_range(1..10);
 
@@ -1908,7 +1963,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(
@@ -2053,7 +2109,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
 
     // create new wallet
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     // scan the first block
     scan_wallet(&mut wallet, BlockHeight::new(0), vec![block1]);
@@ -2159,7 +2216,8 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
     let chain_config = Arc::new(create_mainnet());
 
     let db = create_wallet_in_memory().unwrap();
-    let mut wallet = Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None).unwrap();
+    let mut wallet =
+        Wallet::new_wallet(Arc::clone(&chain_config), db, MNEMONIC, None, false).unwrap();
 
     let coin_balance = wallet
         .get_balance(

--- a/wallet/storage/Cargo.toml
+++ b/wallet/storage/Cargo.toml
@@ -18,6 +18,7 @@ wallet-types = { path = '../types' }
 utils = { path = '../../utils' }
 
 thiserror.workspace = true
+bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
 
 [dev-dependencies]
 test-utils = {path = '../../test-utils'}

--- a/wallet/storage/src/internal/mod.rs
+++ b/wallet/storage/src/internal/mod.rs
@@ -87,6 +87,7 @@ impl<B: storage::Backend> Store<B> {
             }
         };
         tx.encrypt_root_keys(&sym_key)?;
+        tx.encrypt_seed_phrase(&sym_key)?;
         tx.commit()?;
 
         self.encryption_state = EncryptionState::Unlocked(sym_key);

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -27,8 +27,10 @@ use utils::{
     maybe_encrypted::{MaybeEncrypted, MaybeEncryptedError},
 };
 use wallet_types::{
-    keys::RootKeyConstant, keys::RootKeys, AccountDerivationPathId, AccountId, AccountInfo,
-    AccountKeyPurposeId, AccountWalletCreatedTxId, AccountWalletTxId, KeychainUsageState, WalletTx,
+    keys::{RootKeyConstant, SeedPhraseConstant},
+    keys::{RootKeys, SeedPhrase},
+    AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletCreatedTxId,
+    AccountWalletTxId, KeychainUsageState, WalletTx,
 };
 
 use crate::{
@@ -315,6 +317,13 @@ macro_rules! impl_read_unlocked_ops {
                     }),
                 )
             }
+            fn get_seed_phrase(&self) -> crate::Result<Option<SeedPhrase>> {
+                Ok(
+                    self.read::<db::DBSeedPhrase, _, _>(&SeedPhraseConstant {})?.map(|v| {
+                        v.try_take(self.encryption_key).expect("key was checked when unlocked")
+                    }),
+                )
+            }
         }
     };
 }
@@ -457,6 +466,26 @@ impl<'st, B: storage::Backend> WalletStorageEncryptionWrite for StoreTxRwUnlocke
             .into_iter()
             .try_for_each(|(k, v)| self.write::<db::DBRootKeys, _, _, _>(k, v))
     }
+
+    fn encrypt_seed_phrase(
+        &mut self,
+        new_encryption_key: &Option<SymmetricKey>,
+    ) -> crate::Result<()> {
+        let encrypted_seed_phrase: Vec<_> = self
+            .storage
+            .get::<db::DBSeedPhrase, _>()
+            .prefix_iter_decoded(&())?
+            .map(|(k, v)| {
+                let decrypted =
+                    v.try_take(self.encryption_key).expect("key was checked when unlocked");
+                (k, MaybeEncrypted::new(&decrypted, new_encryption_key))
+            })
+            .collect();
+
+        encrypted_seed_phrase
+            .into_iter()
+            .try_for_each(|(k, v)| self.write::<db::DBSeedPhrase, _, _, _>(k, v))
+    }
 }
 
 /// Wallet data storage transaction
@@ -471,6 +500,11 @@ impl<'st, B: storage::Backend> WalletStorageWriteUnlocked for StoreTxRwUnlocked<
             .get_mut::<db::DBRootKeys, _>()
             .del(&RootKeyConstant {})
             .map_err(Into::into)
+    }
+
+    fn set_seed_phrase(&mut self, seed_phrase: SeedPhrase) -> crate::Result<()> {
+        let value = MaybeEncrypted::new(&seed_phrase, self.encryption_key);
+        self.write::<db::DBSeedPhrase, _, _, _>(SeedPhraseConstant, value)
     }
 }
 

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -506,6 +506,12 @@ impl<'st, B: storage::Backend> WalletStorageWriteUnlocked for StoreTxRwUnlocked<
         let value = MaybeEncrypted::new(&seed_phrase, self.encryption_key);
         self.write::<db::DBSeedPhrase, _, _, _>(SeedPhraseConstant, value)
     }
+
+    fn del_seed_phrase(&mut self) -> crate::Result<Option<SeedPhrase>> {
+        let phrase = self.get_seed_phrase()?;
+        self.storage.get_mut::<db::DBSeedPhrase, _>().del(&SeedPhraseConstant {})?;
+        Ok(phrase)
+    }
 }
 
 impl<'st, B: storage::Backend> crate::TransactionRoLocked for StoreTxRo<'st, B> {

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -142,6 +142,7 @@ pub trait WalletStorageWriteUnlocked: WalletStorageReadUnlocked + WalletStorageW
     fn set_root_key(&mut self, content: &RootKeys) -> Result<()>;
     fn del_root_key(&mut self) -> Result<()>;
     fn set_seed_phrase(&mut self, seed_phrase: SeedPhrase) -> Result<()>;
+    fn del_seed_phrase(&mut self) -> Result<Option<SeedPhrase>>;
 }
 
 /// Modifying operations on persistent wallet data for encryption

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -28,8 +28,9 @@ pub use internal::{Store, StoreTxRo, StoreTxRoUnlocked, StoreTxRw, StoreTxRwUnlo
 use std::collections::BTreeMap;
 
 use wallet_types::{
-    keys::RootKeys, AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId,
-    AccountWalletCreatedTxId, AccountWalletTxId, KeychainUsageState, WalletTx,
+    keys::{RootKeys, SeedPhrase},
+    AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletCreatedTxId,
+    AccountWalletTxId, KeychainUsageState, WalletTx,
 };
 
 /// Wallet Errors
@@ -92,6 +93,7 @@ pub trait WalletStorageReadLocked {
 /// Queries on persistent wallet data with access to encrypted data
 pub trait WalletStorageReadUnlocked: WalletStorageReadLocked {
     fn get_root_key(&self) -> Result<Option<RootKeys>>;
+    fn get_seed_phrase(&self) -> Result<Option<SeedPhrase>>;
 }
 
 /// Queries on persistent wallet data for encryption
@@ -139,6 +141,7 @@ pub trait WalletStorageWriteLocked: WalletStorageReadLocked {
 pub trait WalletStorageWriteUnlocked: WalletStorageReadUnlocked + WalletStorageWriteLocked {
     fn set_root_key(&mut self, content: &RootKeys) -> Result<()>;
     fn del_root_key(&mut self) -> Result<()>;
+    fn set_seed_phrase(&mut self, seed_phrase: SeedPhrase) -> Result<()>;
 }
 
 /// Modifying operations on persistent wallet data for encryption
@@ -146,6 +149,7 @@ pub trait WalletStorageEncryptionWrite {
     fn set_encryption_kdf_challenge(&mut self, salt: &KdfChallenge) -> Result<()>;
     fn del_encryption_kdf_challenge(&mut self) -> Result<()>;
     fn encrypt_root_keys(&mut self, new_encryption_key: &Option<SymmetricKey>) -> Result<()>;
+    fn encrypt_seed_phrase(&mut self, new_encryption_key: &Option<SymmetricKey>) -> Result<()>;
 }
 
 /// Marker trait for types where read/write operations are run in a transaction

--- a/wallet/storage/src/schema.rs
+++ b/wallet/storage/src/schema.rs
@@ -19,7 +19,7 @@ use common::chain::SignedTransaction;
 use crypto::key::extended::ExtendedPublicKey;
 use utils::maybe_encrypted::MaybeEncrypted;
 use wallet_types::{
-    keys::{RootKeyConstant, RootKeys},
+    keys::{RootKeyConstant, RootKeys, SeedPhrase, SeedPhraseConstant},
     AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletCreatedTxId,
     AccountWalletTxId, KeychainUsageState, WalletTx,
 };
@@ -43,5 +43,7 @@ storage::decl_schema! {
         pub DBTxs: Map<AccountWalletTxId, WalletTx>,
         /// Store for wallet created transactions
         pub DBUserTx: Map<AccountWalletCreatedTxId, SignedTransaction>,
+        /// Store for the wallet's passphrase
+        pub DBSeedPhrase: Map<SeedPhraseConstant, MaybeEncrypted<SeedPhrase>>,
     }
 }

--- a/wallet/types/Cargo.toml
+++ b/wallet/types/Cargo.toml
@@ -13,8 +13,9 @@ crypto = { path = "../../crypto/" }
 serialization = { path = "../../serialization" }
 storage = { path = '../../storage', features = ['inmemory'] }
 
-bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
+bip39 = { workspace = true, default-features = false, features = ["std", "zeroize", "rand"] }
 parity-scale-codec.workspace = true
+itertools.workspace = true
 thiserror.workspace = true
 zeroize.workspace = true
 

--- a/wallet/types/src/keys.rs
+++ b/wallet/types/src/keys.rs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::BufWriter;
+use itertools::Itertools;
+use std::str::FromStr;
 
 use crate::keys::KeyPurpose::{Change, ReceiveFunds};
 use crypto::key::extended::ExtendedPrivateKey;
@@ -143,43 +144,25 @@ pub struct SeedPhrase {
 }
 
 impl Encode for SeedPhrase {
-    fn encode(&self) -> Vec<u8> {
-        let mut buf = BufWriter::new(Vec::new());
-        self.encode_to(&mut buf);
-        buf.into_inner().expect("Flushing should never fail")
-    }
-
     fn size_hint(&self) -> usize {
         // Preallocate enough space for the longest possible word list
-        33
-    }
-
-    fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
-        f(self.encode().as_slice())
-    }
-
-    fn encoded_size(&self) -> usize {
-        self.encode().len()
+        Itertools::intersperse(self.mnemonic.word_iter().map(|w| w.len()), 1).sum::<usize>()
+            + std::mem::size_of::<u16>()
     }
 
     fn encode_to<T: serialization::Output + ?Sized>(&self, dest: &mut T) {
-        let entropy = self.mnemonic.to_entropy();
-        dest.write(&entropy.len().to_le_bytes());
-        dest.write(entropy.as_slice());
+        let words: String = self.mnemonic.word_iter().join(" ");
+        words.encode_to(dest);
     }
 }
 
 impl Decode for SeedPhrase {
     fn decode<I: serialization::Input>(input: &mut I) -> Result<Self, serialization::Error> {
-        let mut bytes: [u8; std::mem::size_of::<usize>()] = [0; std::mem::size_of::<usize>()];
-        input.read(&mut bytes)?;
-        let len = usize::from_le_bytes(bytes);
-
-        let entropy = (0..len).map(|_| input.read_byte()).collect::<Result<Vec<_>, _>>()?;
+        let words = String::decode(input)?;
 
         Ok(Self {
             mnemonic: zeroize::Zeroizing::new(
-                bip39::Mnemonic::from_entropy(entropy.as_slice())
+                bip39::Mnemonic::from_str(words.as_str())
                     .map_err(|_| serialization::Error::from("Mnemonic deserialization failed"))?,
             ),
         })
@@ -189,6 +172,17 @@ impl Decode for SeedPhrase {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn seed_phrase_size_hint() {
+        let seed_phrase = SeedPhrase {
+            mnemonic: zeroize::Zeroizing::new(bip39::Mnemonic::generate(24).unwrap()),
+        };
+
+        let size_hint = seed_phrase.size_hint();
+        let encoded = seed_phrase.encode();
+        assert_eq!(size_hint, encoded.len());
+    }
 
     #[test]
     fn keychain_usage_state() {

--- a/wallet/wallet-cli-lib/src/commands/helper_types.rs
+++ b/wallet/wallet-cli-lib/src/commands/helper_types.rs
@@ -142,3 +142,9 @@ impl CliWithLocked {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum CliSaveSeedPhrase {
+    Save,
+    DoNotSave,
+}

--- a/wallet/wallet-cli-lib/tests/basic.rs
+++ b/wallet/wallet-cli-lib/tests/basic.rs
@@ -54,7 +54,7 @@ async fn wallet_cli_file(#[case] seed: Seed) {
         .to_owned();
 
     // Start the wallet, create it, then close it, then shutdown
-    let output = test.run(&[&format!("createwallet \"{file_name}\""), "closewallet"]).await;
+    let output = test.run(&[&format!("createwallet \"{file_name}\" save"), "closewallet"]).await;
     assert_eq!(output.len(), 2, "Unexpected output: {:?}", output);
     assert!(output[0].starts_with("New wallet created successfully\n"));
     assert_eq!(output[1], "Successfully closed the wallet.");
@@ -87,7 +87,7 @@ async fn produce_blocks(#[case] seed: Seed) {
         .to_owned();
 
     // Create wallet
-    let cmd1 = format!("createwallet \"{}\" \"{}\"", file_name, MNEMONIC);
+    let cmd1 = format!("createwallet \"{}\" save \"{}\"", file_name, MNEMONIC);
     let output = test.run(&[&cmd1, "getbalance", "generateblocks 20"]).await;
     assert_eq!(output.len(), 3, "Unexpected output: {:?}", output);
     assert_eq!(output[0], "New wallet created successfully");

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -192,6 +192,14 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
             .map_err(ControllerError::WalletError)
     }
 
+    /// Delete the seed phrase if stored in the database
+    pub fn delete_seed_phrase(&self) -> Result<Option<String>, ControllerError<T>> {
+        self.wallet
+            .delete_seed_phrase()
+            .map(|opt| opt.map(|phrase| phrase.mnemonic.to_string()))
+            .map_err(ControllerError::WalletError)
+    }
+
     /// Encrypts the wallet using the specified `password`, or removes the existing encryption if `password` is `None`.
     ///
     /// # Arguments

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -140,6 +140,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         file_path: impl AsRef<Path>,
         mnemonic: mnemonic::Mnemonic,
         passphrase: Option<&str>,
+        save_seed_phrase: bool,
     ) -> Result<DefaultWallet, ControllerError<T>> {
         utils::ensure!(
             !file_path.as_ref().exists(),
@@ -152,10 +153,11 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         let db = wallet::wallet::open_or_create_wallet_file(file_path)
             .map_err(ControllerError::WalletError)?;
         let wallet = wallet::Wallet::new_wallet(
-            Arc::clone(&chain_config),
+            chain_config.clone(),
             db,
             &mnemonic.to_string(),
             passphrase,
+            save_seed_phrase,
         )
         .map_err(ControllerError::WalletError)?;
 
@@ -180,6 +182,14 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
             .map_err(ControllerError::WalletError)?;
 
         Ok(wallet)
+    }
+
+    /// Retrieve the seed phrase if stored in the database
+    pub fn seed_phrase(&self) -> Result<Option<String>, ControllerError<T>> {
+        self.wallet
+            .seed_phrase()
+            .map(|opt| opt.map(|phrase| phrase.mnemonic.to_string()))
+            .map_err(ControllerError::WalletError)
     }
 
     /// Encrypts the wallet using the specified `password`, or removes the existing encryption if `password` is `None`.


### PR DESCRIPTION
Now you can optionally choose to save the seed phrase when creating the wallet for later retrieval. 
The seed phrase is encrypted if a password is set, same as the master keys.