### PR TITLE
Make block production recognize recoverable errors when collecting transactions

### DIFF
--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -189,11 +189,11 @@ mod collect_transactions {
         mock_mempool
             .expect_collect_txs()
             .returning(|_, _, _| {
-                Ok(Box::new(DefaultTxAccumulator::new(
+                Ok(Some(Box::new(DefaultTxAccumulator::new(
                     usize::default(),
                     Id::new(H256::zero()),
                     DUMMY_TIMESTAMP,
-                )))
+                ))))
             })
             .times(1);
 

--- a/mempool/src/error/mod.rs
+++ b/mempool/src/error/mod.rs
@@ -32,8 +32,6 @@ use crate::pool::fee::Fee;
 pub enum BlockConstructionError {
     #[error(transparent)]
     Validity(#[from] TxValidationError),
-    #[error("The tip expected by accumulator ({0:?}) does not match mempool tip ({1:?})")]
-    AccumTipMismatch(Id<GenBlock>, Id<GenBlock>),
     #[error("The moved during block construction: {0:?} -> {1:?}")]
     TipMoved(Id<GenBlock>, Id<GenBlock>),
     #[error("Subsystem call: {0}")]

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -60,12 +60,15 @@ pub trait MempoolInterface: Send + Sync {
     fn best_block_id(&self) -> Id<GenBlock>;
 
     /// Collect transactions by putting them in given accumulator
+    /// Returns the accumulator with the collected transactions
+    /// Ok(None) is returned on recoverable errors, such as if
+    /// the tip changed before collecting transactions started.
     fn collect_txs(
         &self,
         tx_accumulator: Box<dyn TransactionAccumulator + Send>,
         transaction_ids: Vec<Id<Transaction>>,
         packing_strategy: PackingStrategy,
-    ) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError>;
+    ) -> Result<Option<Box<dyn TransactionAccumulator>>, BlockConstructionError>;
 
     /// Subscribe to events emitted by mempool
     fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>);

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -172,7 +172,7 @@ impl MempoolInterface for MempoolImpl {
         tx_accumulator: Box<dyn TransactionAccumulator + Send>,
         transaction_ids: Vec<Id<Transaction>>,
         packing_strategy: PackingStrategy,
-    ) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError> {
+    ) -> Result<Option<Box<dyn TransactionAccumulator>>, BlockConstructionError> {
         self.mempool.collect_txs(tx_accumulator, transaction_ids, packing_strategy)
     }
 

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -957,7 +957,7 @@ impl<M: MemoryUsageEstimator> Mempool<M> {
         tx_accumulator: Box<dyn TransactionAccumulator>,
         transaction_ids: Vec<Id<Transaction>>,
         packing_strategy: PackingStrategy,
-    ) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError> {
+    ) -> Result<Option<Box<dyn TransactionAccumulator>>, BlockConstructionError> {
         collect_txs::collect_txs(self, tx_accumulator, transaction_ids, packing_strategy)
     }
 

--- a/mempool/src/pool/tests/accumulator.rs
+++ b/mempool/src/pool/tests/accumulator.rs
@@ -111,8 +111,12 @@ async fn transaction_order_respects_deps(#[case] seed: Seed) {
     let accumulator = mempool
         .collect_txs(accumulator, vec![], PackingStrategy::FillSpaceFromMempool)
         .unwrap();
-    let tx_ids: Vec<_> =
-        accumulator.transactions().iter().map(|tx| tx.transaction().get_id()).collect();
+    let tx_ids: Vec<_> = accumulator
+        .unwrap()
+        .transactions()
+        .iter()
+        .map(|tx| tx.transaction().get_id())
+        .collect();
 
     assert_eq!(tx_ids, vec![tx0_id, tx1_id, tx2_id]);
 }
@@ -154,6 +158,7 @@ async fn transaction_graph_respects_deps(#[case] seed: Seed) {
         )
         .unwrap();
     let position_map: BTreeMap<Id<Transaction>, usize> = accumulator
+        .unwrap()
         .transactions()
         .iter()
         .enumerate()
@@ -189,7 +194,8 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
             PackingStrategy::FillSpaceFromMempool,
         )
         .unwrap();
-    let collected_txs = returned_accumulator.transactions();
+    let collected_txs = returned_accumulator.unwrap();
+    let collected_txs = collected_txs.transactions();
     let expected_num_txs_collected: usize = 0;
     assert_eq!(collected_txs.len(), expected_num_txs_collected);
 
@@ -232,7 +238,8 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
             PackingStrategy::FillSpaceFromMempool,
         )
         .unwrap();
