### PR TITLE
Mlt -> CoinUnit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,9 @@ jobs:
       - name: Build
         run: cargo build --release --locked
       - name: Run tests
-        run: cargo test --release --all
+        run: cargo test --release --workspace
+      - name: Run doc tests
+        run: cargo test --release --doc
       # This test is ignored, so it needs to run separately.
       - name: Run mixed_sighash_types test
         run: cargo test --release -p common mixed_sighash_types -- --ignored
@@ -101,7 +103,9 @@ jobs:
       - name: Build
         run: cargo build --release --locked
       - name: Run tests
-        run: cargo test --release --all
+        run: cargo test --release --workspace
+      - name: Run doc tests
+        run: cargo test --release --doc
       # This test is ignored, so it needs to run separately.
       - name: Run mixed_sighash_types test
         run: cargo test --release mixed_sighash_types
@@ -136,7 +140,9 @@ jobs:
       - name: Build
         run: cargo build --release --locked
       - name: Run tests
-        run: cargo test --release --all
+        run: cargo test --release --workspace
+      - name: Run doc tests
+        run: cargo test --release --doc
       # This test is ignored, so it needs to run separately.
       - name: Run mixed_sighash_types test
         run: cargo test --release mixed_sighash_types

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build
         run: cargo build --release --locked
       - name: Run tests
-        run: cargo test --release --workspace
+        run: cargo test --release --all
       # This test is ignored, so it needs to run separately.
       - name: Run mixed_sighash_types test
         run: cargo test --release -p common mixed_sighash_types -- --ignored
@@ -101,7 +101,7 @@ jobs:
       - name: Build
         run: cargo build --release --locked
       - name: Run tests
-        run: cargo test --release --workspace
+        run: cargo test --release --all
       # This test is ignored, so it needs to run separately.
       - name: Run mixed_sighash_types test
         run: cargo test --release mixed_sighash_types
@@ -136,7 +136,7 @@ jobs:
       - name: Build
         run: cargo build --release --locked
       - name: Run tests
-        run: cargo test --release --workspace
+        run: cargo test --release --all
       # This test is ignored, so it needs to run separately.
       - name: Run mixed_sighash_types test
         run: cargo test --release mixed_sighash_types

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,17 +93,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom 0.2.10",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
@@ -115,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -181,9 +170,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "f6cd65a4b849ace0b7f6daeebcc1a1d111282227ca745458c61dbf670e52a597"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -195,15 +184,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -219,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "0238ca56c96dfa37bdf7c373c8886dd591322500aceeeccdb2216fe06dc2f796"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -331,7 +320,7 @@ dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
- "predicates 3.0.3",
+ "predicates 3.0.4",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -354,7 +343,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -706,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-slice-cast"
@@ -733,7 +722,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -750,9 +739,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4d115132e01c0165e3bf5f56aedee8980b0b96ede4eb000b693c05a8adb8ff"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "libc",
  "system-deps",
@@ -997,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1058,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.3"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1068,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1087,7 +1076,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1155,15 +1144,14 @@ dependencies = [
 
 [[package]]
 name = "cocoa-foundation"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
 dependencies = [
  "bitflags 1.3.2",
  "block",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
  "libc",
  "objc",
 ]
@@ -1574,12 +1562,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f34ba9a9bcb8645379e9de8cb3ecfcf4d1c85ba66d90deb3259206fa5aa193b"
+checksum = "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
 dependencies = [
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1593,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622178105f911d937a42cdb140730ba4a3ed2becd8ae6ce39c7d28b5d75d4588"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1616,7 +1604,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1848,7 +1836,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1958,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fd-lock"
@@ -2156,7 +2144,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2317,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42218cb640844e3872cc3c153dc975229e080a6c4733b34709ef445610550226"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
 
 [[package]]
 name = "glib-sys"
@@ -2464,22 +2452,22 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
+checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "gpu-descriptor-types",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
+checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
 ]
 
 [[package]]
@@ -2550,9 +2538,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.6",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2560,7 +2545,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
- "ahash 0.8.3",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -2596,9 +2581,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -2955,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
@@ -3475,16 +3460,17 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
+ "cfg-if",
  "digest 0.10.7",
 ]
 
@@ -3931,7 +3917,7 @@ dependencies = [
  "tempfile",
  "test-rpc-functions",
  "tokio",
- "toml 0.8.0",
+ "toml 0.8.1",
  "utils",
 ]
 
@@ -4012,7 +3998,7 @@ checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4107,7 +4093,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4262,7 +4248,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4400,7 +4386,7 @@ checksum = "b7db010ec5ff3d4385e4f133916faacd9dad0f6a09394c92d825b3aed310fa0a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4542,7 +4528,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4571,7 +4557,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4750,13 +4736,13 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "predicates-core",
 ]
 
@@ -4848,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f10e75d83c7aec79a6aa46f897075890e156b105eebe51cfa0abce51af025f"
+checksum = "f89dff0959d98c9758c88826cc002e2c3d0b9dfac4139711d1f30de442f1139b"
 
 [[package]]
 name = "proptest"
@@ -5027,9 +5013,9 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -5037,14 +5023,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -5114,7 +5098,7 @@ checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5282,7 +5266,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.33",
+ "syn 2.0.37",
  "unicode-ident",
 ]
 
