### PR TITLE
blockprod: Ability to specify custom transactions

### DIFF
--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -30,9 +30,9 @@ use common::{
             block_body::BlockBody, signed_block_header::SignedBlockHeader,
             timestamp::BlockTimestamp, BlockCreationError, BlockHeader, BlockReward, ConsensusData,
         },
-        Block, ChainConfig, GenBlock, SignedTransaction,
+        Block, ChainConfig, GenBlock, SignedTransaction, Transaction,
     },
-    primitives::{BlockHeight, Id},
+    primitives::{Amount, BlockHeight, Id, Idable},
     time_getter::TimeGetter,
 };
 use consensus::{
@@ -42,7 +42,7 @@ use consensus::{
 use crypto::random::{make_true_rng, Rng};
 use logging::log;
 use mempool::{
-    tx_accumulator::{DefaultTxAccumulator, TransactionAccumulator},
+    tx_accumulator::{DefaultTxAccumulator, PackingStrategy, TransactionAccumulator},
     MempoolHandle,
 };
 use p2p::P2pHandle;
@@ -180,19 +180,31 @@ impl BlockProduction {
         &self,
         current_tip: Id<GenBlock>,
         min_block_timestamp: BlockTimestamp,
-    ) -> Result<Option<Box<dyn TransactionAccumulator>>, BlockProductionError> {
-        let max_block_size = self.chain_config.max_block_size_from_std_scripts();
+        transactions: Vec<SignedTransaction>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
+    ) -> Result<Box<dyn TransactionAccumulator>, BlockProductionError> {
+        let mut accumulator = Box::new(DefaultTxAccumulator::new(
+            self.chain_config.max_block_size_from_std_scripts(),
+            current_tip,
+            min_block_timestamp,
+        ));
+
+        for transaction in transactions.into_iter() {
+            let transaction_id = transaction.transaction().get_id();
+
+            accumulator
+                .add_tx(transaction, Amount::ZERO.into())
+                .map_err(|err| BlockProductionError::FailedToAddTransaction(transaction_id, err))?
+        }
+
         let returned_accumulator = self
             .mempool_handle
             .call(move |mempool| {
-                mempool.collect_txs(Box::new(DefaultTxAccumulator::new(
-                    max_block_size,
-                    current_tip,
-                    min_block_timestamp,
-                )))
+                mempool.collect_txs(accumulator, transaction_ids, packing_strategy)
             })
-            .await?
-            .map_err(|_| BlockProductionError::MempoolChannelClosed)?;
+            .await??;
+
         Ok(returned_accumulator)
     }
 
@@ -310,15 +322,26 @@ impl BlockProduction {
     pub async fn produce_block(
         &self,
         input_data: GenerateBlockInputData,
-        transactions_source: TransactionsSource,
+        transactions: Vec<SignedTransaction>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
     ) -> Result<(Block, oneshot::Receiver<usize>), BlockProductionError> {
-        self.produce_block_with_custom_id(input_data, transactions_source, None).await
+        self.produce_block_with_custom_id(
+            input_data,
+            transactions,
+            transaction_ids,
+            packing_strategy,
+            None,
+        )
+        .await
     }
 
     async fn produce_block_with_custom_id(
         &self,
         input_data: GenerateBlockInputData,
-        transactions_source: TransactionsSource,
+        transactions: Vec<SignedTransaction>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
         custom_id_maybe: Option<Vec<u8>>,
     ) -> Result<(Block, oneshot::Receiver<usize>), BlockProductionError> {
         if !self.blockprod_config.skip_ibd_check {
@@ -435,36 +458,27 @@ impl BlockProduction {
                 ));
             }
 
-            // TODO: see if we can simplify this
-            let transactions = match transactions_source.clone() {
-                TransactionsSource::Mempool => {
-                    // We conservatively use the minimum timestamp here in order to figure out
-                    // which transactions are valid for the block.
-                    // TODO: Alternatively, we can construct the transaction sequence from the
-                    // scratch every time a different timestamp is attempted. That is more costly
-                    // in terms of computational resources but will allow the node to include more
-                    // transactions since the passing time may release some time locks.
-                    let accumulator = self
-                        .collect_transactions(
-                            current_tip_index.block_id(),
-                            min_constructed_block_timestamp,
-                        )
-                        .await?;
-                    match accumulator {
-                        Some(acc) => acc.transactions().clone(),
-                        None => {
-                            // If the mempool rejects the accumulator (due to tip mismatch, or otherwise), we should start over and try again
-                            log::info!(
-                                "Mempool rejected the transaction accumulator. Restarting the block production attempt."
-                            );
-                            continue;
-                        }
-                    }
-                }
-                TransactionsSource::Provided(txs) => txs,
+            // We conservatively use the minimum timestamp here in order to figure out
+            // which transactions are valid for the block.
+            // TODO: Alternatively, we can construct the transaction sequence from
+            // scratch every time a different timestamp is attempted. That is more costly
+            // in terms of computational resources but will allow the node to include more
+            // transactions since the passing time may release some time locks.
+            let collected_transactions = {
+                let accumulator = self
+                    .collect_transactions(
+                        current_tip_index.block_id(),
+                        min_constructed_block_timestamp,
+                        transactions.clone(),
+                        transaction_ids.clone(),
+                        packing_strategy,
+                    )
+                    .await?;
+
+                accumulator.transactions().clone()
             };
 
-            let block_body = BlockBody::new(block_reward, transactions);
+            let block_body = BlockBody::new(block_reward, collected_transactions);
 
             // A synchronous channel that sends only when the mining/staking is done
             let (ended_sender, ended_receiver) = mpsc::channel::<()>();

--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -464,19 +464,17 @@ impl BlockProduction {
             // scratch every time a different timestamp is attempted. That is more costly
             // in terms of computational resources but will allow the node to include more
             // transactions since the passing time may release some time locks.
-            let collected_transactions = {
-                let accumulator = self
-                    .collect_transactions(
-                        current_tip_index.block_id(),
-                        min_constructed_block_timestamp,
-                        transactions.clone(),
-                        transaction_ids.clone(),
-                        packing_strategy,
-                    )
-                    .await?;
-
-                accumulator.transactions().clone()
-            };
+            let collected_transactions = self
+                .collect_transactions(
+                    current_tip_index.block_id(),
+                    min_constructed_block_timestamp,
+                    transactions.clone(),
+                    transaction_ids.clone(),
+                    packing_strategy,
+                )
+                .await?
+                .transactions()
+                .clone();
 
             let block_body = BlockBody::new(block_reward, collected_transactions);
 

--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -917,7 +917,7 @@ mod produce_block {
                     chain_config,
                     Arc::new(test_blockprod_config()),
                     chainstate.clone(),
-                    mempool,
+                    mempool.clone(),
                     p2p,
                     Default::default(),
                     prepare_thread_pool(1),
@@ -938,7 +938,7 @@ mod produce_block {
                 job_finished_receiver.await.expect("Job finished receiver closed");
 
                 assert_job_count(&block_production, 0).await;
-                assert_process_block(&chainstate, new_block).await;
+                assert_process_block(&chainstate, &mempool, new_block).await;
             }
         });
 
@@ -962,7 +962,7 @@ mod produce_block {
                     chain_config,
                     Arc::new(test_blockprod_config()),
                     chainstate.clone(),
-                    mempool,
+                    mempool.clone(),
                     p2p,
                     Default::default(),
                     prepare_thread_pool(1),
@@ -983,7 +983,7 @@ mod produce_block {
                 job_finished_receiver.await.expect("Job finished receiver closed");
 
                 assert_job_count(&block_production, 0).await;
-                assert_process_block(&chainstate, new_block).await;
+                assert_process_block(&chainstate, &mempool, new_block).await;
             }
         });
 
@@ -1095,7 +1095,7 @@ mod produce_block {
                     chain_config,
                     Arc::new(test_blockprod_config()),
                     chainstate.clone(),
-                    mempool,
+                    mempool.clone(),
                     p2p,
                     Default::default(),
                     prepare_thread_pool(1),
@@ -1115,7 +1115,7 @@ mod produce_block {
                 job_finished_receiver.await.expect("Job finished receiver closed");
 
                 assert_job_count(&block_production, 0).await;
-                assert_process_block(&chainstate, new_block).await;
+                assert_process_block(&chainstate, &mempool, new_block).await;
             }
         });
 
@@ -1152,7 +1152,7 @@ mod produce_block {
                     chain_config,
                     Arc::new(test_blockprod_config()),
                     chainstate.clone(),
-                    mempool,
+                    mempool.clone(),
                     p2p,
                     Default::default(),
                     prepare_thread_pool(1),
@@ -1174,7 +1174,7 @@ mod produce_block {
                 job_finished_receiver.await.expect("Job finished receiver closed");
 
                 assert_job_count(&block_production, 0).await;
-                assert_process_block(&chainstate, new_block).await;
+                assert_process_block(&chainstate, &mempool, new_block).await;
             }
         });
 
@@ -1209,7 +1209,7 @@ mod produce_block {
                     chain_config.clone(),
                     Arc::new(test_blockprod_config()),
                     chainstate.clone(),
-                    mempool,
+                    mempool.clone(),
                     p2p,
                     Default::default(),
                     prepare_thread_pool(1),
@@ -1240,7 +1240,7 @@ mod produce_block {
                 job_finished_receiver.await.expect("Job finished receiver closed");
 
                 assert_job_count(&block_production, 0).await;
-                assert_process_block(&chainstate, new_block).await;
+                assert_process_block(&chainstate, &mempool, new_block).await;
             }
         });
 
