### PR TITLE
P2p crawler peers ban

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ name = "dns_server"
 version = "0.1.2"
 dependencies = [
  "async-trait",
+ "chainstate",
  "clap",
  "common",
  "crypto",

--- a/dns_server/Cargo.toml
+++ b/dns_server/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chainstate = { path = "../chainstate" }
 common = { path = "../common" }
 crypto = { path = "../crypto" }
 logging = { path = "../logging" }

--- a/dns_server/src/crawler_p2p/crawler/tests/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler/tests/mod.rs
@@ -570,6 +570,7 @@ fn dont_connect_to_initially_banned_peer(#[case] seed: Seed) {
     crawler.assert_banned_addresses(&[(node1.as_bannable(), ban_end_time)]);
 }
 
+// Check that a peer is banned on CrawlerEvent::ConnectionError.
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]

--- a/dns_server/src/crawler_p2p/crawler/tests/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler/tests/mod.rs
@@ -16,15 +16,19 @@
 mod mock_crawler;
 
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     time::Duration,
 };
 
-use common::primitives::user_agent::mintlayer_core_user_agent;
+use chainstate::ban_score::BanScore;
+use common::{
+    chain::ChainConfig,
+    primitives::{time::Time, user_agent::mintlayer_core_user_agent},
+};
 use p2p::{
-    config::NodeType,
-    error::{DialError, P2pError},
+    config::{BanDuration, BanThreshold, NodeType},
+    error::{DialError, P2pError, ProtocolError},
     net::types::PeerInfo,
     testing_utils::TEST_PROTOCOL_VERSION,
     types::{peer_id::PeerId, socket_address::SocketAddress},
@@ -41,6 +45,8 @@ use mock_crawler::test_crawler;
 
 use crate::crawler_p2p::crawler::CrawlerEvent;
 
+use super::CrawlerConfig;
+
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
@@ -49,7 +55,12 @@ fn basic(#[case] seed: Seed) {
     let node1: SocketAddress = "1.2.3.4:3031".parse().unwrap();
     let peer1 = PeerId::new();
     let chain_config = common::chain::config::create_mainnet();
-    let mut crawler = test_crawler(BTreeSet::new(), [node1].into_iter().collect());
+    let mut crawler = test_crawler(
+        make_config(),
+        BTreeSet::new(),
+        BTreeMap::new(),
+        [node1].into_iter().collect(),
+    );
 
     crawler.timer(Duration::from_secs(100), &mut rng);
     assert_eq!(crawler.pending_connects.len(), 1);
@@ -58,14 +69,7 @@ fn basic(#[case] seed: Seed) {
     crawler.step(
         CrawlerEvent::Connected {
             address: node1,
-            peer_info: PeerInfo {
-                peer_id: peer1,
-                protocol_version: TEST_PROTOCOL_VERSION,
-                network: *chain_config.magic_bytes(),
-                software_version: *chain_config.software_version(),
-                user_agent: mintlayer_core_user_agent(),
-                common_services: NodeType::DnsServer.into(),
-            },
+            peer_info: make_peer_info(peer1, &chain_config),
         },
         &mut rng,
     );
@@ -90,14 +94,7 @@ fn basic(#[case] seed: Seed) {
     crawler.step(
         CrawlerEvent::Connected {
             address: node2,
-            peer_info: PeerInfo {
-                peer_id: peer2,
-                protocol_version: TEST_PROTOCOL_VERSION,
-                network: *chain_config.magic_bytes(),
-                software_version: *chain_config.software_version(),
-                user_agent: mintlayer_core_user_agent(),
-                common_services: NodeType::DnsServer.into(),
-            },
+            peer_info: make_peer_info(peer2, &chain_config),
         },
         &mut rng,
     );
@@ -147,7 +144,7 @@ fn randomized(#[case] seed: Seed) {
     let loaded_count = rng.gen_range(0..10);
     let loaded_nodes = nodes.choose_multiple(&mut rng, loaded_count).cloned().collect();
 
-    let mut crawler = test_crawler(loaded_nodes, reserved_nodes);
+    let mut crawler = test_crawler(make_config(), loaded_nodes, BTreeMap::new(), reserved_nodes);
 
     for _ in 0..rng.gen_range(0..100000) {
         crawler.timer(Duration::from_secs(rng.gen_range(0..100)), &mut rng);
@@ -170,14 +167,7 @@ fn randomized(#[case] seed: Seed) {
             crawler.step(
                 CrawlerEvent::Connected {
                     address,
-                    peer_info: PeerInfo {
-                        peer_id: PeerId::new(),
-                        protocol_version: TEST_PROTOCOL_VERSION,
-                        network: *chain_config.magic_bytes(),
-                        software_version: *chain_config.software_version(),
-                        user_agent: mintlayer_core_user_agent(),
-                        common_services: NodeType::DnsServer.into(),
-                    },
+                    peer_info: make_peer_info(PeerId::new(), &chain_config),
                 },
                 &mut rng,
             )
@@ -189,14 +179,7 @@ fn randomized(#[case] seed: Seed) {
             crawler.step(
                 CrawlerEvent::Connected {
                     address,
-                    peer_info: PeerInfo {
-                        peer_id: PeerId::new(),
-                        protocol_version: TEST_PROTOCOL_VERSION,
-                        network: [255, 255, 255, 255],
-                        software_version: *chain_config.software_version(),
-                        user_agent: mintlayer_core_user_agent(),
-                        common_services: NodeType::DnsServer.into(),
-                    },
+                    peer_info: make_peer_info(PeerId::new(), &chain_config),
                 },
                 &mut rng,
             )
@@ -230,13 +213,18 @@ fn incompatible_node(#[case] seed: Seed) {
     let node1: SocketAddress = "1.2.3.4:3031".parse().unwrap();
     let peer1 = PeerId::new();
     let chain_config = common::chain::config::create_mainnet();
-    let mut crawler = test_crawler(BTreeSet::new(), [node1].into_iter().collect());
+    let mut crawler = test_crawler(
+        make_config(),
+        BTreeSet::new(),
+        BTreeMap::new(),
+        [node1].into_iter().collect(),
+    );
 
-    // // Crawler attempts to connect to the specified node
+    // Crawler attempts to connect to the specified node
     crawler.timer(Duration::from_secs(100), &mut rng);
     assert!(crawler.pending_connects.contains(&node1));
 
-    // // Connection to the node is successful
+    // Connection to the node is successful
     crawler.step(
         CrawlerEvent::Connected {
             address: node1,
@@ -264,7 +252,9 @@ fn long_offline(#[case] seed: Seed) {
     let loaded_node: SocketAddress = "1.0.0.0:3031".parse().unwrap();
     let added_node: SocketAddress = "2.0.0.0:3031".parse().unwrap();
     let mut crawler = test_crawler(
+        make_config(),
         [loaded_node].into_iter().collect(),
+        BTreeMap::new(),
         [added_node].into_iter().collect(),
     );
     assert!(crawler.persistent.contains(&loaded_node));
@@ -298,4 +288,368 @@ fn long_offline(#[case] seed: Seed) {
     assert!(!crawler.connect_requests.iter().any(|addr| *addr == loaded_node));
     assert!(crawler.connect_requests.iter().any(|addr| *addr == added_node));
     crawler.connect_requests.clear();
+}
+
+// Connect to two peers and then send CrawlerEvent::Misbehaved for one of them several times,
+// making sure that the ban score is updated accordingly and that eventually the peer is banned.
+// Also check that we don't reconnect to the banned peer until the ban end is reached.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn ban_misbehaved_peer(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let node1: SocketAddress = "1.2.3.4:1234".parse().unwrap();
+    let peer1 = PeerId::new();
+    let node2: SocketAddress = "2.3.4.5:2345".parse().unwrap();
+    let peer2 = PeerId::new();
+
+    let test_error = P2pError::ProtocolError(ProtocolError::UnexpectedMessage("".to_owned()));
+    let test_error_ban_score = test_error.ban_score();
+    assert!(test_error_ban_score > 0);
+    let ban_threshold = test_error_ban_score * 2;
+
+    let chain_config = common::chain::config::create_mainnet();
+    let mut crawler = test_crawler(
+        CrawlerConfig {
+            ban_duration: BanDuration::new(BAN_DURATION),
+            ban_threshold: BanThreshold::new(ban_threshold),
+        },
+        BTreeSet::new(),
+        BTreeMap::new(),
+        [node1, node2].into_iter().collect(),
+    );
+
+    let times_step = Duration::from_secs(100);
+
+    crawler.timer(times_step, &mut rng);
+
+    crawler.assert_pending_connects(&[node1, node2]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[]);
+
+    crawler.step(
+        CrawlerEvent::Connected {
+            address: node1,
+            peer_info: make_peer_info(peer1, &chain_config),
+        },
+        &mut rng,
+    );
+
+    crawler.step(
+        CrawlerEvent::Connected {
+            address: node2,
+            peer_info: make_peer_info(peer2, &chain_config),
+        },
+        &mut rng,
+    );
+
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer1, peer2]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[]);
+
+    crawler.step(
+        CrawlerEvent::Misbehaved {
+            peer_id: peer1,
+            error: test_error.clone(),
+        },
+        &mut rng,
+    );
+
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer1, peer2]);
+    crawler.assert_ban_scores(&[(peer1, test_error_ban_score)]);
+    crawler.assert_banned_addresses(&[]);
+
+    let ban_start_time = crawler.now();
+    let ban_end_time = (ban_start_time + BAN_DURATION).unwrap();
+
+    crawler.step(
+        CrawlerEvent::Misbehaved {
+            peer_id: peer1,
+            error: test_error,
+        },
+        &mut rng,
+    );
+
+    // The peer is banned.
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[peer1]);
+    crawler.assert_connected_peers(&[peer1, peer2]);
+    crawler.assert_ban_scores(&[(peer1, test_error_ban_score * 2)]);
+    crawler.assert_banned_addresses(&[(node1.as_bannable(), ban_end_time)]);
+
+    crawler.step(CrawlerEvent::Disconnected { peer_id: peer1 }, &mut rng);
+
+    // The peer has become disconnected and its ban score was lost. But it's still banned.
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer2]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[(node1.as_bannable(), ban_end_time)]);
+
+    // Wait some (small) time, the peer should still be banned.
+    crawler.timer(times_step, &mut rng);
+
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer2]);
+    crawler.assert_ban_scores(&[(peer1, test_error_ban_score * 10)]);
+    crawler.assert_banned_addresses(&[(node1.as_bannable(), ban_end_time)]);
+
+    // Sanity check
+    assert!(crawler.now() < ban_end_time);
+
+    // Wait for the remaining ban time.
+    crawler.timer((ban_end_time - crawler.now()).unwrap(), &mut rng);
+
+    // The peer is no longer banned; instead, it is being connected to.
+    crawler.assert_pending_connects(&[node1]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer2]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[]);
+}
+
+// Connect to three peers, where two of them share the same ip address, and then send
+// CrawlerEvent::Misbehaved for one of those. Make sure that both peers get disconnected and
+// no connect attempts are made until the ban end is reached.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn ban_misbehaved_peers_with_same_address(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let node1: SocketAddress = "1.2.3.4:1234".parse().unwrap();
+    let peer1 = PeerId::new();
+    let node2: SocketAddress = "2.3.4.5:2345".parse().unwrap();
+    let peer2 = PeerId::new();
+    let node3: SocketAddress = "1.2.3.4:4321".parse().unwrap();
+    let peer3 = PeerId::new();
+
+    assert_eq!(node3.as_bannable(), node1.as_bannable());
+
+    let test_error = P2pError::ProtocolError(ProtocolError::UnexpectedMessage("".to_owned()));
+    let test_error_ban_score = test_error.ban_score();
+    assert!(test_error_ban_score > 0);
+    let ban_threshold = test_error_ban_score;
+
+    let chain_config = common::chain::config::create_mainnet();
+    let mut crawler = test_crawler(
+        CrawlerConfig {
+            ban_duration: BanDuration::new(BAN_DURATION),
+            ban_threshold: BanThreshold::new(ban_threshold),
+        },
+        BTreeSet::new(),
+        BTreeMap::new(),
+        [node1, node2, node3].into_iter().collect(),
+    );
+
+    let times_step = Duration::from_secs(100);
+
+    crawler.timer(times_step, &mut rng);
+
+    crawler.assert_pending_connects(&[node1, node2, node3]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[]);
+
+    crawler.step(
+        CrawlerEvent::Connected {
+            address: node1,
+            peer_info: make_peer_info(peer1, &chain_config),
+        },
+        &mut rng,
+    );
+
+    crawler.step(
+        CrawlerEvent::Connected {
+            address: node2,
+            peer_info: make_peer_info(peer2, &chain_config),
+        },
+        &mut rng,
+    );
+
+    crawler.step(
+        CrawlerEvent::Connected {
+            address: node3,
+            peer_info: make_peer_info(peer3, &chain_config),
+        },
+        &mut rng,
+    );
+
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer1, peer2, peer3]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[]);
+
+    let ban_start_time = crawler.now();
+    let ban_end_time = (ban_start_time + BAN_DURATION).unwrap();
+
+    crawler.step(
+        CrawlerEvent::Misbehaved {
+            peer_id: peer1,
+            error: test_error.clone(),
+        },
+        &mut rng,
+    );
+
+    // The peer1's address is banned; peer1 and peer3 are being disconnected.
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[peer1, peer3]);
+    crawler.assert_connected_peers(&[peer1, peer2, peer3]);
+    crawler.assert_ban_scores(&[(peer1, test_error_ban_score)]);
+    crawler.assert_banned_addresses(&[(node1.as_bannable(), ban_end_time)]);
+
+    crawler.step(CrawlerEvent::Disconnected { peer_id: peer1 }, &mut rng);
+    crawler.step(CrawlerEvent::Disconnected { peer_id: peer3 }, &mut rng);
+
+    // peer1 and peer3 are now disconnected; the ban score was lost, but the address is still banned.
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer2]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[(node1.as_bannable(), ban_end_time)]);
+
+    // Wait some (small) time, the address should still be banned.
+    crawler.timer(times_step, &mut rng);
+
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer2]);
+    crawler.assert_ban_scores(&[(peer1, test_error_ban_score * 10)]);
+    crawler.assert_banned_addresses(&[(node1.as_bannable(), ban_end_time)]);
+
+    // Sanity check
+    assert!(crawler.now() < ban_end_time);
+
+    // Wait for the remaining ban time.
+    crawler.timer((ban_end_time - crawler.now()).unwrap(), &mut rng);
+
+    // The address is no longer banned; instead, both peer1 and peer3 are being connected to.
+    crawler.assert_pending_connects(&[node1, node3]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer2]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[]);
+}
+
+// Create a crawler with 2 addresses and mark one of them as banned.
+// Make sure it doesn't try to connect to the banned address.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn dont_connect_to_initially_banned_peer(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let node1: SocketAddress = "1.2.3.4:1234".parse().unwrap();
+    let node2: SocketAddress = "2.3.4.5:2345".parse().unwrap();
+
+    let ban_end_time = Time::from_duration_since_epoch(BAN_DURATION);
+
+    let mut crawler = test_crawler(
+        make_config(),
+        BTreeSet::new(),
+        [(node1.as_bannable(), ban_end_time)].into_iter().collect(),
+        [node1, node2].into_iter().collect(),
+    );
+
+    crawler.timer(Duration::from_secs(100), &mut rng);
+
+    crawler.assert_pending_connects(&[node2]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[(node1.as_bannable(), ban_end_time)]);
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn ban_on_connection_error(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let node1: SocketAddress = "1.2.3.4:1234".parse().unwrap();
+    let peer1 = PeerId::new();
+    let node2: SocketAddress = "2.3.4.5:2345".parse().unwrap();
+
+    let test_error = P2pError::ProtocolError(ProtocolError::HandshakeExpected);
+    let test_error_ban_score = test_error.ban_score();
+    assert!(test_error_ban_score > 0);
+    let ban_threshold = test_error_ban_score;
+
+    let chain_config = common::chain::config::create_mainnet();
+    let mut crawler = test_crawler(
+        CrawlerConfig {
+            ban_duration: BanDuration::new(BAN_DURATION),
+            ban_threshold: BanThreshold::new(ban_threshold),
+        },
+        BTreeSet::new(),
+        BTreeMap::new(),
+        [node1, node2].into_iter().collect(),
+    );
+
+    let times_step = Duration::from_secs(100);
+
+    crawler.timer(times_step, &mut rng);
+
+    crawler.assert_pending_connects(&[node1, node2]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[]);
+
+    crawler.step(
+        CrawlerEvent::Connected {
+            address: node1,
+            peer_info: make_peer_info(peer1, &chain_config),
+        },
+        &mut rng,
+    );
+
+    crawler.step(
+        CrawlerEvent::ConnectionError {
+            address: node2,
+            error: test_error,
+        },
+        &mut rng,
+    );
+
+    let ban_start_time = crawler.now();
+    let ban_end_time = (ban_start_time + BAN_DURATION).unwrap();
+
+    // The ban score is not recorded, but the peer is banned.
+    crawler.assert_pending_connects(&[]);
+    crawler.assert_pending_disconnects(&[]);
+    crawler.assert_connected_peers(&[peer1]);
+    crawler.assert_ban_scores(&[]);
+    crawler.assert_banned_addresses(&[(node2.as_bannable(), ban_end_time)]);
+}
+
+const BAN_DURATION: Duration = Duration::from_secs(1000);
+const BAN_THRESHOLD: u32 = 100;
+
+fn make_config() -> CrawlerConfig {
+    CrawlerConfig {
+        ban_duration: BanDuration::new(BAN_DURATION),
+        ban_threshold: BanThreshold::new(BAN_THRESHOLD),
+    }
+}
+
+fn make_peer_info(peer_id: PeerId, chain_config: &ChainConfig) -> PeerInfo {
+    PeerInfo {
+        peer_id,
+        protocol_version: TEST_PROTOCOL_VERSION,
+        network: *chain_config.magic_bytes(),
+        software_version: *chain_config.software_version(),
+        user_agent: mintlayer_core_user_agent(),
+        common_services: NodeType::DnsServer.into(),
+    }
 }

