### PR TITLE
Introduce `PoSChainConfigBuilder` and change maturity distances for Testnet

### DIFF
--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{num::NonZeroU64, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use chainstate::{ChainstateError, ChainstateHandle, GenBlockIndex, PropertyQueryError};
 use common::{
@@ -22,8 +22,8 @@ use common::{
         config::{create_testnet, create_unit_test_config, Builder, ChainType},
         stakelock::StakePoolData,
         transaction::TxInput,
-        ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades, OutPointSourceId,
-        PoSChainConfig, PoSConsensusVersion, PoolId, RequiredConsensus, TxOutput, UpgradeVersion,
+        ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades, OutPointSourceId, PoolId,
+        RequiredConsensus, TxOutput, UpgradeVersion,
     },
     primitives::{per_thousand::PerThousand, time, Amount, BlockHeight, Id, H256},
     time_getter::TimeGetter,
@@ -233,6 +233,7 @@ mod collect_transactions {
 }
 
 mod produce_block {
+    use common::chain::PoSChainConfigBuilder;
     use utils::atomics::SeqCstAtomicU64;
 
     use super::*;
@@ -1252,16 +1253,7 @@ mod produce_block {
                 vec![kernel_input_utxo.clone()],
             );
 
-            let easy_pos_config = PoSChainConfig::new(
-                Uint256::MAX,
-                NonZeroU64::new(2 * 60).expect("cannot be 0").into(),
-                2000.into(),
-                2000.into(),
-                5,
-                PerThousand::new(1).expect("must be valid"),
-                PoSConsensusVersion::V1,
-            )
-            .expect("Valid PoS config values");
+            let easy_pos_config = PoSChainConfigBuilder::new_for_unit_test().build();
 
             let consensus_types = vec![
                 ConsensusUpgrade::IgnoreConsensus,

--- a/blockprod/src/lib.rs
+++ b/blockprod/src/lib.rs
@@ -126,9 +126,10 @@ mod tests {
         chain::{
             block::timestamp::BlockTimestamp,
             config::{create_unit_test_config, Builder, ChainConfig, ChainType},
-            create_unittest_pos_config, pos_initial_difficulty,
+            pos_initial_difficulty,
             stakelock::StakePoolData,
-            Block, ConsensusUpgrade, Destination, Genesis, NetUpgrades, TxOutput, UpgradeVersion,
+            Block, ConsensusUpgrade, Destination, Genesis, NetUpgrades, PoSChainConfigBuilder,
+            TxOutput, UpgradeVersion,
         },
         primitives::{per_thousand::PerThousand, Amount, BlockHeight, H256},
         time_getter::TimeGetter,
@@ -305,7 +306,7 @@ mod tests {
                     BlockHeight::new(1),
                     UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                         initial_difficulty: Some(pos_initial_difficulty(ChainType::Regtest).into()),
-                        config: create_unittest_pos_config(),
+                        config: PoSChainConfigBuilder::new_for_unit_test().build(),
                     }),
                 ),
             ])

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -23,7 +23,6 @@ use common::{
     chain::{
         block::{consensus_data::PoSData, timestamp::BlockTimestamp, BlockRewardTransactable},
         config::{create_unit_test_config, Builder as ConfigBuilder, ChainType, EpochIndex},
-        create_unittest_pos_config,
         output_value::OutputValue,
         signature::{
             inputsig::{standard_signature::StandardInputSignature, InputWitness},
@@ -32,8 +31,8 @@ use common::{
         stakelock::StakePoolData,
         tokens::{TokenData, TokenTransfer},
         Block, ChainConfig, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis,
-        NetUpgrades, OutPointSourceId, PoSChainConfig, PoolId, RequiredConsensus, TxInput,
-        TxOutput, UpgradeVersion, UtxoOutPoint,
+        NetUpgrades, OutPointSourceId, PoSChainConfig, PoSChainConfigBuilder, PoolId,
+        RequiredConsensus, TxInput, TxOutput, UpgradeVersion, UtxoOutPoint,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Compact, Id, Idable, H256},
     Uint256,
@@ -360,7 +359,7 @@ pub fn create_chain_config_with_staking_pool(
             BlockHeight::new(1),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                 initial_difficulty: Some(Uint256::MAX.into()),
-                config: create_unittest_pos_config(),
+                config: PoSChainConfigBuilder::new_for_unit_test().build(),
             }),
         ),
     ];

--- a/chainstate/test-suite/src/tests/pos_maturity_settings.rs
+++ b/chainstate/test-suite/src/tests/pos_maturity_settings.rs
@@ -21,10 +21,10 @@ use common::{
     chain::{
         config::Builder as ConfigBuilder, output_value::OutputValue, stakelock::StakePoolData,
         timelock::OutputTimeLock, AccountNonce, AccountOutPoint, AccountSpending, ConsensusUpgrade,
-        Destination, NetUpgrades, OutPointSourceId, PoSChainConfig, PoSConsensusVersion, TxInput,
-        TxOutput, UpgradeVersion, UtxoOutPoint,
+        Destination, NetUpgrades, OutPointSourceId, PoSChainConfigBuilder, TxInput, TxOutput,
+        UpgradeVersion, UtxoOutPoint,
     },
-    primitives::{per_thousand::PerThousand, Amount, BlockHeight, Idable},
+    primitives::{per_thousand::PerThousand, Amount, BlockDistance, BlockHeight, Idable},
     Uint256,
 };
 use crypto::{
@@ -51,32 +51,18 @@ fn decommission_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
             BlockHeight::new(1),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                 initial_difficulty: Some(Uint256::MAX.into()),
-                config: PoSChainConfig::new(
-                    Uint256::MAX,
-                    1,
-                    100.into(),
-                    1.into(),
-                    5,
-                    PerThousand::new(100).unwrap(),
-                    PoSConsensusVersion::V1,
-                )
-                .unwrap(),
+                config: PoSChainConfigBuilder::new_for_unit_test()
+                    .decommission_maturity_distance(BlockDistance::new(100))
+                    .build(),
             }),
         ),
         (
             BlockHeight::new(3),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                 initial_difficulty: None,
-                config: PoSChainConfig::new(
-                    Uint256::MAX,
-                    1,
-                    50.into(), // decrease maturity setting
-                    1.into(),
-                    5,
-                    PerThousand::new(100).unwrap(),
-                    PoSConsensusVersion::V1,
-                )
-                .unwrap(),
+                config: PoSChainConfigBuilder::new_for_unit_test()
+                    .decommission_maturity_distance(BlockDistance::new(50))
+                    .build(),
             }),
         ),
     ];
