### PR TITLE
Replace API Server's mock data responses with database calls

### DIFF
--- a/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
@@ -26,6 +26,7 @@ use crate::storage::storage_api::{block_aux_data::BlockAuxData, ApiServerStorage
 
 use super::CURRENT_STORAGE_VERSION;
 
+#[derive(Clone)]
 struct ApiServerInMemoryStorage {
     block_table: BTreeMap<Id<Block>, Block>,
     block_aux_data_table: BTreeMap<Id<Block>, BlockAuxData>,

--- a/api-server/web-server/src/lib.rs
+++ b/api-server/web-server/src/lib.rs
@@ -17,7 +17,11 @@ pub mod error;
 
 pub use error::APIServerWebServerError;
 
+use common::chain::ChainConfig;
+use std::sync::Arc;
+
 #[derive(Debug, Clone)]
-pub struct APIServerWebServerState {
-    pub example_shared_value: String,
+pub struct APIServerWebServerState<T> {
+    pub db: T,
+    pub chain_config: Arc<ChainConfig>,
 }

--- a/api-server/web-server/src/main.rs
+++ b/api-server/web-server/src/main.rs
@@ -17,11 +17,14 @@ mod api;
 mod config;
 mod error;
 
-use axum::{extract::State, response::IntoResponse, routing::get, Json, Router};
+use api_server_common::storage::impls::in_memory::transactional::TransactionalApiServerInMemoryStorage;
+use axum::{response::IntoResponse, routing::get, Json, Router};
 use clap::Parser;
+use common::chain::config::create_unit_test_config;
 use config::ApiServerWebServerConfig;
 use logging::log;
 use serde_json::json;
+use std::sync::Arc;
 use web_server::{
     error::APIServerWebServerClientError, APIServerWebServerError, APIServerWebServerState,
 };
@@ -37,8 +40,13 @@ async fn main() {
     let args = ApiServerWebServerConfig::parse();
     log::info!("Command line options: {args:?}");
 
+    // TODO: generalise network configuration
+    let chain_config = Arc::new(create_unit_test_config());
+
+    // TODO: point database to PostgreSQL from command line arguments
     let state = APIServerWebServerState {
-        example_shared_value: "test value".to_string(),
+        db: Arc::new(TransactionalApiServerInMemoryStorage::new(&chain_config)),
+        chain_config,
     };
 
     let routes = Router::new()
@@ -54,9 +62,7 @@ async fn main() {
 }
 
 #[allow(clippy::unused_async)]
-async fn server_status(
-    State(_state): State<APIServerWebServerState>,
-) -> Result<impl IntoResponse, APIServerWebServerError> {
+async fn server_status() -> Result<impl IntoResponse, APIServerWebServerError> {
     Ok(Json(json!({
         "versions": [api::v1::API_VERSION]
         //"network": "testnet",

--- a/api-server/web-server/src/main.rs
+++ b/api-server/web-server/src/main.rs
@@ -40,7 +40,7 @@ async fn main() {
     let args = ApiServerWebServerConfig::parse();
     log::info!("Command line options: {args:?}");
 
-    // TODO: generalise network configuration
+    // TODO: generalize network configuration
     let chain_config = Arc::new(create_unit_test_config());
 
     // TODO: point database to PostgreSQL from command line arguments

--- a/common/src/chain/genesis.rs
+++ b/common/src/chain/genesis.rs
@@ -40,6 +40,10 @@ impl Genesis {
         }
     }
 
+    pub fn fun_message(&self) -> &str {
+        &self.fun_message
+    }
+
     pub fn utxos(&self) -> &[TxOutput] {
         &self.utxos
     }


### PR DESCRIPTION
Most of the current API server endpoints are now pulling from a database handle.