@@ -1354,7 +1354,7 @@ mod produce_block {
                     chain_config.clone(),
                     Arc::new(test_blockprod_config()),
                     chainstate.clone(),
-                    mempool,
+                    mempool.clone(),
                     p2p,
                     Default::default(),
                     prepare_thread_pool(1),
@@ -1400,7 +1400,7 @@ mod produce_block {
 
                             job_finished_receiver.await.expect("Job finished receiver closed");
 
-                            assert_process_block(&chainstate, new_block.clone()).await;
+                            assert_process_block(&chainstate, &mempool, new_block.clone()).await;
                         }
                         RequiredConsensus::PoS(_) => {
                             // Try no input data for PoS consensus
@@ -1457,7 +1457,8 @@ mod produce_block {
 
                             job_finished_receiver.await.expect("Job finished receiver closed");
 
-                            let result = assert_process_block(&chainstate, new_block).await;
+                            let result =
+                                assert_process_block(&chainstate, &mempool, new_block).await;
 
                             // Update kernel input parameters for future PoS blocks
 
@@ -1528,7 +1529,7 @@ mod produce_block {
 
                             job_finished_receiver.await.expect("Job finished receiver closed");
 
-                            assert_process_block(&chainstate, new_block.clone()).await;
+                            assert_process_block(&chainstate, &mempool, new_block.clone()).await;
                         }
                     }
                 }

--- a/mempool/src/error/mod.rs
+++ b/mempool/src/error/mod.rs
@@ -20,9 +20,27 @@ use chainstate::{tx_verifier::error::ConnectTransactionError, ChainstateError};
 use subsystem::error::CallError;
 use thiserror::Error;
 
-use common::primitives::H256;
+use common::{
+    chain::{GenBlock, Transaction},
+    primitives::{Id, H256},
+};
 
 use crate::pool::fee::Fee;
+
+/// Error related to the construction of transaction sequence for inclusion in a block
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum BlockConstructionError {
+    #[error(transparent)]
+    Validity(#[from] TxValidationError),
+    #[error("The tip expected by accumulator ({0:?}) does not match mempool tip ({1:?})")]
+    AccumTipMismatch(Id<GenBlock>, Id<GenBlock>),
+    #[error("The moved during block construction: {0:?} -> {1:?}")]
+    TipMoved(Id<GenBlock>, Id<GenBlock>),
+    #[error("Subsystem call: {0}")]
+    Call(#[from] subsystem::error::CallError),
+    #[error("User-requested transaction {0} not found in mempool")]
+    TxNotFound(Id<Transaction>),
+}
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum Error {

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -14,9 +14,9 @@
 // limitations under the License.
 
 use crate::{
-    error::Error,
+    error::{BlockConstructionError, Error},
     event::MempoolEvent,
-    tx_accumulator::TransactionAccumulator,
+    tx_accumulator::{PackingStrategy, TransactionAccumulator},
     tx_origin::{LocalTxOrigin, RemoteTxOrigin},
     FeeRate, MempoolMaxSize, TxStatus,
 };
@@ -60,11 +60,12 @@ pub trait MempoolInterface: Send + Sync {
     fn best_block_id(&self) -> Id<GenBlock>;
 
     /// Collect transactions by putting them in given accumulator
-    /// Ok(None) is returned if mempool rejects the accumulator due configuration mismatch (e.g., tip mismatch)
     fn collect_txs(
         &self,
         tx_accumulator: Box<dyn TransactionAccumulator + Send>,
-    ) -> Result<Option<Box<dyn TransactionAccumulator>>, Error>;
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
+    ) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError>;
 
     /// Subscribe to events emitted by mempool
     fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>);

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -14,10 +14,10 @@
 // limitations under the License.
 
 use crate::{
-    error::Error,
+    error::{BlockConstructionError, Error},
     event::MempoolEvent,
     pool::memory_usage_estimator::StoreMemoryUsageEstimator,
-    tx_accumulator::TransactionAccumulator,
+    tx_accumulator::{PackingStrategy, TransactionAccumulator},
     tx_origin::{LocalTxOrigin, RemoteTxOrigin},
     FeeRate, MempoolInterface, MempoolMaxSize, TxStatus,
 };
@@ -170,8 +170,10 @@ impl MempoolInterface for MempoolImpl {
     fn collect_txs(
         &self,
         tx_accumulator: Box<dyn TransactionAccumulator + Send>,
-    ) -> Result<Option<Box<dyn TransactionAccumulator>>, Error> {
-        Ok(self.mempool.collect_txs(tx_accumulator))
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
+    ) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError> {
+        self.mempool.collect_txs(tx_accumulator, transaction_ids, packing_strategy)
     }
 
     fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>) {

--- a/mempool/src/pool/collect_txs.rs
+++ b/mempool/src/pool/collect_txs.rs
@@ -1,0 +1,247 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    error::{BlockConstructionError, TxValidationError},
+    pool::{tx_verifier, Mempool, TxMempoolEntry},
+    tx_accumulator::{PackingStrategy, TransactionAccumulator},
+};
+
+use std::{
+    cmp::Ordering,
+    collections::{binary_heap, btree_map, BTreeMap, BTreeSet, BinaryHeap},
+    ops::Deref,
+};
+
+use chainstate::tx_verifier::transaction_verifier::TransactionSourceForConnect;
+use common::{
+    chain::transaction::Transaction,
+    primitives::{Id, Idable},
+};
+use logging::log;
+use utils::{ensure, graph_traversals, shallow_clone::ShallowClone};
+
+/// Transaction entry together with priority
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct EntryByScore<'a> {
+    entry: &'a TxMempoolEntry,
+}
+
+impl PartialOrd for EntryByScore<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::ops::Deref for EntryByScore<'_> {
+    type Target = TxMempoolEntry;
+    fn deref(&self) -> &Self::Target {
+        self.entry
+    }
+}
+
+impl Ord for EntryByScore<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ancestor_score()
+            .cmp(&other.ancestor_score())
+            .then_with(|| self.tx_id().cmp(other.tx_id()))
+    }
+}
+
+impl<'a> From<&'a TxMempoolEntry> for EntryByScore<'a> {
+    fn from(entry: &'a TxMempoolEntry) -> Self {
+        Self { entry }
+    }
+}
+
+pub fn collect_txs<M>(
+    mempool: &Mempool<M>,
+    mut tx_accumulator: Box<dyn TransactionAccumulator>,
+    transaction_ids: Vec<Id<Transaction>>,
+    packing_strategy: PackingStrategy,
+) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError> {
+    let mempool_tip = mempool.best_block_id();
+    let block_timestamp = tx_accumulator.block_timestamp();
+
+    ensure!(
+        tx_accumulator.expected_tip() == mempool_tip,
+        BlockConstructionError::AccumTipMismatch(tx_accumulator.expected_tip(), mempool_tip),
+    );
+
+    let chainstate = tx_verifier::ChainstateHandle::new(mempool.chainstate_handle.shallow_clone());
+    let chain_config = mempool.chain_config.deref();
+    let utxo_view = tx_verifier::MempoolUtxoView::new(mempool, chainstate.shallow_clone());
+
+    // Transaction verifier to detect cases where mempool is not fully up-to-date with
+    // transaction dependencies.
+    let mut tx_verifier = tx_verifier::create(
+        mempool.chain_config.shallow_clone(),
+        mempool.chainstate_handle.shallow_clone(),
+    );
+
+    let verifier_time = tx_accumulator.block_timestamp();
+
+    let best_index = mempool
+        .blocking_chainstate_handle()
+        .call(|c| c.get_best_block_index())?
+        .expect("best index to exist");
+    let tx_source = TransactionSourceForConnect::for_mempool(&best_index);
+
+    // Use transactions already in the Accumulator to check for uniqueness and to update the
+    // verifier state to update UTXOs they consume / provide.
+    let accum_ids = tx_accumulator
+        .transactions()
+        .iter()
+        .map(|transaction| {
+            let _fee =
+                tx_verifier.connect_transaction(&tx_source, transaction, &verifier_time, None)?;
+            Ok(transaction.transaction().get_id())
+        })
+        .collect::<Result<Vec<_>, TxValidationError>>()?;
+
+    // Set of transactions already placed into the accumulator
+    let mut emitted: BTreeSet<_> = accum_ids.iter().collect();
+    // Set of already processed transactions, for de-duplication
+    let mut processed = emitted.clone();
+
+    // Transaction IDs specified by the user
+    let given_txids = {
+        for tx_id in &transaction_ids {
+            ensure!(
+                mempool.store.get_entry(tx_id).is_some(),
+                BlockConstructionError::TxNotFound(*tx_id),
+            );
+        }
+        // Pull in the parents before the user-specified transactions so we get a valid sequence
+        graph_traversals::dag_depth_postorder_multiroot(&transaction_ids, |tx_id| {
+            mempool.store.get_entry(tx_id).expect("already checked").parents()
+        })
+    };
+
+    // Transaction IDs taken from mempool to fill in the rest of the block
+    let mempool_txids = {
+        // Get transactions from mempool by score
+        let txids = mempool.store.txs_by_ancestor_score.iter().map(|x| &x.1).rev();
+        // Take the appropriate amount of them as determined by the packing strategy
+        txids.take(match packing_strategy {
+            PackingStrategy::FillSpaceFromMempool => usize::MAX,
+            PackingStrategy::LeaveEmptySpace => 0,
+        })
+    };
+
+    // Put all the transaction IDs together
+    let mut tx_iter = given_txids
+        .chain(mempool_txids)
+        .filter_map(|tx_id| {
+            // If the transaction with this ID has already been processed, skip it
+            ensure!(processed.insert(tx_id));
+            let tx = mempool.store.txs_by_id.get(tx_id).expect("already checked").deref();
+            let timelock_check = chainstate::tx_verifier::timelock_check::check_timelocks(
+                &chainstate,
+                chain_config,
+                &utxo_view,
+                tx.transaction(),
+                &tx_source,
+                &block_timestamp,
+            );
+            ensure!(timelock_check.is_ok());
+            Some(tx)
+        })
+        .fuse()
+        .peekable();
+
+    // Set of transaction waiting for one or more parents to be emitted
+    let mut pending = BTreeMap::new();
+    // A queue of transactions that can be emitted
+    let mut ready = BinaryHeap::<EntryByScore>::new();
+
+    while !tx_accumulator.done() {
+        // Take out the transactions from tx_iter until there is one ready
+        while let Some(tx) = tx_iter.peek() {
+            let missing_parents: usize = tx.parents().filter(|p| !emitted.contains(p)).count();
+            if missing_parents == 0 {
+                break;
+            } else {
+                pending.insert(tx.tx_id(), missing_parents);
+                let _ = tx_iter.next();
+            }
+        }
+
+        let next_tx = match (tx_iter.peek(), ready.peek_mut()) {
+            (Some(store_tx), Some(ready_tx)) => {
+                if store_tx.ancestor_score() > ready_tx.ancestor_score() {
+                    tx_iter.next().expect("just checked")
+                } else {
+                    binary_heap::PeekMut::pop(ready_tx).entry
+                }
+            }
+            (Some(_store_tx), None) => tx_iter.next().expect("just checked"),
+            (None, Some(ready_tx)) => binary_heap::PeekMut::pop(ready_tx).entry,
+            (None, None) => break,
+        };
+
+        let verification_result = tx_verifier.connect_transaction(
+            &tx_source,
+            next_tx.transaction(),
+            &verifier_time,
+            None,
+        );
+
+        if let Err(err) = verification_result {
+            // TODO Narrow down when the critical error is presented. Printing the error may be a
+            // false positive if the tip moves during the execution of this function.
+            log::error!(
+                "CRITICAL: Verifier and mempool do not agree on transaction deps for {}: {err}",
+                next_tx.tx_id()
+            );
+            continue;
+        }
+
+        if let Err(err) = tx_accumulator.add_tx(next_tx.transaction().clone(), next_tx.fee()) {
+            log::error!(
+                "CRITICAL: Failed to add transaction {} from mempool. Error: {err}",
+                next_tx.tx_id(),
+            );
+            break;
+        }
+
+        emitted.insert(next_tx.tx_id());
+
+        // Release newly ready transactions
+        for child in next_tx.children() {
+            match pending.entry(child) {
+                btree_map::Entry::Vacant(_) => (),
+                btree_map::Entry::Occupied(mut c) => match c.get_mut() {
+                    0 => panic!("pending with 0 missing parents"),
+                    1 => {
+                        // This was the last missing parent, put the tx into the ready queue
+                        ready.push(mempool.store.txs_by_id[c.key()].deref().into());
+                        c.remove();
+                    }
+                    n => *n -= 1,
+                },
+            }
+        }
+    }
+
+    let final_chainstate_tip =
+        utxo::UtxosView::best_block_hash(&chainstate).expect("cannot fetch tip");
+    ensure!(
+        mempool_tip == final_chainstate_tip,
+        BlockConstructionError::TipMoved(mempool_tip, final_chainstate_tip),
+    );
+
+    Ok(tx_accumulator)
+}

