### PR TITLE
Fix some p2p issues

### DIFF
--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -133,12 +133,14 @@ where
         };
         messaging_handle_2
             .send_message(peer, SyncMessage::HeaderList(HeaderList::new(Vec::new())))
+            .await
             .unwrap();
         messaging_handle_2
             .send_message(
                 peer,
                 SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
             )
+            .await
             .unwrap();
     });
 

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -94,6 +94,7 @@ where
             peer2.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
+        .await
         .unwrap();
 
     let mut sync_msg_rx_2 = match sync2.poll_next().await.unwrap() {
@@ -130,6 +131,7 @@ where
             peer1.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
+        .await
         .unwrap();
 
     let mut sync_msg_rx_1 = match sync1.poll_next().await.unwrap() {
@@ -236,6 +238,7 @@ where
             peer2.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
+        .await
         .unwrap();
 
     shutdown.store(true);

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -118,7 +118,7 @@ impl P2pBasicTestTimeGetter {
 }
 
 /// A timeout for blocking calls.
-pub const LONG_TIMEOUT: Duration = Duration::from_secs(120); // FIXME
+pub const LONG_TIMEOUT: Duration = Duration::from_secs(600);
 /// A short timeout for events that shouldn't occur.
 pub const SHORT_TIMEOUT: Duration = Duration::from_millis(500);
 

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -118,7 +118,7 @@ impl P2pBasicTestTimeGetter {
 }
 
 /// A timeout for blocking calls.
-pub const LONG_TIMEOUT: Duration = Duration::from_secs(600);
+pub const LONG_TIMEOUT: Duration = Duration::from_secs(120); // FIXME
 /// A short timeout for events that shouldn't occur.
 pub const SHORT_TIMEOUT: Duration = Duration::from_millis(500);
 

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -49,8 +49,15 @@ pub enum ProtocolError {
     DuplicatedBlockRequest(Id<Block>),
     #[error("Headers aren't connected")]
     DisconnectedHeaders,
-    #[error("Received a message ({0}) that wasn't expected")]
+    #[error("Peer sent a message ({0}) that wasn't expected")]
     UnexpectedMessage(String),
+    #[error("Peer sent a block ({0}) that wasn't requested")]
+    UnsolicitedBlockReceived(Id<Block>),
+    #[error("Peer sent block {expected_block_id} while it was expected to send {actual_block_id}")]
+    BlocksReceivedInWrongOrder {
+        expected_block_id: Id<Block>,
+        actual_block_id: Id<Block>,
+    },
     #[error("Empty block list requested")]
     ZeroBlocksInRequest,
     #[error("Handshake expected")]
@@ -227,6 +234,11 @@ impl BanScore for ProtocolError {
             ProtocolError::DuplicatedBlockRequest(_) => 20,
             ProtocolError::DisconnectedHeaders => 20,
             ProtocolError::UnexpectedMessage(_) => 20,
+            ProtocolError::UnsolicitedBlockReceived(_) => 20,
+            ProtocolError::BlocksReceivedInWrongOrder {
+                expected_block_id: _,
+                actual_block_id: _,
+            } => 20,
             ProtocolError::ZeroBlocksInRequest => 20,
             ProtocolError::HandshakeExpected => 100,
             ProtocolError::AddressListLimitExceeded => 100,

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -142,8 +142,10 @@ where
     }
 }
 
+#[async_trait]
 impl MessagingService for MessagingHandle {
-    fn send_message(&mut self, peer_id: PeerId, message: SyncMessage) -> crate::Result<()> {
+    async fn send_message(&mut self, peer_id: PeerId, message: SyncMessage) -> crate::Result<()> {
+        // Note: send_message was made async to be able to use a bounded channel in tests.
         Ok(self.command_sender.send(types::Command::SendMessage {
             peer_id,
             message: message.into(),

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -122,9 +122,10 @@ where
 }
 
 /// An interface for sending messages and announcements to peers.
+#[async_trait]
 pub trait MessagingService: Clone {
     /// Sends a message to the peer.
-    fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()>;
+    async fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()>;
 }
 
 #[async_trait]

--- a/p2p/src/sync/peer_v1.rs
+++ b/p2p/src/sync/peer_v1.rs
@@ -508,6 +508,16 @@ where
             ))?;
 
         // Check that all the blocks are known and haven't been already requested.
+        // First check self.outgoing.blocks_queue
+        let already_requested_blocks: BTreeSet<_> = self.outgoing.blocks_queue.iter().collect();
+        let doubly_requested_id = block_ids.iter().find(|id| already_requested_blocks.get(id).is_some());
+        if let Some(id) = doubly_requested_id {
+            return Err(P2pError::ProtocolError(
+                ProtocolError::DuplicatedBlockRequest(*id),
+            ));
+        }
+
+        // Then check the chainstate
         let ids = block_ids.clone();
         let best_sent_block = self.outgoing.best_sent_block.clone();
         self.chainstate_handle

--- a/p2p/src/sync/peer_v1.rs
+++ b/p2p/src/sync/peer_v1.rs
@@ -103,7 +103,7 @@ struct IncomingDataState {
     /// requested the blocks for.
     pending_headers: Vec<SignedBlockHeader>,
     /// A list of blocks that we requested from this peer.
-    requested_blocks: BTreeSet<Id<Block>>,
+    requested_blocks: VecDeque<Id<Block>>,
     /// The id of the best block header that we've received from the peer and that we also have.
     /// This includes headers received by any means, e.g. via HeaderList messages, as part
     /// of a locator during peer's header requests, via block responses.
@@ -158,7 +158,7 @@ where
             time_getter,
             incoming: IncomingDataState {
                 pending_headers: Vec::new(),
-                requested_blocks: BTreeSet::new(),
+                requested_blocks: VecDeque::new(),
                 peers_best_block_that_we_have: None,
                 singular_unconnected_headers_count: 0,
             },
@@ -225,15 +225,15 @@ where
         }
     }
 
-    fn send_message(&mut self, message: SyncMessage) -> Result<()> {
-        self.messaging_handle.send_message(self.id(), message)
+    async fn send_message(&mut self, message: SyncMessage) -> Result<()> {
+        self.messaging_handle.send_message(self.id(), message).await
     }
 
-    fn send_headers(&mut self, headers: HeaderList) -> Result<()> {
+    async fn send_headers(&mut self, headers: HeaderList) -> Result<()> {
         if let Some(last_header) = headers.headers().last() {
             self.outgoing.best_sent_block_header = Some(last_header.block_id().into());
         }
-        self.send_message(SyncMessage::HeaderList(headers))
+        self.send_message(SyncMessage::HeaderList(headers)).await
     }
 
     async fn handle_new_tip(&mut self, new_tip_id: &Id<Block>) -> Result<()> {
@@ -290,11 +290,8 @@ where
                     .await?;
 
                 if headers.is_empty() {
-                    log::warn!(
-                        concat!(
-                            "[peer id = {}] Got new tip event with block id {}, ",
-                            "but there is nothing to send"
-                        ),
+                    log::debug!(
+                        "[peer id = {}] Got new tip event with block id {}, but there is nothing to send",
                         self.id(),
                         new_tip_id,
                     );
@@ -302,11 +299,8 @@ where
                     // If we got here, another "new tip" event should be generated soon,
                     // so we may ignore this one (and it makes sense to ignore it to avoid sending
                     // the same header list multiple times).
-                    log::warn!(
-                        concat!(
-                            "[peer id = {}] Got new tip event with block id {}, ",
-                            "but the tip has changed since then to {}"
-                        ),
+                    log::info!(
+                        "[peer id = {}] Got new tip event with block id {}, but the tip has changed since then to {}",
                         self.id(),
                         new_tip_id,
                         best_block_id
@@ -317,7 +311,7 @@ where
                         self.id(),
                         headers.len()
                     );
-                    return self.send_headers(HeaderList::new(headers));
+                    return self.send_headers(HeaderList::new(headers)).await;
                 }
             } else {
                 // Note: if we got here, then we haven't received a single header request or
@@ -346,7 +340,7 @@ where
                     && self.common_services.has_service(Service::Transactions)
                 {
                     self.add_known_transaction(txid);
-                    self.send_message(SyncMessage::NewTransaction(txid))
+                    self.send_message(SyncMessage::NewTransaction(txid)).await
                 } else {
                     Ok(())
                 }
@@ -357,9 +351,6 @@ where
     async fn request_headers(&mut self) -> Result<()> {
         let locator = self.chainstate_handle.call(|this| Ok(this.get_locator()?)).await?;
         if locator.len() > *self.p2p_config.protocol_config.msg_max_locator_count {
-            // Note: msg_max_locator_count is not supposed to be configurable outside of tests,
-            // so we should never get here in production code. Moreover, currently it's not
-            // modified even in tests. TODO: make it a constant.
             log::warn!(
                 "[peer id = {}] Sending locator of the length {}, which exceeds the maximum length {:?}",
                 self.id(),
@@ -371,7 +362,8 @@ where
         log::debug!("[peer id = {}] Sending header list request", self.id());
         self.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
             locator,
-        )))?;
+        )))
+        .await?;
 
         self.peer_activity
             .set_expecting_headers_since(Some(self.time_getter.get_time()));
@@ -445,7 +437,7 @@ where
         // all headers that were available at the moment.
         self.have_sent_all_headers = headers.len() < header_count_limit;
 
-        self.send_headers(HeaderList::new(headers))
+        self.send_headers(HeaderList::new(headers)).await
     }
 
     /// Processes the blocks request.
@@ -719,7 +711,7 @@ where
                 .await?;
         }
 
-        self.request_blocks(new_block_headers)
+        self.request_blocks(new_block_headers).await
     }
 
     async fn handle_block_response(&mut self, block: Block) -> Result<()> {
@@ -734,10 +726,28 @@ where
         // The code below will set it again if needed.
         self.peer_activity.set_expecting_blocks_since(None);
 
-        if self.incoming.requested_blocks.take(&block.get_id()).is_none() {
-            return Err(P2pError::ProtocolError(ProtocolError::UnexpectedMessage(
-                "block response".to_owned(),
-            )));
+        if self.incoming.requested_blocks.front().is_some_and(|id| id == &block.get_id()) {
+            self.incoming.requested_blocks.pop_front();
+        } else {
+            let idx = self.incoming.requested_blocks.iter().position(|id| id == &block.get_id());
+            // Note: we treat wrongly ordered blocks in the same way as unsolicited ones, i.e.
+            // we don't remove their ids from the list.
+            if idx.is_some() {
+                return Err(P2pError::ProtocolError(
+                    ProtocolError::BlocksReceivedInWrongOrder {
+                        expected_block_id: *self
+                            .incoming
+                            .requested_blocks
+                            .front()
+                            .expect("The deque is known to be non-empty"),
+                        actual_block_id: block.get_id(),
+                    },
+                ));
+            } else {
+                return Err(P2pError::ProtocolError(
+                    ProtocolError::UnsolicitedBlockReceived(block.get_id()),
+                ));
+            }
         }
 
         let block = self.chainstate_handle.call(|c| Ok(c.preliminary_block_check(block)?)).await?;
@@ -798,7 +808,7 @@ where
                 self.request_headers().await?;
             } else {
                 // Download remaining blocks.
-                self.request_blocks(headers)?;
+                self.request_blocks(headers).await?;
             }
         } else {
             // We expect additional blocks from the peer, update the timestamp.
@@ -821,7 +831,7 @@ where
             None => TransactionResponse::NotFound(id),
         };
 
-        self.send_message(SyncMessage::TransactionResponse(res))?;
+        self.send_message(SyncMessage::TransactionResponse(res)).await?;
 
         Ok(())
     }
@@ -905,7 +915,7 @@ where
         }
 
         if !(self.mempool_handle.call(move |m| m.contains_transaction(&tx)).await?) {
-            self.send_message(SyncMessage::TransactionRequest(tx))?;
+            self.send_message(SyncMessage::TransactionRequest(tx)).await?;
             assert!(self.announced_transactions.insert(tx));
         }
 
@@ -916,7 +926,7 @@ where
     ///
     /// The number of blocks requested equals `P2pConfig::requested_blocks_limit`, the remaining
     /// headers are stored in the peer context.
-    fn request_blocks(&mut self, mut headers: Vec<SignedBlockHeader>) -> Result<()> {
+    async fn request_blocks(&mut self, mut headers: Vec<SignedBlockHeader>) -> Result<()> {
         debug_assert!(self.incoming.pending_headers.is_empty());
         debug_assert!(self.incoming.requested_blocks.is_empty());
         debug_assert!(!headers.is_empty());
@@ -936,7 +946,8 @@ where
         );
         self.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(
             block_ids.clone(),
-        )))?;
+        )))
+        .await?;
         self.incoming.requested_blocks.extend(block_ids);
 
         self.peer_activity.set_expecting_blocks_since(Some(self.time_getter.get_time()));