@@ -201,32 +187,19 @@ fn spend_share_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
             BlockHeight::new(1),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                 initial_difficulty: Some(Uint256::MAX.into()),
-                config: PoSChainConfig::new(
-                    Uint256::MAX,
-                    1,
-                    1.into(),
-                    100.into(),
-                    5,
-                    PerThousand::new(100).unwrap(),
-                    PoSConsensusVersion::V1,
-                )
-                .unwrap(),
+                config: PoSChainConfigBuilder::new_for_unit_test()
+                    .spend_share_maturity_distance(BlockDistance::new(100))
+                    .build(),
             }),
         ),
         (
             BlockHeight::new(3),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                 initial_difficulty: None,
-                config: PoSChainConfig::new(
-                    Uint256::MAX,
-                    1,
-                    1.into(),
-                    50.into(), // decrease maturity setting
-                    5,
-                    PerThousand::new(100).unwrap(),
-                    PoSConsensusVersion::V1,
-                )
-                .unwrap(),
+                config: PoSChainConfigBuilder::new_for_unit_test()
+                    // decrease maturity setting
+                    .spend_share_maturity_distance(BlockDistance::new(50))
+                    .build(),
             }),
         ),
     ];

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/constraints_accumulator.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/constraints_accumulator.rs
@@ -207,11 +207,10 @@ mod tests {
         chain::{
             config::ChainType, output_value::OutputValue, stakelock::StakePoolData,
             timelock::OutputTimeLock, AccountNonce, AccountSpending, ConsensusUpgrade,
-            DelegationId, Destination, NetUpgrades, OutPointSourceId, PoSChainConfig,
-            PoSConsensusVersion, PoolId, TxOutput, UpgradeVersion, UtxoOutPoint,
+            DelegationId, Destination, NetUpgrades, OutPointSourceId, PoSChainConfigBuilder,
+            PoolId, TxOutput, UpgradeVersion, UtxoOutPoint,
         },
         primitives::{per_thousand::PerThousand, Amount, Id, H256},
-        Uint256,
     };
     use crypto::{
         random::{CryptoRng, Rng},
@@ -426,16 +425,10 @@ mod tests {
             BlockHeight::new(0),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                 initial_difficulty: None,
-                config: PoSChainConfig::new(
-                    Uint256::MAX,
-                    1,
-                    required_decommission_maturity.into(),
-                    required_spend_share_maturity.into(),
-                    2,
-                    PerThousand::new(0).unwrap(),
-                    PoSConsensusVersion::V1,
-                )
-                .unwrap(),
+                config: PoSChainConfigBuilder::new_for_unit_test()
+                    .decommission_maturity_distance(required_decommission_maturity.into())
+                    .spend_share_maturity_distance(required_spend_share_maturity.into())
+                    .build(),
             }),
         )];
         let net_upgrades = NetUpgrades::initialize(upgrades).expect("valid net-upgrades");

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -21,7 +21,9 @@ use crate::{
             create_mainnet_genesis, create_testnet_genesis, create_unit_test_genesis,
             emission_schedule, ChainConfig, ChainType, EmissionScheduleTabular,
         },