--- a/mempool/src/pool/collect_txs.rs
+++ b/mempool/src/pool/collect_txs.rs
@@ -91,8 +91,6 @@ pub fn collect_txs<M>(
         mempool.chainstate_handle.shallow_clone(),
     );
 
-    let verifier_time = tx_accumulator.block_timestamp();
-
     let best_index = mempool
         .blocking_chainstate_handle()
         .call(|c| c.get_best_block_index())?
@@ -106,7 +104,7 @@ pub fn collect_txs<M>(
         .iter()
         .map(|transaction| {
             let _fee =
-                tx_verifier.connect_transaction(&tx_source, transaction, &verifier_time, None)?;
+                tx_verifier.connect_transaction(&tx_source, transaction, &block_timestamp, None)?;
             Ok(transaction.transaction().get_id())
         })
         .collect::<Result<Vec<_>, TxValidationError>>()?;
@@ -195,7 +193,7 @@ pub fn collect_txs<M>(
         let verification_result = tx_verifier.connect_transaction(
             &tx_source,
             next_tx.transaction(),
-            &verifier_time,
+            &block_timestamp,
             None,
         );
 

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -15,14 +15,7 @@
 
 use mempool_types::tx_origin::LocalTxOrigin;
 use parking_lot::RwLock;
-use std::{
-    collections::{binary_heap, btree_map, BTreeMap, BTreeSet, BinaryHeap},
-    mem,
-    num::NonZeroUsize,
-    ops::Deref,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::BTreeSet, mem, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use chainstate::{
     chainstate_interface::ChainstateInterface,
@@ -56,15 +49,19 @@ use self::{
 };
 use crate::{
     config,
-    error::{Error, MempoolConflictError, MempoolPolicyError, OrphanPoolError, TxValidationError},
+    error::{
+        BlockConstructionError, Error, MempoolConflictError, MempoolPolicyError, OrphanPoolError,
+        TxValidationError,
+    },
     event::{self, MempoolEvent},
-    tx_accumulator::TransactionAccumulator,
+    tx_accumulator::{PackingStrategy, TransactionAccumulator},
     tx_origin::{RemoteTxOrigin, TxOrigin},
     TxStatus,
 };
 
 use crate::config::*;
 
+mod collect_txs;
 mod entry;
 pub mod fee;
 mod feerate;
@@ -958,145 +955,11 @@ impl<M: MemoryUsageEstimator> Mempool<M> {
 
     pub fn collect_txs(
         &self,
-        mut tx_accumulator: Box<dyn TransactionAccumulator>,
-    ) -> Option<Box<dyn TransactionAccumulator>> {
-        let mempool_tip = self.best_block_id();
-
-        if tx_accumulator.expected_tip() != mempool_tip {
-            log::debug!(
-                "Mempool rejected transaction accumulator due to different tip: expected tip {:?} (current tip {:?})",
-                tx_accumulator.expected_tip(),
-                self.best_block_id(),
-            );
-            return None;
-        }
-
-        let chainstate = tx_verifier::ChainstateHandle::new(self.chainstate_handle.shallow_clone());
-        let chain_config = self.chain_config.deref();
-        let utxo_view = tx_verifier::MempoolUtxoView::new(self, chainstate.shallow_clone());
-
-        // Transaction verifier to detect cases where mempool is not fully up-to-date with
-        // transaction dependencies.
-        let mut tx_verifier = tx_verifier::create(
-            self.chain_config.shallow_clone(),
-            self.chainstate_handle.shallow_clone(),
-        );
-
-        let verifier_time = tx_accumulator.block_timestamp();
-
-        let best_index = self
-            .blocking_chainstate_handle()
-            .call(|c| c.get_best_block_index())
-            .expect("chainstate to live")
-            .expect("best index to exist");
-        let tx_source = TransactionSourceForConnect::for_mempool(&best_index);
-
-        let block_timestamp = tx_accumulator.block_timestamp();
-        let tx_id_iter = self.store.txs_by_ancestor_score.iter().map(|(_, id)| id).rev();
-        let mut tx_iter = tx_id_iter
-            .filter_map(|tx_id| {
-                let tx = self.store.txs_by_id.get(tx_id)?.deref();
-                chainstate::tx_verifier::timelock_check::check_timelocks(
-                    &chainstate,
-                    chain_config,
-                    &utxo_view,
-                    tx.transaction(),
-                    &tx_source,
-                    &block_timestamp,
-                )
-                .ok()?;
-                Some(tx)
-            })
-            .fuse()
-            .peekable();
-
-        // Set of transactions already placed into the accumulator
-        let mut emitted = BTreeSet::new();
-        // Set of transaction waiting for one or more parents to be emitted
-        let mut pending = BTreeMap::new();
-        // A queue of transactions that can be emitted
-        let mut ready = BinaryHeap::<store::TxMempoolEntryByScore<&TxMempoolEntry>>::new();
-
-        while !tx_accumulator.done() {
-            // Take out the transactions from tx_iter until there is one ready
-            while let Some(tx) = tx_iter.peek() {
-                let missing_parents: usize = tx.parents().filter(|p| !emitted.contains(p)).count();
-                if missing_parents == 0 {
-                    break;
-                } else {
-                    pending.insert(tx.tx_id(), missing_parents);
-                    let _ = tx_iter.next();
-                }
-            }
-
-            let next_tx = match (tx_iter.peek(), ready.peek_mut()) {
-                (Some(store_tx), Some(ready_tx)) => {
-                    if store_tx.ancestor_score() > ready_tx.ancestor_score() {
-                        tx_iter.next().expect("just checked")
-                    } else {
-                        binary_heap::PeekMut::pop(ready_tx).take_entry()
-                    }
-                }
-                (Some(_store_tx), None) => tx_iter.next().expect("just checked"),
-                (None, Some(ready_tx)) => binary_heap::PeekMut::pop(ready_tx).take_entry(),
-                (None, None) => break,
-            };
-
-            let verification_result = tx_verifier.connect_transaction(
-                &tx_source,
-                next_tx.transaction(),
-                &verifier_time,
-                None,
-            );
-
-            if let Err(err) = verification_result {
-                log::error!(
-                    "CRITICAL ERROR: Verifier and mempool do not agree on transaction deps for {}. Error: {err}",
-                    next_tx.tx_id()
-                );
-                continue;
-            }
-
-            if let Err(err) = tx_accumulator.add_tx(next_tx.transaction().clone(), next_tx.fee()) {
-                log::error!(
-                    "CRITICAL: Failed to add transaction {} from mempool. Error: {}",
-                    next_tx.tx_id(),
-                    err
-                );
-                break;
-            }
-
-            emitted.insert(next_tx.tx_id());
-
-            // Release newly ready transactions
-            for child in next_tx.children() {
-                match pending.entry(child) {
-                    btree_map::Entry::Vacant(_) => (),
-                    btree_map::Entry::Occupied(mut c) => match c.get_mut() {
-                        0 => panic!("pending with 0 missing parents"),
-                        1 => {
-                            // This was the last missing parent, put the tx into the ready queue
-                            ready.push(self.store.txs_by_id[c.key()].deref().into());
-                            c.remove();
-                        }
-                        n => *n -= 1,
-                    },
-                }
-            }
-        }
-
-        let final_chainstate_tip =
-            utxo::UtxosView::best_block_hash(&chainstate).expect("cannot fetch tip");
-        if final_chainstate_tip != mempool_tip {
-            log::debug!(
-                "Chainstate moved while collecting txns: mempool {:?}, chainstate {:?}",
-                mempool_tip,
-                final_chainstate_tip,
-            );
-            return None;
-        }
-
-        Some(tx_accumulator)
+        tx_accumulator: Box<dyn TransactionAccumulator>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
+    ) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError> {
+        collect_txs::collect_txs(self, tx_accumulator, transaction_ids, packing_strategy)
     }
 
     pub fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>) {

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -752,38 +752,3 @@ impl Ord for TxMempoolEntry {
         other.tx_id().cmp(self.tx_id())
     }
 }
-
-/// Wrapper over [TxMempoolEntry] but ordered by ancestor score from highest to lowest
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TxMempoolEntryByScore<T>(T);
-
-impl<T> TxMempoolEntryByScore<T> {
-    pub fn take_entry(self) -> T {
-        self.0
-    }
-}
-
-impl<T: std::borrow::Borrow<TxMempoolEntry>> From<T> for TxMempoolEntryByScore<T> {
-    fn from(entry: T) -> Self {
-        Self(entry)
-    }
-}
-
-impl<T: std::borrow::Borrow<TxMempoolEntry>> std::ops::Deref for TxMempoolEntryByScore<T> {
-    type Target = TxMempoolEntry;
-    fn deref(&self) -> &Self::Target {
-        self.0.borrow()
-    }
-}
-
-impl<T: std::borrow::Borrow<TxMempoolEntry> + Eq> PartialOrd for TxMempoolEntryByScore<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T: std::borrow::Borrow<TxMempoolEntry> + Eq> Ord for TxMempoolEntryByScore<T> {
-    fn cmp(&self, rhs: &Self) -> Ordering {
-        (rhs.ancestor_score(), self.tx_id()).cmp(&(self.ancestor_score(), rhs.tx_id()))
-    }
-}

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -31,7 +31,7 @@ use common::{
     },
     primitives::{Id, Idable, H256},
 };
-use std::sync::Arc;
+use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
 mod accumulator;
 mod expiry;

--- a/mempool/src/tx_accumulator.rs
+++ b/mempool/src/tx_accumulator.rs
@@ -21,10 +21,16 @@ use serialization::Encode;
 
 use crate::pool::fee::Fee;
 
-#[derive(thiserror::Error, Debug, Clone)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum TxAccumulatorError {
     #[error("Fee overflow: {0:?} + {1:?} failed")]
     FeeAccumulationError(Fee, Fee),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub enum PackingStrategy {
+    FillSpaceFromMempool,
+    LeaveEmptySpace,
 }
 
 pub trait TransactionAccumulator: Send {

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -22,9 +22,9 @@ use common::{
     primitives::Id,
 };
 use mempool::{
-    error::Error,
+    error::{BlockConstructionError, Error},
     event::MempoolEvent,
-    tx_accumulator::TransactionAccumulator,
+    tx_accumulator::{PackingStrategy, TransactionAccumulator},
     tx_origin::{LocalTxOrigin, RemoteTxOrigin},
     FeeRate, MempoolInterface, MempoolMaxSize, TxStatus,
 };
@@ -55,7 +55,9 @@ mockall::mock! {
         fn collect_txs(
             &self,
             tx_accumulator: Box<dyn TransactionAccumulator + Send>,
-        ) -> Result<Option<Box<dyn TransactionAccumulator>>, Error>;
+            transaction_ids: Vec<Id<Transaction>>,
+            packing_strategy: PackingStrategy,
+        ) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError>;
 
         fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>);
         fn memory_usage(&self) -> usize;

--- a/test/functional/blockprod_generate_blocks_all_sources.py
+++ b/test/functional/blockprod_generate_blocks_all_sources.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from scalecodec.base import ScaleBytes, RuntimeConfiguration, ScaleDecoder
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.mintlayer import *
+
+import time
+
+class GenerateBlocksFromAllSourcesTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[
+            "--blockprod-min-peers-to-produce-blocks=0",
+        ]]
+
+    def assert_transaction_in_block(self, expected_transaction, block):
+        (expected_txid, expected_index) = expected_transaction
+
+        for generated_transaction in block["body"]["transactions"]:
+            for input in generated_transaction["transaction"]["inputs"]:
+                if expected_txid == input["Utxo"]["id"]["Transaction"][2:] and expected_index == input["Utxo"]["index"]:
+                    return True
+
+        return False
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        block_input_data = block_input_data_obj.encode(
+            {
+                "PoW": {
+                    "reward_destination": "AnyoneCanSpend",
+                }
+            }
+        ).to_hex()[2:]
+
+        (generate_utxos, utxo_id) = make_tx(
+            [reward_input(node.chainstate_best_block_id())],
+            [1000 for _ in range(20)],
+        )
+
+        block = node.blockprod_generate_block(block_input_data, [generate_utxos], [], "LeaveEmptySpace")
+        node.chainstate_submit_block(block)
+        utxos = [(utxo_id, i) for i in range(20)]
+
+        for include_transaction in ([True, False]):
+            for include_transaction_id in ([True, False]):
+                for include_mempool in ([True, False]):
+                    # Clear the mempool
+                    self.stop_node(0)
+                    self.start_node(0)
+
+                    transactions = []
+                    transaction_ids = []
+                    expected_transactions = []
+                    missing_transactions = []
+                    mempool_transactions = []
+
+                    #
+                    # Populate the mempool
+                    #
+
+                    (utxo_id, utxo_index) = utxos.pop()
+                    utxo = tx_input(utxo_id, utxo_index)
+                    (tx, tx_id) = make_tx([utxo], [100])
+
+                    node.mempool_submit_transaction(tx)
+
+                    if include_mempool:
+                        missing_transactions.append(tx_id)
+                    else:
+                        mempool_transactions.append(tx_id)
+
+                    #
+                    # Setup transactions parameter
+                    #
+
+                    if include_transaction:
+                        (utxo_id, utxo_index) = utxos.pop()
+                        utxo = tx_input(utxo_id, utxo_index)
+                        (tx, _) = make_tx([utxo], [100])
+                        expected_transactions.append([utxo_id, utxo_index])
+
+                        transactions.append(tx)
+
+                    #
+                    # Setup transaction Id parameter
+                    #
+
+                    if include_transaction_id:
+                        (utxo_id, utxo_index) = utxos.pop()
+                        utxo = tx_input(utxo_id, utxo_index)
+                        (tx, tx_id) = make_tx([utxo], [100])
+
+                        missing_transactions.append(tx_id)
+                        node.mempool_submit_transaction(tx)
+                        assert(node.mempool_contains_tx(tx_id))
+
+                        transaction_ids.append(tx_id)
+                        expected_transactions.append([utxo_id, utxo_index])
+
+                    #
+                    # Setup Mempool parameter
+                    #
+
+                    packing_strategy = "LeaveEmptySpace"
+
+                    if include_mempool:
+                        (utxo_id, utxo_index) = utxos.pop()
+                        utxo = tx_input(utxo_id, utxo_index)
+                        (tx, tx_id) = make_tx([utxo], [100])
+
+                        missing_transactions.append(tx_id)
+                        node.mempool_submit_transaction(tx)
+                        assert(node.mempool_contains_tx(tx_id))
+
+                        packing_strategy = "FillSpaceFromMempool"
+
+                        expected_transactions.append([utxo_id, utxo_index])
+
+                    self.wait_until(
+                        lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(),
+                        timeout = 5
+                    )
+
+                    block_hex = node.blockprod_generate_block(
+                        block_input_data,
+                        transactions,
+                        transaction_ids,
+                        packing_strategy
+                    )
+
+                    block = ScaleDecoder.get_decoder_class('BlockV1', ScaleBytes(bytearray.fromhex(block_hex))).decode()
+
+                    for expected_transaction in expected_transactions:
+                        self.assert_transaction_in_block(expected_transaction, block)
+
+                    old_tip = node.chainstate_best_block_id()
+                    node.chainstate_submit_block(block_hex)
+                    new_tip = node.chainstate_best_block_id()
+                    assert(old_tip != new_tip)
+
+                    #
+                    # Check chainstate and mempool is as expected
+                    #
+
+                    new_block_hex = node.chainstate_get_block(new_tip)
+                    new_block = ScaleDecoder.get_decoder_class('BlockV1', ScaleBytes(bytearray.fromhex(new_block_hex))).decode()
+
+                    for expected_transaction in expected_transactions:
+                        self.assert_transaction_in_block(expected_transaction, new_block)
+
+                    for missing_transaction in missing_transactions:
+                        assert(not node.mempool_contains_tx(missing_transaction))
+
+                    for mempool_transaction in mempool_transactions:
+                        assert(node.mempool_contains_tx(mempool_transaction))
+
+if __name__ == '__main__':
+    GenerateBlocksFromAllSourcesTest().main()

--- a/test/functional/blockprod_generate_blocks_all_sources.py
+++ b/test/functional/blockprod_generate_blocks_all_sources.py
@@ -138,6 +138,8 @@ class GenerateBlocksFromAllSourcesTest(BitcoinTestFramework):
                         timeout = 5
                     )
 
+                    old_tip = node.chainstate_best_block_id()
+
                     block_hex = node.blockprod_generate_block(
                         block_input_data,
                         transactions,
@@ -150,10 +152,14 @@ class GenerateBlocksFromAllSourcesTest(BitcoinTestFramework):
                     for expected_transaction in expected_transactions:
                         self.assert_transaction_in_block(expected_transaction, block)
 
-                    old_tip = node.chainstate_best_block_id()
                     node.chainstate_submit_block(block_hex)
                     new_tip = node.chainstate_best_block_id()
                     assert(old_tip != new_tip)
+
+                    self.wait_until(
+                        lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(),
+                        timeout = 5
+                    )
 
                     #
                     # Check chainstate and mempool is as expected

--- a/test/functional/blockprod_generate_pos_blocks.py
+++ b/test/functional/blockprod_generate_pos_blocks.py
@@ -69,21 +69,23 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
         assert_equal(block, expected_block)
 
     def generate_block(self, expected_height, block_input_data, transactions):
-        previous_block_id = self.nodes[0].chainstate_best_block_id()
+        node = self.nodes[0]
+        previous_block_id = node.chainstate_best_block_id()
 
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
             try:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
+                block_hex = node.blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 break
             except JSONRPCException:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
+                block_hex = node.blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 time.sleep(1)
 
         block_hex_array = bytearray.fromhex(block_hex)
         block = ScaleDecoder.get_decoder_class('BlockV1', ScaleBytes(block_hex_array)).decode()
 
-        self.nodes[0].chainstate_submit_block(block_hex)
+        node.chainstate_submit_block(block_hex)
+        self.wait_until(lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(), timeout = 5)
 
         self.assert_tip(block_hex)
         self.assert_height(expected_height, block_hex)

--- a/test/functional/blockprod_generate_pos_blocks.py
+++ b/test/functional/blockprod_generate_pos_blocks.py
@@ -74,10 +74,10 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
             try:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 break
             except JSONRPCException:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 time.sleep(1)
 
         block_hex_array = bytearray.fromhex(block_hex)

--- a/test/functional/blockprod_generate_pos_blocks_rand_genesis_keys.py
+++ b/test/functional/blockprod_generate_pos_blocks_rand_genesis_keys.py
@@ -99,10 +99,10 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
             try:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 break
             except JSONRPCException:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 time.sleep(1)
 
         block_hex_array = bytearray.fromhex(block_hex)

--- a/test/functional/blockprod_generate_pos_blocks_rand_genesis_keys.py
+++ b/test/functional/blockprod_generate_pos_blocks_rand_genesis_keys.py
@@ -94,21 +94,23 @@ class GeneratePoSBlocksTest(BitcoinTestFramework):
         return self.nodes[n].chainstate_block_height_in_main_chain(tip)
 
     def generate_block(self, expected_height, block_input_data, transactions):
-        previous_block_id = self.nodes[0].chainstate_best_block_id()
+        node = self.nodes[0]
+        previous_block_id = node.chainstate_best_block_id()
 
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
             try:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
+                block_hex = node.blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 break
             except JSONRPCException:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
+                block_hex = node.blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 time.sleep(1)
 
         block_hex_array = bytearray.fromhex(block_hex)
         block = ScaleDecoder.get_decoder_class('BlockV1', ScaleBytes(block_hex_array)).decode()
 
-        self.nodes[0].chainstate_submit_block(block_hex)
+        node.chainstate_submit_block(block_hex)
+        self.wait_until(lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(), timeout = 5)
 
         self.assert_tip(block_hex)
         self.assert_height(expected_height, block_hex)

--- a/test/functional/blockprod_generate_pos_genesis_blocks.py
+++ b/test/functional/blockprod_generate_pos_genesis_blocks.py
@@ -72,10 +72,10 @@ class GeneratePoSGenesisBlocksTest(BitcoinTestFramework):
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
             try:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 break
             except JSONRPCException:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 time.sleep(1)
 
         block_hex_array = bytearray.fromhex(block_hex)

--- a/test/functional/blockprod_generate_pos_genesis_blocks.py
+++ b/test/functional/blockprod_generate_pos_genesis_blocks.py
@@ -67,21 +67,23 @@ class GeneratePoSGenesisBlocksTest(BitcoinTestFramework):
         assert_equal(block, expected_block)
 
     def generate_block(self, expected_height, block_input_data, transactions):
-        previous_block_id = self.nodes[0].chainstate_best_block_id()
+        node = self.nodes[0]
+        previous_block_id = node.chainstate_best_block_id()
 
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
             try:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
+                block_hex = node.blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 break
             except JSONRPCException:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
+                block_hex = node.blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 time.sleep(1)
 
         block_hex_array = bytearray.fromhex(block_hex)
         block = ScaleDecoder.get_decoder_class('BlockV1', ScaleBytes(block_hex_array)).decode()
 
-        self.nodes[0].chainstate_submit_block(block_hex)
+        node.chainstate_submit_block(block_hex)
+        self.wait_until(lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(), timeout = 5)
 
         self.assert_tip(block_hex)
         self.assert_height(expected_height, block_hex)

--- a/test/functional/blockprod_generate_pow_blocks.py
+++ b/test/functional/blockprod_generate_pow_blocks.py
@@ -59,10 +59,10 @@ class GeneratePoWBlocksTest(BitcoinTestFramework):
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
             try:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 break
             except JSONRPCException:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], "LeaveEmptySpace")
                 time.sleep(1)
 
         block_hex_array = bytearray.fromhex(block_hex)

