### PR TITLE
Separate account authorizable commands into separate struct V2

### DIFF
--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -16,7 +16,7 @@
 use crate::{
     chain::{
         tokens::{IsTokenUnfreezable, TokenId},
-        AccountNonce, DelegationId,
+        DelegationId,
     },
     primitives::Amount,
 };
@@ -34,66 +34,67 @@ pub enum AccountType {
     Token(TokenId),
 }
 
-impl From<AccountOp> for AccountType {
-    fn from(spending: AccountOp) -> Self {
+impl From<AccountSpending> for AccountType {
+    fn from(spending: AccountSpending) -> Self {
         match spending {
-            AccountOp::SpendDelegationBalance(id, _) => AccountType::Delegation(id),
-            AccountOp::MintTokens(id, _)
-            | AccountOp::UnmintTokens(id)
-            | AccountOp::LockTokenSupply(id)
-            | AccountOp::FreezeToken(id, _)
-            | AccountOp::UnfreezeToken(id)
-            | AccountOp::ChangeTokenAuthority(id, _) => AccountType::Token(id),
+            AccountSpending::DelegationBalance(id, _) => AccountType::Delegation(id),
         }
     }
+}
+
+impl From<AuthorityCommand> for AccountType {
+    fn from(op: AuthorityCommand) -> Self {
+        match op {
+            AuthorityCommand::MintTokens(id, _)
+            | AuthorityCommand::UnmintTokens(id)
+            | AuthorityCommand::LockTokenSupply(id)
+            | AuthorityCommand::FreezeToken(id, _)
+            | AuthorityCommand::UnfreezeToken(id)
+            | AuthorityCommand::ChangeTokenAuthority(id, _) => AccountType::Token(id),
+        }
+    }
+}
+
+// FIXME: better name?
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode, serde::Serialize)]
+pub enum AccountOperation {
+    #[codec(index = 0)]
+    Spending(AccountSpending),
+    #[codec(index = 1)]
+    Command(AuthorityCommand),
 }
 
 /// The type represents the amount to withdraw from a particular account.
 /// Otherwise it's unclear how much should be deducted from an account balance.
 /// It also helps solving 2 additional problems: calculating fees and providing ability to sign input balance with the witness.
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode, serde::Serialize)]
-pub enum AccountOp {
+pub enum AccountSpending {
     #[codec(index = 0)]
-    SpendDelegationBalance(DelegationId, Amount),
+    DelegationBalance(DelegationId, Amount),
+}
+
+// Represents an operation that can be performed on an account.
+// Operation must be unique and authorized.
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode, serde::Serialize)]
+pub enum AuthorityCommand {
     // Create certain amount of tokens and add them to circulating supply
-    #[codec(index = 1)]
+    #[codec(index = 0)]
     MintTokens(TokenId, Amount),
     // Take tokens out of circulation. Not the same as Burn because unminting means that certain amount
     // of tokens is no longer supported by underlying fiat currency, which can only be done by the authority.
-    #[codec(index = 2)]
+    #[codec(index = 1)]
     UnmintTokens(TokenId),
     // After supply is locked tokens cannot be minted or unminted ever again.
     // Works only for Lockable tokens supply.
-    #[codec(index = 3)]
+    #[codec(index = 2)]
     LockTokenSupply(TokenId),
     // Freezing token forbids any operation with all the tokens (except for optional unfreeze)
-    #[codec(index = 4)]
+    #[codec(index = 3)]
     FreezeToken(TokenId, IsTokenUnfreezable),
     // By unfreezing token all operations are available for the tokens again
-    #[codec(index = 5)]
+    #[codec(index = 4)]
     UnfreezeToken(TokenId),
     // Change the authority who can authorize operations for a token
-    #[codec(index = 6)]
+    #[codec(index = 5)]
     ChangeTokenAuthority(TokenId, Destination),
-}
-
-/// Type of OutPoint that represents spending from an account
-#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode, serde::Serialize)]
-pub struct AccountOutPoint {
-    nonce: AccountNonce,
-    account: AccountOp,
-}
-
-impl AccountOutPoint {
-    pub fn new(nonce: AccountNonce, account: AccountOp) -> Self {
-        Self { nonce, account }
-    }
-
-    pub fn nonce(&self) -> AccountNonce {
-        self.nonce
-    }
-
-    pub fn account(&self) -> &AccountOp {
-        &self.account
-    }
 }

--- a/common/src/chain/transaction/input.rs
+++ b/common/src/chain/transaction/input.rs
@@ -17,14 +17,14 @@ use serialization::{Decode, Encode};
 
 use crate::chain::AccountNonce;
 
-use super::{AccountOp, AccountOutPoint, OutPointSourceId, UtxoOutPoint};
+use super::{AccountOperation, OutPointSourceId, UtxoOutPoint};
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Encode, Decode, serde::Serialize)]
 pub enum TxInput {
     #[codec(index = 0)]
     Utxo(UtxoOutPoint),
     #[codec(index = 1)]
-    Account(AccountOutPoint),
+    Account(AccountNonce, AccountOperation),
 }
 
 impl TxInput {
@@ -32,14 +32,14 @@ impl TxInput {
         TxInput::Utxo(UtxoOutPoint::new(outpoint_source_id, output_index))
     }
 
-    pub fn from_account(nonce: AccountNonce, account: AccountOp) -> Self {
-        TxInput::Account(AccountOutPoint::new(nonce, account))
+    pub fn from_account(nonce: AccountNonce, account: AccountOperation) -> Self {
+        TxInput::Account(nonce, account)
     }
 
     pub fn utxo_outpoint(&self) -> Option<&UtxoOutPoint> {
         match self {
             TxInput::Utxo(outpoint) => Some(outpoint),
-            TxInput::Account(_) => None,
+            TxInput::Account(_, _) => None,
         }
     }
 }


### PR DESCRIPTION
This approach keeps TxInput as enum of {Utxo, Account} but splits the enum inside an account into 2: Spending or Command where command must be unique in a tx.

I like it more because it seems more consise to have top level separation of TxInput into utxo world or accounting and then specifying what type of accounting operation is performed.