### PR TITLE
Use bounded channels for peer events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4430,6 +4430,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-socks",
+ "tokio-stream",
  "tokio-util",
  "utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,7 @@ testing_logger = "0.1"
 thiserror = "1.0"
 tokio = { version = "1.27", default-features = false }
 tokio-socks = "0.5"
+tokio-stream = "0.1"
 tokio-util = { version = "0.7", default-features = false }
 toml = "0.8"
 tower = "0.4"

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -165,6 +165,7 @@ where
     ) -> Self {
         // TODO: both "expect"s in this function may fire when exiting the node-gui app;
         // get rid of them and return a proper Result.
+        // See https://github.com/mintlayer/mintlayer-core/issues/1221
         let best_block = storage
             .get_best_block_for_utxos()
             .expect("Database error while reading utxos best block");

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -163,6 +163,8 @@ where
         accounting: A,
         verifier_config: TransactionVerifierConfig,
     ) -> Self {
+        // TODO: both "expect"s in this function may fire when exiting the node-gui app;
+        // get rid of them and return a proper Result.
         let best_block = storage
             .get_best_block_for_utxos()
             .expect("Database error while reading utxos best block");

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -41,6 +41,7 @@ sscanf.workspace = true
 tap.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio-stream.workspace = true
 tokio-socks.workspace = true
 tokio-util = { workspace = true, default-features = false, features = ["codec"] }
 


### PR DESCRIPTION
This fixes #664 (note that as we've discussed earlier, the solution proposed in the issue itself is redundant; using an unbounded channel for peer events should be enough).

P.S. I've based this PR on top of #1183 to simplify merging.