### PR TITLE
Remove the spuriously failing test "dont_make_announcements_while_blocks_are_being_sent"

### DIFF
--- a/p2p/backend-test-suite/src/ban.rs
+++ b/p2p/backend-test-suite/src/ban.rs
@@ -133,14 +133,12 @@ where
         };
         messaging_handle_2
             .send_message(peer, SyncMessage::HeaderList(HeaderList::new(Vec::new())))
-            .await
             .unwrap();
         messaging_handle_2
             .send_message(
                 peer,
                 SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
             )
-            .await
             .unwrap();
     });
 

--- a/p2p/backend-test-suite/src/block_announcement.rs
+++ b/p2p/backend-test-suite/src/block_announcement.rs
@@ -94,7 +94,6 @@ where
             peer2.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
-        .await
         .unwrap();
 
     let mut sync_msg_rx_2 = match sync2.poll_next().await.unwrap() {
@@ -131,7 +130,6 @@ where
             peer1.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
-        .await
         .unwrap();
 
     let mut sync_msg_rx_1 = match sync1.poll_next().await.unwrap() {
@@ -238,7 +236,6 @@ where
             peer2.peer_id,
             SyncMessage::HeaderList(HeaderList::new(vec![block.header().clone()])),
         )
-        .await
         .unwrap();
 
     shutdown.store(true);

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -142,10 +142,8 @@ where
     }
 }
 
-#[async_trait]
 impl MessagingService for MessagingHandle {
-    async fn send_message(&mut self, peer_id: PeerId, message: SyncMessage) -> crate::Result<()> {
-        // Note: send_message was made async to be able to use a bounded channel in tests.
+    fn send_message(&mut self, peer_id: PeerId, message: SyncMessage) -> crate::Result<()> {
         Ok(self.command_sender.send(types::Command::SendMessage {
             peer_id,
             message: message.into(),

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -122,10 +122,9 @@ where
 }
 
 /// An interface for sending messages and announcements to peers.
-#[async_trait]
 pub trait MessagingService: Clone {
     /// Sends a message to the peer.
-    async fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()>;
+    fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> crate::Result<()>;
 }
 
 #[async_trait]

--- a/p2p/src/sync/peer_v1.rs
+++ b/p2p/src/sync/peer_v1.rs
@@ -225,15 +225,15 @@ where
         }
     }
 
-    async fn send_message(&mut self, message: SyncMessage) -> Result<()> {
-        self.messaging_handle.send_message(self.id(), message).await
+    fn send_message(&mut self, message: SyncMessage) -> Result<()> {
+        self.messaging_handle.send_message(self.id(), message)
     }
 
-    async fn send_headers(&mut self, headers: HeaderList) -> Result<()> {
+    fn send_headers(&mut self, headers: HeaderList) -> Result<()> {
         if let Some(last_header) = headers.headers().last() {
             self.outgoing.best_sent_block_header = Some(last_header.block_id().into());
         }
-        self.send_message(SyncMessage::HeaderList(headers)).await
+        self.send_message(SyncMessage::HeaderList(headers))
     }
 
     async fn handle_new_tip(&mut self, new_tip_id: &Id<Block>) -> Result<()> {
@@ -311,7 +311,7 @@ where
                         self.id(),
                         headers.len()
                     );
-                    return self.send_headers(HeaderList::new(headers)).await;
+                    return self.send_headers(HeaderList::new(headers));
                 }
             } else {
                 // Note: if we got here, then we haven't received a single header request or
@@ -340,7 +340,7 @@ where
                     && self.common_services.has_service(Service::Transactions)
                 {
                     self.add_known_transaction(txid);
-                    self.send_message(SyncMessage::NewTransaction(txid)).await
+                    self.send_message(SyncMessage::NewTransaction(txid))
                 } else {
                     Ok(())
                 }
@@ -362,8 +362,7 @@ where
         log::debug!("[peer id = {}] Sending header list request", self.id());
         self.send_message(SyncMessage::HeaderListRequest(HeaderListRequest::new(
             locator,
-        )))
-        .await?;
+        )))?;
 
         self.peer_activity
             .set_expecting_headers_since(Some(self.time_getter.get_time()));
@@ -437,7 +436,7 @@ where
         // all headers that were available at the moment.
         self.have_sent_all_headers = headers.len() < header_count_limit;
 
-        self.send_headers(HeaderList::new(headers)).await
+        self.send_headers(HeaderList::new(headers))
     }
 
     /// Processes the blocks request.
