### PR TITLE
RPC json elements now can return proper addresses instead of hex values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "parity-scale-codec",
  "proptest",
  "ref-cast",
+ "regex",
  "rstest",
  "script",
  "serde",
@@ -1192,6 +1193,7 @@ dependencies = [
  "thiserror",
  "typename",
  "utils",
+ "variant_count",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -29,6 +29,9 @@ ref-cast.workspace = true
 serde = { workspace = true, features = ["derive"] }
 static_assertions.workspace = true
 thiserror.workspace = true
+variant_count.workspace = true
+
+regex = "1.9"
 
 [dev-dependencies]
 test-utils = {path = '../test-utils'}

--- a/common/src/address/dehexify.rs
+++ b/common/src/address/dehexify.rs
@@ -26,3 +26,5 @@ pub fn dehexify_all_addresses(conf: &ChainConfig, input: &str) -> String {
 
     result
 }
+
+// TODO: add tests that create blocks, and ensure the replacement in json works properly.

--- a/common/src/address/dehexify.rs
+++ b/common/src/address/dehexify.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::chain::{tokens::TokenId, ChainConfig, DelegationId, Destination, PoolId};
+
+use super::hexified::HexifiedAddress;
+
+#[allow(clippy::let_and_return)]
+pub fn dehexify_all_addresses(conf: &ChainConfig, input: &str) -> String {
+    let result = HexifiedAddress::<Destination>::replace_with_address(conf, input).to_string();
+    let result = HexifiedAddress::<PoolId>::replace_with_address(conf, &result).to_string();
+    let result = HexifiedAddress::<DelegationId>::replace_with_address(conf, &result).to_string();
+    let result = HexifiedAddress::<TokenId>::replace_with_address(conf, &result).to_string();
+
+    result
+}

--- a/common/src/address/hexified.rs
+++ b/common/src/address/hexified.rs
@@ -1,0 +1,266 @@
+use crate::chain::ChainConfig;
+
+use super::{traits::Addressable, Address};
+use parity_scale_codec::DecodeAll;
+use regex::Regex;
+
+const REGEX_SUFFIX: &str = r#"\{0x([0-9a-fA-F]+)\}"#;
+
+pub struct HexifiedAddress<A> {
+    addressable: A,
+}
+
+impl<A: Addressable + DecodeAll> HexifiedAddress<A> {
+    pub fn new(addressable: A) -> Self {
+        Self { addressable }
+    }
+
+    fn make_regex_pattern() -> String {
+        A::json_wrapper_prefix().to_string() + REGEX_SUFFIX
+    }
+
+    fn make_regex_object() -> Regex {
+        Regex::new(&Self::make_regex_pattern()).expect("Regex pattern cannot fail")
+    }
+
+    #[must_use]
+    pub fn replace_with_address(chain_config: &ChainConfig, target_str: &str) -> String {
+        let matcher = Self::make_regex_object();
+        let replacer = AddressableReplacer::<A>::new(chain_config);
+        let result = matcher.replace_all(target_str, replacer);
+
+        result.to_string()
+    }
+}
+
+impl<A: Addressable> std::fmt::Display for HexifiedAddress<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let result = format!(
+            "{}{{0x{}}}",
+            A::json_wrapper_prefix(),
+            hex::ToHex::encode_hex::<String>(&self.addressable.encode_to_bytes_for_address())
+        );
+        result.fmt(f)
+    }
+}
+
+struct AddressableReplacer<'a, A> {
+    chain_config: &'a ChainConfig,
+    _marker: std::marker::PhantomData<A>,
+}
+
+impl<'a, A: Addressable> AddressableReplacer<'a, A> {
+    pub fn new(chain_config: &'a ChainConfig) -> Self {
+        Self {
+            chain_config,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a, A: Addressable + DecodeAll> regex::Replacer for AddressableReplacer<'a, A> {
+    fn replace_append(&mut self, caps: &regex::Captures<'_>, dst: &mut String) {
+        let hex_data = caps.get(1).expect("It's already verified it exists").as_str();
+        let bytes = match hex::decode(hex_data) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                logging::log::error!(
+                    "While de-hexifying, failed to decode hex to bytes for a {}",
+                    A::json_wrapper_prefix()
+                );
+                // replace with hex value
+                dst.push_str("0x");
+                dst.push_str(&hex_data);
+                return;
+            }
+        };
+        let obj = match A::decode_all(&mut &*bytes) {
+            Ok(obj) => obj,
+            Err(_) => {
+                logging::log::error!(
+                    "While de-hexifying, failed to decode bytes to data for object for a {}",
+                    A::json_wrapper_prefix()
+                );
+                // replace with hex value
+                dst.push_str("0x");
+                dst.push_str(&hex_data);
+                return;
+            }
+        };
+        let address = match Address::new(self.chain_config, &obj) {
+            Ok(address) => address,
+            Err(_) => {
+                logging::log::error!(
+                    "While de-hexifying, failed to create address for object for a {}",
+                    A::json_wrapper_prefix()
+                );
+                // replace with hex value
+                dst.push_str("0x");
+                dst.push_str(&hex_data);
+                return;
+            }
+        };
+        dst.push_str(&address.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto::{
+        key::{KeyKind, PrivateKey},
+        random,
+    };
+    use parity_scale_codec::Encode;
+    use rstest::rstest;
+    use test_utils::random::{make_seedable_rng, Rng, Seed};
+
+    use crate::{
+        address::{
+            hexified::HexifiedAddress, pubkeyhash::PublicKeyHash, traits::Addressable, Address,
+        },
+        chain::{config::create_regtest, Destination},
+        primitives::H256,
+    };
+
+    fn random_string(length: usize, rng: &mut impl Rng) -> String {
+        rng.sample_iter(&random::distributions::Alphanumeric)
+            .take(length)
+            .map(char::from)
+            .collect()
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn basic_search_and_replace(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let (_private_key, public_key) =
+            PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+        let address = Destination::PublicKey(public_key);
+
+        let chain_config = create_regtest();
+
+        let s = format!("{}", HexifiedAddress::new(address.clone()));
+        let res = HexifiedAddress::<Destination>::replace_with_address(&chain_config, &s);
+        assert_eq!(
+            res,
+            format!("{}", Address::new(&chain_config, &address).unwrap())
+        );
+    }
+
+    #[test]
+    fn basic_search_and_replace_simple_invalid_wont_change() {
+        let chain_config = create_regtest();
+
+        let s = "some-random-stuff";
+        let res = HexifiedAddress::<Destination>::replace_with_address(&chain_config, &s);
+        assert_eq!(res, s)
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn many_random_instances(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+        let chain_config = create_regtest();
+
+        let strings = (0..100)
+            .map(|_| {
+                let size = rng.gen::<usize>() % 50;
+                random_string(size, &mut rng)
+            })
+            .collect::<Vec<String>>();
+
+        let keys = (0..strings.len())
+            .map(|_| match rng.gen::<usize>() % Destination::VARIANT_COUNT {
+                0..=1 => {
+                    let (_private_key, public_key) =
+                        PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+                    Destination::PublicKey(public_key)
+                }
+                2 => {
+                    let (_private_key, public_key) =
+                        PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+                    Destination::Address(PublicKeyHash::from(&public_key))
+                }
+                3 => Destination::ScriptHash(crate::primitives::Id::new(H256::random_using(
+                    &mut rng,
+                ))),
+                4 => {
+                    let (_private_key, public_key) =
+                        PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+                    Destination::ClassicMultisig(PublicKeyHash::from(&public_key))
+                }
+                _ => unreachable!(),
+            })
+            .collect::<Vec<_>>();
+
+        let final_str = strings
+            .iter()
+            .zip(keys.iter())
+            .map(|(s, k)| {
+                let hexified = HexifiedAddress::new(k.clone());
+                s.clone() + &hexified.to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        let to_test =
+            HexifiedAddress::<Destination>::replace_with_address(&chain_config, &final_str);
+
+        let expected = strings
+            .iter()
+            .zip(keys.iter())
+            .map(|(s, k)| {
+                let address_str = Address::new(&chain_config, k).unwrap();
+                s.clone() + &address_str.to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        assert_eq!(to_test, expected);
+    }
+
+    #[test]
+    fn invalid_match_should_replace_with_hex_case_invalid_hex() {
+        let chain_config = create_regtest();
+
+        let s = format!("{}{{0xabc}}", Destination::json_wrapper_prefix()); // Invalid hex
+
+        let re = HexifiedAddress::<Destination>::make_regex_object();
+        assert!(re.is_match(&s));
+
+        let res = HexifiedAddress::<Destination>::replace_with_address(&chain_config, &s);
+        assert_eq!(res, "0xabc");
+    }
+
+    #[test]
+    fn invalid_match_should_replace_with_hex_case_invalid_obj() {
+        let chain_config = create_regtest();
+
+        let s = format!("{}{{0xabcd}}", Destination::json_wrapper_prefix()); // Invalid object
+
+        let re = HexifiedAddress::<Destination>::make_regex_object();
+        assert!(re.is_match(&s));
+
+        let res = HexifiedAddress::<Destination>::replace_with_address(&chain_config, &s);
+        assert_eq!(res, "0xabcd");
+    }
+
+    #[test]
+    fn invalid_match_should_replace_with_hex_creating_case_address_creation_error() {
+        let chain_config = create_regtest();
+
+        let s = format!("{}", HexifiedAddress::new(Destination::AnyoneCanSpend)); // AnyoneCanSpend cannot be converted to an address
+
+        let re = HexifiedAddress::<Destination>::make_regex_object();
+        assert!(re.is_match(&s));
+
+        let res = HexifiedAddress::<Destination>::replace_with_address(&chain_config, &s);
+        assert_eq!(
+            res,
+            "0x".to_string()
+                + &hex::ToHex::encode_hex::<String>(&Destination::AnyoneCanSpend.encode())
+        );
+    }
+}

--- a/common/src/address/hexified.rs
+++ b/common/src/address/hexified.rs
@@ -1,10 +1,25 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::chain::ChainConfig;
 
 use super::{traits::Addressable, Address};
-use parity_scale_codec::DecodeAll;
 use regex::Regex;
+use serialization::DecodeAll;
 
-const REGEX_SUFFIX: &str = r#"\{0x([0-9a-fA-F]+)\}"#;
+const REGEX_SUFFIX: &str = r"\{0x([0-9a-fA-F]+)\}";
 
 pub struct HexifiedAddress<'a, A> {
     addressable: &'a A,
@@ -70,7 +85,7 @@ impl<'a, A: Addressable + DecodeAll> regex::Replacer for AddressableReplacer<'a,
                 );
                 // replace with hex value
                 dst.push_str("0x");
-                dst.push_str(&hex_data);
+                dst.push_str(hex_data);
                 return;
             }
         };
@@ -83,7 +98,7 @@ impl<'a, A: Addressable + DecodeAll> regex::Replacer for AddressableReplacer<'a,
                 );
                 // replace with hex value
                 dst.push_str("0x");
-                dst.push_str(&hex_data);
+                dst.push_str(hex_data);
                 return;
             }
         };
@@ -96,7 +111,7 @@ impl<'a, A: Addressable + DecodeAll> regex::Replacer for AddressableReplacer<'a,
                 );
                 // replace with hex value
                 dst.push_str("0x");
-                dst.push_str(&hex_data);
+                dst.push_str(hex_data);
                 return;
             }
         };
