### PR TITLE
Make subsystems with built-in event loop serve immutable calls in parallel

### DIFF
--- a/blockprod/src/interface/blockprod_interface.rs
+++ b/blockprod/src/interface/blockprod_interface.rs
@@ -19,7 +19,7 @@ use consensus::GenerateBlockInputData;
 use crate::{detail::job_manager::JobKey, BlockProductionError};
 
 #[async_trait::async_trait]
-pub trait BlockProductionInterface: Send {
+pub trait BlockProductionInterface: Send + Sync {
     /// When called, the job manager will be notified to send a signal
     /// to all currently running jobs to stop running
     async fn stop_all(&mut self) -> Result<usize, BlockProductionError>;

--- a/blockprod/src/lib.rs
+++ b/blockprod/src/lib.rs
@@ -35,7 +35,7 @@ use detail::{
 use interface::blockprod_interface::BlockProductionInterface;
 use mempool::MempoolHandle;
 use p2p::P2pHandle;
-use subsystem::subsystem::CallError;
+use subsystem::error::CallError;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum BlockProductionError {

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -34,7 +34,7 @@ use pos_accounting::{DelegationData, PoolData};
 use utils::eventhandler::EventHandler;
 use utxo::Utxo;
 
-pub trait ChainstateInterface: Send {
+pub trait ChainstateInterface: Send + Sync {
     fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(ChainstateEvent) + Send + Sync>);
     fn process_block(
         &mut self,

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -53,8 +53,10 @@ impl<S, V> ChainstateInterfaceImpl<S, V> {
     }
 }
 
-impl<S: BlockchainStorage, V: TransactionVerificationStrategy> ChainstateInterface
-    for ChainstateInterfaceImpl<S, V>
+impl<S, V> ChainstateInterface for ChainstateInterfaceImpl<S, V>
+where
+    S: BlockchainStorage + Sync,
+    V: TransactionVerificationStrategy + Sync,
 {
     fn subscribe_to_events(&mut self, handler: EventHandler<ChainstateEvent>) {
         self.chainstate.subscribe_to_events(handler)

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -39,7 +39,7 @@ use crate::{
     ChainstateError, ChainstateEvent,
 };
 
-impl<T: Deref + DerefMut + Send> ChainstateInterface for T
+impl<T: Deref + DerefMut + Send + Sync> ChainstateInterface for T
 where
     T::Target: ChainstateInterface,
 {

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -77,17 +77,18 @@ impl subsystem::Subsystem for Box<dyn ChainstateInterface> {}
 
 pub type ChainstateHandle = subsystem::Handle<Box<dyn ChainstateInterface>>;
 
-pub fn make_chainstate<
-    S: chainstate_storage::BlockchainStorage + 'static,
-    V: TransactionVerificationStrategy + 'static,
->(
+pub fn make_chainstate<S, V>(
     chain_config: Arc<ChainConfig>,
     chainstate_config: ChainstateConfig,
     chainstate_storage: S,
     tx_verification_strategy: V,
     custom_orphan_error_hook: Option<Arc<detail::OrphanErrorHandler>>,
     time_getter: TimeGetter,
-) -> Result<Box<dyn ChainstateInterface>, ChainstateError> {
+) -> Result<Box<dyn ChainstateInterface>, ChainstateError>
+where
+    S: chainstate_storage::BlockchainStorage + Sync + 'static,
+    V: TransactionVerificationStrategy + Sync + 'static,
+{
     let chainstate = Chainstate::new(
         chain_config,
         chainstate_config,

--- a/mempool/src/error/mod.rs
+++ b/mempool/src/error/mod.rs
@@ -17,7 +17,7 @@ mod ban_score;
 
 pub use ban_score::MempoolBanScore;
 use chainstate::{tx_verifier::error::ConnectTransactionError, ChainstateError};
-use subsystem::subsystem::CallError;
+use subsystem::error::CallError;
 use thiserror::Error;
 
 use common::primitives::H256;

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -112,7 +112,7 @@ impl MempoolSubsystemInterface for MempoolInit {
                 Some(evt) = chainstate_events_rx.recv() => mempool.process_chainstate_event(evt),
 
                 // Calls from other subsystems or RPC go next.
-                call = call_rq.recv() => call(&mut mempool).await,
+                call = call_rq.recv() => call.handle_call_mut(&mut mempool).await,
 
                 // Finally, if there's nothing else to do, handle orphan tx processing.
                 () = work_signal => mempool.perform_work_unit(),

--- a/mempool/src/pool/reorg.rs
+++ b/mempool/src/pool/reorg.rs
@@ -43,7 +43,7 @@ pub enum ReorgError {
     #[error("Block {0:?} not found while traversing history")]
     BlockNotFound(Id<Block>),
     #[error("Chainstate call: {0}")]
-    ChainstateCall(#[from] subsystem::subsystem::CallError),
+    ChainstateCall(#[from] subsystem::error::CallError),
 }
 
 /// Collect blocks between the given two points

--- a/mempool/src/pool/tx_verifier/chainstate_handle.rs
+++ b/mempool/src/pool/tx_verifier/chainstate_handle.rs
@@ -45,7 +45,7 @@ pub enum Error {
     #[error("Chainstate error: {0}")]
     Chainstate(#[from] ChainstateError),
     #[error("Subsystem error: {0}")]
-    Subsystem(#[from] subsystem::subsystem::CallError),
+    Subsystem(#[from] subsystem::error::CallError),
 }
 
 impl HasTxIndexDisabledError for Error {

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -76,7 +76,7 @@ impl MempoolSubsystemInterface for MockMempoolInterface {
     ) {
         loop {
             tokio::select! {
-                call = call_rq.recv() => call(&mut self).await,
+                call = call_rq.recv() => call.handle_call_mut(&mut self).await,
                 () = shut_rq.recv() => return,
             }
         }

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -181,8 +181,8 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for P2pError {
     }
 }
 
-impl From<subsystem::subsystem::CallError> for P2pError {
-    fn from(_e: subsystem::subsystem::CallError) -> P2pError {
+impl From<subsystem::error::CallError> for P2pError {
+    fn from(_e: subsystem::error::CallError) -> P2pError {
         P2pError::ChannelClosed
     }
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -214,7 +214,7 @@ where
                     self.shutdown().await;
                     break;
                 },
-                call = call.recv() => call(&mut self).await,
+                call = call.recv() => call.handle_call_mut(&mut self).await,
             }
         }
     }

--- a/subsystem/examples/stopwatch.rs
+++ b/subsystem/examples/stopwatch.rs
@@ -27,7 +27,7 @@ impl Stopwatch {
         loop {
             tokio::select! {
                 () = shutdown_rq.recv() => break,
-                call = call_rq.recv() => call(&mut stopwatch).await,
+                call = call_rq.recv() => call.handle_call_mut(&mut stopwatch).await,
                 _ = interval.tick() => stopwatch.report("Running"),
             }
         }

--- a/subsystem/src/blocking.rs
+++ b/subsystem/src/blocking.rs
@@ -50,7 +50,7 @@ impl<T: ?Sized> BlockingHandle<T> {
     }
 }
 
-impl<T: 'static + Send + ?Sized> BlockingHandle<T> {
+impl<T: 'static + Send + Sync + ?Sized> BlockingHandle<T> {
     /// Perform given closure in a worker, passing the handle to it, get the result
     fn with_handle<R: 'static + Send>(
         &self,

--- a/subsystem/src/blocking.rs
+++ b/subsystem/src/blocking.rs
@@ -15,7 +15,7 @@
 
 //! Blocking interface to subsystem.
 
-use crate::{subsystem::CallError, CallResult, Handle};
+use crate::{error::CallError, CallResult, Handle};
 use futures::future::BoxFuture;
 use utils::shallow_clone::ShallowClone;
 

--- a/subsystem/src/error.rs
+++ b/subsystem/src/error.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2022-2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Subsystem call related error types
+
+/// Error during a subsystem call
+#[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]
+pub enum CallError {
+    #[error(transparent)]
+    Submission(#[from] SubmissionError),
+    #[error(transparent)]
+    Response(#[from] ResponseError),
+}
+
+/// Error during a subsystem call submission
+#[derive(Debug, PartialEq, Eq, Clone, Copy, thiserror::Error)]
+pub enum SubmissionError {
+    #[error("Call send channel closed")]
+    ChannelClosed,
+}
+
+/// Error retrieving a subsystem call response
+#[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]
+pub enum ResponseError {
+    #[error("Callee subsystem did not respond")]
+    NoResponse,
+}

--- a/subsystem/src/lib.rs
+++ b/subsystem/src/lib.rs
@@ -34,6 +34,7 @@
 //! 3. The main task waits for all subsystems to terminate.
 
 pub mod blocking;
+pub mod error;
 pub mod manager;
 pub mod subsystem;
 

--- a/subsystem/tests/async_calls.rs
+++ b/subsystem/tests/async_calls.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use subsystem::subsystem::{CallError, CallRequest};
+use subsystem::{error::CallError, subsystem::CallRequest};
 
 mod helpers;
 

--- a/test-rpc-functions/src/interface/rpc_test_interface.rs
+++ b/test-rpc-functions/src/interface/rpc_test_interface.rs
@@ -18,6 +18,6 @@ use std::sync::Arc;
 use common::chain::ChainConfig;
 
 #[async_trait::async_trait]
-pub trait RpcTestFunctionsInterface: Send {
+pub trait RpcTestFunctionsInterface: Send + Sync {
     fn get_chain_config(&self) -> Option<Arc<ChainConfig>>;
 }

--- a/test-rpc-functions/src/lib.rs
+++ b/test-rpc-functions/src/lib.rs
@@ -21,7 +21,7 @@ use crypto::key::SignatureError;
 use interface::{
     rpc_test_interface::RpcTestFunctionsInterface, rpc_test_interface_impl::RpcTestFunctionsImpl,
 };
-use subsystem::subsystem::CallError;
+use subsystem::error::CallError;
 
 pub mod empty;
 mod interface;

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -53,7 +53,7 @@ impl std::fmt::Debug for WalletHandlesClient {
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum WalletHandlesClientError {
     #[error("Call error: {0}")]
-    CallError(#[from] subsystem::subsystem::CallError),
+    CallError(#[from] subsystem::error::CallError),
     #[error("Chainstate error: {0}")]
     Chainstate(#[from] ChainstateError),
     #[error("P2p error: {0}")]


### PR DESCRIPTION
* Adding parallelism to read-only requests to subsystems with built-in event loop
* Bit more granular error reporting in subsystem calls
* Some minor implementation refactoring

Only addresses subsystems using the built-in event loop, that is `chainstate` and `blockprod` of the significant ones.