@@ -945,7 +956,7 @@ where
     }
 
     async fn send_block(&mut self, id: Id<Block>) -> Result<()> {
-        let (block, index) = self
+        let (block, block_index) = self
             .chainstate_handle
             .call(move |c| {
                 let index = c.get_block_index(&id);
@@ -960,14 +971,27 @@ where
         // to delete block indices of missing blocks when resetting their failure flags).
         // P2p should handle such situations correctly (see issue #1033 for more details).
         let block = block?.unwrap_or_else(|| panic!("Unknown block requested: {id}"));
-        self.outgoing.best_sent_block = index?;
+        let block_index = block_index?.expect("Block index must exist");
+
+        let old_best_sent_block_id = self.outgoing.best_sent_block.as_ref().map(|idx| {
+            let id: Id<GenBlock> = (*idx.block_id()).into();
+            id
+        });
+        let new_best_sent_block_id = self
+            .chainstate_handle
+            .call(move |c| choose_peers_best_block(c, old_best_sent_block_id, Some(id.into())))
+            .await?;
+
+        if new_best_sent_block_id == Some(id.into()) {
+            self.outgoing.best_sent_block = Some(block_index);
+        }
 
         log::debug!(
             "[peer id = {}] Sending block with id = {} to the peer",
             self.id(),
             block.get_id()
         );
-        self.send_message(SyncMessage::BlockResponse(BlockResponse::new(block)))
+        self.send_message(SyncMessage::BlockResponse(BlockResponse::new(block))).await
     }
 
     async fn disconnect_if_stalling(&mut self) -> Result<()> {

--- a/p2p/src/sync/peer_v1.rs
+++ b/p2p/src/sync/peer_v1.rs
@@ -611,8 +611,7 @@ where
             return Err(P2pError::ProtocolError(ProtocolError::DisconnectedHeaders));
         }
 
-        // The first header must be connected to a known block (it can be in
-        // the chainstate or requested_blocks).
+        // The first header must be connected to the chainstate.
         let first_header_prev_id = *headers
             .first()
             // This is OK because of the `headers.is_empty()` check above.
@@ -620,18 +619,19 @@ where
             .prev_block_id();
 
         // Note: we require a peer to send headers starting from a block that we already have
-        // in our chainstate or from one that we've already requested from the peer.
-        // I.e. peers shouldn't track what block headers they've sent us already and use
-        // the last header (best_sent_block_header) as a starting point for future HeaderList
-        // updates.
-        // This restriction is needed to prevent malicious peers from flooding the node with
-        // headers, potentially exhausting the node's memory.
-        // The downside of this is that the peer may have to send the same headers multiple times.
-        // So, to avoid extra traffic, an honest peer should't send header updates when the node
-        // is already downloading blocks. But still, the node shouldn't punish the peer for
-        // doing so, because it's possible for it to do so on accident, e.g. a "new tip" event
-        // may happen on the peer's side after it has sent us the last requested block but
-        // before we've asked it for more.
+        // in our chainstate. I.e. we don't allow:
+        // 1) Basing new headers on a previously sent header, because this would give a malicious
+        // peer an opportunity to flood the node with headers, potentially exhausting its memory.
+        // The downside of this restriction is that the peer may have to send the same headers
+        // multiple times. So, to avoid extra traffic, an honest peer should't send header updates
+        // when the node is already downloading blocks. (But still, the node shouldn't punish
+        // the peer for doing so, because it's possible for it to do so by accident, e.g.
+        // a "new tip" event may happen on the peer's side after it has sent us the last requested
+        // block but before we've asked it for more.)
+        // 2) Basing new headers on a block that we've requested from the peer but that has not
+        // yet been sent. This is a rather useless optimization (provided that peers don't send
+        // header updates when we're downloading blocks from them, as mentioned above) that
+        // would only complicate the logic.
 
         let first_header_is_connected_to_chainstate = self
             .chainstate_handle
@@ -639,15 +639,7 @@ where
             .await?
             .is_some();
 
-        let first_header_is_connected_to_requested_blocks = first_header_prev_id
-            .classify(&self.chain_config)
-            .chain_block_id()
-            .and_then(|id| self.incoming.requested_blocks.get(&id))
-            .is_some();
-
-        if !(first_header_is_connected_to_chainstate
-            || first_header_is_connected_to_requested_blocks)
-        {
+        if !first_header_is_connected_to_chainstate {
             // Note: legacy nodes will send singular unconnected headers during block announcement,
             // so we have to handle this behavior here.
             if headers.len() == 1 {

--- a/p2p/src/sync/peer_v1.rs
+++ b/p2p/src/sync/peer_v1.rs
@@ -119,7 +119,7 @@ struct OutgoingDataState {
     /// The index of the best block that we've sent to the peer.
     best_sent_block: Option<BlockIndex>,
     /// The id of the best block header that we've sent to the peer.
-    /// Note: at this moment this field is only informational, i.e. we only print it to the log.
+    // Note: at this moment this field is only informational, i.e. we only print it to the log.
     best_sent_block_header: Option<Id<GenBlock>>,
 }
 
@@ -256,7 +256,7 @@ where
             self.incoming.peers_best_block_that_we_have
         );
 
-        // Note: if we haven't sent all out headers last time, the peer will ask us for more anyway,
+        // Note: if we haven't sent all our headers last time, the peer will ask us for more anyway,
         // so no need to send the update just now.
         // Likewise, if the peer has requested blocks, it will send another header request once
         // it gets the blocks, so no need to send the update in this case either.
@@ -620,7 +620,7 @@ where
             .prev_block_id();
 
         // Note: we require a peer to send headers starting from a block that we already have
-        // in our chainstate or to one that we've already requested from the peer.
+        // in our chainstate or from one that we've already requested from the peer.
         // I.e. peers shouldn't track what block headers they've sent us already and use
         // the last header (best_sent_block_header) as a starting point for future HeaderList
         // updates.

--- a/p2p/src/sync/peer_v2.rs
+++ b/p2p/src/sync/peer_v2.rs
@@ -92,9 +92,10 @@ pub struct Peer<T: NetworkingService> {
     announced_transactions: BTreeSet<Id<Transaction>>,
     /// Current activity with the peer.
     peer_activity: PeerActivity,
-    /// If set, send the new tip notification when the tip moves.
-    /// It's set when we know that the peer knows about all of our current mainchain headers.
-    send_tip_updates: bool,
+    /// If this is set, it means that we've sent a HeaderList to the peer with the number
+    /// of headers less than the maximum. This is the signal to the peer that we have no more
+    /// headers, so it may not ask us for more of them in the future.
+    have_sent_all_headers: bool,
 }
 
 struct IncomingDataState {
@@ -115,6 +116,8 @@ struct OutgoingDataState {
     /// The index of the best block that we've sent to the peer.
     best_sent_block: Option<BlockIndex>,
     /// The id of the best block header that we've sent to the peer.
+    /// Note: at this moment this field is only informational, i.e. we only print it to the log.
+    /// TODO: remove it?
     best_sent_block_header: Option<Id<GenBlock>>,
 }
 
@@ -164,7 +167,7 @@ where
             known_transactions,
             announced_transactions: BTreeSet::new(),
             peer_activity: PeerActivity::new(),
-            send_tip_updates: false,
+            have_sent_all_headers: false,
         }
     }
 
@@ -239,23 +242,25 @@ where
 
         log::debug!(
             concat!(
-                "[peer id = {}] In handle_new_tip: send_tip_updates = {}, ",
+                "[peer id = {}] In handle_new_tip: have_sent_all_headers = {}, ",
                 "best_sent_block_header = {:?}, best_sent_block = {:?}, ",
                 "peers_best_block_that_we_have = {:?}"
             ),
             self.id(),
-            self.send_tip_updates,
+            self.have_sent_all_headers,
             self.outgoing.best_sent_block_header,
             best_sent_block_id,
             self.incoming.peers_best_block_that_we_have
         );
 
-        if self.send_tip_updates {
+        // Note: if we haven't sent all out headers last time, the peer will ask us for more anyway,
+        // so no need to send the update just now.
+        // Likewise, if the peer has requested blocks, it will send another header request once
+        // it gets the blocks, so no need to send the update in this case either.
+        if self.have_sent_all_headers && self.outgoing.blocks_queue.is_empty() {
             debug_assert!(self.common_services.has_service(Service::Blocks));
 
-            if self.incoming.peers_best_block_that_we_have.is_some()
-                || best_sent_block_id.is_some()
-                || self.outgoing.best_sent_block_header.is_some()
+            if self.incoming.peers_best_block_that_we_have.is_some() || best_sent_block_id.is_some()
             {
                 let limit = *self.p2p_config.protocol_config.msg_header_count_limit;
                 let new_tip_id = *new_tip_id;
@@ -265,7 +270,6 @@ where
                     .peers_best_block_that_we_have
                     .iter()
                     .chain(best_sent_block_id.iter())
-                    .chain(self.outgoing.best_sent_block_header.iter())
                     .copied()
                     .collect();
 
@@ -295,9 +299,6 @@ where
                     // If we got here, another "new tip" event should be generated soon,
                     // so we may ignore this one (and it makes sense to ignore it to avoid sending
                     // the same header list multiple times).
-                    // Note: once we take best_sent_block_header into account when sending headers,
-                    // this special handling won't be needed, because we'll never send the same
-                    // header list twice in that case.
                     log::warn!(
                         concat!(
                             "[peer id = {}] Got new tip event with block id {}, ",
@@ -441,9 +442,8 @@ where
         self.incoming.peers_best_block_that_we_have = peers_best_block_that_we_have;
 
         // Sending a below-the-max amount of headers is a signal to the peer that we've sent
-        // all headers that were available at the moment; after this, the peer may not ask us
-        // for headers anymore, so we should start sending tip updates.
-        self.send_tip_updates = headers.len() < header_count_limit;
+        // all headers that were available at the moment.
+        self.have_sent_all_headers = headers.len() < header_count_limit;
 
         self.send_headers(HeaderList::new(headers))
     }
@@ -525,6 +525,11 @@ where
             })
             .await?;
 
+        // TODO: technically, we should also check that the requested blocks are not in
+        // blocks_queue already. But it's not that important - an honest peer
+        // won't send requests for the same block multiple times and a malicious one
+        // won't be able to exploit it much due to the limit on blocks_queue's size.
+
         self.outgoing.blocks_queue.extend(block_ids.into_iter());
 
         Ok(())
@@ -597,33 +602,32 @@ where
         self.wait_for_clock_diff(last_header.timestamp()).await;
 
         // The first header must be connected to a known block (it can be in
-        // the chainstate, pending_headers or requested_blocks).
+        // the chainstate or requested_blocks).
         let first_header_prev_id = *headers
             .first()
             // This is OK because of the `headers.is_empty()` check above.
             .expect("Headers shouldn't be empty")
             .prev_block_id();
 
+        // Note: we require a peer to send headers starting from a block that we already have
+        // in our chainstate or to one that we've already requested from the peer.
+        // I.e. peers shouldn't track what block headers they've sent us already and use
+        // the last header (best_sent_block_header) as a starting point for future HeaderList
+        // updates.
+        // This restriction is needed to prevent malicious peers from flooding the node with
+        // headers, potentially exhausting the node's memory.
+        // The downside of this is that the peer may have to send the same headers multiple times.
+        // So, to avoid extra traffic, an honest peer should't send header updates when the node
+        // is already downloading blocks. But still, the node shouldn't punish the peer for
+        // doing so, because it's possible for it to do so on accident, e.g. a "new tip" event
+        // may happen on the peer's side after it has sent us the last requested block but
+        // before we've asked it for more.
+
         let first_header_is_connected_to_chainstate = self
             .chainstate_handle
             .call(move |c| Ok(c.get_gen_block_index(&first_header_prev_id)?))
             .await?
             .is_some();
-
-        let first_header_is_connected_to_pending_headers = {
-            // If the peer reorged, the new header list may not start where the previous one ended.
-            // If so, the non-connecting old headers are now considered stale by the peer, so
-            // we should remove them from pending_headers.
-            while let Some(known_header) = self.incoming.pending_headers.last() {
-                if known_header.get_id() == first_header_prev_id {
-                    break;
-                }
-
-                self.incoming.pending_headers.pop();
-            }
-
-            !self.incoming.pending_headers.is_empty()
-        };
 
         let first_header_is_connected_to_requested_blocks = first_header_prev_id
             .classify(&self.chain_config)
@@ -632,30 +636,9 @@ where
             .is_some();
 
         if !(first_header_is_connected_to_chainstate
-            || first_header_is_connected_to_pending_headers
             || first_header_is_connected_to_requested_blocks)
         {
             return Err(P2pError::ProtocolError(ProtocolError::DisconnectedHeaders));
-        }
-
-        let already_downloading_blocks = if !self.incoming.requested_blocks.is_empty() {
-            true
-        } else if !self.incoming.pending_headers.is_empty() {
-            log::debug!(
-                concat!(
-                    "[peer id = {}] self.incoming.requested_blocks is empty, ",
-                    "but self.incoming.pending_headers is not"
-                ),
-                self.id()
-            );
-            true
-        } else {
-            false
-        };
-
-        if already_downloading_blocks {
-            self.incoming.pending_headers.extend(headers.into_iter());
-            return Ok(());
         }
 
         let peer_may_have_more_headers =
@@ -680,6 +663,15 @@ where
             .await?;
 
         self.incoming.peers_best_block_that_we_have = peers_best_block_that_we_have;
+
+        if !self.incoming.requested_blocks.is_empty() {
+            // We are already downloading blocks, so bail out.
+            // Note that we unconditionally replace pending_headers with new_block_headers
+            // even if the latter is empty (because this will just mean that the peer has reorged
+            // to something similar to our mainchain, so the old pending_headers are stale now).
+            self.incoming.pending_headers = new_block_headers;
+            return Ok(());
+        }
 
         if new_block_headers.is_empty() {
             if peer_may_have_more_headers {
@@ -904,12 +896,7 @@ where
     fn request_blocks(&mut self, mut headers: Vec<SignedBlockHeader>) -> Result<()> {
         debug_assert!(self.incoming.pending_headers.is_empty());
         debug_assert!(self.incoming.requested_blocks.is_empty());
-
-        // Remove already requested blocks.
-        headers.retain(|h| !self.incoming.requested_blocks.contains(&h.get_id()));
-        if headers.is_empty() {
-            return Ok(());
-        }
+        debug_assert!(!headers.is_empty());
 
         if headers.len() > *self.p2p_config.protocol_config.max_request_blocks_count {
             self.incoming.pending_headers =
@@ -950,6 +937,18 @@ where
         // to delete block indices of missing blocks when resetting their failure flags).
         // P2p should handle such situations correctly (see issue #1033 for more details).
         let block = block?.unwrap_or_else(|| panic!("Unknown block requested: {id}"));
+
+        // TODO: technically, the blocks may be sent out of order, so best_sent_block may not
+        // be set correctly here.
+        // Note that it doesn't seem to be a serious issue at this moment, because if two Mintlayer
+        // nodes are communicating, then headers in header requests will be ordered and block requests
+        // by the other side will re-use that order; then, the sender will put the requested block
+        // ids in a queue and send_block will re-use that order as well.
+        // I.e. this may be an issue only if the peer is trying to do something shady. But the only
+        // problem that may arise from an incorrect best_sent_block is that we may send the peer
+        // an unconnected list of headers next time. Which is not a big deal provided that the peer
+        // already behaves in a suspicious way.
+        // But this is still not very reliable and must be fixed.
         self.outgoing.best_sent_block = index?;
 
         log::debug!(

--- a/p2p/src/sync/peer_v2.rs
+++ b/p2p/src/sync/peer_v2.rs
@@ -716,6 +716,10 @@ where
         // The code below will set it again if needed.
         self.peer_activity.set_expecting_blocks_since(None);
 
+        // TODO: here we allow the peer to send blocks out of order. This means that we may receive
+        // an orphan block first and then its parent. Because of this, the NewTipReceived event
+        // generated below may not contain the actual tip. It doesn't seem like it may lead
+        // to problems at this moment, but it's still better to be more strict about it.
         if self.incoming.requested_blocks.take(&block.get_id()).is_none() {
             return Err(P2pError::ProtocolError(ProtocolError::UnexpectedMessage(
                 "block response".to_owned(),

--- a/p2p/src/sync/peer_v2.rs
+++ b/p2p/src/sync/peer_v2.rs
@@ -116,8 +116,8 @@ struct OutgoingDataState {
     /// The index of the best block that we've sent to the peer.
     best_sent_block: Option<BlockIndex>,
     /// The id of the best block header that we've sent to the peer.
-    /// Note: at this moment this field is only informational, i.e. we only print it to the log.
-    /// TODO: remove it?
+    // Note: at this moment this field is only informational, i.e. we only print it to the log.
+    // TODO: remove it?
     best_sent_block_header: Option<Id<GenBlock>>,
 }
 
@@ -253,7 +253,7 @@ where
             self.incoming.peers_best_block_that_we_have
         );
 
-        // Note: if we haven't sent all out headers last time, the peer will ask us for more anyway,
+        // Note: if we haven't sent all our headers last time, the peer will ask us for more anyway,
         // so no need to send the update just now.
         // Likewise, if the peer has requested blocks, it will send another header request once
         // it gets the blocks, so no need to send the update in this case either.
@@ -491,7 +491,8 @@ where
         // Check that all the blocks are known and haven't been already requested.
         // First check self.outgoing.blocks_queue
         let already_requested_blocks: BTreeSet<_> = self.outgoing.blocks_queue.iter().collect();
-        let doubly_requested_id = block_ids.iter().find(|id| already_requested_blocks.get(id).is_some());
+        let doubly_requested_id =
+            block_ids.iter().find(|id| already_requested_blocks.get(id).is_some());
         if let Some(id) = doubly_requested_id {
             return Err(P2pError::ProtocolError(
                 ProtocolError::DuplicatedBlockRequest(*id),
@@ -615,7 +616,7 @@ where
             .prev_block_id();
 
         // Note: we require a peer to send headers starting from a block that we already have
-        // in our chainstate or to one that we've already requested from the peer.
+        // in our chainstate or from one that we've already requested from the peer.
         // I.e. peers shouldn't track what block headers they've sent us already and use
         // the last header (best_sent_block_header) as a starting point for future HeaderList
         // updates.

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -33,7 +33,7 @@ use test_utils::random::Seed;
 use crate::{
     config::P2pConfig,
     error::ProtocolError,
-    message::{BlockListRequest, HeaderList, HeaderListRequest, SyncMessage},
+    message::{BlockListRequest, BlockResponse, HeaderList, HeaderListRequest, SyncMessage},
     protocol::{ProtocolConfig, SupportedProtocolVersion},
     sync::tests::helpers::TestNode,
     testing_utils::{for_each_protocol_version, test_p2p_config},
@@ -448,13 +448,13 @@ async fn valid_block(#[case] seed: Seed) {
     .await;
 }
 
-// Check that the best known header is taken into account when making block announcements.
+// Check that peer's best known block is taken into account when making block announcements.
 #[tracing::instrument(skip(seed))]
 #[rstest::rstest]
 #[trace]
 #[case(Seed::from_entropy())]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn best_known_header_is_considered(#[case] seed: Seed) {
+async fn best_known_block_is_considered(#[case] seed: Seed) {
     for_each_protocol_version(|protocol_version| async move {
         let mut rng = test_utils::random::make_seedable_rng(seed);
 
@@ -482,6 +482,9 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
         // I.e. we expect that though the node haven't sent any headers, it has remembered that
         // the peer already has the tip.
         {
+            // First, respond to node's initial header request (made inside connect_peer).
+            peer.send_headers(vec![]).await;
+
             let locator = node.get_locator_from_height(1.into()).await;
 
             peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
@@ -498,10 +501,11 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
             );
         }
 
-        {
+        let first_two_headers = {
             // Create two blocks. Note that this may result in generating two "ChainstateNewTip"
             // local events in rapid succession. But the implementation must make sure that only
             // one HeaderList message is produced.
+
             let headers = make_new_top_blocks_return_headers(
                 node.chainstate(),
                 time_getter.get_time_getter(),
@@ -521,15 +525,16 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
 
             log::debug!("Expecting no further announcements for now");
             node.assert_no_event().await;
-        }
 
-        // Note: since best_sent_block_header is not taken into account by V1, this portion
-        // of the test has to be disabled.
-        if protocol_version >= SupportedProtocolVersion::V2.into() {
-            // Do exactly the same as in the previous section; the expected result is the same as well.
-            // The purpose of this is to ensure that the node correctly takes into account
-            // headers that it has already sent (as opposed to what headers have been revealed
-            // by the peer, which is checked by the previous section).
+            headers
+        };
+
+        let second_two_headers = {
+            // Create two more blocks; the expected result is that the node will send both
+            // the previous two headers and the new ones.
+            // I.e. the node should not consider what headers it has sent previously; only the
+            // blocks that the peer has must be considered.
+
             let headers = make_new_top_blocks_return_headers(
                 node.chainstate(),
                 time_getter.get_time_getter(),
@@ -544,7 +549,101 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
             assert_eq!(sent_to, peer.get_id());
             assert_eq!(
                 message,
-                SyncMessage::HeaderList(HeaderList::new(headers.clone()))
+                SyncMessage::HeaderList(HeaderList::new(
+                    [&first_two_headers[..], &headers[..]].concat()
+                ))
+            );
+
+            log::debug!("Expecting no further announcements for now");
+            node.assert_no_event().await;
+
+            headers
+        };
+
+        let third_two_headers = {
+            // Now make a block request to the node and expect it to send the blocks.
+            // After that, create two more blocks and check that the header announcement
+            // doesn't include the headers of the already sent blocks.
+
+            log::debug!("Sending block list request to the node");
+            peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(
+                first_two_headers.iter().map(|hdr| hdr.block_id()).collect(),
+            )))
+            .await;
+
+            let block1 = node.get_block(first_two_headers[0].block_id()).await.unwrap();
+            let block2 = node.get_block(first_two_headers[1].block_id()).await.unwrap();
+
+            log::debug!("Expecting first block response");
+            let (sent_to, message) = node.get_sent_message().await;
+            assert_eq!(sent_to, peer.get_id());
+            assert_eq!(
+                message,
+                SyncMessage::BlockResponse(BlockResponse::new(block1))
+            );
+
+            log::debug!("Expecting second block response");
+            let (sent_to, message) = node.get_sent_message().await;
+            assert_eq!(sent_to, peer.get_id());
+            assert_eq!(
+                message,
+                SyncMessage::BlockResponse(BlockResponse::new(block2))
+            );
+
+            let headers = make_new_top_blocks_return_headers(
+                node.chainstate(),
+                time_getter.get_time_getter(),
+                &mut rng,
+                0,
+                2,
+            )
+            .await;
+
+            log::debug!("Expecting third announcement");
+            let (sent_to, message) = node.get_sent_message().await;
+            assert_eq!(sent_to, peer.get_id());
+            assert_eq!(
+                message,
+                SyncMessage::HeaderList(HeaderList::new(
+                    [&second_two_headers[..], &headers[..]].concat()
+                ))
+            );
+
+            log::debug!("Expecting no further announcements for now");
+            node.assert_no_event().await;
+
+            headers
+        };
+
+        {
+            // Send a header announcement from the peer containing second_two_headers.
+            // After that, create two more blocks on the node. The announcement that the node will
+            // send must not include second_two_headers, because the node must have remembered
+            // that the peer already has those blocks.
+
+            log::debug!("Sending header announcement to the node");
+            peer.send_headers(second_two_headers).await;
+
+            log::debug!("Expecting no events from the node for now");
+            node.assert_no_event().await;
+
+            let headers = make_new_top_blocks_return_headers(
+                node.chainstate(),
+                time_getter.get_time_getter(),
+                &mut rng,
+                0,
+                2,
+            )
+            .await;
+
+            log::debug!("Expecting fourth announcement");
+            let (sent_to, message) = node.get_sent_message().await;
+            assert_eq!(sent_to, peer.get_id());
+            assert_eq!(
+                message,
+                SyncMessage::HeaderList(HeaderList::new(
+                    [&third_two_headers[..], &headers[..]].concat()
+                ))
             );
 
             log::debug!("Expecting no further announcements for now");
@@ -558,12 +657,12 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
                 node.chainstate(),
                 time_getter.get_time_getter(),
                 &mut rng,
-                5,
-                6,
+                9,
+                10,
             )
             .await;
 
-            log::debug!("Expecting third announcement");
+            log::debug!("Expecting fifth announcement");
             let (sent_to, message) = node.get_sent_message().await;
             assert_eq!(sent_to, peer.get_id());
             assert_eq!(
@@ -578,4 +677,432 @@ async fn best_known_header_is_considered(#[case] seed: Seed) {
         node.join_subsystem_manager().await;
     })
     .await;
+}
+
+// Send two HeaderList messages to the node, where the headers of the second one are connected
+// to the headers in the first one, but not to anything else.
+// The node should see them as disconnected and increase the peer's ban score.
+#[tracing::instrument(skip(seed))]
+#[rstest::rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_headers_connected_to_previously_sent_headers_v2(#[case] seed: Seed) {
+    let protocol_version = SupportedProtocolVersion::V2.into();
+
+    let mut rng = test_utils::random::make_seedable_rng(seed);
+
+    let chain_config = Arc::new(create_unit_test_config());
+    let time_getter = P2pBasicTestTimeGetter::new();
+    let p2p_config = Arc::new(P2pConfig {
+        protocol_config: ProtocolConfig {
+            max_request_blocks_count: 1.into(),
+
+            msg_header_count_limit: Default::default(),
+            msg_max_locator_count: Default::default(),
+            max_message_size: Default::default(),
+            max_peer_tx_announcements: Default::default(),
+            max_singular_unconnected_headers: Default::default(),
+        },
+
+        bind_addresses: Default::default(),
+        socks5_proxy: Default::default(),
+        disable_noise: Default::default(),
+        boot_nodes: Default::default(),
+        reserved_nodes: Default::default(),
+        ban_threshold: Default::default(),
+        ban_duration: Default::default(),
+        outbound_connection_timeout: Default::default(),
+        ping_check_period: Default::default(),
+        ping_timeout: Default::default(),
+        max_clock_diff: Default::default(),
+        node_type: Default::default(),
+        allow_discover_private_ips: Default::default(),
+        user_agent: mintlayer_core_user_agent(),
+        sync_stalling_timeout: Default::default(),
+        enable_block_relay_peers: Default::default(),
+        connection_count_limits: Default::default(),
+    });
+
+    let initial_blocks = make_new_blocks(
+        &chain_config,
+        None,
+        &time_getter.get_time_getter(),
+        1,
+        &mut rng,
+    );
+    let mut node = TestNode::builder(protocol_version)
+        .with_chain_config(Arc::clone(&chain_config))
+        .with_p2p_config(Arc::clone(&p2p_config))
+        .with_blocks(initial_blocks.clone())
+        .build()
+        .await;
+
+    let peer = node.connect_peer(PeerId::new(), protocol_version).await;
+
+    let peers_blocks = make_new_blocks(
+        &chain_config,
+        Some(&initial_blocks[0]),
+        &time_getter.get_time_getter(),
+        4,
+        &mut rng,
+    );
+    let peers_block_headers: Vec<_> = peers_blocks.iter().map(|blk| blk.header().clone()).collect();
+
+    // Announce first 2 blocks to the node; the node should request one block (because it's the
+    // limit specified in p2p_config above).
+    log::debug!("Sending first 2 headers");
+    peer.send_headers(peers_block_headers[0..2].to_owned()).await;
+    let (sent_to, message) = node.get_sent_message().await;
+    assert_eq!(sent_to, peer.get_id());
+    assert_eq!(
+        message,
+        SyncMessage::BlockListRequest(BlockListRequest::new(vec![peers_blocks[0].get_id()]))
+    );
+    node.assert_no_peer_manager_event().await;
+
+    // Announce the second 2 blocks to the node.
+    // The node should see them as disconnected and increase the peer's ban score.
+    log::debug!("Sending second 2 headers");
+    peer.send_headers(peers_block_headers[2..4].to_owned()).await;
+
+    node.assert_peer_score_adjustment(
+        peer.get_id(),
+        P2pError::ProtocolError(ProtocolError::DisconnectedHeaders).ban_score(),
+    )
+    .await;
+
+    node.assert_no_event().await;
+    node.join_subsystem_manager().await;
+}
+
+// This is similar to send_headers_connected_to_previously_sent_headers, but here the second
+// header list is connected to a block which the node is trying to download. The headers
+// should not be considered disconnected in this case.
+#[tracing::instrument(skip(seed))]
+#[rstest::rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_headers_connected_to_block_which_is_being_downloaded(#[case] seed: Seed) {
+    for_each_protocol_version(|protocol_version| async move {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
+
+        let chain_config = Arc::new(create_unit_test_config());
+        let time_getter = P2pBasicTestTimeGetter::new();
+        let p2p_config = Arc::new(P2pConfig {
+            protocol_config: ProtocolConfig {
+                max_request_blocks_count: 1.into(),
+
+                msg_header_count_limit: Default::default(),
+                msg_max_locator_count: Default::default(),
+                max_message_size: Default::default(),
+                max_peer_tx_announcements: Default::default(),
+                max_singular_unconnected_headers: Default::default(),
+            },
+
+            bind_addresses: Default::default(),
+            socks5_proxy: Default::default(),
+            disable_noise: Default::default(),
+            boot_nodes: Default::default(),
+            reserved_nodes: Default::default(),
+            ban_threshold: Default::default(),
+            ban_duration: Default::default(),
+            outbound_connection_timeout: Default::default(),
+            ping_check_period: Default::default(),
+            ping_timeout: Default::default(),
+            max_clock_diff: Default::default(),
+            node_type: Default::default(),
+            allow_discover_private_ips: Default::default(),
+            user_agent: mintlayer_core_user_agent(),
+            sync_stalling_timeout: Default::default(),
+            enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
+        });
+
+        let initial_blocks = make_new_blocks(
+            &chain_config,
+            None,
+            &time_getter.get_time_getter(),
+            1,
+            &mut rng,
+        );
+        let mut node = TestNode::builder(protocol_version)
+            .with_chain_config(Arc::clone(&chain_config))
+            .with_p2p_config(Arc::clone(&p2p_config))
+            .with_blocks(initial_blocks.clone())
+            .build()
+            .await;
+
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
+
+        let peers_blocks = make_new_blocks(
+            &chain_config,
+            Some(&initial_blocks[0]),
+            &time_getter.get_time_getter(),
+            4,
+            &mut rng,
+        );
+        let peers_block_headers: Vec<_> =
+            peers_blocks.iter().map(|blk| blk.header().clone()).collect();
+
+        // Announce first 2 blocks to the node; the node should request one block (because it's the
+        // limit specified in p2p_config above).
+        log::debug!("Sending first 2 headers");
+        peer.send_headers(peers_block_headers[0..2].to_owned()).await;
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::BlockListRequest(BlockListRequest::new(vec![peers_blocks[0].get_id()]))
+        );
+        node.assert_no_peer_manager_event().await;
+
+        // Announce blocks 1, 2, 3 to the node - since block 1 is connected to block 0, which
+        // the node has already requested, the header list should not be considered disconnected.
+        log::debug!("Sending headers 1, 2, 3");
+        peer.send_headers(peers_block_headers[1..4].to_owned()).await;
+        node.assert_no_peer_manager_event().await;
+
+        node.assert_no_event().await;
+        node.join_subsystem_manager().await;
+    })
+    .await;
+}
+
+// The peer announces block headers 0, 1, 2, 3, while the header 2 is already in the node's
+// pending_headers.
+#[tracing::instrument(skip(seed))]
+#[rstest::rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn correct_pending_headers_update(#[case] seed: Seed) {
+    for_each_protocol_version(|protocol_version| async move {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
+
+        let chain_config = Arc::new(create_unit_test_config());
+        let time_getter = P2pBasicTestTimeGetter::new();
+        let p2p_config = Arc::new(P2pConfig {
+            protocol_config: ProtocolConfig {
+                max_request_blocks_count: 2.into(),
+
+                msg_header_count_limit: Default::default(),
+                msg_max_locator_count: Default::default(),
+                max_message_size: Default::default(),
+                max_peer_tx_announcements: Default::default(),
+                max_singular_unconnected_headers: Default::default(),
+            },
+
+            bind_addresses: Default::default(),
+            socks5_proxy: Default::default(),
+            disable_noise: Default::default(),
+            boot_nodes: Default::default(),
+            reserved_nodes: Default::default(),
+            ban_threshold: Default::default(),
+            ban_duration: Default::default(),
+            outbound_connection_timeout: Default::default(),
+            ping_check_period: Default::default(),
+            ping_timeout: Default::default(),
+            max_clock_diff: Default::default(),
+            node_type: Default::default(),
+            allow_discover_private_ips: Default::default(),
+            user_agent: mintlayer_core_user_agent(),
+            sync_stalling_timeout: Default::default(),
+            enable_block_relay_peers: Default::default(),
+            connection_count_limits: Default::default(),
+        });
+
+        let initial_blocks = make_new_blocks(
+            &chain_config,
+            None,
+            &time_getter.get_time_getter(),
+            1,
+            &mut rng,
+        );
+        let mut node = TestNode::builder(protocol_version)
+            .with_chain_config(Arc::clone(&chain_config))
+            .with_p2p_config(Arc::clone(&p2p_config))
+            .with_blocks(initial_blocks.clone())
+            .build()
+            .await;
+
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
+
+        let peers_blocks = make_new_blocks(
+            &chain_config,
+            Some(&initial_blocks[0]),
+            &time_getter.get_time_getter(),
+            4,
+            &mut rng,
+        );
+        let peers_block_headers: Vec<_> =
+            peers_blocks.iter().map(|blk| blk.header().clone()).collect();
+
+        // Announce first 3 blocks to the node; the node should request 2 blocks (because it's the
+        // limit specified in p2p_config above).
+        log::debug!("Sending first 3 headers");
+        peer.send_headers(peers_block_headers[0..3].to_owned()).await;
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::BlockListRequest(BlockListRequest::new(vec![
+                peers_blocks[0].get_id(),
+                peers_blocks[1].get_id()
+            ]))
+        );
+        node.assert_no_peer_manager_event().await;
+
+        // Simulate the following situation: the 4th block has just been produced but the peer hasn't
+        // yet received the block request, so it has to send all 4 headers.
+        // The node, which already has block 2 in its pending_headers collection, must update
+        // it correctly.
+        log::debug!("Sending headers 0, 1, 2, 3");
+        peer.send_headers(peers_block_headers[0..4].to_owned()).await;
+        node.assert_no_peer_manager_event().await;
+
+        log::debug!("Sending blocks 0, 1");
+        peer.send_message(SyncMessage::BlockResponse(BlockResponse::new(
+            peers_blocks[0].clone(),
+        )))
+        .await;
+        peer.send_message(SyncMessage::BlockResponse(BlockResponse::new(
+            peers_blocks[1].clone(),
+        )))
+        .await;
+
+        log::debug!("Expecting request for blocks 2, 3");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::BlockListRequest(BlockListRequest::new(vec![
+                peers_blocks[2].get_id(),
+                peers_blocks[3].get_id()
+            ]))
+        );
+        node.assert_no_peer_manager_event().await;
+
+        node.assert_no_event().await;
+        node.join_subsystem_manager().await;
+    })
+    .await;
+}
+
+// 1) Produce a block at the node while it's already sending blocks to the peer.
+// The node should not send the announcement just yet.
+// 2) Then produce another block after all requested ones has already been sent.
+// At this point the announcement should be sent.
+// Note: in some of the tests above we simulate the situation where the peer sends block
+// announcements while the node is downloading block from it. This is not a contradiction -
+// we allow peers to do so, but still want out nodes to avoid doing so, because it is redundant.
+#[tracing::instrument(skip(seed))]
+#[rstest::rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dont_make_announcements_while_blocks_are_being_sent_v2(#[case] seed: Seed) {
+    let protocol_version = SupportedProtocolVersion::V2.into();
+
+    let mut rng = test_utils::random::make_seedable_rng(seed);
+
+    let chain_config = Arc::new(create_unit_test_config());
+    let time_getter = P2pBasicTestTimeGetter::new();
+
+    let initial_blocks = make_new_blocks(
+        &chain_config,
+        None,
+        &time_getter.get_time_getter(),
+        10,
+        &mut rng,
+    );
+    let initial_block_headers: Vec<_> =
+        initial_blocks.iter().map(|blk| blk.header().clone()).collect();
+
+    let mut node = TestNode::builder(protocol_version)
+        .with_chain_config(Arc::clone(&chain_config))
+        .with_blocks(initial_blocks.clone())
+        .build()
+        .await;
+
+    let peer = node.connect_peer(PeerId::new(), protocol_version).await;
+
+    // Respond to node's initial header request (made inside connect_peer)
+    peer.send_headers(vec![]).await;
+
+    // Ask the node for headers
+    log::debug!("Sending header list request to the node");
+    let locator = node.get_locator_from_height(0.into()).await;
+    peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
+        locator,
+    )))
+    .await;
+
+    log::debug!("Expecting header list response");
+    let (sent_to, message) = node.get_sent_message().await;
+    assert_eq!(sent_to, peer.get_id());
+    assert_eq!(
+        message,
+        SyncMessage::HeaderList(HeaderList::new(initial_block_headers.clone()))
+    );
+
+    log::debug!("Sending block list request to the node");
+    peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(
+        initial_block_headers.iter().map(|hdr| hdr.block_id()).collect(),
+    )))
+    .await;
+
+    let mut intermediate_block_headers = Vec::new();
+
+    for (idx, blk) in initial_blocks.iter().enumerate() {
+        log::debug!("Expecting block response #{idx}");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::BlockResponse(BlockResponse::new(blk.clone()))
+        );
+
+        if idx == 0 {
+            log::debug!("Creating one more block");
+            intermediate_block_headers = make_new_top_blocks_return_headers(
+                node.chainstate(),
+                time_getter.get_time_getter(),
+                &mut rng,
+                0,
+                1,
+            )
+            .await;
+        }
+    }
+    assert_eq!(intermediate_block_headers.len(), 1);
+
+    node.assert_no_peer_manager_event().await;
+    node.assert_no_event().await;
+
+    let final_block_headers = make_new_top_blocks_return_headers(
+        node.chainstate(),
+        time_getter.get_time_getter(),
+        &mut rng,
+        0,
+        1,
+    )
+    .await;
+    assert_eq!(final_block_headers.len(), 1);
+
+    log::debug!("Expecting header list update");
+    let (sent_to, message) = node.get_sent_message().await;
+    assert_eq!(sent_to, peer.get_id());
+    assert_eq!(
+        message,
+        SyncMessage::HeaderList(HeaderList::new(vec![
+            intermediate_block_headers[0].clone(),
+            final_block_headers[0].clone()
+        ]))
+    );
+
+    node.assert_no_peer_manager_event().await;
+    node.assert_no_event().await;
+    node.join_subsystem_manager().await;
 }

--- a/p2p/src/sync/tests/block_list_request.rs
+++ b/p2p/src/sync/tests/block_list_request.rs
@@ -23,8 +23,7 @@ use common::{
 };
 use crypto::random::Rng;
 use logging::log;
-use p2p_test_utils::create_n_blocks;
-use p2p_test_utils::P2pBasicTestTimeGetter;
+use p2p_test_utils::{create_n_blocks, P2pBasicTestTimeGetter};
 use test_utils::random::Seed;
 
 use crate::{

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -159,7 +159,11 @@ impl TestNode {
     }
 
     pub async fn get_block(&self, block_id: Id<Block>) -> Option<Block> {
-        self.chainstate_handle.call(move |cs| cs.get_block(block_id)).await.unwrap().unwrap()
+        self.chainstate_handle
+            .call(move |cs| cs.get_block(block_id))
+            .await
+            .unwrap()
+            .unwrap()
     }
 
     pub fn mempool(&self) -> &MempoolHandle {

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -158,6 +158,10 @@ impl TestNode {
         &self.chainstate_handle
     }
 
+    pub async fn get_block(&self, block_id: Id<Block>) -> Option<Block> {
+        self.chainstate_handle.call(move |cs| cs.get_block(block_id)).await.unwrap().unwrap()
+    }
+
     pub fn mempool(&self) -> &MempoolHandle {
         &self.mempool_handle
     }

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -22,7 +22,7 @@ use p2p_types::socket_address::SocketAddress;
 use test_utils::random::Seed;
 use tokio::{
     sync::{
-        mpsc::{self, Sender, UnboundedReceiver, UnboundedSender},
+        mpsc::{self, Receiver, Sender, UnboundedReceiver, UnboundedSender},
         oneshot,
     },
     task::JoinHandle,
@@ -74,7 +74,7 @@ pub struct TestNode {
     p2p_config: Arc<P2pConfig>,
     peer_manager_event_receiver: UnboundedReceiver<PeerManagerEvent>,
     syncing_event_sender: UnboundedSender<SyncingEvent>,
-    sync_msg_receiver: UnboundedReceiver<(PeerId, SyncMessage)>,
+    sync_msg_receiver: Receiver<(PeerId, SyncMessage)>,
     error_receiver: UnboundedReceiver<P2pError>,
     sync_manager_handle: JoinHandle<()>,
     shutdown_trigger: ShutdownTrigger,
@@ -106,10 +106,11 @@ impl TestNode {
         subsystem_manager_handle: ManagerJoinHandle,
         time_getter: TimeGetter,
         protocol_version: ProtocolVersion,
+        sync_msg_channel_buffer_size: usize,
     ) -> Self {
         let (peer_manager_event_sender, peer_manager_event_receiver) = mpsc::unbounded_channel();
 
-        let (sync_msg_sender, sync_msg_receiver) = mpsc::unbounded_channel();
+        let (sync_msg_sender, sync_msg_receiver) = mpsc::channel(sync_msg_channel_buffer_size);
         let (syncing_event_sender, syncing_event_receiver) = mpsc::unbounded_channel();
         let messaging_handle = MessagingHandleMock { sync_msg_sender };
         let syncing_event_receiver_mock = SyncingEventReceiverMock {
@@ -266,7 +267,7 @@ impl TestNode {
         .unwrap_err();
     }
 
-    /// Panics if there is an event from the peer manager (except for the NewTipReceived/NewValidTransactionReceived messages)
+    /// Panics if there is an event from the peer manager (except for the NewTipReceived/NewChainstateTip/NewValidTransactionReceived messages)
     // TODO: Rename the function
     pub async fn assert_no_peer_manager_event(&mut self) {
         time::timeout(SHORT_TIMEOUT, async {
@@ -380,6 +381,7 @@ pub struct TestNodeBuilder {
     time_getter: TimeGetter,
     blocks: Vec<Block>,
     protocol_version: ProtocolVersion,
+    sync_msg_channel_buffer_size: usize,
 }
 
 impl TestNodeBuilder {
@@ -391,6 +393,12 @@ impl TestNodeBuilder {
             time_getter: TimeGetter::default(),
             blocks: Vec::new(),
             protocol_version,
+            // Note: setting the default value here to something small is not a good idea,
+            // because many tests don't care about reading all sync messages. If that happens,
+            // the corresponding Peer task and the test itself may freeze up.
+            // Note: can't use usize::MAX here; also, the actual MAX constant is not exposed,
+            // so we use u32::MAX.
+            sync_msg_channel_buffer_size: u32::MAX as usize,
         }
     }
 
@@ -419,6 +427,11 @@ impl TestNodeBuilder {
         self
     }
 
+    pub fn with_sync_msg_channel_buffer_size(mut self, size: usize) -> Self {
+        self.sync_msg_channel_buffer_size = size;
+        self
+    }
+
     pub async fn build(self) -> TestNode {
         let TestNodeBuilder {
             chain_config,
@@ -427,6 +440,7 @@ impl TestNodeBuilder {
             time_getter,
             blocks,
             protocol_version,
+            sync_msg_channel_buffer_size,
         } = self;
 
         let mut manager = subsystem::Manager::new("p2p-sync-test-manager");
@@ -466,6 +480,7 @@ impl TestNodeBuilder {
             manager_handle,
             time_getter,
             protocol_version,
+            sync_msg_channel_buffer_size,
         )
         .await
     }
@@ -506,12 +521,13 @@ impl NetworkingService for NetworkingServiceStub {
 
 #[derive(Clone)]
 struct MessagingHandleMock {
-    sync_msg_sender: UnboundedSender<(PeerId, SyncMessage)>,
+    sync_msg_sender: Sender<(PeerId, SyncMessage)>,
 }
 
+#[async_trait]
 impl MessagingService for MessagingHandleMock {
-    fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> Result<()> {
-        self.sync_msg_sender.send((peer, message)).unwrap();
+    async fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> Result<()> {
+        self.sync_msg_sender.send((peer, message)).await.unwrap();
         Ok(())
     }
 }

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -309,7 +309,7 @@ impl TestNodeGroup {
         self.prevent_peer_manager_events = set;
     }
 
-    /// NewTipReceived/NewValidTransactionReceived messages are ignored
+    /// NewTipReceived/NewChainstateTip/NewValidTransactionReceived messages are ignored
     // TODO: Rename the function
     fn assert_no_peer_manager_events_if_needed(&mut self) {
         if self.prevent_peer_manager_events {


### PR DESCRIPTION
The following was done for both v1 and v2:

1) Fix potential header flooding by a malicious peer.
The node no longer allows new block headers to connect to `pending_headers` only.
Conversely, when sending new headers, v2 node no longer takes `best_sent_block_header` into account (and v1 didn't do this anyway).

2) Nodes no longer send block announcements if `outgoing.blocks_queue` is non-empty (because the peer will send a header request anyway when it's done downloading the blocks).

3) The check for a duplicate block request was only working for already downloaded blocks, but not for those which are inside `outgoing.blocks_queue`. I've added an additional check.

4) I renamed the flag `send_tip_updates` to `have_sent_all_headers`, because it's exactly what it means.

P.S. The fix for the failing test is in the separate PR #1309

Edit: PRs #1309 and #1316 were also merged into this one