@@ -5329,9 +5313,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -5348,7 +5332,7 @@ checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.5",
+ "rustls-webpki 0.101.6",
  "sct",
 ]
 
@@ -5385,9 +5369,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -5566,9 +5550,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "send_wrapper"
@@ -5602,7 +5586,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5678,7 +5662,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5722,7 +5706,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5751,9 +5735,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5772,9 +5756,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
 dependencies = [
  "lazy_static",
 ]
@@ -5862,15 +5846,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
+checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
 dependencies = [
  "bitflags 1.3.2",
  "calloop",
@@ -6030,7 +6014,7 @@ dependencies = [
  "quote",
  "regex-syntax 0.6.29",
  "strsim",
- "syn 2.0.33",
+ "syn 2.0.37",
  "unicode-width",
 ]
 
@@ -6160,7 +6144,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6215,9 +6199,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.33"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6271,7 +6255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
+ "fastrand 2.0.1",
  "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
@@ -6290,9 +6274,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -6347,22 +6331,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6386,9 +6370,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
  "libc",
@@ -6399,9 +6383,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tiny-skia"
@@ -6506,7 +6490,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6570,9 +6554,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6606,14 +6590,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
+checksum = "1bc1433177506450fe920e46a4f9812d0c211f5dd556da10e731a0a3dfa151f0"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.0",
+ "toml_edit 0.20.1",
 ]
 
 [[package]]
