### PR TITLE
Improve methods names in p2p/sync/TestNode

### DIFF
--- a/p2p/src/sync/tests/ban_scores.rs
+++ b/p2p/src/sync/tests/ban_scores.rs
@@ -131,17 +131,15 @@ async fn receive_header_with_invalid_parent_block(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer_id = PeerId::new();
-        node.connect_peer(peer_id, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
-        node.send_message(
-            peer_id,
-            SyncMessage::HeaderList(HeaderList::new(vec![valid_child_block.header().clone()])),
-        )
+        peer.send_message(SyncMessage::HeaderList(HeaderList::new(vec![
+            valid_child_block.header().clone(),
+        ])))
         .await;
 
         let (adjusted_peer_id, ban_score_delta) = node.adjust_peer_score_event().await;
-        assert_eq!(adjusted_peer_id, peer_id);
+        assert_eq!(adjusted_peer_id, peer.get_id());
         assert_eq!(ban_score_delta, 100);
 
         node.join_subsystem_manager().await;

--- a/p2p/src/sync/tests/ban_scores.rs
+++ b/p2p/src/sync/tests/ban_scores.rs
@@ -138,7 +138,7 @@ async fn receive_header_with_invalid_parent_block(#[case] seed: Seed) {
         ])))
         .await;
 