--- a/test/functional/blockprod_ibd.py
+++ b/test/functional/blockprod_ibd.py
@@ -67,7 +67,9 @@ class BlockprodIBDTest(BitcoinTestFramework):
             IBD_ERR,
             node.blockprod_generate_block,
             block_input_data,
-            []
+            [],
+            [],
+            'FillSpaceFromMempool',
         )
 
         # Advance the blockchain but wait, which should still cause blockprod to fail
@@ -82,7 +84,9 @@ class BlockprodIBDTest(BitcoinTestFramework):
             IBD_ERR,
             node.blockprod_generate_block,
             block_input_data,
-            []
+            [],
+            [],
+            'FillSpaceFromMempool',
         )
 
         # Advance the blockchain but this time succeed in producing a block
@@ -92,7 +96,7 @@ class BlockprodIBDTest(BitcoinTestFramework):
         (block2, block2_id) = mine_pow_block(block1_id, timestamp = self.mock_time)
         self.submit_block(block2)
 
-        node.blockprod_generate_block(block_input_data, [])
+        node.blockprod_generate_block(block_input_data, [], [], 'FillSpaceFromMempool')
 
 if __name__ == '__main__':
     BlockprodIBDTest().main()

--- a/test/functional/blockprod_ibd.py
+++ b/test/functional/blockprod_ibd.py
@@ -42,6 +42,7 @@ class BlockprodIBDTest(BitcoinTestFramework):
         node = self.nodes[0]
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
+        self.wait_until(lambda: node.mempool_local_best_block_id() == block_id, timeout = 5)
         return block_id
 
     def run_test(self):

