### PR TITLE
Change binary names for consistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ default-members = [
   "logging",
   "mempool",
   "node-daemon",
-  "node-gui",
   "node-lib",
   "p2p",
   "rpc",
@@ -224,3 +223,4 @@ overflow-checks = true
 
 [profile.test.package.script]
 opt-level = 2
+

--- a/api-server/web-server/Cargo.toml
+++ b/api-server/web-server/Cargo.toml
@@ -19,3 +19,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+
+[[bin]]
+name = "mintlayer-api"
+path = "src/main.rs"

--- a/node-daemon/Cargo.toml
+++ b/node-daemon/Cargo.toml
@@ -17,3 +17,7 @@ tokio = { workspace = true, default-features = false }
 
 [dev-dependencies]
 assert_cmd.workspace = true
+
+[[bin]]
+name = "mintlayerd"
+path = "src/main.rs"

--- a/node-daemon/tests/tui.rs
+++ b/node-daemon/tests/tui.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 
 use assert_cmd::Command;
 
-const BIN_NAME: &str = env!("CARGO_BIN_EXE_node-daemon");
+const BIN_NAME: &str = env!("CARGO_BIN_EXE_mintlayerd");
 
 // This test is only needed because the node name is hardcoded here, so if the name is changed we
 // get an error that is easy to understand.

--- a/node-gui/Cargo.toml
+++ b/node-gui/Cargo.toml
@@ -31,3 +31,7 @@ rfd = { workspace = true, features = ["gtk3"] } # revert to "xdg-portal" once ht
 thiserror.workspace = true
 tokio.workspace = true
 variant_count.workspace = true
+
+[[bin]]
+name = "mintlayer-gui"
+path = "src/main.rs"

--- a/wallet/wallet-address-generator/Cargo.toml
+++ b/wallet/wallet-address-generator/Cargo.toml
@@ -19,3 +19,7 @@ crypto = { path = "../../crypto" }
 clap = { workspace = true, features = ["derive"] }
 
 thiserror.workspace = true
+
+[[bin]]
+name = "mintlayer-address-generator"
+path = "src/main.rs"

--- a/wallet/wallet-cli/Cargo.toml
+++ b/wallet/wallet-cli/Cargo.toml
@@ -13,3 +13,7 @@ wallet-cli-lib = { path = "../wallet-cli-lib" }
 
 clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }
+
+[[bin]]
+name = "mintlayer-cli"
+path = "src/main.rs"


### PR DESCRIPTION
### Changes to Binary Names and Default Behavior

Please consider this PR. I am happy to re-add `node-gui` to the defaults if this creates any issues. The goal of this PR is to simplify the build process. Most users are not interested in building the GUI, and it comes with many unwanted dependencies, such as GTK. Additionally, we aim to ensure consistency in binary names, as we are beginning to develop scripts and documentation that reference them.

#### 1. Updated Binary Names

The binary names have been updated as follows:

- `node-gui` is now `mintlayer-gui`
- `node-daemon` is now `mintlayerd`
- `wallet-cli` is now `mintlayer-cli`
- `wallet-address-generator` is now `mintlayer-address-generator`
- `web-server` is now `mintlayer-api`

To run the binaries, use the new names as in the example below:

```sh
cargo run --bin mintlayerd
```

#### 2. Changes to `node-gui`

`node-gui` has been removed from the default build and test targets. To run it, specify the package and binary explicitly:

```sh
cargo run -p node-gui --bin mintlayer-gui
```
