### PR TITLE
Clean up io policy tests and checks

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -497,8 +497,6 @@ impl BanScore for IOPolicyError {
             IOPolicyError::InvalidInputTypeInReward => 100,
             IOPolicyError::InvalidOutputTypeInReward => 100,
             IOPolicyError::InvalidInputTypeInTx => 100,
-            IOPolicyError::MultiplePoolCreated => 100,
-            IOPolicyError::MultipleDelegationCreated => 100,
             IOPolicyError::ProduceBlockInTx => 100,
             IOPolicyError::AmountOverflow => 100,
             IOPolicyError::AttemptToPrintMoneyOrViolateTimelockConstraints => 100,

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -15,7 +15,7 @@
 
 use super::helpers::pos::create_stake_pool_data_with_all_reward_to_owner;
 
-use chainstate::{BlockError, ChainstateError, ConnectTransactionError, IOPolicyError};
+use chainstate::{BlockError, ChainstateError, ConnectTransactionError};
 use chainstate_storage::TipStorageTag;
 use chainstate_test_framework::{
     empty_witness, get_output_value, TestFramework, TestStore, TransactionBuilder,
@@ -260,15 +260,13 @@ fn create_delegation_twice(#[case] seed: Seed) {
                 pool_id,
             ))
             .build();
-        let tx_id = tx.transaction().get_id();
 
         let res = tf.make_block_builder().add_transaction(tx).build_and_process().unwrap_err();
         assert_eq!(
             res,
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::IOPolicyError(
-                    IOPolicyError::MultipleDelegationCreated,
-                    tx_id.into()
+                ConnectTransactionError::PoSAccountingError(
+                    pos_accounting::Error::InvariantErrorDelegationCreationFailedIdAlreadyExists
                 )
             ))
         );

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -16,7 +16,7 @@
 use super::helpers::pos::create_stake_pool_data_with_all_reward_to_owner;
 
 use chainstate::BlockSource;
-use chainstate::{BlockError, ChainstateError, ConnectTransactionError, IOPolicyError};
+use chainstate::{BlockError, ChainstateError, ConnectTransactionError};
 use chainstate_storage::TipStorageTag;
 use chainstate_test_framework::{
     anyonecanspend_address, empty_witness, get_output_value, TestFramework, TransactionBuilder,
@@ -292,16 +292,14 @@ fn stake_pool_twice(#[case] seed: Seed) {
                 Box::new(stake_pool_data),
             ))
             .build();
