### PR TITLE
Reduce log level of certain logging lines from "debug" to "trace" to reduce test logs bloat

### DIFF
--- a/mempool/src/pool/reorg.rs
+++ b/mempool/src/pool/reorg.rs
@@ -169,7 +169,10 @@ fn reorg_mempool_transactions<M: MemoryUsageEstimator>(
         let tx_id = tx.transaction().get_id();
         let origin = LocalTxOrigin::PastBlock.into();
         if let Err(e) = mempool.add_transaction(tx, origin, work_queue) {
-            log::debug!("Disconnected transaction {tx_id:?} no longer validates: {e:?}")
+            // Note: logging this error can make our test logs huge, so we use the "trace"
+            // level in this case, see
+            // https://github.com/mintlayer/mintlayer-core/issues/1219#issuecomment-1728176441
+            log::trace!("Disconnected transaction {tx_id:?} no longer validates: {e:?}")
         }
     }
 

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -195,7 +195,7 @@ impl TestNodeGroup {
         let sentinel_tx_id = get_random_hash(rng).into();
         let sentinel_msg = SyncMessage::TransactionRequest(sentinel_tx_id);
 
-        log::debug!("Using transaction {sentinel_tx_id} as a sentinel");
+        log::trace!("Using transaction {sentinel_tx_id} as a sentinel");
 
         let mut msg_count = 0;
 
@@ -208,7 +208,7 @@ impl TestNodeGroup {
 
             {
                 // Send the sentinel
-                log::debug!("Sending sentinel transaction {sentinel_tx_id} to peer {cur_peer_id}");
+                log::trace!("Sending sentinel transaction {sentinel_tx_id} to peer {cur_peer_id}");
 
                 let tx_sender_peer_id = self
                     .data
@@ -236,7 +236,7 @@ impl TestNodeGroup {
                     SyncMessage::TransactionResponse(TransactionResponse::NotFound(tx_id))
                         if *tx_id == sentinel_tx_id =>
                     {
-                        log::debug!("Sentinel transaction {tx_id} received by peer {cur_peer_id}");
+                        log::trace!("Sentinel transaction {tx_id} received by peer {cur_peer_id}");
                         break;
                     }
                     message => {


### PR DESCRIPTION
Initially I was going to reduce the number of blocks generated by tests to fix this, but now I think it would be a bad idea. So, in the end I've just demoted the most spamming logging lines from "debug" to "trace".
(Just in case: the main offenders here are the lines in mempool, the other ones are just accomplices).

I also described the issue in detail here - https://github.com/mintlayer/mintlayer-core/issues/1219#issuecomment-1728176441