-        let (adjusted_peer_id, ban_score_delta) = node.adjust_peer_score_event().await;
+        let (adjusted_peer_id, ban_score_delta) = node.receive_adjust_peer_score_event().await;
         assert_eq!(adjusted_peer_id, peer.get_id());
         assert_eq!(ban_score_delta, 100);
 

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -97,26 +97,25 @@ async fn single_header_with_unknown_prev_block_v1(#[case] seed: Seed) {
         .build()
         .await;
 
-    let peer = PeerId::new();
-    node.connect_peer(peer, protocol_version).await;
+    let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
     // The first attempt to send an unconnected header should trigger HeaderListRequest.
-    node.send_headers(peer, vec![block_2.header().clone()]).await;
+    peer.send_headers(vec![block_2.header().clone()]).await;
 
     // Note: we call assert_no_peer_manager_event twice; the last call is needed to make sure
     // that the event is caught even if it's late; the first one just allows the test to fail
     // faster if the event is not late.
     node.assert_no_peer_manager_event().await;
     let (sent_to, message) = node.message().await;
-    assert_eq!(sent_to, peer);
+    assert_eq!(sent_to, peer.get_id());
     assert!(matches!(message, SyncMessage::HeaderListRequest(_)));
     node.assert_no_peer_manager_event().await;
 
     // The second attempt to send an unconnected header should increase the ban score.
-    node.send_headers(peer, vec![block_2.header().clone()]).await;
+    peer.send_headers(vec![block_2.header().clone()]).await;
 
     node.assert_peer_score_adjustment(
-        peer,
+        peer.get_id(),
         P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score(),
     )
     .await;
@@ -186,35 +185,34 @@ async fn single_header_with_unknown_prev_block_with_intermittent_connected_heade
         .build()
         .await;
 
-    let peer = PeerId::new();
-    node.connect_peer(peer, protocol_version).await;
+    let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
     // The first attempt to send an unconnected header should trigger HeaderListRequest.
-    node.send_headers(peer, vec![block_2.header().clone()]).await;
+    peer.send_headers(vec![block_2.header().clone()]).await;
 
     node.assert_no_peer_manager_event().await;
     let (sent_to, message) = node.message().await;
-    assert_eq!(sent_to, peer);
+    assert_eq!(sent_to, peer.get_id());
     assert!(matches!(message, SyncMessage::HeaderListRequest(_)));
     node.assert_no_peer_manager_event().await;
 
     // Send a header with a known parent, the node should ask for blocks
-    node.send_headers(peer, vec![block_11.header().clone()]).await;
+    peer.send_headers(vec![block_11.header().clone()]).await;
 
     node.assert_no_peer_manager_event().await;
     let (sent_to, message) = node.message().await;
-    assert_eq!(sent_to, peer);
+    assert_eq!(sent_to, peer.get_id());
     assert!(matches!(message, SyncMessage::BlockListRequest(_)));
     node.assert_no_peer_manager_event().await;
 
     // The second attempt to send an unconnected header should again trigger HeaderListRequest,
     // because a correct header list message was received between the attempts and the counter
     // for the unconnected headers has been reset.
-    node.send_headers(peer, vec![block_2.header().clone()]).await;
+    peer.send_headers(vec![block_2.header().clone()]).await;
 
     node.assert_no_peer_manager_event().await;
     let (sent_to, message) = node.message().await;
-    assert_eq!(sent_to, peer);
+    assert_eq!(sent_to, peer.get_id());
     assert!(matches!(message, SyncMessage::HeaderListRequest(_)));
     node.assert_no_peer_manager_event().await;
 
@@ -248,14 +246,13 @@ async fn single_header_with_unknown_prev_block_v2(#[case] seed: Seed) {
         .build()
         .await;
 
-    let peer = PeerId::new();
-    node.connect_peer(peer, protocol_version).await;
+    let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
     // Sending even 1 unconnected header should lead to ban score increase.
-    node.send_headers(peer, vec![block_2.header().clone()]).await;
+    peer.send_headers(vec![block_2.header().clone()]).await;
 
     node.assert_peer_score_adjustment(
-        peer,
+        peer.get_id(),
         P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score(),
     )
     .await;
@@ -275,8 +272,7 @@ async fn invalid_timestamp() {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let block = Block::new(
             Vec::new(),
@@ -286,14 +282,13 @@ async fn invalid_timestamp() {
             BlockReward::new(Vec::new()),
         )
         .unwrap();
-        node.send_message(
-            peer,
-            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
-        )
-        .await;
+        peer.send_message(SyncMessage::HeaderList(HeaderList::new(vec![block
+            .header()
+            .clone()])))
+            .await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::ChainstateError(ChainstateError::ProcessBlockError(
@@ -327,8 +322,7 @@ async fn invalid_consensus_data() {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let block = Block::new(
             Vec::new(),
@@ -338,14 +332,13 @@ async fn invalid_consensus_data() {
             BlockReward::new(Vec::new()),
         )
         .unwrap();
-        node.send_message(
-            peer,
-            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
-        )
-        .await;
+        peer.send_message(SyncMessage::HeaderList(HeaderList::new(vec![block
+            .header()
+            .clone()])))
+            .await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::ChainstateError(ChainstateError::ProcessBlockError(
@@ -388,17 +381,16 @@ async fn multiple_headers_with_unknown_prev_block(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
-        node.send_headers(
-            peer,
-            vec![orphan_block1.header().clone(), orphan_block2.header().clone()],
-        )
+        peer.send_headers(vec![
+            orphan_block1.header().clone(),
+            orphan_block2.header().clone(),
+        ])
         .await;
 
         node.assert_peer_score_adjustment(
-            peer,
+            peer.get_id(),
             P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score(),
         )
         .await;
@@ -430,17 +422,15 @@ async fn valid_block(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
-        node.send_message(
-            peer,
-            SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
-        )
-        .await;
+        peer.send_message(SyncMessage::HeaderList(HeaderList::new(vec![block
+            .header()
+            .clone()])))
+            .await;
 
         let (sent_to, message) = node.message().await;
-        assert_eq!(sent_to, peer);
+        assert_eq!(sent_to, peer.get_id());
         assert_eq!(
             message,
             SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()]))
@@ -479,8 +469,7 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         // Simulate the initial header exchange; make the peer send the node a locator containing
         // the node's tip, so that it responds with an empty header list.
@@ -489,15 +478,14 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
         {
             let locator = node.get_locator_from_height(1.into()).await;
 
-            node.send_message(
-                peer,
-                SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)),
-            )
+            peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
+                locator,
+            )))
             .await;
 
             log::debug!("Expecting initial header response");
             let (sent_to, message) = node.message().await;
-            assert_eq!(sent_to, peer);
+            assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,
                 SyncMessage::HeaderList(HeaderList::new(Vec::new()))
@@ -519,7 +507,7 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
 
             log::debug!("Expecting first announcement");
             let (sent_to, message) = node.message().await;
-            assert_eq!(sent_to, peer);
+            assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,
                 SyncMessage::HeaderList(HeaderList::new(headers.clone()))
@@ -547,7 +535,7 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
 
             log::debug!("Expecting second announcement");
             let (sent_to, message) = node.message().await;
-            assert_eq!(sent_to, peer);
+            assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,
                 SyncMessage::HeaderList(HeaderList::new(headers.clone()))
@@ -571,7 +559,7 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
 
             log::debug!("Expecting third announcement");
             let (sent_to, message) = node.message().await;
-            assert_eq!(sent_to, peer);
+            assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,
                 SyncMessage::HeaderList(HeaderList::new(reorg_headers))

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -106,7 +106,7 @@ async fn single_header_with_unknown_prev_block_v1(#[case] seed: Seed) {
     // that the event is caught even if it's late; the first one just allows the test to fail
     // faster if the event is not late.
     node.assert_no_peer_manager_event().await;
-    let (sent_to, message) = node.message().await;
+    let (sent_to, message) = node.get_sent_message().await;
     assert_eq!(sent_to, peer.get_id());
     assert!(matches!(message, SyncMessage::HeaderListRequest(_)));
     node.assert_no_peer_manager_event().await;
@@ -191,7 +191,7 @@ async fn single_header_with_unknown_prev_block_with_intermittent_connected_heade
     peer.send_headers(vec![block_2.header().clone()]).await;
 
     node.assert_no_peer_manager_event().await;
-    let (sent_to, message) = node.message().await;
+    let (sent_to, message) = node.get_sent_message().await;
     assert_eq!(sent_to, peer.get_id());
     assert!(matches!(message, SyncMessage::HeaderListRequest(_)));
     node.assert_no_peer_manager_event().await;
@@ -200,7 +200,7 @@ async fn single_header_with_unknown_prev_block_with_intermittent_connected_heade
     peer.send_headers(vec![block_11.header().clone()]).await;
 
     node.assert_no_peer_manager_event().await;
-    let (sent_to, message) = node.message().await;
+    let (sent_to, message) = node.get_sent_message().await;
     assert_eq!(sent_to, peer.get_id());
     assert!(matches!(message, SyncMessage::BlockListRequest(_)));
     node.assert_no_peer_manager_event().await;
@@ -211,7 +211,7 @@ async fn single_header_with_unknown_prev_block_with_intermittent_connected_heade
     peer.send_headers(vec![block_2.header().clone()]).await;
 
     node.assert_no_peer_manager_event().await;
-    let (sent_to, message) = node.message().await;
+    let (sent_to, message) = node.get_sent_message().await;
     assert_eq!(sent_to, peer.get_id());
     assert!(matches!(message, SyncMessage::HeaderListRequest(_)));
     node.assert_no_peer_manager_event().await;
@@ -287,7 +287,7 @@ async fn invalid_timestamp() {
             .clone()])))
             .await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
@@ -337,7 +337,7 @@ async fn invalid_consensus_data() {
             .clone()])))
             .await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
@@ -429,7 +429,7 @@ async fn valid_block(#[case] seed: Seed) {
             .clone()])))
             .await;
 