--- a/test/functional/blockprod_ibd_genesis.py
+++ b/test/functional/blockprod_ibd_genesis.py
@@ -53,7 +53,9 @@ class BlockprodIBDGenesisFailsTest(BitcoinTestFramework):
             IBD_ERR,
             node.blockprod_generate_block,
             block_input_data,
-            []
+            [],
+            [],
+            "FillSpaceFromMempool",
         )
 
 class BlockprodIBDGenesisFailsButSkipSucceedsTest(BitcoinTestFramework):
@@ -82,7 +84,7 @@ class BlockprodIBDGenesisFailsButSkipSucceedsTest(BitcoinTestFramework):
 
         # Blockprod should succeed because we're skipping the initial block download check
 
-        block = node.blockprod_generate_block(block_input_data, [])
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
 
         assert(genesis_id != node.chainstate_best_block_id())
 
@@ -111,7 +113,7 @@ class BlockprodIBDGenesisSucceedsTest(BitcoinTestFramework):
 
         # Blockprod should succeed because we're no longer in initial block download
 
-        block = node.blockprod_generate_block(block_input_data, [])
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
 
         assert(genesis_id != node.chainstate_best_block_id())

--- a/test/functional/feature_db_reinit.py
+++ b/test/functional/feature_db_reinit.py
@@ -33,10 +33,11 @@ class RestartWithDifferentMagicBytes(BitcoinTestFramework):
 
     def run_test(self):
         # generate and process block to update chainstate db