--- a/dns_server/src/crawler_p2p/crawler_manager/storage.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/storage.rs
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common::primitives::time::Time;
 use p2p::peer_manager::peerdb_common::{TransactionRo, TransactionRw, Transactional};
 
 pub trait DnsServerStorageRead {
     fn get_version(&self) -> Result<Option<u32>, storage::Error>;
 
     fn get_addresses(&self) -> Result<Vec<String>, storage::Error>;
+
+    fn get_banned_addresses(&self) -> Result<Vec<(String, Time)>, storage::Error>;
 }
 
 pub trait DnsServerStorageWrite {
@@ -27,6 +30,10 @@ pub trait DnsServerStorageWrite {
     fn add_address(&mut self, address: &str) -> Result<(), storage::Error>;
 
     fn del_address(&mut self, address: &str) -> Result<(), storage::Error>;
+
+    fn add_banned_address(&mut self, address: &str, time: Time) -> Result<(), storage::Error>;
+
+    fn del_banned_address(&mut self, address: &str) -> Result<(), storage::Error>;
 }
 
 // Note: here we want to say something like:

--- a/dns_server/src/crawler_p2p/crawler_manager/tests/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/tests/mod.rs
@@ -17,12 +17,17 @@ mod mock_manager;
 
 use std::time::Duration;
 
-use p2p::{peer_manager::peerdb_common::Transactional, types::socket_address::SocketAddress};
+use chainstate::ban_score::BanScore;
+use p2p::{
+    config::{BanDuration, BanThreshold},
+    types::socket_address::SocketAddress,
+};
+use p2p_test_utils::{assert_no_value_in_channel, get_value_from_channel};
 
 use crate::{
-    crawler_p2p::crawler_manager::{
-        storage::DnsServerStorageRead,
-        tests::mock_manager::{advance_time, test_crawler},
+    crawler_p2p::crawler_manager::tests::mock_manager::{
+        advance_time, assert_banned_addresses, assert_known_addresses,
+        erratic_node_connection_error, test_crawler,
     },
     dns_server::DnsServerCommand,
 };
@@ -36,7 +41,7 @@ async fn basic() {
     state.node_online(node1);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node1.socket_addr().ip())
     );
 
@@ -44,7 +49,7 @@ async fn basic() {
     state.node_offline(node1);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::DelAddress(node1.socket_addr().ip())
     );
 }
