### PR TITLE
Make connection count limits modifiable in tests

### DIFF
--- a/dns_server/src/main.rs
+++ b/dns_server/src/main.rs
@@ -75,6 +75,7 @@ async fn run(config: Arc<DnsServerConfig>) -> Result<Never, error::DnsServerErro
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
 
     let transport = p2p::make_p2p_transport();

--- a/node-lib/src/config_files/p2p.rs
+++ b/node-lib/src/config_files/p2p.rs
@@ -106,6 +106,7 @@ impl From<P2pConfigFile> for P2pConfig {
             ping_check_period: c.ping_check_period.map(Duration::from_secs).into(),
             ping_timeout: c.ping_timeout.map(|t| Duration::from_secs(t.into())).into(),
             node_type: c.node_type.map(Into::into).into(),
+
             allow_discover_private_ips: Default::default(),
             msg_header_count_limit: Default::default(),
             msg_max_locator_count: Default::default(),
@@ -119,6 +120,7 @@ impl From<P2pConfigFile> for P2pConfig {
                 .map(|t| Duration::from_secs(t.into()))
                 .into(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         }
     }
 }

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -193,6 +193,7 @@ where
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let (shutdown_sender_1, shutdown_receiver) = oneshot::channel();

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -19,7 +19,10 @@ use common::primitives::user_agent::UserAgent;
 use p2p_types::ip_or_socket_address::IpOrSocketAddress;
 use utils::make_config_setting;
 
-use crate::net::types::services::{Service, Services};
+use crate::{
+    net::types::services::{Service, Services},
+    peer_manager::ConnectionCountLimits,
+};
 
 make_config_setting!(MaxInboundConnections, usize, 128);
 make_config_setting!(BanThreshold, u32, 100);
@@ -128,4 +131,6 @@ pub struct P2pConfig {
     pub sync_stalling_timeout: SyncStallingTimeout,
     /// Enable/disable block relay peers (only used in unit tests)
     pub enable_block_relay_peers: BlockRelayPeers,
+    /// Various limits for connection counts; should only be overridden by tests.
+    pub connection_count_limits: ConnectionCountLimits,
 }

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -62,6 +62,7 @@ fn unban_peer() {
             max_singular_unconnected_headers: Default::default(),
             sync_stalling_timeout: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         }),
         time_getter.get_time_getter(),
         db_store,