-        let (sent_to, message) = node.message().await;
+        let (sent_to, message) = node.get_sent_message().await;
         assert_eq!(sent_to, peer.get_id());
         assert_eq!(
             message,
@@ -484,7 +484,7 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
             .await;
 
             log::debug!("Expecting initial header response");
-            let (sent_to, message) = node.message().await;
+            let (sent_to, message) = node.get_sent_message().await;
             assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,
@@ -506,7 +506,7 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
             .await;
 
             log::debug!("Expecting first announcement");
-            let (sent_to, message) = node.message().await;
+            let (sent_to, message) = node.get_sent_message().await;
             assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,
@@ -534,7 +534,7 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
             .await;
 
             log::debug!("Expecting second announcement");
-            let (sent_to, message) = node.message().await;
+            let (sent_to, message) = node.get_sent_message().await;
             assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,
@@ -558,7 +558,7 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
             .await;
 
             log::debug!("Expecting third announcement");
-            let (sent_to, message) = node.message().await;
+            let (sent_to, message) = node.get_sent_message().await;
             assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,

--- a/p2p/src/sync/tests/block_list_request.rs
+++ b/p2p/src/sync/tests/block_list_request.rs
@@ -67,7 +67,7 @@ async fn max_block_count_in_request_exceeded(#[case] seed: Seed) {
         peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(blocks)))
             .await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
