### PR TITLE
Feature/wallet token supply change

### DIFF
--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -175,12 +175,11 @@ class WalletCliController:
 
     async def issue_new_token(self,
                               token_ticker: str,
-                              amount_to_issue: str,
                               number_of_decimals: int,
                               metadata_uri: str,
                               destination_address: str,
                               token_supply: str = 'unlimited') -> Tuple[Optional[str], Optional[str]]:
-        output = await self._write_command(f'issuenewtoken "{token_ticker}" "{amount_to_issue}" "{number_of_decimals}" "{metadata_uri}" {destination_address} {token_supply}\n')
+        output = await self._write_command(f'issuenewtoken "{token_ticker}" "{number_of_decimals}" "{metadata_uri}" {destination_address} {token_supply}\n')
         if output.startswith("A new token has been issued with ID"):
             return output[output.find(':')+2:], None
 
@@ -192,8 +191,8 @@ class WalletCliController:
     async def unmint_tokens(self, token_id: str, amount: int) -> str:
         return await self._write_command(f"unminttokens {token_id} {amount}\n")
 
-    async def lock_tokens(self, token_id: str) -> str:
-        return await self._write_command(f"locktokens {token_id}\n")
+    async def lock_token_suply(self, token_id: str) -> str:
+        return await self._write_command(f"locktokensuply {token_id}\n")
 
     async def issue_new_nft(self,
                             destination_address: str,

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -191,7 +191,7 @@ class WalletCliController:
     async def unmint_tokens(self, token_id: str, amount: int) -> str:
         return await self._write_command(f"unminttokens {token_id} {amount}\n")
 
-    async def lock_token_suply(self, token_id: str) -> str:
+    async def lock_token_supply(self, token_id: str) -> str:
         return await self._write_command(f"locktokensupply {token_id}\n")
 
     async def issue_new_nft(self,

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -189,8 +189,8 @@ class WalletCliController:
     async def mint_tokens(self, token_id: str, address: str, amount: int) -> str:
         return await self._write_command(f"minttokens {token_id} {address} {amount}\n")
 
-    async def redeem_tokens(self, token_id: str, amount: int) -> str:
-        return await self._write_command(f"redeemtokens {token_id} {amount}\n")
+    async def unmint_tokens(self, token_id: str, amount: int) -> str:
+        return await self._write_command(f"unminttokens {token_id} {amount}\n")
 
     async def lock_tokens(self, token_id: str) -> str:
         return await self._write_command(f"locktokens {token_id}\n")

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -192,7 +192,7 @@ class WalletCliController:
         return await self._write_command(f"unminttokens {token_id} {amount}\n")
 
     async def lock_token_suply(self, token_id: str) -> str:
-        return await self._write_command(f"locktokensuply {token_id}\n")
+        return await self._write_command(f"locktokensupply {token_id}\n")
 
     async def issue_new_nft(self,
                             destination_address: str,

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -178,12 +178,22 @@ class WalletCliController:
                               amount_to_issue: str,
                               number_of_decimals: int,
                               metadata_uri: str,
-                              destination_address: str) -> Tuple[Optional[str], Optional[str]]:
-        output = await self._write_command(f'issuenewtoken "{token_ticker}" "{amount_to_issue}" "{number_of_decimals}" "{metadata_uri}" {destination_address}\n')
+                              destination_address: str,
+                              token_supply: str = 'unlimited') -> Tuple[Optional[str], Optional[str]]:
+        output = await self._write_command(f'issuenewtoken "{token_ticker}" "{amount_to_issue}" "{number_of_decimals}" "{metadata_uri}" {destination_address} {token_supply}\n')
         if output.startswith("A new token has been issued with ID"):
             return output[output.find(':')+2:], None
 
         return None, output
+
+    async def mint_tokens(self, token_id: str, address: str, amount: int) -> str:
+        return await self._write_command(f"minttokens {token_id} {address} {amount}\n")
+
+    async def redeem_tokens(self, token_id: str, amount: int) -> str:
+        return await self._write_command(f"redeemtokens {token_id} {amount}\n")
+
+    async def lock_tokens(self, token_id: str) -> str:
+        return await self._write_command(f"locktokens {token_id}\n")
 
     async def issue_new_nft(self,
                             destination_address: str,

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -258,5 +258,5 @@ class WalletCliController:
     async def get_addresses_usage(self) -> str:
         return await self._write_command("showreceiveaddresses\n")
 
-    async def get_balance(self, with_locked: str = 'unlocked') -> str:
-        return await self._write_command(f"getbalance {with_locked}\n")
+    async def get_balance(self, with_locked: str = 'unlocked', utxo_states: List[str] = ['confirmed']) -> str:
+        return await self._write_command(f"getbalance {with_locked} {' '.join(utxo_states)}\n")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -30,6 +30,7 @@ import configparser
 import datetime
 import locale
 import os
+import random
 import time
 import shutil
 import signal
@@ -444,6 +445,7 @@ class TestHandler:
         self.num_running = 0
         self.jobs = []
         self.use_term_control = use_term_control
+        self.randomseed = random.randrange(sys.maxsize)
 
     def get_next(self):
         while self.num_running < self.num_jobs and self.test_list:
@@ -452,6 +454,7 @@ class TestHandler:
             test = self.test_list.pop(0)
             portseed = len(self.test_list)
             portseed_arg = ["--portseed={}".format(portseed)]
+            randomseed_arg = [f"--randomseed={self.randomseed}"]
             log_stdout = tempfile.SpooledTemporaryFile(max_size=2**16)
             log_stderr = tempfile.SpooledTemporaryFile(max_size=2**16)
             test_argv = test.split()
@@ -459,7 +462,7 @@ class TestHandler:
             tmpdir_arg = ["--tmpdir={}".format(testdir)]
             self.jobs.append((test,
                               time.time(),
-                              subprocess.Popen([sys.executable, self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + portseed_arg + tmpdir_arg,
+                              subprocess.Popen([sys.executable, self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + portseed_arg + tmpdir_arg + randomseed_arg,
                                                universal_newlines=True,
                                                stdout=log_stdout,
                                                stderr=log_stderr),

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -132,6 +132,7 @@ BASE_SCRIPTS = [
     'wallet_recover_accounts.py',
     'wallet_get_address_usage.py',
     'wallet_tokens.py',
+    'wallet_tokens_change_supply.py',
     'wallet_nfts.py',
     'wallet_delegations.py',
     'wallet_high_fee.py',

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -389,7 +389,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             self.wait_until(lambda: node.chainstate_best_block_id() != tip_id, timeout = 5)
             assert_in("Success", await wallet.sync())
 
-            # check that we still don't have any delagations for this account
+            # check that we still don't have any delegations for this account
             delegations = await wallet.list_delegation_ids()
             assert_equal(len(delegations), 0)
 
@@ -399,7 +399,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             self.wait_until(lambda: node.chainstate_best_block_id() != tip_id, timeout = 5)
             assert_in("Success", await wallet.sync())
 
-            # check that we still don't have any delagations for this account
+            # check that we still don't have any delegations for this account
             delegations = await wallet.list_delegation_ids()
             assert_equal(len(delegations), 0)
 

--- a/test/functional/wallet_nfts.py
+++ b/test/functional/wallet_nfts.py
@@ -119,27 +119,25 @@ class WalletNfts(BitcoinTestFramework):
             assert_in("Success", await wallet.sync())
 
 
-            # TODO: add support for tokens v1
-            # See https://github.com/mintlayer/mintlayer-core/issues/1237
-            #self.log.info(await wallet.get_balance())
-            #assert_in(f"{nft_id} amount: 1", await wallet.get_balance())
+            self.log.info(await wallet.get_balance())
+            assert_in(f"{nft_id} amount: 1", await wallet.get_balance())
 
-            ## create a new account and send some tokens to it
-            #await wallet.create_new_account()
-            #await wallet.select_account(1)
-            #address = await wallet.new_address()
+            # create a new account and send some tokens to it
+            await wallet.create_new_account()
+            await wallet.select_account(1)
+            address = await wallet.new_address()
 
-            #await wallet.select_account(0)
-            #assert_in(f"{nft_id} amount: 1", await wallet.get_balance())
-            #output = await wallet.send_tokens_to_address(nft_id, address, 1)
-            #self.log.info(output)
-            #assert_in("The transaction was submitted successfully", output)
+            await wallet.select_account(0)
+            assert_in(f"{nft_id} amount: 1", await wallet.get_balance())
+            output = await wallet.send_tokens_to_address(nft_id, address, 1)
+            self.log.info(output)
+            assert_in("The transaction was submitted successfully", output)
 
-            #self.generate_block()
-            #assert_in("Success", await wallet.sync())
+            self.generate_block()
+            assert_in("Success", await wallet.sync())
 
-            ## check the new balance nft is not present
-            #assert nft_id not in await wallet.get_balance()
+            # check the new balance nft is not present
+            assert nft_id not in await wallet.get_balance()
 
 if __name__ == '__main__':
     WalletNfts().main()

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -113,30 +113,30 @@ class WalletTokens(BitcoinTestFramework):
 
             # invalid ticker
             # > max len
-            token_id, err = await wallet.issue_new_token("asdddd", "10000", 2, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("asdddd", 2, "http://uri", address)
             assert token_id is None
             assert err is not None
             assert_in("Invalid ticker length", err)
             # non alphanumeric
-            token_id, err = await wallet.issue_new_token("asd#", "10000", 2, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("asd#", 2, "http://uri", address)
             assert token_id is None
             assert err is not None
             assert_in("Invalid character in token ticker", err)
 
             # invalid url
-            token_id, err = await wallet.issue_new_token("XXX", "10000", 2, "123 123", address)
+            token_id, err = await wallet.issue_new_token("XXX", 2, "123 123", address)
             assert token_id is None
             assert err is not None
             assert_in("Incorrect metadata URI", err)
 
             # invalid num decimals
-            token_id, err = await wallet.issue_new_token("XXX", "10000", 99, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("XXX", 99, "http://uri", address)
             assert token_id is None
             assert err is not None
             assert_in("Too many decimals", err)
 
             # issue a valid token
-            token_id, err = await wallet.issue_new_token("XXX", "10000", 2, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("XXX", 2, "http://uri", address)
             assert token_id is not None
             assert err is None
             self.log.info(f"new token id: {token_id}")
@@ -167,7 +167,7 @@ class WalletTokens(BitcoinTestFramework):
             assert_in(f"{token_id} amount: 9989.99", await wallet.get_balance())
 
             ## try to issue a new token, should fail with not enough coins
-            token_id, err = await wallet.issue_new_token("XXX", "10000", 2, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("XXX", 2, "http://uri", address)
             assert token_id is None
             assert err is not None
             assert_in("Not enough funds", err)

--- a/test/functional/wallet_tokens_change_supply.py
+++ b/test/functional/wallet_tokens_change_supply.py
@@ -92,7 +92,7 @@ class WalletTokens(BitcoinTestFramework):
 
             # Submit a valid transaction
             output = {
-                    'Transfer': [ { 'Coin': 1001 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+                    'Transfer': [ { 'Coin': 2001 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
@@ -109,36 +109,36 @@ class WalletTokens(BitcoinTestFramework):
             assert_equal(await wallet.get_best_block_height(), '1')
             assert_equal(await wallet.get_best_block(), block_id)
 
-            assert_in("Coins amount: 1001", await wallet.get_balance())
+            assert_in("Coins amount: 2001", await wallet.get_balance())
 
             address = await wallet.new_address()
 
             # invalid ticker
             # > max len
-            token_id, err = await wallet.issue_new_token("asdddd", "10000", 2, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("asdddd", 2, "http://uri", address)
             assert token_id is None
             assert err is not None
             assert_in("Invalid ticker length", err)
             # non alphanumeric
-            token_id, err = await wallet.issue_new_token("asd#", "10000", 2, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("asd#", 2, "http://uri", address)
             assert token_id is None
             assert err is not None
             assert_in("Invalid character in token ticker", err)
 
             # invalid url
-            token_id, err = await wallet.issue_new_token("XXX", "10000", 2, "123 123", address)
+            token_id, err = await wallet.issue_new_token("XXX", 2, "123 123", address)
             assert token_id is None
             assert err is not None
             assert_in("Incorrect metadata URI", err)
 
             # invalid num decimals
-            token_id, err = await wallet.issue_new_token("XXX", "10000", 99, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("XXX", 99, "http://uri", address)
             assert token_id is None
             assert err is not None
             assert_in("Too many decimals", err)
 
             # issue a valid token
-            token_id, err = await wallet.issue_new_token("XXX", "10000", 2, "http://uri", address, 'lockable')
+            token_id, err = await wallet.issue_new_token("XXX", 2, "http://uri", address, 'lockable')
             assert token_id is not None
             assert err is None
             self.log.info(f"new token id: {token_id}")
@@ -179,7 +179,7 @@ class WalletTokens(BitcoinTestFramework):
                 assert_in(f"{token_id} amount: {total_tokens_supply}", await wallet.get_balance(utxo_states=['confirmed', 'inactive']))
 
             # lock token supply
-            assert_in("The transaction was submitted successfully", await wallet.lock_tokens(token_id))
+            assert_in("The transaction was submitted successfully", await wallet.lock_token_suply(token_id))
             self.generate_block()
             assert_in("Success", await wallet.sync())
             assert_in(f"{token_id} amount: {total_tokens_supply}", await wallet.get_balance())
@@ -187,7 +187,7 @@ class WalletTokens(BitcoinTestFramework):
             # cannot mint any more tokens as it is locked
             assert_in("Cannot change a Locked Token supply", await wallet.mint_tokens(token_id, address, tokens_to_mint))
             assert_in("Cannot change a Locked Token supply", await wallet.unmint_tokens(token_id, tokens_to_mint))
-            assert_in("Cannot lock Token supply in state: Locked", await wallet.lock_tokens(token_id))
+            assert_in("Cannot lock Token supply in state: Locked", await wallet.lock_token_suply(token_id))
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_tokens_change_supply.py
+++ b/test/functional/wallet_tokens_change_supply.py
@@ -24,7 +24,7 @@ Check that:
 * check balance
 * issue new token
 * mint new tokens
-* redeem existing tokens
+* unmint existing tokens
 * lock the tokens supply
 """
 
@@ -155,11 +155,11 @@ class WalletTokens(BitcoinTestFramework):
             assert_in(f"{token_id} amount: {total_tokens_supply}", await wallet.get_balance())
 
             # cannot unmint more than minted
-            assert_in(f"Trying to redeem Amount {{ val: {tokens_to_mint+1}00 }} but the current supply is Amount {{ val: {tokens_to_mint}00 }}", await wallet.redeem_tokens(token_id, tokens_to_mint + 1))
+            assert_in(f"Trying to unmint Amount {{ val: {tokens_to_mint+1}00 }} but the current supply is Amount {{ val: {tokens_to_mint}00 }}", await wallet.unmint_tokens(token_id, tokens_to_mint + 1))
 
-            tokens_to_redeem = 1000
-            total_tokens_supply = total_tokens_supply - tokens_to_redeem
-            assert_in("The transaction was submitted successfully", await wallet.redeem_tokens(token_id, tokens_to_redeem))
+            tokens_to_unmint = 1000
+            total_tokens_supply = total_tokens_supply - tokens_to_unmint
+            assert_in("The transaction was submitted successfully", await wallet.unmint_tokens(token_id, tokens_to_unmint))
 
             self.generate_block()
             assert_in("Success", await wallet.sync())
@@ -182,7 +182,7 @@ class WalletTokens(BitcoinTestFramework):
 
             # cannot mint any more tokens as it is locked
             assert_in("Cannot change a Locked Token supply", await wallet.mint_tokens(token_id, address, tokens_to_mint))
-            assert_in("Cannot change a Locked Token supply", await wallet.redeem_tokens(token_id, tokens_to_mint))
+            assert_in("Cannot change a Locked Token supply", await wallet.unmint_tokens(token_id, tokens_to_mint))
             assert_in("Cannot lock Token supply in state: Locked", await wallet.lock_tokens(token_id))
 
 

--- a/test/functional/wallet_tokens_change_supply.py
+++ b/test/functional/wallet_tokens_change_supply.py
@@ -58,7 +58,7 @@ class WalletTokens(BitcoinTestFramework):
         block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
 
         # create a new block, taking transactions from mempool
-        block = node.blockprod_generate_block(block_input_data, None)
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
         node.chainstate_submit_block(block)
         block_id = node.chainstate_best_block_id()
 

--- a/test/functional/wallet_tokens_change_supply.py
+++ b/test/functional/wallet_tokens_change_supply.py
@@ -179,7 +179,7 @@ class WalletTokens(BitcoinTestFramework):
                 assert_in(f"{token_id} amount: {total_tokens_supply}", await wallet.get_balance(utxo_states=['confirmed', 'inactive']))
 
             # lock token supply
-            assert_in("The transaction was submitted successfully", await wallet.lock_token_suply(token_id))
+            assert_in("The transaction was submitted successfully", await wallet.lock_token_supply(token_id))
             self.generate_block()
             assert_in("Success", await wallet.sync())
             assert_in(f"{token_id} amount: {total_tokens_supply}", await wallet.get_balance())
@@ -187,7 +187,7 @@ class WalletTokens(BitcoinTestFramework):
             # cannot mint any more tokens as it is locked
             assert_in("Cannot change a Locked Token supply", await wallet.mint_tokens(token_id, address, tokens_to_mint))
             assert_in("Cannot change a Locked Token supply", await wallet.unmint_tokens(token_id, tokens_to_mint))
-            assert_in("Cannot lock Token supply in state: Locked", await wallet.lock_token_suply(token_id))
+            assert_in("Cannot lock Token supply in state: Locked", await wallet.lock_token_supply(token_id))
 
 
 if __name__ == '__main__':

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -32,8 +32,9 @@ use wallet_types::with_locked::WithLocked;
 use crate::account::utxo_selector::{select_coins, OutputGroup};
 use crate::key_chain::{make_path_to_vrf_key, AccountKeyChain, KeyChainError};
 use crate::send_request::{
-    make_address_output, make_address_output_from_delegation, make_address_output_token,
-    make_decomission_stake_pool_output, make_stake_output, IssueNftArguments,
+    get_tx_output_destination, make_address_output, make_address_output_from_delegation,
+    make_address_output_token, make_decomission_stake_pool_output, make_lock_token_outputs,
+    make_mint_token_outputs, make_redeem_token_outputs, make_stake_output, IssueNftArguments,
     StakePoolDataArguments,
 };
 use crate::wallet_events::{WalletEvents, WalletEventsNoOp};
@@ -57,8 +58,9 @@ use crypto::key::PublicKey;
 use crypto::vrf::{VRFPrivateKey, VRFPublicKey};
 use itertools::Itertools;
 use std::cmp::Reverse;
+use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
-use std::ops::Add;
+use std::ops::{Add, Sub};
 use std::sync::Arc;
 use wallet_storage::{
     StoreTxRw, WalletStorageReadLocked, WalletStorageReadUnlocked, WalletStorageWriteLocked,
@@ -72,9 +74,14 @@ use wallet_types::{
 };
 
 pub use self::output_cache::DelegationData;
-use self::output_cache::OutputCache;
+use self::output_cache::{OutputCache, TokenIssuanceData};
 use self::transaction_list::{get_transaction_list, TransactionList};
 use self::utxo_selector::{CoinSelectionAlgo, PayFee};
+
+pub struct CurrentFeeRate {
+    pub current_fee_rate: FeeRate,
+    pub consolidate_fee_rate: FeeRate,
+}
 
 pub struct Account {
     chain_config: Arc<ChainConfig>,
@@ -176,10 +183,15 @@ impl Account {
             timestamp: median_time,
         };
 
+        let mut preselected_inputs = group_preselected_inputs(&request, current_fee_rate)?;
+
         let (utxos, selection_algo) = if input_utxos.is_empty() {
             (
                 self.get_utxos(
-                    UtxoType::Transfer | UtxoType::LockThenTransfer,
+                    UtxoType::Transfer
+                        | UtxoType::LockThenTransfer
+                        | UtxoType::IssueNft
+                        | UtxoType::MintTokens,
                     median_time,
                     UtxoState::Confirmed | UtxoState::InMempool | UtxoState::Inactive,
                     WithLocked::Unlocked,
@@ -209,6 +221,8 @@ impl Account {
             .iter()
             .map(|(currency, output_amount)| -> WalletResult<_> {
                 let utxos = utxos_by_currency.remove(currency).unwrap_or(vec![]);
+                let (preselected_amount, preselected_fee) =
+                    preselected_inputs.remove(currency).unwrap_or((Amount::ZERO, Amount::ZERO));
 
                 let cost_of_change = match currency {
                     Currency::Coin => coin_change_fee,
@@ -216,7 +230,7 @@ impl Account {
                 };
                 let selection_result = select_coins(
                     utxos,
-                    *output_amount,
+                    output_amount.sub(preselected_amount).unwrap_or(Amount::ZERO),
                     PayFee::DoNotPayFeeWithThisCurrency,
                     cost_of_change,
                     selection_algo,
@@ -224,7 +238,12 @@ impl Account {
 
                 total_fees_not_paid = (total_fees_not_paid + selection_result.get_total_fees())
                     .ok_or(WalletError::OutputAmountOverflow)?;
+                total_fees_not_paid = (total_fees_not_paid + preselected_fee)
+                    .ok_or(WalletError::OutputAmountOverflow)?;
 
+                let preselected_change =
+                    (preselected_amount - *output_amount).unwrap_or(Amount::ZERO);
+                let selection_result = selection_result.add_change(preselected_change)?;
                 let change_amount = selection_result.get_change();
                 if change_amount > Amount::ZERO {
                     total_fees_not_paid = (total_fees_not_paid + cost_of_change)
@@ -236,7 +255,12 @@ impl Account {
             .try_collect()?;
 
         let utxos = utxos_by_currency.remove(&pay_fee_with_currency).unwrap_or(vec![]);
+        let (preselected_amount, preselected_fee) = preselected_inputs
+            .remove(&pay_fee_with_currency)
+            .unwrap_or((Amount::ZERO, Amount::ZERO));
 
+        total_fees_not_paid =
+            (total_fees_not_paid + preselected_fee).ok_or(WalletError::OutputAmountOverflow)?;
         let mut amount_to_be_paid_in_currency_with_fees = (amount_to_be_paid_in_currency_with_fees
             + total_fees_not_paid)
             .ok_or(WalletError::OutputAmountOverflow)?;
@@ -248,12 +272,15 @@ impl Account {
 
         let selection_result = select_coins(
             utxos,
-            amount_to_be_paid_in_currency_with_fees,
+            (amount_to_be_paid_in_currency_with_fees - preselected_amount).unwrap_or(Amount::ZERO),
             PayFee::PayFeeWithThisCurrency,
             cost_of_change,
             selection_algo,
         )?;
 
+        let selection_result = selection_result.add_change(
+            (preselected_amount - amount_to_be_paid_in_currency_with_fees).unwrap_or(Amount::ZERO),
+        )?;
         let change_amount = selection_result.get_change();
         if change_amount > Amount::ZERO {
             amount_to_be_paid_in_currency_with_fees = (amount_to_be_paid_in_currency_with_fees
@@ -304,7 +331,7 @@ impl Account {
 
         let selected_inputs = selected_inputs.into_iter().flat_map(|x| x.1.into_output_pairs());
 
-        Ok(request.with_inputs(selected_inputs))
+        request.with_inputs(selected_inputs)
     }
 
     fn utxo_output_groups_by_currency(
@@ -319,7 +346,7 @@ impl Account {
                 let tx_input: TxInput = outpoint.into();
                 let input_size = serialization::Encode::encoded_size(&tx_input);
 
-                let destination = Self::get_tx_output_destination(&txo).ok_or_else(|| {
+                let destination = get_tx_output_destination(&txo).ok_or_else(|| {
                     WalletError::UnsupportedTransactionOutput(Box::new(txo.clone()))
                 })?;
 
@@ -376,16 +403,15 @@ impl Account {
         request: SendRequest,
         inputs: Vec<UtxoOutPoint>,
         median_time: BlockTimestamp,
-        current_fee_rate: FeeRate,
-        consolidate_fee_rate: FeeRate,
+        fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
         let request = self.select_inputs_for_send_request(
             request,
             inputs,
             db_tx,
             median_time,
-            current_fee_rate,
-            consolidate_fee_rate,
+            fee_rate.current_fee_rate,
+            fee_rate.consolidate_fee_rate,
         )?;
         // TODO: Randomize inputs and outputs
 
@@ -543,14 +569,20 @@ impl Account {
             .ok_or(WalletError::DelegationNotFound(*delegation_id))
     }
 
+    pub fn find_token(&self, token_id: &TokenId) -> WalletResult<&TokenIssuanceData> {
+        self.output_cache
+            .token_data(token_id)
+            .filter(|data| self.is_mine_or_watched_destination(&data.reissuance_controller))
+            .ok_or(WalletError::UnknownTokenId(*token_id))
+    }
+
     pub fn create_stake_pool_tx(
         &mut self,
         db_tx: &mut impl WalletStorageWriteUnlocked,
         stake_pool_arguments: StakePoolDataArguments,
         decomission_key: Option<PublicKey>,
         median_time: BlockTimestamp,
-        current_fee_rate: FeeRate,
-        consolidate_fee_rate: FeeRate,
+        fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
         // TODO: Use other accounts here
         let staker = self.key_chain.issue_key(db_tx, KeyPurpose::ReceiveFunds)?;
@@ -576,8 +608,8 @@ impl Account {
             vec![],
             db_tx,
             median_time,
-            current_fee_rate,
-            consolidate_fee_rate,
+            fee_rate.current_fee_rate,
+            fee_rate.consolidate_fee_rate,
         )?;
 
         let new_pool_id = match request
@@ -618,10 +650,9 @@ impl Account {
         db_tx: &mut impl WalletStorageWriteUnlocked,
         nft_issue_arguments: IssueNftArguments,
         median_time: BlockTimestamp,
-        current_fee_rate: FeeRate,
-        consolidate_fee_rate: FeeRate,
+        fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
-        // the first UTXO is needed in advance to calculate pool_id, so just make a dummy one
+        // the first UTXO is needed in advance to issue a new nft, so just make a dummy one
         // and then replace it with when we can calculate the pool_id
         let dummy_token_id = TokenId::new(H256::zero());
         let dummy_issuance_output = TxOutput::IssueNft(
@@ -643,8 +674,8 @@ impl Account {
             vec![],
             db_tx,
             median_time,
-            current_fee_rate,
-            consolidate_fee_rate,
+            fee_rate.current_fee_rate,
+            fee_rate.consolidate_fee_rate,
         )?;
 
         let new_token_id = make_token_id(request.inputs()).ok_or(WalletError::NoUtxos)?;
@@ -666,11 +697,109 @@ impl Account {
                     (*token_id == dummy_token_id).then_some(token_id)
                 }
             })
-            .expect("find output with dummy_pool_id");
+            .expect("find output with dummy_token_id");
         *old_token_id = new_token_id;
 
         let tx = self.sign_transaction_from_req(request, db_tx)?;
         Ok(tx)
+    }
+
+    pub fn mint_tokens(
+        &mut self,
+        db_tx: &mut impl WalletStorageWriteUnlocked,
+        token_id: TokenId,
+        address: Address<Destination>,
+        amount: Amount,
+        median_time: BlockTimestamp,
+        fee_rate: CurrentFeeRate,
+    ) -> WalletResult<SignedTransaction> {
+        let outputs =
+            make_mint_token_outputs(token_id, amount, address, self.chain_config.as_ref())?;
+
+        self.change_token_supply_transaction(
+            token_id,
+            amount,
+            outputs,
+            db_tx,
+            median_time,
+            fee_rate,
+        )
+    }
+
+    fn change_token_supply_transaction(
+        &mut self,
+        token_id: TokenId,
+        amount: Amount,
+        outputs: Vec<TxOutput>,
+        db_tx: &mut impl WalletStorageWriteUnlocked,
+        median_time: BlockTimestamp,
+        fee_rate: CurrentFeeRate,
+    ) -> Result<SignedTransaction, WalletError> {
+        let token_data = self.find_token(&token_id)?;
+        let nonce = token_data
+            .last_nonce
+            .map_or(Some(AccountNonce::new(0)), |nonce| nonce.increment())
+            .ok_or(WalletError::TokenIssuanceNonceOverflow(token_id))?;
+        //FIXME: pass different input in
+        let tx_input = TxInput::Account(AccountOutPoint::new(
+            nonce,
+            AccountOp::MintTokens(token_id, amount),
+        ));
+
+        let request = SendRequest::new()
+            .with_outputs(outputs)
+            .with_inputs_and_destinations([(tx_input, token_data.reissuance_controller.clone())]);
+
+        let request = self.select_inputs_for_send_request(
+            request,
+            vec![],
+            db_tx,
+            median_time,
+            fee_rate.current_fee_rate,
+            fee_rate.consolidate_fee_rate,
+        )?;
+
+        let tx = self.sign_transaction_from_req(request, db_tx)?;
+        Ok(tx)
+    }
+
+    pub fn redeem_tokens(
+        &mut self,
+        db_tx: &mut impl WalletStorageWriteUnlocked,
+        token_id: TokenId,
+        amount: Amount,
+        median_time: BlockTimestamp,
+        fee_rate: CurrentFeeRate,
+    ) -> WalletResult<SignedTransaction> {
+        let outputs = make_redeem_token_outputs(token_id, amount, self.chain_config.as_ref())?;
+
+        self.change_token_supply_transaction(
+            token_id,
+            amount,
+            outputs,
+            db_tx,
+            median_time,
+            fee_rate,
+        )
+    }
+
+    pub fn lock_tokens(
+        &mut self,
+        db_tx: &mut impl WalletStorageWriteUnlocked,
+        token_id: TokenId,
+        median_time: BlockTimestamp,
+        fee_rate: CurrentFeeRate,
+    ) -> WalletResult<SignedTransaction> {
+        let outputs = make_lock_token_outputs(self.chain_config.as_ref())?;
+
+        self.change_token_supply_transaction(
+            token_id,
+            Amount::ZERO,
+            outputs,
+            db_tx,
+            median_time,
+            fee_rate,
+        )
     }
 
     pub fn get_pos_gen_block_data(
@@ -704,7 +833,7 @@ impl Account {
             .ok_or(WalletError::UnknownPoolId(pool_id))?;
         let kernel_input: TxInput = kernel_input_outpoint.into();
 
-        let stake_destination = Self::get_tx_output_destination(kernel_input_utxo)
+        let stake_destination = get_tx_output_destination(kernel_input_utxo)
             .expect("must succeed for CreateStakePool and ProduceBlockFromStake outputs");
         let stake_private_key = self
             .key_chain
@@ -730,18 +859,11 @@ impl Account {
         request: SendRequest,
         db_tx: &impl WalletStorageReadUnlocked,
     ) -> WalletResult<SignedTransaction> {
-        let (tx, utxos) = request.into_transaction_and_utxos()?;
-        let destinations = utxos
-            .iter()
-            .map(|utxo| {
-                Self::get_tx_output_destination(utxo).ok_or_else(|| {
-                    WalletError::UnsupportedTransactionOutput(Box::new(utxo.clone()))
-                })
-            })
-            .collect::<Result<Vec<_>, WalletError>>()?;
-        let input_utxos = utxos.iter().map(Some).collect::<Vec<_>>();
+        let (tx, input_utxos, destinations) = request.into_transaction_and_utxos()?;
+        let destinations = destinations.iter().collect_vec();
+        let input_utxos = input_utxos.iter().map(Option::as_ref).collect_vec();
 
-        self.sign_transaction(tx, destinations.as_slice(), &input_utxos, db_tx)
+        self.sign_transaction(tx, destinations.as_slice(), input_utxos.as_slice(), db_tx)
     }
 
     // TODO: Use a different type to support partially signed transactions
@@ -830,26 +952,10 @@ impl Account {
         self.key_chain.get_addresses_usage_state()
     }
 
-    fn get_tx_output_destination(txo: &TxOutput) -> Option<&Destination> {
-        // TODO: Reuse code from TxVerifier
-        match txo {
-            TxOutput::Transfer(_, d)
-            | TxOutput::LockThenTransfer(_, d, _)
-            | TxOutput::CreateDelegationId(d, _)
-            | TxOutput::ProduceBlockFromStake(d, _) => Some(d),
-            TxOutput::CreateStakePool(_, data) => Some(data.staker()),
-            TxOutput::IssueNft(_, _, d) => Some(d),
-            TxOutput::IssueFungibleToken(_)
-            | TxOutput::Burn(_)
-            | TxOutput::DelegateStaking(_, _) => None,
-        }
-    }
-
     /// Return true if this transaction output is can be spent by this account or if it is being
     /// watched.
     fn is_mine_or_watched(&self, txo: &TxOutput) -> bool {
-        Self::get_tx_output_destination(txo)
-            .map_or(false, |d| self.is_mine_or_watched_destination(d))
+        get_tx_output_destination(txo).map_or(false, |d| self.is_mine_or_watched_destination(d))
     }
 
     /// Return true if this destination can be spent by this account or if it is being watched.
@@ -880,7 +986,7 @@ impl Account {
         db_tx: &mut impl WalletStorageWriteLocked,
         output: &TxOutput,
     ) -> WalletResult<bool> {
-        if let Some(d) = Self::get_tx_output_destination(output) {
+        if let Some(d) = get_tx_output_destination(output) {
             match d {
                 Destination::Address(pkh) => {
                     let found = self.key_chain.mark_public_key_hash_as_used(db_tx, pkh)?;
@@ -1003,13 +1109,9 @@ impl Account {
                 AccountOp::SpendDelegationBalance(delegation_id, _) => {
                     self.find_delegation(delegation_id).is_ok()
                 }
-                AccountOp::MintTokens(_, _)
-                | AccountOp::UnmintTokens(_)
-                | AccountOp::LockTokenSupply(_) => {
-                    // TODO: add support for tokens v1
-                    // See https://github.com/mintlayer/mintlayer-core/issues/1237
-                    unimplemented!()
-                }
+                AccountOp::MintTokens(token_id, _)
+                | AccountOp::UnmintTokens(token_id)
+                | AccountOp::LockTokenSupply(token_id) => self.find_token(token_id).is_ok(),
             },
         });
         let relevant_outputs = self.mark_outputs_as_seen(db_tx, tx.outputs())?;
@@ -1262,6 +1364,52 @@ impl Account {
     }
 }
 
+fn group_preselected_inputs(
+    request: &SendRequest,
+    current_fee_rate: FeeRate,
+) -> Result<BTreeMap<Currency, (Amount, Amount)>, WalletError> {
+    let mut preselected_inputs = BTreeMap::new();
+    for (input, destination) in request.inputs().iter().zip(request.destinations()) {
+        let input_size = serialization::Encode::encoded_size(&input);
+        let inp_sig_size = input_signature_size(destination)?;
+
+        let fee = current_fee_rate
+            .compute_fee(input_size + inp_sig_size)
+            .map_err(|_| UtxoSelectorError::AmountArithmeticError)?;
+
+        let mut update_preselected_inputs =
+            |currency: Currency, amount: Amount, fee: Amount| -> WalletResult<()> {
+                match preselected_inputs.entry(currency) {
+                    Entry::Vacant(entry) => {
+                        entry.insert((amount, fee));
+                    }
+                    Entry::Occupied(mut entry) => {
+                        let (existing_amount, existing_fee) = entry.get_mut();
+                        *existing_amount =
+                            (*existing_amount + amount).ok_or(WalletError::OutputAmountOverflow)?;
+                        *existing_fee =
+                            (*existing_fee + fee).ok_or(WalletError::OutputAmountOverflow)?;
+                    }
+                }
+                Ok(())
+            };
+
+        match input {
+            TxInput::Utxo(_) => {}
+            TxInput::Account(acc) => match acc.account() {
+                AccountOp::MintTokens(token_id, amount) => {
+                    update_preselected_inputs(Currency::Token(*token_id), *amount, *fee)?;
+                }
+                AccountOp::LockTokenSupply(_) | AccountOp::UnmintTokens(_) => {}
+                AccountOp::SpendDelegationBalance(_, amount) => {
+                    update_preselected_inputs(Currency::Coin, *amount, *fee)?;
+                }
+            },
+        }
+    }
+    Ok(preselected_inputs)
+}
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub enum Currency {
     Coin,
@@ -1342,12 +1490,14 @@ fn group_utxos_for_input<T, Grouped: Clone>(
         let output_value = match get_tx_output(&output) {
             TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) => v.clone(),
             TxOutput::CreateStakePool(_, stake) => OutputValue::Coin(stake.value()),
+            TxOutput::IssueNft(token_id, _, _) => {
+                OutputValue::TokenV1(*token_id, Amount::from_atoms(1))
+            }
             TxOutput::ProduceBlockFromStake(_, _)
             | TxOutput::Burn(_)
             | TxOutput::CreateDelegationId(_, _)
             | TxOutput::DelegateStaking(_, _)
-            | TxOutput::IssueFungibleToken(_)
-            | TxOutput::IssueNft(_, _, _) => {
+            | TxOutput::IssueFungibleToken(_) => {
                 return Err(WalletError::UnsupportedTransactionOutput(Box::new(
                     get_tx_output(&output).clone(),
                 )))

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -34,7 +34,7 @@ use crate::key_chain::{make_path_to_vrf_key, AccountKeyChain, KeyChainError};
 use crate::send_request::{
     get_tx_output_destination, make_address_output, make_address_output_from_delegation,
     make_address_output_token, make_decomission_stake_pool_output, make_lock_token_outputs,
-    make_mint_token_outputs, make_redeem_token_outputs, make_stake_output, IssueNftArguments,
+    make_mint_token_outputs, make_stake_output, make_unmint_token_outputs, IssueNftArguments,
     StakePoolDataArguments,
 };
 use crate::wallet_events::{WalletEvents, WalletEventsNoOp};
@@ -741,7 +741,7 @@ impl Account {
         )
     }
 
-    pub fn redeem_tokens(
+    pub fn unmint_tokens(
         &mut self,
         db_tx: &mut impl WalletStorageWriteUnlocked,
         token_id: TokenId,
@@ -749,10 +749,10 @@ impl Account {
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
-        let outputs = make_redeem_token_outputs(token_id, amount, self.chain_config.as_ref())?;
+        let outputs = make_unmint_token_outputs(token_id, amount, self.chain_config.as_ref())?;
 
         let token_data = self.find_token(&token_id)?;
-        token_data.total_supply.check_can_redeem(amount)?;
+        token_data.total_supply.check_can_unmint(amount)?;
 
         let nonce = token_data
             .last_nonce

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -188,7 +188,7 @@ impl Account {
         let (utxos, selection_algo) = if input_utxos.is_empty() {
             (
                 self.get_utxos(
-                    UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::TokensOp,
+                    UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::IssueNft,
                     median_time,
                     UtxoState::Confirmed | UtxoState::InMempool | UtxoState::Inactive,
                     WithLocked::Unlocked,

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -774,7 +774,7 @@ impl Account {
         )
     }
 
-    pub fn lock_tokens(
+    pub fn lock_token_supply(
         &mut self,
         db_tx: &mut impl WalletStorageWriteUnlocked,
         token_id: TokenId,

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -485,7 +485,7 @@ impl OutputCache {
                                         outpoint,
                                         tx_id,
                                     )?;
-                                    data.total_supply.mint(*amount)?;
+                                    data.total_supply = data.total_supply.mint(*amount)?;
                                 }
                             }
                             AccountOp::UnmintTokens(token_id) => {
@@ -498,7 +498,7 @@ impl OutputCache {
                                         tx_id,
                                     )?;
                                     let amount = sum_burned_token_amount(tx.outputs(), token_id)?;
-                                    data.total_supply.redeem(amount)?;
+                                    data.total_supply = data.total_supply.redeem(amount)?;
                                 }
                             }
                             | AccountOp::LockTokenSupply(token_id) => {
@@ -510,7 +510,7 @@ impl OutputCache {
                                         outpoint,
                                         tx_id,
                                     )?;
-                                    data.total_supply.lock()?;
+                                    data.total_supply = data.total_supply.lock()?;
                                 }
                             }
                         }
@@ -605,7 +605,7 @@ impl OutputCache {
                                 data.last_nonce = outpoint.nonce().decrement();
                                 data.last_parent =
                                     find_parent(&self.unconfirmed_descendants, tx_id.clone());
-                                data.total_supply.redeem(*amount)?;
+                                data.total_supply = data.total_supply.redeem(*amount)?;
                             }
                         }
 
@@ -615,7 +615,7 @@ impl OutputCache {
                                 data.last_parent =
                                     find_parent(&self.unconfirmed_descendants, tx_id.clone());
                                 let amount = sum_burned_token_amount(tx.outputs(), token_id)?;
-                                data.total_supply.mint(amount)?;
+                                data.total_supply = data.total_supply.mint(amount)?;
                             }
                         }
                         AccountOp::LockTokenSupply(token_id) => {
@@ -623,7 +623,7 @@ impl OutputCache {
                                 data.last_nonce = outpoint.nonce().decrement();
                                 data.last_parent =
                                     find_parent(&self.unconfirmed_descendants, tx_id.clone());
-                                data.total_supply.unlock()?;
+                                data.total_supply = data.total_supply.unlock()?;
                             }
                         }
                     },
@@ -806,7 +806,8 @@ impl OutputCache {
                                                     &self.unconfirmed_descendants,
                                                     tx_id.into(),
                                                 );
-                                                data.total_supply.redeem(*amount)?;
+                                                data.total_supply =
+                                                    data.total_supply.redeem(*amount)?;
                                             }
                                         }
                                         | AccountOp::UnmintTokens(token_id) => {
@@ -822,7 +823,8 @@ impl OutputCache {
                                                     tx.get_transaction().outputs(),
                                                     token_id,
                                                 )?;
-                                                data.total_supply.mint(amount)?;
+                                                data.total_supply =
+                                                    data.total_supply.mint(amount)?;
                                             }
                                         }
                                         | AccountOp::LockTokenSupply(token_id) => {
@@ -834,7 +836,7 @@ impl OutputCache {
                                                     &self.unconfirmed_descendants,
                                                     tx_id.into(),
                                                 );
-                                                data.total_supply.unlock()?;
+                                                data.total_supply = data.total_supply.unlock()?;
                                             }
                                         }
                                     },

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -336,7 +336,7 @@ impl OutputCache {
     }
 
     pub fn add_tx(&mut self, tx_id: OutPointSourceId, tx: WalletTx) -> WalletResult<()> {
-        let already_present = self.txs.contains_key(&tx_id);
+        let already_present = self.txs.get(&tx_id).map_or(false, |tx| !tx.state().is_abandoned());
         let is_unconfirmed = match tx.state() {
             TxState::Inactive(_)
             | TxState::InMempool(_)

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -212,14 +212,14 @@ fn sign_transaction(#[case] seed: Seed) {
 
     let tx = Transaction::new(0, inputs, outputs).unwrap();
 
-    let req = SendRequest::from_transaction(tx, utxos.clone());
+    let req = SendRequest::from_transaction(tx, utxos.clone()).unwrap();
 
     let sig_tx = account.sign_transaction_from_req(req, &db_tx).unwrap();
 
     let utxos_ref = utxos.iter().map(Some).collect::<Vec<_>>();
 
     for i in 0..sig_tx.inputs().len() {
-        let destination = Account::get_tx_output_destination(utxos_ref[i].unwrap()).unwrap();
+        let destination = get_tx_output_destination(utxos_ref[i].unwrap()).unwrap();
         verify_signature(&config, destination, &sig_tx, &utxos_ref, i).unwrap();
     }
 }

--- a/wallet/src/account/utxo_selector/mod.rs
+++ b/wallet/src/account/utxo_selector/mod.rs
@@ -27,6 +27,7 @@ use utils::ensure;
 
 const TOTAL_TRIES: u32 = 100_000;
 
+#[derive(Debug)]
 pub struct SelectionResult {
     outputs: Vec<(TxInput, TxOutput)>,
     effective_value: Amount,
@@ -56,6 +57,11 @@ impl SelectionResult {
 
     pub fn get_change(&self) -> Amount {
         self.change
+    }
+
+    pub fn add_change(mut self, change: Amount) -> Result<Self, UtxoSelectorError> {
+        self.change = (self.change + change).ok_or(UtxoSelectorError::AmountArithmeticError)?;
+        Ok(self)
     }
 
     pub fn into_output_pairs(self) -> Vec<(TxInput, TxOutput)> {

--- a/wallet/src/account/utxo_selector/mod.rs
+++ b/wallet/src/account/utxo_selector/mod.rs
@@ -669,6 +669,9 @@ pub fn select_coins(
     cost_of_change: Amount,
     coin_selection_algo: CoinSelectionAlgo,
 ) -> Result<SelectionResult, UtxoSelectorError> {
+    if selection_target == Amount::ZERO && pay_fees == PayFee::DoNotPayFeeWithThisCurrency {
+        return Ok(SelectionResult::new(selection_target));
+    }
     ensure!(!utxo_pool.is_empty(), UtxoSelectorError::NoUtxos);
 
     let total_available_value = utxo_pool

--- a/wallet/src/account/utxo_selector/output_group.rs
+++ b/wallet/src/account/utxo_selector/output_group.rs
@@ -41,7 +41,7 @@ pub struct OutputGroup {
 
 /// Should we pay fee with this currency or not in the case we pay the total fees with another
 /// currency. Here Currency refers to either a coin or a token_id.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PayFee {
     PayFeeWithThisCurrency,
     DoNotPayFeeWithThisCurrency,

--- a/wallet/src/account/utxo_selector/output_group.rs
+++ b/wallet/src/account/utxo_selector/output_group.rs
@@ -56,13 +56,15 @@ impl OutputGroup {
     ) -> Result<Self, UtxoSelectorError> {
         let output_value = match &output.1 {
             TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) => v.clone(),
+            TxOutput::IssueNft(token_id, _, _) => {
+                OutputValue::TokenV1(*token_id, Amount::from_atoms(1))
+            }
             TxOutput::CreateStakePool(_, _)
             | TxOutput::ProduceBlockFromStake(_, _)
             | TxOutput::Burn(_)
             | TxOutput::CreateDelegationId(_, _)
             | TxOutput::DelegateStaking(_, _)
-            | TxOutput::IssueFungibleToken(_)
-            | TxOutput::IssueNft(_, _, _) => {
+            | TxOutput::IssueFungibleToken(_) => {
                 return Err(UtxoSelectorError::UnsupportedTransactionOutput(Box::new(
                     output.1.clone(),
                 )))

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -21,7 +21,7 @@ pub mod wallet;
 pub mod wallet_events;
 
 pub use crate::account::Account;
-pub use crate::send_request::SendRequest;
+pub use crate::send_request::{get_tx_output_destination, SendRequest};
 pub use crate::wallet::{Wallet, WalletError, WalletResult};
 
 pub type DefaultWallet = Wallet<wallet_storage::DefaultBackend>;

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -99,7 +99,7 @@ pub fn make_mint_token_outputs(
     Ok(vec![mint_output, token_change_supply_fee])
 }
 
-pub fn make_redeem_token_outputs(
+pub fn make_unmint_token_outputs(
     token_id: TokenId,
     amount: Amount,
     chain_config: &ChainConfig,

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -151,8 +151,8 @@ pub enum WalletError {
         "Cannot mint Token over the fixed supply {0:?}, current supply {1:?} trying to mint {2:?}"
     )]
     CannotMintFixedTokenSupply(Amount, Amount, Amount),
-    #[error("Trying to redeem {0:?} but the current supply is {1:?}")]
-    CannotRedeemTokenSupply(Amount, Amount),
+    #[error("Trying to unmint {0:?} but the current supply is {1:?}")]
+    CannotUnmintTokenSupply(Amount, Amount),
 }
 
 /// Result type used for the wallet
@@ -828,7 +828,7 @@ impl<B: storage::Backend> Wallet<B> {
         })
     }
 
-    pub fn redeem_tokens(
+    pub fn unmint_tokens(
         &mut self,
         account_index: U31,
         token_id: TokenId,
@@ -838,7 +838,7 @@ impl<B: storage::Backend> Wallet<B> {
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
-            account.redeem_tokens(
+            account.unmint_tokens(
                 db_tx,
                 token_id,
                 amount,

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -851,7 +851,7 @@ impl<B: storage::Backend> Wallet<B> {
         })
     }
 
-    pub fn lock_tokens(
+    pub fn lock_token_supply(
         &mut self,
         account_index: U31,
         token_id: TokenId,
@@ -860,7 +860,7 @@ impl<B: storage::Backend> Wallet<B> {
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
-            account.lock_tokens(
+            account.lock_token_supply(
                 db_tx,
                 token_id,
                 latest_median_time,

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -103,6 +103,10 @@ pub enum WalletError {
     InconsistentProduceBlockFromStake(PoolId),
     #[error("Delegation nonce overflow for id: {0}")]
     DelegationNonceOverflow(DelegationId),
+    #[error("Token issuance nonce overflow for id: {0}")]
+    TokenIssuanceNonceOverflow(TokenId),
+    #[error("Token with id: {0} with duplicate AccountNonce: {1}")]
+    InconsistentTokenIssuanceDuplicateNonce(TokenId, AccountNonce),
     #[error("Empty inputs in token issuance transaction")]
     MissingTokenId,
     #[error("Unknown token with Id {0}")]
@@ -135,6 +139,14 @@ pub enum WalletError {
     ConsumedUtxo(UtxoOutPoint),
     #[error("Selected UTXO is still locked")]
     LockedUtxo(UtxoOutPoint),
+    #[error("Selected UTXO is a token v0 and cannot be used")]
+    TokenV0Utxo(UtxoOutPoint),
+    #[error("Cannot change Token supply in state: {0}")]
+    CannotChangeTokenSupply(&'static str),
+    #[error("Cannot lock Token supply in state: {0}")]
+    CannotLockTokenSupply(&'static str),
+    #[error("Cannot revert lock Token supply in state: {0}")]
+    InconsistentUnLockTokenSupply(&'static str),
 }
 
 /// Result type used for the wallet

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -141,12 +141,18 @@ pub enum WalletError {
     LockedUtxo(UtxoOutPoint),
     #[error("Selected UTXO is a token v0 and cannot be used")]
     TokenV0Utxo(UtxoOutPoint),
-    #[error("Cannot change Token supply in state: {0}")]
-    CannotChangeTokenSupply(&'static str),
+    #[error("Cannot change a Locked Token supply")]
+    CannotChangeLockedTokenSupply,
     #[error("Cannot lock Token supply in state: {0}")]
     CannotLockTokenSupply(&'static str),
     #[error("Cannot revert lock Token supply in state: {0}")]
-    InconsistentUnLockTokenSupply(&'static str),
+    InconsistentUnlockTokenSupply(&'static str),
+    #[error(
+        "Cannot mint Token over the fixed supply {0:?}, current supply {1:?} trying to mint {2:?}"
+    )]
+    CannotMintFixedTokenSupply(Amount, Amount, Amount),
+    #[error("Trying to redeem {0:?} but the current supply is {1:?}")]
+    CannotRedeemTokenSupply(Amount, Amount),
 }
 
 /// Result type used for the wallet

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -31,7 +31,7 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         timelock::OutputTimeLock,
-        tokens::{TokenData, TokenIssuanceV1, TokenTransfer},
+        tokens::{TokenData, TokenIssuanceV0, TokenIssuanceV1},
         Destination, Genesis, OutPointSourceId, TxInput,
     },
     primitives::{per_thousand::PerThousand, Idable, H256},
@@ -2200,10 +2200,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
 
     let some_other_address = PublicKeyHash::from_low_u64_be(1);
     let new_output = TxOutput::Transfer(
-        OutputValue::TokenV0(Box::new(TokenData::TokenTransfer(TokenTransfer {
-            token_id: *token_id,
-            amount: tokens_to_transfer,
-        }))),
+        OutputValue::TokenV1(*token_id, tokens_to_transfer),
         Destination::Address(some_other_address),
     );
 
@@ -2275,10 +2272,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
 
     let some_other_address = PublicKeyHash::from_low_u64_be(1);
     let new_output = TxOutput::Transfer(
-        OutputValue::TokenV0(Box::new(TokenData::TokenTransfer(TokenTransfer {
-            token_id: *token_id,
-            amount: not_enough_tokens_to_transfer,
-        }))),
+        OutputValue::TokenV1(*token_id, not_enough_tokens_to_transfer),
         Destination::Address(some_other_address),
     );
 
@@ -2313,7 +2307,665 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn change_and_lock_token_supply(#[case] seed: Seed) {
+fn check_tokens_v0_are_ignored(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    let mut wallet = create_wallet(chain_config.clone());
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = (Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000))
+        + chain_config.token_min_issuance_fee())
+    .unwrap();
+
+    let address = get_address(
+        &chain_config,
+        MNEMONIC,
+        DEFAULT_ACCOUNT_INDEX,
+        KeyPurpose::ReceiveFunds,
+        0.try_into().unwrap(),
+    );
+    let block1 = Block::new(
+        vec![],
+        chain_config.genesis_block_id(),
+        chain_config.genesis_block().timestamp(),
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block1_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    let block1_id = block1.get_id();
+    let block1_timestamp = block1.timestamp();
+
+    scan_wallet(&mut wallet, BlockHeight::new(0), vec![block1]);
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, block1_amount);
+
+    let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
+    let token_issuance_transaction = wallet
+        .create_transaction_to_addresses(
+            DEFAULT_ACCOUNT_INDEX,
+            [TxOutput::Transfer(
+                OutputValue::TokenV0(Box::new(TokenData::TokenIssuance(Box::new(
+                    TokenIssuanceV0 {
+                        token_ticker: "XXXX".as_bytes().to_vec(),
+                        number_of_decimals: rng.gen_range(1..18),
+                        metadata_uri: "http://uri".as_bytes().to_vec(),
+                        amount_to_issue: Amount::from_atoms(rng.gen_range(1..10000)),
+                    },
+                )))),
+                address2.decode_object(&chain_config).unwrap(),
+            )],
+            [],
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block2_amount = chain_config.token_min_supply_change_fee();
+
+    let block2 = Block::new(
+        vec![token_issuance_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(1), vec![block2]);
+
+    let currency_balances = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap();
+
+    let token_balances = currency_balances
+        .into_iter()
+        .filter_map(|(c, amount)| match c {
+            Currency::Coin => None,
+            Currency::Token(token_id) => Some((token_id, amount)),
+        })
+        .collect_vec();
+    // the token should be ignored
+    assert_eq!(token_balances.len(), 0);
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn change_token_supply_fixed(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    let mut wallet = create_wallet(chain_config.clone());
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = (Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000))
+        + chain_config.token_min_issuance_fee())
+    .unwrap();
+
+    let address = get_address(
+        &chain_config,
+        MNEMONIC,
+        DEFAULT_ACCOUNT_INDEX,
+        KeyPurpose::ReceiveFunds,
+        0.try_into().unwrap(),
+    );
+    let block1 = Block::new(
+        vec![],
+        chain_config.genesis_block_id(),
+        chain_config.genesis_block().timestamp(),
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block1_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    let block1_id = block1.get_id();
+    let block1_timestamp = block1.timestamp();
+
+    scan_wallet(&mut wallet, BlockHeight::new(0), vec![block1]);
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, block1_amount);
+
+    let fixed_max_amount = Amount::from_atoms(rng.gen_range(1..100000));
+    let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
+    let (issued_token_id, token_issuance_transaction) = wallet
+        .issue_new_token(
+            DEFAULT_ACCOUNT_INDEX,
+            TokenIssuance::V1(TokenIssuanceV1 {
+                token_ticker: "XXXX".as_bytes().to_vec(),
+                number_of_decimals: rng.gen_range(1..18),
+                metadata_uri: "http://uri".as_bytes().to_vec(),
+                total_supply: common::chain::tokens::TokenTotalSupply::Fixed(fixed_max_amount),
+                reissuance_controller: address2.decode_object(&chain_config).unwrap(),
+            }),
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block2_amount = chain_config.token_min_supply_change_fee();
+
+    let block2 = Block::new(
+        vec![token_issuance_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(1), vec![block2]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(
+        token_issuance_data.reissuance_controller,
+        address2.decode_object(&chain_config).unwrap()
+    );
+
+    assert_eq!(token_issuance_data.last_nonce, None);
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        Amount::ZERO,
+    );
+
+    let token_amount_to_mint = Amount::from_atoms(rng.gen_range(1..fixed_max_amount.into_atoms()));
+    let mint_transaction = wallet
+        .mint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_mint,
+            address2.clone(),
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    wallet.add_unconfirmed_tx(mint_transaction.clone(), &WalletEventsNoOp).unwrap();
+
+    // Try to mint more then the fixed maximum
+    let leftover = (fixed_max_amount - token_amount_to_mint).unwrap();
+    let token_amount_to_mint_more_than_maximum =
+        (leftover + Amount::from_atoms(rng.gen_range(1..1000))).unwrap();
+    let err = wallet
+        .mint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_mint_more_than_maximum,
+            address2.clone(),
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        WalletError::CannotMintFixedTokenSupply(
+            fixed_max_amount,
+            token_amount_to_mint,
+            token_amount_to_mint_more_than_maximum
+        )
+    );
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        token_amount_to_mint,
+    );
+
+    // test abandoning a transaction
+    wallet
+        .abandon_transaction(
+            DEFAULT_ACCOUNT_INDEX,
+            mint_transaction.transaction().get_id(),
+        )
+        .unwrap();
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, None);
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        Amount::ZERO,
+    );
+
+    let block3 = Block::new(
+        vec![mint_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(2), vec![block3]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        token_amount_to_mint,
+    );
+
+    // Try to unmint more than the current total supply
+    let token_amount_to_unmint = (token_amount_to_mint + Amount::from_atoms(1)).unwrap();
+    let err = wallet
+        .unmint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_unmint,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+    assert_eq!(
+        err,
+        WalletError::CannotUnmintTokenSupply(token_amount_to_unmint, token_amount_to_mint)
+    );
+
+    let token_amount_to_unmint =
+        Amount::from_atoms(rng.gen_range(1..token_amount_to_mint.into_atoms()));
+    let unmint_transaction = wallet
+        .unmint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_unmint,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block4 = Block::new(
+        vec![unmint_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(3), vec![block4]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(1)));
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        (token_amount_to_mint - token_amount_to_unmint).unwrap(),
+    );
+    assert_eq!(
+        token_issuance_data.total_supply.check_can_lock().unwrap_err(),
+        WalletError::CannotLockTokenSupply("Fixed")
+    );
+
+    let err = wallet
+        .lock_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+    assert_eq!(err, WalletError::CannotLockTokenSupply("Fixed"));
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn change_token_supply_unlimited(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    let mut wallet = create_wallet(chain_config.clone());
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = (Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000))
+        + chain_config.token_min_issuance_fee())
+    .unwrap();
+
+    let address = get_address(
+        &chain_config,
+        MNEMONIC,
+        DEFAULT_ACCOUNT_INDEX,
+        KeyPurpose::ReceiveFunds,
+        0.try_into().unwrap(),
+    );
+    let block1 = Block::new(
+        vec![],
+        chain_config.genesis_block_id(),
+        chain_config.genesis_block().timestamp(),
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block1_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    let block1_id = block1.get_id();
+    let block1_timestamp = block1.timestamp();
+
+    scan_wallet(&mut wallet, BlockHeight::new(0), vec![block1]);
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, block1_amount);
+
+    let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
+    let (issued_token_id, token_issuance_transaction) = wallet
+        .issue_new_token(
+            DEFAULT_ACCOUNT_INDEX,
+            TokenIssuance::V1(TokenIssuanceV1 {
+                token_ticker: "XXXX".as_bytes().to_vec(),
+                number_of_decimals: rng.gen_range(1..18),
+                metadata_uri: "http://uri".as_bytes().to_vec(),
+                total_supply: common::chain::tokens::TokenTotalSupply::Unlimited,
+                reissuance_controller: address2.decode_object(&chain_config).unwrap(),
+            }),
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block2_amount = chain_config.token_min_supply_change_fee();
+
+    let block2 = Block::new(
+        vec![token_issuance_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(1), vec![block2]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(
+        token_issuance_data.reissuance_controller,
+        address2.decode_object(&chain_config).unwrap()
+    );
+
+    assert_eq!(token_issuance_data.last_nonce, None);
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        Amount::ZERO,
+    );
+
+    let token_amount_to_mint = Amount::from_atoms(rng.gen_range(1..10000));
+    let mint_transaction = wallet
+        .mint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_mint,
+            address2.clone(),
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    wallet.add_unconfirmed_tx(mint_transaction.clone(), &WalletEventsNoOp).unwrap();
+
+    let block3 = Block::new(
+        vec![mint_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(2), vec![block3]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        token_amount_to_mint,
+    );
+
+    // Try to unmint more than the current total supply
+    let token_amount_to_unmint = (token_amount_to_mint + Amount::from_atoms(1)).unwrap();
+    let err = wallet
+        .unmint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_unmint,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+    assert_eq!(
+        err,
+        WalletError::CannotUnmintTokenSupply(token_amount_to_unmint, token_amount_to_mint)
+    );
+
+    let token_amount_to_unmint =
+        Amount::from_atoms(rng.gen_range(1..token_amount_to_mint.into_atoms()));
+    let unmint_transaction = wallet
+        .unmint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_unmint,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block4 = Block::new(
+        vec![unmint_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(3), vec![block4]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(1)));
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        (token_amount_to_mint - token_amount_to_unmint).unwrap(),
+    );
+    assert_eq!(
+        token_issuance_data.total_supply.check_can_lock().unwrap_err(),
+        WalletError::CannotLockTokenSupply("Unlimited")
+    );
+
+    let err = wallet
+        .lock_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+    assert_eq!(err, WalletError::CannotLockTokenSupply("Unlimited"));
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let chain_config = Arc::new(create_mainnet());
 

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -2716,7 +2716,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
     );
 
     let err = wallet
-        .lock_tokens(
+        .lock_token_supply(
             DEFAULT_ACCOUNT_INDEX,
             issued_token_id,
             FeeRate::new(Amount::ZERO),
@@ -2952,7 +2952,7 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
     );
 
     let err = wallet
-        .lock_tokens(
+        .lock_token_supply(
             DEFAULT_ACCOUNT_INDEX,
             issued_token_id,
             FeeRate::new(Amount::ZERO),
@@ -3183,7 +3183,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     assert!(token_issuance_data.total_supply.check_can_lock().is_ok());
 
     let lock_transaction = wallet
-        .lock_tokens(
+        .lock_token_supply(
             DEFAULT_ACCOUNT_INDEX,
             issued_token_id,
             FeeRate::new(Amount::ZERO),
@@ -3249,7 +3249,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     assert_eq!(err, WalletError::CannotChangeLockedTokenSupply);
 
     let err = wallet
-        .lock_tokens(
+        .lock_token_supply(
             DEFAULT_ACCOUNT_INDEX,
             issued_token_id,
             FeeRate::new(Amount::ZERO),

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -2169,7 +2169,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let currency_balances = wallet
         .get_balance(
             DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::TokensOp,
+            UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::IssueNft,
             UtxoState::Confirmed.into(),
             WithLocked::Unlocked,
         )

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -2169,10 +2169,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let currency_balances = wallet
         .get_balance(
             DEFAULT_ACCOUNT_INDEX,
-            UtxoType::Transfer
-                | UtxoType::LockThenTransfer
-                | UtxoType::MintTokens
-                | UtxoType::IssueNft,
+            UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::TokensOp,
             UtxoState::Confirmed.into(),
             WithLocked::Unlocked,
         )

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -2471,36 +2471,36 @@ fn change_and_lock_token_supply(#[case] seed: Seed) {
         token_amount_to_mint,
     );
 
-    // Try to redeem more than the current total supply
-    let token_amount_to_redeem = (token_amount_to_mint + Amount::from_atoms(1)).unwrap();
+    // Try to unmint more than the current total supply
+    let token_amount_to_unmint = (token_amount_to_mint + Amount::from_atoms(1)).unwrap();
     let err = wallet
-        .redeem_tokens(
+        .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
             issued_token_id,
-            token_amount_to_redeem,
+            token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
         .unwrap_err();
     assert_eq!(
         err,
-        WalletError::CannotRedeemTokenSupply(token_amount_to_redeem, token_amount_to_mint)
+        WalletError::CannotUnmintTokenSupply(token_amount_to_unmint, token_amount_to_mint)
     );
 
-    let token_amount_to_redeem =
+    let token_amount_to_unmint =
         Amount::from_atoms(rng.gen_range(1..token_amount_to_mint.into_atoms()));
-    let redeem_transaction = wallet
-        .redeem_tokens(
+    let unmint_transaction = wallet
+        .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
             issued_token_id,
-            token_amount_to_redeem,
+            token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
         .unwrap();
 
     let block4 = Block::new(
-        vec![redeem_transaction],
+        vec![unmint_transaction],
         block1_id.into(),
         block1_timestamp,
         ConsensusData::None,
@@ -2526,7 +2526,7 @@ fn change_and_lock_token_supply(#[case] seed: Seed) {
 
     assert_eq!(
         token_issuance_data.total_supply.current_supply(),
-        (token_amount_to_mint - token_amount_to_redeem).unwrap(),
+        (token_amount_to_mint - token_amount_to_unmint).unwrap(),
     );
     assert!(token_issuance_data.total_supply.check_can_lock().is_ok());
 
@@ -2566,7 +2566,7 @@ fn change_and_lock_token_supply(#[case] seed: Seed) {
 
     assert_eq!(
         token_issuance_data.total_supply.current_supply(),
-        (token_amount_to_mint - token_amount_to_redeem).unwrap(),
+        (token_amount_to_mint - token_amount_to_unmint).unwrap(),
     );
 
     assert_eq!(
@@ -2586,10 +2586,10 @@ fn change_and_lock_token_supply(#[case] seed: Seed) {
         .unwrap_err();
     assert_eq!(err, WalletError::CannotChangeLockedTokenSupply);
     let err = wallet
-        .redeem_tokens(
+        .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
             issued_token_id,
-            token_amount_to_redeem,
+            token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -2316,6 +2316,303 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
+fn change_and_lock_token_supply(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    let mut wallet = create_wallet(chain_config.clone());
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = (Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000))
+        + chain_config.token_min_issuance_fee())
+    .unwrap();
+
+    let address = get_address(
+        &chain_config,
+        MNEMONIC,
+        DEFAULT_ACCOUNT_INDEX,
+        KeyPurpose::ReceiveFunds,
+        0.try_into().unwrap(),
+    );
+    let block1 = Block::new(
+        vec![],
+        chain_config.genesis_block_id(),
+        chain_config.genesis_block().timestamp(),
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block1_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    let block1_id = block1.get_id();
+    let block1_timestamp = block1.timestamp();
+
+    scan_wallet(&mut wallet, BlockHeight::new(0), vec![block1]);
+
+    let coin_balance = wallet
+        .get_balance(
+            DEFAULT_ACCOUNT_INDEX,
+            UtxoType::Transfer | UtxoType::LockThenTransfer,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap()
+        .get(&Currency::Coin)
+        .copied()
+        .unwrap_or(Amount::ZERO);
+    assert_eq!(coin_balance, block1_amount);
+
+    let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
+    let (issued_token_id, token_issuance_transaction) = wallet
+        .issue_new_token(
+            DEFAULT_ACCOUNT_INDEX,
+            TokenIssuance::V1(TokenIssuanceV1 {
+                token_ticker: "XXXX".as_bytes().to_vec(),
+                number_of_decimals: rng.gen_range(1..18),
+                metadata_uri: "http://uri".as_bytes().to_vec(),
+                total_supply: common::chain::tokens::TokenTotalSupply::Lockable,
+                reissuance_controller: address2.decode_object(&chain_config).unwrap(),
+            }),
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block2_amount = chain_config.token_min_supply_change_fee();
+
+    let block2 = Block::new(
+        vec![token_issuance_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(1), vec![block2]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(
+        token_issuance_data.reissuance_controller,
+        address2.decode_object(&chain_config).unwrap()
+    );
+
+    assert_eq!(token_issuance_data.last_nonce, None);
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        Amount::ZERO,
+    );
+
+    let token_amount_to_mint = Amount::from_atoms(rng.gen_range(2..100));
+    let mint_transaction = wallet
+        .mint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_mint,
+            address2.clone(),
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block3 = Block::new(
+        vec![mint_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(2), vec![block3]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        token_amount_to_mint,
+    );
+
+    // Try to redeem more than the current total supply
+    let token_amount_to_redeem = (token_amount_to_mint + Amount::from_atoms(1)).unwrap();
+    let err = wallet
+        .redeem_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_redeem,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+    assert_eq!(
+        err,
+        WalletError::CannotRedeemTokenSupply(token_amount_to_redeem, token_amount_to_mint)
+    );
+
+    let token_amount_to_redeem =
+        Amount::from_atoms(rng.gen_range(1..token_amount_to_mint.into_atoms()));
+    let redeem_transaction = wallet
+        .redeem_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_redeem,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block4 = Block::new(
+        vec![redeem_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(3), vec![block4]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(1)));
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        (token_amount_to_mint - token_amount_to_redeem).unwrap(),
+    );
+    assert!(token_issuance_data.total_supply.check_can_lock().is_ok());
+
+    let lock_transaction = wallet
+        .lock_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap();
+
+    let block5 = Block::new(
+        vec![lock_transaction],
+        block1_id.into(),
+        block1_timestamp,
+        ConsensusData::None,
+        BlockReward::new(vec![make_address_output(
+            chain_config.as_ref(),
+            address.clone(),
+            block2_amount,
+        )
+        .unwrap()]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(4), vec![block5]);
+
+    let token_issuance_data = wallet
+        .accounts
+        .get(&DEFAULT_ACCOUNT_INDEX)
+        .unwrap()
+        .find_token(&issued_token_id)
+        .unwrap();
+
+    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(2)));
+
+    assert_eq!(
+        token_issuance_data.total_supply.current_supply(),
+        (token_amount_to_mint - token_amount_to_redeem).unwrap(),
+    );
+
+    assert_eq!(
+        token_issuance_data.total_supply.check_can_lock(),
+        Err(WalletError::CannotLockTokenSupply("Locked"))
+    );
+
+    let err = wallet
+        .mint_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_mint,
+            address2.clone(),
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+    assert_eq!(err, WalletError::CannotChangeLockedTokenSupply);
+    let err = wallet
+        .redeem_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            token_amount_to_redeem,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+    assert_eq!(err, WalletError::CannotChangeLockedTokenSupply);
+
+    let err = wallet
+        .lock_tokens(
+            DEFAULT_ACCOUNT_INDEX,
+            issued_token_id,
+            FeeRate::new(Amount::ZERO),
+            FeeRate::new(Amount::ZERO),
+        )
+        .unwrap_err();
+    assert_eq!(err, WalletError::CannotLockTokenSupply("Locked"));
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
 fn lock_then_transfer(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let chain_config = Arc::new(create_mainnet());

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -2309,7 +2309,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn check_tokens_v0_are_ignored(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
-    let chain_config = Arc::new(create_mainnet());
+    let chain_config = Arc::new(create_regtest());
 
     let mut wallet = create_wallet(chain_config.clone());
 

--- a/wallet/types/src/utxo_types.rs
+++ b/wallet/types/src/utxo_types.rs
@@ -31,7 +31,7 @@ pub enum UtxoType {
     ProduceBlockFromStake = 1 << 4,
     CreateDelegationId = 1 << 5,
     DelegateStaking = 1 << 6,
-    TokensOp = 1 << 7,
+    IssueNft = 1 << 7,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,8 +53,8 @@ pub fn get_utxo_type(output: &TxOutput) -> Option<UtxoType> {
         TxOutput::ProduceBlockFromStake(_, _) => Some(UtxoType::ProduceBlockFromStake),
         TxOutput::CreateDelegationId(_, _) => Some(UtxoType::CreateDelegationId),
         TxOutput::DelegateStaking(_, _) => Some(UtxoType::DelegateStaking),
+        TxOutput::IssueNft(_, _, _) => Some(UtxoType::IssueNft),
         TxOutput::IssueFungibleToken(_) => None,
-        TxOutput::IssueNft(_, _, _) => Some(UtxoType::TokensOp),
     }
 }
 pub fn get_utxo_state(output: &TxState) -> UtxoState {

--- a/wallet/types/src/utxo_types.rs
+++ b/wallet/types/src/utxo_types.rs
@@ -31,6 +31,8 @@ pub enum UtxoType {
     ProduceBlockFromStake = 1 << 4,
     CreateDelegationId = 1 << 5,
     DelegateStaking = 1 << 6,
+    MintTokens = 1 << 7,
+    IssueNft = 1 << 8,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/wallet/types/src/utxo_types.rs
+++ b/wallet/types/src/utxo_types.rs
@@ -31,8 +31,7 @@ pub enum UtxoType {
     ProduceBlockFromStake = 1 << 4,
     CreateDelegationId = 1 << 5,
     DelegateStaking = 1 << 6,
-    MintTokens = 1 << 7,
-    IssueNft = 1 << 8,
+    TokensOp = 1 << 7,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,7 +53,8 @@ pub fn get_utxo_type(output: &TxOutput) -> Option<UtxoType> {
         TxOutput::ProduceBlockFromStake(_, _) => Some(UtxoType::ProduceBlockFromStake),
         TxOutput::CreateDelegationId(_, _) => Some(UtxoType::CreateDelegationId),
         TxOutput::DelegateStaking(_, _) => Some(UtxoType::DelegateStaking),
-        TxOutput::IssueFungibleToken(_) | TxOutput::IssueNft(_, _, _) => None,
+        TxOutput::IssueFungibleToken(_) => None,
+        TxOutput::IssueNft(_, _, _) => Some(UtxoType::TokensOp),
     }
 }
 pub fn get_utxo_state(output: &TxState) -> UtxoState {

--- a/wallet/types/src/wallet_tx.rs
+++ b/wallet/types/src/wallet_tx.rs
@@ -73,6 +73,16 @@ impl TxState {
             TxState::Abandoned => "Abandoned",
         }
     }
+
+    pub fn is_abandoned(&self) -> bool {
+        match self {
+            TxState::Abandoned => true,
+            TxState::Confirmed(_, _, _)
+            | TxState::Conflicted(_)
+            | TxState::InMempool(_)
+            | TxState::Inactive(_) => false,
+        }
+    }
 }
 
 impl Display for TxState {

--- a/wallet/wallet-cli-lib/src/commands/helper_types.rs
+++ b/wallet/wallet-cli-lib/src/commands/helper_types.rs
@@ -238,7 +238,7 @@ pub fn to_per_thousand(
     variable_name: &str,
 ) -> Result<PerThousand, WalletCliError> {
     PerThousand::from_decimal_str(value_str).ok_or(WalletCliError::InvalidInput(format!(
-        "Failed to parse {variable_name} the decimal that must be in the range [0.001,1.000] or [0.1%,100%]",
+        "Failed to parse {variable_name}. The decimal must be in the range [0.001,1.000] or [0.1%,100%]",
     )))
 }
 

--- a/wallet/wallet-cli-lib/src/commands/helper_types.rs
+++ b/wallet/wallet-cli-lib/src/commands/helper_types.rs
@@ -21,10 +21,11 @@ use wallet_controller::{UtxoState, UtxoStates, UtxoType, UtxoTypes};
 use common::{
     address::Address,
     chain::{
-        block::timestamp::BlockTimestamp, ChainConfig, DelegationId, OutPointSourceId, PoolId,
-        UtxoOutPoint,
+        block::timestamp::BlockTimestamp,
+        tokens::{TokenId, TokenTotalSupply},
+        ChainConfig, DelegationId, Destination, OutPointSourceId, PoolId, UtxoOutPoint,
     },
-    primitives::{Amount, BlockHeight, Id, H256},
+    primitives::{per_thousand::PerThousand, Amount, BlockHeight, Id, H256},
 };
 use wallet_types::{seed_phrase::StoreSeedPhrase, with_locked::WithLocked};
 
@@ -200,6 +201,92 @@ pub fn parse_utxo_outpoint(mut input: String) -> Result<UtxoOutPoint, WalletCliE
     };
 
     Ok(UtxoOutPoint::new(source_id, output_index))
+}
+
+/// Try to parse a total token supply from a string
+/// Valid values are "unlimited", "lockable" and "fixed(Amount)"
+pub fn parse_token_supply(
+    input: &str,
+    token_number_of_decimals: u8,
+) -> Result<TokenTotalSupply, WalletCliError> {
+    match input {
+        "unlimited" => Ok(TokenTotalSupply::Unlimited),
+        "lockable" => Ok(TokenTotalSupply::Lockable),
+        _ => parse_fixed_token_supply(input, token_number_of_decimals),
+    }
+}
+
+/// Try to parse a fixed total token supply in the format of "fixed(Amount)"
+fn parse_fixed_token_supply(
+    input: &str,
+    token_number_of_decimals: u8,
+) -> Result<TokenTotalSupply, WalletCliError> {
+    if let Some(inner) = input.strip_prefix("fixed(").and_then(|str| str.strip_suffix(')')) {
+        Ok(TokenTotalSupply::Fixed(parse_token_amount(
+            token_number_of_decimals,
+            inner,
+        )?))
+    } else {
+        Err(WalletCliError::InvalidInput(format!(
+            "Failed to parse token supply from {input}"
+        )))
+    }
+}
+
+pub fn to_per_thousand(
+    value_str: &str,
+    variable_name: &str,
+) -> Result<PerThousand, WalletCliError> {
+    PerThousand::from_decimal_str(value_str).ok_or(WalletCliError::InvalidInput(format!(
+        "Failed to parse {variable_name} the decimal that must be in the range [0.001,1.000] or [0.1%,100%]",
+    )))
+}
+
+pub fn parse_address(
+    chain_config: &ChainConfig,
+    address: &str,
+) -> Result<Address<Destination>, WalletCliError> {
+    Address::from_str(chain_config, address)
+        .map_err(|e| WalletCliError::InvalidInput(format!("Invalid address '{address}': {e}")))
+}
+
+pub fn parse_pool_id(chain_config: &ChainConfig, pool_id: &str) -> Result<PoolId, WalletCliError> {
+    Address::<PoolId>::from_str(chain_config, pool_id)
+        .and_then(|address| address.decode_object(chain_config))
+        .map_err(|e| WalletCliError::InvalidInput(format!("Invalid pool ID '{pool_id}': {e}")))
+}
+
+pub fn parse_token_id(
+    chain_config: &ChainConfig,
+    token_id: &str,
+) -> Result<TokenId, WalletCliError> {
+    Address::<TokenId>::from_str(chain_config, token_id)
+        .and_then(|address| address.decode_object(chain_config))
+        .map_err(|e| WalletCliError::InvalidInput(format!("Invalid token ID '{token_id}': {e}")))
+}
+
+pub fn parse_coin_amount(
+    chain_config: &ChainConfig,
+    value: &str,
+) -> Result<Amount, WalletCliError> {
+    Amount::from_fixedpoint_str(value, chain_config.coin_decimals())
+        .ok_or_else(|| WalletCliError::InvalidInput(value.to_owned()))
+}
+
+pub fn parse_token_amount(
+    token_number_of_decimals: u8,
+    value: &str,
+) -> Result<Amount, WalletCliError> {
+    Amount::from_fixedpoint_str(value, token_number_of_decimals)
+        .ok_or_else(|| WalletCliError::InvalidInput(value.to_owned()))
+}
+
+pub fn print_coin_amount(chain_config: &ChainConfig, value: Amount) -> String {
+    value.into_fixedpoint_str(chain_config.coin_decimals())
+}
+
+pub fn print_token_amount(token_number_of_decimals: u8, value: Amount) -> String {
+    value.into_fixedpoint_str(token_number_of_decimals)
 }
 
 #[cfg(test)]

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -214,8 +214,8 @@ pub enum WalletCommand {
         amount: String,
     },
 
-    /// Redeem existing tokens and reduce the total supply
-    RedeemTokens {
+    /// Unmint existing tokens and reduce the total supply
+    UnmintTokens {
         token_id: String,
         amount: String,
     },
@@ -871,7 +871,7 @@ impl CommandHandler {
                 Ok(Self::tx_submitted_command())
             }
 
-            WalletCommand::RedeemTokens { token_id, amount } => {
+            WalletCommand::UnmintTokens { token_id, amount } => {
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
                 let amount = {
                     let token_number_of_decimals = self
@@ -884,7 +884,7 @@ impl CommandHandler {
 
                 self.get_synced_controller()
                     .await?
-                    .redeem_tokens(token_id, amount)
+                    .unmint_tokens(token_id, amount)
                     .await
                     .map_err(WalletCliError::Controller)?;
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -220,7 +220,7 @@ pub enum WalletCommand {
     },
 
     /// Lock the circulating supply for the token
-    LockTokenSuply {
+    LockTokenSupply {
         token_id: String,
     },
 
@@ -889,7 +889,7 @@ impl CommandHandler {
                 Ok(Self::tx_submitted_command())
             }
 
-            WalletCommand::LockTokenSuply { token_id } => {
+            WalletCommand::LockTokenSupply { token_id } => {
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
 
                 self.get_synced_controller()

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -896,7 +896,7 @@ impl CommandHandler {
 
                 self.get_synced_controller()
                     .await?
-                    .lock_tokens(token_id)
+                    .lock_token_supply(token_id)
                     .await
                     .map_err(WalletCliError::Controller)?;
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -187,7 +187,6 @@ pub enum WalletCommand {
     /// Issue a new token
     IssueNewToken {
         token_ticker: String,
-        amount_to_issue: String,
         number_of_decimals: u8,
         metadata_uri: String,
         destination_address: String,
@@ -220,8 +219,8 @@ pub enum WalletCommand {
         amount: String,
     },
 
-    /// Lock the total supply for the tokens
-    LockTokens {
+    /// Lock the circulating supply for the token
+    LockTokenSuply {
         token_id: String,
     },
 
@@ -773,7 +772,6 @@ impl CommandHandler {
 
             WalletCommand::IssueNewToken {
                 token_ticker,
-                amount_to_issue: _,
                 number_of_decimals,
                 metadata_uri,
                 destination_address,
@@ -891,7 +889,7 @@ impl CommandHandler {
                 Ok(Self::tx_submitted_command())
             }
 
-            WalletCommand::LockTokens { token_id } => {
+            WalletCommand::LockTokenSuply { token_id } => {
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
 
                 self.get_synced_controller()

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -72,10 +72,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
         self.wallet
             .get_balance(
                 self.account_index,
-                UtxoType::Transfer
-                    | UtxoType::LockThenTransfer
-                    | UtxoType::MintTokens
-                    | UtxoType::IssueNft,
+                UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::TokensOp,
                 utxo_states,
                 with_locked,
             )

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -72,7 +72,10 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
         self.wallet
             .get_balance(
                 self.account_index,
-                UtxoType::Transfer | UtxoType::LockThenTransfer,
+                UtxoType::Transfer
+                    | UtxoType::LockThenTransfer
+                    | UtxoType::MintTokens
+                    | UtxoType::IssueNft,
                 utxo_states,
                 with_locked,
             )

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -72,7 +72,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
         self.wallet
             .get_balance(
                 self.account_index,
-                UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::TokensOp,
+                UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::IssueNft,
                 utxo_states,
                 with_locked,
             )

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -205,13 +205,13 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         self.broadcast_to_mempool(tx).await
     }
 
-    pub async fn lock_tokens(&mut self, token_id: TokenId) -> Result<(), ControllerError<T>> {
+    pub async fn lock_token_supply(&mut self, token_id: TokenId) -> Result<(), ControllerError<T>> {
         let (current_fee_rate, consolidate_fee_rate) =
             self.get_current_and_consolidation_fee_rate().await?;
 
         let tx = self
             .wallet
-            .lock_tokens(
+            .lock_token_supply(
                 self.account_index,
                 token_id,
                 current_fee_rate,

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -183,7 +183,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         self.broadcast_to_mempool(tx).await
     }
 
-    pub async fn redeem_tokens(
+    pub async fn unmint_tokens(
         &mut self,
         token_id: TokenId,
         amount: Amount,
@@ -193,7 +193,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
 
         let tx = self
             .wallet
-            .redeem_tokens(
+            .unmint_tokens(
                 self.account_index,
                 token_id,
                 amount,

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -159,6 +159,69 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         Ok(token_id)
     }
 
+    pub async fn mint_tokens(
+        &mut self,
+        token_id: TokenId,
+        amount: Amount,
+        address: Address<Destination>,
+    ) -> Result<(), ControllerError<T>> {
+        let (current_fee_rate, consolidate_fee_rate) =
+            self.get_current_and_consolidation_fee_rate().await?;
+
+        let tx = self
+            .wallet
+            .mint_tokens(
+                self.account_index,
+                token_id,
+                amount,
+                address,
+                current_fee_rate,
+                consolidate_fee_rate,
+            )
+            .map_err(ControllerError::WalletError)?;
+
+        self.broadcast_to_mempool(tx).await
+    }
+
+    pub async fn redeem_tokens(
+        &mut self,
+        token_id: TokenId,
+        amount: Amount,
+    ) -> Result<(), ControllerError<T>> {
+        let (current_fee_rate, consolidate_fee_rate) =
+            self.get_current_and_consolidation_fee_rate().await?;
+
+        let tx = self
+            .wallet
+            .redeem_tokens(
+                self.account_index,
+                token_id,
+                amount,
+                current_fee_rate,
+                consolidate_fee_rate,
+            )
+            .map_err(ControllerError::WalletError)?;
+
+        self.broadcast_to_mempool(tx).await
+    }
+
+    pub async fn lock_tokens(&mut self, token_id: TokenId) -> Result<(), ControllerError<T>> {
+        let (current_fee_rate, consolidate_fee_rate) =
+            self.get_current_and_consolidation_fee_rate().await?;
+
+        let tx = self
+            .wallet
+            .lock_tokens(
+                self.account_index,
+                token_id,
+                current_fee_rate,
+                consolidate_fee_rate,
+            )
+            .map_err(ControllerError::WalletError)?;
+
+        self.broadcast_to_mempool(tx).await
+    }
+
     pub async fn send_to_address(
         &mut self,
         address: Address<Destination>,


### PR DESCRIPTION
Add support for the v1 tokens in the Wallet
- track the total supply of the issued tokens
- add new commands for mint/unmint of tokens and locking the token supply
- existing issue token command now issues the v1 tokens and has an extra argument for token supply
- ignore all v0 tokens, they are filtered out in all operations, e.g. not show up in getbalance
- new tests

closes #1237