@@ -110,8 +125,8 @@ mod tests {
         key::{KeyKind, PrivateKey},
         random,
     };
-    use parity_scale_codec::Encode;
     use rstest::rstest;
+    use serialization::Encode;
     use test_utils::random::{make_seedable_rng, Rng, Seed};
 
     use crate::{
@@ -153,7 +168,7 @@ mod tests {
         let chain_config = create_regtest();
 
         let s = "some-random-stuff";
-        let res = HexifiedAddress::<Destination>::replace_with_address(&chain_config, &s);
+        let res = HexifiedAddress::<Destination>::replace_with_address(&chain_config, s);
         assert_eq!(res, s)
     }
 

--- a/common/src/address/mod.rs
+++ b/common/src/address/mod.rs
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Display;
+pub mod hexified;
+pub mod pubkeyhash;
+pub mod traits;
 
 use crate::chain::ChainConfig;
 use crate::primitives::{encoding, Bech32Error};
-pub mod pubkeyhash;
-pub mod traits;
+use std::fmt::Display;
 use utils::qrcode::{qrcode_from_str, QrCode, QrCodeError};
 
 use self::traits::Addressable;

--- a/common/src/address/mod.rs
+++ b/common/src/address/mod.rs
@@ -83,6 +83,17 @@ impl<T: Addressable> Address<T> {
         Ok(result)
     }
 
+    /// Decode an address without verifying the hrp
+    /// This is used only for the case of json deserialization, which is done as a compromise as the alternative
+    /// would be to not serialize at all. This is because chain config cannot be passed to the json serializer/deserializer.
+    fn from_str_no_hrp_verify(address: impl AsRef<str>) -> Result<T, AddressError> {
+        let data = encoding::decode(address)?;
+        let raw_data = data.data();
+        let result = T::decode_from_bytes_from_address(raw_data)
+            .map_err(|e| AddressError::DecodingError(e.to_string()))?;
+        Ok(result)
+    }
+
     pub fn from_str(cfg: &ChainConfig, address: &str) -> Result<Self, AddressError> {
         let address = Self {
             address: address.to_owned(),

--- a/common/src/address/mod.rs
+++ b/common/src/address/mod.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod dehexify;
 pub mod hexified;
 pub mod pubkeyhash;
 pub mod traits;

--- a/common/src/address/traits.rs
+++ b/common/src/address/traits.rs
@@ -29,4 +29,7 @@ pub trait Addressable {
     ) -> Result<Self, Self::Error>
     where
         Self: Sized;
+
+    /// Returns the prefix to be used for json conversions that cannot be done with a ChainConfig
+    fn json_wrapper_prefix() -> &'static str;
 }

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -218,6 +218,12 @@ impl PartialEq for WithId<Block> {
     }
 }
 
+impl serde::Serialize for Id<Block> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.serde_serialize(s)
+    }
+}
+
 impl Eq for WithId<Block> {}
 
 #[cfg(test)]

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -224,6 +224,12 @@ impl serde::Serialize for Id<Block> {
     }
 }
 