-        block_input_data = block_input_data_obj.encode({"PoW": {"reward_destination": "AnyoneCanSpend"}}
-                                                       ).to_hex()[2:]
+        block_input_data = block_input_data_obj.encode(
+            {"PoW": {"reward_destination": "AnyoneCanSpend"}}
+        ).to_hex()[2:]
 
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         self.nodes[0].chainstate_submit_block(block)
 
         tip_height = self.nodes[0].chainstate_best_block_height()

--- a/test/functional/feature_lmdb_backend_test.py
+++ b/test/functional/feature_lmdb_backend_test.py
@@ -66,10 +66,10 @@ class ExampleTest(BitcoinTestFramework):
         ).to_hex()[2:]
 
         # add two blocks
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
         node.chainstate_submit_block(blocks[0])
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
         node.chainstate_submit_block(blocks[1])
         assert_equal(self.block_height(), 2)
@@ -84,7 +84,7 @@ class ExampleTest(BitcoinTestFramework):
 
         # Add three more blocks
         for i in range(2, 5):
-            block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+            block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
             blocks.append(block)
             node.chainstate_submit_block(blocks[i])
         assert_equal(self.block_height(), 5)

--- a/test/functional/feature_lmdb_backend_test.py
+++ b/test/functional/feature_lmdb_backend_test.py
@@ -66,12 +66,16 @@ class ExampleTest(BitcoinTestFramework):
         ).to_hex()[2:]
 
         # add two blocks
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
+        block = node.blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
         node.chainstate_submit_block(blocks[0])
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
+        self.wait_until(lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(), timeout = 5)
+
+        block = node.blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
         node.chainstate_submit_block(blocks[1])