@@ -114,7 +114,7 @@ async fn unknown_blocks(#[case] seed: Seed) {
         )))
         .await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(score, expected_score);
         node.assert_no_event().await;
@@ -157,7 +157,7 @@ async fn valid_request(#[case] seed: Seed) {
             .await;
 
         for block in blocks {
-            let (sent_to, message) = node.message().await;
+            let (sent_to, message) = node.get_sent_message().await;
             assert_eq!(peer.get_id(), sent_to);
             assert_eq!(
                 message,
@@ -205,7 +205,7 @@ async fn request_same_block_twice(#[case] seed: Seed) {
         ])))
         .await;
 
-        let (sent_to, message) = node.message().await;
+        let (sent_to, message) = node.get_sent_message().await;
         assert_eq!(peer.get_id(), sent_to);
         assert_eq!(
             message,
@@ -221,7 +221,7 @@ async fn request_same_block_twice(#[case] seed: Seed) {
         ])))
         .await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,

--- a/p2p/src/sync/tests/block_list_request.rs
+++ b/p2p/src/sync/tests/block_list_request.rs
@@ -59,20 +59,16 @@ async fn max_block_count_in_request_exceeded(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let blocks = iter::repeat(block.get_id())
             .take(*p2p_config.max_request_blocks_count + 1)
             .collect();
-        node.send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(blocks)),
-        )
-        .await;
+        peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(blocks)))
+            .await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::ProtocolError(ProtocolError::BlocksRequestLimitExceeded(0, 0)).ban_score()
@@ -108,20 +104,18 @@ async fn unknown_blocks(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let expected_score =
             P2pError::ProtocolError(ProtocolError::UnknownBlockRequested(unknown_blocks[0]))
                 .ban_score();
-        node.send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(unknown_blocks)),
-        )
+        peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(
+            unknown_blocks,
+        )))
         .await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(score, expected_score);
         node.assert_no_event().await;
 
@@ -156,19 +150,15 @@ async fn valid_request(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let ids = blocks.iter().map(|b| b.get_id()).collect();
-        node.send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(ids)),
-        )
-        .await;
+        peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(ids)))
+            .await;
 
         for block in blocks {
             let (sent_to, message) = node.message().await;
-            assert_eq!(peer, sent_to);
+            assert_eq!(peer.get_id(), sent_to);
             assert_eq!(
                 message,
                 SyncMessage::BlockResponse(BlockResponse::new(block))
@@ -208,17 +198,15 @@ async fn request_same_block_twice(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
-        node.send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()])),
-        )
+        peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(vec![
+            block.get_id(),
+        ])))
         .await;
 
         let (sent_to, message) = node.message().await;
-        assert_eq!(peer, sent_to);
+        assert_eq!(peer.get_id(), sent_to);
         assert_eq!(
             message,
             SyncMessage::BlockResponse(BlockResponse::new(block.clone()))
@@ -228,14 +216,13 @@ async fn request_same_block_twice(#[case] seed: Seed) {
         node.assert_no_peer_manager_event().await;
 
         // Request the same block twice.
-        node.send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()])),
-        )
+        peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(vec![
+            block.get_id(),
+        ])))
         .await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::ProtocolError(ProtocolError::UnexpectedMessage("".to_owned())).ban_score()

--- a/p2p/src/sync/tests/header_list_request.rs
+++ b/p2p/src/sync/tests/header_list_request.rs
@@ -56,18 +56,16 @@ async fn max_locator_size_exceeded(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let headers = iter::repeat(block.get_id().into()).take(102).collect();
-        node.send_message(
-            peer,
-            SyncMessage::HeaderListRequest(HeaderListRequest::new(Locator::new(headers))),
-        )
+        peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
+            Locator::new(headers),
+        )))
         .await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::ProtocolError(ProtocolError::LocatorSizeExceeded(0, 0)).ban_score()