+impl<'de> serde::Deserialize<'de> for Id<Block> {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::serde_deserialize(d)
+    }
+}
+
 impl Eq for WithId<Block> {}
 
 #[cfg(test)]

--- a/common/src/chain/gen_block.rs
+++ b/common/src/chain/gen_block.rs
@@ -76,6 +76,12 @@ impl PartialEq<Id<GenBlock>> for Id<Genesis> {
     }
 }
 
+impl serde::Serialize for Id<GenBlock> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.serde_serialize(s)
+    }
+}
+
 impl Id<GenBlock> {
     /// Figure out if this [Id] refers to a [Genesis] or a proper [Block].
     pub fn classify(&self, c: &crate::chain::config::ChainConfig) -> GenBlockId {

--- a/common/src/chain/gen_block.rs
+++ b/common/src/chain/gen_block.rs
@@ -82,6 +82,12 @@ impl serde::Serialize for Id<GenBlock> {
     }
 }
 
+impl<'de> serde::Deserialize<'de> for Id<GenBlock> {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::serde_deserialize(d)
+    }
+}
+
 impl Id<GenBlock> {
     /// Figure out if this [Id] refers to a [Genesis] or a proper [Block].
     pub fn classify(&self, c: &crate::chain::config::ChainConfig) -> GenBlockId {

--- a/common/src/chain/genesis.rs
+++ b/common/src/chain/genesis.rs
@@ -63,3 +63,9 @@ impl Idable for Genesis {
         Id::new(id::hash_encoded(&self))
     }
 }
+
+impl serde::Serialize for Id<Genesis> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.serde_serialize(s)
+    }
+}

