### PR TITLE
docker compose file for testing p2p v2 protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7821,6 +7821,7 @@ dependencies = [
  "reedline",
  "rpc",
  "rstest",
+ "serde_json",
  "serialization",
  "shlex",
  "subsystem",

--- a/build-tools/p2p-v2-test/.env
+++ b/build-tools/p2p-v2-test/.env
@@ -1,0 +1,13 @@
+# We want to name our containers explicitly to avoid the extra "-1" suffix.
+# This variable contains the base name for the containers.
+BASE_NAME=p2p-v2-test
+
+# We still want to specify the project name, because it'll be used as the base name for volumes
+# (otherwise the directory name will be used, which may or may not be consistent with BASE_NAME).
+COMPOSE_PROJECT_NAME=p2p-v2-test
+
+DATA_DIR_IN_CONTAINER=/root/.mintlayer
+RPC_PORT=13030
+
+NODES_LIST="node01 node02 node03 node04 node05 node06 node07 node08 node09 node10 node11 node12 node13 node14 node15"
+NODE_DAEMON_CMD="node-daemon testnet --http-rpc-addr 0.0.0.0:$RPC_PORT $(dig +short $NODES_LIST | xargs printf '--p2p-boot-node %s ')"

--- a/build-tools/p2p-v2-test/Dockerfile
+++ b/build-tools/p2p-v2-test/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:1.73
+
+WORKDIR /src/
+
+RUN apt-get update && \
+    apt-get install -y \
+        ca-certificates libgtk-3-dev \
+        nmap procps net-tools iputils-ping dnsutils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+ARG NUM_JOBS=16
+RUN cargo build --release -j${NUM_JOBS} --bin node-daemon
+RUN cargo build --release -j${NUM_JOBS} --bin wallet-cli
+
+RUN cp /src/target/release/node-daemon /usr/bin
+RUN cp /src/target/release/wallet-cli /usr/bin

--- a/build-tools/p2p-v2-test/Dockerfile.dockerignore
+++ b/build-tools/p2p-v2-test/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+.gitlab
+.vscode
+build-tools
+target

--- a/build-tools/p2p-v2-test/README.md
+++ b/build-tools/p2p-v2-test/README.md
@@ -1,0 +1,53 @@
+Here we have helper docker files that allow us to run multiple nodes on the same machine
+in order to check that the updated p2p protocol works correctly, in addition to these nodes being expected to connect to the public network.
+
+### Usage:
+
+`cd` to this directory and run
+```
+docker compose up --build
+```
+or
+```
+docker compose up --build -d
+```
+In the latter case the containers will be run in the background. To view their console output, you can run:
+```
+docker compose logs -f
+```
+When you are done, run
+```
+docker compose down
+```
+to shut down the containers.
+
+### Details:
+
+"docker compose up..." will build a docker image containing `node-daemon` and `wallet-cli` and launch multiple containers (currently 15) that will be running the nodes. Each node will get other nodes' ip addresses at the start via the `--p2p-boot-node` option, so they all will be able to start connecting to each other immediately.
+
+### Helper scripts:
+#### run_wallet_cmd.sh
+```
+run_wallet_cmd.sh node_idx cmd [cmd_params...]
+```
+Run the specified wallet-cli command on the specified node. E.g. `run_wallet_cmd.sh 1 connectedpeers` will print peer information for the 1st node.
+
+#### prune_node.sh
+```
+prune_node.sh node_idx
+```
+Stop the node's container, remove its data and start the container again.
+
+#### print_ip_addresses.sh
+```
+print_ip_addresses.sh
+```
+Print nodes' ip addresses.
+
+#### print_connected_peers.sh
+```
+print_connected_peers.sh [node_idx1 node_idx2 ...]
+```
+Call `run_wallet_cmd.sh` for each specified node index or, if no indices are specified, for all node indices and print a short summary of the node's connected peers.
+
+This script uses the `jq` tool, so make sure it's installed.

--- a/build-tools/p2p-v2-test/docker-compose.yml
+++ b/build-tools/p2p-v2-test/docker-compose.yml
@@ -1,0 +1,229 @@
+version: "3.8"
+
+services:
+  node01:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node01
+
+    volumes:
+      - data01:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40001:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node02:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node02
+
+    volumes:
+      - data02:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40002:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node03:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node03
+
+    volumes:
+      - data03:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40003:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node04:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node04
+
+    volumes:
+      - data04:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40004:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node05:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node05
+
+    volumes:
+      - data05:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40005:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node06:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node06
+
+    volumes:
+      - data06:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40006:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node07:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node07
+
+    volumes:
+      - data07:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40007:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node08:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node08
+
+    volumes:
+      - data08:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40008:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node09:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node09
+
+    volumes:
+      - data09:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40009:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node10:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node10
+
+    volumes:
+      - data10:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40010:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node11:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node11
+
+    volumes:
+      - data11:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40011:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node12:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node12
+
+    volumes:
+      - data12:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40012:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node13:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node13
+
+    volumes:
+      - data13:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40013:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node14:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node14
+
+    volumes:
+      - data14:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40014:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+  node15:
+    build:
+      context: ../..
+      dockerfile: build-tools/p2p-v2-test/Dockerfile
+    container_name: $BASE_NAME-node15
+
+    volumes:
+      - data15:$DATA_DIR_IN_CONTAINER
+    ports:
+      - '40015:$RPC_PORT'
+    command: bash -c "$NODE_DAEMON_CMD"
+    environment:
+      - RUST_LOG
+
+volumes:
+  data01:
+  data02:
+  data03:
+  data04:
+  data05:
+  data06:
+  data07:
+  data08:
+  data09:
+  data10:
+  data11:
+  data12:
+  data13:
+  data14:
+  data15:

--- a/build-tools/p2p-v2-test/print_connected_peers.sh
+++ b/build-tools/p2p-v2-test/print_connected_peers.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+print_peers() {
+    local node_id=$1
+    echo "Node ${node_id}'s peers:"
+    "${SCRIPT_DIR}/run_wallet_cmd.sh" "$node_id" connectedpeersjson 2> /dev/null | \
+        jq -c '.[] | [.peer_id, .address, .software_version, .peer_role]'
+    echo
+}
+
+if [[ $# -lt 1 ]]; then
+    for i in {1..15}
+    do
+        print_peers "$i"
+    done
+else
+    for i in "$@"
+    do
+        print_peers "$i"
+    done
+fi

--- a/build-tools/p2p-v2-test/print_ip_addresses.sh
+++ b/build-tools/p2p-v2-test/print_ip_addresses.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+cd "$SCRIPT_DIR"
+
+for i in {1..15}
+do
+    NODE_NAME_SUFFIX=$(printf '%02d' "$i")
+    # Note: from address resolution perspective, it doesn't matter which container to execute 'dig'
+    # in. But since some containers may be down, it makes sense to use the one the address
+    # of which we're trying to resolve.
+    ADDR=$(docker compose exec "node${NODE_NAME_SUFFIX}" dig +short "node${NODE_NAME_SUFFIX}")
+    echo "node${NODE_NAME_SUFFIX}: $ADDR"
+done

--- a/build-tools/p2p-v2-test/prune_node.sh
+++ b/build-tools/p2p-v2-test/prune_node.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+source "$SCRIPT_DIR/.env"
+
+if [[ $# -lt 1 ]]; then
+    echo "Stop the specified node, remove its data, start it again"
+    echo "Usage: $(basename "$0") container_idx"
+    echo "  node_idx - the index of the node, e.g. 1, 2, 3 etc"
+    exit 1
+fi
+
+NODE_NAME_SUFFIX=$(printf '%02d' "$1")
+shift
+
+cd "$SCRIPT_DIR"
+
+docker compose stop "node${NODE_NAME_SUFFIX}"
+docker compose rm --force "node${NODE_NAME_SUFFIX}"
+docker volume rm "${BASE_NAME}_data${NODE_NAME_SUFFIX}"
+docker compose up -d "node${NODE_NAME_SUFFIX}"

--- a/build-tools/p2p-v2-test/run_wallet_cmd.sh
+++ b/build-tools/p2p-v2-test/run_wallet_cmd.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+source "$SCRIPT_DIR/.env"
+
+if [[ $# -lt 2 ]]; then
+    echo "Run a wallet command on the specified node"
+    echo "Usage: $(basename "$0") container_idx wallet_cmd [wallet_cmd_params...]"
+    echo "  node_idx - the index of the node, e.g. 1, 2, 3 etc"
+    echo "  wallet_cmd - the command to send to the wallet, e.g. connectedpeers"
+    echo "  wallet_cmd_params - optional parameters for the specified command"
+    exit 1
+fi
+
+cd "$SCRIPT_DIR"
+
+NODE_NAME_SUFFIX=$(printf '%02d' "$1")
+shift
+
+NODE=node${NODE_NAME_SUFFIX}
+
+docker compose exec "${NODE}" bash -c "echo $@ > /tmp/cmd.txt"
+# Note: by default, 'docker compose exec' will print everything to stdout, even if originally
+# it was printed to stderr, e.g. the logs, making it a PITA to parse the normal output.
+# The '-T' AKA '--no-TTY' option solves this somehow. But the logs become non-colored in this case
+# though.
+docker compose exec -T "${NODE}" wallet-cli --commands-file /tmp/cmd.txt

--- a/p2p/src/net/default_backend/default_networking_service.rs
+++ b/p2p/src/net/default_backend/default_networking_service.rs
@@ -41,7 +41,7 @@ use super::{backend::Backend, ConnectivityHandle, MessagingHandle, SyncingEventR
 // The preferred protocol version.
 // Note that we intentionally keep this constant private, because most of the code should
 // not depend on its value.
-const PREFERRED_PROTOCOL_VERSION: SupportedProtocolVersion = SupportedProtocolVersion::V1;
+const PREFERRED_PROTOCOL_VERSION: SupportedProtocolVersion = SupportedProtocolVersion::V2;
 
 // Some tests do need this value though in order to check the correct version selection.
 // So we make it available for them via a function with a test-specific name and under cfg(test).

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -341,7 +341,7 @@ where
                         ).await?;
                     }
                     Err(err) => {
-                        log::info!("peer connection closed, reason {err:?}");
+                        log::info!("Connection closed for peer {}, reason {err:?}", self.peer_id);
                         return Ok(());
                     }
                 }

--- a/p2p/src/net/default_backend/tests.rs
+++ b/p2p/src/net/default_backend/tests.rs
@@ -112,10 +112,9 @@ where
     )
     .await;
 
-    // Note: V2 is not finalized yet, so it should not be selected.
     connect_to_remote_impl::<A, T>(
         SupportedProtocolVersion::V2.into(),
-        SupportedProtocolVersion::V1.into(),
+        SupportedProtocolVersion::V2.into(),
     )
     .await;
 }
@@ -211,10 +210,9 @@ where
     )
     .await;
 
-    // Note: V2 is not finalized yet, so it should not be selected.
     accept_incoming_impl::<A, T>(
         SupportedProtocolVersion::V2.into(),
-        SupportedProtocolVersion::V1.into(),
+        SupportedProtocolVersion::V2.into(),
     )
     .await;
 }

--- a/wallet/wallet-cli-lib/Cargo.toml
+++ b/wallet/wallet-cli-lib/Cargo.toml
@@ -29,6 +29,7 @@ crossterm.workspace = true
 directories.workspace = true
 hex.workspace = true
 reedline = { workspace = true, features = ["external_printer"] }
+serde_json.workspace = true
 shlex.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -385,6 +385,9 @@ pub enum WalletCommand {
     /// Get connected peers
     ConnectedPeers,
 
+    /// Get connected peers in JSON format
+    ConnectedPeersJson,
+
     /// Add reserved peer
     AddReservedPeer {
         address: IpOrSocketAddress,
@@ -1384,6 +1387,12 @@ impl CommandHandler {
                 let peers =
                     rpc_client.p2p_get_connected_peers().await.map_err(WalletCliError::RpcError)?;
                 Ok(ConsoleCommand::Print(format!("{peers:#?}")))
+            }
+            WalletCommand::ConnectedPeersJson => {
+                let peers =
+                    rpc_client.p2p_get_connected_peers().await.map_err(WalletCliError::RpcError)?;
+                let peers_json = serde_json::to_string(&peers)?;
+                Ok(ConsoleCommand::Print(peers_json))
             }
             WalletCommand::AddReservedPeer { address } => {
                 rpc_client

--- a/wallet/wallet-cli-lib/src/errors.rs
+++ b/wallet/wallet-cli-lib/src/errors.rs
@@ -53,4 +53,6 @@ pub enum WalletCliError {
     AddressEncodingError(#[from] AddressError),
     #[error("Retrieving addresses with usage failed for account {0}: {1}")]
     AddressesRetrievalFailed(U31, String),
+    #[error("Error converting to json: {0}")]
+    SerdeJsonFormatError(#[from] serde_json::Error),
 }


### PR DESCRIPTION
The `docker compose` file allows to run 15 nodes on the same machine simultaneously. The purpose is to be able to test the V2 protocol, so `PREFERRED_PROTOCOL_VERSION` was bumped up to V2 as well. I also increased the software version to 0.2.1 to be able to distinguish the new nodes from the old ones.

For nodes to find each other I specify them as "boot nodes" to each other. I decided not to uses reserved nodes, because it'd give them advantage over older nodes.

In addition to the docker files, there is a bunch of shell scripts to make working with the nodes easier, see `README.md` for details.

Some additional changes in the production code were also made:
1. The node now always does one dns reload early, see the `had_dns_reload` flag in peer manager and the corresponding comment. I'm not sure whether we need to merge this change into master (it's only useful when a fresh node is passed some boot nodes at startup and most of them belong to the same address group).
2. `ConnectedPeersJson` command was added to wallet-cli, which prints peers' info as json. This is used by one of the helper scripts.
3. Minor logging improvements.

P.S. This branch is not supposed to be merged into master, it's just for local testing.