+        self.wait_until(lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(), timeout = 5)
+
         assert_equal(self.block_height(), 2)
         self.assert_tip(blocks[1])
 
@@ -84,9 +88,10 @@ class ExampleTest(BitcoinTestFramework):
 
         # Add three more blocks
         for i in range(2, 5):
-            block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
+            block = node.blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
             blocks.append(block)
             node.chainstate_submit_block(blocks[i])
+            self.wait_until(lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(), timeout = 5)
         assert_equal(self.block_height(), 5)
         self.assert_tip(blocks[4])
 

--- a/test/functional/mempool_basic_reorg.py
+++ b/test/functional/mempool_basic_reorg.py
@@ -65,8 +65,8 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
             }
         ).to_hex()[2:]
 
-        # create a new block, taking transactions from mempool
-        block1 = node.blockprod_generate_block(block_input_data, [tx1])
+        # create a new block, not taking transactions from mempool
+        block1 = node.blockprod_generate_block(block_input_data, [tx1], [], "LeaveEmptySpace")
         node.chainstate_submit_block(block1)
         block1_id = node.chainstate_best_block_id()
         self.wait_until(lambda: node.mempool_local_best_block_id() == block1_id, timeout = 5)
@@ -82,7 +82,7 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         assert node.mempool_contains_tx(tx3_id)
 
         # Submit a block with the other two transactions
-        block2 = node.blockprod_generate_block(block_input_data, [tx2, tx3])
+        block2 = node.blockprod_generate_block(block_input_data, [tx2, tx3], [], "LeaveEmptySpace")
         node.chainstate_submit_block(block2)
         block2_id = node.chainstate_best_block_id()
         self.wait_until(lambda: node.mempool_local_best_block_id() == block2_id, timeout = 5)

--- a/test/functional/mempool_timelocked_tx.py
+++ b/test/functional/mempool_timelocked_tx.py
@@ -40,7 +40,7 @@ class MempoolTimelockedTxTest(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/p2p_syncing_test.py
+++ b/test/functional/p2p_syncing_test.py
@@ -47,6 +47,11 @@ class SyncingTest(BitcoinTestFramework):
         block = self.nodes[n].chainstate_get_block(tip)
         assert_equal(block, expected)
 
+    def submit_block(self, block):
+        node = self.nodes[0]
+        node.chainstate_submit_block(block)
+        self.wait_until(lambda: node.mempool_local_best_block_id() == node.chainstate_best_block_id(), timeout = 5)
+
     def run_test(self):
         # get current tip hash
         node0_tip = self.nodes[0].chainstate_best_block_id()
@@ -71,7 +76,7 @@ class SyncingTest(BitcoinTestFramework):
         # add first block
         block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
-        self.nodes[0].chainstate_submit_block(blocks[0])
+        self.submit_block(blocks[0])
         assert_equal(self.block_height(0), 1)
         assert_equal(self.block_height(1), 0)
         self.assert_tip(0, blocks[0])
@@ -79,7 +84,7 @@ class SyncingTest(BitcoinTestFramework):
         # add second block
         block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
-        self.nodes[0].chainstate_submit_block(blocks[1])
+        self.submit_block(blocks[1])
         assert_equal(self.block_height(0), 2)
         assert_equal(self.block_height(1), 0)
         self.assert_tip(0, blocks[1])
@@ -102,14 +107,14 @@ class SyncingTest(BitcoinTestFramework):
         # submit third block
         block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
-        self.nodes[0].chainstate_submit_block(blocks[2])
+        self.submit_block(blocks[2])
         assert_equal(self.block_height(0), 3)
         self.assert_tip(0, blocks[2])
 
         # submit final block
         block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
-        self.nodes[0].chainstate_submit_block(blocks[3])
+        self.submit_block(blocks[3])
         assert_equal(self.block_height(0), 4)
         self.assert_tip(0, blocks[3])
 

--- a/test/functional/p2p_syncing_test.py
+++ b/test/functional/p2p_syncing_test.py
@@ -69,7 +69,7 @@ class SyncingTest(BitcoinTestFramework):
         ).to_hex()[2:]
 
         # add first block
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
         self.nodes[0].chainstate_submit_block(blocks[0])
         assert_equal(self.block_height(0), 1)