--- a/common/src/chain/pos.rs
+++ b/common/src/chain/pos.rs
@@ -19,7 +19,7 @@ use serialization::{DecodeAll, Encode};
 use typename::TypeName;
 
 use crate::{
-    address::{traits::Addressable, AddressError},
+    address::{hexified::HexifiedAddress, traits::Addressable, AddressError},
     primitives::{per_thousand::PerThousand, BlockDistance, Id, H256},
     Uint256,
 };
@@ -60,6 +60,12 @@ pub struct PoSChainConfig {
     difficulty_change_limit: PerThousand,
     /// Version of the consensus protocol
     consensus_version: PoSConsensusVersion,
+}
+
+impl serde::Serialize for PoolId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&HexifiedAddress::new(self).to_string())
+    }
 }
 
 impl Addressable for PoolId {
@@ -107,6 +113,12 @@ impl Addressable for DelegationId {
 
     fn json_wrapper_prefix() -> &'static str {
         "HexifiedDelegationId"
+    }
+}
+
+impl serde::Serialize for DelegationId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&HexifiedAddress::new(self).to_string())
     }
 }
 

--- a/common/src/chain/pos.rs
+++ b/common/src/chain/pos.rs
@@ -80,6 +80,10 @@ impl Addressable for PoolId {
         Self::decode_all(&mut address_bytes.as_ref())
             .map_err(|e| AddressError::DecodingError(e.to_string()))
     }
