### PR TITLE
Add support to change token authority in the wallet

### DIFF
--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -19,8 +19,9 @@ use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockReward},
         tokens::{
-            NftIssuance, RPCFungibleTokenInfo, RPCNonFungibleTokenInfo, RPCTokenInfo,
-            RPCTokenTotalSupply, TokenAuxiliaryData, TokenData, TokenId,
+            NftIssuance, RPCFungibleTokenInfo, RPCIsTokenFreezable, RPCIsTokenFrozen,
+            RPCNonFungibleTokenInfo, RPCTokenInfo, RPCTokenTotalSupply, TokenAuxiliaryData,
+            TokenData, TokenId,
         },
         Block, GenBlock, Transaction, TxOutput,
     },
@@ -265,7 +266,9 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                         token_data.metadata_uri().to_owned(),
                         circulating_supply,
                         (*token_data.total_supply()).into(),
-                        token_data.is_frozen(),
+                        token_data.is_locked(),
+                        RPCIsTokenFrozen::new(token_data.frozen_state()),
+                        Some(token_data.authority().clone()),
                     ));
                     Ok(Some(rpc_issuance))
                 }
@@ -359,7 +362,9 @@ fn to_rpc_token_info(
                 issuance.metadata_uri.clone(),
                 issuance.amount_to_issue,
                 RPCTokenTotalSupply::Fixed(issuance.amount_to_issue),
-                false,
+                true,
+                RPCIsTokenFrozen::No(RPCIsTokenFreezable::No),
+                None,
             )))
         }
         TokenData::NftIssuance(nft) => {

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -19,9 +19,8 @@ use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockReward},
         tokens::{
-            NftIssuance, RPCFungibleTokenInfo, RPCIsTokenFreezable, RPCIsTokenFrozen,
-            RPCNonFungibleTokenInfo, RPCTokenInfo, RPCTokenTotalSupply, TokenAuxiliaryData,
-            TokenData, TokenId,
+            NftIssuance, RPCFungibleTokenInfo, RPCIsTokenFrozen, RPCNonFungibleTokenInfo,
+            RPCTokenInfo, TokenAuxiliaryData, TokenId,
         },
         Block, GenBlock, Transaction, TxOutput,
     },
@@ -268,7 +267,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                         (*token_data.total_supply()).into(),
                         token_data.is_locked(),
                         RPCIsTokenFrozen::new(token_data.frozen_state()),
-                        Some(token_data.authority().clone()),
+                        token_data.authority().clone(),
                     ));
                     Ok(Some(rpc_issuance))
                 }
@@ -285,12 +284,10 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
                 .iter()
                 // find tokens
                 .find_map(|output| match output {
-                    TxOutput::Transfer(v, _)
-                    | TxOutput::LockThenTransfer(v, _, _)
-                    | TxOutput::Burn(v) => v.token_data().and_then(|token_data| {
-                        to_rpc_token_info(token_data, token_id, &token_aux_data)
-                    }),
-                    TxOutput::CreateStakePool(_, _)
+                    TxOutput::Transfer(_, _)
+                    | TxOutput::LockThenTransfer(_, _, _)
+                    | TxOutput::Burn(_)
+                    | TxOutput::CreateStakePool(_, _)
                     | TxOutput::ProduceBlockFromStake(_, _)
                     | TxOutput::CreateDelegationId(_, _)
                     | TxOutput::DelegateStaking(_, _)
@@ -345,36 +342,5 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         id: &TokenId,
     ) -> Result<Option<Amount>, PropertyQueryError> {
         self.chainstate_ref.get_circulating_supply(id).map_err(PropertyQueryError::from)
-    }
-}
-
-fn to_rpc_token_info(
-    token_data: &TokenData,
-    token_id: TokenId,
-    token_aux_data: &TokenAuxiliaryData,
-) -> Option<RPCTokenInfo> {
-    match token_data {
-        TokenData::TokenIssuance(issuance) => {
-            Some(RPCTokenInfo::new_fungible(RPCFungibleTokenInfo::new(
-                token_id,
-                issuance.token_ticker.clone(),
-                issuance.number_of_decimals,
-                issuance.metadata_uri.clone(),
-                issuance.amount_to_issue,
-                RPCTokenTotalSupply::Fixed(issuance.amount_to_issue),
-                true,
-                RPCIsTokenFrozen::No(RPCIsTokenFreezable::No),
-                None,
-            )))
-        }
-        TokenData::NftIssuance(nft) => {
-            Some(RPCTokenInfo::new_nonfungible(RPCNonFungibleTokenInfo::new(
-                token_id,
-                token_aux_data.issuance_tx().get_id(),
-                token_aux_data.issuance_block_id(),
-                &nft.metadata,
-            )))
-        }
-        TokenData::TokenTransfer(_) => None,
     }
 }