@@ -77,7 +77,7 @@ class SyncingTest(BitcoinTestFramework):
         self.assert_tip(0, blocks[0])
 
         # add second block
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
         self.nodes[0].chainstate_submit_block(blocks[1])
         assert_equal(self.block_height(0), 2)
@@ -100,14 +100,14 @@ class SyncingTest(BitcoinTestFramework):
         self.assert_tip(1, blocks[1])
 
         # submit third block
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
         self.nodes[0].chainstate_submit_block(blocks[2])
         assert_equal(self.block_height(0), 3)
         self.assert_tip(0, blocks[2])
 
         # submit final block
-        block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+        block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
         blocks.append(block)
         self.nodes[0].chainstate_submit_block(blocks[3])
         assert_equal(self.block_height(0), 4)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -423,7 +423,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             # To ensure that all nodes are out of IBD, the most recent block
             # must have a timestamp not too old (see chainstate_is_initial_block_download()).
             self.log.debug('Generate a block with current time')
-            block = self.nodes[0].blockprod_generate_block(block_input_data, [])
+            block = self.nodes[0].blockprod_generate_block(block_input_data, [], [], "LeaveEmptySpace")
             for n in self.nodes:
                 n.chainstate_submit_block(block)
                 info = n.chainstate_info()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -113,6 +113,7 @@ BASE_SCRIPTS = [
     # vv Tests less than 60s vv
 
     # vv Tests less than 30s vv
+    'blockprod_generate_blocks_all_sources.py',
     'blockprod_generate_pos_blocks.py',
     'blockprod_generate_pos_blocks_rand_genesis_keys.py',
     'blockprod_generate_pos_genesis_blocks.py',

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -99,13 +99,14 @@ class WalletSubmitTransaction(BitcoinTestFramework):
     def generate_block(self, expected_height, block_input_data, transactions):
         previous_block_id = self.nodes[0].chainstate_best_block_id()
 
+        fill_mode = 'LeaveEmptySpace'
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
             try:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], fill_mode)
                 break
             except JSONRPCException:
-                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions)
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], fill_mode)
                 time.sleep(1)
 
         block_hex_array = bytearray.fromhex(block_hex)

--- a/test/functional/wallet_generate_addresses.py
+++ b/test/functional/wallet_generate_addresses.py
@@ -57,7 +57,7 @@ class WalletAddressGenerator(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], 'FillSpaceFromMempool')
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/wallet_get_address_usage.py
+++ b/test/functional/wallet_get_address_usage.py
@@ -54,7 +54,7 @@ class WalletGetAddressUsage(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/wallet_high_fee.py
+++ b/test/functional/wallet_high_fee.py
@@ -69,7 +69,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/wallet_nfts.py
+++ b/test/functional/wallet_nfts.py
@@ -56,7 +56,7 @@ class WalletNfts(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/wallet_recover_accounts.py
+++ b/test/functional/wallet_recover_accounts.py
@@ -58,7 +58,7 @@ class WalletRecoverAccounts(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/wallet_select_utxos.py
+++ b/test/functional/wallet_select_utxos.py
@@ -56,7 +56,7 @@ class WalletSubmitTransactionSpecificUtxo(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/wallet_submit_tx.py
+++ b/test/functional/wallet_submit_tx.py
@@ -54,7 +54,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -56,7 +56,7 @@ class WalletTokens(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -23,7 +23,7 @@ use chainstate_test_framework::TestFramework;
 use common::{
     chain::{
         tokens::{RPCTokenInfo, TokenId},
-        DelegationId, PoolId, SignedTransaction,
+        DelegationId, PoolId, SignedTransaction, Transaction,
     },
     primitives::Amount,
 };
@@ -31,7 +31,7 @@ use consensus::GenerateBlockInputData;
 use crypto::random::{seq::IteratorRandom, CryptoRng, Rng};
 use futures::executor::block_on;
 use logging::log;
-use mempool::FeeRate;
+use mempool::{tx_accumulator::PackingStrategy, FeeRate};
 use node_comm::{
     node_traits::{ConnectedPeer, PeerId},
     rpc_client::NodeRpcError,
@@ -270,7 +270,9 @@ impl NodeInterface for MockNode {
     async fn generate_block(
         &self,
         _input_data: GenerateBlockInputData,
-        _transactions_hex: Option<Vec<SignedTransaction>>,
+        _transactions_hex: Vec<SignedTransaction>,
+        _transaction_ids: Vec<Id<Transaction>>,
+        _packing_strategy: PackingStrategy,
     ) -> Result<Block, Self::Error> {
         unreachable!()
     }

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -17,13 +17,13 @@ use chainstate::ChainInfo;
 use common::{
     chain::{
         tokens::{RPCTokenInfo, TokenId},
-        Block, DelegationId, GenBlock, PoolId, SignedTransaction,
+        Block, DelegationId, GenBlock, PoolId, SignedTransaction, Transaction,
     },
     primitives::{Amount, BlockHeight, Id},
 };
 
 use consensus::GenerateBlockInputData;
-use mempool::FeeRate;
+use mempool::{tx_accumulator::PackingStrategy, FeeRate};
 use p2p::types::{bannable_address::BannableAddress, ip_or_socket_address::IpOrSocketAddress};
 pub use p2p::{interface::types::ConnectedPeer, types::peer_id::PeerId};
 
@@ -60,7 +60,9 @@ pub trait NodeInterface {
     async fn generate_block(
         &self,
         input_data: GenerateBlockInputData,
-        transactions: Option<Vec<SignedTransaction>>,
+        transactions: Vec<SignedTransaction>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
     ) -> Result<Block, Self::Error>;
     async fn submit_block(&self, block: Block) -> Result<(), Self::Error>;
     async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error>;

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -18,12 +18,12 @@ use chainstate::{rpc::ChainstateRpcClient, ChainInfo};
 use common::{
     chain::{
         tokens::{RPCTokenInfo, TokenId},
-        Block, DelegationId, GenBlock, PoolId, SignedTransaction,
+        Block, DelegationId, GenBlock, PoolId, SignedTransaction, Transaction,
     },
     primitives::{Amount, BlockHeight, Id},
 };
 use consensus::GenerateBlockInputData;
-use mempool::{rpc::MempoolRpcClient, FeeRate};
+use mempool::{rpc::MempoolRpcClient, tx_accumulator::PackingStrategy, FeeRate};
 use p2p::{
     interface::types::ConnectedPeer,
     rpc::P2pRpcClient,
@@ -131,13 +131,21 @@ impl NodeInterface for NodeRpcClient {
     async fn generate_block(
         &self,
         input_data: GenerateBlockInputData,
-        transactions: Option<Vec<SignedTransaction>>,
+        transactions: Vec<SignedTransaction>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
     ) -> Result<Block, Self::Error> {
-        let transactions = transactions.map(|txs| txs.into_iter().map(HexEncoded::new).collect());
-        BlockProductionRpcClient::generate_block(&self.http_client, input_data.into(), transactions)
-            .await
-            .map(HexEncoded::take)
-            .map_err(NodeRpcError::ResponseError)
+        let transactions = transactions.into_iter().map(HexEncoded::new).collect::<Vec<_>>();
+        BlockProductionRpcClient::generate_block(
+            &self.http_client,
+            input_data.into(),
+            transactions,
+            transaction_ids,
+            packing_strategy,
+        )
+        .await
+        .map(HexEncoded::take)
+        .map_err(NodeRpcError::ResponseError)
     }
 
     async fn submit_block(&self, block: Block) -> Result<(), Self::Error> {


### PR DESCRIPTION
This gives the user the option to add a custom list of transactions when asking the node to generate a new block.

Based on the original work of @alfiedotwtf.

Related:
* #756 
* #1158