-    let collected_txs = returned_accumulator.transactions();
+    let collected_txs = returned_accumulator.unwrap();
+    let collected_txs = collected_txs.transactions();
     log::debug!("ancestor index: {:?}", mempool.store.txs_by_ancestor_score);
     let expected_num_txs_collected = 6;
     assert_eq!(collected_txs.len(), expected_num_txs_collected);
@@ -247,7 +254,8 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
             PackingStrategy::FillSpaceFromMempool,
         )
         .unwrap();
-    let collected_txs = returned_accumulator.transactions();
+    let collected_txs = returned_accumulator.unwrap();
+    let collected_txs = collected_txs.transactions();
     assert_eq!(collected_txs.len(), 0);
 
     let tx_accumulator = DefaultTxAccumulator::new(1, mempool.best_block_id(), DUMMY_TIMESTAMP);
@@ -258,7 +266,8 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
             PackingStrategy::FillSpaceFromMempool,
         )
         .unwrap();
-    let collected_txs = returned_accumulator.transactions();
+    let collected_txs = returned_accumulator.unwrap();
+    let collected_txs = collected_txs.transactions();
     assert_eq!(collected_txs.len(), 0);
     Ok(())
 }
@@ -362,8 +371,12 @@ async fn timelocked(#[case] seed: Seed, #[case] timelock: OutputTimeLock, #[case
     let accumulator = mempool
         .collect_txs(accumulator, vec![], PackingStrategy::FillSpaceFromMempool)
         .unwrap();
-    let accumulated_ids: BTreeSet<_> =
-        accumulator.transactions().iter().map(|tx| tx.transaction().get_id()).collect();
+    let accumulated_ids: BTreeSet<_> = accumulator
+        .unwrap()
+        .transactions()
+        .iter()
+        .map(|tx| tx.transaction().get_id())
+        .collect();
 
     assert!(accumulated_ids.contains(&tx0_id));
     assert_eq!(accumulated_ids.contains(&tx1_id), in_accumulator_at0);
@@ -396,6 +409,7 @@ async fn timelocked(#[case] seed: Seed, #[case] timelock: OutputTimeLock, #[case
     ));
     let accumulator = mempool
         .collect_txs(accumulator, vec![], PackingStrategy::FillSpaceFromMempool)
+        .unwrap()
         .unwrap();
     let has_tx1 = accumulator.transactions().iter().any(|tx| tx.transaction().get_id() == tx1_id);
 

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -57,7 +57,7 @@ mockall::mock! {
             tx_accumulator: Box<dyn TransactionAccumulator + Send>,
             transaction_ids: Vec<Id<Transaction>>,
             packing_strategy: PackingStrategy,
-        ) -> Result<Box<dyn TransactionAccumulator>, BlockConstructionError>;
+        ) -> Result<Option<Box<dyn TransactionAccumulator>>, BlockConstructionError>;
 
         fn subscribe_to_events(&mut self, handler: Arc<dyn Fn(MempoolEvent) + Send + Sync>);
         fn memory_usage(&self) -> usize;


### PR DESCRIPTION
Apparently, while generating many blocks in the wallet, it's possible that block production fails due to a race between the mempool and chainstate. The following logs are from an incident in CI.

```
2023-10-27T13:10:46.419995Z DEBUG hyper::proto::h1::conn: incoming body is content-length (999 bytes)
  left: "Controller error: Node call error: Response error: RPC call failed: ErrorObject { code: ServerError(-32000), message: \"Mempool failed to construct block: The tip expected by accumulator (Id<GenBlock>{0x59cf32c1c805d755e98f9b4c39179c371f526e0e2b30845f6e1e8fc67727ec48}) does not match mempool tip (Id<GenBlock>{0x3d5b1d13f3f8b0da0b1219f280ef2fc2ef10c86e48be00d9c55afa1ce45b46b1})\", data: None }"
2023-10-27T13:10:46.420013Z DEBUG hyper::proto::h1::conn: incoming body completed
 right: "Success"
```

The race between chainstate and mempool isn't anything new; however, returning an error in BlockProduction for that is wrong. This PR makes it possible to recognize that another attempt is in order.