### PR TITLE
Add new functions to wasm-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7586,6 +7586,8 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 name = "wasm-crypto"
 version = "0.1.2"
 dependencies = [
+ "bip39",
+ "common",
  "crypto",
  "getrandom 0.2.10",
  "rstest",

--- a/wasm-crypto/Cargo.toml
+++ b/wasm-crypto/Cargo.toml
@@ -13,6 +13,9 @@ crate-type = ["cdylib"]
 [dependencies]
 crypto = { path = '../crypto' }
 serialization = { path = "../serialization" }
+common = { path = "../common" }
+
+bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
 
 # This crate is required for rand to work with wasm. See: https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 getrandom = { version = "0.2", features = ["js"] }

--- a/wasm-crypto/js-bindings/crypto_test.js
+++ b/wasm-crypto/js-bindings/crypto_test.js
@@ -10,6 +10,10 @@ import {
   public_key_from_private_key,
   sign_message,
   verify_signature,
+  make_default_account_pubkey,
+  make_receiving_address,
+  pubkey_to_string,
+  Network,
 } from "../pkg/wasm_crypto.js";
 
 export async function run_test() {
@@ -43,5 +47,67 @@ export async function run_test() {
       );
     }
     console.log("Tested decoding bad private key successfully");
+  }
+
+  try {
+    const invalid_mnemonic = "asd asd";
+    make_default_account_pubkey(invalid_mnemonic, Network.Mainnet);
+    throw new Error("Invalid mnemonic worked somehow!");
+  } catch (e) {
+    if (!e.includes("Invalid mnemonic string")) {
+      throw e;
+    }
+    console.log("Tested invalid menemonic successfully");
+  }
+
+  try {
+    make_receiving_address(bad_priv_key, 0);
+    throw new Error("Invalid public key worked somehow!");
+  } catch (e) {
+    if (!e.includes("Invalid public key encoding")) {
+      throw e;
+    }
+    console.log("Tested decoding bad account public key successfully");
+  }
+
+  const mnemonic = "walk exile faculty near leg neutral license matrix maple invite cupboard hat opinion excess coffee leopard latin regret document core limb crew dizzy movie";
+  {
+    const account_pubkey = make_default_account_pubkey(mnemonic, Network.Mainnet);
+    console.log(`acc pubkey = ${account_pubkey}`);
+
+    const receiving_pubkey = make_receiving_address(account_pubkey, 0);
+    console.log(`receiving pubkey = ${receiving_pubkey}`);
+
+    // test bad key index
+    try {
+      make_receiving_address(account_pubkey, 1<<31);
+      throw new Error("Invalid key index worked somehow!");
+    } catch (e) {
+      if (!e.includes("Invalid key index, MSB bit set")) {
+        throw e;
+      }
+      console.log("Tested invalid key index with set MSB bit successfully");
+    }
+
+    const address = pubkey_to_string(receiving_pubkey, Network.Mainnet);
+    console.log(`address = ${address}`);
+    if (address != "mtc1qyqmdpxk2w42w37qsdj0e8g54ysvnlvpny3svzqx") {
+      throw new Error("Incorrect address generated");
+    }
+  }
+
+
+  {
+    // Test generating an address for Testnet
+    const account_pubkey = make_default_account_pubkey(mnemonic, Network.Testnet);
+    console.log(`acc pubkey = ${account_pubkey}`);
+
+    const receiving_pubkey = make_receiving_address(account_pubkey, 0);
+    console.log(`receiving pubkey = ${receiving_pubkey}`);
+    const address = pubkey_to_string(receiving_pubkey, Network.Testnet);
+    console.log(`address = ${address}`);
+    if (address != "tmt1q9dn5m4svn8sds3fcy09kpxrefnu75xekgr5wa3n") {
+      throw new Error("Incorrect address generated");
+    }
   }
 }

--- a/wasm-crypto/src/error.rs
+++ b/wasm-crypto/src/error.rs
@@ -25,6 +25,10 @@ pub enum Error {
     InvalidPublicKeyEncoding,
     #[error("Invalid signature encoding")]
     InvalidSignatureEncoding,
+    #[error("Invalid mnemonic string")]
+    InvalidMnemonic,
+    #[error("Invalid key index, MSB bit set")]
+    InvalidKeyIndex,
 }
 
 // This is required to make an error readable in JavaScript


### PR DESCRIPTION
- new function make_default_account_pubkey to generate new account pubkey from a mnemonic
- new function make_receiving_address to generate a receiving address for a given account pubkey + key index
- new function pubkey_to_string to convert a receiving public key to string