-        create_testnet_pos_config, get_initial_randomness, pos_initial_difficulty,
+        get_initial_randomness,
+        pos::config_builder::PoSChainConfigBuilder,
+        pos_initial_difficulty,
         pow::PoWChainConfigBuilder,
         CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
         PoSConsensusVersion, PoWChainConfig, UpgradeVersion,
@@ -72,7 +74,9 @@ impl ChainType {
                             initial_difficulty: Some(
                                 pos_initial_difficulty(ChainType::Testnet).into(),
                             ),
-                            config: create_testnet_pos_config(PoSConsensusVersion::V0),
+                            config: PoSChainConfigBuilder::new(ChainType::Testnet)
+                                .consensus_version(PoSConsensusVersion::V0)
+                                .build(),
                         }),
                     ),
                     (
@@ -80,7 +84,9 @@ impl ChainType {
                         BlockHeight::new(9999999999),
                         UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                             initial_difficulty: None,
-                            config: create_testnet_pos_config(PoSConsensusVersion::V1),
+                            config: PoSChainConfigBuilder::new(ChainType::Testnet)
+                                .consensus_version(PoSConsensusVersion::V1)
+                                .build(),
                         }),
                     ),
                 ];

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -86,6 +86,8 @@ impl ChainType {
                             initial_difficulty: None,
                             config: PoSChainConfigBuilder::new(ChainType::Testnet)
                                 .consensus_version(PoSConsensusVersion::V1)
+                                .decommission_maturity_distance(BlockDistance::new(7200))
+                                .spend_share_maturity_distance(BlockDistance::new(7200))
                                 .build(),
                         }),
                     ),

--- a/common/src/chain/config/regtest_options.rs
+++ b/common/src/chain/config/regtest_options.rs
@@ -23,8 +23,8 @@ use crate::{
             regtest::{create_regtest_pos_genesis, create_regtest_pow_genesis},
             Builder, ChainType, EmissionScheduleTabular,
         },
-        create_regtest_pos_config, pos_initial_difficulty, ConsensusUpgrade, Destination,
-        NetUpgrades, PoSConsensusVersion, UpgradeVersion,
+        pos_initial_difficulty, ConsensusUpgrade, Destination, NetUpgrades, PoSChainConfigBuilder,
+        PoSConsensusVersion, UpgradeVersion,
     },
     primitives::{self, semver::SemVer, BlockHeight},
 };
@@ -185,14 +185,18 @@ pub fn regtest_chain_config(options: &ChainConfigOptions) -> Result<ChainConfig>
                                     .map(primitives::Compact)
                                     .unwrap_or(pos_initial_difficulty(ChainType::Regtest).into()),
                             ),