@@ -67,7 +72,7 @@ async fn long_offline() {
     state.node_online(node1);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 24 * 60).await;
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node1.socket_addr().ip())
     );
 }
@@ -85,29 +90,25 @@ async fn announced_online() {
 
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node1.socket_addr().ip())
     );
 
     state.announce_address(node1, node2);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node2.socket_addr().ip())
     );
 
     state.announce_address(node2, node3);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node3.socket_addr().ip())
     );
 
-    let addresses = crawler.storage.transaction_ro().unwrap().get_addresses().unwrap();
-    assert_eq!(
-        addresses,
-        vec![node1.to_string(), node2.to_string(), node3.to_string()]
-    );
+    assert_known_addresses(&crawler, &[node1, node2, node3]);
 }
 
 #[tokio::test]
@@ -120,7 +121,7 @@ async fn announced_offline() {
 
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 60).await;
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node1.socket_addr().ip())
     );
     assert_eq!(state.connection_attempts.lock().unwrap().len(), 1);
@@ -135,7 +136,7 @@ async fn announced_offline() {
     state.announce_address(node1, node2);
     advance_time(&mut crawler, &time_getter, Duration::from_secs(60), 24 * 60).await;
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node2.socket_addr().ip())
     );
     assert_eq!(state.connection_attempts.lock().unwrap().len(), 3);