+
+    fn json_wrapper_prefix() -> &'static str {
+        "HexifiedPoolId"
+    }
 }
 
 impl Addressable for DelegationId {
@@ -99,6 +103,10 @@ impl Addressable for DelegationId {
     {
         Self::decode_all(&mut address_bytes.as_ref())
             .map_err(|e| AddressError::DecodingError(e.to_string()))
+    }
+
+    fn json_wrapper_prefix() -> &'static str {
+        "HexifiedDelegationId"
     }
 }
 

--- a/common/src/chain/pos.rs
+++ b/common/src/chain/pos.rs
@@ -64,7 +64,13 @@ pub struct PoSChainConfig {
 
 impl serde::Serialize for PoolId {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&HexifiedAddress::new(self).to_string())
+        HexifiedAddress::serde_serialize(self, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for PoolId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        HexifiedAddress::<Self>::serde_deserialize(deserializer)
     }
 }
 
@@ -118,7 +124,13 @@ impl Addressable for DelegationId {
 
 impl serde::Serialize for DelegationId {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&HexifiedAddress::new(self).to_string())
+        HexifiedAddress::serde_serialize(self, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DelegationId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        HexifiedAddress::<Self>::serde_deserialize(deserializer)
     }
 }
 

--- a/common/src/chain/tokens/mod.rs
+++ b/common/src/chain/tokens/mod.rs
@@ -63,7 +63,13 @@ impl Addressable for TokenId {
 
 impl serde::Serialize for TokenId {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&HexifiedAddress::new(self).to_string())
+        HexifiedAddress::serde_serialize(self, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for TokenId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        HexifiedAddress::<Self>::serde_deserialize(deserializer)
     }
 }
 

--- a/common/src/chain/tokens/mod.rs
+++ b/common/src/chain/tokens/mod.rs
@@ -55,6 +55,10 @@ impl Addressable for TokenId {
         Self::decode_all(&mut address_bytes.as_ref())
             .map_err(|e| AddressError::DecodingError(e.to_string()))
     }
+
+    fn json_wrapper_prefix() -> &'static str {
+        "HexifiedTokenId"
+    }
 }
 
 mod nft;

--- a/common/src/chain/tokens/mod.rs
+++ b/common/src/chain/tokens/mod.rs
@@ -23,7 +23,7 @@ pub enum Token {}
 pub type TokenId = Id<Token>;
 pub type NftDataHash = Vec<u8>;
 use crate::{
-    address::{traits::Addressable, AddressError},
+    address::{hexified::HexifiedAddress, traits::Addressable, AddressError},
     primitives::{Amount, Id, H256},
 };
 
@@ -58,6 +58,12 @@ impl Addressable for TokenId {
 
     fn json_wrapper_prefix() -> &'static str {
         "HexifiedTokenId"
+    }
+}
+
+impl serde::Serialize for TokenId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&HexifiedAddress::new(self).to_string())
     }
 }
 

--- a/common/src/chain/transaction/mod.rs
+++ b/common/src/chain/transaction/mod.rs
@@ -150,6 +150,12 @@ impl serde::Serialize for Id<Transaction> {
     }
 }
 
