### PR TITLE
Miscellaneous fixes for the fork

### DIFF
--- a/common/src/chain/chaintrust/asymptote.rs
+++ b/common/src/chain/chaintrust/asymptote.rs
@@ -40,10 +40,10 @@ where
 const ALPHA: f64 = 0.025;
 
 // We scale the weights by this factor to ensure that they are resolvable as integers, to avoid using floating-point numbers.
-const SCALING_FACTOR: f64 = 1000000000.;
+const SCALING_FACTOR: f64 = 1e18;
 
 // The size of the precomputed weights
-const VEC_SIZE: u64 = 240;
+const VEC_SIZE: u64 = 1200;
 
 // Epsilon is the smallest positive value that can be represented by the scaled weights.
 const EPSILON: u64 = 1;

--- a/p2p/src/sync/peer_common/mod.rs
+++ b/p2p/src/sync/peer_common/mod.rs
@@ -113,7 +113,7 @@ pub async fn handle_message_processing_result(
 }
 
 /// This function is used to update peers_best_block_that_we_have.
-/// The "better" block is the one that is on the main chain and has bigger height.
+/// The "better" block is the one that is on the main chain and has a higher chain-trust.
 /// In the case of a tie, new_block_id is preferred.
 pub fn choose_peers_best_block(
     chainstate: &dyn ChainstateInterface,
@@ -126,14 +126,10 @@ pub fn choose_peers_best_block(
         (Some(old_id), Some(new_id)) => {
             let old_block_chain_trust = chainstate
                 .get_gen_block_index(&old_id)?
-                .map_or(Uint256::ZERO, |idx: chainstate::GenBlockIndex| {
-                    idx.chain_trust()
-                });
+                .map_or(Uint256::ZERO, |idx| idx.chain_trust());
             let new_block_chain_trust = chainstate
                 .get_gen_block_index(&new_id)?
-                .map_or(Uint256::ZERO, |idx: chainstate::GenBlockIndex| {
-                    idx.chain_trust()
-                });
+                .map_or(Uint256::ZERO, |idx| idx.chain_trust());
             if new_block_chain_trust >= old_block_chain_trust {
                 Ok(Some(new_id))
             } else {


### PR DESCRIPTION
1. The asymptote for chain trust now has more points before flattening
2. The function `choose_peers_best_block()` now uses the chain trust instead of height, as should be.