@@ -711,7 +710,7 @@ where
                 .await?;
         }
 
-        self.request_blocks(new_block_headers).await
+        self.request_blocks(new_block_headers)
     }
 
     async fn handle_block_response(&mut self, block: Block) -> Result<()> {
@@ -808,7 +807,7 @@ where
                 self.request_headers().await?;
             } else {
                 // Download remaining blocks.
-                self.request_blocks(headers).await?;
+                self.request_blocks(headers)?;
             }
         } else {
             // We expect additional blocks from the peer, update the timestamp.
@@ -831,7 +830,7 @@ where
             None => TransactionResponse::NotFound(id),
         };
 
-        self.send_message(SyncMessage::TransactionResponse(res)).await?;
+        self.send_message(SyncMessage::TransactionResponse(res))?;
 
         Ok(())
     }
@@ -915,7 +914,7 @@ where
         }
 
         if !(self.mempool_handle.call(move |m| m.contains_transaction(&tx)).await?) {
-            self.send_message(SyncMessage::TransactionRequest(tx)).await?;
+            self.send_message(SyncMessage::TransactionRequest(tx))?;
             assert!(self.announced_transactions.insert(tx));
         }
 
@@ -926,7 +925,7 @@ where
     ///
     /// The number of blocks requested equals `P2pConfig::requested_blocks_limit`, the remaining
     /// headers are stored in the peer context.
-    async fn request_blocks(&mut self, mut headers: Vec<SignedBlockHeader>) -> Result<()> {
+    fn request_blocks(&mut self, mut headers: Vec<SignedBlockHeader>) -> Result<()> {
         debug_assert!(self.incoming.pending_headers.is_empty());
         debug_assert!(self.incoming.requested_blocks.is_empty());
         debug_assert!(!headers.is_empty());
@@ -946,8 +945,7 @@ where
         );
         self.send_message(SyncMessage::BlockListRequest(BlockListRequest::new(
             block_ids.clone(),
-        )))
-        .await?;
+        )))?;
         self.incoming.requested_blocks.extend(block_ids);
 
         self.peer_activity.set_expecting_blocks_since(Some(self.time_getter.get_time()));
@@ -991,7 +989,7 @@ where
             self.id(),
             block.get_id()
         );
