### PR TITLE
Feature/get wallet transaction

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -48,6 +48,10 @@ def assert_in(thing1: str, thing2: str):
     if thing1 not in thing2:
         raise AssertionError(f"{thing1} is not in {thing2}")
 
+def assert_not_in(thing1: str, thing2: str):
+    if thing1 in thing2:
+        raise AssertionError(f"{thing1} is in {thing2}")
+
 def assert_equal(thing1, thing2, *args):
     if thing1 != thing2 or any(thing1 != arg for arg in args):
         raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -169,6 +169,9 @@ class WalletCliController:
     async def get_transaction(self, tx_id: str) -> str:
         return await self._write_command(f"gettransaction {tx_id}\n")
 
+    async def get_raw_signed_transaction(self, tx_id: str) -> str:
+        return await self._write_command(f"getrawsignedtransaction {tx_id}\n")
+
     async def send_to_address(self, address: str, amount: int, selected_utxos: List[UtxoOutpoint] = []) -> str:
         return await self._write_command(f"sendtoaddress {address} {amount} {' '.join(map(str, selected_utxos))}\n")
 

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -22,7 +22,7 @@ import re
 from dataclasses import dataclass
 from tempfile import NamedTemporaryFile
 
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Union
 
 ONE_MB = 2**20
 READ_TIMEOUT_SEC = 30
@@ -166,11 +166,13 @@ class WalletCliController:
         matches = re.findall(pattern, output, re.DOTALL)
         return [UtxoOutpoint(id=match[0].strip(), index=int(match[1].strip())) for match in matches]
 
+    async def get_transaction(self, tx_id: str) -> str:
+        return await self._write_command(f"gettransaction {tx_id}\n")
 
     async def send_to_address(self, address: str, amount: int, selected_utxos: List[UtxoOutpoint] = []) -> str:
         return await self._write_command(f"sendtoaddress {address} {amount} {' '.join(map(str, selected_utxos))}\n")
 