@@ -163,26 +164,117 @@ async fn private_ip() {
 
     // Check that only nodes with public addresses and on the default port are added to DNS
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node1.socket_addr().ip())
     );
     assert_eq!(
-        command_rx.recv().await.unwrap(),
+        get_value_from_channel(&mut command_rx).await.unwrap(),
         DnsServerCommand::AddAddress(node2.socket_addr().ip())
     );
-    assert!(command_rx.try_recv().is_err());
+    assert_no_value_in_channel(&mut command_rx).await;
 
     // Check that all reachable nodes are stored in the DB
-    let mut addresses = crawler.storage.transaction_ro().unwrap().get_addresses().unwrap();
-    let mut addresses_expected = vec![
-        node1.to_string(),
-        node2.to_string(),
-        node3.to_string(),
-        node4.to_string(),
-        node5.to_string(),
-        node6.to_string(),
-    ];
-    addresses.sort();
-    addresses_expected.sort();
-    assert_eq!(addresses, addresses_expected);
+    assert_known_addresses(&crawler, &[node1, node2, node3, node4, node5, node6]);
+}
+
+#[tokio::test]
+async fn ban_unban() {
+    let node1: SocketAddress = "1.2.3.4:3031".parse().unwrap();
+    let node2: SocketAddress = "2.3.4.5:3031".parse().unwrap();
+    let node3: SocketAddress = "3.4.5.6:3031".parse().unwrap();
+
+    let (mut crawler, state, mut command_rx, time_getter) = test_crawler(vec![node1, node2, node3]);
+
+    // Sanity check
+    assert!(erratic_node_connection_error().ban_score() >= *BanThreshold::default());
+
+    let ban_duration = *BanDuration::default();
+
+    state.node_online(node1);
+    state.erratic_node_online(node2);
+    state.node_online(node3);
+
+    let time_step = Duration::from_secs(60);
+
+    advance_time(&mut crawler, &time_getter, time_step, 1).await;
+
+    let node2_ban_end_time = (time_getter.get_time_getter().get_time() + ban_duration).unwrap();
+
+    // Only normal nodes are added to DNS
+    assert_eq!(
+        get_value_from_channel(&mut command_rx).await.unwrap(),
+        DnsServerCommand::AddAddress(node1.socket_addr().ip())
+    );
+    assert_eq!(
+        get_value_from_channel(&mut command_rx).await.unwrap(),
+        DnsServerCommand::AddAddress(node3.socket_addr().ip())
+    );
+    assert_no_value_in_channel(&mut command_rx).await;
+
+    // node2 is banned
+    assert_banned_addresses(&crawler, &[(node2.as_bannable(), node2_ban_end_time)]);
+
+    advance_time(&mut crawler, &time_getter, time_step, 1).await;
+
+    // Report misbehavior for node1; the passed error has big enough ban score, so the node should
+    // be banned immediately.
+    state.report_misbehavior(node1, erratic_node_connection_error());
+
+    advance_time(&mut crawler, &time_getter, time_step, 1).await;
+
+    let node1_ban_end_time = (time_getter.get_time_getter().get_time() + ban_duration).unwrap();
+
+    // Check that it's been removed from DNS.
+    assert_eq!(
+        get_value_from_channel(&mut command_rx).await.unwrap(),
+        DnsServerCommand::DelAddress(node1.socket_addr().ip())
+    );
+
+    // Both bad nodes are now banned.
+    assert_banned_addresses(
+        &crawler,
+        &[
+            (node1.as_bannable(), node1_ban_end_time),
+            (node2.as_bannable(), node2_ban_end_time),
+        ],
+    );
+
+    // Node 2 comes online again and now it'll behave correctly. This shouldn't have any immediate effect though.
+    state.node_offline(node2);
+    state.node_online(node2);
+
+    // Wait some more time, the nodes should still be banned.
+    advance_time(&mut crawler, &time_getter, time_step, 1).await;
+    assert_banned_addresses(
+        &crawler,
+        &[
+            (node1.as_bannable(), node1_ban_end_time),
+            (node2.as_bannable(), node2_ban_end_time),
+        ],
+    );
+    assert_no_value_in_channel(&mut command_rx).await;
+
+    // Wait enough time for node2 to be unbanned.
+    let time_until_node2_unban =
+        (node2_ban_end_time - time_getter.get_time_getter().get_time()).unwrap();
+    advance_time(&mut crawler, &time_getter, time_until_node2_unban, 1).await;
+
+    // node2 is no longer banned; its address has been added to DNS.
+    assert_banned_addresses(&crawler, &[(node1.as_bannable(), node1_ban_end_time)]);
+    assert_eq!(
+        get_value_from_channel(&mut command_rx).await.unwrap(),
+        DnsServerCommand::AddAddress(node2.socket_addr().ip())
+    );
+
+    // Wait enough time for node1 to be unbanned.
+    let time_until_node1_unban =
+        (node1_ban_end_time - time_getter.get_time_getter().get_time()).unwrap();
+    advance_time(&mut crawler, &time_getter, time_until_node1_unban, 1).await;
+
+    // node1 is no longer banned; its address has been added to DNS.
+    assert_banned_addresses(&crawler, &[]);
+    assert_eq!(
+        get_value_from_channel(&mut command_rx).await.unwrap(),
+        DnsServerCommand::AddAddress(node1.socket_addr().ip())
+    );
 }

