### PR TITLE
Ensure that transactions are wrapped asynchronously in the parent database object instead of blocking on transactions' drop function.

### DIFF
--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/mod.rs
@@ -100,19 +100,19 @@ impl TransactionalApiServerInMemoryStorage {
 }
 
 #[async_trait::async_trait]
-impl<'t> Transactional<'t> for TransactionalApiServerInMemoryStorage {
-    type TransactionRo = ApiServerInMemoryStorageTransactionalRo<'t>;
+impl<'tx> Transactional<'tx> for TransactionalApiServerInMemoryStorage {
+    type TransactionRo = ApiServerInMemoryStorageTransactionalRo<'tx>;
 
-    type TransactionRw = ApiServerInMemoryStorageTransactionalRw<'t>;
+    type TransactionRw = ApiServerInMemoryStorageTransactionalRw<'tx>;
 
-    async fn transaction_ro<'s: 't>(
-        &'s self,
+    async fn transaction_ro<'db: 'tx>(
+        &'db self,
     ) -> Result<Self::TransactionRo, ApiServerStorageError> {
         Ok(ApiServerInMemoryStorageTransactionalRo::new(self).await)
     }
 
-    async fn transaction_rw<'s: 't>(
-        &'s mut self,
+    async fn transaction_rw<'db: 'tx>(
+        &'db mut self,
     ) -> Result<Self::TransactionRw, ApiServerStorageError> {
         Ok(ApiServerInMemoryStorageTransactionalRw::new(self).await)
     }

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/mod.rs
@@ -100,19 +100,19 @@ impl TransactionalApiServerInMemoryStorage {
 }
 
 #[async_trait::async_trait]
-impl<'tx> Transactional<'tx> for TransactionalApiServerInMemoryStorage {
-    type TransactionRo = ApiServerInMemoryStorageTransactionalRo<'tx>;
+impl<'t> Transactional<'t> for TransactionalApiServerInMemoryStorage {
+    type TransactionRo = ApiServerInMemoryStorageTransactionalRo<'t>;
 
-    type TransactionRw = ApiServerInMemoryStorageTransactionalRw<'tx>;
+    type TransactionRw = ApiServerInMemoryStorageTransactionalRw<'t>;
 
-    async fn transaction_ro<'db: 'tx>(
-        &'db self,
+    async fn transaction_ro<'s: 't>(
+        &'s self,
     ) -> Result<Self::TransactionRo, ApiServerStorageError> {
         Ok(ApiServerInMemoryStorageTransactionalRo::new(self).await)
     }
 
-    async fn transaction_rw<'db: 'tx>(
-        &'db mut self,
+    async fn transaction_rw<'s: 't>(
+        &'s mut self,
     ) -> Result<Self::TransactionRw, ApiServerStorageError> {
         Ok(ApiServerInMemoryStorageTransactionalRw::new(self).await)
     }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
@@ -39,6 +39,8 @@ pub struct ApiServerPostgresTransactionalRo<'a> {
     db_tx_sender: tokio::sync::mpsc::UnboundedSender<
         PooledConnection<'static, PostgresConnectionManager<NoTls>>,
     >,
+    // Note: This exists to enforce that a transaction never outlives the database object,
+    //       given that all connections have 'static lifetimes
     _marker: std::marker::PhantomData<&'a ()>,
 }
 
@@ -138,6 +140,8 @@ pub struct ApiServerPostgresTransactionalRw<'a> {
     db_tx_sender: tokio::sync::mpsc::UnboundedSender<
         PooledConnection<'static, PostgresConnectionManager<NoTls>>,
     >,
+    // Note: This exists to enforce that a transaction never outlives the database object,
+    //       given that all connections have 'static lifetimes
     _marker: std::marker::PhantomData<&'a ()>,
 }
 

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
@@ -30,34 +30,50 @@ use crate::storage::storage_api::{
 
 use super::{queries::QueryFromConnection, TransactionalApiServerPostgresStorage};
 
+const CONN_ERR: &str = "CRITICAL ERROR: failed to get postgres tx connection. Invariant broken.";
+
 pub struct ApiServerPostgresTransactionalRo<'a> {
-    connection: PooledConnection<'a, PostgresConnectionManager<NoTls>>,
+    connection: Option<PooledConnection<'static, PostgresConnectionManager<NoTls>>>,
     finished: bool,
+    db_tx_sender: tokio::sync::mpsc::UnboundedSender<
+        PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+    >,
+    _marker: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> ApiServerPostgresTransactionalRo<'a> {
     pub(super) async fn from_connection(
-        connection: PooledConnection<'a, PostgresConnectionManager<NoTls>>,
-    ) -> Result<ApiServerPostgresTransactionalRo, ApiServerStorageError> {
+        connection: PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+        db_tx_sender: tokio::sync::mpsc::UnboundedSender<
+            PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+        >,
+    ) -> Result<ApiServerPostgresTransactionalRo<'a>, ApiServerStorageError> {
         let tx = Self {
-            connection,
+            connection: Some(connection),
             finished: false,
+            db_tx_sender,
+            _marker: std::marker::PhantomData,
         };
-        tx.connection.batch_execute("BEGIN READ ONLY").await.map_err(|e| {
-            ApiServerStorageError::RoTxBeginFailed(format!("Transaction begin failed: {}", e))
-        })?;
+        tx.connection
+            .as_ref()
+            .expect(CONN_ERR)
+            .batch_execute("BEGIN READ ONLY")
+            .await
+            .map_err(|e| {
+                ApiServerStorageError::RoTxBeginFailed(format!("Transaction begin failed: {}", e))
+            })?;
         Ok(tx)
     }
 
     pub async fn is_initialized(&mut self) -> Result<bool, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.is_initialized().await?;
 
         Ok(res)
     }
 
     pub async fn get_storage_version(&mut self) -> Result<Option<u32>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_storage_version().await?;
 
         Ok(res)
@@ -66,7 +82,7 @@ impl<'a> ApiServerPostgresTransactionalRo<'a> {
     pub async fn get_best_block(
         &mut self,
     ) -> Result<(BlockHeight, Id<GenBlock>), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_best_block().await?;
 
         Ok(res)
@@ -76,7 +92,7 @@ impl<'a> ApiServerPostgresTransactionalRo<'a> {
         &mut self,
         block_height: BlockHeight,
     ) -> Result<Option<Id<Block>>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_main_chain_block_id(block_height).await?;
 
         Ok(res)
@@ -86,7 +102,7 @@ impl<'a> ApiServerPostgresTransactionalRo<'a> {
         &mut self,
         block_id: Id<Block>,
     ) -> Result<Option<Block>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_block(block_id).await?;
 
         Ok(res)
@@ -97,7 +113,7 @@ impl<'a> ApiServerPostgresTransactionalRo<'a> {
         &mut self,
         transaction_id: Id<Transaction>,
     ) -> Result<Option<(Option<Id<Block>>, SignedTransaction)>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_transaction(transaction_id).await?;
 
         Ok(res)
@@ -107,7 +123,7 @@ impl<'a> ApiServerPostgresTransactionalRo<'a> {
         &mut self,
         block_id: Id<Block>,
     ) -> Result<Option<BlockAuxData>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_block_aux_data(block_id).await?;
 
         Ok(res)
@@ -115,35 +131,49 @@ impl<'a> ApiServerPostgresTransactionalRo<'a> {
 }
 
 pub struct ApiServerPostgresTransactionalRw<'a> {
-    connection: PooledConnection<'a, PostgresConnectionManager<NoTls>>,
+    connection: Option<PooledConnection<'static, PostgresConnectionManager<NoTls>>>,
     finished: bool,
+    db_tx_sender: tokio::sync::mpsc::UnboundedSender<
+        PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+    >,
+    _marker: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> Drop for ApiServerPostgresTransactionalRw<'a> {
     fn drop(&mut self) {
         if !self.finished {
-            futures::executor::block_on(self.connection.batch_execute("ROLLBACK")).unwrap_or_else(
-                |e| {
+            self.db_tx_sender
+                .send(self.connection.take().expect(CONN_ERR))
+                .unwrap_or_else(|e| {
                     logging::log::error!(
-                        "CRITICAL ERROR: failed to rollback failed postgres RW transaction: {e}"
+                        "CRITICAL ERROR: failed to send postgres RW transaction connection for closure: {e}"
                     )
-                },
-            );
+                });
         }
     }
 }
 
 impl<'a> ApiServerPostgresTransactionalRw<'a> {
     pub(super) async fn from_connection(
-        connection: PooledConnection<'a, PostgresConnectionManager<NoTls>>,
+        connection: PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+        db_tx_sender: tokio::sync::mpsc::UnboundedSender<
+            PooledConnection<'static, PostgresConnectionManager<NoTls>>,
+        >,
     ) -> Result<ApiServerPostgresTransactionalRw<'a>, ApiServerStorageError> {
         let tx = Self {
-            connection,
+            connection: Some(connection),
             finished: false,
+            db_tx_sender,
+            _marker: std::marker::PhantomData,
         };
-        tx.connection.batch_execute("BEGIN READ WRITE").await.map_err(|e| {
-            ApiServerStorageError::RwTxBeginFailed(format!("Transaction begin failed: {}", e))
-        })?;
+        tx.connection
+            .as_ref()
+            .expect(CONN_ERR)
+            .batch_execute("BEGIN READ WRITE")
+            .await
+            .map_err(|e| {
+                ApiServerStorageError::RwTxBeginFailed(format!("Transaction begin failed: {}", e))
+            })?;
         Ok(tx)
     }
 }
@@ -152,6 +182,8 @@ impl<'a> ApiServerPostgresTransactionalRw<'a> {
 impl<'a> ApiServerTransactionRw for ApiServerPostgresTransactionalRw<'a> {
     async fn commit(mut self) -> Result<(), crate::storage::storage_api::ApiServerStorageError> {
         self.connection
+            .as_ref()
+            .expect(CONN_ERR)
             .batch_execute("COMMIT")
             .await
             .map_err(|e| ApiServerStorageError::TxCommitFailed(e.to_string()))?;
@@ -161,6 +193,8 @@ impl<'a> ApiServerTransactionRw for ApiServerPostgresTransactionalRw<'a> {
 
     async fn rollback(mut self) -> Result<(), crate::storage::storage_api::ApiServerStorageError> {
         self.connection
+            .as_ref()
+            .expect(CONN_ERR)
             .batch_execute("ROLLBACK")
             .await
             .map_err(|e| ApiServerStorageError::TxCommitFailed(e.to_string()))?;
@@ -179,31 +213,31 @@ impl<'a> ApiServerTransactionRo for ApiServerPostgresTransactionalRo<'a> {
 impl<'a> Drop for ApiServerPostgresTransactionalRo<'a> {
     fn drop(&mut self) {
         if !self.finished {
-            futures::executor::block_on(self.connection.batch_execute("ROLLBACK")).unwrap_or_else(
-                |e| {
+            self.db_tx_sender
+                .send(self.connection.take().expect(CONN_ERR))
+                .unwrap_or_else(|e| {
                     logging::log::error!(
-                        "CRITICAL ERROR: failed to rollback failed postgres RO transaction: {e}"
+                        "CRITICAL ERROR: failed to return postgres RO transaction connection: {e}"
                     )
-                },
-            );
+                });
         }
     }
 }
 
 #[async_trait::async_trait]
-impl<'t> Transactional<'t> for TransactionalApiServerPostgresStorage {
-    type TransactionRo = ApiServerPostgresTransactionalRo<'t>;
+impl<'tx> Transactional<'tx> for TransactionalApiServerPostgresStorage {
+    type TransactionRo = ApiServerPostgresTransactionalRo<'tx>;
 
-    type TransactionRw = ApiServerPostgresTransactionalRw<'t>;
+    type TransactionRw = ApiServerPostgresTransactionalRw<'tx>;
 
-    async fn transaction_ro<'s: 't>(
-        &'s self,
+    async fn transaction_ro<'db: 'tx>(
+        &'db self,
     ) -> Result<Self::TransactionRo, ApiServerStorageError> {
         self.begin_ro_transaction().await
     }
 
-    async fn transaction_rw<'s: 't>(
-        &'s mut self,
+    async fn transaction_rw<'db: 'tx>(
+        &'db mut self,
     ) -> Result<Self::TransactionRw, ApiServerStorageError> {
         self.begin_rw_transaction().await
     }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
@@ -33,6 +33,7 @@ use super::{queries::QueryFromConnection, TransactionalApiServerPostgresStorage}
 const CONN_ERR: &str = "CRITICAL ERROR: failed to get postgres tx connection. Invariant broken.";
 
 pub struct ApiServerPostgresTransactionalRo<'a> {
+    // Note: This is an Option due to needing to pry the connection out of Self in Drop
     connection: Option<PooledConnection<'static, PostgresConnectionManager<NoTls>>>,
     finished: bool,
     db_tx_sender: tokio::sync::mpsc::UnboundedSender<
@@ -131,6 +132,7 @@ impl<'a> ApiServerPostgresTransactionalRo<'a> {
 }
 
 pub struct ApiServerPostgresTransactionalRw<'a> {
+    // Note: This is an Option due to needing to pry the connection out of Self in Drop
     connection: Option<PooledConnection<'static, PostgresConnectionManager<NoTls>>>,
     finished: bool,
     db_tx_sender: tokio::sync::mpsc::UnboundedSender<

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
@@ -217,7 +217,7 @@ impl<'a> Drop for ApiServerPostgresTransactionalRo<'a> {
                 .send(self.connection.take().expect(CONN_ERR))
                 .unwrap_or_else(|e| {
                     logging::log::error!(
-                        "CRITICAL ERROR: failed to return postgres RO transaction connection: {e}"
+                        "CRITICAL ERROR: failed to send postgres RO transaction connection for closure: {e}"
                     )
                 });
         }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
@@ -17,14 +17,14 @@ use crate::storage::{
     impls::postgres::queries::QueryFromConnection, storage_api::ApiServerStorageRead,
 };
 
-use super::ApiServerPostgresTransactionalRo;
+use super::{ApiServerPostgresTransactionalRo, CONN_ERR};
 
 #[async_trait::async_trait]
 impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
     async fn is_initialized(
         &mut self,
     ) -> Result<bool, crate::storage::storage_api::ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.is_initialized().await?;
 
         Ok(res)
@@ -33,7 +33,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
     async fn get_storage_version(
         &mut self,
     ) -> Result<Option<u32>, crate::storage::storage_api::ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_storage_version().await?;
 
         Ok(res)
@@ -48,7 +48,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
         ),
         crate::storage::storage_api::ApiServerStorageError,
     > {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_best_block().await?;
 
         Ok(res)
@@ -59,7 +59,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
         block_id: common::primitives::Id<common::chain::Block>,
     ) -> Result<Option<common::chain::Block>, crate::storage::storage_api::ApiServerStorageError>
     {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_block(block_id).await?;
 
         Ok(res)
@@ -72,7 +72,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
         Option<crate::storage::storage_api::block_aux_data::BlockAuxData>,
         crate::storage::storage_api::ApiServerStorageError,
     > {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_block_aux_data(block_id).await?;
 
         Ok(res)

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
@@ -26,7 +26,7 @@ use crate::storage::{
     },
 };
 
-use super::ApiServerPostgresTransactionalRw;
+use super::{ApiServerPostgresTransactionalRw, CONN_ERR};
 
 #[async_trait::async_trait]
 impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
@@ -34,7 +34,7 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         &mut self,
         chain_config: &ChainConfig,
     ) -> Result<(), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.initialize_database(chain_config).await?;
 
         Ok(())
@@ -45,7 +45,7 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         block_height: BlockHeight,
         block_id: Id<GenBlock>,
     ) -> Result<(), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.set_best_block(block_height, block_id).await?;
 
         Ok(())
@@ -56,7 +56,7 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         block_id: Id<Block>,
         block: &Block,
     ) -> Result<(), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.set_block(block_id, block).await?;
 
         Ok(())
@@ -68,7 +68,7 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         owning_block: Option<Id<Block>>,
         transaction: &SignedTransaction,
     ) -> Result<(), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.set_transaction(transaction_id, owning_block, transaction).await?;
 
         Ok(())
@@ -79,7 +79,7 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         block_id: Id<Block>,
         block_aux_data: &BlockAuxData,
     ) -> Result<(), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.set_block_aux_data(block_id, block_aux_data).await?;
 
         Ok(())
@@ -90,7 +90,7 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         block_height: BlockHeight,
         block_id: Id<Block>,
     ) -> Result<(), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.set_main_chain_block_id(block_height, block_id).await?;
 
         Ok(())
@@ -100,7 +100,7 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         &mut self,
         block_height: BlockHeight,
     ) -> Result<(), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.del_main_chain_block_id(block_height).await?;
 
         Ok(())
@@ -110,14 +110,14 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
 #[async_trait::async_trait]
 impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
     async fn is_initialized(&mut self) -> Result<bool, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.is_initialized().await?;
 
         Ok(res)
     }
 
     async fn get_storage_version(&mut self) -> Result<Option<u32>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_storage_version().await?;
 
         Ok(res)
@@ -126,7 +126,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
     async fn get_best_block(
         &mut self,
     ) -> Result<(BlockHeight, Id<GenBlock>), ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_best_block().await?;
 
         Ok(res)
@@ -136,7 +136,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
         &mut self,
         block_id: Id<Block>,
     ) -> Result<Option<Block>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_block(block_id).await?;
 
         Ok(res)
@@ -146,7 +146,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
         &mut self,
         block_id: Id<Block>,
     ) -> Result<Option<BlockAuxData>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_block_aux_data(block_id).await?;
 
         Ok(res)
@@ -156,7 +156,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
         &mut self,
         block_height: BlockHeight,
     ) -> Result<Option<Id<Block>>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_main_chain_block_id(block_height).await?;
 
         Ok(res)
@@ -166,7 +166,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
         &mut self,
         transaction_id: Id<Transaction>,
     ) -> Result<Option<(Option<Id<Block>>, SignedTransaction)>, ApiServerStorageError> {
-        let mut conn = QueryFromConnection::new(&self.connection);
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_transaction(transaction_id).await?;
 
         Ok(res)


### PR DESCRIPTION
This merges to the postgres-async branch and fixes the issue that transactions that aren't ended explicitly would block the thread until they do that. 

Now with this solution, transactions that aren't finished will simply use their Drop trait to send back themselves to the parent, owning database object, which will take care of decommissioning the transaction asynchronously