-    async def send_tokens_to_address(self, token_id: str, address: str, amount: float):
+    async def send_tokens_to_address(self, token_id: str, address: str, amount: Union[float, str]):
         return await self._write_command(f"sendtokenstoaddress {token_id} {address} {amount}\n")
 
     async def issue_new_token(self,

--- a/test/functional/wallet_recover_accounts.py
+++ b/test/functional/wallet_recover_accounts.py
@@ -36,6 +36,7 @@ from test_framework.wallet_cli_controller import DEFAULT_ACCOUNT_INDEX, WalletCl
 
 import asyncio
 import sys
+from random import randint
 
 
 class WalletRecoverAccounts(BitcoinTestFramework):
@@ -120,8 +121,8 @@ class WalletRecoverAccounts(BitcoinTestFramework):
             balance = await wallet.get_balance()
             assert_in("Coins amount: 10", balance)
 
-            # create 3 new accounts
-            num_accounts = 3
+            # create new accounts
+            num_accounts = randint(1, 3)
             for idx in range(num_accounts):
                 assert_in("Success", await wallet.create_new_account())
                 assert_in("Success", await wallet.select_account(idx+1))

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1085,6 +1085,10 @@ impl Account {
         get_transaction_list(&self.key_chain, &self.output_cache, skip, count)
     }
 
+    pub fn get_transaction(&self, transaction_id: Id<Transaction>) -> WalletResult<&WalletTx> {
+        self.output_cache.get_transaction(transaction_id)
+    }
+
     pub fn reset_to_height<B: storage::Backend>(
         &mut self,
         db_tx: &mut StoreTxRw<B>,

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1212,16 +1212,13 @@ impl Account {
                     |mut new_tx_was_added, (idx, signed_tx)| {
                         let tx_state =
                             TxState::Confirmed(block_height, block.timestamp(), idx as u64);
-                        let wallet_tx = WalletTx::Tx(TxData::new(
-                            signed_tx.transaction().clone().into(),
-                            tx_state,
-                        ));
+                        let wallet_tx = WalletTx::Tx(TxData::new(signed_tx.clone(), tx_state));
                         new_tx_was_added |= self
                             .add_wallet_tx_if_relevant_and_remove_from_user_txs(
                                 db_tx,
                                 wallet_events,
                                 wallet_tx,
-                                signed_tx,
+                                signed_tx.transaction().get_id(),
                             )?;
                         Ok(new_tx_was_added)
                     },
@@ -1246,14 +1243,11 @@ impl Account {
         db_tx: &mut impl WalletStorageWriteLocked,
         wallet_events: &impl WalletEvents,
         wallet_tx: WalletTx,
-        signed_tx: &SignedTransaction,
+        tx_id: Id<Transaction>,
     ) -> Result<bool, WalletError> {
         Ok(
             if self.add_wallet_tx_if_relevant(db_tx, wallet_events, wallet_tx)? {
-                let id = AccountWalletCreatedTxId::new(
-                    self.get_account_id(),
-                    signed_tx.transaction().get_id(),
-                );
+                let id = AccountWalletCreatedTxId::new(self.get_account_id(), tx_id);
                 db_tx.del_user_transaction(&id)?;
                 true
             } else {
@@ -1316,10 +1310,7 @@ impl Account {
         for signed_tx in transactions {
             counter += 1;
             let tx_state = make_tx_state(counter);
-            let wallet_tx = WalletTx::Tx(TxData::new(
-                signed_tx.transaction().clone().into(),
-                tx_state,
-            ));
+            let wallet_tx = WalletTx::Tx(TxData::new(signed_tx.clone(), tx_state));
 
             if !self.add_wallet_tx_if_relevant(db_tx, wallet_events, wallet_tx)? {
                 not_added.push((signed_tx, tx_state));
@@ -1330,19 +1321,17 @@ impl Account {
         // and keep looping as long as we add a new tx
         loop {
             let mut not_added_next = vec![];
-            for (signed_tx, tx_state) in not_added.iter() {
-                let wallet_tx = WalletTx::Tx(TxData::new(
-                    signed_tx.transaction().clone().into(),
-                    *tx_state,
-                ));
+            let previously_not_added = not_added.len();
+            for (signed_tx, tx_state) in not_added {
+                let wallet_tx = WalletTx::Tx(TxData::new(signed_tx.clone(), tx_state));
 
                 if !self.add_wallet_tx_if_relevant(db_tx, wallet_events, wallet_tx)? {
-                    not_added_next.push((*signed_tx, *tx_state));
+                    not_added_next.push((signed_tx, tx_state));
                 }
             }
 
             // if no new tx was added break
-            if not_added.len() == not_added_next.len() {
+            if not_added_next.len() == previously_not_added {
                 break;
             }
 
@@ -1370,7 +1359,7 @@ impl Account {
         self.account_info.name()
     }
 
-    pub fn pending_transactions(&self) -> Vec<&WithId<Transaction>> {
+    pub fn pending_transactions(&self) -> Vec<WithId<&Transaction>> {
         self.output_cache.pending_transactions()
     }
 

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1085,7 +1085,7 @@ impl Account {
         get_transaction_list(&self.key_chain, &self.output_cache, skip, count)
     }
 
-    pub fn get_transaction(&self, transaction_id: Id<Transaction>) -> WalletResult<&WalletTx> {
+    pub fn get_transaction(&self, transaction_id: Id<Transaction>) -> WalletResult<&TxData> {
         self.output_cache.get_transaction(transaction_id)
     }
 

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -858,6 +858,12 @@ impl OutputCache {
 
         Ok(all_abandoned)
     }
+
+    pub fn get_transaction(&self, transaction_id: Id<Transaction>) -> WalletResult<&WalletTx> {
+        self.txs
+            .get(&transaction_id.into())
+            .ok_or(WalletError::NoTransactionFound(transaction_id))
+    }
 }
 
 fn sum_burned_token_amount(

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -33,7 +33,7 @@ use pos_accounting::make_delegation_id;
 use utils::ensure;
 use wallet_types::{
     utxo_types::{get_utxo_state, UtxoState, UtxoStates},
-    wallet_tx::TxState,
+    wallet_tx::{TxData, TxState},
     with_locked::WithLocked,
     AccountWalletTxId, BlockInfo, WalletTx,
 };
@@ -859,10 +859,11 @@ impl OutputCache {
         Ok(all_abandoned)
     }
 
-    pub fn get_transaction(&self, transaction_id: Id<Transaction>) -> WalletResult<&WalletTx> {
-        self.txs
-            .get(&transaction_id.into())
-            .ok_or(WalletError::NoTransactionFound(transaction_id))
+    pub fn get_transaction(&self, transaction_id: Id<Transaction>) -> WalletResult<&TxData> {
+        match self.txs.get(&transaction_id.into()) {
+            None | Some(WalletTx::Block(_)) => Err(WalletError::NoTransactionFound(transaction_id)),
+            Some(WalletTx::Tx(tx)) => Ok(tx),
+        }
     }
 }
 

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -745,7 +745,7 @@ impl OutputCache {
             .collect()
     }
 
-    pub fn pending_transactions(&self) -> Vec<&WithId<Transaction>> {
+    pub fn pending_transactions(&self) -> Vec<WithId<&Transaction>> {
         self.txs
             .values()
             .filter_map(|tx| match tx {

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -53,7 +53,7 @@ use wallet_types::seed_phrase::{SerializableSeedPhrase, StoreSeedPhrase};
 use wallet_types::utxo_types::{UtxoStates, UtxoTypes};
 use wallet_types::wallet_tx::TxState;
 use wallet_types::with_locked::WithLocked;
-use wallet_types::{AccountId, BlockInfo, KeyPurpose, KeychainUsageState};
+use wallet_types::{AccountId, BlockInfo, KeyPurpose, KeychainUsageState, WalletTx};
 
 pub const WALLET_VERSION_UNINITIALIZED: u32 = 0;
 pub const WALLET_VERSION_V1: u32 = 1;
@@ -714,6 +714,15 @@ impl<B: storage::Backend> Wallet<B> {
     ) -> WalletResult<TransactionList> {
         let account = self.get_account(account_index)?;
         account.get_transaction_list(skip, count)
+    }
+
+    pub fn get_transaction(
+        &self,
+        account_index: U31,
+        transaction_id: Id<Transaction>,
+    ) -> WalletResult<&WalletTx> {
+        let account = self.get_account(account_index)?;
+        account.get_transaction(transaction_id)
     }
 
     pub fn get_transactions_to_be_broadcast(&self) -> WalletResult<Vec<SignedTransaction>> {

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -654,7 +654,7 @@ impl<B: storage::Backend> Wallet<B> {
     pub fn pending_transactions(
         &self,
         account_index: U31,
-    ) -> WalletResult<Vec<&WithId<Transaction>>> {
+    ) -> WalletResult<Vec<WithId<&Transaction>>> {
         let account = self.get_account(account_index)?;
         let transactions = account.pending_transactions();
         Ok(transactions)

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -51,9 +51,9 @@ use wallet_storage::{
 use wallet_types::chain_info::ChainInfo;
 use wallet_types::seed_phrase::{SerializableSeedPhrase, StoreSeedPhrase};
 use wallet_types::utxo_types::{UtxoStates, UtxoTypes};
-use wallet_types::wallet_tx::TxState;
+use wallet_types::wallet_tx::{TxData, TxState};
 use wallet_types::with_locked::WithLocked;
-use wallet_types::{AccountId, BlockInfo, KeyPurpose, KeychainUsageState, WalletTx};
+use wallet_types::{AccountId, BlockInfo, KeyPurpose, KeychainUsageState};
 
 pub const WALLET_VERSION_UNINITIALIZED: u32 = 0;
 pub const WALLET_VERSION_V1: u32 = 1;
@@ -720,7 +720,7 @@ impl<B: storage::Backend> Wallet<B> {
         &self,
         account_index: U31,
         transaction_id: Id<Transaction>,
-    ) -> WalletResult<&WalletTx> {
+    ) -> WalletResult<&TxData> {
         let account = self.get_account(account_index)?;
         account.get_transaction(transaction_id)
     }

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -1044,15 +1044,8 @@ fn wallet_get_transaction(#[case] seed: Seed) {
     wallet.add_unconfirmed_tx(tx.clone(), &WalletEventsNoOp).unwrap();
     let found_tx = wallet.get_transaction(DEFAULT_ACCOUNT_INDEX, tx_id).unwrap();
 
-    match found_tx {
-        WalletTx::Tx(found_tx) => {
-            assert_eq!(*found_tx.state(), TxState::Inactive(1));
-            assert_eq!(found_tx.get_transaction(), tx.transaction());
-        }
-        WalletTx::Block(_) => {
-            panic!("unexpected result");
-        }
-    }
+    assert_eq!(*found_tx.state(), TxState::Inactive(1));
+    assert_eq!(found_tx.get_transaction(), tx.transaction());
 
     // put the tx in a block and scan it as confirmed
     let (_, block) = create_block(
@@ -1064,18 +1057,11 @@ fn wallet_get_transaction(#[case] seed: Seed) {
     );
     let found_tx = wallet.get_transaction(DEFAULT_ACCOUNT_INDEX, tx_id).unwrap();
 
-    match found_tx {
-        WalletTx::Tx(found_tx) => {
-            assert_eq!(
-                *found_tx.state(),
-                TxState::Confirmed(BlockHeight::new(2), block.timestamp(), 0)
-            );
-            assert_eq!(found_tx.get_transaction(), tx.transaction());
-        }
-        WalletTx::Block(_) => {
-            panic!("unexpected result");
-        }
-    }
+    assert_eq!(
+        *found_tx.state(),
+        TxState::Confirmed(BlockHeight::new(2), block.timestamp(), 0)
+    );
+    assert_eq!(found_tx.get_transaction(), tx.transaction());
 }
 
 #[rstest]

--- a/wallet/types/src/wallet_tx.rs
+++ b/wallet/types/src/wallet_tx.rs
@@ -178,6 +178,10 @@ impl TxData {
         Self { tx, state }
     }
 
+    pub fn get_signed_transaction(&self) -> &SignedTransaction {
+        &self.tx
+    }
+
     pub fn get_transaction(&self) -> &Transaction {
         self.tx.transaction()
     }

--- a/wallet/types/src/wallet_tx.rs
+++ b/wallet/types/src/wallet_tx.rs
@@ -19,7 +19,9 @@ use common::chain::block::timestamp::BlockTimestamp;
 use common::chain::block::ConsensusData;
 use serialization::{Decode, Encode};
 
-use common::chain::{Block, GenBlock, Genesis, OutPointSourceId, Transaction, TxInput, TxOutput};
+use common::chain::{
+    Block, GenBlock, Genesis, OutPointSourceId, SignedTransaction, Transaction, TxInput, TxOutput,
+};
 use common::primitives::id::WithId;
 use common::primitives::{BlockHeight, Id, Idable};
 
@@ -114,7 +116,7 @@ pub enum WalletTx {
 
 #[derive(Debug, PartialEq, Eq, Clone, Decode, Encode)]
 pub struct TxData {
-    tx: WithId<Transaction>,
+    tx: SignedTransaction,
 
     state: TxState,
 }
@@ -145,7 +147,7 @@ impl WalletTx {
     pub fn id(&self) -> OutPointSourceId {
         match self {
             WalletTx::Block(block) => OutPointSourceId::BlockReward(*block.block_id()),
-            WalletTx::Tx(tx) => OutPointSourceId::Transaction(tx.tx.get_id()),
+            WalletTx::Tx(tx) => OutPointSourceId::Transaction(tx.tx.transaction().get_id()),
         }
     }
 
@@ -172,16 +174,16 @@ impl WalletTx {
 }
 
 impl TxData {
-    pub fn new(tx: WithId<Transaction>, state: TxState) -> Self {
+    pub fn new(tx: SignedTransaction, state: TxState) -> Self {
         Self { tx, state }
     }
 
     pub fn get_transaction(&self) -> &Transaction {
-        WithId::get(&self.tx)
+        self.tx.transaction()
     }
 
-    pub fn get_transaction_with_id(&self) -> &WithId<Transaction> {
-        &self.tx
+    pub fn get_transaction_with_id(&self) -> WithId<&Transaction> {
+        WithId::new(self.tx.transaction())
     }
 
     pub fn state(&self) -> &TxState {

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -260,6 +260,11 @@ pub enum WalletCommand {
     /// Generate a new unused public key
     NewPublicKey,
 
+    /// Get the transaction from the wallet if present
+    GetTransaction {
+        transaction_id: HexEncoded<Id<Transaction>>,
+    },
+
     GetVrfPublicKey,
 
     SendToAddress {
@@ -1006,6 +1011,16 @@ impl CommandHandler {
                     .get_vrf_public_key()
                     .map_err(WalletCliError::Controller)?;
                 Ok(ConsoleCommand::Print(vrf_public_key.hex_encode()))
+            }
+
+            WalletCommand::GetTransaction { transaction_id } => {
+                let tx = self
+                    .get_readonly_controller()?
+                    .get_transaction(transaction_id.take())
+                    .map(|tx| format!("{:?}", tx))
+                    .map_err(WalletCliError::Controller)?;
+
+                Ok(ConsoleCommand::Print(tx))
             }
 
             WalletCommand::SendToAddress {

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -265,6 +265,16 @@ pub enum WalletCommand {
         transaction_id: HexEncoded<Id<Transaction>>,
     },
 
+    /// Get the transaction from the wallet if present as hex encoded raw transaction
+    GetRawTransaction {
+        transaction_id: HexEncoded<Id<Transaction>>,
+    },
+
+    /// Get the signed transaction from the wallet if present as hex encoded raw transaction
+    GetRawSignedTransaction {
+        transaction_id: HexEncoded<Id<Transaction>>,
+    },
+
     GetVrfPublicKey,
 
     SendToAddress {
@@ -1018,6 +1028,26 @@ impl CommandHandler {
                     .get_readonly_controller()?
                     .get_transaction(transaction_id.take())
                     .map(|tx| format!("{:?}", tx))
+                    .map_err(WalletCliError::Controller)?;
+
+                Ok(ConsoleCommand::Print(tx))
+            }
+
+            WalletCommand::GetRawTransaction { transaction_id } => {
+                let tx = self
+                    .get_readonly_controller()?
+                    .get_transaction(transaction_id.take())
+                    .map(|tx| HexEncode::hex_encode(tx.get_transaction()))
+                    .map_err(WalletCliError::Controller)?;
+
+                Ok(ConsoleCommand::Print(tx))
+            }
+
+            WalletCommand::GetRawSignedTransaction { transaction_id } => {
+                let tx = self
+                    .get_readonly_controller()?
+                    .get_transaction(transaction_id.take())
+                    .map(|tx| HexEncode::hex_encode(tx.get_signed_transaction()))
                     .map_err(WalletCliError::Controller)?;
 
                 Ok(ConsoleCommand::Print(tx))

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -32,8 +32,9 @@ use wallet::{
 };
 use wallet_types::{
     utxo_types::{UtxoStates, UtxoType, UtxoTypes},
+    wallet_tx::TxData,
     with_locked::WithLocked,
-    BlockInfo, KeychainUsageState, WalletTx,
+    BlockInfo, KeychainUsageState,
 };
 
 use crate::ControllerError;
@@ -109,7 +110,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
     pub fn get_transaction(
         &self,
         transaction_id: Id<Transaction>,
-    ) -> Result<&WalletTx, ControllerError<T>> {
+    ) -> Result<&TxData, ControllerError<T>> {
         self.wallet
             .get_transaction(self.account_index, transaction_id)
             .map_err(ControllerError::WalletError)

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -90,7 +90,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
             .map_err(ControllerError::WalletError)
     }
 
-    pub fn pending_transactions(&self) -> Result<Vec<&'a WithId<Transaction>>, ControllerError<T>> {
+    pub fn pending_transactions(&self) -> Result<Vec<WithId<&'a Transaction>>, ControllerError<T>> {
         self.wallet
             .pending_transactions(self.account_index)
             .map_err(ControllerError::WalletError)

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -20,7 +20,7 @@ use std::collections::BTreeMap;
 use common::{
     address::Address,
     chain::{ChainConfig, DelegationId, Destination, PoolId, Transaction, TxOutput, UtxoOutPoint},
-    primitives::{id::WithId, Amount},
+    primitives::{id::WithId, Amount, Id},
 };
 use crypto::key::hdkd::{child_number::ChildNumber, u31::U31};
 use futures::{stream::FuturesUnordered, TryStreamExt};
@@ -33,7 +33,7 @@ use wallet::{
 use wallet_types::{
     utxo_types::{UtxoStates, UtxoType, UtxoTypes},
     with_locked::WithLocked,
-    BlockInfo, KeychainUsageState,
+    BlockInfo, KeychainUsageState, WalletTx,
 };
 
 use crate::ControllerError;
@@ -103,6 +103,15 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
     ) -> Result<TransactionList, ControllerError<T>> {
         self.wallet
             .get_transaction_list(self.account_index, skip, count)
+            .map_err(ControllerError::WalletError)
+    }
+
+    pub fn get_transaction(
+        &self,
+        transaction_id: Id<Transaction>,
+    ) -> Result<&WalletTx, ControllerError<T>> {
+        self.wallet
+            .get_transaction(self.account_index, transaction_id)
             .map_err(ControllerError::WalletError)
     }
 


### PR DESCRIPTION
- new get transaction command in the wallet CLI, will return the transaction along with its state (confirmed, in-mempool...)
- randomize wallet functional tests
- wallet DB migration v3 store SignedTransaction instead of Transaction
- new commands for raw signed transaction and raw transaction, returning hex encoded serialized result