-        self.send_message(SyncMessage::BlockResponse(BlockResponse::new(block))).await
+        self.send_message(SyncMessage::BlockResponse(BlockResponse::new(block)))
     }
 
     async fn disconnect_if_stalling(&mut self) -> Result<()> {

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -22,7 +22,7 @@ use p2p_types::socket_address::SocketAddress;
 use test_utils::random::Seed;
 use tokio::{
     sync::{
-        mpsc::{self, Receiver, Sender, UnboundedReceiver, UnboundedSender},
+        mpsc::{self, Sender, UnboundedReceiver, UnboundedSender},
         oneshot,
     },
     task::JoinHandle,
@@ -74,7 +74,7 @@ pub struct TestNode {
     p2p_config: Arc<P2pConfig>,
     peer_manager_event_receiver: UnboundedReceiver<PeerManagerEvent>,
     syncing_event_sender: UnboundedSender<SyncingEvent>,
-    sync_msg_receiver: Receiver<(PeerId, SyncMessage)>,
+    sync_msg_receiver: UnboundedReceiver<(PeerId, SyncMessage)>,
     error_receiver: UnboundedReceiver<P2pError>,
     sync_manager_handle: JoinHandle<()>,
     shutdown_trigger: ShutdownTrigger,
@@ -106,11 +106,10 @@ impl TestNode {
         subsystem_manager_handle: ManagerJoinHandle,
         time_getter: TimeGetter,
         protocol_version: ProtocolVersion,
-        sync_msg_channel_buffer_size: usize,
     ) -> Self {
         let (peer_manager_event_sender, peer_manager_event_receiver) = mpsc::unbounded_channel();
 
-        let (sync_msg_sender, sync_msg_receiver) = mpsc::channel(sync_msg_channel_buffer_size);
+        let (sync_msg_sender, sync_msg_receiver) = mpsc::unbounded_channel();
         let (syncing_event_sender, syncing_event_receiver) = mpsc::unbounded_channel();
         let messaging_handle = MessagingHandleMock { sync_msg_sender };
         let syncing_event_receiver_mock = SyncingEventReceiverMock {
@@ -381,7 +380,6 @@ pub struct TestNodeBuilder {
     time_getter: TimeGetter,
     blocks: Vec<Block>,
     protocol_version: ProtocolVersion,
-    sync_msg_channel_buffer_size: usize,
 }
 
 impl TestNodeBuilder {
@@ -393,12 +391,6 @@ impl TestNodeBuilder {
             time_getter: TimeGetter::default(),
             blocks: Vec::new(),
             protocol_version,
-            // Note: setting the default value here to something small is not a good idea,
-            // because many tests don't care about reading all sync messages. If that happens,
-            // the corresponding Peer task and the test itself may freeze up.
-            // Note: can't use usize::MAX here; also, the actual MAX constant is not exposed,
-            // so we use u32::MAX.
-            sync_msg_channel_buffer_size: u32::MAX as usize,
         }
     }
 
@@ -427,11 +419,6 @@ impl TestNodeBuilder {
         self
     }
 
-    pub fn with_sync_msg_channel_buffer_size(mut self, size: usize) -> Self {
-        self.sync_msg_channel_buffer_size = size;
-        self
-    }
-
     pub async fn build(self) -> TestNode {
         let TestNodeBuilder {
             chain_config,
@@ -440,7 +427,6 @@ impl TestNodeBuilder {
             time_getter,
             blocks,
             protocol_version,
-            sync_msg_channel_buffer_size,
         } = self;
 
         let mut manager = subsystem::Manager::new("p2p-sync-test-manager");
@@ -480,7 +466,6 @@ impl TestNodeBuilder {
             manager_handle,
             time_getter,
             protocol_version,
-            sync_msg_channel_buffer_size,
         )
         .await
     }
@@ -521,13 +506,12 @@ impl NetworkingService for NetworkingServiceStub {
 
 #[derive(Clone)]
 struct MessagingHandleMock {
-    sync_msg_sender: Sender<(PeerId, SyncMessage)>,
+    sync_msg_sender: UnboundedSender<(PeerId, SyncMessage)>,
 }
 
-#[async_trait]
 impl MessagingService for MessagingHandleMock {
-    async fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> Result<()> {
-        self.sync_msg_sender.send((peer, message)).await.unwrap();
+    fn send_message(&mut self, peer: PeerId, message: SyncMessage) -> Result<()> {
+        self.sync_msg_sender.send((peer, message)).unwrap();
         Ok(())
     }
 }


### PR DESCRIPTION
Here I remove the spuriously failing test `dont_make_announcements_while_blocks_are_being_sent`, as well as the changes that were made when trying to fix it.
Two reasons for it:
1. The test checks a very minor improvement - the fact that the node should avoid sending header updates to a peer, while the peer is downloading blocks from it.
2. It turned out to be hard to avoid spurious failures in it - the test block that is supposed not to trigger an update may miss the window where the older blocks are being sent, so the update would actually be triggered.
The only alternative to removing the test is to increase the number of initial blocks, so that they take longer time to send. But it slows down the test noticeably and still doesn't guarantee the absence of spurious failures.