@@ -6631,7 +6615,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6640,11 +6624,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
+checksum = "ca676d9ba1a322c1b64eb8045a5ec5c0cfb0c9d08e15e9ff622589ad5221c8fe"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6720,7 +6704,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6900,14 +6884,14 @@ version = "0.1.2"
 dependencies = [
  "itertools 0.11.0",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unarray"
@@ -6974,9 +6958,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -7328,7 +7312,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -7362,7 +7346,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7693,9 +7677,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -7881,9 +7865,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winit"
-version = "0.28.6"
+version = "0.28.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866db3f712fffba75d31bf0cdecf357c8aeafd158c5b7ab51dba2a2b2d47f196"
+checksum = "9596d90b45384f5281384ab204224876e8e8bf7d58366d9b795ad99aa9894b94"
 dependencies = [
  "android-activity",
  "bitflags 1.3.2",
@@ -7991,9 +7975,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab77e97b50aee93da431f2cee7cd0f43b4d1da3c408042f2d7d164187774f0a"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "yazi"
@@ -8024,5 +8008,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn 2.0.37",
 ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please note, the code in this repository is currently under active development. 
 
 Discovered a potential security issue? We urge you to contact us directly at security@mintlayer.org. When reporting, please encrypt your report using Ben's GPG key which can be found [here](https://www.mintlayer.org/assets/keys/ben).
 
-Mintlayer runs a [bug bounty program](https://www.mintlayer.org/bug-bounties), meaning that if your report is valid, you could be eligible for a reward paid in MLT tokens. Please refrain from publicly disclosing any potential security issues until our core Mintlayer team has confirmed that the matter can be shared. Further information can be found in our [SECURITY.md](https://github.com/mintlayer/mintlayer-core/blob/master/SECURITY.md) guidelines.
+Mintlayer runs a [bug bounty program](https://www.mintlayer.org/bug-bounties), meaning that if your report is valid, you could be eligible for a reward paid in ML tokens. Please refrain from publicly disclosing any potential security issues until our core Mintlayer team has confirmed that the matter can be shared. Further information can be found in our [SECURITY.md](https://github.com/mintlayer/mintlayer-core/blob/master/SECURITY.md) guidelines.
 
 ## Bug Reporting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 Mintlayer runs a responsible disclosure program for security issues, as such all security issues should be reported to security@mintlayer.org or ben@mintlayer.org.
-If you disclose a valid security issue then you may be eligible for a bounty paid in MLT see the details [here](https://www.mintlayer.org/bug-bounties/).
+If you disclose a valid security issue then you may be eligible for a bounty paid in ML see the details [here](https://www.mintlayer.org/bug-bounties/).
 
 It's best to err on the side of caution, if you find something you think is security related but not eligible for the bounty or something you're not 100% sure about then let us know on the above email addresses anyway as we treat each report on a report by report basis so you may still be paid a bounty.
 

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -31,9 +31,9 @@ use common::{
         },
         stakelock::StakePoolData,
         tokens::{TokenData, TokenTransfer},
-        Block, ChainConfig, ConsensusUpgrade, Destination, GenBlock, Genesis, Mlt, NetUpgrades,
-        OutPointSourceId, PoSChainConfig, PoolId, RequiredConsensus, TxInput, TxOutput,
-        UpgradeVersion, UtxoOutPoint,
+        Block, ChainConfig, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis,
+        NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId, RequiredConsensus, TxInput,
+        TxOutput, UpgradeVersion, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Compact, Id, Idable, H256},
     Uint256,
@@ -325,7 +325,7 @@ pub fn create_chain_config_with_default_staking_pool(
     vrf_pk: VRFPublicKey,
 ) -> (ConfigBuilder, PoolId) {
     let stake_amount = create_unit_test_config().min_stake_pool_pledge();
-    let mint_amount = Amount::from_atoms(100_000_000 * common::chain::Mlt::ATOMS_PER_MLT);
+    let mint_amount = Amount::from_atoms(100_000_000 * common::chain::CoinUnit::ATOMS_PER_COIN);
 
     let genesis_pool_id = PoolId::new(H256::random_using(rng));
     let genesis_stake_pool_data = StakePoolData::new(
@@ -421,7 +421,7 @@ pub fn pos_mine(
     vrf_sk: &VRFPrivateKey,
     sealed_epoch_randomness: PoSRandomness,
     pool_id: PoolId,
-    final_supply: Mlt,
+    final_supply: CoinUnit,
     epoch_index: EpochIndex,
     target: Compact,
 ) -> Option<(PoSData, BlockTimestamp)> {

--- a/chainstate/test-suite/src/tests/helpers/pos.rs
+++ b/chainstate/test-suite/src/tests/helpers/pos.rs
@@ -18,7 +18,7 @@ use chainstate_test_framework::TestFramework;
 use common::{
     chain::{
         block::timestamp::BlockTimestamp, output_value::OutputValue, stakelock::StakePoolData,
-        Destination, Genesis, Mlt, RequiredConsensus, TxOutput,
+        CoinUnit, Destination, Genesis, RequiredConsensus, TxOutput,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Compact, H256},
 };
@@ -81,7 +81,7 @@ pub fn create_custom_genesis_with_stake_pool(
     staker_pk: PublicKey,
     vrf_pk: VRFPublicKey,
 ) -> Genesis {
-    let initial_amount = Mlt::from_mlt(100_000_000).to_amount_atoms();
+    let initial_amount = CoinUnit::from_coins(100_000_000).to_amount_atoms();
     let initial_pool_amount = (initial_amount / 3).unwrap();
     let mint_output_amount = (initial_amount - initial_pool_amount).unwrap();
 

--- a/chainstate/test-suite/src/tests/pos_maturity_settings.rs
+++ b/chainstate/test-suite/src/tests/pos_maturity_settings.rs
@@ -102,7 +102,7 @@ fn decommission_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
     );
 
     let pool_id = pos_accounting::make_pool_id(&genesis_mint_outpoint);
-    let stake_amount = Amount::from_atoms(40_000_000 * common::chain::Mlt::ATOMS_PER_MLT);
+    let stake_amount = Amount::from_atoms(40_000_000 * common::chain::CoinUnit::ATOMS_PER_COIN);
 
     let tx = TransactionBuilder::new()
         .add_input(genesis_mint_outpoint.into(), empty_witness(&mut rng))

--- a/chainstate/test-suite/src/tests/pos_maturity_settings.rs
+++ b/chainstate/test-suite/src/tests/pos_maturity_settings.rs
@@ -163,7 +163,7 @@ fn decommission_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
     );
 
     //
-    // produce some block at height 2 just to move to the next netupgrade
+    // produce some block at height 2 just to move to the next NetUpgrade
     //
     tf.make_pos_block_builder(&mut rng)
         .with_block_signing_key(staking_sk.clone())
@@ -323,7 +323,7 @@ fn spend_share_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
     );
 
     //
-    // produce some block at height 2 just to move to the next netupgrade
+    // produce some block at height 2 just to move to the next NetUpgrade
     //
     tf.make_pos_block_builder(&mut rng)
         .with_block_signing_key(staking_sk.clone())

--- a/common/src/chain/coin_unit.rs
+++ b/common/src/chain/coin_unit.rs
@@ -33,8 +33,6 @@ impl CoinUnit {
     pub const ZERO: Self = Self(Amount::from_atoms(0));
     /// Maximum representable amount of coins
     pub const MAX: Self = Self(Amount::MAX);
-    /// The coin ticker
-    pub const TICKER: &'static str = "ML";
 
     /// Construct from the number atom units
     pub const fn from_atoms(n: u128) -> Self {

--- a/common/src/chain/coin_unit.rs
+++ b/common/src/chain/coin_unit.rs
@@ -17,33 +17,36 @@ use std::str::FromStr;
 
 use crate::primitives::Amount;
 
-/// Represents a certain amount of MLT.
+/// Represents a certain amount of coins.
+/// An atom is the smallest, non-divisible, unit of the currency in the protocol.
+/// A coin is the smallest, non-fractional, unit of the currency in the protocol.
+/// Given a fixed number of decimals, call it DECIMALS, a coin is equal to 10^DECIMALS atom units.
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Debug)]
-pub struct Mlt(Amount);
+pub struct CoinUnit(Amount);
 
-impl Mlt {
-    /// Number of decimal digits used to represent MLT
+impl CoinUnit {
+    /// Number of decimal digits used to represent the coin
     pub const DECIMALS: u8 = 11;
-    /// Number of atoms in 1 MLT
-    pub const ATOMS_PER_MLT: u128 = 10u128.pow(Self::DECIMALS as u32);
-    /// Zero MLTs
+    /// Number of atoms in 1 coin
+    pub const ATOMS_PER_COIN: u128 = 10u128.pow(Self::DECIMALS as u32);
+    /// Zero coins
     pub const ZERO: Self = Self(Amount::from_atoms(0));
-    /// Maximum representable amount of MLTs
+    /// Maximum representable amount of coins
     pub const MAX: Self = Self(Amount::MAX);
     /// The coin ticker
     pub const TICKER: &'static str = "ML";
 
-    /// Construct from the number atomic units
+    /// Construct from the number atom units
     pub const fn from_atoms(n: u128) -> Self {
         Self(Amount::from_atoms(n))
     }
 
-    /// Construct from the number of MLTs
-    pub const fn from_mlt(n: u64) -> Self {
-        // Since the argument is u64 and number of atoms in 1 MLT is <= u64::MAX,
+    /// Construct from the number of coins
+    pub const fn from_coins(n: u64) -> Self {
+        // Since the argument is u64 and number of atoms in 1 coin is <= u64::MAX,
         // the result is guaranteed to fit into the internal representation of Amount (u128)
-        static_assertions::const_assert!(Mlt::ATOMS_PER_MLT <= u64::MAX as u128);
-        Self(Amount::from_atoms(n as u128 * Mlt::ATOMS_PER_MLT))
+        static_assertions::const_assert!(CoinUnit::ATOMS_PER_COIN <= u64::MAX as u128);
+        Self(Amount::from_atoms(n as u128 * CoinUnit::ATOMS_PER_COIN))
     }
 
     /// Convert the number of atoms to Amount
@@ -52,45 +55,45 @@ impl Mlt {
     }
 }
 
-impl std::ops::Add for Mlt {
+impl std::ops::Add for CoinUnit {
     type Output = Option<Self>;
     fn add(self, rhs: Self) -> Option<Self> {
         (self.0 + rhs.0).map(Self)
     }
 }
 
-impl std::ops::Sub for Mlt {
+impl std::ops::Sub for CoinUnit {
     type Output = Option<Self>;
     fn sub(self, rhs: Self) -> Option<Self> {
         (self.0 - rhs.0).map(Self)
     }
 }
 
-impl std::ops::Mul<u128> for Mlt {
+impl std::ops::Mul<u128> for CoinUnit {
     type Output = Option<Self>;
     fn mul(self, rhs: u128) -> Option<Self> {
         (self.0 * rhs).map(Self)
     }
 }
 
-impl std::fmt::Display for Mlt {
+impl std::fmt::Display for CoinUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(&self.0.into_fixedpoint_str(Mlt::DECIMALS))
+        f.write_str(&self.0.into_fixedpoint_str(CoinUnit::DECIMALS))
     }
 }
 
-/// MLT amount parsing error
+/// Coin amount parsing error
 #[derive(Eq, PartialEq, Clone, Debug, thiserror::Error)]
-pub enum ParseMltError {
-    #[error("MLT amount parsing error")]
+pub enum ParseCoinUnitError {
+    #[error("Coin amount parsing error")]
     ParsingNumbericAmountFromStrFailed,
 }
 
-impl FromStr for Mlt {
-    type Err = ParseMltError;
+impl FromStr for CoinUnit {
+    type Err = ParseCoinUnitError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Amount::from_fixedpoint_str(s, Mlt::DECIMALS)
-            .ok_or(ParseMltError::ParsingNumbericAmountFromStrFailed)
-            .map(Mlt)
+        Amount::from_fixedpoint_str(s, CoinUnit::DECIMALS)
+            .ok_or(ParseCoinUnitError::ParsingNumbericAmountFromStrFailed)
+            .map(CoinUnit)
     }
 }

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -156,7 +156,7 @@ impl Builder {
             chain_type,
             bip44_coin_type: chain_type.default_bip44_coin_type(),
             coin_decimals: CoinUnit::DECIMALS,
-            coin_ticker: CoinUnit::TICKER,
+            coin_ticker: chain_type.coin_ticker(),
             magic_bytes: chain_type.default_magic_bytes(),
             p2p_port: chain_type.default_p2p_port(),
             software_version: SemVer::try_from(env!("CARGO_PKG_VERSION"))

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -23,8 +23,8 @@ use crate::{
         },
         create_testnet_pos_config, get_initial_randomness, pos_initial_difficulty,
         pow::PoWChainConfigBuilder,
-        ConsensusUpgrade, Destination, GenBlock, Genesis, Mlt, NetUpgrades, PoSConsensusVersion,
-        PoWChainConfig, UpgradeVersion,
+        CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
+        PoSConsensusVersion, PoWChainConfig, UpgradeVersion,
     },
     primitives::{
         id::WithId, semver::SemVer, Amount, BlockDistance, BlockHeight, Id, Idable, H256,
@@ -155,8 +155,8 @@ impl Builder {
         Self {
             chain_type,
             bip44_coin_type: chain_type.default_bip44_coin_type(),
-            coin_decimals: Mlt::DECIMALS,
-            coin_ticker: Mlt::TICKER,
+            coin_decimals: CoinUnit::DECIMALS,
+            coin_ticker: CoinUnit::TICKER,
             magic_bytes: chain_type.default_magic_bytes(),
             p2p_port: chain_type.default_p2p_port(),
             software_version: SemVer::try_from(env!("CARGO_PKG_VERSION"))

--- a/common/src/chain/config/emission_schedule.rs
+++ b/common/src/chain/config/emission_schedule.rs
@@ -216,7 +216,7 @@ impl FromStr for EmissionScheduleTabular {
     /// ```
     /// # use common::chain::config::emission_schedule::*;
     /// let es: EmissionScheduleTabular = "100+0".parse().unwrap();
-    /// assert_eq!(es.final_supply(), Some(Mlt::from_mlt(100)));
+    /// assert_eq!(es.final_supply(), Some(CoinUnit::from_coins(100)));
     /// ```
     ///
     /// Start with 1000 MLTs, add 0.1 MLT each block forever:

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -558,7 +558,7 @@ fn create_mainnet_genesis() -> Genesis {
 }
 
 fn create_testnet_genesis() -> Genesis {
-    // We add 3_600_000_000 MLT to the genesis mint account since it's just for testing. Nothing else changes.
+    // We add 3_600_000_000 coins to the genesis mint account since it's just for testing. Nothing else changes.
     let extra_testnet_mint = Amount::from_atoms(3_600_000_000 * CoinUnit::ATOMS_PER_COIN);
     let total_amount = (extra_testnet_mint + DEFAULT_INITIAL_MINT).expect("Cannot fail");
     let initial_pool_amount = MIN_STAKE_POOL_PLEDGE;

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -83,6 +83,15 @@ impl ChainType {
         }
     }
 
+    const fn coin_ticker(&self) -> &'static str {
+        match self {
+            ChainType::Mainnet => "ML",
+            ChainType::Testnet => "TML",
+            ChainType::Regtest => "RML",
+            ChainType::Signet => "SML",
+        }
+    }
+
     const fn default_magic_bytes(&self) -> [u8; 4] {
         match self {
             ChainType::Mainnet => [0x1a, 0x64, 0xe5, 0xf1],

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -20,7 +20,7 @@ pub mod regtest;
 pub use builder::Builder;
 use crypto::key::PublicKey;
 use crypto::vrf::VRFPublicKey;
-use emission_schedule::Mlt;
+use emission_schedule::CoinUnit;
 pub use emission_schedule::{EmissionSchedule, EmissionScheduleFn, EmissionScheduleTabular};
 
 use hex::FromHex;
@@ -157,7 +157,7 @@ pub struct ChainConfig {
     coin_decimals: u8,
     coin_ticker: &'static str,
     emission_schedule: EmissionSchedule,
-    final_supply: Option<Mlt>, // `None` if the supply increases indefinitely
+    final_supply: Option<CoinUnit>, // `None` if the supply increases indefinitely
     max_block_header_size: usize,
     max_block_size_with_standard_txs: usize,
     max_block_size_with_smart_contracts: usize,
@@ -493,7 +493,7 @@ impl ChainConfig {
         self.min_stake_pool_pledge
     }
 
-    pub fn final_supply(&self) -> Option<Mlt> {
+    pub fn final_supply(&self) -> Option<CoinUnit> {
         self.final_supply
     }
 }
@@ -508,7 +508,7 @@ const MAX_BLOCK_HEADER_SIZE: usize = 1024;
 const MAX_BLOCK_TXS_SIZE: usize = 1_048_576;
 const MAX_BLOCK_CONTRACTS_SIZE: usize = 1_048_576;
 const MAX_TX_NO_SIG_WITNESS_SIZE: usize = 128;
-const TOKEN_MIN_ISSUANCE_FEE: Amount = Amount::from_atoms(100 * Mlt::ATOMS_PER_MLT);
+const TOKEN_MIN_ISSUANCE_FEE: Amount = Amount::from_atoms(100 * CoinUnit::ATOMS_PER_COIN);
 const TOKEN_MAX_DEC_COUNT: u8 = 18;
 const TOKEN_MAX_TICKER_LEN: usize = 5;
 const TOKEN_MIN_HASH_LEN: usize = 4;
@@ -517,7 +517,7 @@ const TOKEN_MAX_NAME_LEN: usize = 10;
 const TOKEN_MAX_DESCRIPTION_LEN: usize = 100;
 const TOKEN_MAX_URI_LEN: usize = 1024;
 const MAX_CLASSIC_MULTISIG_PUBLIC_KEYS_COUNT: usize = 16;
-const MIN_STAKE_POOL_PLEDGE: Amount = Amount::from_atoms(40_000 * Mlt::ATOMS_PER_MLT);
+const MIN_STAKE_POOL_PLEDGE: Amount = Amount::from_atoms(40_000 * CoinUnit::ATOMS_PER_COIN);
 
 fn decode_hex<T: serialization::DecodeAll>(hex: &str) -> T {
     let bytes = Vec::from_hex(hex).expect("Hex decoding shouldn't fail");
@@ -550,7 +550,7 @@ fn create_mainnet_genesis() -> Genesis {
 
 fn create_testnet_genesis() -> Genesis {
     // We add 3_600_000_000 MLT to the genesis mint account since it's just for testing. Nothing else changes.
-    let extra_testnet_mint = Amount::from_atoms(3_600_000_000 * Mlt::ATOMS_PER_MLT);
+    let extra_testnet_mint = Amount::from_atoms(3_600_000_000 * CoinUnit::ATOMS_PER_COIN);
     let total_amount = (extra_testnet_mint + DEFAULT_INITIAL_MINT).expect("Cannot fail");
     let initial_pool_amount = MIN_STAKE_POOL_PLEDGE;
     let mint_output_amount = (total_amount - initial_pool_amount).expect("must be valid");

--- a/common/src/chain/mod.rs
+++ b/common/src/chain/mod.rs
@@ -21,7 +21,7 @@ pub mod genesis;
 pub mod tokens;
 pub mod transaction;
 
-mod mlt;
+mod coin_unit;
 mod pos;
 mod pow;
 mod upgrades;
@@ -33,7 +33,7 @@ pub use block::Block;
 pub use config::ChainConfig;
 pub use gen_block::{GenBlock, GenBlockId};
 pub use genesis::Genesis;
-pub use mlt::Mlt;
+pub use coin_unit::CoinUnit;
 pub use pos::{
     create_regtest_pos_config, create_testnet_pos_config, create_unittest_pos_config,
     get_initial_randomness, pos_initial_difficulty, DelegationId, PoSChainConfig,

--- a/common/src/chain/mod.rs
+++ b/common/src/chain/mod.rs
@@ -30,10 +30,10 @@ pub use signed_transaction::SignedTransaction;
 pub use transaction::*;
 
 pub use block::Block;
+pub use coin_unit::CoinUnit;
 pub use config::ChainConfig;
 pub use gen_block::{GenBlock, GenBlockId};
 pub use genesis::Genesis;
-pub use coin_unit::CoinUnit;
 pub use pos::{
     create_regtest_pos_config, create_testnet_pos_config, create_unittest_pos_config,
     get_initial_randomness, pos_initial_difficulty, DelegationId, PoSChainConfig,

--- a/test/functional/blockprod_generate_pos_blocks.py
+++ b/test/functional/blockprod_generate_pos_blocks.py
@@ -21,7 +21,7 @@ from test_framework.mintlayer import (
     base_tx_obj,
     block_input_data_obj,
     mintlayer_hash,
-    MLT_COIN,
+    ATOMS_PER_COIN,
     outpoint_obj,
     signed_tx_obj,
 )
@@ -203,7 +203,7 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
                         "CreateStakePool": [
                             self.genesis_pool_id(),
                             {
-                                "value": 40_000*MLT_COIN,
+                                "value": 40_000*ATOMS_PER_COIN,
                                 "staker": {
                                     "PublicKey": self.stake_public_key(GENESIS_STAKE_PUBLIC_KEY),
                                 },
@@ -238,7 +238,7 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
                     {
                         "Transfer": [
                             {
-                                "Coin": 100_000*MLT_COIN,
+                                "Coin": 100_000*ATOMS_PER_COIN,
                             },
                             "AnyoneCanSpend",
                         ],
@@ -311,7 +311,7 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
                         "CreateStakePool": [
                             new_pool_id,
                             {
-                                "value": 100_000*MLT_COIN,
+                                "value": 100_000*ATOMS_PER_COIN,
                                 "staker": {
                                     "PublicKey": new_stake_public_key,
                                 },
@@ -349,7 +349,7 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
             "CreateStakePool": [
                 new_pool_id,
                 {
-                    "value": 100_000*MLT_COIN,
+                    "value": 100_000*ATOMS_PER_COIN,
                     "staker": {
                         "PublicKey": new_stake_public_key,
                     },

--- a/test/functional/blockprod_generate_pos_blocks_rand_genesis_keys.py
+++ b/test/functional/blockprod_generate_pos_blocks_rand_genesis_keys.py
@@ -22,7 +22,7 @@ from test_framework.mintlayer import (
     block_input_data_obj,
     outpoint_obj,
     mintlayer_hash,
-    MLT_COIN,
+    ATOMS_PER_COIN,
     signed_tx_obj,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -233,7 +233,7 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
                         "CreateStakePool": [
                             genesis_pool_id,
                             {
-                                "value": 40_000*MLT_COIN,
+                                "value": 40_000*ATOMS_PER_COIN,
                                 "staker": {
                                     "PublicKey": genesis_stake_public_key,
                                 },
@@ -268,7 +268,7 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
                     {
                         "Transfer": [
                             {
-                                "Coin": 100_000*MLT_COIN,
+                                "Coin": 100_000*ATOMS_PER_COIN,
                             },
                             "AnyoneCanSpend",
                         ],
@@ -341,7 +341,7 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
                         "CreateStakePool": [
                             new_pool_id,
                             {
-                                "value": 100_000*MLT_COIN,
+                                "value": 100_000*ATOMS_PER_COIN,
                                 "staker": {
                                     "PublicKey": new_stake_public_key,
                                 },
@@ -379,7 +379,7 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
             "CreateStakePool": [
                 new_pool_id,
                 {
-                    "value": 100_000*MLT_COIN,
+                    "value": 100_000*ATOMS_PER_COIN,
                     "staker": {
                         "PublicKey": new_stake_public_key,
                     },

--- a/test/functional/blockprod_generate_pos_genesis_blocks.py
+++ b/test/functional/blockprod_generate_pos_genesis_blocks.py
@@ -21,7 +21,7 @@ from test_framework.mintlayer import (
     base_tx_obj,
     block_input_data_obj,
     mintlayer_hash,
-    MLT_COIN,
+    ATOMS_PER_COIN,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -159,7 +159,7 @@ class GeneratePoSGenesisBlocksTest(BitcoinTestFramework):
                         "CreateStakePool": [
                             self.genesis_pool_id(),
                             {
-                                "value": 40_000*MLT_COIN,
+                                "value": 40_000*ATOMS_PER_COIN,
                                 "staker": {
                                     "PublicKey": self.stake_public_key(GENESIS_STAKE_PUBLIC_KEY),
                                 },

--- a/test/functional/blockprod_pos_pledge_incentives.py
+++ b/test/functional/blockprod_pos_pledge_incentives.py
@@ -23,7 +23,7 @@ from test_framework.mintlayer import (
     make_delegation_id,
     make_pool_id,
     hex_to_dec_array,
-    MLT_COIN,
+    ATOMS_PER_COIN,
     outpoint_obj,
     signed_tx_obj,
 )
@@ -405,7 +405,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
                         "CreateStakePool": [
                             self.genesis_pool_id(),
                             {
-                                "value": 40_000*MLT_COIN,
+                                "value": 40_000*ATOMS_PER_COIN,
                                 "staker": {
                                     "PublicKey": self.stake_public_key(GENESIS_STAKE_PUBLIC_KEY),
                                 },
@@ -424,7 +424,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
 
         (stake_sk_1, stake_pk_1) = self.new_stake_keys()
         (vrf_sk_1, vrf_pk_1) = self.new_vrf_keys()
-        pool_1_pledge = 40_000*MLT_COIN
+        pool_1_pledge = 40_000*ATOMS_PER_COIN
 
         genesis_kernel0_outpoint = {
             "id": {
@@ -433,7 +433,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
             "index": 0,
         }
         (pool_id_1, tx1_encoded, tx1_id) = self.create_pool_tx(
-            genesis_kernel0_outpoint, stake_pk_1, vrf_pk_1, pool_1_pledge, 1000, 400_000*MLT_COIN)
+            genesis_kernel0_outpoint, stake_pk_1, vrf_pk_1, pool_1_pledge, 1000, 400_000*ATOMS_PER_COIN)
 
         tx1_outpoint = {
             "id": {
@@ -442,7 +442,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
             "index": 1,
         }
         (delegation_id_1, tx2_encoded, tx2_id) = self.create_delegation_id_tx(
-            tx1_outpoint, pool_id_1, 400_000*MLT_COIN)
+            tx1_outpoint, pool_id_1, 400_000*ATOMS_PER_COIN)
 
         tx2_outpoint = {
             "id": {
@@ -451,7 +451,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
             "index": 1,
         }
         (tx3_encoded, tx3_id) = self.create_delegate_staking_tx(
-            tx2_outpoint, delegation_id_1, 160_000*MLT_COIN, 200_000*MLT_COIN)
+            tx2_outpoint, delegation_id_1, 160_000*ATOMS_PER_COIN, 200_000*ATOMS_PER_COIN)
 
         self.generate_and_submit_block(0, block_input_data, [
             tx1_encoded, tx2_encoded, tx3_encoded])
@@ -490,7 +490,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
 
         (stake_sk_2, stake_pk_2) = self.new_stake_keys()
         (vrf_sk_2, vrf_pk_2) = self.new_vrf_keys()
-        pool_2_pledge = 150_000*MLT_COIN
+        pool_2_pledge = 150_000*ATOMS_PER_COIN
 
         tx3_outpoint = {
             "id": {
@@ -500,7 +500,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
         }
 
         (pool_id_2, tx4_encoded, tx4_id) = self.create_pool_tx(
-            tx3_outpoint, stake_pk_2, vrf_pk_2, pool_2_pledge, 1000, 50_000*MLT_COIN)
+            tx3_outpoint, stake_pk_2, vrf_pk_2, pool_2_pledge, 1000, 50_000*ATOMS_PER_COIN)
 
         tx4_outpoint = {
             "id": {
@@ -509,7 +509,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
             "index": 1,
         }
         (delegation_id_2, tx5_encoded, tx5_id) = self.create_delegation_id_tx(
-            tx4_outpoint, pool_id_2, 50_000*MLT_COIN)
+            tx4_outpoint, pool_id_2, 50_000*ATOMS_PER_COIN)
 
         tx5_outpoint = {
             "id": {
@@ -518,7 +518,7 @@ class StakingIncentivesTest(BitcoinTestFramework):
             "index": 1,
         }
         (tx6_encoded, tx6_id) = self.create_delegate_staking_tx(
-            tx5_outpoint, delegation_id_2, 50_000*MLT_COIN, 0)
+            tx5_outpoint, delegation_id_2, 50_000*ATOMS_PER_COIN, 0)
 
         self.generate_and_submit_block(0, block_input_data, [
             tx4_encoded, tx5_encoded, tx6_encoded])

--- a/test/functional/test_framework/mintlayer.py
+++ b/test/functional/test_framework/mintlayer.py
@@ -19,7 +19,7 @@ import hashlib
 import scalecodec
 import time
 
-MLT_COIN = 100_000_000_000
+ATOMS_PER_COIN = 100_000_000_000
 
 base_tx_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('TransactionV1')
 block_header_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('BlockHeader')

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -35,7 +35,7 @@ from test_framework.mintlayer import (
     base_tx_obj,
     block_input_data_obj,
     mintlayer_hash,
-    MLT_COIN,
+    ATOMS_PER_COIN,
     outpoint_obj,
     signed_tx_obj,
 )
@@ -234,7 +234,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
                         "CreateStakePool": [
                             self.genesis_pool_id(),
                             {
-                                "value": 40_000*MLT_COIN,
+                                "value": 40_000*ATOMS_PER_COIN,
                                 "staker": {
                                     "PublicKey": self.stake_public_key(GENESIS_STAKE_PUBLIC_KEY),
                                 },
@@ -305,7 +305,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
             # Submit a valid transaction
             output = {
-                    'Transfer': [ { 'Coin': 50_000 * MLT_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+                    'Transfer': [ { 'Coin': 50_000 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
             self.log.debug(f"Encoded transaction {tx_id}: {encoded_tx}")

--- a/test/functional/wallet_get_address_usage.py
+++ b/test/functional/wallet_get_address_usage.py
@@ -25,7 +25,7 @@ Check that:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mintlayer import (MLT_COIN, make_tx, reward_input, tx_input)
+from test_framework.mintlayer import (ATOMS_PER_COIN, make_tx, reward_input, tx_input)
 from test_framework.util import assert_raises_rpc_error
 from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
 from test_framework.wallet_cli_controller import WalletCliController
@@ -98,7 +98,7 @@ class WalletGetAddressUsage(BitcoinTestFramework):
 
             # Submit a valid transaction
             output = {
-                    'Transfer': [ { 'Coin': 10 * MLT_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+                    'Transfer': [ { 'Coin': 10 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 

--- a/test/functional/wallet_high_fee.py
+++ b/test/functional/wallet_high_fee.py
@@ -29,7 +29,7 @@ Check that:
 from time import time
 import scalecodec
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mintlayer import (calc_tx_id, make_tx_dict, reward_input, tx_input, MLT_COIN, tx_output)
+from test_framework.mintlayer import (calc_tx_id, make_tx_dict, reward_input, tx_input, ATOMS_PER_COIN, tx_output)
 from test_framework.util import assert_raises_rpc_error
 from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
 from test_framework.wallet_cli_controller import WalletCliController
@@ -104,11 +104,11 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
             # Submit a valid transaction
             output = {
-                    'Transfer': [ { 'Coin': 10 * MLT_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+                    'Transfer': [ { 'Coin': 10 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
             }
             total = 300000
             output2 = {
-                'Transfer': [ { 'Coin': total * MLT_COIN }, { 'AnyoneCanSpend': None } ],
+                'Transfer': [ { 'Coin': total * ATOMS_PER_COIN }, { 'AnyoneCanSpend': None } ],
             }
             encoded_tx, tx_id = self.make_tx([reward_input(tip_id)], [output2, output], 0)
 

--- a/test/functional/wallet_nfts.py
+++ b/test/functional/wallet_nfts.py
@@ -28,7 +28,7 @@ Check that:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mintlayer import (make_tx, reward_input, tx_input, MLT_COIN)
+from test_framework.mintlayer import (make_tx, reward_input, tx_input, ATOMS_PER_COIN)
 from test_framework.util import assert_raises_rpc_error
 from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
 from test_framework.wallet_cli_controller import WalletCliController
@@ -90,7 +90,7 @@ class WalletNfts(BitcoinTestFramework):
 
             # Submit a valid transaction
             output = {
-                    'Transfer': [ { 'Coin': 1000 * MLT_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+                    'Transfer': [ { 'Coin': 1000 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 

--- a/test/functional/wallet_recover_accounts.py
+++ b/test/functional/wallet_recover_accounts.py
@@ -29,7 +29,7 @@ Check that:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mintlayer import (make_tx, reward_input, tx_input, MLT_COIN)
+from test_framework.mintlayer import (make_tx, reward_input, tx_input, ATOMS_PER_COIN)
 from test_framework.util import assert_raises_rpc_error
 from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
 from test_framework.wallet_cli_controller import DEFAULT_ACCOUNT_INDEX, WalletCliController
@@ -96,7 +96,7 @@ class WalletRecoverAccounts(BitcoinTestFramework):
 
             # Submit a valid transaction
             output = {
-                    'Transfer': [ { 'Coin': 10 * MLT_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+                    'Transfer': [ { 'Coin': 10 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 

--- a/test/functional/wallet_submit_tx.py
+++ b/test/functional/wallet_submit_tx.py
@@ -25,7 +25,7 @@ Check that:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mintlayer import (make_tx, reward_input, tx_input, MLT_COIN)
+from test_framework.mintlayer import (make_tx, reward_input, tx_input, ATOMS_PER_COIN)
 from test_framework.util import assert_raises_rpc_error
 from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
 from test_framework.wallet_cli_controller import WalletCliController
@@ -89,7 +89,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
             # Submit a valid transaction
             output = {
-                    'Transfer': [ { 'Coin': 10 * MLT_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+                    'Transfer': [ { 'Coin': 10 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -28,7 +28,7 @@ Check that:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mintlayer import (make_tx, reward_input, tx_input, MLT_COIN)
+from test_framework.mintlayer import (make_tx, reward_input, tx_input, ATOMS_PER_COIN)
 from test_framework.util import assert_raises_rpc_error
 from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
 from test_framework.wallet_cli_controller import WalletCliController
@@ -90,7 +90,7 @@ class WalletTokens(BitcoinTestFramework):
 
             # Submit a valid transaction
             output = {
-                    'Transfer': [ { 'Coin': 101 * MLT_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+                    'Transfer': [ { 'Coin': 101 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 


### PR DESCRIPTION
Two problems are solved in this PR:

1. The struct Mlt is renamed to CoinUnit, to keep the code coin-agnostic... this may be annoying in cases where we're dealing with testnet or similar. It should have a different ticker.

2. The ticker configuration is removed from that struct, because it should be different for different networks. It was being set as a constant everywhere. Now it comes from `ChainType`.

Closes #1178