### PR TITLE
Isolate database expensive reads in its own module and isolate its `use` lines to avoid unused warnings

### DIFF
--- a/chainstate/storage/src/internal/expensive.rs
+++ b/chainstate/storage/src/internal/expensive.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+use crate::schema::{self as db};
+use storage::MakeMapRef;
+
+impl<B: storage::Backend> Store<B> {
+    /// Dump raw database contents
+    pub fn dump_raw(&self) -> crate::Result<storage::raw::StorageContents<Schema>> {
+        self.0.dump_raw().map_err(crate::Error::from)
+    }
+
+    /// Collect and return all utxos from the storage
+    pub fn read_utxo_set(&self) -> crate::Result<BTreeMap<UtxoOutPoint, Utxo>> {
+        let db = self.transaction_ro()?;
+        db.0.get::<db::DBUtxo, _>()
+            .prefix_iter_decoded(&())
+            .map(Iterator::collect)
+            .map_err(crate::Error::from)
+    }
+
+    /// Collect and return all tip accounting data from storage
+    pub fn read_pos_accounting_data_tip(&self) -> crate::Result<pos_accounting::PoSAccountingData> {
+        let db = self.transaction_ro()?;
+
+        let pool_data =
+            db.0.get::<db::DBAccountingPoolDataTip, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let pool_balances =
+            db.0.get::<db::DBAccountingPoolBalancesTip, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let delegation_data =
+            db.0.get::<db::DBAccountingDelegationDataTip, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let delegation_balances =
+            db.0.get::<db::DBAccountingDelegationBalancesTip, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let pool_delegation_shares =
+            db.0.get::<db::DBAccountingPoolDelegationSharesTip, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        Ok(pos_accounting::PoSAccountingData {
+            pool_data,
+            pool_balances,
+            pool_delegation_shares,
+            delegation_balances,
+            delegation_data,
+        })
+    }
+
+    /// Collect and return all sealed accounting data from storage
+    pub fn read_pos_accounting_data_sealed(
+        &self,
+    ) -> crate::Result<pos_accounting::PoSAccountingData> {
+        let db = self.transaction_ro()?;
+
+        let pool_data =
+            db.0.get::<db::DBAccountingPoolDataSealed, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let pool_balances =
+            db.0.get::<db::DBAccountingPoolBalancesSealed, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let delegation_data =
+            db.0.get::<db::DBAccountingDelegationDataSealed, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let delegation_balances =
+            db.0.get::<db::DBAccountingDelegationBalancesSealed, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let pool_delegation_shares =
+            db.0.get::<db::DBAccountingPoolDelegationSharesSealed, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        Ok(pos_accounting::PoSAccountingData {
+            pool_data,
+            pool_balances,
+            pool_delegation_shares,
+            delegation_balances,
+            delegation_data,
+        })
+    }
+
+    pub fn read_tokens_accounting_data(
+        &self,
+    ) -> crate::Result<tokens_accounting::TokensAccountingData> {
+        let db = self.transaction_ro()?;
+
+        let token_data =
+            db.0.get::<db::DBTokensData, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        let circulating_supply =
+            db.0.get::<db::DBTokensCirculatingSupply, _>()
+                .prefix_iter_decoded(&())?
+                .collect::<BTreeMap<_, _>>();
+
+        Ok(tokens_accounting::TokensAccountingData {
+            token_data,
+            circulating_supply,
+        })
+    }
+}

--- a/chainstate/storage/src/internal/expensive.rs
+++ b/chainstate/storage/src/internal/expensive.rs
@@ -1,3 +1,18 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::*;
 
 use crate::schema::{self as db};

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -15,6 +15,9 @@
 
 mod store_tx;
 
+#[cfg(any(test, feature = "expensive-reads"))]
+mod expensive;
+
 use std::collections::BTreeMap;
 
 use chainstate_types::{BlockIndex, EpochData, EpochStorageRead, EpochStorageWrite};
@@ -33,14 +36,12 @@ use pos_accounting::{
     AccountingBlockUndo, DelegationData, DeltaMergeUndo, PoSAccountingDeltaData,
     PoSAccountingStorageRead, PoSAccountingStorageWrite, PoolData,
 };