@@ -105,17 +103,15 @@ async fn valid_request(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
-        node.send_message(
-            peer,
-            SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)),
-        )
+        peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
+            locator,
+        )))
         .await;
 
         let (sent_to, message) = node.message().await;
-        assert_eq!(peer, sent_to);
+        assert_eq!(peer.get_id(), sent_to);
         let headers = match message {
             SyncMessage::HeaderList(l) => l.into_headers(),
             m => panic!("Unexpected message: {m:?}"),
@@ -194,15 +190,13 @@ async fn allow_peer_to_ignore_header_requests_when_asking_for_blocks(
         .build()
         .await;
 
-    let peer = PeerId::new();
-    node.connect_peer(peer, protocol_version).await;
+    let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
     // Simulate the peer sending HeaderListRequest too.
     let locator = node.get_locator_from_height(0.into()).await;
-    node.send_message(
-        peer,
-        SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)),
-    )
+    peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
+        locator,
+    )))
     .await;
 
     // The node should send the header list.
@@ -214,10 +208,9 @@ async fn allow_peer_to_ignore_header_requests_when_asking_for_blocks(
     // Now send each block after a delay.
     for block in blocks.into_iter() {
         time_getter.advance_time(DELAY);
-        node.send_message(
-            peer,
-            SyncMessage::BlockListRequest(BlockListRequest::new(vec![block.get_id()])),
-        )
+        peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(vec![
+            block.get_id(),
+        ])))
         .await;
 
         // Eventually, the total time passed will become bigger than the timeout. Still, the peer
@@ -289,15 +282,13 @@ async fn respond_with_empty_header_list_when_in_ibd(#[case] protocol_version: Pr
         .await
         .unwrap());
 
-    let peer = PeerId::new();
-    node.connect_peer(peer, protocol_version).await;
+    let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
     // Simulate the peer sending HeaderListRequest.
     let locator = node.get_locator_from_height(0.into()).await;
-    node.send_message(
-        peer,
-        SyncMessage::HeaderListRequest(HeaderListRequest::new(locator)),
-    )
+    peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
+        locator,
+    )))
     .await;
 
     // The node should send an empty header list.

--- a/p2p/src/sync/tests/header_list_request.rs
+++ b/p2p/src/sync/tests/header_list_request.rs
@@ -64,7 +64,7 @@ async fn max_locator_size_exceeded(#[case] seed: Seed) {
         )))
         .await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
@@ -110,7 +110,7 @@ async fn valid_request(#[case] seed: Seed) {
         )))
         .await;
 
