### PR TITLE
Restrict building the lmdb crate to 64-bit only

### DIFF
--- a/storage/lmdb/src/lib.rs
+++ b/storage/lmdb/src/lib.rs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("LMDB only compiles for 64-bit targets due to the way memory mapping works");
+
 mod error;
 pub mod initial_map_size;
 pub mod memsize;


### PR DESCRIPTION
Since lmdb is the library with issues for 64-bit, we restrict it there. I'm not sure whether we should make a global restriction. In that case, we'll have to add this in all binaries.

Closes #1151