-use storage::MakeMapRef;
 use tokens_accounting::{TokensAccountingStorageRead, TokensAccountingStorageWrite};
 use utxo::{Utxo, UtxosBlockUndo, UtxosStorageRead, UtxosStorageWrite};
 
 use crate::{
-    schema::{self as db, Schema},
-    BlockchainStorage, BlockchainStorageRead, BlockchainStorageWrite, SealedStorageTag,
-    TipStorageTag, TransactionRw, Transactional,
+    schema::Schema, BlockchainStorage, BlockchainStorageRead, BlockchainStorageWrite,
+    SealedStorageTag, TipStorageTag, TransactionRw, Transactional,
 };
 
 pub use store_tx::{StoreTxRo, StoreTxRw};
@@ -79,124 +80,6 @@ impl<B: storage::Backend> Store<B> {
     fn from_backend(backend: B) -> crate::Result<Self> {
         let storage = Self(storage::Storage::new(backend).map_err(crate::Error::from)?);
         Ok(storage)
-    }
-
-    /// Dump raw database contents
-    #[cfg(any(test, feature = "expensive-reads"))]
-    pub fn dump_raw(&self) -> crate::Result<storage::raw::StorageContents<Schema>> {
-        self.0.dump_raw().map_err(crate::Error::from)
-    }
-
-    /// Collect and return all utxos from the storage
-    #[cfg(any(test, feature = "expensive-reads"))]
-    pub fn read_utxo_set(&self) -> crate::Result<BTreeMap<UtxoOutPoint, Utxo>> {
-        let db = self.transaction_ro()?;
-        db.0.get::<db::DBUtxo, _>()
-            .prefix_iter_decoded(&())
-            .map(Iterator::collect)
-            .map_err(crate::Error::from)
-    }
-
-    /// Collect and return all tip accounting data from storage
-    #[cfg(any(test, feature = "expensive-reads"))]
-    pub fn read_pos_accounting_data_tip(&self) -> crate::Result<pos_accounting::PoSAccountingData> {
-        let db = self.transaction_ro()?;
-
-        let pool_data =
-            db.0.get::<db::DBAccountingPoolDataTip, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let pool_balances =
-            db.0.get::<db::DBAccountingPoolBalancesTip, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let delegation_data =
-            db.0.get::<db::DBAccountingDelegationDataTip, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let delegation_balances =
-            db.0.get::<db::DBAccountingDelegationBalancesTip, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let pool_delegation_shares =
-            db.0.get::<db::DBAccountingPoolDelegationSharesTip, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        Ok(pos_accounting::PoSAccountingData {
-            pool_data,
-            pool_balances,
-            pool_delegation_shares,
-            delegation_balances,
-            delegation_data,
-        })
-    }
-
-    /// Collect and return all sealed accounting data from storage
-    #[cfg(any(test, feature = "expensive-reads"))]
-    pub fn read_pos_accounting_data_sealed(
-        &self,
-    ) -> crate::Result<pos_accounting::PoSAccountingData> {
-        let db = self.transaction_ro()?;
-
-        let pool_data =
-            db.0.get::<db::DBAccountingPoolDataSealed, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let pool_balances =
-            db.0.get::<db::DBAccountingPoolBalancesSealed, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let delegation_data =
-            db.0.get::<db::DBAccountingDelegationDataSealed, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let delegation_balances =
-            db.0.get::<db::DBAccountingDelegationBalancesSealed, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let pool_delegation_shares =
-            db.0.get::<db::DBAccountingPoolDelegationSharesSealed, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        Ok(pos_accounting::PoSAccountingData {
-            pool_data,
-            pool_balances,
-            pool_delegation_shares,
-            delegation_balances,
-            delegation_data,
-        })
-    }
-
-    #[cfg(any(test, feature = "expensive-reads"))]
-    pub fn read_tokens_accounting_data(
-        &self,
-    ) -> crate::Result<tokens_accounting::TokensAccountingData> {
-        let db = self.transaction_ro()?;
-
-        let token_data =
-            db.0.get::<db::DBTokensData, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        let circulating_supply =
-            db.0.get::<db::DBTokensCirculatingSupply, _>()
-                .prefix_iter_decoded(&())?
-                .collect::<BTreeMap<_, _>>();
-
-        Ok(tokens_accounting::TokensAccountingData {
-            token_data,
-            circulating_supply,
-        })
     }
 }
 


### PR DESCRIPTION
The warning would happen when running something that doesn't involve tests, such as `cargo run --bin node-daemon`.