-                            config: create_regtest_pos_config(PoSConsensusVersion::V0),
+                            config: PoSChainConfigBuilder::new(ChainType::Regtest)
+                                .consensus_version(PoSConsensusVersion::V0)
+                                .build(),
                         }),
                     ),
                     (
                         (*upgrade_height).into(),
                         UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                             initial_difficulty: None,
-                            config: create_regtest_pos_config(PoSConsensusVersion::V1),
+                            config: PoSChainConfigBuilder::new(ChainType::Regtest)
+                                .consensus_version(PoSConsensusVersion::V1)
+                                .build(),
                         }),
                     ),
                 ])

--- a/common/src/chain/config/regtest_options.rs
+++ b/common/src/chain/config/regtest_options.rs
@@ -23,10 +23,14 @@ use crate::{
             regtest::{create_regtest_pos_genesis, create_regtest_pow_genesis},
             Builder, ChainType, EmissionScheduleTabular,
         },
-        pos_initial_difficulty, ConsensusUpgrade, Destination, NetUpgrades, PoSChainConfigBuilder,
+        pos::{
+            DEFAULT_BLOCK_COUNT_TO_AVERAGE, DEFAULT_MATURITY_DISTANCE, DEFAULT_TARGET_BLOCK_TIME,
+        },
+        pos_initial_difficulty, ConsensusUpgrade, Destination, NetUpgrades, PoSChainConfig,
         PoSConsensusVersion, UpgradeVersion,
     },
-    primitives::{self, semver::SemVer, BlockHeight},
+    primitives::{self, per_thousand::PerThousand, semver::SemVer, BlockHeight},
+    Uint256,
 };
 
 use super::{regtest::GenesisStakingSettings, ChainConfig};
@@ -170,6 +174,10 @@ pub fn regtest_chain_config(options: &ChainConfigOptions) -> Result<ChainConfig>
     }
 
     if let Some(upgrade_height) = chain_pos_netupgrades_v0_to_v1 {
+        let target_block_time = DEFAULT_TARGET_BLOCK_TIME;
+        let target_limit = (Uint256::MAX / Uint256::from_u64(target_block_time.get()))
+            .expect("Target block time cannot be zero as per NonZeroU64");
+
         builder = builder
             .net_upgrades(
                 NetUpgrades::initialize(vec![
@@ -185,18 +193,30 @@ pub fn regtest_chain_config(options: &ChainConfigOptions) -> Result<ChainConfig>
                                     .map(primitives::Compact)
                                     .unwrap_or(pos_initial_difficulty(ChainType::Regtest).into()),
                             ),
-                            config: PoSChainConfigBuilder::new(ChainType::Regtest)
-                                .consensus_version(PoSConsensusVersion::V0)
-                                .build(),
+                            config: PoSChainConfig::new(
+                                target_limit,
+                                target_block_time,
+                                DEFAULT_MATURITY_DISTANCE,
+                                DEFAULT_MATURITY_DISTANCE,
+                                DEFAULT_BLOCK_COUNT_TO_AVERAGE,
+                                PerThousand::new(1).expect("must be valid"),
+                                PoSConsensusVersion::V0,
+                            ),
                         }),
                     ),
                     (
                         (*upgrade_height).into(),
                         UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                             initial_difficulty: None,
-                            config: PoSChainConfigBuilder::new(ChainType::Regtest)
-                                .consensus_version(PoSConsensusVersion::V1)
-                                .build(),
+                            config: PoSChainConfig::new(
+                                target_limit,
+                                target_block_time,
+                                DEFAULT_MATURITY_DISTANCE,
+                                DEFAULT_MATURITY_DISTANCE,
+                                DEFAULT_BLOCK_COUNT_TO_AVERAGE,
+                                PerThousand::new(1).expect("must be valid"),
+                                PoSConsensusVersion::V1,
+                            ),
                         }),
                     ),
                 ])

--- a/common/src/chain/mod.rs
+++ b/common/src/chain/mod.rs
@@ -35,9 +35,8 @@ pub use config::ChainConfig;
 pub use gen_block::{GenBlock, GenBlockId};
 pub use genesis::Genesis;
 pub use pos::{
-    create_regtest_pos_config, create_testnet_pos_config, create_unittest_pos_config,
-    get_initial_randomness, pos_initial_difficulty, DelegationId, PoSChainConfig,
-    PoSConsensusVersion, PoolId,
+    config::PoSChainConfig, config_builder::PoSChainConfigBuilder, get_initial_randomness,
+    pos_initial_difficulty, DelegationId, PoSConsensusVersion, PoolId,
 };
 pub use pow::{PoWChainConfig, PoWChainConfigBuilder};
 pub use upgrades::*;