--- a/p2p/src/peer_manager/tests/addresses.rs
+++ b/p2p/src/peer_manager/tests/addresses.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     peer_manager::{
         tests::{make_peer_manager_custom, utils::cmd_to_peer_man_msg},
-        OutboundConnectType, PeerManager, OUTBOUND_FULL_AND_BLOCK_RELAY_COUNT,
+        OutboundConnectType, PeerManager,
     },
     testing_utils::{
         peerdb_inmemory_store, test_p2p_config, TestAddressMaker, TestTransportChannel,
@@ -232,6 +232,7 @@ fn test_addr_list_handling_outbound() {
         max_peer_tx_announcements: Default::default(),
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::unbounded_channel();
     let (_conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -349,7 +350,8 @@ async fn resend_own_addresses() {
     )
     .unwrap();
 
-    for peer_index in 0..OUTBOUND_FULL_AND_BLOCK_RELAY_COUNT {
+    let peer_count = p2p_config.connection_count_limits.outbound_full_and_block_relay_count();
+    for peer_index in 0..peer_count {
         let new_peer_id = PeerId::new();
         let peer_address = TestAddressMaker::new_random_address();
         let peer_info = PeerInfo {
@@ -379,7 +381,7 @@ async fn resend_own_addresses() {
 
         pm.accept_connection(peer_address, Role::Outbound, peer_info, Some(own_ip.into()));
     }
-    assert_eq!(pm.peers.len(), OUTBOUND_FULL_AND_BLOCK_RELAY_COUNT);
+    assert_eq!(pm.peers.len(), peer_count);
 
     let (started_tx, started_rx) = oneshot_nofail::channel();
     logging::spawn_in_current_span(async move { pm.run_internal(Some(started_tx)).await });

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -666,6 +666,7 @@ async fn connection_timeout_rpc_notified<T>(
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let shutdown = Arc::new(SeqCstAtomicBool::new(false));
     let time_getter = TimeGetter::default();
@@ -783,6 +784,7 @@ where
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let (tx1, _shutdown_sender, _subscribers_sender) = run_peer_manager::<T>(
         A::make_transport(),
@@ -829,6 +831,7 @@ where
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let (tx1, _shutdown_sender, _subscribers_sender) = run_peer_manager::<T>(
         A::make_transport(),
@@ -917,6 +920,7 @@ where
         max_peer_tx_announcements: Default::default(),
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let (tx1, _shutdown_sender, _subscribers_sender) = run_peer_manager::<T>(
         A::make_transport(),
@@ -964,6 +968,7 @@ where
         max_peer_tx_announcements: Default::default(),
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let (tx2, _shutdown_sender, _subscribers_sender) = run_peer_manager::<T>(
         A::make_transport(),
@@ -1005,6 +1010,7 @@ where
         max_peer_tx_announcements: Default::default(),
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let (tx3, _shutdown_sender, _subscribers_sender) = run_peer_manager::<T>(
         A::make_transport(),

--- a/p2p/src/peer_manager/tests/peer_types.rs
+++ b/p2p/src/peer_manager/tests/peer_types.rs
@@ -68,6 +68,7 @@ fn validate_services() {
             max_singular_unconnected_headers: Default::default(),
             sync_stalling_timeout: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         });
 
         let (cmd_tx, _cmd_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -69,6 +69,7 @@ async fn ping_timeout() {
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
     let ping_check_period = *p2p_config.ping_check_period;
     let ping_timeout = *p2p_config.ping_timeout;

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -88,6 +88,7 @@ async fn single_header_with_unknown_prev_block_v1(#[case] seed: Seed) {
         max_peer_tx_announcements: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
 
     let mut node = TestNode::builder(protocol_version)
@@ -176,6 +177,7 @@ async fn single_header_with_unknown_prev_block_with_intermittent_connected_heade
         max_peer_tx_announcements: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
 
     let mut node = TestNode::builder(protocol_version)

--- a/p2p/src/sync/tests/block_response.rs
+++ b/p2p/src/sync/tests/block_response.rs
@@ -168,6 +168,7 @@ async fn disconnect(#[case] seed: Seed) {
             max_peer_tx_announcements: Default::default(),
             max_singular_unconnected_headers: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         });
         let mut node = TestNode::builder(protocol_version)
             .with_chain_config(chain_config)
@@ -240,6 +241,7 @@ async fn slow_response(#[case] seed: Seed) {
             max_peer_tx_announcements: Default::default(),
             max_singular_unconnected_headers: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         });
 
         let mut tf = TestFramework::builder(&mut rng)

--- a/p2p/src/sync/tests/header_list_request.rs
+++ b/p2p/src/sync/tests/header_list_request.rs
@@ -171,6 +171,7 @@ async fn allow_peer_to_ignore_header_requests_when_asking_for_blocks(
         max_peer_tx_announcements: Default::default(),
         max_singular_unconnected_headers: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
 
     let blocks = make_new_blocks(
@@ -266,6 +267,7 @@ async fn respond_with_empty_header_list_when_in_ibd(#[case] protocol_version: Pr
         max_peer_tx_announcements: Default::default(),
         max_singular_unconnected_headers: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     });
 
     let mut node = TestNode::builder(protocol_version)

--- a/p2p/src/sync/tests/header_list_response.rs
+++ b/p2p/src/sync/tests/header_list_response.rs
@@ -230,6 +230,7 @@ async fn disconnect() {
             max_peer_tx_announcements: Default::default(),
             max_singular_unconnected_headers: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         });
         let mut node = TestNode::builder(protocol_version)
             .with_p2p_config(Arc::clone(&p2p_config))

--- a/p2p/src/sync/tests/network_sync.rs
+++ b/p2p/src/sync/tests/network_sync.rs
@@ -68,6 +68,7 @@ async fn basic(#[case] seed: Seed) {
             max_singular_unconnected_headers: Default::default(),
             sync_stalling_timeout: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         });
 
         let blocks = make_new_blocks(
@@ -303,6 +304,7 @@ async fn block_announcement_disconnected_headers(#[case] seed: Seed) {
             max_singular_unconnected_headers: Default::default(),
             sync_stalling_timeout: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         });
 
         let initial_block_count = rng.gen_range(1..=MAX_REQUEST_BLOCKS_COUNT);

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -163,6 +163,7 @@ async fn no_transaction_service(#[case] seed: Seed) {
             max_singular_unconnected_headers: Default::default(),
             sync_stalling_timeout: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         });
         let mut node = TestNode::builder(protocol_version)
             .with_chain_config(Arc::clone(&chain_config))
@@ -230,6 +231,7 @@ async fn too_many_announcements(#[case] seed: Seed) {
             max_singular_unconnected_headers: Default::default(),
             sync_stalling_timeout: Default::default(),
             enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
         });
         let mut node = TestNode::builder(protocol_version)
             .with_chain_config(Arc::clone(&chain_config))

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -258,6 +258,7 @@ pub fn test_p2p_config() -> P2pConfig {
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     }
 }
 

--- a/p2p/src/tests/helpers/test_node_group.rs
+++ b/p2p/src/tests/helpers/test_node_group.rs
@@ -13,14 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use common::{chain::Block, primitives::Id};
 use p2p_test_utils::{P2pBasicTestTimeGetter, SHORT_TIMEOUT};
 use p2p_types::socket_address::SocketAddress;
 use tokio::time;
 
-use crate::net::default_backend::transport::TransportSocket;
+use crate::{config::P2pConfig, net::default_backend::transport::TransportSocket};
 
 use super::test_node::TestNode;
 
@@ -30,14 +30,23 @@ where
 {
     nodes: Vec<TestNode<Transport>>,
     time_getter: P2pBasicTestTimeGetter,
+    p2p_config: Arc<P2pConfig>,
 }
 
 impl<Transport> TestNodeGroup<Transport>
 where
     Transport: TransportSocket,
 {
-    pub fn new(nodes: Vec<TestNode<Transport>>, time_getter: P2pBasicTestTimeGetter) -> Self {
-        Self { nodes, time_getter }
+    pub fn new(
+        nodes: Vec<TestNode<Transport>>,
+        time_getter: P2pBasicTestTimeGetter,
+        p2p_config: Arc<P2pConfig>,
+    ) -> Self {
+        Self {
+            nodes,
+            time_getter,
+            p2p_config,
+        }
     }
 
     pub fn nodes(&self) -> &[TestNode<Transport>] {
@@ -46,6 +55,10 @@ where
 
     pub fn time_getter(&self) -> &P2pBasicTestTimeGetter {
         &self.time_getter
+    }
+
+    pub fn p2p_config(&self) -> &P2pConfig {
+        &self.p2p_config
     }
 
     pub fn get_adresses(&self) -> Vec<SocketAddress> {

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -186,6 +186,7 @@ async fn start_node(chain_config: Arc<ChainConfig>) -> (subsystem::Manager, Sock
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     };
     let rpc_creds = RpcCreds::basic(RPC_USERNAME, RPC_PASSWORD).unwrap();
 

--- a/wallet/wallet-node-client/tests/call_tests.rs
+++ b/wallet/wallet-node-client/tests/call_tests.rs
@@ -74,6 +74,7 @@ pub async fn start_subsystems(
         max_singular_unconnected_headers: Default::default(),
         sync_stalling_timeout: Default::default(),
         enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
     };
 
     let chainstate = make_chainstate(


### PR DESCRIPTION
The constants related to the number of connections were placed into a struct `ConnectionCountLimits` which is a part of `P2pConfig`.
This is a follow-up for the PR #1292. It's not strictly necessary, but it allows to make the tests in that PR less "heavy" by reducing the number of connections that those tests have to make.