### PR TITLE
mempool: Fix tx accumulator block size calculation

### DIFF
--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -474,7 +474,7 @@ impl BlockProduction {
                 )
                 .await?
                 .transactions()
-                .clone();
+                .to_vec();
 
             let block_body = BlockBody::new(block_reward, collected_transactions);
 


### PR DESCRIPTION
The encoded sequence of transactions starts with the number of transactions. However, the transaction accumulator failed to take that into account, only considering the space taken up by raw transaction data without the transaction count annotation. This is a fix.