--- a/common/src/chain/pos/config.rs
+++ b/common/src/chain/pos/config.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::num::NonZeroU64;
+
+use crate::{
+    primitives::{per_thousand::PerThousand, BlockDistance},
+    Uint256,
+};
+
+use super::PoSConsensusVersion;
+
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
+pub struct PoSChainConfig {
+    /// The lowest possible difficulty
+    target_limit: Uint256,
+    /// Time interval in secs between the blocks targeted by the difficulty adjustment algorithm
+    target_block_time: NonZeroU64,
+    /// The distance required to pass to allow spending the decommission pool
+    decommission_maturity_distance: BlockDistance,
+    /// The distance required to pass to allow spending delegation share
+    spend_share_maturity_distance: BlockDistance,
+    /// Max number of blocks required to calculate average block time. Min is 2
+    block_count_to_average_for_blocktime: usize,
+    /// The limit on how much the difficulty can go up or down after each block
+    difficulty_change_limit: PerThousand,
+    /// Version of the consensus protocol
+    consensus_version: PoSConsensusVersion,
+}
+
+impl PoSChainConfig {
+    pub(super) fn new(
+        target_limit: Uint256,
+        target_block_time: NonZeroU64,
+        decommission_maturity_distance: BlockDistance,
+        spend_share_maturity_distance: BlockDistance,
+        block_count_to_average_for_blocktime: usize,
+        difficulty_change_limit: PerThousand,
+        consensus_version: PoSConsensusVersion,
+    ) -> Self {
+        assert!(block_count_to_average_for_blocktime >= 2);
+
+        Self {
+            target_limit,
+            target_block_time,
+            decommission_maturity_distance,
+            spend_share_maturity_distance,
+            block_count_to_average_for_blocktime,
+            difficulty_change_limit,
+            consensus_version,
+        }
+    }
+
+    pub fn target_limit(&self) -> Uint256 {
+        self.target_limit
+    }
+
+    pub fn target_block_time(&self) -> NonZeroU64 {
+        self.target_block_time
+    }
+
+    pub fn decommission_maturity_distance(&self) -> BlockDistance {
+        self.decommission_maturity_distance
+    }
+
+    pub fn spend_share_maturity_distance(&self) -> BlockDistance {
+        self.spend_share_maturity_distance
+    }
+
+    pub fn block_count_to_average_for_blocktime(&self) -> usize {
+        self.block_count_to_average_for_blocktime
+    }
+
+    pub fn difficulty_change_limit(&self) -> PerThousand {
+        self.difficulty_change_limit
+    }
+
+    pub fn consensus_version(&self) -> PoSConsensusVersion {
+        self.consensus_version
+    }
+}