--- a/common/src/chain/tokens/rpc.rs
+++ b/common/src/chain/tokens/rpc.rs
@@ -138,7 +138,7 @@ pub struct RPCFungibleTokenInfo {
     pub total_supply: RPCTokenTotalSupply,
     pub is_locked: bool,
     pub frozen: RPCIsTokenFrozen,
-    pub authority: Option<Destination>,
+    pub authority: Destination,
 }
 
 impl RPCFungibleTokenInfo {
@@ -152,7 +152,7 @@ impl RPCFungibleTokenInfo {
         total_supply: RPCTokenTotalSupply,
         is_locked: bool,
         frozen: RPCIsTokenFrozen,
-        authority: Option<Destination>,
+        authority: Destination,
     ) -> Self {
         Self {
             token_id,

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -270,8 +270,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
         if seed is None:
             seed = random.randrange(sys.maxsize)
-        else:
-            self.log.debug("User supplied random seed {}".format(seed))
+        self.log.info("Using random seed {}".format(seed))
 
         random.seed(seed)
         self.log.debug("PRNG seed is: {}".format(seed))

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -206,6 +206,9 @@ class WalletCliController:
     async def unfreeze_token(self, token_id: str) -> str:
         return await self._write_command(f"unfreezetoken {token_id}\n")
 
+    async def change_token_authority(self, token_id: str, new_authority: str) -> str:
+        return await self._write_command(f"changetokenauthority {token_id} {new_authority}\n")
+
     async def issue_new_nft(self,
                             destination_address: str,
                             media_hash: str,

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -134,6 +134,7 @@ BASE_SCRIPTS = [
     'wallet_get_address_usage.py',
     'wallet_tokens.py',
     'wallet_tokens_freeze.py',
+    'wallet_tokens_change_authority.py',
     'wallet_tokens_change_supply.py',
     'wallet_nfts.py',
     'wallet_delegations.py',

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -431,4 +431,3 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletSubmitTransaction().main()
-

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -432,4 +432,3 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 if __name__ == '__main__':
     WalletSubmitTransaction().main()
 
-

--- a/test/functional/wallet_generate_addresses.py
+++ b/test/functional/wallet_generate_addresses.py
@@ -166,4 +166,3 @@ class WalletAddressGenerator(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletAddressGenerator().main()
-

--- a/test/functional/wallet_generate_addresses.py
+++ b/test/functional/wallet_generate_addresses.py
@@ -167,4 +167,3 @@ class WalletAddressGenerator(BitcoinTestFramework):
 if __name__ == '__main__':
     WalletAddressGenerator().main()
 
-

--- a/test/functional/wallet_get_address_usage.py
+++ b/test/functional/wallet_get_address_usage.py
@@ -170,4 +170,3 @@ class WalletGetAddressUsage(BitcoinTestFramework):
 if __name__ == '__main__':
     WalletGetAddressUsage().main()
 
-

--- a/test/functional/wallet_get_address_usage.py
+++ b/test/functional/wallet_get_address_usage.py
@@ -169,4 +169,3 @@ class WalletGetAddressUsage(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletGetAddressUsage().main()
-

--- a/test/functional/wallet_high_fee.py
+++ b/test/functional/wallet_high_fee.py
@@ -148,4 +148,3 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletSubmitTransaction().main()
-

--- a/test/functional/wallet_nfts.py
+++ b/test/functional/wallet_nfts.py
@@ -141,4 +141,3 @@ class WalletNfts(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletNfts().main()
-

--- a/test/functional/wallet_recover_accounts.py
+++ b/test/functional/wallet_recover_accounts.py
@@ -149,4 +149,3 @@ class WalletRecoverAccounts(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletRecoverAccounts().main()
-

--- a/test/functional/wallet_recover_accounts.py
+++ b/test/functional/wallet_recover_accounts.py
@@ -150,4 +150,3 @@ class WalletRecoverAccounts(BitcoinTestFramework):
 if __name__ == '__main__':
     WalletRecoverAccounts().main()
 
-

--- a/test/functional/wallet_select_utxos.py
+++ b/test/functional/wallet_select_utxos.py
@@ -172,4 +172,3 @@ class WalletSubmitTransactionSpecificUtxo(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletSubmitTransactionSpecificUtxo().main()
-

--- a/test/functional/wallet_select_utxos.py
+++ b/test/functional/wallet_select_utxos.py
@@ -173,4 +173,3 @@ class WalletSubmitTransactionSpecificUtxo(BitcoinTestFramework):
 if __name__ == '__main__':
     WalletSubmitTransactionSpecificUtxo().main()
 
-

--- a/test/functional/wallet_submit_tx.py
+++ b/test/functional/wallet_submit_tx.py
@@ -139,4 +139,3 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletSubmitTransaction().main()
-

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -191,4 +191,3 @@ class WalletTokens(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletTokens().main()
-

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -192,4 +192,3 @@ class WalletTokens(BitcoinTestFramework):
 if __name__ == '__main__':
     WalletTokens().main()
 
-

--- a/test/functional/wallet_tokens_change_authority.py
+++ b/test/functional/wallet_tokens_change_authority.py
@@ -152,8 +152,10 @@ class WalletTokens(BitcoinTestFramework):
             assert_in("The transaction was submitted successfully", await wallet.change_token_authority(token_id, new_acc_address))
 
             # randomly put the tx in a block or keep in mempool unconfirmed
-            self.generate_block()
-            assert_in("Success", await wallet.sync())
+            produce_block = random.choice([True, False])
+            if produce_block:
+                self.generate_block()
+                assert_in("Success", await wallet.sync())
 
 
             # try to mint, unmint, lock, freeze and unfreeze
@@ -165,6 +167,10 @@ class WalletTokens(BitcoinTestFramework):
 
 
             await wallet.select_account(1)
+            # make sure the transfer of authority is confirmed
+            if not produce_block:
+                self.generate_block()
+                assert_in("Success", await wallet.sync())
 
             # check that the other account is now the owner and can do anything
             assert_in("The transaction was submitted successfully", await wallet.mint_tokens(token_id, address, 1))
@@ -174,7 +180,5 @@ class WalletTokens(BitcoinTestFramework):
             assert_in("The transaction was submitted successfully", await wallet.unfreeze_token(token_id))
 
 
-
 if __name__ == '__main__':
     WalletTokens().main()
-

--- a/test/functional/wallet_tokens_change_supply.py
+++ b/test/functional/wallet_tokens_change_supply.py
@@ -200,5 +200,3 @@ class WalletTokens(BitcoinTestFramework):
 if __name__ == '__main__':
     WalletTokens().main()
 
-
-

--- a/test/functional/wallet_tokens_change_supply.py
+++ b/test/functional/wallet_tokens_change_supply.py
@@ -199,4 +199,3 @@ class WalletTokens(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletTokens().main()
-

--- a/test/functional/wallet_tokens_freeze.py
+++ b/test/functional/wallet_tokens_freeze.py
@@ -38,6 +38,7 @@ from test_framework.wallet_cli_controller import DEFAULT_ACCOUNT_INDEX, WalletCl
 
 import asyncio
 import sys
+import random
 
 class WalletTokens(BitcoinTestFramework):
 
@@ -147,6 +148,11 @@ class WalletTokens(BitcoinTestFramework):
 
             assert_in("The transaction was submitted successfully", await wallet.freeze_token(token_id, 'unfreezable'))
 
+            # randomly put the tx in a block or keep in mempool unconfirmed
+            if random.choice([True, False]):
+                self.generate_block()
+                assert_in("Success", await wallet.sync())
+
             # try to send tokens should fail
             output = await wallet.send_tokens_to_address(token_id, address, 1)
             assert_in("Cannot use a frozen token", output)
@@ -158,6 +164,11 @@ class WalletTokens(BitcoinTestFramework):
             # unfreeze the token
             assert_in("The transaction was submitted successfully", await wallet.unfreeze_token(token_id))
 
+            # randomly put the tx in a block or keep in mempool unconfirmed
+            if random.choice([True, False]):
+                self.generate_block()
+                assert_in("Success", await wallet.sync())
+
             # sending tokens should work again
             output = await wallet.send_tokens_to_address(token_id, address, 1)
             assert_in("The transaction was submitted successfully", output)
@@ -166,6 +177,4 @@ class WalletTokens(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletTokens().main()
-
-
 

--- a/test/functional/wallet_tokens_freeze.py
+++ b/test/functional/wallet_tokens_freeze.py
@@ -177,4 +177,3 @@ class WalletTokens(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletTokens().main()
-

--- a/tokens-accounting/src/data.rs
+++ b/tokens-accounting/src/data.rs
@@ -167,6 +167,10 @@ impl FungibleTokenData {
         }
     }
 
+    pub fn frozen_state(&self) -> IsTokenFrozen {
+        self.frozen
+    }
+
     pub fn is_frozen(&self) -> bool {
         match self.frozen {
             IsTokenFrozen::No(_) => false,

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -34,8 +34,7 @@ use crate::key_chain::{make_path_to_vrf_key, AccountKeyChain, KeyChainError};
 use crate::send_request::{
     get_tx_output_destination, make_address_output, make_address_output_from_delegation,
     make_address_output_token, make_decomission_stake_pool_output, make_mint_token_outputs,
-    make_stake_output, make_unmint_token_outputs, make_zero_burn_output, IssueNftArguments,
-    StakePoolDataArguments,
+    make_stake_output, make_unmint_token_outputs, IssueNftArguments, StakePoolDataArguments,
 };
 use crate::wallet_events::{WalletEvents, WalletEventsNoOp};
 use crate::{SendRequest, WalletError, WalletResult};
@@ -794,8 +793,6 @@ impl Account {
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
-        let outputs = make_zero_burn_output();
-
         let token_id = *token_info.token_id();
         token_info.check_can_lock()?;
 
@@ -806,7 +803,7 @@ impl Account {
         self.change_token_supply_transaction(
             authority,
             tx_input,
-            outputs,
+            vec![],
             db_tx,
             median_time,
             fee_rate,
@@ -821,8 +818,6 @@ impl Account {
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
-        let outputs = make_zero_burn_output();
-
         token_info.check_can_freeze()?;
 
         let nonce = token_info.get_next_nonce()?;
@@ -835,7 +830,7 @@ impl Account {
         self.change_token_supply_transaction(
             authority,
             tx_input,
-            outputs,
+            vec![],
             db_tx,
             median_time,
             fee_rate,
@@ -849,8 +844,6 @@ impl Account {
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
-        let outputs = make_zero_burn_output();
-
         token_info.check_can_unfreeze()?;
 
         let nonce = token_info.get_next_nonce()?;
@@ -861,7 +854,7 @@ impl Account {
         self.change_token_supply_transaction(
             authority,
             tx_input,
-            outputs,
+            vec![],
             db_tx,
             median_time,
             fee_rate,
@@ -876,7 +869,6 @@ impl Account {
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
-        let outputs = make_zero_burn_output();
         let new_authority = address.decode_object(&self.chain_config)?;
 
         let nonce = token_info.get_next_nonce()?;
@@ -889,7 +881,7 @@ impl Account {
         self.change_token_supply_transaction(
             authority,
             tx_input,
-            outputs,
+            vec![],
             db_tx,
             median_time,
             fee_rate,

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -22,14 +22,16 @@ use common::{
     chain::{
         output_value::OutputValue,
         tokens::{
-            is_token_or_nft_issuance, make_token_id, IsTokenFreezable, IsTokenUnfreezable, TokenId,
-            TokenIssuance, TokenTotalSupply,
+            is_token_or_nft_issuance, make_token_id, IsTokenFreezable, IsTokenUnfreezable,
+            RPCFungibleTokenInfo, RPCIsTokenFreezable, RPCIsTokenFrozen, RPCIsTokenUnfreezable,
+            RPCTokenTotalSupply, TokenId, TokenIssuance, TokenTotalSupply,
         },
         AccountCommand, AccountNonce, AccountSpending, DelegationId, Destination, OutPointSourceId,
         PoolId, Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{id::WithId, Amount, Id},
 };
+use itertools::Itertools;
 use pos_accounting::make_delegation_id;
 use utils::ensure;
 use wallet_types::{
@@ -98,6 +100,18 @@ impl From<TokenTotalSupply> for TokenCurrentSupplyState {
     }
 }
 
+impl From<RPCTokenTotalSupply> for TokenCurrentSupplyState {
+    fn from(value: RPCTokenTotalSupply) -> Self {
+        match value {
+            RPCTokenTotalSupply::Fixed(amount) => {
+                TokenCurrentSupplyState::Fixed(amount, Amount::ZERO)
+            }
+            RPCTokenTotalSupply::Lockable => TokenCurrentSupplyState::Lockable(Amount::ZERO),
+            RPCTokenTotalSupply::Unlimited => TokenCurrentSupplyState::Unlimited(Amount::ZERO),
+        }
+    }
+}
+
 impl TokenCurrentSupplyState {
     pub fn str_state(&self) -> &'static str {
         match self {
@@ -105,6 +119,16 @@ impl TokenCurrentSupplyState {
             Self::Locked(_) => "Locked",
             Self::Lockable(_) => "Lockable",
             Self::Fixed(_, _) => "Fixed",
+        }
+    }
+
+    #[cfg(test)]
+    pub fn current_supply(&self) -> Amount {
+        match self {
+            Self::Unlimited(amount)
+            | Self::Fixed(_, amount)
+            | Self::Locked(amount)
+            | Self::Lockable(amount) => *amount,
         }
     }
 
@@ -144,15 +168,6 @@ impl TokenCurrentSupplyState {
             | TokenCurrentSupplyState::Locked(_) => {
                 Err(WalletError::CannotLockTokenSupply(self.str_state()))
             }
-        }
-    }
-
-    pub fn current_supply(&self) -> Amount {
-        match self {
-            Self::Unlimited(amount)
-            | Self::Fixed(_, amount)
-            | Self::Locked(amount)
-            | Self::Lockable(amount) => *amount,
         }
     }
 
@@ -207,42 +222,170 @@ impl TokenCurrentSupplyState {
             }
         }
     }
+}
 
-    fn unlock(&self) -> WalletResult<TokenCurrentSupplyState> {
+pub struct FungibleTokenInfo {
+    frozen: TokenFreezableState,
+    last_nonce: Option<AccountNonce>,
+    total_supply: TokenCurrentSupplyState,
+    authority: Destination,
+}
+
+pub enum UnconfirmedTokenInfo {
+    OwnFungibleToken(TokenId, FungibleTokenInfo),
+    FungibleToken(TokenId, TokenFreezableState),
+    NonFungibleToken(TokenId),
+}
+
+impl UnconfirmedTokenInfo {
+    pub fn token_id(&self) -> &TokenId {
         match self {
-            TokenCurrentSupplyState::Locked(current) => {
-                Ok(TokenCurrentSupplyState::Lockable(*current))
+            Self::OwnFungibleToken(token_id, _)
+            | Self::FungibleToken(token_id, _)
+            | Self::NonFungibleToken(token_id) => token_id,
+        }
+    }
+
+    pub fn check_can_be_used(&self) -> WalletResult<()> {
+        match self {
+            Self::OwnFungibleToken(_, state) => state.frozen.check_can_be_used(),
+            Self::FungibleToken(_, state) => state.check_can_be_used(),
+            Self::NonFungibleToken(_) => Ok(()),
+        }
+    }
+
+    pub fn check_can_freeze(&self) -> WalletResult<()> {
+        match self {
+            Self::OwnFungibleToken(_, state) => state.frozen.check_can_freeze(),
+            Self::FungibleToken(token_id, _) => {
+                Err(WalletError::CannotChangeNotOwnedToken(*token_id))
             }
-            TokenCurrentSupplyState::Unlimited(_)
-            | TokenCurrentSupplyState::Fixed(_, _)
-            | TokenCurrentSupplyState::Lockable(_) => {
-                Err(WalletError::InconsistentUnlockTokenSupply(self.str_state()))
+            Self::NonFungibleToken(token_id) => {
+                Err(WalletError::CannotChangeNonFungableToken(*token_id))
             }
+        }
+    }
+
+    pub fn check_can_unfreeze(&self) -> WalletResult<()> {
+        match self {
+            Self::OwnFungibleToken(_, state) => state.frozen.check_can_unfreeze(),
+            Self::FungibleToken(token_id, _) => {
+                Err(WalletError::CannotChangeNotOwnedToken(*token_id))
+            }
+            Self::NonFungibleToken(token_id) => {
+                Err(WalletError::CannotChangeNonFungableToken(*token_id))
+            }
+        }
+    }
+
+    pub fn get_next_nonce(&self) -> WalletResult<AccountNonce> {
+        match self {
+            Self::OwnFungibleToken(token_id, state) => state
+                .last_nonce
+                .map_or(Some(AccountNonce::new(0)), |nonce| nonce.increment())
+                .ok_or(WalletError::TokenIssuanceNonceOverflow(*token_id)),
+            Self::FungibleToken(token_id, _) => {
+                Err(WalletError::CannotChangeNotOwnedToken(*token_id))
+            }
+            Self::NonFungibleToken(token_id) => {
+                Err(WalletError::CannotChangeNonFungableToken(*token_id))
+            }
+        }
+    }
+
+    pub fn authority(&self) -> WalletResult<&Destination> {
+        match self {
+            Self::OwnFungibleToken(_, state) => Ok(&state.authority),
+            Self::FungibleToken(token_id, _) => {
+                Err(WalletError::CannotChangeNotOwnedToken(*token_id))
+            }
+            Self::NonFungibleToken(token_id) => {
+                Err(WalletError::CannotChangeNonFungableToken(*token_id))
+            }
+        }
+    }
+
+    pub fn check_can_mint(&self, amount: Amount) -> WalletResult<()> {
+        match self {
+            Self::OwnFungibleToken(_, state) => state.total_supply.check_can_mint(amount),
+            Self::FungibleToken(token_id, _) => {
+                Err(WalletError::CannotChangeNotOwnedToken(*token_id))
+            }
+            Self::NonFungibleToken(token_id) => {
+                Err(WalletError::CannotChangeNonFungableToken(*token_id))
+            }
+        }
+    }
+
+    pub fn check_can_unmint(&self, amount: Amount) -> WalletResult<()> {
+        match self {
+            Self::OwnFungibleToken(_, state) => state.total_supply.check_can_unmint(amount),
+            Self::FungibleToken(token_id, _) => {
+                Err(WalletError::CannotChangeNotOwnedToken(*token_id))
+            }
+            Self::NonFungibleToken(token_id) => {
+                Err(WalletError::CannotChangeNonFungableToken(*token_id))
+            }
+        }
+    }
+
+    pub fn check_can_lock(&self) -> WalletResult<()> {
+        match self {
+            Self::OwnFungibleToken(_, state) => state.total_supply.check_can_lock(),
+            Self::FungibleToken(token_id, _) => {
+                Err(WalletError::CannotChangeNotOwnedToken(*token_id))
+            }
+            Self::NonFungibleToken(token_id) => {
+                Err(WalletError::CannotChangeNonFungableToken(*token_id))
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn current_supply(&self) -> Option<Amount> {
+        match self {
+            Self::OwnFungibleToken(_, state) => Some(state.total_supply.current_supply()),
+            Self::FungibleToken(_, _) => None,
+            Self::NonFungibleToken(_) => None,
         }
     }
 }
 
 pub enum TokenFreezableState {
     NotFrozen(IsTokenFreezable),
-    Frozen(IsTokenFreezable, IsTokenUnfreezable),
+    Frozen(IsTokenUnfreezable),
+}
+
+impl From<RPCIsTokenFrozen> for TokenFreezableState {
+    fn from(value: RPCIsTokenFrozen) -> Self {
+        match value {
+            RPCIsTokenFrozen::No(is_freezable) => match is_freezable {
+                RPCIsTokenFreezable::No => Self::NotFrozen(IsTokenFreezable::No),
+                RPCIsTokenFreezable::Yes => Self::NotFrozen(IsTokenFreezable::Yes),
+            },
+            RPCIsTokenFrozen::Yes(is_unfreezable) => match is_unfreezable {
+                RPCIsTokenUnfreezable::No => Self::Frozen(IsTokenUnfreezable::No),
+                RPCIsTokenUnfreezable::Yes => Self::Frozen(IsTokenUnfreezable::Yes),
+            },
+        }
+    }
 }
 
 impl TokenFreezableState {
     pub fn check_can_be_used(&self) -> WalletResult<()> {
         match self {
-            Self::Frozen(_, _) => Err(WalletError::CannotUseFrozenToken),
+            Self::Frozen(_) => Err(WalletError::CannotUseFrozenToken),
             Self::NotFrozen(_) => Ok(()),
         }
     }
+
     fn freeze(&self, is_unfreezable: IsTokenUnfreezable) -> WalletResult<Self> {
         match self {
-            Self::NotFrozen(IsTokenFreezable::Yes) => {
-                Ok(Self::Frozen(IsTokenFreezable::Yes, is_unfreezable))
-            }
+            Self::NotFrozen(IsTokenFreezable::Yes) => Ok(Self::Frozen(is_unfreezable)),
             Self::NotFrozen(IsTokenFreezable::No) => {
                 Err(WalletError::CannotFreezeNotFreezableToken)
             }
-            Self::Frozen(_, _) => Err(WalletError::CannotFreezeAlreadyFrozenToken),
+            Self::Frozen(_) => Err(WalletError::CannotFreezeAlreadyFrozenToken),
         }
     }
 
@@ -252,64 +395,46 @@ impl TokenFreezableState {
             Self::NotFrozen(IsTokenFreezable::No) => {
                 Err(WalletError::CannotFreezeNotFreezableToken)
             }
-            Self::Frozen(_, _) => Err(WalletError::CannotFreezeAlreadyFrozenToken),
+            Self::Frozen(_) => Err(WalletError::CannotFreezeAlreadyFrozenToken),
         }
     }
 
     fn unfreeze(&self) -> WalletResult<Self> {
         match self {
-            Self::Frozen(is_freezable, IsTokenUnfreezable::Yes) => {
-                Ok(Self::NotFrozen(*is_freezable))
-            }
-            Self::Frozen(_, IsTokenUnfreezable::No) => Err(WalletError::CannotUnfreezeToken),
+            Self::Frozen(IsTokenUnfreezable::Yes) => Ok(Self::NotFrozen(IsTokenFreezable::Yes)),
+            Self::Frozen(IsTokenUnfreezable::No) => Err(WalletError::CannotUnfreezeToken),
             Self::NotFrozen(_) => Err(WalletError::CannotUnfreezeANotFrozenToken),
         }
     }
 
     pub fn check_can_unfreeze(&self) -> WalletResult<()> {
         match self {
-            Self::Frozen(_, IsTokenUnfreezable::Yes) => Ok(()),
-            Self::Frozen(_, IsTokenUnfreezable::No) => Err(WalletError::CannotUnfreezeToken),
+            Self::Frozen(IsTokenUnfreezable::Yes) => Ok(()),
+            Self::Frozen(IsTokenUnfreezable::No) => Err(WalletError::CannotUnfreezeToken),
             Self::NotFrozen(_) => Err(WalletError::CannotUnfreezeANotFrozenToken),
         }
     }
-
-    fn undo_freeze(&self) -> WalletResult<Self> {
-        match self {
-            Self::Frozen(is_freezable, _) => Ok(Self::NotFrozen(*is_freezable)),
-            Self::NotFrozen(_) => Err(WalletError::MissingTokenId),
-        }
-    }
-
-    fn undo_unfreeze(&self) -> WalletResult<Self> {
-        match self {
-            Self::NotFrozen(IsTokenFreezable::Yes) => {
-                Ok(Self::Frozen(IsTokenFreezable::Yes, IsTokenUnfreezable::Yes))
-            }
-            Self::NotFrozen(IsTokenFreezable::No) | Self::Frozen(_, _) => {
-                Err(WalletError::MissingTokenId)
-            }
-        }
-    }
 }
 
+#[derive(Debug)]
 pub struct TokenIssuanceData {
-    pub total_supply: TokenCurrentSupplyState,
     pub authority: Destination,
     pub last_nonce: Option<AccountNonce>,
+
     /// last parent transaction if the parent is unconfirmed
     pub last_parent: Option<OutPointSourceId>,
-    pub frozen_state: TokenFreezableState,
+
+    /// unconfirmed transactions that modify the total supply or frozen state of this token
+    unconfirmed_txs: BTreeSet<OutPointSourceId>,
 }
 
 impl TokenIssuanceData {
-    fn new(data: TokenTotalSupply, authority: Destination, is_freezable: IsTokenFreezable) -> Self {
+    fn new(authority: Destination) -> Self {
         Self {
-            total_supply: data.into(),
             authority,
             last_nonce: None,
             last_parent: None,
-            frozen_state: TokenFreezableState::NotFrozen(is_freezable),
+            unconfirmed_txs: BTreeSet::new(),
         }
     }
 }
@@ -349,18 +474,7 @@ impl OutputCache {
     pub fn new(mut txs: Vec<(AccountWalletTxId, WalletTx)>) -> WalletResult<Self> {
         let mut cache = Self::empty();
 
-        txs.sort_by(|x, y| match (x.1.state(), y.1.state()) {
-            (TxState::Confirmed(h1, _, idx1), TxState::Confirmed(h2, _, idx2)) => {
-                (h1, idx1).cmp(&(h2, idx2))
-            }
-            (TxState::Confirmed(_, _, _), _) => std::cmp::Ordering::Less,
-            (_, TxState::Confirmed(_, _, _)) => std::cmp::Ordering::Greater,
-            (TxState::InMempool(idx1), TxState::InMempool(idx2)) => idx1.cmp(&idx2),
-            (TxState::InMempool(idx1), TxState::Inactive(idx2)) => idx1.cmp(&idx2),
-            (TxState::Inactive(idx1), TxState::Inactive(idx2)) => idx1.cmp(&idx2),
-            (TxState::Inactive(idx1), TxState::InMempool(idx2)) => idx1.cmp(&idx2),
-            (_, _) => std::cmp::Ordering::Equal,
-        });
+        txs.sort_by(|x, y| wallet_tx_order(&x.1, &y.1));
         for (tx_id, tx) in txs {
             cache.add_tx(tx_id.into_item_id(), tx)?;
         }
@@ -411,6 +525,61 @@ impl OutputCache {
 
     pub fn token_data(&self, token_id: &TokenId) -> Option<&TokenIssuanceData> {
         self.token_issuance.get(token_id)
+    }
+
+    pub fn get_token_unconfirmed_info<F: Fn(&Destination) -> bool>(
+        &self,
+        token_info: &RPCFungibleTokenInfo,
+        is_mine: F,
+    ) -> WalletResult<UnconfirmedTokenInfo> {
+        let token_data = match self.token_issuance.get(&token_info.token_id) {
+            Some(token_data) => {
+                if !is_mine(&token_data.authority) {
+                    return Ok(UnconfirmedTokenInfo::FungibleToken(
+                        token_info.token_id,
+                        token_info.frozen.into(),
+                    ));
+                }
+                token_data
+            }
+            // If it is not ours just return what is in the token_info
+            None => {
+                return Ok(UnconfirmedTokenInfo::FungibleToken(
+                    token_info.token_id,
+                    token_info.frozen.into(),
+                ));
+            }
+        };
+
+        let unconfirmed_txs = token_data
+            .unconfirmed_txs
+            .iter()
+            .map(|tx_id| self.txs.get(tx_id).expect("tx must be present"))
+            .sorted_by(|x, y| wallet_tx_order(x, y))
+            .collect_vec();
+
+        let mut frozen_state = token_info.frozen.into();
+        let mut total_supply: TokenCurrentSupplyState = token_info.total_supply.into();
+        total_supply = total_supply.mint(token_info.circulating_supply)?;
+        if token_info.is_locked {
+            total_supply = total_supply.lock()?;
+        }
+
+        for tx in unconfirmed_txs {
+            frozen_state = apply_freeze_mutations_from_tx(frozen_state, tx, &token_info.token_id)?;
+            total_supply =
+                apply_total_supply_mutations_from_tx(total_supply, tx, &token_info.token_id)?;
+        }
+
+        Ok(UnconfirmedTokenInfo::OwnFungibleToken(
+            token_info.token_id,
+            FungibleTokenInfo {
+                frozen: frozen_state,
+                last_nonce: token_data.last_nonce,
+                total_supply,
+                authority: token_data.authority.clone(),
+            },
+        ))
     }
 
     pub fn add_tx(&mut self, tx_id: OutPointSourceId, tx: WalletTx) -> WalletResult<()> {
@@ -503,14 +672,8 @@ impl OutputCache {
                     let token_id = make_token_id(input0_outpoint).ok_or(WalletError::NoUtxos)?;
                     match issuance.as_ref() {
                         TokenIssuance::V1(data) => {
-                            self.token_issuance.insert(
-                                token_id,
-                                TokenIssuanceData::new(
-                                    data.total_supply,
-                                    data.authority.clone(),
-                                    data.is_freezable,
-                                ),
-                            );
+                            self.token_issuance
+                                .insert(token_id, TokenIssuanceData::new(data.authority.clone()));
                         }
                     }
                 }
@@ -542,92 +705,70 @@ impl OutputCache {
                         self.unconfirmed_descendants.remove(tx_id);
                     }
                 }
-                TxInput::Account(outpoint) => {
-                    if !already_present {
-                        match outpoint.account() {
-                            AccountSpending::DelegationBalance(delegation_id, _) => {
-                                if let Some(data) = self.delegations.get_mut(delegation_id) {
-                                    Self::update_delegation_state(
-                                        &mut self.unconfirmed_descendants,
-                                        data,
-                                        delegation_id,
-                                        outpoint.nonce(),
-                                        tx_id,
-                                    )?;
-                                }
+                TxInput::Account(outpoint) => match outpoint.account() {
+                    AccountSpending::DelegationBalance(delegation_id, _) => {
+                        if !already_present {
+                            if let Some(data) = self.delegations.get_mut(delegation_id) {
+                                Self::update_delegation_state(
+                                    &mut self.unconfirmed_descendants,
+                                    data,
+                                    delegation_id,
+                                    outpoint.nonce(),
+                                    tx_id,
+                                )?;
                             }
                         }
                     }
-                }
-                TxInput::AccountCommand(nonce, op) => {
-                    if !already_present {
-                        match op {
-                            AccountCommand::MintTokens(token_id, amount) => {
-                                if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                    Self::update_token_issuance_state(
-                                        &mut self.unconfirmed_descendants,
-                                        data,
-                                        token_id,
-                                        *nonce,
-                                        tx_id,
-                                    )?;
-                                    data.total_supply = data.total_supply.mint(*amount)?;
-                                }
+                },
+                TxInput::AccountCommand(nonce, op) => match op {
+                    AccountCommand::MintTokens(token_id, _)
+                    | AccountCommand::UnmintTokens(token_id)
+                    | AccountCommand::LockTokenSupply(token_id)
+                    | AccountCommand::FreezeToken(token_id, _)
+                    | AccountCommand::UnfreezeToken(token_id) => {
+                        if let Some(data) = self.token_issuance.get_mut(token_id) {
+                            if !already_present {
+                                Self::update_token_issuance_state(
+                                    &mut self.unconfirmed_descendants,
+                                    data,
+                                    token_id,
+                                    *nonce,
+                                    tx_id,
+                                )?;
                             }
-                            AccountCommand::UnmintTokens(token_id) => {
-                                if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                    Self::update_token_issuance_state(
-                                        &mut self.unconfirmed_descendants,
-                                        data,
-                                        token_id,
-                                        *nonce,
-                                        tx_id,
-                                    )?;
-                                    let amount = sum_burned_token_amount(tx.outputs(), token_id)?;
-                                    data.total_supply = data.total_supply.unmint(amount)?;
-                                }
+                            if is_unconfirmed {
+                                data.unconfirmed_txs.insert(tx_id.clone());
+                            } else {
+                                data.unconfirmed_txs.remove(tx_id);
                             }
-                            | AccountCommand::LockTokenSupply(token_id) => {
-                                if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                    Self::update_token_issuance_state(
-                                        &mut self.unconfirmed_descendants,
-                                        data,
-                                        token_id,
-                                        *nonce,
-                                        tx_id,
-                                    )?;
-                                    data.total_supply = data.total_supply.lock()?;
-                                }
-                            }
-                            AccountCommand::FreezeToken(token_id, is_unfreezable) => {
-                                if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                    Self::update_token_issuance_state(
-                                        &mut self.unconfirmed_descendants,
-                                        data,
-                                        token_id,
-                                        *nonce,
-                                        tx_id,
-                                    )?;
-                                    data.frozen_state =
-                                        data.frozen_state.freeze(*is_unfreezable)?;
-                                }
-                            }
-                            AccountCommand::UnfreezeToken(token_id) => {
-                                if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                    Self::update_token_issuance_state(
-                                        &mut self.unconfirmed_descendants,
-                                        data,
-                                        token_id,
-                                        *nonce,
-                                        tx_id,
-                                    )?;
-                                    data.frozen_state = data.frozen_state.unfreeze()?;
-                                }
-                            }
-                            AccountCommand::ChangeTokenAuthority(_, _) => unimplemented!(),
                         }
                     }
-                }
+                    AccountCommand::ChangeTokenAuthority(token_id, authority) => {
+                        if let Some(data) = self.token_issuance.get_mut(token_id) {
+                            if !already_present {
+                                Self::update_token_issuance_state(
+                                    &mut self.unconfirmed_descendants,
+                                    data,
+                                    token_id,
+                                    *nonce,
+                                    tx_id,
+                                )?;
+                                data.authority = authority.clone();
+                            }
+                            if is_unconfirmed {
+                                data.unconfirmed_txs.insert(tx_id.clone());
+                            } else {
+                                data.unconfirmed_txs.remove(tx_id);
+                            }
+                        } else if !is_unconfirmed {
+                            let mut data = TokenIssuanceData::new(authority.clone());
+                            // TODO: is this correct should we continue from the previous
+                            // or start from 0
+                            data.last_nonce = Some(*nonce);
+                            self.token_issuance.insert(*token_id, data);
+                        }
+                    }
+                },
             }
         }
         Ok(())
@@ -714,50 +855,19 @@ impl OutputCache {
                         }
                     },
                     TxInput::AccountCommand(nonce, op) => match op {
-                        AccountCommand::MintTokens(token_id, amount) => {
+                        AccountCommand::MintTokens(token_id, _)
+                        | AccountCommand::UnmintTokens(token_id)
+                        | AccountCommand::LockTokenSupply(token_id)
+                        | AccountCommand::FreezeToken(token_id, _)
+                        | AccountCommand::UnfreezeToken(token_id)
+                        | AccountCommand::ChangeTokenAuthority(token_id, _) => {
                             if let Some(data) = self.token_issuance.get_mut(token_id) {
                                 data.last_nonce = nonce.decrement();
                                 data.last_parent =
                                     find_parent(&self.unconfirmed_descendants, tx_id.clone());
-                                data.total_supply = data.total_supply.unmint(*amount)?;
+                                data.unconfirmed_txs.remove(tx_id);
                             }
                         }
-
-                        AccountCommand::UnmintTokens(token_id) => {
-                            if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                data.last_nonce = nonce.decrement();
-                                data.last_parent =
-                                    find_parent(&self.unconfirmed_descendants, tx_id.clone());
-                                let amount = sum_burned_token_amount(tx.outputs(), token_id)?;
-                                data.total_supply = data.total_supply.mint(amount)?;
-                            }
-                        }
-                        AccountCommand::LockTokenSupply(token_id) => {
-                            if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                data.last_nonce = nonce.decrement();
-                                data.last_parent =
-                                    find_parent(&self.unconfirmed_descendants, tx_id.clone());
-                                data.total_supply = data.total_supply.unlock()?;
-                            }
-                        }
-                        AccountCommand::FreezeToken(token_id, _) => {
-                            if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                data.last_nonce = nonce.decrement();
-                                data.last_parent =
-                                    find_parent(&self.unconfirmed_descendants, tx_id.clone());
-
-                                data.frozen_state = data.frozen_state.undo_freeze()?;
-                            }
-                        }
-                        AccountCommand::UnfreezeToken(token_id) => {
-                            if let Some(data) = self.token_issuance.get_mut(token_id) {
-                                data.last_nonce = nonce.decrement();
-                                data.last_parent =
-                                    find_parent(&self.unconfirmed_descendants, tx_id.clone());
-                                data.frozen_state = data.frozen_state.undo_unfreeze()?;
-                            }
-                        }
-                        AccountCommand::ChangeTokenAuthority(_, _) => unimplemented!(),
                     },
                 }
             }
@@ -816,11 +926,12 @@ impl OutputCache {
         };
 
         // check token is not frozen and can be used
-        token_id
-            .and_then(|token_id| self.token_data(&token_id))
-            .map_or(Ok(()), |token_data| {
-                token_data.frozen_state.check_can_be_used()
-            })?;
+        // TODO:
+        // token_id
+        //     .and_then(|token_id| self.token_data(&token_id))
+        //     .map_or(Ok(()), |token_data| {
+        //         token_data.frozen_state.check_can_be_used()
+        //     })?;
 
         Ok((output, token_id))
     }
@@ -938,7 +1049,12 @@ impl OutputCache {
                                         }
                                     },
                                     TxInput::AccountCommand(nonce, op) => match op {
-                                        AccountCommand::MintTokens(token_id, amount) => {
+                                        AccountCommand::MintTokens(token_id, _)
+                                        | AccountCommand::UnmintTokens(token_id)
+                                        | AccountCommand::LockTokenSupply(token_id)
+                                        | AccountCommand::FreezeToken(token_id, _)
+                                        | AccountCommand::UnfreezeToken(token_id)
+                                        | AccountCommand::ChangeTokenAuthority(token_id, _) => {
                                             if let Some(data) =
                                                 self.token_issuance.get_mut(token_id)
                                             {
@@ -947,67 +1063,8 @@ impl OutputCache {
                                                     &self.unconfirmed_descendants,
                                                     tx_id.into(),
                                                 );
-                                                data.total_supply =
-                                                    data.total_supply.unmint(*amount)?;
+                                                data.unconfirmed_txs.remove(&tx_id.into());
                                             }
-                                        }
-                                        | AccountCommand::UnmintTokens(token_id) => {
-                                            if let Some(data) =
-                                                self.token_issuance.get_mut(token_id)
-                                            {
-                                                data.last_nonce = nonce.decrement();
-                                                data.last_parent = find_parent(
-                                                    &self.unconfirmed_descendants,
-                                                    tx_id.into(),
-                                                );
-                                                let amount = sum_burned_token_amount(
-                                                    tx.get_transaction().outputs(),
-                                                    token_id,
-                                                )?;
-                                                data.total_supply =
-                                                    data.total_supply.mint(amount)?;
-                                            }
-                                        }
-                                        | AccountCommand::LockTokenSupply(token_id) => {
-                                            if let Some(data) =
-                                                self.token_issuance.get_mut(token_id)
-                                            {
-                                                data.last_nonce = nonce.decrement();
-                                                data.last_parent = find_parent(
-                                                    &self.unconfirmed_descendants,
-                                                    tx_id.into(),
-                                                );
-                                                data.total_supply = data.total_supply.unlock()?;
-                                            }
-                                        }
-                                        AccountCommand::FreezeToken(token_id, _) => {
-                                            if let Some(data) =
-                                                self.token_issuance.get_mut(token_id)
-                                            {
-                                                data.last_nonce = nonce.decrement();
-                                                data.last_parent = find_parent(
-                                                    &self.unconfirmed_descendants,
-                                                    tx_id.into(),
-                                                );
-                                                data.frozen_state =
-                                                    data.frozen_state.undo_freeze()?;
-                                            }
-                                        }
-                                        AccountCommand::UnfreezeToken(token_id) => {
-                                            if let Some(data) =
-                                                self.token_issuance.get_mut(token_id)
-                                            {
-                                                data.last_nonce = nonce.decrement();
-                                                data.last_parent = find_parent(
-                                                    &self.unconfirmed_descendants,
-                                                    tx_id.into(),
-                                                );
-                                                data.frozen_state =
-                                                    data.frozen_state.undo_unfreeze()?;
-                                            }
-                                        }
-                                        AccountCommand::ChangeTokenAuthority(_, _) => {
-                                            unimplemented!()
                                         }
                                     },
                                 }
@@ -1029,6 +1086,21 @@ impl OutputCache {
             None | Some(WalletTx::Block(_)) => Err(WalletError::NoTransactionFound(transaction_id)),
             Some(WalletTx::Tx(tx)) => Ok(tx),
         }
+    }
+}
+
+fn wallet_tx_order(x: &WalletTx, y: &WalletTx) -> std::cmp::Ordering {
+    match (x.state(), y.state()) {
+        (TxState::Confirmed(h1, _, idx1), TxState::Confirmed(h2, _, idx2)) => {
+            (h1, idx1).cmp(&(h2, idx2))
+        }
+        (TxState::Confirmed(_, _, _), _) => std::cmp::Ordering::Less,
+        (_, TxState::Confirmed(_, _, _)) => std::cmp::Ordering::Greater,
+        (TxState::InMempool(idx1), TxState::InMempool(idx2)) => idx1.cmp(&idx2),
+        (TxState::InMempool(idx1), TxState::Inactive(idx2)) => idx1.cmp(&idx2),
+        (TxState::Inactive(idx1), TxState::Inactive(idx2)) => idx1.cmp(&idx2),
+        (TxState::Inactive(idx1), TxState::InMempool(idx2)) => idx1.cmp(&idx2),
+        (_, _) => std::cmp::Ordering::Equal,
     }
 }
 
@@ -1144,4 +1216,71 @@ fn find_parent(
         .iter()
         .find_map(|(parent_id, descendants)| descendants.contains(&tx_id).then_some(parent_id))
         .cloned()
+}
+
+fn apply_freeze_mutations_from_tx(
+    mut frozen_state: TokenFreezableState,
+    tx: &WalletTx,
+    own_token_id: &TokenId,
+) -> WalletResult<TokenFreezableState> {
+    for inp in tx.inputs() {
+        match inp {
+            TxInput::Utxo(_) => {}
+            TxInput::Account(acc) => match acc.account() {
+                AccountSpending::DelegationBalance(_, _) => {}
+            },
+            TxInput::AccountCommand(_, op) => match op {
+                AccountCommand::FreezeToken(token_id, is_unfreezable) => {
+                    if token_id == own_token_id {
+                        frozen_state = frozen_state.freeze(*is_unfreezable)?;
+                    }
+                }
+                AccountCommand::UnfreezeToken(token_id) => {
+                    if token_id == own_token_id {
+                        frozen_state = frozen_state.unfreeze()?;
+                    }
+                }
+                AccountCommand::MintTokens(_, _)
+                | AccountCommand::UnmintTokens(_)
+                | AccountCommand::LockTokenSupply(_)
+                | AccountCommand::ChangeTokenAuthority(_, _) => {}
+            },
+        }
+    }
+
+    Ok(frozen_state)
+}
+
+fn apply_total_supply_mutations_from_tx(
+    mut total_supply: TokenCurrentSupplyState,
+    tx: &WalletTx,
+    own_token_id: &TokenId,
+) -> WalletResult<TokenCurrentSupplyState> {
+    for inp in tx.inputs() {
+        match inp {
+            TxInput::Utxo(_) => {}
+            TxInput::Account(acc) => match acc.account() {
+                AccountSpending::DelegationBalance(_, _) => {}
+            },
+            TxInput::AccountCommand(_, op) => match op {
+                AccountCommand::MintTokens(token_id, amount) => {
+                    if token_id == own_token_id {
+                        total_supply = total_supply.mint(*amount)?;
+                    }
+                }
+                AccountCommand::UnmintTokens(token_id) => {
+                    let amount = sum_burned_token_amount(tx.outputs(), token_id)?;
+                    total_supply = total_supply.unmint(amount)?;
+                }
+                AccountCommand::LockTokenSupply(_) => {
+                    total_supply = total_supply.lock()?;
+                }
+                AccountCommand::FreezeToken(_, _)
+                | AccountCommand::UnfreezeToken(_)
+                | AccountCommand::ChangeTokenAuthority(_, _) => {}
+            },
+        }
+    }
+
+    Ok(total_supply)
 }

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -98,12 +98,6 @@ pub fn make_unmint_token_outputs(token_id: TokenId, amount: Amount) -> Vec<TxOut
     vec![burn_tokens]
 }
 
-pub fn make_zero_burn_output() -> Vec<TxOutput> {
-    // Just so that the transaction doesn't have 0 outputs
-    let token_change_supply_fee = TxOutput::Burn(OutputValue::Coin(Amount::ZERO));
-    vec![token_change_supply_fee]
-}
-
 pub fn make_create_delegation_output(
     chain_config: &ChainConfig,
     address: Address<Destination>,

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -18,7 +18,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::account::transaction_list::TransactionList;
-use crate::account::{Currency, CurrentFeeRate, DelegationData, UtxoSelectorError};
+use crate::account::{
+    Currency, CurrentFeeRate, DelegationData, UnconfirmedTokenInfo, UtxoSelectorError,
+};
 use crate::key_chain::{KeyChainError, MasterKeyChain};
 use crate::send_request::{make_issue_token_outputs, IssueNftArguments, StakePoolDataArguments};
 use crate::wallet_events::{WalletEvents, WalletEventsNoOp};
@@ -27,7 +29,9 @@ pub use bip39::{Language, Mnemonic};
 use common::address::{Address, AddressError};
 use common::chain::block::timestamp::BlockTimestamp;
 use common::chain::signature::TransactionSigError;
-use common::chain::tokens::{make_token_id, IsTokenUnfreezable, Metadata, TokenId, TokenIssuance};
+use common::chain::tokens::{
+    make_token_id, IsTokenUnfreezable, Metadata, RPCFungibleTokenInfo, TokenId, TokenIssuance,
+};
 use common::chain::{
     AccountNonce, Block, ChainConfig, DelegationId, Destination, GenBlock, PoolId,
     SignedTransaction, Transaction, TransactionCreationError, TxOutput, UtxoOutPoint,
@@ -164,6 +168,10 @@ pub enum WalletError {
     CannotUnfreezeANotFrozenToken,
     #[error("Cannot use a frozen token")]
     CannotUseFrozenToken,
+    #[error("Cannot change a not owned token")]
+    CannotChangeNotOwnedToken(TokenId),
+    #[error("Cannot change a nonfungable token")]
+    CannotChangeNonFungableToken(TokenId),
 }
 
 /// Result type used for the wallet
@@ -358,7 +366,9 @@ impl<B: storage::Backend> Wallet<B> {
     /// this will cause the wallet to rescan the blockchain
     pub fn reset_wallet_to_genesis(&mut self) -> WalletResult<()> {
         let mut db_tx = self.db.transaction_rw(None)?;
-        Self::reset_wallet_transactions(self.chain_config.clone(), &mut db_tx)
+        Self::reset_wallet_transactions(self.chain_config.clone(), &mut db_tx)?;
+        db_tx.commit()?;
+        Ok(())
     }
 
     fn reset_wallet_transactions(
@@ -416,6 +426,8 @@ impl<B: storage::Backend> Wallet<B> {
         for account in self.accounts.values_mut() {
             account.reset_to_height(&mut db_tx, wallet_events, BlockHeight::new(0))?;
         }
+
+        db_tx.commit()?;
 
         Ok(())
     }
@@ -845,7 +857,7 @@ impl<B: storage::Backend> Wallet<B> {
     pub fn mint_tokens(
         &mut self,
         account_index: U31,
-        token_id: TokenId,
+        token_info: &UnconfirmedTokenInfo,
         amount: Amount,
         destination: Address<Destination>,
         current_fee_rate: FeeRate,
@@ -855,7 +867,7 @@ impl<B: storage::Backend> Wallet<B> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
             account.mint_tokens(
                 db_tx,
-                token_id,
+                token_info,
                 destination,
                 amount,
                 latest_median_time,
@@ -870,7 +882,7 @@ impl<B: storage::Backend> Wallet<B> {
     pub fn unmint_tokens(
         &mut self,
         account_index: U31,
-        token_id: TokenId,
+        token_info: &UnconfirmedTokenInfo,
         amount: Amount,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
@@ -879,7 +891,7 @@ impl<B: storage::Backend> Wallet<B> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
             account.unmint_tokens(
                 db_tx,
-                token_id,
+                token_info,
                 amount,
                 latest_median_time,
                 CurrentFeeRate {
@@ -893,7 +905,7 @@ impl<B: storage::Backend> Wallet<B> {
     pub fn lock_token_supply(
         &mut self,
         account_index: U31,
-        token_id: TokenId,
+        token_info: &UnconfirmedTokenInfo,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
@@ -901,7 +913,7 @@ impl<B: storage::Backend> Wallet<B> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
             account.lock_token_supply(
                 db_tx,
-                token_id,
+                token_info,
                 latest_median_time,
                 CurrentFeeRate {
                     current_fee_rate,
@@ -914,7 +926,7 @@ impl<B: storage::Backend> Wallet<B> {
     pub fn freeze_token(
         &mut self,
         account_index: U31,
-        token_id: TokenId,
+        token_info: &UnconfirmedTokenInfo,
         is_token_unfreezable: IsTokenUnfreezable,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
@@ -923,7 +935,7 @@ impl<B: storage::Backend> Wallet<B> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
             account.freeze_token(
                 db_tx,
-                token_id,
+                token_info,
                 is_token_unfreezable,
                 latest_median_time,
                 CurrentFeeRate {
@@ -937,7 +949,7 @@ impl<B: storage::Backend> Wallet<B> {
     pub fn unfreeze_token(
         &mut self,
         account_index: U31,
-        token_id: TokenId,
+        token_info: &UnconfirmedTokenInfo,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
@@ -945,7 +957,7 @@ impl<B: storage::Backend> Wallet<B> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
             account.unfreeze_token(
                 db_tx,
-                token_id,
+                token_info,
                 latest_median_time,
                 CurrentFeeRate {
                     current_fee_rate,
@@ -955,12 +967,35 @@ impl<B: storage::Backend> Wallet<B> {
         })
     }
 
-    pub fn check_token_can_be_used(
+    pub fn change_token_authority(
         &mut self,
         account_index: U31,
-        token_id: TokenId,
-    ) -> WalletResult<()> {
-        self.get_account(account_index)?.check_token_can_be_used(&token_id)
+        token_info: &UnconfirmedTokenInfo,
+        address: Address<Destination>,
+        current_fee_rate: FeeRate,
+        consolidate_fee_rate: FeeRate,
+    ) -> WalletResult<SignedTransaction> {
+        let latest_median_time = self.latest_median_time;
+        self.for_account_rw_unlocked(account_index, |account, db_tx| {
+            account.change_token_authority(
+                db_tx,
+                token_info,
+                address,
+                latest_median_time,
+                CurrentFeeRate {
+                    current_fee_rate,
+                    consolidate_fee_rate,
+                },
+            )
+        })
+    }
+
+    pub fn get_token_unconfirmed_info(
+        &mut self,
+        account_index: U31,
+        token_info: &RPCFungibleTokenInfo,
+    ) -> WalletResult<UnconfirmedTokenInfo> {
+        self.get_account(account_index)?.get_token_unconfirmed_info(token_info)
     }
 
     pub fn create_delegation(
@@ -1214,6 +1249,8 @@ impl<B: storage::Backend> Wallet<B> {
             account.scan_new_inmempool_transactions(transactions, &mut db_tx, wallet_events)?;
         }
 
+        db_tx.commit()?;
+
         Ok(())
     }
 
@@ -1231,12 +1268,16 @@ impl<B: storage::Backend> Wallet<B> {
             account.scan_new_inactive_transactions(&txs, &mut db_tx, wallet_events)?;
         }
 
+        db_tx.commit()?;
+
         Ok(())
     }
 
     pub fn set_median_time(&mut self, median_time: BlockTimestamp) -> WalletResult<()> {
         self.latest_median_time = median_time;
-        self.db.transaction_rw(None)?.set_median_time(median_time)?;
+        let mut db_tx = self.db.transaction_rw(None)?;
+        db_tx.set_median_time(median_time)?;
+        db_tx.commit()?;
         Ok(())
     }
 }

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -31,7 +31,7 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         timelock::OutputTimeLock,
-        tokens::{TokenData, TokenIssuanceV0, TokenIssuanceV1},
+        tokens::{RPCIsTokenFrozen, TokenData, TokenIssuanceV0, TokenIssuanceV1},
         Destination, Genesis, OutPointSourceId, TxInput,
     },
     primitives::{per_thousand::PerThousand, Idable, H256},
@@ -1746,30 +1746,45 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let mut token_amount_to_issue = Amount::from_atoms(rng.gen_range(1..amount_fraction));
 
     let (issued_token_id, token_issuance_transaction) = if issue_token {
+        let token_issuance = TokenIssuanceV1 {
+            token_ticker: "XXXX".as_bytes().to_vec(),
+            number_of_decimals: rng.gen_range(1..18),
+            metadata_uri: "http://uri".as_bytes().to_vec(),
+            total_supply: common::chain::tokens::TokenTotalSupply::Unlimited,
+            authority: address2.decode_object(&chain_config).unwrap(),
+            is_freezable: common::chain::tokens::IsTokenFreezable::No,
+        };
         let (issued_token_id, token_issuance_transaction) = wallet
             .issue_new_token(
                 DEFAULT_ACCOUNT_INDEX,
-                TokenIssuance::V1(TokenIssuanceV1 {
-                    token_ticker: "XXXX".as_bytes().to_vec(),
-                    number_of_decimals: rng.gen_range(1..18),
-                    metadata_uri: "http://uri".as_bytes().to_vec(),
-                    total_supply: common::chain::tokens::TokenTotalSupply::Unlimited,
-                    authority: address2.decode_object(&chain_config).unwrap(),
-                    is_freezable: common::chain::tokens::IsTokenFreezable::No,
-                }),
+                TokenIssuance::V1(token_issuance.clone()),
                 FeeRate::new(Amount::ZERO),
                 FeeRate::new(Amount::ZERO),
             )
             .unwrap();
 
+        let token_info = RPCFungibleTokenInfo::new(
+            issued_token_id,
+            token_issuance.token_ticker,
+            token_issuance.number_of_decimals,
+            token_issuance.metadata_uri,
+            Amount::ZERO,
+            token_issuance.total_supply.into(),
+            false,
+            RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
+            Some(token_issuance.authority),
+        );
+
         wallet
             .add_unconfirmed_tx(token_issuance_transaction.clone(), &WalletEventsNoOp)
             .unwrap();
 
+        let unconfirmed_token_info =
+            wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
         let mint_transaction = wallet
             .mint_tokens(
                 DEFAULT_ACCOUNT_INDEX,
-                issued_token_id,
+                &unconfirmed_token_info,
                 token_amount_to_issue,
                 address2,
                 FeeRate::new(Amount::ZERO),
@@ -1990,17 +2005,19 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
 
     let fixed_max_amount = Amount::from_atoms(rng.gen_range(1..100000));
     let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
+    let token_issuance = TokenIssuanceV1 {
+        token_ticker: "XXXX".as_bytes().to_vec(),
+        number_of_decimals: rng.gen_range(1..18),
+        metadata_uri: "http://uri".as_bytes().to_vec(),
+        total_supply: common::chain::tokens::TokenTotalSupply::Fixed(fixed_max_amount),
+        authority: address2.decode_object(&chain_config).unwrap(),
+        is_freezable: common::chain::tokens::IsTokenFreezable::Yes,
+    };
+
     let (issued_token_id, token_issuance_transaction) = wallet
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,
-            TokenIssuance::V1(TokenIssuanceV1 {
-                token_ticker: "XXXX".as_bytes().to_vec(),
-                number_of_decimals: rng.gen_range(1..18),
-                metadata_uri: "http://uri".as_bytes().to_vec(),
-                total_supply: common::chain::tokens::TokenTotalSupply::Fixed(fixed_max_amount),
-                authority: address2.decode_object(&chain_config).unwrap(),
-                is_freezable: common::chain::tokens::IsTokenFreezable::Yes,
-            }),
+            TokenIssuance::V1(token_issuance.clone()),
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2015,25 +2032,25 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
         1,
     );
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    token_issuance_data.frozen_state.check_can_freeze().unwrap();
-    assert_eq!(
-        token_issuance_data.frozen_state.check_can_unfreeze().unwrap_err(),
-        WalletError::CannotUnfreezeANotFrozenToken
+    let token_info = RPCFungibleTokenInfo::new(
+        issued_token_id,
+        token_issuance.token_ticker,
+        token_issuance.number_of_decimals,
+        token_issuance.metadata_uri,
+        Amount::ZERO,
+        token_issuance.total_supply.into(),
+        false,
+        RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
+        Some(token_issuance.authority),
     );
 
-    assert_eq!(token_issuance_data.last_nonce, None);
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     let freeze_tx = wallet
         .freeze_token(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             IsTokenUnfreezable::Yes,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
@@ -2042,27 +2059,26 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
 
     wallet.add_unconfirmed_tx(freeze_tx.clone(), &WalletEventsNoOp).unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.frozen_state.check_can_freeze().unwrap_err(),
+        unconfirmed_token_info.check_can_freeze().unwrap_err(),
         WalletError::CannotFreezeAlreadyFrozenToken
     );
-    token_issuance_data.frozen_state.check_can_unfreeze().unwrap();
+    unconfirmed_token_info.check_can_unfreeze().unwrap();
 
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+    assert_eq!(
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(1)
+    );
 
     // unfreeze the token
 
     let unfreeze_tx = wallet
         .unfreeze_token(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2070,40 +2086,38 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
 
     wallet.add_unconfirmed_tx(unfreeze_tx.clone(), &WalletEventsNoOp).unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
-    token_issuance_data.frozen_state.check_can_freeze().unwrap();
+    unconfirmed_token_info.check_can_freeze().unwrap();
     assert_eq!(
-        token_issuance_data.frozen_state.check_can_unfreeze().unwrap_err(),
+        unconfirmed_token_info.check_can_unfreeze().unwrap_err(),
         WalletError::CannotUnfreezeANotFrozenToken
     );
 
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(1)));
+    assert_eq!(
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(2)
+    );
 
     // test abandoning a transaction
     wallet
         .abandon_transaction(DEFAULT_ACCOUNT_INDEX, freeze_tx.transaction().get_id())
         .unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
-    token_issuance_data.frozen_state.check_can_freeze().unwrap();
+    unconfirmed_token_info.check_can_freeze().unwrap();
     assert_eq!(
-        token_issuance_data.frozen_state.check_can_unfreeze().unwrap_err(),
+        unconfirmed_token_info.check_can_unfreeze().unwrap_err(),
         WalletError::CannotUnfreezeANotFrozenToken
     );
 
-    assert_eq!(token_issuance_data.last_nonce, None);
+    assert_eq!(
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(0)
+    );
 
     let _ = create_block(
         &chain_config,
@@ -2113,18 +2127,17 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
         2,
     );
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(1)));
-
-    token_issuance_data.frozen_state.check_can_freeze().unwrap();
     assert_eq!(
-        token_issuance_data.frozen_state.check_can_unfreeze().unwrap_err(),
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(2)
+    );
+
+    unconfirmed_token_info.check_can_freeze().unwrap();
+    assert_eq!(
+        unconfirmed_token_info.check_can_unfreeze().unwrap_err(),
         WalletError::CannotUnfreezeANotFrozenToken
     );
 
@@ -2132,7 +2145,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
     let freeze_tx = wallet
         .freeze_token(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             IsTokenUnfreezable::No,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
@@ -2141,29 +2154,28 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
 
     wallet.add_unconfirmed_tx(freeze_tx.clone(), &WalletEventsNoOp).unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.frozen_state.check_can_freeze().unwrap_err(),
+        unconfirmed_token_info.check_can_freeze().unwrap_err(),
         WalletError::CannotFreezeAlreadyFrozenToken
     );
     assert_eq!(
-        token_issuance_data.frozen_state.check_can_unfreeze().unwrap_err(),
+        unconfirmed_token_info.check_can_unfreeze().unwrap_err(),
         WalletError::CannotUnfreezeToken
     );
 
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(2)));
+    assert_eq!(
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(3)
+    );
 
-    // cannot feeze again
+    // cannot freeze again
     let err = wallet
         .freeze_token(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             IsTokenUnfreezable::No,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
@@ -2175,7 +2187,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
     let err = wallet
         .unfreeze_token(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2207,17 +2219,18 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
 
     let fixed_max_amount = Amount::from_atoms(rng.gen_range(1..100000));
     let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
+    let token_issuance = TokenIssuanceV1 {
+        token_ticker: "XXXX".as_bytes().to_vec(),
+        number_of_decimals: rng.gen_range(1..18),
+        metadata_uri: "http://uri".as_bytes().to_vec(),
+        total_supply: common::chain::tokens::TokenTotalSupply::Fixed(fixed_max_amount),
+        authority: address2.decode_object(&chain_config).unwrap(),
+        is_freezable: common::chain::tokens::IsTokenFreezable::No,
+    };
     let (issued_token_id, token_issuance_transaction) = wallet
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,
-            TokenIssuance::V1(TokenIssuanceV1 {
-                token_ticker: "XXXX".as_bytes().to_vec(),
-                number_of_decimals: rng.gen_range(1..18),
-                metadata_uri: "http://uri".as_bytes().to_vec(),
-                total_supply: common::chain::tokens::TokenTotalSupply::Fixed(fixed_max_amount),
-                authority: address2.decode_object(&chain_config).unwrap(),
-                is_freezable: common::chain::tokens::IsTokenFreezable::No,
-            }),
+            TokenIssuance::V1(token_issuance.clone()),
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2232,22 +2245,33 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
         1,
     );
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(
-        token_issuance_data.authority,
-        address2.decode_object(&chain_config).unwrap()
+    let mut token_info = RPCFungibleTokenInfo::new(
+        issued_token_id,
+        token_issuance.token_ticker,
+        token_issuance.number_of_decimals,
+        token_issuance.metadata_uri,
+        Amount::ZERO,
+        token_issuance.total_supply.into(),
+        false,
+        RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
+        Some(token_issuance.authority),
     );
 
-    assert_eq!(token_issuance_data.last_nonce, None);
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.authority().unwrap(),
+        &address2.decode_object(&chain_config).unwrap()
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(0)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         Amount::ZERO,
     );
 
@@ -2255,7 +2279,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
     let mint_transaction = wallet
         .mint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_mint,
             address2.clone(),
             FeeRate::new(Amount::ZERO),
@@ -2265,6 +2289,9 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
 
     wallet.add_unconfirmed_tx(mint_transaction.clone(), &WalletEventsNoOp).unwrap();
 
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
+
     // Try to mint more then the fixed maximum
     let leftover = (fixed_max_amount - token_amount_to_mint).unwrap();
     let token_amount_to_mint_more_than_maximum =
@@ -2272,7 +2299,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
     let err = wallet
         .mint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_mint_more_than_maximum,
             address2.clone(),
             FeeRate::new(Amount::ZERO),
@@ -2289,41 +2316,38 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
         )
     );
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+    assert_eq!(
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(1)
+    );
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.current_supply().unwrap(),
         token_amount_to_mint,
     );
 
     // test abandoning a transaction
-    wallet
-        .abandon_transaction(
-            DEFAULT_ACCOUNT_INDEX,
-            mint_transaction.transaction().get_id(),
-        )
-        .unwrap();
+    {
+        wallet
+            .abandon_transaction(
+                DEFAULT_ACCOUNT_INDEX,
+                mint_transaction.transaction().get_id(),
+            )
+            .unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
+        let unconfirmed_token_info =
+            wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
-    assert_eq!(token_issuance_data.last_nonce, None);
+        assert_eq!(
+            unconfirmed_token_info.get_next_nonce().unwrap(),
+            AccountNonce::new(0)
+        );
 
-    assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
-        Amount::ZERO,
-    );
+        assert_eq!(
+            unconfirmed_token_info.current_supply().unwrap(),
+            Amount::ZERO,
+        );
+    }
 
     let _ = create_block(
         &chain_config,
@@ -2332,18 +2356,18 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
         block2_amount,
         2,
     );
+    token_info.circulating_supply = unconfirmed_token_info.current_supply().unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(1)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         token_amount_to_mint,
     );
 
@@ -2352,7 +2376,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
     let err = wallet
         .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
@@ -2368,12 +2392,18 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
     let unmint_transaction = wallet
         .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
         .unwrap();
+
+    wallet
+        .add_unconfirmed_tx(unmint_transaction.clone(), &WalletEventsNoOp)
+        .unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     let _ = create_block(
         &chain_config,
@@ -2382,29 +2412,29 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
         block2_amount,
         3,
     );
+    token_info.circulating_supply = unconfirmed_token_info.current_supply().unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(1)));
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(2)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         (token_amount_to_mint - token_amount_to_unmint).unwrap(),
     );
     assert_eq!(
-        token_issuance_data.total_supply.check_can_lock().unwrap_err(),
+        unconfirmed_token_info.check_can_lock().unwrap_err(),
         WalletError::CannotLockTokenSupply("Fixed")
     );
 
     let err = wallet
         .lock_token_supply(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2435,17 +2465,18 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
     assert_eq!(coin_balance, block1_amount);
 
     let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
+    let token_issuance = TokenIssuanceV1 {
+        token_ticker: "XXXX".as_bytes().to_vec(),
+        number_of_decimals: rng.gen_range(1..18),
+        metadata_uri: "http://uri".as_bytes().to_vec(),
+        total_supply: common::chain::tokens::TokenTotalSupply::Unlimited,
+        authority: address2.decode_object(&chain_config).unwrap(),
+        is_freezable: common::chain::tokens::IsTokenFreezable::No,
+    };
     let (issued_token_id, token_issuance_transaction) = wallet
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,
-            TokenIssuance::V1(TokenIssuanceV1 {
-                token_ticker: "XXXX".as_bytes().to_vec(),
-                number_of_decimals: rng.gen_range(1..18),
-                metadata_uri: "http://uri".as_bytes().to_vec(),
-                total_supply: common::chain::tokens::TokenTotalSupply::Unlimited,
-                authority: address2.decode_object(&chain_config).unwrap(),
-                is_freezable: common::chain::tokens::IsTokenFreezable::No,
-            }),
+            TokenIssuance::V1(token_issuance.clone()),
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2461,22 +2492,33 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
         1,
     );
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(
-        token_issuance_data.authority,
-        address2.decode_object(&chain_config).unwrap()
+    let mut token_info = RPCFungibleTokenInfo::new(
+        issued_token_id,
+        token_issuance.token_ticker,
+        token_issuance.number_of_decimals,
+        token_issuance.metadata_uri,
+        Amount::ZERO,
+        token_issuance.total_supply.into(),
+        false,
+        RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
+        Some(token_issuance.authority),
     );
 
-    assert_eq!(token_issuance_data.last_nonce, None);
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.authority().unwrap(),
+        &address2.decode_object(&chain_config).unwrap()
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(0)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         Amount::ZERO,
     );
 
@@ -2484,7 +2526,7 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
     let mint_transaction = wallet
         .mint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_mint,
             address2.clone(),
             FeeRate::new(Amount::ZERO),
@@ -2493,6 +2535,8 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
         .unwrap();
 
     wallet.add_unconfirmed_tx(mint_transaction.clone(), &WalletEventsNoOp).unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     let _ = create_block(
         &chain_config,
@@ -2501,18 +2545,18 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
         block2_amount,
         2,
     );
+    token_info.circulating_supply = unconfirmed_token_info.current_supply().unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(1)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         token_amount_to_mint,
     );
 
@@ -2521,7 +2565,7 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
     let err = wallet
         .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
@@ -2537,12 +2581,17 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
     let unmint_transaction = wallet
         .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
         .unwrap();
+    wallet
+        .add_unconfirmed_tx(unmint_transaction.clone(), &WalletEventsNoOp)
+        .unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     let _ = create_block(
         &chain_config,
@@ -2551,29 +2600,29 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
         block2_amount,
         3,
     );
+    token_info.circulating_supply = unconfirmed_token_info.current_supply().unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(1)));
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(2)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         (token_amount_to_mint - token_amount_to_unmint).unwrap(),
     );
     assert_eq!(
-        token_issuance_data.total_supply.check_can_lock().unwrap_err(),
+        unconfirmed_token_info.check_can_lock().unwrap_err(),
         WalletError::CannotLockTokenSupply("Unlimited")
     );
 
     let err = wallet
         .lock_token_supply(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2604,17 +2653,18 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     assert_eq!(coin_balance, block1_amount);
 
     let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
+    let token_issuance = TokenIssuanceV1 {
+        token_ticker: "XXXX".as_bytes().to_vec(),
+        number_of_decimals: rng.gen_range(1..18),
+        metadata_uri: "http://uri".as_bytes().to_vec(),
+        total_supply: common::chain::tokens::TokenTotalSupply::Lockable,
+        authority: address2.decode_object(&chain_config).unwrap(),
+        is_freezable: common::chain::tokens::IsTokenFreezable::No,
+    };
     let (issued_token_id, token_issuance_transaction) = wallet
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,
-            TokenIssuance::V1(TokenIssuanceV1 {
-                token_ticker: "XXXX".as_bytes().to_vec(),
-                number_of_decimals: rng.gen_range(1..18),
-                metadata_uri: "http://uri".as_bytes().to_vec(),
-                total_supply: common::chain::tokens::TokenTotalSupply::Lockable,
-                authority: address2.decode_object(&chain_config).unwrap(),
-                is_freezable: common::chain::tokens::IsTokenFreezable::No,
-            }),
+            TokenIssuance::V1(token_issuance.clone()),
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2630,22 +2680,33 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
         1,
     );
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(
-        token_issuance_data.authority,
-        address2.decode_object(&chain_config).unwrap()
+    let mut token_info = RPCFungibleTokenInfo::new(
+        issued_token_id,
+        token_issuance.token_ticker,
+        token_issuance.number_of_decimals,
+        token_issuance.metadata_uri,
+        Amount::ZERO,
+        token_issuance.total_supply.into(),
+        false,
+        RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
+        Some(token_issuance.authority),
     );
 
-    assert_eq!(token_issuance_data.last_nonce, None);
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.authority().unwrap(),
+        &address2.decode_object(&chain_config).unwrap()
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(0)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         Amount::ZERO,
     );
 
@@ -2653,13 +2714,16 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     let mint_transaction = wallet
         .mint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_mint,
             address2.clone(),
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
         .unwrap();
+    wallet.add_unconfirmed_tx(mint_transaction.clone(), &WalletEventsNoOp).unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     let _ = create_block(
         &chain_config,
@@ -2668,18 +2732,18 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
         block2_amount,
         2,
     );
+    token_info.circulating_supply = unconfirmed_token_info.current_supply().unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(0)));
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(1)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         token_amount_to_mint,
     );
 
@@ -2688,7 +2752,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     let err = wallet
         .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
@@ -2704,12 +2768,18 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     let unmint_transaction = wallet
         .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
         .unwrap();
+
+    wallet
+        .add_unconfirmed_tx(unmint_transaction.clone(), &WalletEventsNoOp)
+        .unwrap();
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     let _ = create_block(
         &chain_config,
@@ -2718,26 +2788,26 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
         block2_amount,
         3,
     );
+    token_info.circulating_supply = unconfirmed_token_info.current_supply().unwrap();
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(1)));
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(2)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         (token_amount_to_mint - token_amount_to_unmint).unwrap(),
     );
-    assert!(token_issuance_data.total_supply.check_can_lock().is_ok());
+    assert!(unconfirmed_token_info.check_can_lock().is_ok());
 
     let lock_transaction = wallet
         .lock_token_supply(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2750,30 +2820,30 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
         block2_amount,
         4,
     );
+    token_info.is_locked = true;
 
-    let token_issuance_data = wallet
-        .accounts
-        .get(&DEFAULT_ACCOUNT_INDEX)
-        .unwrap()
-        .find_token(&issued_token_id)
-        .unwrap();
-
-    assert_eq!(token_issuance_data.last_nonce, Some(AccountNonce::new(2)));
+    let unconfirmed_token_info =
+        wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
     assert_eq!(
-        token_issuance_data.total_supply.current_supply(),
+        unconfirmed_token_info.get_next_nonce().unwrap(),
+        AccountNonce::new(3)
+    );
+
+    assert_eq!(
+        unconfirmed_token_info.current_supply().unwrap(),
         (token_amount_to_mint - token_amount_to_unmint).unwrap(),
     );
 
     assert_eq!(
-        token_issuance_data.total_supply.check_can_lock(),
+        unconfirmed_token_info.check_can_lock(),
         Err(WalletError::CannotLockTokenSupply("Locked"))
     );
 
     let err = wallet
         .mint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_mint,
             address2.clone(),
             FeeRate::new(Amount::ZERO),
@@ -2784,7 +2854,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     let err = wallet
         .unmint_tokens(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             token_amount_to_unmint,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
@@ -2795,7 +2865,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
     let err = wallet
         .lock_token_supply(
             DEFAULT_ACCOUNT_INDEX,
-            issued_token_id,
+            &unconfirmed_token_info,
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -801,7 +801,7 @@ fn wallet_accounts_creation() {
                 OutputValue::Coin(Amount::from_atoms(1)),
                 Destination::PublicKey(acc1_pk),
             )],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -959,7 +959,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
         wallet.create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [new_output.clone()],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         ),
@@ -975,7 +975,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 [new_output],
-                [],
+                vec![],
                 FeeRate::new(Amount::ZERO),
                 FeeRate::new(Amount::ZERO),
             )
@@ -1003,7 +1003,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 [new_output],
-                [],
+                vec![],
                 FeeRate::new(Amount::ZERO),
                 FeeRate::new(Amount::ZERO),
             )
@@ -1029,7 +1029,7 @@ fn wallet_get_transaction(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [gen_random_transfer(&mut rng, Amount::from_atoms(1))],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -1095,7 +1095,7 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 [gen_random_transfer(&mut rng, Amount::from_atoms(1))],
-                [],
+                vec![],
                 very_big_feerate,
                 very_big_feerate,
             )
@@ -1118,7 +1118,7 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
 
     let feerate = FeeRate::new(Amount::from_atoms(1000));
     let transaction = wallet
-        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, outputs, [], feerate, feerate)
+        .create_transaction_to_addresses(DEFAULT_ACCOUNT_INDEX, outputs, vec![], feerate, feerate)
         .unwrap();
 
     let tx_size = serialization::Encode::encoded_size(&transaction);
@@ -1199,15 +1199,21 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
                 FeeRate::new(Amount::ZERO),
             )
             .unwrap_err();
+        assert_eq!(err, WalletError::CannotFindUtxo(missing_utxo.clone()));
 
-        assert_eq!(err, WalletError::CannotFindUtxo(missing_utxo))
+        let err = wallet
+            .find_used_tokens(DEFAULT_ACCOUNT_INDEX, &[missing_utxo.clone()])
+            .unwrap_err();
+
+        assert_eq!(err, WalletError::CannotFindUtxo(missing_utxo));
     }
 
     let selected_utxos = utxos
-        .keys()
+        .iter()
+        .map(|(outpoint, _)| outpoint)
         .take(rng.gen_range(1..utxos.len()))
         .cloned()
-        .collect::<BTreeSet<_>>();
+        .collect_vec();
 
     let tx = wallet
         .create_transaction_to_addresses(
@@ -1421,7 +1427,7 @@ fn send_to_unknown_delegation(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [TxOutput::DelegateStaking(delegation_amount, unknown_delegation_id)],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -1573,7 +1579,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [TxOutput::DelegateStaking(delegation_amount, delegation_id)],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -1852,7 +1858,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [new_output],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -1900,7 +1906,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [new_output],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -1961,7 +1967,7 @@ fn check_tokens_v0_are_ignored(#[case] seed: Seed) {
                 )))),
                 address2.decode_object(&chain_config).unwrap(),
             )],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -2942,7 +2948,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [new_output],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -3068,7 +3074,7 @@ fn wallet_multiple_transactions_in_single_block(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 [new_output],
-                [],
+                vec![],
                 FeeRate::new(Amount::ZERO),
                 FeeRate::new(Amount::ZERO),
             )
@@ -3158,7 +3164,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 [new_output, change_output],
-                [],
+                vec![],
                 FeeRate::new(Amount::ZERO),
                 FeeRate::new(Amount::ZERO),
             )
@@ -3192,7 +3198,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [new_output],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -3230,7 +3236,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [new_output],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -3255,7 +3261,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
             [new_output],
-            [],
+            vec![],
             FeeRate::new(Amount::ZERO),
             FeeRate::new(Amount::ZERO),
         )
@@ -3338,7 +3344,7 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
             .create_transaction_to_addresses(
                 DEFAULT_ACCOUNT_INDEX,
                 [new_output, change_output],
-                [],
+                vec![],
                 FeeRate::new(Amount::ZERO),
                 FeeRate::new(Amount::ZERO),
             )

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -1778,7 +1778,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             token_issuance.total_supply.into(),
             false,
             RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
-            Some(token_issuance.authority),
+            token_issuance.authority,
         );
 
         wallet
@@ -2047,7 +2047,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
         token_issuance.total_supply.into(),
         false,
         RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
-        Some(token_issuance.authority),
+        token_issuance.authority,
     );
 
     let unconfirmed_token_info =
@@ -2260,7 +2260,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
         token_issuance.total_supply.into(),
         false,
         RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
-        Some(token_issuance.authority),
+        token_issuance.authority,
     );
 
     let unconfirmed_token_info =
@@ -2507,7 +2507,7 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
         token_issuance.total_supply.into(),
         false,
         RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
-        Some(token_issuance.authority),
+        token_issuance.authority,
     );
 
     let unconfirmed_token_info =
@@ -2695,7 +2695,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
         token_issuance.total_supply.into(),
         false,
         RPCIsTokenFrozen::No(token_issuance.is_freezable.into()),
-        Some(token_issuance.authority),
+        token_issuance.authority,
     );
 
     let unconfirmed_token_info =

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -1138,7 +1138,7 @@ impl CommandHandler {
                 amount,
                 utxos,
             } => {
-                let utxos: Vec<UtxoOutPoint> = utxos
+                let input_utxos: Vec<UtxoOutPoint> = utxos
                     .into_iter()
                     .map(parse_utxo_outpoint)
                     .collect::<Result<Vec<_>, WalletCliError>>()?;
@@ -1146,7 +1146,7 @@ impl CommandHandler {
                 let address = parse_address(chain_config, &address)?;
                 self.get_synced_controller()
                     .await?
-                    .send_to_address(address, amount, utxos)
+                    .send_to_address(address, amount, input_utxos)
                     .await
                     .map_err(WalletCliError::Controller)?;
                 Ok(Self::tx_submitted_command())

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -237,6 +237,12 @@ pub enum WalletCommand {
         token_id: String,
     },
 
+    /// Change the authority of a token
+    ChangeTokenAuthority {
+        token_id: String,
+        address: String,
+    },
+
     /// Rescan
     Rescan,
 
@@ -880,20 +886,20 @@ impl CommandHandler {
                 address,
                 amount,
             } => {
+                // TODO: maybe extract token_id and token_info in a helper function
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
                 let address = parse_address(chain_config, &address)?;
-                let amount = {
-                    let token_number_of_decimals = self
-                        .controller()?
-                        .get_token_number_of_decimals(token_id)
-                        .await
-                        .map_err(WalletCliError::Controller)?;
-                    parse_token_amount(token_number_of_decimals, &amount)?
-                };
+                let token_info = self
+                    .controller()?
+                    .get_token_info(token_id)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
+
+                let amount = parse_token_amount(token_info.token_number_of_decimals(), &amount)?;
 
                 self.get_synced_controller()
                     .await?
-                    .mint_tokens(token_id, amount, address)
+                    .mint_tokens(token_info, amount, address)
                     .await
                     .map_err(WalletCliError::Controller)?;
                 Ok(Self::tx_submitted_command())
@@ -901,18 +907,17 @@ impl CommandHandler {
 
             WalletCommand::UnmintTokens { token_id, amount } => {
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
-                let amount = {
-                    let token_number_of_decimals = self
-                        .controller()?
-                        .get_token_number_of_decimals(token_id)
-                        .await
-                        .map_err(WalletCliError::Controller)?;
-                    parse_token_amount(token_number_of_decimals, &amount)?
-                };
+                let token_info = self
+                    .controller()?
+                    .get_token_info(token_id)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
+
+                let amount = parse_token_amount(token_info.token_number_of_decimals(), &amount)?;
 
                 self.get_synced_controller()
                     .await?
-                    .unmint_tokens(token_id, amount)
+                    .unmint_tokens(token_info, amount)
                     .await
                     .map_err(WalletCliError::Controller)?;
 
@@ -921,10 +926,15 @@ impl CommandHandler {
 
             WalletCommand::LockTokenSupply { token_id } => {
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
+                let token_info = self
+                    .controller()?
+                    .get_token_info(token_id)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
 
                 self.get_synced_controller()
                     .await?
-                    .lock_token_supply(token_id)
+                    .lock_token_supply(token_info)
                     .await
                     .map_err(WalletCliError::Controller)?;
 
@@ -936,10 +946,15 @@ impl CommandHandler {
                 is_unfreezable,
             } => {
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
+                let token_info = self
+                    .controller()?
+                    .get_token_info(token_id)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
 
                 self.get_synced_controller()
                     .await?
-                    .freeze_token(token_id, is_unfreezable.to_wallet_types())
+                    .freeze_token(token_info, is_unfreezable.to_wallet_types())
                     .await
                     .map_err(WalletCliError::Controller)?;
 
@@ -948,10 +963,33 @@ impl CommandHandler {
 
             WalletCommand::UnfreezeToken { token_id } => {
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
+                let token_info = self
+                    .controller()?
+                    .get_token_info(token_id)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
 
                 self.get_synced_controller()
                     .await?
-                    .unfreeze_token(token_id)
+                    .unfreeze_token(token_info)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
+
+                Ok(Self::tx_submitted_command())
+            }
+
+            WalletCommand::ChangeTokenAuthority { token_id, address } => {
+                let token_id = parse_token_id(chain_config, token_id.as_str())?;
+                let address = parse_address(chain_config, &address)?;
+                let token_info = self
+                    .controller()?
+                    .get_token_info(token_id)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
+
+                self.get_synced_controller()
+                    .await?
+                    .change_token_authority(token_info, address)
                     .await
                     .map_err(WalletCliError::Controller)?;
 
@@ -1121,18 +1159,17 @@ impl CommandHandler {
             } => {
                 let token_id = parse_token_id(chain_config, token_id.as_str())?;
                 let address = parse_address(chain_config, &address)?;
-                let amount = {
-                    let token_number_of_decimals = self
-                        .controller()?
-                        .get_token_number_of_decimals_if_not_frozen(token_id)
-                        .await
-                        .map_err(WalletCliError::Controller)?;
-                    parse_token_amount(token_number_of_decimals, &amount)?
-                };
+                let token_info = self
+                    .controller()?
+                    .get_token_info(token_id)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
+
+                let amount = parse_token_amount(token_info.token_number_of_decimals(), &amount)?;
 
                 self.get_synced_controller()
                     .await?
-                    .send_tokens_to_address(token_id, address, amount)
+                    .send_tokens_to_address(token_info, address, amount)
                     .await
                     .map_err(WalletCliError::Controller)?;
                 Ok(Self::tx_submitted_command())

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -498,7 +498,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 WithLocked::Unlocked,
             )
             .map_err(ControllerError::WalletError)?;
-        let pool_ids = stake_pool_utxos.values().filter_map(|utxo| match utxo {
+        let pool_ids = stake_pool_utxos.into_iter().filter_map(|(_, utxo)| match utxo {
             TxOutput::ProduceBlockFromStake(_, pool_id) | TxOutput::CreateStakePool(pool_id, _) => {
                 Some(pool_id)
             }
@@ -515,11 +515,11 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         for pool_id in pool_ids {
             let balance_opt = self
                 .rpc_client
-                .get_stake_pool_balance(*pool_id)
+                .get_stake_pool_balance(pool_id)
                 .await
                 .map_err(ControllerError::NodeCallError)?;
             if let Some(balance) = balance_opt {
-                balances.insert(*pool_id, balance);
+                balances.insert(pool_id, balance);
             }
         }
         Ok(balances)

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -85,7 +85,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
         utxo_types: UtxoTypes,
         utxo_states: UtxoStates,
         with_locked: WithLocked,
-    ) -> Result<BTreeMap<UtxoOutPoint, TxOutput>, ControllerError<T>> {
+    ) -> Result<Vec<(UtxoOutPoint, TxOutput)>, ControllerError<T>> {
         self.wallet
             .get_utxos(self.account_index, utxo_types, utxo_states, with_locked)
             .map_err(ControllerError::WalletError)

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -19,7 +19,7 @@ use common::{
     address::Address,
     chain::{
         tokens::{
-            IsTokenFreezable, IsTokenUnfreezable, Metadata, TokenId, TokenIssuance,
+            IsTokenFreezable, IsTokenUnfreezable, Metadata, RPCTokenInfo, TokenId, TokenIssuance,
             TokenIssuanceV1, TokenTotalSupply,
         },
         ChainConfig, DelegationId, Destination, PoolId, SignedTransaction, Transaction, TxOutput,
@@ -38,6 +38,7 @@ use logging::log;
 use mempool::FeeRate;
 use node_comm::node_traits::NodeInterface;
 use wallet::{
+    account::UnconfirmedTokenInfo,
     send_request::{
         make_address_output, make_address_output_token, make_create_delegation_output,
         StakePoolDataArguments,
@@ -166,19 +167,21 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
 
     pub async fn mint_tokens(
         &mut self,
-        token_id: TokenId,
+        token_info: RPCTokenInfo,
         amount: Amount,
         address: Address<Destination>,
     ) -> Result<(), ControllerError<T>> {
         self.create_and_send_token_tx(
-            token_id,
+            &token_info,
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
                   wallet: &mut DefaultWallet,
-                  account_index: U31| {
+                  account_index: U31,
+                  token_info: &UnconfirmedTokenInfo| {
+                token_info.check_can_be_used()?;
                 wallet.mint_tokens(
                     account_index,
-                    token_id,
+                    token_info,
                     amount,
                     address,
                     current_fee_rate,
@@ -190,18 +193,20 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     }
     pub async fn unmint_tokens(
         &mut self,
-        token_id: TokenId,
+        token_info: RPCTokenInfo,
         amount: Amount,
     ) -> Result<(), ControllerError<T>> {
         self.create_and_send_token_tx(
-            token_id,
+            &token_info,
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
                   wallet: &mut DefaultWallet,
-                  account_index: U31| {
+                  account_index: U31,
+                  token_info: &UnconfirmedTokenInfo| {
+                token_info.check_can_be_used()?;
                 wallet.unmint_tokens(
                     account_index,
-                    token_id,
+                    token_info,
                     amount,
                     current_fee_rate,
                     consolidate_fee_rate,
@@ -211,16 +216,21 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         .await
     }
 
-    pub async fn lock_token_supply(&mut self, token_id: TokenId) -> Result<(), ControllerError<T>> {
+    pub async fn lock_token_supply(
+        &mut self,
+        token_info: RPCTokenInfo,
+    ) -> Result<(), ControllerError<T>> {
         self.create_and_send_token_tx(
-            token_id,
+            &token_info,
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
                   wallet: &mut DefaultWallet,
-                  account_index: U31| {
+                  account_index: U31,
+                  token_info: &UnconfirmedTokenInfo| {
+                token_info.check_can_be_used()?;
                 wallet.lock_token_supply(
                     account_index,
-                    token_id,
+                    token_info,
                     current_fee_rate,
                     consolidate_fee_rate,
                 )
@@ -233,17 +243,19 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     /// on that token are forbidden until it is unfrozen
     pub async fn freeze_token(
         &mut self,
-        token_id: TokenId,
+        token_info: RPCTokenInfo,
         is_token_unfreezable: IsTokenUnfreezable,
     ) -> Result<(), ControllerError<T>> {
-        self.create_and_send_tx(
+        self.create_and_send_token_tx(
+            &token_info,
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
                   wallet: &mut DefaultWallet,
-                  account_index: U31| {
+                  account_index: U31,
+                  token_info: &UnconfirmedTokenInfo| {
                 wallet.freeze_token(
                     account_index,
-                    token_id,
+                    token_info,
                     is_token_unfreezable,
                     current_fee_rate,
                     consolidate_fee_rate,
@@ -254,15 +266,46 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     }
 
     /// After unfreezing a token all operations on that token are again permitted
-    pub async fn unfreeze_token(&mut self, token_id: TokenId) -> Result<(), ControllerError<T>> {
-        self.create_and_send_tx(
+    pub async fn unfreeze_token(
+        &mut self,
+        token_info: RPCTokenInfo,
+    ) -> Result<(), ControllerError<T>> {
+        self.create_and_send_token_tx(
+            &token_info,
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
                   wallet: &mut DefaultWallet,
-                  account_index: U31| {
+                  account_index: U31,
+                  token_info: &UnconfirmedTokenInfo| {
                 wallet.unfreeze_token(
                     account_index,
-                    token_id,
+                    token_info,
+                    current_fee_rate,
+                    consolidate_fee_rate,
+                )
+            },
+        )
+        .await
+    }
+
+    /// After changing the authority of the token, all operations like mint/unmint/freeze/unfreeze
+    /// will be controlled by the new authority
+    pub async fn change_token_authority(
+        &mut self,
+        token_info: RPCTokenInfo,
+        address: Address<Destination>,
+    ) -> Result<(), ControllerError<T>> {
+        self.create_and_send_token_tx(
+            &token_info,
+            move |current_fee_rate: FeeRate,
+                  consolidate_fee_rate: FeeRate,
+                  wallet: &mut DefaultWallet,
+                  account_index: U31,
+                  token_info: &UnconfirmedTokenInfo| {
+                wallet.change_token_authority(
+                    account_index,
+                    token_info,
+                    address,
                     current_fee_rate,
                     consolidate_fee_rate,
                 )
@@ -383,18 +426,21 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
 
     pub async fn send_tokens_to_address(
         &mut self,
-        token_id: TokenId,
+        token_info: RPCTokenInfo,
         address: Address<Destination>,
         amount: Amount,
     ) -> Result<(), ControllerError<T>> {
-        let output = make_address_output_token(self.chain_config, address, amount, token_id)
-            .map_err(ControllerError::WalletError)?;
+        let output =
+            make_address_output_token(self.chain_config, address, amount, token_info.token_id())
+                .map_err(ControllerError::WalletError)?;
         self.create_and_send_token_tx(
-            token_id,
+            &token_info,
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
                   wallet: &mut DefaultWallet,
-                  account_index: U31| {
+                  account_index: U31,
+                  token_info: &UnconfirmedTokenInfo| {
+                token_info.check_can_be_used()?;
                 wallet.create_transaction_to_addresses(
                     account_index,
                     [output],
@@ -531,17 +577,42 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     /// Create and broadcast a transaction that uses token,
     /// check if that token can be used i.e. not frozen
     async fn create_and_send_token_tx<
-        F: FnOnce(FeeRate, FeeRate, &mut DefaultWallet, U31) -> WalletResult<SignedTransaction>,
+        F: FnOnce(
+            FeeRate,
+            FeeRate,
+            &mut DefaultWallet,
+            U31,
+            &UnconfirmedTokenInfo,
+        ) -> WalletResult<SignedTransaction>,
     >(
         &mut self,
-        token_id: TokenId,
+        token_info: &RPCTokenInfo,
         tx_maker: F,
     ) -> Result<(), ControllerError<T>> {
         // make sure we can use the token before create an tx using it
-        self.wallet
-            .check_token_can_be_used(self.account_index, token_id)
-            .map_err(ControllerError::WalletError)?;
-        self.create_and_send_tx(tx_maker).await
+        let token_freezable_info = match token_info {
+            RPCTokenInfo::FungibleToken(token_info) => self
+                .wallet
+                .get_token_unconfirmed_info(self.account_index, token_info)
+                .map_err(ControllerError::WalletError)?,
+            RPCTokenInfo::NonFungibleToken(info) => {
+                UnconfirmedTokenInfo::NonFungibleToken(info.token_id)
+            }
+        };
+
+        let (current_fee_rate, consolidate_fee_rate) =
+            self.get_current_and_consolidation_fee_rate().await?;
+
+        let tx = tx_maker(
+            current_fee_rate,
+            consolidate_fee_rate,
+            self.wallet,
+            self.account_index,
+            &token_freezable_info,
+        )
+        .map_err(ControllerError::WalletError)?;
+
+        self.broadcast_to_mempool(tx).await
     }
 
     /// Similar to create_and_send_tx but some transactions also create an ID


### PR DESCRIPTION
- remove keeping track of token circulating supply and frozen state
- only keep track of unconfirmed transactions
- on each token change operation, the wallet will pull the latest token state from chainstate and apply the unconfirmed transactions on top of it
- add new command for changing the token authority from the wallet CLI