### PR TITLE
Attempt to fix spuriously failing test "dont_make_announcements_while_blocks_are_being_sent"

### DIFF
--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -133,12 +133,14 @@ where
         };
         messaging_handle_2
             .send_message(peer, SyncMessage::HeaderList(HeaderList::new(Vec::new())))
+            .await
             .unwrap();
         messaging_handle_2
             .send_message(
                 peer,
                 SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
             )
+            .await
             .unwrap();
     });
 

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -94,6 +94,7 @@ where
             peer2.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
+        .await
         .unwrap();
 
     let mut sync_msg_rx_2 = match sync2.poll_next().await.unwrap() {
@@ -130,6 +131,7 @@ where
             peer1.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
+        .await
         .unwrap();
 
     let mut sync_msg_rx_1 = match sync1.poll_next().await.unwrap() {
@@ -236,6 +238,7 @@ where
             peer2.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
+        .await
         .unwrap();
 
     shutdown.store(true);

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -49,8 +49,15 @@ pub enum ProtocolError {
     DuplicatedBlockRequest(Id<Block>),
     #[error("Headers aren't connected")]
     DisconnectedHeaders,
-    #[error("Received a message ({0}) that wasn't expected")]
+    #[error("Peer sent a message ({0}) that wasn't expected")]
     UnexpectedMessage(String),
+    #[error("Peer sent a block ({0}) that wasn't requested")]
+    UnsolicitedBlockReceived(Id<Block>),
+    #[error("Peer sent block {expected_block_id} while it was expected to send {actual_block_id}")]
+    BlocksReceivedInWrongOrder {
+        expected_block_id: Id<Block>,
+        actual_block_id: Id<Block>,
+    },
     #[error("Empty block list requested")]
     ZeroBlocksInRequest,
     #[error("Handshake expected")]
@@ -227,6 +234,11 @@ impl BanScore for ProtocolError {
             ProtocolError::DuplicatedBlockRequest(_) => 20,
             ProtocolError::DisconnectedHeaders => 20,
             ProtocolError::UnexpectedMessage(_) => 20,
+            ProtocolError::UnsolicitedBlockReceived(_) => 20,
+            ProtocolError::BlocksReceivedInWrongOrder {
+                expected_block_id: _,
+                actual_block_id: _,
+            } => 20,
             ProtocolError::ZeroBlocksInRequest => 20,
             ProtocolError::HandshakeExpected => 100,
             ProtocolError::AddressListLimitExceeded => 100,

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -146,12 +146,6 @@ where
 impl MessagingService for MessagingHandle {
     async fn send_message(&mut self, peer_id: PeerId, message: SyncMessage) -> crate::Result<()> {
         // Note: send_message was made async to be able to use a bounded channel in tests.
-        // TODO: it may make sense to use a bounded channel in production as well. One possible
-        // reason for this might be to limit the number of BlockResponse messages that can exist
-        // at the same time. E.g. currently sync::Peer will produce a BlockResponse for each
-        // requested block almost immediately. The maximum number of simultaneously requested
-        // blocks is 500 per peer, a block can be up to 1Mb in size, so several malicious peers
-        // can eat up several Gb of RAM on the node.
         Ok(self.command_sender.send(types::Command::SendMessage {
             peer_id,
             message: message.into(),

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -122,9 +122,10 @@ where
 }
 
 /// An interface for sending messages and announcements to peers.
+#[async_trait]
 pub trait MessagingService: Clone {
     /// Sends a message to the peer.
-    fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()>;
+    async fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()>;
 }
 
 #[async_trait]

--- a/p2p/src/sync/peer_v1.rs
+++ b/p2p/src/sync/peer_v1.rs
@@ -290,11 +290,8 @@ where
                     .await?;
 
                 if headers.is_empty() {
-                    log::warn!(
-                        concat!(
-                            "[peer id = {}] Got new tip event with block id {}, ",
-                            "but there is nothing to send"
-                        ),
+                    log::debug!(
+                        "[peer id = {}] Got new tip event with block id {}, but there is nothing to send",
                         self.id(),
                         new_tip_id,
                     );
@@ -302,11 +299,8 @@ where
                     // If we got here, another "new tip" event should be generated soon,
                     // so we may ignore this one (and it makes sense to ignore it to avoid sending
                     // the same header list multiple times).
-                    log::warn!(
-                        concat!(
-                            "[peer id = {}] Got new tip event with block id {}, ",
-                            "but the tip has changed since then to {}"
-                        ),
+                    log::info!(
+                        "[peer id = {}] Got new tip event with block id {}, but the tip has changed since then to {}",
                         self.id(),
                         new_tip_id,
                         best_block_id
@@ -357,9 +351,6 @@ where
     async fn request_headers(&mut self) -> Result<()> {
         let locator = self.chainstate_handle.call(|this| Ok(this.get_locator()?)).await?;
         if locator.len() > *self.p2p_config.protocol_config.msg_max_locator_count {
-            // Note: msg_max_locator_count is not supposed to be configurable outside of tests,
-            // so we should never get here in production code. Moreover, currently it's not
-            // modified even in tests. TODO: make it a constant.
             log::warn!(
                 "[peer id = {}] Sending locator of the length {}, which exceeds the maximum length {:?}",
                 self.id(),

--- a/p2p/src/sync/peer_v2.rs
+++ b/p2p/src/sync/peer_v2.rs
@@ -287,11 +287,8 @@ where
                     .await?;
 
                 if headers.is_empty() {
-                    log::warn!(
-                        concat!(
-                            "[peer id = {}] Got new tip event with block id {}, ",
-                            "but there is nothing to send"
-                        ),
+                    log::debug!(
+                        "[peer id = {}] Got new tip event with block id {}, but there is nothing to send",
                         self.id(),
                         new_tip_id,
                     );
@@ -300,10 +297,7 @@ where
                     // so we may ignore this one (and it makes sense to ignore it to avoid sending
                     // the same header list multiple times).
                     log::warn!(
-                        concat!(
-                            "[peer id = {}] Got new tip event with block id {}, ",
-                            "but the tip has changed since then to {}"
-                        ),
+                        "[peer id = {}] Got new tip event with block id {}, but the tip has changed since then to {}",
                         self.id(),
                         new_tip_id,
                         best_block_id
@@ -354,10 +348,6 @@ where
     async fn request_headers(&mut self) -> Result<()> {
         let locator = self.chainstate_handle.call(|this| Ok(this.get_locator()?)).await?;
         if locator.len() > *self.p2p_config.protocol_config.msg_max_locator_count {
-            // Note: msg_max_locator_count is not supposed to be configurable outside of tests,
-            // so we should never get here in production code. Moreover, currently it's not
-            // modified even in tests. TODO: make it a constant.
-            // See https://github.com/mintlayer/mintlayer-core/issues/1201
             log::warn!(
                 "[peer id = {}] Sending locator of the length {}, which exceeds the maximum length {:?}",
                 self.id(),

--- a/p2p/src/sync/peer_v2.rs
+++ b/p2p/src/sync/peer_v2.rs
@@ -103,7 +103,7 @@ struct IncomingDataState {
     /// requested the blocks for.
     pending_headers: Vec<SignedBlockHeader>,
     /// A list of blocks that we requested from this peer.
-    requested_blocks: BTreeSet<Id<Block>>,
+    requested_blocks: VecDeque<Id<Block>>,
     /// The id of the best block header that we've received from the peer and that we also have.
     /// This includes headers received by any means, e.g. via HeaderList messages, as part
     /// of a locator during peer's header requests, via block responses.
@@ -156,7 +156,7 @@ where
             time_getter,
             incoming: IncomingDataState {
                 pending_headers: Vec::new(),
-                requested_blocks: BTreeSet::new(),
+                requested_blocks: VecDeque::new(),
                 peers_best_block_that_we_have: None,
             },
             outgoing: OutgoingDataState {
@@ -700,14 +700,28 @@ where
         // The code below will set it again if needed.
         self.peer_activity.set_expecting_blocks_since(None);
 
-        // TODO: here we allow the peer to send blocks out of order. This means that we may receive
-        // an orphan block first and then its parent. Because of this, the NewTipReceived event
-        // generated below may not contain the actual tip. It doesn't seem like it may lead
-        // to problems at this moment, but it's still better to be more strict about it.
-        if self.incoming.requested_blocks.take(&block.get_id()).is_none() {
-            return Err(P2pError::ProtocolError(ProtocolError::UnexpectedMessage(
-                "block response".to_owned(),
-            )));
+        if self.incoming.requested_blocks.front().is_some_and(|id| id == &block.get_id()) {
+            self.incoming.requested_blocks.pop_front();
+        } else {
+            let idx = self.incoming.requested_blocks.iter().position(|id| id == &block.get_id());
+            // Note: we treat wrongly ordered blocks in the same way as unsolicited ones, i.e.
+            // we don't remove their ids from the list.
+            if idx.is_some() {
+                return Err(P2pError::ProtocolError(
+                    ProtocolError::BlocksReceivedInWrongOrder {
+                        expected_block_id: *self
+                            .incoming
+                            .requested_blocks
+                            .front()
+                            .expect("The deque is known to be non-empty"),
+                        actual_block_id: block.get_id(),
+                    },
+                ));
+            } else {
+                return Err(P2pError::ProtocolError(
+                    ProtocolError::UnsolicitedBlockReceived(block.get_id()),
+                ));
+            }
         }
 
         let block = self.chainstate_handle.call(|c| Ok(c.preliminary_block_check(block)?)).await?;
@@ -916,7 +930,7 @@ where
     }
 
     async fn send_block(&mut self, id: Id<Block>) -> Result<()> {
-        let (block, index) = self
+        let (block, block_index) = self
             .chainstate_handle
             .call(move |c| {
                 let index = c.get_block_index(&id);
@@ -931,19 +945,20 @@ where
         // to delete block indices of missing blocks when resetting their failure flags).
         // P2p should handle such situations correctly (see issue #1033 for more details).
         let block = block?.unwrap_or_else(|| panic!("Unknown block requested: {id}"));
+        let block_index = block_index?.expect("Block index must exist");
 
-        // TODO: technically, the blocks may be sent out of order, so best_sent_block may not
-        // be set correctly here.
-        // Note that it doesn't seem to be a serious issue at this moment, because if two Mintlayer
-        // nodes are communicating, then headers in header requests will be ordered and block requests
-        // by the other side will re-use that order; then, the sender will put the requested block
-        // ids in a queue and send_block will re-use that order as well.
-        // I.e. this may be an issue only if the peer is trying to do something shady. But the only
-        // problem that may arise from an incorrect best_sent_block is that we may send the peer
-        // an unconnected list of headers next time. Which is not a big deal provided that the peer
-        // already behaves in a suspicious way.
-        // But this is still not very reliable and must be fixed.
-        self.outgoing.best_sent_block = index?;
+        let old_best_sent_block_id = self.outgoing.best_sent_block.as_ref().map(|idx| {
+            let id: Id<GenBlock> = (*idx.block_id()).into();
+            id
+        });
+        let new_best_sent_block_id = self
+            .chainstate_handle
+            .call(move |c| choose_peers_best_block(c, old_best_sent_block_id, Some(id.into())))
+            .await?;
+
+        if new_best_sent_block_id == Some(id.into()) {
+            self.outgoing.best_sent_block = Some(block_index);
+        }
 
         log::debug!(
             "[peer id = {}] Sending block with id = {} to the peer",

--- a/p2p/src/sync/peer_v2.rs
+++ b/p2p/src/sync/peer_v2.rs
@@ -222,15 +222,15 @@ where
         }
     }
 
-    fn send_message(&mut self, message: SyncMessage) -> Result<()> {
-        self.messaging_handle.send_message(self.id(), message)
+    async fn send_message(&mut self, message: SyncMessage) -> Result<()> {
+        self.messaging_handle.send_message(self.id(), message).await
     }
 
-    fn send_headers(&mut self, headers: HeaderList) -> Result<()> {
+    async fn send_headers(&mut self, headers: HeaderList) -> Result<()> {
         if let Some(last_header) = headers.headers().last() {
             self.outgoing.best_sent_block_header = Some(last_header.block_id().into());
         }
-        self.send_message(SyncMessage::HeaderList(headers))
+        self.send_message(SyncMessage::HeaderList(headers)).await
     }
 
     async fn handle_new_tip(&mut self, new_tip_id: &Id<Block>) -> Result<()> {
@@ -314,7 +314,7 @@ where
                         self.id(),
                         headers.len()
                     );
-                    return self.send_headers(HeaderList::new(headers));
+                    return self.send_headers(HeaderList::new(headers)).await;
                 }
             } else {
                 // Note: if we got here, then we haven't received a single header request or
@@ -343,7 +343,7 @@ where
                     && self.common_services.has_service(Service::Transactions)
                 {
                     self.add_known_transaction(txid);
-                    self.send_message(SyncMessage::NewTransaction(txid))
+                    self.send_message(SyncMessage::NewTransaction(txid)).await
                 } else {
                     Ok(())
                 }
@@ -369,7 +369,8 @@ where
         log::debug!("[peer id = {}] Sending header list request", self.id());
         self.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
             locator,
-        )))?;
+        )))
+        .await?;
 
         self.peer_activity
             .set_expecting_headers_since(Some(self.time_getter.get_time()));
@@ -409,7 +410,7 @@ where
         if self.chainstate_handle.is_initial_block_download().await? {
             log::debug!("[peer id = {}] Responding with empty headers list because the node is in initial block download", self.id());
             // Respond with an empty list to avoid being marked as stalled
-            self.send_headers(HeaderList::new(Vec::new()))?;
+            self.send_headers(HeaderList::new(Vec::new())).await?;
             return Ok(());
         }
 
@@ -445,7 +446,7 @@ where
         // all headers that were available at the moment.
         self.have_sent_all_headers = headers.len() < header_count_limit;
 
-        self.send_headers(HeaderList::new(headers))
+        self.send_headers(HeaderList::new(headers)).await
     }
 
     /// Processes the blocks request.
@@ -694,7 +695,7 @@ where
                 .await?;
         }
 
-        self.request_blocks(new_block_headers)
+        self.request_blocks(new_block_headers).await
     }
 
     async fn handle_block_response(&mut self, block: Block) -> Result<()> {
@@ -777,7 +778,7 @@ where
                 self.request_headers().await?;
             } else {
                 // Download remaining blocks.
-                self.request_blocks(headers)?;
+                self.request_blocks(headers).await?;
             }
         } else {
             // We expect additional blocks from the peer, update the timestamp.
@@ -800,7 +801,7 @@ where
             None => TransactionResponse::NotFound(id),
         };
 
-        self.send_message(SyncMessage::TransactionResponse(res))?;
+        self.send_message(SyncMessage::TransactionResponse(res)).await?;
 
         Ok(())
     }
@@ -884,7 +885,7 @@ where
         }
 
         if !(self.mempool_handle.call(move |m| m.contains_transaction(&tx)).await?) {
-            self.send_message(SyncMessage::TransactionRequest(tx))?;
+            self.send_message(SyncMessage::TransactionRequest(tx)).await?;
             assert!(self.announced_transactions.insert(tx));
         }
 
@@ -895,7 +896,7 @@ where
     ///
     /// The number of blocks requested equals `P2pConfig::requested_blocks_limit`, the remaining
     /// headers are stored in the peer context.
-    fn request_blocks(&mut self, mut headers: Vec<SignedBlockHeader>) -> Result<()> {
+    async fn request_blocks(&mut self, mut headers: Vec<SignedBlockHeader>) -> Result<()> {
         debug_assert!(self.incoming.pending_headers.is_empty());
         debug_assert!(self.incoming.requested_blocks.is_empty());
         debug_assert!(!headers.is_empty());
@@ -915,7 +916,8 @@ where
         );
         self.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(
             block_ids.clone(),
-        )))?;
+        )))
+        .await?;
         self.incoming.requested_blocks.extend(block_ids);
 
         self.peer_activity.set_expecting_blocks_since(Some(self.time_getter.get_time()));
@@ -958,7 +960,7 @@ where
             self.id(),
             block.get_id()
         );
-        self.send_message(SyncMessage::BlockResponse(BlockResponse::new(block)))
+        self.send_message(SyncMessage::BlockResponse(BlockResponse::new(block))).await
     }
 
     async fn disconnect_if_stalling(&mut self) -> Result<()> {

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -1035,9 +1035,10 @@ async fn dont_make_announcements_while_blocks_are_being_sent(#[case] seed: Seed)
         let mut node = TestNode::builder(protocol_version)
             .with_chain_config(Arc::clone(&chain_config))
             .with_blocks(initial_blocks.clone())
-            // Note: this limit guarantees that there is some pause after each BlockResponse is
-            // sent, giving more time for the required LocalEvent::ChainstateNewTip to propagate.
-            // (though it still doesn't guarantee the lack of spurious failures for this test).
+            // Note: because of this limit, the "sleep" call inside the loop creates a pause
+            // after each BlockResponse is sent; this gives more time for the required
+            // LocalEvent::ChainstateNewTip to propagate (though it still doesn't guarantee
+            // the lack of spurious failures for this test).
             .with_sync_msg_channel_buffer_size(1)
             .build()
             .await;

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -1026,7 +1026,7 @@ async fn dont_make_announcements_while_blocks_are_being_sent(#[case] seed: Seed)
             // because the LocalEvent::ChainstateNewTip for the new block (the one created
             // inside the loop) may reach Peer when all initial blocks have already been sent,
             // in which case it'll happily produce a block announcement.
-            20,
+            100,
             &mut rng,
         );
         let initial_block_headers: Vec<_> =

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use chainstate::{ban_score::BanScore, BlockError, ChainstateError, CheckBlockError};
 use chainstate_test_framework::TestFramework;
@@ -1026,7 +1026,7 @@ async fn dont_make_announcements_while_blocks_are_being_sent(#[case] seed: Seed)
             // because the LocalEvent::ChainstateNewTip for the new block (the one created
             // inside the loop) may reach Peer when all initial blocks have already been sent,
             // in which case it'll happily produce a block announcement.
-            100,
+            20,
             &mut rng,
         );
         let initial_block_headers: Vec<_> =
@@ -1091,6 +1091,8 @@ async fn dont_make_announcements_while_blocks_are_being_sent(#[case] seed: Seed)
                 )
                 .await;
             }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
         assert_eq!(intermediate_block_headers.len(), 1);
 

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -1127,3 +1127,98 @@ async fn dont_make_announcements_while_blocks_are_being_sent(#[case] seed: Seed)
     })
     .await;
 }
+
+// The peer asks for blocks in the reverse order; the node sends the blocks in that order.
+// Then some new blocks are created on the node; the node must announce the new blocks,
+// correctly taking into account the previously sent ones (i.e. only headers of the newly
+// created blocks should be sent).
+#[tracing::instrument(skip(seed))]
+#[rstest::rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn correct_best_sent_block_update(#[case] seed: Seed) {
+    for_each_protocol_version(|protocol_version| async move {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
+
+        let chain_config = Arc::new(create_unit_test_config());
+        let time_getter = P2pBasicTestTimeGetter::new();
+
+        let initial_blocks = make_new_blocks(
+            &chain_config,
+            None,
+            &time_getter.get_time_getter(),
+            2,
+            &mut rng,
+        );
+        let initial_block_headers: Vec<_> =
+            initial_blocks.iter().map(|blk| blk.header().clone()).collect();
+
+        let mut node = TestNode::builder(protocol_version)
+            .with_chain_config(Arc::clone(&chain_config))
+            .with_blocks(initial_blocks.clone())
+            .build()
+            .await;
+
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
+
+        // Respond to node's initial header request (made inside connect_peer)
+        peer.send_headers(vec![]).await;
+
+        log::debug!("Sending header list request to the node");
+        let locator = node.get_locator_from_height(0.into()).await;
+        peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
+            locator,
+        )))
+        .await;
+
+        log::debug!("Expecting header list response");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::HeaderList(HeaderList::new(initial_block_headers.clone()))
+        );
+
+        log::debug!("Sending block list request to the node with reversed block order");
+        peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(
+            initial_block_headers.iter().map(|hdr| hdr.block_id()).rev().collect(),
+        )))
+        .await;
+
+        log::debug!("Expecting block response for block #1");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::BlockResponse(BlockResponse::new(initial_blocks[1].clone()))
+        );
+
+        log::debug!("Expecting block response for block #0");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::BlockResponse(BlockResponse::new(initial_blocks[0].clone()))
+        );
+
+        let headers = make_new_top_blocks_return_headers(
+            node.chainstate(),
+            time_getter.get_time_getter(),
+            &mut rng,
+            0,
+            2,
+        )
+        .await;
+
+        log::debug!("Expecting block announcement");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(message, SyncMessage::HeaderList(HeaderList::new(headers)));
+
+        node.assert_no_event().await;
+        node.assert_no_peer_manager_event().await;
+        node.join_subsystem_manager().await;
+    })
+    .await;
+}

