### PR TITLE
Change min change to 0 for tokens

### DIFF
--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -232,7 +232,9 @@ impl Account {
                     utxos,
                     output_amount.sub(preselected_amount).unwrap_or(Amount::ZERO),
                     PayFee::DoNotPayFeeWithThisCurrency,
-                    cost_of_change,
+                    // TODO: change this to cost_of_change calculated in this currency
+                    // when we allow paying fees with different currency
+                    Amount::ZERO,
                     selection_algo,
                 )?;
 


### PR DESCRIPTION
as cost of change was calculated in coins instead of tokens, now it is set to 0 as we don't know how much the tokens costs relative to the coins, this way you always get a change output for tokens.

Fixes a functional test that failed when the expected token change was 3.5