-        let tx_id = tx.transaction().get_id();
 
         let result = tf.make_block_builder().add_transaction(tx).build_and_process();
 
         assert_eq!(
             result.unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                ConnectTransactionError::IOPolicyError(
-                    IOPolicyError::MultiplePoolCreated,
-                    tx_id.into()
+                ConnectTransactionError::PoSAccountingError(
+                    pos_accounting::Error::InvariantErrorPoolBalanceAlreadyExists
                 )
             ))
         );

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
@@ -37,10 +37,6 @@ pub enum IOPolicyError {
     InvalidOutputTypeInReward,
     #[error("Attempted to use a invalid input type in a tx")]
     InvalidInputTypeInTx,
-    #[error("Attempted to create multiple stake pools in a single tx")]
-    MultiplePoolCreated,
-    #[error("Attempted to create multiple delegations in a single tx")]
-    MultipleDelegationCreated,
     #[error("Attempted to produce block in a tx")]
     ProduceBlockInTx,
     #[error("Amount overflow")]

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/constraints_tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/constraints_tests.rs
@@ -30,6 +30,7 @@ use crypto::{
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
 
+use super::outputs_utils::*;
 use super::*;
 
 fn decompose_value(rng: &mut impl Rng, value: u128) -> Vec<u128> {

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/outputs_utils.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/outputs_utils.rs
@@ -1,0 +1,189 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::{
+    chain::{
+        output_value::OutputValue,
+        stakelock::StakePoolData,
+        timelock::OutputTimeLock,
+        tokens::{
+            Metadata, NftIssuance, NftIssuanceV0, TokenId, TokenIssuance, TokenIssuanceV1,
+            TokenTotalSupply,
+        },
+        DelegationId, Destination, PoolId, TokenOutput, TxOutput,
+    },
+    primitives::{per_thousand::PerThousand, Amount, H256},
+};
+use crypto::vrf::{VRFKeyKind, VRFPrivateKey};
+use serialization::extras::non_empty_vec::DataOrNoVec;
+
+#[allow(dead_code)]
+fn update_functions_below_if_new_outputs_were_added(output: TxOutput) {
+    match output {
+        TxOutput::Transfer(_, _) => unimplemented!(),
+        TxOutput::LockThenTransfer(_, _, _) => unimplemented!(),
+        TxOutput::Burn(_) => unimplemented!(),
+        TxOutput::CreateStakePool(_, _) => unimplemented!(),
+        TxOutput::ProduceBlockFromStake(_, _) => unimplemented!(),
+        TxOutput::CreateDelegationId(_, _) => unimplemented!(),
+        TxOutput::DelegateStaking(_, _) => unimplemented!(),
+        TxOutput::TokensOp(token) => match token {
+            TokenOutput::IssueFungibleToken(_) => unimplemented!(),
+            TokenOutput::IssueNft(_, _, _) => unimplemented!(),
+            TokenOutput::MintTokens(_, _, _) => unimplemented!(),
+            TokenOutput::RedeemTokens(_, _) => unimplemented!(),
+            TokenOutput::LockCirculatingSupply(_) => unimplemented!(),
+        },
+    }
+}
+
+pub fn all_outputs() -> [TxOutput; 12] {
+    [
+        transfer(),
+        burn(),
+        lock_then_transfer(),
+        stake_pool(),
+        produce_block(),
+        create_delegation(),
+        delegate_staking(),
+        issue_tokens(),
+        issue_nft(),
+        mint_tokens(),
+        redeem_tokens(),
+        lock_tokens_supply(),
+    ]
+}
+
+pub fn valid_tx_outputs() -> [TxOutput; 11] {
+    [
+        transfer(),
+        burn(),
+        lock_then_transfer(),
+        stake_pool(),
+        create_delegation(),
+        delegate_staking(),
+        issue_tokens(),
+        issue_nft(),
+        mint_tokens(),
+        redeem_tokens(),
+        lock_tokens_supply(),
+    ]
+}
+
+pub fn valid_tx_inputs() -> [TxOutput; 6] {
+    [
+        transfer(),
+        lock_then_transfer(),
+        stake_pool(),
+        produce_block(),
+        issue_nft(),
+        mint_tokens(),
+    ]
+}
+
+pub fn transfer() -> TxOutput {
+    TxOutput::Transfer(OutputValue::Coin(Amount::ZERO), Destination::AnyoneCanSpend)
+}
+
+pub fn burn() -> TxOutput {
+    TxOutput::Burn(OutputValue::Coin(Amount::ZERO))
+}
+
+pub fn lock_then_transfer() -> TxOutput {
+    TxOutput::LockThenTransfer(
+        OutputValue::Coin(Amount::ZERO),
+        Destination::AnyoneCanSpend,
+        OutputTimeLock::ForBlockCount(1),
+    )
+}
+
+pub fn stake_pool() -> TxOutput {
+    let (_, vrf_pub_key) = VRFPrivateKey::new_from_entropy(VRFKeyKind::Schnorrkel);
+    TxOutput::CreateStakePool(
+        PoolId::new(H256::zero()),
+        Box::new(StakePoolData::new(
+            Amount::ZERO,
+            Destination::AnyoneCanSpend,
+            vrf_pub_key,
+            Destination::AnyoneCanSpend,
+            PerThousand::new(0).unwrap(),
+            Amount::ZERO,
+        )),
+    )
+}
+
+pub fn produce_block() -> TxOutput {
+    TxOutput::ProduceBlockFromStake(Destination::AnyoneCanSpend, PoolId::new(H256::zero()))
+}
+
+pub fn create_delegation() -> TxOutput {
+    TxOutput::CreateDelegationId(Destination::AnyoneCanSpend, PoolId::new(H256::zero()))
+}
+
+pub fn delegate_staking() -> TxOutput {
+    TxOutput::DelegateStaking(Amount::ZERO, DelegationId::new(H256::zero()))
+}
+
+pub fn issue_tokens() -> TxOutput {
+    TxOutput::TokensOp(TokenOutput::IssueFungibleToken(Box::new(
+        TokenIssuance::V1(TokenIssuanceV1 {
+            token_ticker: Vec::new(),
+            number_of_decimals: 0,
+            metadata_uri: Vec::new(),
+            total_supply: TokenTotalSupply::Unlimited,
+            reissuance_controller: Destination::AnyoneCanSpend,
+        }),
+    )))
+}
+
+pub fn issue_nft() -> TxOutput {
+    TxOutput::TokensOp(TokenOutput::IssueNft(
+        TokenId::new(H256::zero()),
+        Box::new(NftIssuance::V0(NftIssuanceV0 {
+            metadata: Metadata {
+                creator: None,
+                name: Vec::new(),
+                description: Vec::new(),
+                ticker: Vec::new(),
+                icon_uri: DataOrNoVec::from(None),
+                additional_metadata_uri: DataOrNoVec::from(None),
+                media_uri: DataOrNoVec::from(None),
+                media_hash: Vec::new(),
+            },
+        })),
+        Destination::AnyoneCanSpend,
+    ))
+}
+
+pub fn mint_tokens() -> TxOutput {
+    TxOutput::TokensOp(TokenOutput::MintTokens(
+        TokenId::new(H256::zero()),
+        Amount::ZERO,
+        Destination::AnyoneCanSpend,
+    ))
+}
+
+pub fn redeem_tokens() -> TxOutput {
+    TxOutput::TokensOp(TokenOutput::RedeemTokens(
+        TokenId::new(H256::zero()),
+        Amount::ZERO,
+    ))
+}
+
+pub fn lock_tokens_supply() -> TxOutput {
+    TxOutput::TokensOp(TokenOutput::LockCirculatingSupply(TokenId::new(
+        H256::zero(),
+    )))
+}

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/purpose_tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/purpose_tests.rs
@@ -24,98 +24,11 @@ use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
 use utxo::{Utxo, UtxosDBInMemoryImpl};
 
+use super::outputs_utils::*;
 use super::purposes_check::*;
 use super::*;
 
 use crate::error::SpendStakeError;
-
-#[allow(dead_code)]
-fn update_tests_below_if_new_outputs_were_added(output: TxOutput) {
-    match output {
-        TxOutput::Transfer(_, _) => unimplemented!(),
-        TxOutput::LockThenTransfer(_, _, _) => unimplemented!(),
-        TxOutput::Burn(_) => unimplemented!(),
-        TxOutput::CreateStakePool(_, _) => unimplemented!(),
-        TxOutput::ProduceBlockFromStake(_, _) => unimplemented!(),
-        TxOutput::CreateDelegationId(_, _) => unimplemented!(),
-        TxOutput::DelegateStaking(_, _) => unimplemented!(),
-        TxOutput::TokensOp(token) => match token {
-            TokenOutput::IssueFungibleToken(_) => unimplemented!(),
-            TokenOutput::IssueNft(_, _, _) => unimplemented!(),
-            TokenOutput::MintTokens(_, _, _) => unimplemented!(),
-            TokenOutput::RedeemTokens(_, _) => unimplemented!(),
-            TokenOutput::LockCirculatingSupply(_) => unimplemented!(),
-        },
-    }
-}
-
-#[rstest]
-#[trace]
-#[case(Seed::from_entropy())]
-fn tx_stake_multiple_pools(#[case] seed: Seed) {
-    let mut rng = make_seedable_rng(seed);
-
-    let source_inputs = [lock_then_transfer(), transfer()];
-    let source_valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
-    let source_invalid_outputs = [stake_pool()];
-
-    let inputs = get_random_outputs_combination(&mut rng, &source_inputs, 1);
-
-    let number_of_valid_outputs = rng.gen_range(0..10);
-    let number_of_invalid_outputs = rng.gen_range(2..10);
-    let outputs =
-        get_random_outputs_combination(&mut rng, &source_valid_outputs, number_of_valid_outputs)
-            .into_iter()
-            .chain(
-                get_random_outputs_combination(
-                    &mut rng,
-                    &source_invalid_outputs,
-                    number_of_invalid_outputs,
-                )
-                .into_iter(),
-            )
-            .collect();
-
-    let (utxo_db, tx) = prepare_utxos_and_tx(&mut rng, inputs, outputs);
-
-    let inputs_utxos = get_inputs_utxos(&utxo_db, tx.inputs()).unwrap();
-    let result = check_tx_inputs_outputs_purposes(&tx, &inputs_utxos).unwrap_err();
-    assert_eq!(result, IOPolicyError::MultiplePoolCreated);
-}
-
-#[rstest]
-#[trace]
-#[case(Seed::from_entropy())]
-fn tx_create_multiple_delegations(#[case] seed: Seed) {
-    let mut rng = make_seedable_rng(seed);
-
-    let source_inputs = [lock_then_transfer(), transfer()];
-    let source_valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
-    let source_invalid_outputs = [create_delegation()];
-
-    let inputs = get_random_outputs_combination(&mut rng, &source_inputs, 1);
-
-    let number_of_valid_outputs = rng.gen_range(0..10);
-    let number_of_invalid_outputs = rng.gen_range(2..10);
-    let outputs =
-        get_random_outputs_combination(&mut rng, &source_valid_outputs, number_of_valid_outputs)
-            .into_iter()
-            .chain(
-                get_random_outputs_combination(
-                    &mut rng,
-                    &source_invalid_outputs,
-                    number_of_invalid_outputs,
-                )
-                .into_iter(),
-            )
-            .collect();
-
-    let (utxo_db, tx) = prepare_utxos_and_tx(&mut rng, inputs, outputs);
-
-    let inputs_utxos = get_inputs_utxos(&utxo_db, tx.inputs()).unwrap();
-    let result = check_tx_inputs_outputs_purposes(&tx, &inputs_utxos).unwrap_err();
-    assert_eq!(result, IOPolicyError::MultipleDelegationCreated);
-}
 
 #[rstest]
 #[trace]
@@ -125,16 +38,8 @@ fn tx_many_to_many_valid(#[case] seed: Seed) {
     let number_of_inputs = rng.gen_range(1..10);
     let number_of_outputs = rng.gen_range(1..10);
 
-    // valid cases
-    let valid_inputs = [
-        lock_then_transfer(),
-        transfer(),
-        stake_pool(),
-        produce_block(),
-        mint_tokens(),
-        issue_nft(),
-    ];
-    let valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
+    let valid_inputs = super::outputs_utils::valid_tx_inputs();
+    let valid_outputs = super::outputs_utils::valid_tx_outputs();
 
     let (utxo_db, tx) = prepare_utxos_and_tx_with_random_combinations(
         &mut rng,
@@ -151,20 +56,13 @@ fn tx_many_to_many_valid(#[case] seed: Seed) {
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn tx_many_to_many_invalid(#[case] seed: Seed) {
+fn tx_many_to_many_invalid_inputs(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let number_of_inputs = rng.gen_range(1..10);
     let number_of_outputs = rng.gen_range(1..10);
 
-    let valid_inputs = [
-        lock_then_transfer(),
-        transfer(),
-        stake_pool(),
-        produce_block(),
-        mint_tokens(),
-        issue_nft(),
-    ];
-    let valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
+    let valid_inputs = super::outputs_utils::valid_tx_inputs();
+    let valid_outputs = super::outputs_utils::valid_tx_outputs();
 
     let invalid_inputs = [
         burn(),
@@ -179,7 +77,11 @@ fn tx_many_to_many_invalid(#[case] seed: Seed) {
         let mut outputs =
             get_random_outputs_combination(&mut rng, &invalid_inputs, number_of_inputs)
                 .into_iter()
-                .chain(valid_inputs.into_iter())
+                .chain(get_random_outputs_combination(
+                    &mut rng,
+                    &valid_inputs,
+                    number_of_inputs,
+                ))
                 .collect::<Vec<_>>();
         outputs.shuffle(&mut rng);
         outputs
@@ -203,9 +105,8 @@ fn tx_produce_block_in_output(#[case] seed: Seed) {
     let number_of_inputs = rng.gen_range(1..10);
     let number_of_outputs = rng.gen_range(1..10);
 
-    let valid_inputs = [lock_then_transfer(), transfer(), stake_pool(), produce_block()];
-    let valid_outputs = [lock_then_transfer(), transfer(), burn(), delegate_staking()];
-
+    let valid_inputs = super::outputs_utils::valid_tx_inputs();
+    let valid_outputs = super::outputs_utils::valid_tx_outputs();
     let invalid_outputs = [produce_block()];
 
     let input_utxos = get_random_outputs_combination(&mut rng, &valid_inputs, number_of_inputs);
@@ -214,7 +115,11 @@ fn tx_produce_block_in_output(#[case] seed: Seed) {
         let mut outputs =
             get_random_outputs_combination(&mut rng, &invalid_outputs, number_of_outputs)
                 .into_iter()
-                .chain(valid_outputs.into_iter())
+                .chain(get_random_outputs_combination(
+                    &mut rng,
+                    &valid_outputs,
+                    number_of_outputs,
+                ))
                 .collect::<Vec<_>>();
         outputs.shuffle(&mut rng);
         outputs
@@ -246,83 +151,36 @@ fn tx_create_pool_and_delegation_same_tx(#[case] seed: Seed) {
 }
 
 #[rstest]
-#[rustfmt::skip]
-#[case(transfer(), transfer(),           Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(transfer(), burn(),               Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(transfer(), lock_then_transfer(), Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(transfer(), stake_pool(),         Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(transfer(), produce_block(),      Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(transfer(), create_delegation(),  Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(transfer(), delegate_staking(),   Err(IOPolicyError::InvalidInputTypeInReward))]
-/*-----------------------------------------------------------------------------------------------*/
-#[case(burn(), transfer(),           Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(burn(), burn(),               Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(burn(), lock_then_transfer(), Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(burn(), stake_pool(),         Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(burn(), produce_block(),      Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(burn(), create_delegation(),  Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(burn(), delegate_staking(),   Err(IOPolicyError::InvalidInputTypeInReward))]
-/*-----------------------------------------------------------------------------------------------*/
-#[case(lock_then_transfer(), transfer(),           Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(lock_then_transfer(), burn(),               Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(lock_then_transfer(), lock_then_transfer(), Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(lock_then_transfer(), stake_pool(),         Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(lock_then_transfer(), produce_block(),      Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(lock_then_transfer(), create_delegation(),  Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(lock_then_transfer(), delegate_staking(),   Err(IOPolicyError::InvalidInputTypeInReward))]
-/*-----------------------------------------------------------------------------------------------*/
-#[case(stake_pool(), transfer(),           Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(stake_pool(), burn(),               Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(stake_pool(), lock_then_transfer(), Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(stake_pool(), stake_pool(),         Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(stake_pool(), produce_block(),      Ok(()))]
-#[case(stake_pool(), create_delegation(),  Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(stake_pool(), delegate_staking(),   Err(IOPolicyError::InvalidOutputTypeInReward))]
-/*-----------------------------------------------------------------------------------------------*/
-#[case(produce_block(), transfer(),           Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(produce_block(), burn(),               Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(produce_block(), lock_then_transfer(), Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(produce_block(), stake_pool(),         Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(produce_block(), produce_block(),      Ok(()))]
-#[case(produce_block(), create_delegation(), Err(IOPolicyError::InvalidOutputTypeInReward))]
-#[case(produce_block(), delegate_staking(), Err(IOPolicyError::InvalidOutputTypeInReward))]
-/*-----------------------------------------------------------------------------------------------*/
-#[case(create_delegation(), transfer(),           Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(create_delegation(), burn(),               Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(create_delegation(), lock_then_transfer(), Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(create_delegation(), stake_pool(),         Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(create_delegation(), produce_block(),      Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(create_delegation(), create_delegation(),  Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(create_delegation(), delegate_staking(),   Err(IOPolicyError::InvalidInputTypeInReward))]
-/*-----------------------------------------------------------------------------------------------*/
-#[case(delegate_staking(), transfer(),           Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(delegate_staking(), burn(),               Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(delegate_staking(), lock_then_transfer(), Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(delegate_staking(), stake_pool(),         Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(delegate_staking(), produce_block(),      Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(delegate_staking(), create_delegation(),  Err(IOPolicyError::InvalidInputTypeInReward))]
-#[case(delegate_staking(), delegate_staking(),   Err(IOPolicyError::InvalidInputTypeInReward))]
-fn reward_one_to_one(
-    #[case] input_utxo: TxOutput,
-    #[case] output: TxOutput,
-    #[case] result: Result<(), IOPolicyError>,
-) {
+#[trace]
+#[case(Seed::from_entropy())]
+fn reward_one_to_one(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let all_outputs = super::outputs_utils::all_outputs();
+    let input_utxo = get_random_outputs_combination(&mut rng, &all_outputs, 1)[0].clone();
+    let output = get_random_outputs_combination(&mut rng, &all_outputs, 1)[0].clone();
+
     let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(Id::new(H256::zero())), 0);
     let utxo_db = UtxosDBInMemoryImpl::new(
         Id::<GenBlock>::new(H256::zero()),
-        BTreeMap::from_iter([(outpoint.clone(), Utxo::new_for_mempool(input_utxo))]),
+        BTreeMap::from_iter([(outpoint.clone(), Utxo::new_for_mempool(input_utxo.clone()))]),
     );
 
-    let block = make_block(vec![outpoint.into()], vec![output]);
+    let block = make_block(vec![outpoint.into()], vec![output.clone()]);
 
-    assert_eq!(
-        result.map_err(|e| ConnectTransactionError::IOPolicyError(e, block.get_id().into())),
-        check_reward_inputs_outputs_purposes(
-            &block.block_reward_transactable(),
-            &utxo_db,
-            block.get_id()
-        )
+    let result = check_reward_inputs_outputs_purposes(
+        &block.block_reward_transactable(),
+        &utxo_db,
+        block.get_id(),
     );
+
+    if (&input_utxo, &output) == (&stake_pool(), &produce_block())
+        || (&input_utxo, &output) == (&produce_block(), &produce_block())
+    {
+        assert!(result.is_ok());
+    } else {
+        assert!(result.is_err());
+    }
 }
 
 #[rstest]
@@ -426,20 +284,7 @@ fn reward_none_to_any(#[case] seed: Seed) {
 fn reward_many_to_none(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
 
-    let all_purposes = [
-        lock_then_transfer(),
-        transfer(),
-        burn(),
-        stake_pool(),
-        produce_block(),
-        create_delegation(),
-        delegate_staking(),
-        issue_tokens(),
-        mint_tokens(),
-        issue_nft(),
-        redeem_tokens(),
-        lock_tokens_supply(),
-    ];
+    let all_purposes = super::outputs_utils::all_outputs();
 
     let number_of_outputs = rng.gen_range(2..10);
     let kernel_outputs = get_random_outputs_combination(&mut rng, &all_purposes, number_of_outputs)

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -371,8 +371,6 @@ impl MempoolBanScore for IOPolicyError {
             IOPolicyError::InvalidInputTypeInReward => 100,
             IOPolicyError::InvalidOutputTypeInReward => 100,
             IOPolicyError::InvalidInputTypeInTx => 100,
-            IOPolicyError::MultiplePoolCreated => 100,
-            IOPolicyError::MultipleDelegationCreated => 100,
             IOPolicyError::ProduceBlockInTx => 100,
             IOPolicyError::AmountOverflow => 100,
             IOPolicyError::AttemptToPrintMoneyOrViolateTimelockConstraints => 100,


### PR DESCRIPTION
These changes are based on #1179 and inspired by it but aren't strictly required there so I want to discuss them separately.

1. I suggest removing the code that checks that `CreateStakePool` and `CreateDelegationId` are unique among tx outputs. This check is redundant and complicates io policies checks (also it requires adding the same redundant check for token issuance) because it doesn't relate to Policies per se. All this checks are dictated by the way ids are made from `input_utxo0` which is internal logic of `pos_accounting` and `tokens_accounting`. So I suggest relying on the checks in corresponding crates.
2. Clean up `input_output_policy::purposes_check` tests for better support of new token outputs as well as the future ones.