--- a/common/src/chain/pos/config.rs
+++ b/common/src/chain/pos/config.rs
@@ -41,7 +41,7 @@ pub struct PoSChainConfig {
 }
 
 impl PoSChainConfig {
-    pub(super) fn new(
+    pub fn new(
         target_limit: Uint256,
         target_block_time: NonZeroU64,
         decommission_maturity_distance: BlockDistance,

--- a/common/src/chain/pos/config_builder.rs
+++ b/common/src/chain/pos/config_builder.rs
@@ -1,0 +1,138 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::num::NonZeroU64;
+
+use crate::{
+    chain::config::ChainType,
+    primitives::{per_thousand::PerThousand, BlockDistance},
+    Uint256,
+};
+
+use super::{config::PoSChainConfig, PoSConsensusVersion};
+
+const DEFAULT_BLOCK_COUNT_TO_AVERAGE: usize = 100;
+const DEFAULT_MATURITY_DISTANCE: BlockDistance = BlockDistance::new(2000);
+const DEFAULT_TARGET_BLOCK_TIME: NonZeroU64 = match NonZeroU64::new(2 * 60) {
+    Some(v) => v,
+    None => panic!("cannot be 0"),
+};
+
+pub struct PoSChainConfigBuilder {
+    target_limit: Uint256,
+    target_block_time: NonZeroU64,
+    decommission_maturity_distance: BlockDistance,
+    spend_share_maturity_distance: BlockDistance,
+    block_count_to_average_for_blocktime: usize,
+    difficulty_change_limit: PerThousand,
+    consensus_version: PoSConsensusVersion,
+}
+
+impl PoSChainConfigBuilder {
+    pub fn new(chain_type: ChainType) -> Self {
+        match chain_type {
+            ChainType::Mainnet => unimplemented!(),
+            ChainType::Testnet => {
+                let target_block_time = DEFAULT_TARGET_BLOCK_TIME;
+                let target_limit = (Uint256::MAX / Uint256::from_u64(target_block_time.get()))
+                    .expect("Target block time cannot be zero as per NonZeroU64");
+
+                Self {
+                    target_limit,
+                    target_block_time,
+                    decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
+                    spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
+                    block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,
+                    difficulty_change_limit: PerThousand::new(1).expect("must be valid"),
+                    consensus_version: PoSConsensusVersion::V1,
+                }
+            }
+            ChainType::Regtest | ChainType::Signet => {
+                let target_block_time = DEFAULT_TARGET_BLOCK_TIME;
+                let target_limit = (Uint256::MAX / Uint256::from_u64(target_block_time.get()))
+                    .expect("Target block time cannot be zero as per NonZeroU64");
+
+                Self {
+                    target_limit,
+                    target_block_time,
+                    decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
+                    spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
+                    block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,
+                    difficulty_change_limit: PerThousand::new(1).expect("must be valid"),
+                    consensus_version: PoSConsensusVersion::V1,
+                }
+            }
+        }
+    }
+
+    pub fn new_for_unit_test() -> Self {
+        Self {
+            target_limit: Uint256::MAX,
+            target_block_time: NonZeroU64::new(2 * 60).expect("cannot be 0"),
+            decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
+            spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
+            block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,
+            difficulty_change_limit: PerThousand::new(1).expect("must be valid"),
+            consensus_version: PoSConsensusVersion::V1,
+        }
+    }
+
+    pub fn targe_limit(mut self, value: Uint256) -> Self {
+        self.target_limit = value;
+        self
+    }
+
+    pub fn targe_block_time(mut self, value: NonZeroU64) -> Self {
+        self.target_block_time = value;
+        self
+    }
+
+    pub fn decommission_maturity_distance(mut self, value: BlockDistance) -> Self {
+        self.decommission_maturity_distance = value;
+        self
+    }
+
+    pub fn spend_share_maturity_distance(mut self, value: BlockDistance) -> Self {
+        self.spend_share_maturity_distance = value;
+        self
+    }
+
+    pub fn block_count_to_average_for_blocktime(mut self, value: usize) -> Self {
+        self.block_count_to_average_for_blocktime = value;
+        self
+    }
+
+    pub fn difficulty_change_limit(mut self, value: PerThousand) -> Self {
+        self.difficulty_change_limit = value;
+        self
+    }
+
+    pub fn consensus_version(mut self, value: PoSConsensusVersion) -> Self {
+        self.consensus_version = value;
+        self
+    }
+
+    pub fn build(self) -> PoSChainConfig {
+        PoSChainConfig::new(
+            self.target_limit,
+            self.target_block_time,
+            self.decommission_maturity_distance,
+            self.spend_share_maturity_distance,
+            self.block_count_to_average_for_blocktime,
+            self.difficulty_change_limit,
+            self.consensus_version,
+        )
+    }
+}

--- a/common/src/chain/pos/config_builder.rs
+++ b/common/src/chain/pos/config_builder.rs
@@ -16,19 +16,11 @@
 use std::num::NonZeroU64;
 
 use crate::{
-    chain::config::ChainType,
     primitives::{per_thousand::PerThousand, BlockDistance},
     Uint256,
 };
 
 use super::{config::PoSChainConfig, PoSConsensusVersion};
-
-const DEFAULT_BLOCK_COUNT_TO_AVERAGE: usize = 100;
-const DEFAULT_MATURITY_DISTANCE: BlockDistance = BlockDistance::new(2000);
-const DEFAULT_TARGET_BLOCK_TIME: NonZeroU64 = match NonZeroU64::new(2 * 60) {
-    Some(v) => v,
-    None => panic!("cannot be 0"),
-};
 
 pub struct PoSChainConfigBuilder {
     target_limit: Uint256,
@@ -41,49 +33,13 @@ pub struct PoSChainConfigBuilder {
 }
 
 impl PoSChainConfigBuilder {
-    pub fn new(chain_type: ChainType) -> Self {
-        match chain_type {
-            ChainType::Mainnet => unimplemented!(),
-            ChainType::Testnet => {
-                let target_block_time = DEFAULT_TARGET_BLOCK_TIME;
-                let target_limit = (Uint256::MAX / Uint256::from_u64(target_block_time.get()))
-                    .expect("Target block time cannot be zero as per NonZeroU64");
-
-                Self {
-                    target_limit,
-                    target_block_time,
-                    decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
-                    spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
-                    block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,
-                    difficulty_change_limit: PerThousand::new(1).expect("must be valid"),
-                    consensus_version: PoSConsensusVersion::V1,
-                }
-            }
-            ChainType::Regtest | ChainType::Signet => {
-                let target_block_time = DEFAULT_TARGET_BLOCK_TIME;
-                let target_limit = (Uint256::MAX / Uint256::from_u64(target_block_time.get()))
-                    .expect("Target block time cannot be zero as per NonZeroU64");
-
-                Self {
-                    target_limit,
-                    target_block_time,
-                    decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
-                    spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
-                    block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,
-                    difficulty_change_limit: PerThousand::new(1).expect("must be valid"),
-                    consensus_version: PoSConsensusVersion::V1,
-                }
-            }
-        }
-    }
-
     pub fn new_for_unit_test() -> Self {
         Self {
             target_limit: Uint256::MAX,
             target_block_time: NonZeroU64::new(2 * 60).expect("cannot be 0"),
-            decommission_maturity_distance: DEFAULT_MATURITY_DISTANCE,
-            spend_share_maturity_distance: DEFAULT_MATURITY_DISTANCE,
-            block_count_to_average_for_blocktime: DEFAULT_BLOCK_COUNT_TO_AVERAGE,
+            decommission_maturity_distance: super::DEFAULT_MATURITY_DISTANCE,
+            spend_share_maturity_distance: super::DEFAULT_MATURITY_DISTANCE,
+            block_count_to_average_for_blocktime: super::DEFAULT_BLOCK_COUNT_TO_AVERAGE,
             difficulty_change_limit: PerThousand::new(1).expect("must be valid"),
             consensus_version: PoSConsensusVersion::V1,
         }

--- a/common/src/chain/pos/mod.rs
+++ b/common/src/chain/pos/mod.rs
@@ -13,14 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str::FromStr;
+use std::{num::NonZeroU64, str::FromStr};
 
 use serialization::{DecodeAll, Encode};
 use typename::TypeName;
 
 use crate::{
     address::{hexified::HexifiedAddress, traits::Addressable, AddressError},
-    primitives::{Id, H256},
+    primitives::{BlockDistance, Id, H256},
     Uint256,
 };
 
@@ -28,6 +28,13 @@ use super::{config::ChainType, ChainConfig};
 
 pub mod config;
 pub mod config_builder;
+
+pub const DEFAULT_BLOCK_COUNT_TO_AVERAGE: usize = 100;
+pub const DEFAULT_MATURITY_DISTANCE: BlockDistance = BlockDistance::new(2000);
+pub const DEFAULT_TARGET_BLOCK_TIME: NonZeroU64 = match NonZeroU64::new(2 * 60) {
+    Some(v) => v,
+    None => panic!("cannot be 0"),
+};
 
 #[derive(Eq, PartialEq, TypeName)]
 pub enum Pool {}

--- a/common/src/chain/upgrades/netupgrade.rs
+++ b/common/src/chain/upgrades/netupgrade.rs
@@ -18,7 +18,7 @@ use std::ops::Range;
 use crate::chain::config::ChainType;
 use crate::chain::pow::limit;
 use crate::chain::{
-    create_regtest_pos_config, pos_initial_difficulty, PoSChainConfig, PoSConsensusVersion,
+    pos_initial_difficulty, PoSChainConfig, PoSChainConfigBuilder, PoSConsensusVersion,
 };
 use crate::primitives::{BlockHeight, Compact};
 
@@ -66,7 +66,9 @@ impl NetUpgrades<UpgradeVersion> {
                 BlockHeight::new(1),
                 UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                     initial_difficulty: Some(pos_initial_difficulty(ChainType::Regtest).into()),
-                    config: create_regtest_pos_config(PoSConsensusVersion::V1),
+                    config: PoSChainConfigBuilder::new(ChainType::Regtest)
+                        .consensus_version(PoSConsensusVersion::V1)
+                        .build(),
                 }),
             ),
         ])
@@ -257,7 +259,7 @@ impl NetUpgrades<UpgradeVersion> {
 mod tests {
     use super::*;
     use crate::chain::upgrades::netupgrade::NetUpgrades;
-    use crate::chain::{create_unittest_pos_config, Activate};
+    use crate::chain::Activate;
     use crate::primitives::{BlockDistance, BlockHeight};
     use crate::Uint256;
 
@@ -375,7 +377,7 @@ mod tests {
                 first_pos_upgrade,
                 UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                     initial_difficulty: Some(Uint256::from_u64(1500).into()),
-                    config: create_unittest_pos_config(),
+                    config: PoSChainConfigBuilder::new_for_unit_test().build(),
                 }),
             ),
             (
@@ -410,12 +412,14 @@ mod tests {
             upgrades.consensus_status(10_000.into()),
             RequiredConsensus::PoS(PoSStatus::Threshold {
                 initial_difficulty: Some(Uint256::from_u64(1500).into()),
-                config: create_unittest_pos_config(),
+                config: PoSChainConfigBuilder::new_for_unit_test().build(),
             },)
         );
         assert_eq!(
             upgrades.consensus_status(14_999.into()),
-            RequiredConsensus::PoS(PoSStatus::Ongoing(create_unittest_pos_config()))
+            RequiredConsensus::PoS(PoSStatus::Ongoing(
+                PoSChainConfigBuilder::new_for_unit_test().build()
+            ))
         );
         assert_eq!(
             upgrades.consensus_status(15_000.into()),

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -32,11 +32,11 @@ use common::{
     chain::{
         block::timestamp::BlockTimestamp,
         config::{self, regtest::GenesisStakingSettings, ChainType},
-        create_unittest_pos_config,
         output_value::OutputValue,
         pos_initial_difficulty,
         stakelock::StakePoolData,
-        ChainConfig, ConsensusUpgrade, Destination, Genesis, NetUpgrades, TxOutput, UpgradeVersion,
+        ChainConfig, ConsensusUpgrade, Destination, Genesis, NetUpgrades, PoSChainConfigBuilder,
+        TxOutput, UpgradeVersion,
     },
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, H256},
 };
@@ -141,7 +141,6 @@ fn create_custom_regtest_genesis(rng: &mut impl Rng) -> Genesis {
 
 fn create_chain_config(rng: &mut impl Rng) -> ChainConfig {
     let genesis = create_custom_regtest_genesis(rng);
-    let pos_config = create_unittest_pos_config();
     let upgrades = vec![
         (
             BlockHeight::new(0),
@@ -151,7 +150,7 @@ fn create_chain_config(rng: &mut impl Rng) -> ChainConfig {
             BlockHeight::new(1),
             UpgradeVersion::ConsensusUpgrade(ConsensusUpgrade::PoS {
                 initial_difficulty: Some(pos_initial_difficulty(ChainType::Regtest).into()),
-                config: pos_config,
+                config: PoSChainConfigBuilder::new_for_unit_test().build(),
             }),
         ),
     ];


### PR DESCRIPTION
The main goal for this PR is to change maturity distances for `Testnet` from 2000 to 7200 for both decommissioning and spending a share.  
But the way `PoSChainConfig` had been initialising was inconvenient so I added `PoSChainConfigBuilder`.