### PR TITLE
Fixes in p2p related to blocks order

### DIFF
--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -49,8 +49,15 @@ pub enum ProtocolError {
     DuplicatedBlockRequest(Id<Block>),
     #[error("Headers aren't connected")]
     DisconnectedHeaders,
-    #[error("Received a message ({0}) that wasn't expected")]
+    #[error("Peer sent a message ({0}) that wasn't expected")]
     UnexpectedMessage(String),
+    #[error("Peer sent a block ({0}) that wasn't requested")]
+    UnsolicitedBlockReceived(Id<Block>),
+    #[error("Peer sent block {expected_block_id} while it was expected to send {actual_block_id}")]
+    BlocksReceivedInWrongOrder {
+        expected_block_id: Id<Block>,
+        actual_block_id: Id<Block>,
+    },
     #[error("Empty block list requested")]
     ZeroBlocksInRequest,
     #[error("Handshake expected")]
@@ -227,6 +234,11 @@ impl BanScore for ProtocolError {
             ProtocolError::DuplicatedBlockRequest(_) => 20,
             ProtocolError::DisconnectedHeaders => 20,
             ProtocolError::UnexpectedMessage(_) => 20,
+            ProtocolError::UnsolicitedBlockReceived(_) => 20,
+            ProtocolError::BlocksReceivedInWrongOrder {
+                expected_block_id: _,
+                actual_block_id: _,
+            } => 20,
             ProtocolError::ZeroBlocksInRequest => 20,
             ProtocolError::HandshakeExpected => 100,
             ProtocolError::AddressListLimitExceeded => 100,

--- a/p2p/src/sync/peer_v2.rs
+++ b/p2p/src/sync/peer_v2.rs
@@ -103,7 +103,7 @@ struct IncomingDataState {
     /// requested the blocks for.
     pending_headers: Vec<SignedBlockHeader>,
     /// A list of blocks that we requested from this peer.
-    requested_blocks: BTreeSet<Id<Block>>,
+    requested_blocks: VecDeque<Id<Block>>,
     /// The id of the best block header that we've received from the peer and that we also have.
     /// This includes headers received by any means, e.g. via HeaderList messages, as part
     /// of a locator during peer's header requests, via block responses.
@@ -156,7 +156,7 @@ where
             time_getter,
             incoming: IncomingDataState {
                 pending_headers: Vec::new(),
-                requested_blocks: BTreeSet::new(),
+                requested_blocks: VecDeque::new(),
                 peers_best_block_that_we_have: None,
             },
             outgoing: OutgoingDataState {
@@ -700,14 +700,28 @@ where
         // The code below will set it again if needed.
         self.peer_activity.set_expecting_blocks_since(None);
 
-        // TODO: here we allow the peer to send blocks out of order. This means that we may receive
-        // an orphan block first and then its parent. Because of this, the NewTipReceived event
-        // generated below may not contain the actual tip. It doesn't seem like it may lead
-        // to problems at this moment, but it's still better to be more strict about it.
-        if self.incoming.requested_blocks.take(&block.get_id()).is_none() {
-            return Err(P2pError::ProtocolError(ProtocolError::UnexpectedMessage(
-                "block response".to_owned(),
-            )));
+        if self.incoming.requested_blocks.front().is_some_and(|id| id == &block.get_id()) {
+            self.incoming.requested_blocks.pop_front();
+        } else {
+            let idx = self.incoming.requested_blocks.iter().position(|id| id == &block.get_id());
+            // Note: we treat wrongly ordered blocks in the same way as unsolicited ones, i.e.
+            // we don't remove their ids from the list.
+            if idx.is_some() {
+                return Err(P2pError::ProtocolError(
+                    ProtocolError::BlocksReceivedInWrongOrder {
+                        expected_block_id: *self
+                            .incoming
+                            .requested_blocks
+                            .front()
+                            .expect("The deque is known to be non-empty"),
+                        actual_block_id: block.get_id(),
+                    },
+                ));
+            } else {
+                return Err(P2pError::ProtocolError(
+                    ProtocolError::UnsolicitedBlockReceived(block.get_id()),
+                ));
+            }
         }
 
         let block = self.chainstate_handle.call(|c| Ok(c.preliminary_block_check(block)?)).await?;
@@ -916,7 +930,7 @@ where
     }
 
     async fn send_block(&mut self, id: Id<Block>) -> Result<()> {
-        let (block, index) = self
+        let (block, block_index) = self
             .chainstate_handle
             .call(move |c| {
                 let index = c.get_block_index(&id);
@@ -931,19 +945,20 @@ where
         // to delete block indices of missing blocks when resetting their failure flags).
         // P2p should handle such situations correctly (see issue #1033 for more details).
         let block = block?.unwrap_or_else(|| panic!("Unknown block requested: {id}"));
+        let block_index = block_index?.expect("Block index must exist");
 
-        // TODO: technically, the blocks may be sent out of order, so best_sent_block may not
-        // be set correctly here.
-        // Note that it doesn't seem to be a serious issue at this moment, because if two Mintlayer
-        // nodes are communicating, then headers in header requests will be ordered and block requests
-        // by the other side will re-use that order; then, the sender will put the requested block
-        // ids in a queue and send_block will re-use that order as well.
-        // I.e. this may be an issue only if the peer is trying to do something shady. But the only
-        // problem that may arise from an incorrect best_sent_block is that we may send the peer
-        // an unconnected list of headers next time. Which is not a big deal provided that the peer
-        // already behaves in a suspicious way.
-        // But this is still not very reliable and must be fixed.
-        self.outgoing.best_sent_block = index?;
+        let old_best_sent_block_id = self.outgoing.best_sent_block.as_ref().map(|idx| {
+            let id: Id<GenBlock> = (*idx.block_id()).into();
+            id
+        });
+        let new_best_sent_block_id = self
+            .chainstate_handle
+            .call(move |c| choose_peers_best_block(c, old_best_sent_block_id, Some(id.into())))
+            .await?;
+
+        if new_best_sent_block_id == Some(id.into()) {
+            self.outgoing.best_sent_block = Some(block_index);
+        }
 
         log::debug!(
             "[peer id = {}] Sending block with id = {} to the peer",

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -1127,3 +1127,98 @@ async fn dont_make_announcements_while_blocks_are_being_sent(#[case] seed: Seed)
     })
     .await;
 }
+
+// The peer asks for blocks in the reverse order; the node sends the blocks in that order.
+// Then some new blocks are created on the node; the node must announce the new blocks,
+// correctly taking into account the previously sent ones (i.e. only headers of the newly
+// created blocks should be sent).
+#[tracing::instrument(skip(seed))]
+#[rstest::rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn correct_best_sent_block_update(#[case] seed: Seed) {
+    for_each_protocol_version(|protocol_version| async move {
+        let mut rng = test_utils::random::make_seedable_rng(seed);
+
+        let chain_config = Arc::new(create_unit_test_config());
+        let time_getter = P2pBasicTestTimeGetter::new();
+
+        let initial_blocks = make_new_blocks(
+            &chain_config,
+            None,
+            &time_getter.get_time_getter(),
+            2,
+            &mut rng,
+        );
+        let initial_block_headers: Vec<_> =
+            initial_blocks.iter().map(|blk| blk.header().clone()).collect();
+
+        let mut node = TestNode::builder(protocol_version)
+            .with_chain_config(Arc::clone(&chain_config))
+            .with_blocks(initial_blocks.clone())
+            .build()
+            .await;
+
+        let peer = node.connect_peer(PeerId::new(), protocol_version).await;
+
+        // Respond to node's initial header request (made inside connect_peer)
+        peer.send_headers(vec![]).await;
+
+        log::debug!("Sending header list request to the node");
+        let locator = node.get_locator_from_height(0.into()).await;
+        peer.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
+            locator,
+        )))
+        .await;
+
+        log::debug!("Expecting header list response");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::HeaderList(HeaderList::new(initial_block_headers.clone()))
+        );
+
+        log::debug!("Sending block list request to the node with reversed block order");
+        peer.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(
+            initial_block_headers.iter().map(|hdr| hdr.block_id()).rev().collect(),
+        )))
+        .await;
+
+        log::debug!("Expecting block response for block #1");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::BlockResponse(BlockResponse::new(initial_blocks[1].clone()))
+        );
+
+        log::debug!("Expecting block response for block #0");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(
+            message,
+            SyncMessage::BlockResponse(BlockResponse::new(initial_blocks[0].clone()))
+        );
+
+        let headers = make_new_top_blocks_return_headers(
+            node.chainstate(),
+            time_getter.get_time_getter(),
+            &mut rng,
+            0,
+            2,
+        )
+        .await;
+
+        log::debug!("Expecting block announcement");
+        let (sent_to, message) = node.get_sent_message().await;
+        assert_eq!(sent_to, peer.get_id());
+        assert_eq!(message, SyncMessage::HeaderList(HeaderList::new(headers)));
+
+        node.assert_no_event().await;
+        node.assert_no_peer_manager_event().await;
+        node.join_subsystem_manager().await;
+    })
+    .await;
+}