+impl<'de> serde::Deserialize<'de> for Id<Transaction> {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::serde_deserialize(d)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/common/src/chain/transaction/mod.rs
+++ b/common/src/chain/transaction/mod.rs
@@ -144,6 +144,12 @@ impl Transaction {
     }
 }
 
+impl serde::Serialize for Id<Transaction> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.serde_serialize(s)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -14,12 +14,14 @@
 // limitations under the License.
 
 use crate::{
-    address::{pubkeyhash::PublicKeyHash, traits::Addressable, AddressError},
+    address::{
+        hexified::HexifiedAddress, pubkeyhash::PublicKeyHash, traits::Addressable, AddressError,
+    },
     chain::{output_value::OutputValue, tokens::TokenData, ChainConfig, DelegationId, PoolId},
     primitives::{Amount, Id},
 };
 use script::Script;
-use serialization::{hex::HexEncode, Decode, DecodeAll, Encode};
+use serialization::{Decode, DecodeAll, Encode};
 use variant_count::VariantCount;
 
 use self::{stakelock::StakePoolData, timelock::OutputTimeLock};
@@ -45,7 +47,7 @@ pub enum Destination {
 
 impl serde::Serialize for Destination {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&format!("0x{}", self.hex_encode()))
+        serializer.serialize_str(&HexifiedAddress::new(self).to_string())
     }
 }
 

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use script::Script;
 use serialization::{hex::HexEncode, Decode, DecodeAll, Encode};
+use variant_count::VariantCount;
 
 use self::{stakelock::StakePoolData, timelock::OutputTimeLock};
 
@@ -28,7 +29,7 @@ pub mod output_value;
 pub mod stakelock;
 pub mod timelock;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, VariantCount)]
 pub enum Destination {
     #[codec(index = 0)]
     AnyoneCanSpend, // zero verification; used primarily for testing. Never use this for real money
@@ -65,6 +66,10 @@ impl Addressable for Destination {
     {
         Self::decode_all(&mut address_bytes.as_ref())
             .map_err(|e| AddressError::DecodingError(e.to_string()))
+    }
+
+    fn json_wrapper_prefix() -> &'static str {
+        "HexifiedDestination"
     }
 }
 

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -47,7 +47,13 @@ pub enum Destination {
 
 impl serde::Serialize for Destination {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&HexifiedAddress::new(self).to_string())
+        HexifiedAddress::serde_serialize(self, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Destination {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        HexifiedAddress::<Self>::serde_deserialize(deserializer)
     }
 }
 

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -94,12 +94,10 @@ impl<'de> serde::Deserialize<'de> for H256 {
     }
 }
 
-#[derive(PartialEq, Eq, Encode, Decode, serde::Deserialize, RefCast)]
+#[derive(PartialEq, Eq, Encode, Decode, RefCast)]
 #[repr(transparent)]
-#[serde(transparent)]
 pub struct Id<T> {
     hash: H256,
-    #[serde(skip)]
     _shadow: std::marker::PhantomData<fn() -> T>,
 }
 
@@ -163,11 +161,21 @@ impl<T> Id<T> {
     pub fn serde_serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         <H256 as serde::Serialize>::serialize(&self.hash, s)
     }
+
+    pub fn serde_deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        <H256 as serde::Deserialize<'de>>::deserialize(d).map(Self::new)
+    }
 }
 
 impl serde::Serialize for Id<()> {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         self.serde_serialize(s)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Id<()> {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        Self::serde_deserialize(d)
     }
 }
 

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -94,7 +94,7 @@ impl<'de> serde::Deserialize<'de> for H256 {
     }
 }
 
-#[derive(PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize, RefCast)]
+#[derive(PartialEq, Eq, Encode, Decode, serde::Deserialize, RefCast)]
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct Id<T> {
@@ -158,6 +158,16 @@ impl<T> Id<T> {
             hash: h,
             _shadow: std::marker::PhantomData,
         }
+    }
+
+    pub fn serde_serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        <H256 as serde::Serialize>::serialize(&self.hash, s)
+    }
+}
+
+impl serde::Serialize for Id<()> {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.serde_serialize(s)
     }
 }
 


### PR DESCRIPTION
So, given that `serde::Serialize` has no state, this is the only way I could do this. Let me know what you think.

Closes #1200 