### PR TITLE
Respond with an empty headers list if in IBD state

### DIFF
--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -74,7 +74,7 @@ impl From<NodeType> for Services {
 // in tests. It might be better to separate these "settings" off into a separate struct and/or
 // make some of them constants (and the constant corresponding to msg_max_locator_count may
 // even be moved to chainstate, where locators are actually produced).
-// See the issue https://git.mintlayer.org/mintlayer/mintlayer-core/-/issues/1111
+// See the issue https://github.com/mintlayer/mintlayer-core/issues/1201
 #[derive(Debug)]
 pub struct P2pConfig {
     /// Address to bind P2P to.

--- a/p2p/src/sync/peer_v1.rs
+++ b/p2p/src/sync/peer_v1.rs
@@ -422,7 +422,7 @@ where
             // we should communicate our best block (id/height/header?) from the start, so that
             // the peer just knows that we don't have better blocks and doesn't ask us in the
             // first place.
-            // See the issue #1110.
+            // See the issue: https://github.com/mintlayer/mintlayer-core/issues/1199.
             log::debug!("[peer id = {}] Ignoring headers request because the node is in initial block download", self.id());
             return Ok(());
         }
@@ -655,7 +655,8 @@ where
         {
             // Note: legacy nodes will send singular unconnected headers during block announcement,
             // so we have to handle this behavior here.
-            // TODO: this should be removed in the protocol v2. See the issue #1110.
+            // TODO: this should be removed in the protocol v2.
+            // See the issue: https://github.com/mintlayer/mintlayer-core/issues/1199
             if headers.len() == 1 {
                 self.incoming.singular_unconnected_headers_count += 1;
 

--- a/p2p/src/sync/tests/header_list_request.rs
+++ b/p2p/src/sync/tests/header_list_request.rs
@@ -28,6 +28,7 @@ use crate::{
     config::P2pConfig,
     error::ProtocolError,
     message::{BlockListRequest, BlockResponse, HeaderList, HeaderListRequest, SyncMessage},
+    protocol::ProtocolVersion,
     sync::tests::helpers::{make_new_blocks, TestNode},
     testing_utils::for_each_protocol_version,
     types::peer_id::PeerId,
@@ -133,112 +134,179 @@ async fn valid_request(#[case] seed: Seed) {
 #[tracing::instrument(skip(seed))]
 #[rstest::rstest]
 #[trace]
-#[case(Seed::from_entropy())]
+#[case(Seed::from_entropy(), ProtocolVersion::new(1))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn allow_peer_to_ignore_header_requests_when_asking_for_blocks(#[case] seed: Seed) {
-    for_each_protocol_version(|protocol_version| async move {
-        let mut rng = test_utils::random::make_seedable_rng(seed);
-        let time_getter = P2pBasicTestTimeGetter::new();
+async fn allow_peer_to_ignore_header_requests_when_asking_for_blocks(
+    #[case] seed: Seed,
+    #[case] protocol_version: ProtocolVersion,
+) {
+    let mut rng = test_utils::random::make_seedable_rng(seed);
+    let time_getter = P2pBasicTestTimeGetter::new();
 
-        const STALLING_TIMEOUT: Duration = Duration::from_millis(500);
-        const DELAY: Duration = Duration::from_millis(400);
+    const STALLING_TIMEOUT: Duration = Duration::from_millis(500);
+    const DELAY: Duration = Duration::from_millis(400);
 
-        let chain_config = Arc::new(create_unit_test_config());
-        let p2p_config = Arc::new(P2pConfig {
-            // Note: max_request_blocks_count doesn't really matter here. But we'll be sending
-            // one block at a time, so it's better to pretend that we do that because of the limit
-            // (just in case it becomes important in the future, like it is for msg_header_count_limit).
-            max_request_blocks_count: 1.into(),
-            sync_stalling_timeout: STALLING_TIMEOUT.into(),
+    let chain_config = Arc::new(create_unit_test_config());
+    let p2p_config = Arc::new(P2pConfig {
+        // Note: max_request_blocks_count doesn't really matter here. But we'll be sending
+        // one block at a time, so it's better to pretend that we do that because of the limit
+        // (just in case it becomes important in the future, like it is for msg_header_count_limit).
+        max_request_blocks_count: 1.into(),
+        sync_stalling_timeout: STALLING_TIMEOUT.into(),
 
-            bind_addresses: Default::default(),
-            socks5_proxy: Default::default(),
-            disable_noise: Default::default(),
-            boot_nodes: Default::default(),
-            reserved_nodes: Default::default(),
-            max_inbound_connections: Default::default(),
-            ban_threshold: Default::default(),
-            ban_duration: Default::default(),
-            outbound_connection_timeout: Default::default(),
-            ping_check_period: Default::default(),
-            ping_timeout: Default::default(),
-            max_clock_diff: Default::default(),
-            node_type: Default::default(),
-            allow_discover_private_ips: Default::default(),
-            msg_header_count_limit: Default::default(),
-            msg_max_locator_count: Default::default(),
-            user_agent: mintlayer_core_user_agent(),
-            max_message_size: Default::default(),
-            max_peer_tx_announcements: Default::default(),
-            max_singular_unconnected_headers: Default::default(),
-            enable_block_relay_peers: Default::default(),
-        });
+        bind_addresses: Default::default(),
+        socks5_proxy: Default::default(),
+        disable_noise: Default::default(),
+        boot_nodes: Default::default(),
+        reserved_nodes: Default::default(),
+        max_inbound_connections: Default::default(),
+        ban_threshold: Default::default(),
+        ban_duration: Default::default(),
+        outbound_connection_timeout: Default::default(),
+        ping_check_period: Default::default(),
+        ping_timeout: Default::default(),
+        max_clock_diff: Default::default(),
+        node_type: Default::default(),
+        allow_discover_private_ips: Default::default(),
+        msg_header_count_limit: Default::default(),
+        msg_max_locator_count: Default::default(),
+        user_agent: mintlayer_core_user_agent(),
+        max_message_size: Default::default(),
+        max_peer_tx_announcements: Default::default(),
+        max_singular_unconnected_headers: Default::default(),
+        enable_block_relay_peers: Default::default(),
+    });
 
-        let blocks = make_new_blocks(
-            &chain_config,
-            None,
-            &time_getter.get_time_getter(),
-            3,
-            &mut rng,
-        );
-        let headers = blocks.iter().map(|b| b.header().clone()).collect();
+    let blocks = make_new_blocks(
+        &chain_config,
+        None,
+        &time_getter.get_time_getter(),
+        3,
+        &mut rng,
+    );
+    let headers = blocks.iter().map(|b| b.header().clone()).collect();
 
-        let mut node = TestNode::builder(protocol_version)
-            .with_chain_config(chain_config)
-            .with_p2p_config(Arc::clone(&p2p_config))
-            .with_time_getter(time_getter.get_time_getter())
-            .with_blocks(blocks.clone())
-            .build()
-            .await;
+    let mut node = TestNode::builder(protocol_version)
+        .with_chain_config(chain_config)
+        .with_p2p_config(Arc::clone(&p2p_config))
+        .with_time_getter(time_getter.get_time_getter())
+        .with_blocks(blocks.clone())
+        .build()
+        .await;
 
-        let peer = PeerId::new();
-        node.try_connect_peer(peer, protocol_version);
+    let peer = PeerId::new();
+    node.connect_peer(peer, protocol_version).await;
 
-        // The node will immediately send HeaderListRequest.
-        assert!(matches!(
-            node.message().await.1,
-            SyncMessage::HeaderListRequest(HeaderListRequest { .. })
-        ));
+    // Simulate the peer sending HeaderListRequest too.
+    let locator = node.get_locator_from_height(0.into()).await;
+    node.send_message(
+        peer,
+        SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)),
+    )
+    .await;
 
-        // Simulate the peer sending HeaderListRequest too.
-        let locator = node.get_locator_from_height(0.into()).await;
+    // The node should send the header list.
+    assert_eq!(
+        node.message().await.1,
+        SyncMessage::HeaderList(HeaderList::new(headers)),
+    );
+
+    // Now send each block after a delay.
+    for block in blocks.into_iter() {
+        time_getter.advance_time(DELAY);
         node.send_message(
             peer,
-            SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)),
+            SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()])),
         )
         .await;
 
-        // The node should send the header list.
+        // Eventually, the total time passed will become bigger than the timeout. Still, the peer
+        // shouldn't be disconnected because it's been asking for blocks.
+        // Just in case, check that there were no peer manager events at all, not just disconnects.
+        // Also, do it on every iteration to make the test fail faster.
+        node.assert_no_peer_manager_event().await;
+
+        // The node should send the block.
         assert_eq!(
             node.message().await.1,
-            SyncMessage::HeaderList(HeaderList::new(headers)),
+            SyncMessage::BlockResponse(BlockResponse::new(block)),
         );
+    }
 
-        // Now send each block after a delay.
-        for block in blocks.into_iter() {
-            time_getter.advance_time(DELAY);
-            node.send_message(
-                peer,
-                SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()])),
-            )
-            .await;
+    node.assert_no_error().await;
+    node.assert_no_peer_manager_event().await;
+    node.join_subsystem_manager().await;
+}
 