--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -31,6 +31,8 @@ use p2p::{
 use utils::atomics::SeqCstAtomicBool;
 use utils::default_data_dir::{default_data_dir_for_chain, prepare_data_dir};
 
+use crate::crawler_p2p::crawler::CrawlerConfig;
+
 mod config;
 mod crawler_p2p;
 mod dns_server;
@@ -107,13 +109,19 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<Never, error::DnsServerErro
         Default::default(),
     ))?;
 
-    let crawler_config = CrawlerManagerConfig {
+    let crawler_mgr_config = CrawlerManagerConfig {
         reserved_nodes: config.reserved_node.clone(),
         default_p2p_port: chain_config.p2p_port(),
     };
 
+    let crawler_config = CrawlerConfig {
+        ban_duration: p2p_config.ban_duration.clone(),
+        ban_threshold: p2p_config.ban_threshold.clone(),
+    };
+
     let mut crawler_manager = CrawlerManager::<p2p::P2pNetworkingService, _>::new(
         time_getter,
+        crawler_mgr_config,
         crawler_config,
         chain_config,
         conn,

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -121,10 +121,8 @@ pub struct P2pConfig {
     pub max_message_size: MaxMessageSize,
     /// A maximum number of announcements (hashes) for which we haven't receive transactions.
     pub max_peer_tx_announcements: MaxPeerTxAnnouncements,
-    /// A maximum number of singular unconnected headers that a peer can send before
+    /// A maximum number of singular unconnected headers that a V1 peer can send before
     /// it will be considered malicious.
-    // TODO: this is a legacy behavior that should be removed in the protocol v2.
-    // See the issue #1110.
     pub max_singular_unconnected_headers: MaxUnconnectedHeaders,
     /// A timeout after which a peer is disconnected.
     pub sync_stalling_timeout: SyncStallingTimeout,

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -22,6 +22,7 @@ mod utils;
 
 use std::{sync::Arc, time::Duration};
 
+use p2p_test_utils::expect_recv;
 use tokio::sync::{mpsc, oneshot};
 
 use ::utils::atomics::SeqCstAtomicBool;
@@ -35,7 +36,6 @@ use tokio::{
 };
 
 use crate::{
-    expect_recv,
     interface::types::ConnectedPeer,
     message::{PeerManagerMessage, PingRequest, PingResponse},
     net::{

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -16,12 +16,11 @@
 use std::{sync::Arc, time::Duration};
 
 use common::{chain::config, primitives::user_agent::mintlayer_core_user_agent};
-use p2p_test_utils::P2pBasicTestTimeGetter;
+use p2p_test_utils::{expect_recv, P2pBasicTestTimeGetter};
 use test_utils::{assert_matches, assert_matches_return_val};
 
 use crate::{
     config::{NodeType, P2pConfig},
-    expect_recv,
     message::{PeerManagerMessage, PingRequest, PingResponse},
     net::{
         default_backend::{

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -17,12 +17,12 @@ use common::{chain::GenBlock, primitives::Id};
 use crypto::random::Rng;
 use futures::{future::select_all, FutureExt};
 use logging::log;
+use p2p_test_utils::LONG_TIMEOUT;
 use p2p_types::PeerId;
 use tokio::time;
 
 use crate::{
     message::{SyncMessage, TransactionResponse},
-    sync::tests::helpers::LONG_TIMEOUT,
     PeerManagerEvent,
 };
 

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -225,17 +225,6 @@ pub fn peerdb_inmemory_store() -> PeerDbStorageImpl<storage::inmemory::InMemory>
     PeerDbStorageImpl::new(storage).unwrap()
 }
 
-/// Receive a message from the tokio channel.
-/// Panics if the channel is closed or no message received in 10 seconds.
-#[macro_export]
-macro_rules! expect_recv {
-    // Implemented as a macro until #[track_caller] works correctly with async functions
-    // (needed to print the caller location if unwraps fail)
-    ($x:expr) => {
-        tokio::time::timeout(Duration::from_secs(10), $x.recv()).await.unwrap().unwrap()
-    };
-}
-
 pub fn test_p2p_config() -> P2pConfig {
     P2pConfig {
         bind_addresses: Default::default(),


### PR DESCRIPTION
Network crawler now bans misbehaving peers, similar to how it's done in `PeerManager`.