--- a/p2p/src/sync/tests/block_list_request.rs
+++ b/p2p/src/sync/tests/block_list_request.rs
@@ -23,8 +23,7 @@ use common::{
 };
 use crypto::random::Rng;
 use logging::log;
-use p2p_test_utils::create_n_blocks;
-use p2p_test_utils::P2pBasicTestTimeGetter;
+use p2p_test_utils::{create_n_blocks, P2pBasicTestTimeGetter};
 use test_utils::random::Seed;
 
 use crate::{

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -22,7 +22,7 @@ use p2p_types::socket_address::SocketAddress;
 use test_utils::random::Seed;
 use tokio::{
     sync::{
-        mpsc::{self, Sender, UnboundedReceiver, UnboundedSender},
+        mpsc::{self, Receiver, Sender, UnboundedReceiver, UnboundedSender},
         oneshot,
     },
     task::JoinHandle,
@@ -74,7 +74,7 @@ pub struct TestNode {
     p2p_config: Arc<P2pConfig>,
     peer_manager_event_receiver: UnboundedReceiver<PeerManagerEvent>,
     syncing_event_sender: UnboundedSender<SyncingEvent>,
-    sync_msg_receiver: UnboundedReceiver<(PeerId, SyncMessage)>,
+    sync_msg_receiver: Receiver<(PeerId, SyncMessage)>,
     error_receiver: UnboundedReceiver<P2pError>,
     sync_manager_handle: JoinHandle<()>,
     shutdown_trigger: ShutdownTrigger,
@@ -106,10 +106,11 @@ impl TestNode {
         subsystem_manager_handle: ManagerJoinHandle,
         time_getter: TimeGetter,
         protocol_version: ProtocolVersion,
+        sync_msg_channel_buffer_size: usize,
     ) -> Self {
         let (peer_manager_event_sender, peer_manager_event_receiver) = mpsc::unbounded_channel();
 
-        let (sync_msg_sender, sync_msg_receiver) = mpsc::unbounded_channel();
+        let (sync_msg_sender, sync_msg_receiver) = mpsc::channel(sync_msg_channel_buffer_size);
         let (syncing_event_sender, syncing_event_receiver) = mpsc::unbounded_channel();
         let messaging_handle = MessagingHandleMock { sync_msg_sender };
         let syncing_event_receiver_mock = SyncingEventReceiverMock {
@@ -380,6 +381,7 @@ pub struct TestNodeBuilder {
     time_getter: TimeGetter,
     blocks: Vec<Block>,
     protocol_version: ProtocolVersion,
+    sync_msg_channel_buffer_size: usize,
 }
 
 impl TestNodeBuilder {
@@ -391,6 +393,12 @@ impl TestNodeBuilder {
             time_getter: TimeGetter::default(),
             blocks: Vec::new(),
             protocol_version,
+            // Note: setting the default value here to something small is not a good idea,
+            // because many tests don't care about reading all sync messages. If that happens,
+            // the corresponding Peer task and the test itself may freeze up.
+            // Note: can't use usize::MAX here; also, the actual MAX constant is not exposed,
+            // so we use u32::MAX.
+            sync_msg_channel_buffer_size: u32::MAX as usize,
         }
     }
 
@@ -419,6 +427,11 @@ impl TestNodeBuilder {
         self
     }
 
+    pub fn with_sync_msg_channel_buffer_size(mut self, size: usize) -> Self {
+        self.sync_msg_channel_buffer_size = size;
+        self
+    }
+
     pub async fn build(self) -> TestNode {
         let TestNodeBuilder {
             chain_config,
@@ -427,6 +440,7 @@ impl TestNodeBuilder {
             time_getter,
             blocks,
             protocol_version,
+            sync_msg_channel_buffer_size,
         } = self;
 
         let mut manager = subsystem::Manager::new("p2p-sync-test-manager");
@@ -466,6 +480,7 @@ impl TestNodeBuilder {
             manager_handle,
             time_getter,
             protocol_version,
+            sync_msg_channel_buffer_size,
         )
         .await
     }
@@ -506,12 +521,13 @@ impl NetworkingService for NetworkingServiceStub {
 
 #[derive(Clone)]
 struct MessagingHandleMock {
-    sync_msg_sender: UnboundedSender<(PeerId, SyncMessage)>,
+    sync_msg_sender: Sender<(PeerId, SyncMessage)>,
 }
 
+#[async_trait]
 impl MessagingService for MessagingHandleMock {
-    fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> Result<()> {
-        self.sync_msg_sender.send((peer, message)).unwrap();
+    async fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> Result<()> {
+        self.sync_msg_sender.send((peer, message)).await.unwrap();
         Ok(())
     }
 }

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -267,7 +267,7 @@ impl TestNode {
         .unwrap_err();
     }
 
-    /// Panics if there is an event from the peer manager (except for the NewTipReceived/NewValidTransactionReceived messages)
+    /// Panics if there is an event from the peer manager (except for the NewTipReceived/NewChainstateTip/NewValidTransactionReceived messages)
     // TODO: Rename the function
     pub async fn assert_no_peer_manager_event(&mut self) {
         time::timeout(SHORT_TIMEOUT, async {

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -309,7 +309,7 @@ impl TestNodeGroup {
         self.prevent_peer_manager_events = set;
     }
 
-    /// NewTipReceived/NewValidTransactionReceived messages are ignored
+    /// NewTipReceived/NewChainstateTip/NewValidTransactionReceived messages are ignored
     // TODO: Rename the function
     fn assert_no_peer_manager_events_if_needed(&mut self) {
         if self.prevent_peer_manager_events {


### PR DESCRIPTION
The test `dont_make_announcements_while_blocks_are_being_sent` was added in PR #1306; it was failing spuriously on my local machine from time to time (depending on the CPU load), which forced me to increase the number of initial blocks from 10 to 100.  But then it failed on CI anyway.

The behaviour that it checks is basically a small optimization, so I was seriously considering just removing the test. However I decided to try to make it more reliable. I tries several approaches; the final "solution" (which I'm not particularly fond of, to be honest) was to make `MessagingService::send_message` async, so that test implementations of it could use a bounded channel. The problematic test now uses the channel capacity of 1, and can use `sleep` to slow down the rate at which BlockResponse messages are produced (their rate is what was causing the problem). Still, it doesn't guarantee that the spurious failures won't happen again, it just makes it less likely (hopefully much less).

On the other hand, `MessagingService::send_message` being async will allow us to use a bounded channel for sync messages in production code too, which may be a good thing, see the Note/TODO in `p2p/src/net/default_backend/mod.rs`