### PR TITLE
Enforce NoSignature data to follow a rule in ChainConfig for mainnet

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -270,6 +270,7 @@ impl BanScore for CheckBlockTransactionsError {
             CheckBlockTransactionsError::EmptyInputsOutputsInTransactionInBlock(_, _) => 100,
             CheckBlockTransactionsError::TokensError(err) => err.ban_score(),
             CheckBlockTransactionsError::InvalidWitnessCount => 100,
+            CheckBlockTransactionsError::NoSignatureDataNotAllowed(_, _) => 100,
             CheckBlockTransactionsError::NoSignatureDataSizeTooLarge(_, _) => 100,
             CheckBlockTransactionsError::DataDepositNotActivated(_, _, _) => 100,
             CheckBlockTransactionsError::DataDepositMaxSizeExceeded(_, _, _, _) => 100,

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -283,7 +283,7 @@ mod tests {
     fn make_block(epoch_index: EpochIndex) -> Block {
         let pool_id = PoolId::new(H256::zero());
         let timestamp = BlockTimestamp::from_int_seconds(1);
-        let randomness = get_initial_randomness(ChainType::Mainnet);
+        let randomness = get_initial_randomness(ChainType::Testnet);
 
         let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_entropy(VRFKeyKind::Schnorrkel);
         let vrf_transcript = construct_transcript(epoch_index, &randomness, timestamp);

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -836,7 +836,9 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             for signature in tx.signatures() {
                 match signature {
                     common::chain::signature::inputsig::InputWitness::NoSignature(data) => {
-                        if !self.chain_config.no_signature_data_allowed() && data.is_some() {
+                        if !self.chain_config.data_in_no_signature_witness_allowed()
+                            && data.is_some()
+                        {
                             return Err(CheckBlockTransactionsError::NoSignatureDataNotAllowed(
                                 tx.transaction().get_id(),
                                 block.get_id(),
@@ -845,10 +847,11 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
 
                         if let Some(inner_data) = data {
                             ensure!(
-                                inner_data.len() <= self.chain_config.no_signature_data_max_size(),
+                                inner_data.len()
+                                    <= self.chain_config.data_in_no_signature_witness_max_size(),
                                 CheckBlockTransactionsError::NoSignatureDataSizeTooLarge(
                                     inner_data.len(),
-                                    self.chain_config.no_signature_data_max_size(),
+                                    self.chain_config.data_in_no_signature_witness_max_size(),
                                 )
                             )
                         }

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -836,12 +836,19 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             for signature in tx.signatures() {
                 match signature {
                     common::chain::signature::inputsig::InputWitness::NoSignature(data) => {
+                        if !self.chain_config.no_signature_data_allowed() && data.is_some() {
+                            return Err(CheckBlockTransactionsError::NoSignatureDataNotAllowed(
+                                tx.transaction().get_id(),
+                                block.get_id(),
+                            ));
+                        }
+
                         if let Some(inner_data) = data {
                             ensure!(
-                                inner_data.len() <= self.chain_config.max_no_signature_data_size(),
+                                inner_data.len() <= self.chain_config.no_signature_data_max_size(),
                                 CheckBlockTransactionsError::NoSignatureDataSizeTooLarge(
                                     inner_data.len(),
-                                    self.chain_config.max_no_signature_data_size(),
+                                    self.chain_config.no_signature_data_max_size(),
                                 )
                             )
                         }

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -163,6 +163,8 @@ pub enum CheckBlockTransactionsError {
     TokensError(TokensError),
     #[error("No signature data size is too large: {0} > {1}")]
     NoSignatureDataSizeTooLarge(usize, usize),
+    #[error("No signature data is not allowed. Found in transaction {0} and block {1}")]
+    NoSignatureDataNotAllowed(Id<Transaction>, Id<Block>),
     #[error("Data deposit not yet enabled at height {0}. Found in transaction {1} and block {2}")]
     DataDepositNotActivated(BlockHeight, Id<Transaction>, Id<Block>),
     #[error(

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -57,7 +57,7 @@ pub struct TestFrameworkBuilder {
 impl TestFrameworkBuilder {
     /// Constructs a builder instance with values appropriate for most of the tests.
     pub fn new(_rng: &mut (impl Rng + CryptoRng)) -> Self {
-        let chain_config = ChainConfigBuilder::new(ChainType::Mainnet)
+        let chain_config = ChainConfigBuilder::new(ChainType::Testnet)
             .consensus_upgrades(
                 NetUpgrades::initialize(vec![(
                     BlockHeight::zero(),

--- a/chainstate/test-suite/src/tests/block_invalidation.rs
+++ b/chainstate/test-suite/src/tests/block_invalidation.rs
@@ -164,7 +164,7 @@ struct TestChainBlockIds {
 fn make_complex_chain(rng: &mut (impl Rng + CryptoRng)) -> (TestFramework, TestChainBlockIds) {
     let mut tf = TestFramework::builder(rng)
         .with_chain_config(
-            ChainConfigBuilder::new(ChainType::Mainnet)
+            ChainConfigBuilder::new(ChainType::Testnet)
                 .consensus_upgrades(NetUpgrades::unit_tests())
                 .genesis_unittest(Destination::AnyoneCanSpend)
                 .max_depth_for_reorg(BlockDistance::new(5))

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -365,7 +365,8 @@ fn too_large_no_sig_data(#[case] seed: Seed, #[case] valid_size: bool) {
 
         let chain_config = tf.chainstate.get_chain_config().clone();
 
-        let max_no_sig_data_size = tf.chainstate.get_chain_config().no_signature_data_max_size();
+        let max_no_sig_data_size =
+            tf.chainstate.get_chain_config().data_in_no_signature_witness_max_size();
 
         let data_size = if valid_size {
             max_no_sig_data_size
@@ -429,7 +430,7 @@ fn no_sig_data_not_allowed(#[case] seed: Seed, #[case] data_allowed: bool) {
     utils::concurrency::model(move || {
         let mut rng = test_utils::random::make_seedable_rng(seed);
         let chain_config = chain::config::Builder::new(chain::config::ChainType::Testnet)
-            .no_signature_data_allowed(data_allowed)
+            .data_in_no_signature_witness_allowed(data_allowed)
             .consensus_upgrades(
                 NetUpgrades::initialize(vec![(
                     BlockHeight::zero(),
@@ -444,7 +445,8 @@ fn no_sig_data_not_allowed(#[case] seed: Seed, #[case] data_allowed: bool) {
 
         let chain_config = tf.chainstate.get_chain_config().clone();
 
-        let max_no_sig_data_size = tf.chainstate.get_chain_config().no_signature_data_max_size();
+        let max_no_sig_data_size =
+            tf.chainstate.get_chain_config().data_in_no_signature_witness_max_size();
 
         {
             // Valid case

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -49,6 +49,13 @@ impl ChainType {
         }
     }
 
+    fn default_no_signature_data_allowed(&self) -> bool {
+        match self {
+            ChainType::Mainnet => false,
+            ChainType::Regtest | ChainType::Testnet | ChainType::Signet => true,
+        }
+    }
+
     fn default_consensus_upgrades(&self) -> NetUpgrades<ConsensusUpgrade> {
         match self {
             ChainType::Mainnet | ChainType::Regtest => {
@@ -176,7 +183,8 @@ pub struct Builder {
     max_block_header_size: usize,
     max_block_size_with_standard_txs: usize,
     max_block_size_with_smart_contracts: usize,
-    max_no_signature_data_size: usize,
+    no_signature_data_allowed: bool,
+    no_signature_data_max_size: usize,
     max_depth_for_reorg: BlockDistance,
     epoch_length: NonZeroU64,
     sealed_epoch_distance_from_tip: usize,
@@ -217,7 +225,8 @@ impl Builder {
             max_block_header_size: super::MAX_BLOCK_HEADER_SIZE,
             max_block_size_with_standard_txs: super::MAX_BLOCK_TXS_SIZE,
             max_block_size_with_smart_contracts: super::MAX_BLOCK_CONTRACTS_SIZE,
-            max_no_signature_data_size: super::MAX_TX_NO_SIG_WITNESS_SIZE,
+            no_signature_data_allowed: chain_type.default_no_signature_data_allowed(),
+            no_signature_data_max_size: super::TX_NO_SIG_WITNESS_MAX_SIZE,
             max_future_block_time_offset: super::DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET,
             max_depth_for_reorg: super::DEFAULT_MAX_DEPTH_FOR_REORG,
             epoch_length: super::DEFAULT_EPOCH_LENGTH,
@@ -247,7 +256,7 @@ impl Builder {
 
     /// New builder initialized with test chain config
     pub fn test_chain() -> Self {
-        Self::new(ChainType::Mainnet)
+        Self::new(ChainType::Testnet)
             .consensus_upgrades(NetUpgrades::unit_tests())
             .genesis_unittest(Destination::AnyoneCanSpend)
     }
@@ -267,7 +276,8 @@ impl Builder {
             max_block_size_with_standard_txs,
             max_block_size_with_smart_contracts,
             max_future_block_time_offset,
-            max_no_signature_data_size,
+            no_signature_data_allowed,
+            no_signature_data_max_size,
             max_depth_for_reorg,
             epoch_length,
             sealed_epoch_distance_from_tip,
@@ -347,7 +357,8 @@ impl Builder {
             max_block_size_with_standard_txs,
             max_block_size_with_smart_contracts,
             max_future_block_time_offset,
-            max_no_signature_data_size,
+            no_signature_data_allowed,
+            no_signature_data_max_size,
             max_depth_for_reorg,
             pow_chain_config,
             epoch_length,
@@ -398,6 +409,8 @@ impl Builder {
     builder_method!(software_version: SemVer);
     builder_method!(target_block_spacing: Duration);
     builder_method!(coin_decimals: u8);
+    builder_method!(no_signature_data_allowed: bool);
+    builder_method!(no_signature_data_max_size: usize);
     builder_method!(max_block_header_size: usize);
     builder_method!(max_block_size_with_standard_txs: usize);
     builder_method!(max_block_size_with_smart_contracts: usize);

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -49,7 +49,7 @@ impl ChainType {
         }
     }
 
-    fn default_no_signature_data_allowed(&self) -> bool {
+    fn default_data_in_no_signature_witness_allowed(&self) -> bool {
         match self {
             ChainType::Mainnet => false,
             ChainType::Regtest | ChainType::Testnet | ChainType::Signet => true,
@@ -183,8 +183,8 @@ pub struct Builder {
     max_block_header_size: usize,
     max_block_size_with_standard_txs: usize,
     max_block_size_with_smart_contracts: usize,
-    no_signature_data_allowed: bool,
-    no_signature_data_max_size: usize,
+    data_in_no_signature_witness_allowed: bool,
+    data_in_no_signature_witness_max_size: usize,
     max_depth_for_reorg: BlockDistance,
     epoch_length: NonZeroU64,
     sealed_epoch_distance_from_tip: usize,
@@ -225,8 +225,9 @@ impl Builder {
             max_block_header_size: super::MAX_BLOCK_HEADER_SIZE,
             max_block_size_with_standard_txs: super::MAX_BLOCK_TXS_SIZE,
             max_block_size_with_smart_contracts: super::MAX_BLOCK_CONTRACTS_SIZE,
-            no_signature_data_allowed: chain_type.default_no_signature_data_allowed(),
-            no_signature_data_max_size: super::TX_NO_SIG_WITNESS_MAX_SIZE,
+            data_in_no_signature_witness_allowed: chain_type
+                .default_data_in_no_signature_witness_allowed(),
+            data_in_no_signature_witness_max_size: super::TX_DATA_IN_NO_SIG_WITNESS_MAX_SIZE,
             max_future_block_time_offset: super::DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET,
             max_depth_for_reorg: super::DEFAULT_MAX_DEPTH_FOR_REORG,
             epoch_length: super::DEFAULT_EPOCH_LENGTH,
@@ -276,8 +277,8 @@ impl Builder {
             max_block_size_with_standard_txs,
             max_block_size_with_smart_contracts,
             max_future_block_time_offset,
-            no_signature_data_allowed,
-            no_signature_data_max_size,
+            data_in_no_signature_witness_allowed,
+            data_in_no_signature_witness_max_size,
             max_depth_for_reorg,
             epoch_length,
             sealed_epoch_distance_from_tip,
@@ -357,8 +358,8 @@ impl Builder {
             max_block_size_with_standard_txs,
             max_block_size_with_smart_contracts,
             max_future_block_time_offset,
-            no_signature_data_allowed,
-            no_signature_data_max_size,
+            data_in_no_signature_witness_allowed,
+            data_in_no_signature_witness_max_size,
             max_depth_for_reorg,
             pow_chain_config,
             epoch_length,
@@ -409,8 +410,8 @@ impl Builder {
     builder_method!(software_version: SemVer);
     builder_method!(target_block_spacing: Duration);
     builder_method!(coin_decimals: u8);
-    builder_method!(no_signature_data_allowed: bool);
-    builder_method!(no_signature_data_max_size: usize);
+    builder_method!(data_in_no_signature_witness_allowed: bool);
+    builder_method!(data_in_no_signature_witness_max_size: usize);
     builder_method!(max_block_header_size: usize);
     builder_method!(max_block_size_with_standard_txs: usize);
     builder_method!(max_block_size_with_smart_contracts: usize);

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -183,8 +183,8 @@ pub struct ChainConfig {
     max_block_header_size: usize,
     max_block_size_with_standard_txs: usize,
     max_block_size_with_smart_contracts: usize,
-    no_signature_data_max_size: usize,
-    no_signature_data_allowed: bool,
+    data_in_no_signature_witness_max_size: usize,
+    data_in_no_signature_witness_allowed: bool,
     max_depth_for_reorg: BlockDistance,
     pow_chain_config: PoWChainConfig,
     epoch_length: NonZeroU64,
@@ -335,14 +335,14 @@ impl ChainConfig {
 
     /// The maximum size of data attached to NoSignature witness
     #[must_use]
-    pub fn no_signature_data_max_size(&self) -> usize {
-        self.no_signature_data_max_size
+    pub fn data_in_no_signature_witness_max_size(&self) -> usize {
+        self.data_in_no_signature_witness_max_size
     }
 
     /// Whether one is allowed to attach data to NoSignature witness
     #[must_use]
-    pub fn no_signature_data_allowed(&self) -> bool {
-        self.no_signature_data_allowed
+    pub fn data_in_no_signature_witness_allowed(&self) -> bool {
+        self.data_in_no_signature_witness_allowed
     }
 
     /// The maximum offset of time from the current time the timestamp of a new block can be
@@ -566,7 +566,7 @@ impl AsRef<ChainConfig> for ChainConfig {
 const MAX_BLOCK_HEADER_SIZE: usize = 1024;
 const MAX_BLOCK_TXS_SIZE: usize = 1_048_576;
 const MAX_BLOCK_CONTRACTS_SIZE: usize = 1_048_576;
-const TX_NO_SIG_WITNESS_MAX_SIZE: usize = 128;
+const TX_DATA_IN_NO_SIG_WITNESS_MAX_SIZE: usize = 128;
 const TOKEN_MIN_ISSUANCE_FEE: Amount = CoinUnit::from_coins(100).to_amount_atoms();
 const TOKEN_MIN_SUPPLY_CHANGE_FEE: Amount = CoinUnit::from_coins(100).to_amount_atoms();
 const DATA_DEPOSIT_MAX_SIZE: usize = 128;

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -183,7 +183,8 @@ pub struct ChainConfig {
     max_block_header_size: usize,
     max_block_size_with_standard_txs: usize,
     max_block_size_with_smart_contracts: usize,
-    max_no_signature_data_size: usize,
+    no_signature_data_max_size: usize,
+    no_signature_data_allowed: bool,
     max_depth_for_reorg: BlockDistance,
     pow_chain_config: PoWChainConfig,
     epoch_length: NonZeroU64,
@@ -334,8 +335,14 @@ impl ChainConfig {
 
     /// The maximum size of data attached to NoSignature witness
     #[must_use]
-    pub fn max_no_signature_data_size(&self) -> usize {
-        self.max_no_signature_data_size
+    pub fn no_signature_data_max_size(&self) -> usize {
+        self.no_signature_data_max_size
+    }
+
+    /// Whether one is allowed to attach data to NoSignature witness
+    #[must_use]
+    pub fn no_signature_data_allowed(&self) -> bool {
+        self.no_signature_data_allowed
     }
 
     /// The maximum offset of time from the current time the timestamp of a new block can be
@@ -559,7 +566,7 @@ impl AsRef<ChainConfig> for ChainConfig {
 const MAX_BLOCK_HEADER_SIZE: usize = 1024;
 const MAX_BLOCK_TXS_SIZE: usize = 1_048_576;
 const MAX_BLOCK_CONTRACTS_SIZE: usize = 1_048_576;
-const MAX_TX_NO_SIG_WITNESS_SIZE: usize = 128;
+const TX_NO_SIG_WITNESS_MAX_SIZE: usize = 128;
 const TOKEN_MIN_ISSUANCE_FEE: Amount = CoinUnit::from_coins(100).to_amount_atoms();
 const TOKEN_MIN_SUPPLY_CHANGE_FEE: Amount = CoinUnit::from_coins(100).to_amount_atoms();
 const DATA_DEPOSIT_MAX_SIZE: usize = 128;
@@ -677,7 +684,7 @@ pub fn create_regtest() -> ChainConfig {
 }
 
 pub fn create_unit_test_config() -> ChainConfig {
-    Builder::new(ChainType::Mainnet)
+    Builder::new(ChainType::Testnet)
         .consensus_upgrades(NetUpgrades::unit_tests())
         .genesis_unittest(Destination::AnyoneCanSpend)
         .build()

--- a/wallet/src/key_chain/account_key_chain/tests.rs
+++ b/wallet/src/key_chain/account_key_chain/tests.rs
@@ -15,7 +15,7 @@
 
 use super::*;
 use crate::key_chain::MasterKeyChain;
-use common::chain::config::create_unit_test_config;
+use common::chain::config::create_mainnet;
 use crypto::key::secp256k1::Secp256k1PublicKey;
 use rstest::rstest;
 use wallet_storage::{DefaultBackend, Store, TransactionRwUnlocked, Transactional};
@@ -31,7 +31,7 @@ const MNEMONIC: &str =
 #[case("035df5d551bac1d61a5473615a70eb17b2f4ccbf7e354166639428941e4dbbcd81")]
 #[case("030d1d07a8e45110d14f4e2c8623e8db556c11a90c0aac6be9a88f2464e446ee95")]
 fn check_mine_methods(#[case] public: &str) {
-    let chain_config = Arc::new(create_unit_test_config());
+    let chain_config = Arc::new(create_mainnet());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
 

--- a/wallet/src/key_chain/tests.rs
+++ b/wallet/src/key_chain/tests.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use common::chain::config::create_unit_test_config;
+use common::chain::config::{create_mainnet, create_unit_test_config};
 use common::{address::pubkeyhash::PublicKeyHash, chain::Destination::Address};
 use crypto::key::extended::ExtendedPublicKey;
 use crypto::key::hdkd::derivable::Derivable;
@@ -67,7 +67,7 @@ fn key_chain_creation(
     #[case] public: &str,
     #[case] chaincode: &str,
 ) {
-    let chain_config = Arc::new(create_unit_test_config());
+    let chain_config = Arc::new(create_mainnet());
     let db = Arc::new(Store::new(DefaultBackend::new_in_memory()).unwrap());
     let mut db_tx = db.transaction_rw_unlocked(None).unwrap();
     let master_key_chain = MasterKeyChain::new_from_mnemonic(


### PR DESCRIPTION
Also removed many tests' dependency on Mainnet ChainConfig. Soon we will be recreating the mainnet config from scratch, so nothing should depend on it.