-            // Eventually, the total time passed will become bigger than the timeout. Still, the peer
-            // shouldn't be disconnected because it's been asking for blocks.
-            // Just in case, check that there were no peer manager events at all, not just disconnects.
-            // Also, do it on every iteration to make the test fail faster.
-            node.assert_no_peer_manager_event().await;
+#[rstest::rstest]
+#[trace]
+#[case(ProtocolVersion::new(2))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn respond_with_empty_header_list_when_in_ibd(#[case] protocol_version: ProtocolVersion) {
+    let time_getter = P2pBasicTestTimeGetter::new();
 
-            // The node should send the block.
-            assert_eq!(
-                node.message().await.1,
-                SyncMessage::BlockResponse(BlockResponse::new(block)),
-            );
-        }
+    const STALLING_TIMEOUT: Duration = Duration::from_millis(500);
 
-        node.assert_no_error().await;
-        node.assert_no_peer_manager_event().await;
-        node.join_subsystem_manager().await;
-    })
+    let chain_config = Arc::new(create_unit_test_config());
+    let p2p_config = Arc::new(P2pConfig {
+        max_request_blocks_count: Default::default(),
+        sync_stalling_timeout: STALLING_TIMEOUT.into(),
+
+        bind_addresses: Default::default(),
+        socks5_proxy: Default::default(),
+        disable_noise: Default::default(),
+        boot_nodes: Default::default(),
+        reserved_nodes: Default::default(),
+        max_inbound_connections: Default::default(),
+        ban_threshold: Default::default(),
+        ban_duration: Default::default(),
+        outbound_connection_timeout: Default::default(),
+        ping_check_period: Default::default(),
+        ping_timeout: Default::default(),
+        max_clock_diff: Default::default(),
+        node_type: Default::default(),
+        allow_discover_private_ips: Default::default(),
+        msg_header_count_limit: Default::default(),
+        msg_max_locator_count: Default::default(),
+        user_agent: mintlayer_core_user_agent(),
+        max_message_size: Default::default(),
+        max_peer_tx_announcements: Default::default(),
+        max_singular_unconnected_headers: Default::default(),
+        enable_block_relay_peers: Default::default(),
+    });
+
+    let mut node = TestNode::builder(protocol_version)
+        .with_chain_config(chain_config)
+        .with_p2p_config(Arc::clone(&p2p_config))
+        .with_time_getter(time_getter.get_time_getter())
+        .build()
+        .await;
+
+    // Node must be in Initial Download State
+    assert!(node
+        .chainstate()
+        .call(|chainstate| chainstate.is_initial_block_download())
+        .await
+        .unwrap());
+
+    let peer = PeerId::new();
+    node.connect_peer(peer, protocol_version).await;
+
+    // Simulate the peer sending HeaderListRequest.
+    let locator = node.get_locator_from_height(0.into()).await;
+    node.send_message(
+        peer,
+        SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)),
+    )
     .await;
+
+    // The node should send an empty header list.
+    assert_eq!(
+        node.message().await.1,
+        SyncMessage::HeaderList(HeaderList::new(Vec::new())),
+    );
+
+    node.assert_no_error().await;
+    node.assert_no_peer_manager_event().await;
+    node.join_subsystem_manager().await;
 }


### PR DESCRIPTION
Closes bullets 5 and 6 in #1199

v1 logic: ignore headers list request. If the node that requested headers receives blocks request in assumes that the peer is in Initial Block Download state and won't disconnect it as stalled.

new v2 logic: if in IBD respond with an empty list. It's simple and effective. Empty headers list is legal and no assumptions are made. Bitcoin does the same. Todos suggested some advanced logic with exchanging best block on handshake or some permission system. Idk it looks too complicated. Empty list does the job + serves as a pong.

P.S. also in v2 I moved call to the `wait_for_clock_diff` to allow more checks to pass before waiting.