-        let (sent_to, message) = node.message().await;
+        let (sent_to, message) = node.get_sent_message().await;
         assert_eq!(peer.get_id(), sent_to);
         let headers = match message {
             SyncMessage::HeaderList(l) => l.into_headers(),
@@ -201,7 +201,7 @@ async fn allow_peer_to_ignore_header_requests_when_asking_for_blocks(
 
     // The node should send the header list.
     assert_eq!(
-        node.message().await.1,
+        node.get_sent_message().await.1,
         SyncMessage::HeaderList(HeaderList::new(headers)),
     );
 
@@ -221,7 +221,7 @@ async fn allow_peer_to_ignore_header_requests_when_asking_for_blocks(
 
         // The node should send the block.
         assert_eq!(
-            node.message().await.1,
+            node.get_sent_message().await.1,
             SyncMessage::BlockResponse(BlockResponse::new(block)),
         );
     }
@@ -293,7 +293,7 @@ async fn respond_with_empty_header_list_when_in_ibd(#[case] protocol_version: Pr
 
     // The node should send an empty header list.
     assert_eq!(
-        node.message().await.1,
+        node.get_sent_message().await.1,
         SyncMessage::HeaderList(HeaderList::new(Vec::new())),
     );
 

--- a/p2p/src/sync/tests/header_list_response.rs
+++ b/p2p/src/sync/tests/header_list_response.rs
@@ -60,7 +60,7 @@ async fn header_count_limit_exceeded(#[case] seed: Seed) {
             .collect();
         peer.send_message(SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
@@ -104,7 +104,7 @@ async fn unordered_headers(#[case] seed: Seed) {
 
         peer.send_message(SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
@@ -146,7 +146,7 @@ async fn disconnected_headers(#[case] seed: Seed) {
 
         peer.send_message(SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
-        let (adjusted_peer, score) = node.adjust_peer_score_event().await;
+        let (adjusted_peer, score) = node.receive_adjust_peer_score_event().await;
         assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
@@ -185,7 +185,7 @@ async fn valid_headers(#[case] seed: Seed) {
         let headers = blocks.iter().map(|b| b.header().clone()).collect();
         peer.send_message(SyncMessage::HeaderList(HeaderList::new(headers))).await;
 
-        let (sent_to, message) = node.message().await;
+        let (sent_to, message) = node.get_sent_message().await;
         assert_eq!(peer.get_id(), sent_to);
         assert_eq!(
             message,
@@ -239,7 +239,7 @@ async fn disconnect() {
         let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         tokio::time::sleep(Duration::from_millis(300)).await;
-        node.assert_disconnect_peer_event(peer.get_id()).await;
+        node.receive_disconnect_peer_event(peer.get_id()).await;
 
         node.join_subsystem_manager().await;
     })

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, panic, sync::Arc};
+use std::{panic, sync::Arc};
 
 use async_trait::async_trait;
 use crypto::random::Rng;
@@ -82,7 +82,6 @@ pub struct TestNode {
     chainstate_handle: ChainstateHandle,
     mempool_handle: MempoolHandle,
     _new_tip_receiver: UnboundedReceiver<Id<Block>>,
-    connected_peers: BTreeMap<PeerId, Sender<SyncMessage>>,
     protocol_version: ProtocolVersion,
 }
 
@@ -109,7 +108,6 @@ impl TestNode {
         protocol_version: ProtocolVersion,
     ) -> Self {
         let (peer_manager_event_sender, peer_manager_event_receiver) = mpsc::unbounded_channel();
-        let connected_peers = Default::default();
 
         let (sync_msg_sender, sync_msg_receiver) = mpsc::unbounded_channel();
         let (syncing_event_sender, syncing_event_receiver) = mpsc::unbounded_channel();
@@ -129,7 +127,7 @@ impl TestNode {
             time_getter,
         );
 
-        let sync_manager_chanstate_handle = sync_manager.chainstate().clone();
+        let sync_manager_chainstate_handle = sync_manager.chainstate().clone();
 
         let (error_sender, error_receiver) = mpsc::unbounded_channel();
         let sync_manager_handle = logging::spawn_in_current_span(async move {
@@ -137,7 +135,7 @@ impl TestNode {
             let _ = error_sender.send(e);
         });
 
-        let new_tip_receiver = subscribe_to_new_tip(&sync_manager_chanstate_handle).await.unwrap();
+        let new_tip_receiver = subscribe_to_new_tip(&sync_manager_chainstate_handle).await.unwrap();
 
         Self {
             peer_id: PeerId::new(),
@@ -152,7 +150,6 @@ impl TestNode {
             chainstate_handle,
             mempool_handle,
             _new_tip_receiver: new_tip_receiver,
-            connected_peers,
             protocol_version,
         }
     }
@@ -166,7 +163,12 @@ impl TestNode {
     }
 
     /// Sends the `SyncControlEvent::Connected` event without checking outgoing messages.
-    pub fn try_connect_peer(&mut self, peer_id: PeerId, protocol_version: ProtocolVersion) {
+    #[must_use]
+    pub fn try_connect_peer(
+        &mut self,
+        peer_id: PeerId,
+        protocol_version: ProtocolVersion,
+    ) -> TestPeer {
         let (sync_msg_tx, sync_msg_rx) = mpsc::channel(20);
         let common_protocol_version =
             choose_common_protocol_version(self.protocol_version, protocol_version).unwrap();
@@ -178,25 +180,30 @@ impl TestNode {
                 sync_msg_rx,
             })
             .unwrap();
-        self.connected_peers.insert(peer_id, sync_msg_tx);
+        TestPeer::new(peer_id, sync_msg_tx)
     }
 
     /// Connects a peer and checks that the header list request is sent to that peer.
-    pub async fn connect_peer(&mut self, peer: PeerId, protocol_version: ProtocolVersion) {
-        self.try_connect_peer(peer, protocol_version);
+    #[must_use]
+    pub async fn connect_peer(
+        &mut self,
+        peer_id: PeerId,
+        protocol_version: ProtocolVersion,
+    ) -> TestPeer {
+        let peer = self.try_connect_peer(peer_id, protocol_version);
 
         let (sent_to, message) = self.message().await;
-        assert_eq!(peer, sent_to);
+        assert_eq!(peer.get_id(), sent_to);
         assert!(matches!(message, SyncMessage::HeaderListRequest(_)));
+        peer
     }
 
     /// Sends the `SyncControlEvent::Disconnected` event.
     pub fn disconnect_peer(&mut self, peer_id: PeerId) {
         self.syncing_event_sender.send(SyncingEvent::Disconnected { peer_id }).unwrap();
-        self.connected_peers.remove(&peer_id);
     }
 
-    // TODO: naming of methods in this struct should be reconsidered.
+    // FIXME: naming of methods in this struct should be reconsidered.
     // E.g. message, try_message, adjust_peer_score_event should at least get a prefix like
     // "get", "receive" etc.
     // Secondly, send_message and send_headers should be named more specifically, e.g.
@@ -204,13 +211,8 @@ impl TestNode {
     // and not from it.
     // Also, methods dealing with SyncMessage's should probably have "sync" in their name.
 
-    /// Sends an announcement to the sync manager.
-    pub async fn send_message(&mut self, peer: PeerId, message: SyncMessage) {
-        let sync_tx = self.connected_peers.get(&peer).unwrap().clone();
-        sync_tx.send(message).await.unwrap();
-    }
-
     /// Receives a message from the sync manager.
+    // FIXME: this is also unclear
     pub async fn message(&mut self) -> (PeerId, SyncMessage) {
         expect_recv!(self.sync_msg_receiver)
     }
@@ -222,11 +224,6 @@ impl TestNode {
             Err(mpsc::error::TryRecvError::Empty) => None,
             Err(mpsc::error::TryRecvError::Disconnected) => panic!("Failed to receive event"),
         }
-    }
-
-    /// Send the specified headers.
-    pub async fn send_headers(&mut self, peer: PeerId, headers: Vec<SignedBlockHeader>) {
-        self.send_message(peer, SyncMessage::HeaderList(HeaderList::new(headers))).await;
     }
 
     /// Panics if the sync manager returns an error.
@@ -345,6 +342,33 @@ impl TestNode {
             .await
             .unwrap()
             .unwrap()
+    }
+}
+
+// Represents a peer that can send messages to a node it is connected to
+pub struct TestPeer {
+    peer_id: PeerId,
+    sync_msg_tx: Sender<SyncMessage>,
+}
+
+impl TestPeer {
+    pub fn new(peer_id: PeerId, sync_msg_tx: Sender<SyncMessage>) -> Self {
+        Self {
+            peer_id,
+            sync_msg_tx,
+        }
+    }
+
+    pub fn get_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    pub async fn send_message(&self, message: SyncMessage) {
+        self.sync_msg_tx.send(message).await.unwrap();
+    }
+
+    pub async fn send_headers(&self, headers: Vec<SignedBlockHeader>) {
+        self.send_message(SyncMessage::HeaderList(HeaderList::new(headers))).await;
     }
 }
 

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -65,29 +65,26 @@ async fn invalid_transaction(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let tx = Transaction::new(0x00, vec![], vec![]).unwrap();
         let tx = SignedTransaction::new(tx, vec![]).unwrap();
-        node.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-            .await;
+        peer.send_message(SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
         let (sent_to, message) = node.message().await;
-        assert_eq!(peer, sent_to);
+        assert_eq!(peer.get_id(), sent_to);
         assert_eq!(
             message,
             SyncMessage::TransactionRequest(tx.transaction().get_id())
         );
 
-        node.send_message(
-            peer,
-            SyncMessage::TransactionResponse(TransactionResponse::Found(tx)),
-        )
+        peer.send_message(SyncMessage::TransactionResponse(
+            TransactionResponse::Found(tx),
+        ))
         .await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::MempoolError(MempoolError::Policy(MempoolPolicyError::NoInputs)).ban_score()
@@ -111,12 +108,10 @@ async fn initial_block_download() {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let tx = transaction(chain_config.genesis_block_id());
-        node.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-            .await;
+        peer.send_message(SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
         node.assert_no_event().await;
         node.assert_no_peer_manager_event().await;
@@ -176,15 +171,13 @@ async fn no_transaction_service(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let tx = transaction(chain_config.genesis_block_id());
-        node.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-            .await;
+        peer.send_message(SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::ProtocolError(ProtocolError::UnexpectedMessage("".to_owned())).ban_score()
@@ -245,15 +238,13 @@ async fn too_many_announcements(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let tx = transaction(chain_config.genesis_block_id());
-        node.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-            .await;
+        peer.send_message(SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::ProtocolError(ProtocolError::TransactionAnnouncementLimitExceeded(0))
@@ -290,25 +281,22 @@ async fn duplicated_announcement(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let tx = transaction(chain_config.genesis_block_id());
-        node.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-            .await;
+        peer.send_message(SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
         let (sent_to, message) = node.message().await;
-        assert_eq!(peer, sent_to);
+        assert_eq!(peer.get_id(), sent_to);
         assert_eq!(
             message,
             SyncMessage::TransactionRequest(tx.transaction().get_id())
         );
 
-        node.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-            .await;
+        peer.send_message(SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
         let (adjusted_peer, score) = node.adjust_peer_score_event().await;
-        assert_eq!(peer, adjusted_peer);
+        assert_eq!(peer.get_id(), adjusted_peer);
         assert_eq!(
             score,
             P2pError::ProtocolError(ProtocolError::DuplicatedTransactionAnnouncement(
@@ -347,24 +335,21 @@ async fn valid_transaction(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
 
         let tx = transaction(chain_config.genesis_block_id());
-        node.send_message(peer, SyncMessage::NewTransaction(tx.transaction().get_id()))
-            .await;
+        peer.send_message(SyncMessage::NewTransaction(tx.transaction().get_id())).await;
 
         let (sent_to, message) = node.message().await;
-        assert_eq!(peer, sent_to);
+        assert_eq!(peer.get_id(), sent_to);
         assert_eq!(
             message,
             SyncMessage::TransactionRequest(tx.transaction().get_id())
         );
 
-        node.send_message(
-            peer,
-            SyncMessage::TransactionResponse(TransactionResponse::Found(tx.clone())),
-        )
+        peer.send_message(SyncMessage::TransactionResponse(
+            TransactionResponse::Found(tx.clone()),
+        ))
         .await;
 
         // There should be no `NewTransaction` message because the transaction is already known
@@ -399,8 +384,8 @@ async fn transaction_sequence_via_orphan_pool(#[case] seed: Seed) {
             .build()
             .await;
 
-        let peer = PeerId::new();
-        node.connect_peer(peer, protocol_version).await;
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
+        let peer_id = peer.get_id();
 
         let mut txs = std::collections::BTreeMap::<Id<Transaction>, _>::new();
 
@@ -429,7 +414,7 @@ async fn transaction_sequence_via_orphan_pool(#[case] seed: Seed) {
 
         let res = node
             .mempool()
-            .call_mut(move |m| m.add_transaction_remote(tx1, RemoteTxOrigin::new(peer)))
+            .call_mut(move |m| m.add_transaction_remote(tx1, RemoteTxOrigin::new(peer_id)))
             .await
             .unwrap();
         assert_eq!(res, Ok(mempool::TxStatus::InOrphanPool));
@@ -440,7 +425,7 @@ async fn transaction_sequence_via_orphan_pool(#[case] seed: Seed) {
 
         let res = node
             .mempool()
-            .call_mut(move |m| m.add_transaction_remote(tx0, RemoteTxOrigin::new(peer)))
+            .call_mut(move |m| m.add_transaction_remote(tx0, RemoteTxOrigin::new(peer_id)))
             .await
             .unwrap();
         assert_eq!(res, Ok(mempool::TxStatus::InMempool));


### PR DESCRIPTION
`TesNode` methods names were very confusing as the direction of information passing was unclear. Imho now it's much easier to read and understand tests.