--- a/p2p/src/sync/tests/block_list_request.rs
+++ b/p2p/src/sync/tests/block_list_request.rs
@@ -23,8 +23,7 @@ use common::{
 };
 use crypto::random::Rng;
 use logging::log;
-use p2p_test_utils::create_n_blocks;
-use p2p_test_utils::P2pBasicTestTimeGetter;
+use p2p_test_utils::{create_n_blocks, P2pBasicTestTimeGetter};
 use test_utils::random::Seed;
 
 use crate::{

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -267,7 +267,7 @@ impl TestNode {
         .unwrap_err();
     }
 
-    /// Panics if there is an event from the peer manager (except for the NewTipReceived/NewValidTransactionReceived messages)
+    /// Panics if there is an event from the peer manager (except for the NewTipReceived/NewChainstateTip/NewValidTransactionReceived messages)
     // TODO: Rename the function
     pub async fn assert_no_peer_manager_event(&mut self) {
         time::timeout(SHORT_TIMEOUT, async {

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -309,7 +309,7 @@ impl TestNodeGroup {
         self.prevent_peer_manager_events = set;
     }
 
-    /// NewTipReceived/NewValidTransactionReceived messages are ignored
+    /// NewTipReceived/NewChainstateTip/NewValidTransactionReceived messages are ignored
     // TODO: Rename the function
     fn assert_no_peer_manager_events_if_needed(&mut self) {
         if self.prevent_peer_manager_events {


### PR DESCRIPTION
1. `BlockResponse`s are now required to come in the same order in which the blocks were requested originally. If a `BlockResponse` comes out of order, it's treated in the same way as unsolicited blocks are treated.
2. When sending blocks we now update `best_sent_block` more carefully, taking into account the fact that they may have been requested in some random order.

The same fixes were made both in v1 and v2.