### PR TITLE
Unify decommission delegation share spanding maturity and pool decommissioning maturity distances

### DIFF
--- a/chainstate/test-suite/src/tests/pos_maturity_settings.rs
+++ b/chainstate/test-suite/src/tests/pos_maturity_settings.rs
@@ -48,7 +48,7 @@ fn decommission_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
             ConsensusUpgrade::PoS {
                 initial_difficulty: Some(Uint256::MAX.into()),
                 config: PoSChainConfigBuilder::new_for_unit_test()
-                    .decommission_maturity_distance(BlockDistance::new(100))
+                    .staking_pool_spend_maturity_distance(BlockDistance::new(100))
                     .build(),
             },
         ),
@@ -57,7 +57,7 @@ fn decommission_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
             ConsensusUpgrade::PoS {
                 initial_difficulty: None,
                 config: PoSChainConfigBuilder::new_for_unit_test()
-                    .decommission_maturity_distance(BlockDistance::new(50))
+                    .staking_pool_spend_maturity_distance(BlockDistance::new(50))
                     .build(),
             },
         ),
@@ -181,7 +181,7 @@ fn spend_share_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
             ConsensusUpgrade::PoS {
                 initial_difficulty: Some(Uint256::MAX.into()),
                 config: PoSChainConfigBuilder::new_for_unit_test()
-                    .spend_share_maturity_distance(BlockDistance::new(100))
+                    .staking_pool_spend_maturity_distance(BlockDistance::new(100))
                     .build(),
             },
         ),
@@ -191,7 +191,7 @@ fn spend_share_maturity_setting_follows_netupgrade(#[case] seed: Seed) {
                 initial_difficulty: None,
                 config: PoSChainConfigBuilder::new_for_unit_test()
                     // decrease maturity setting
-                    .spend_share_maturity_distance(BlockDistance::new(50))
+                    .staking_pool_spend_maturity_distance(BlockDistance::new(50))
                     .build(),
             },
         ),

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -1516,7 +1516,7 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
             ConsensusUpgrade::PoS {
                 initial_difficulty: Some(MIN_DIFFICULTY.into()),
                 config: PoSChainConfigBuilder::new_for_unit_test()
-                    .decommission_maturity_distance(BlockDistance::new(50))
+                    .staking_pool_spend_maturity_distance(BlockDistance::new(50))
                     .build(),
             },
         ),
@@ -1526,7 +1526,7 @@ fn decommission_from_not_best_block(#[case] seed: Seed) {
                 initial_difficulty: None,
                 config: PoSChainConfigBuilder::new_for_unit_test()
                     // decommission maturity increased
-                    .decommission_maturity_distance(BlockDistance::new(100))
+                    .staking_pool_spend_maturity_distance(BlockDistance::new(100))
                     .build(),
             },
         ),

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/constraints_accumulator.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/constraints_accumulator.rs
@@ -104,7 +104,7 @@ impl ConstrainedValueAccumulator {
                         | TxOutput::ProduceBlockFromStake(_, pool_id) => {
                             let block_distance = chain_config
                                 .as_ref()
-                                .decommission_pool_maturity_distance(block_height);
+                                .staking_pool_spend_maturity_distance(block_height);
                             let pledged_amount = pledge_amount_getter(*pool_id)?
                                 .ok_or(IOPolicyError::PledgeAmountNotFound(*pool_id))?;
 
@@ -120,8 +120,9 @@ impl ConstrainedValueAccumulator {
                 TxInput::Account(outpoint) => {
                     match outpoint.account() {
                         AccountSpending::DelegationBalance(_, spend_amount) => {
-                            let block_distance =
-                                chain_config.as_ref().spend_share_maturity_distance(block_height);
+                            let block_distance = chain_config
+                                .as_ref()
+                                .staking_pool_spend_maturity_distance(block_height);
 
                             let balance = self
                                 .timelock_constrained
@@ -292,7 +293,7 @@ mod tests {
             .consensus_upgrades(NetUpgrades::regtest_with_pos())
             .build();
         let required_maturity_distance =
-            chain_config.decommission_pool_maturity_distance(BlockHeight::new(1));
+            chain_config.staking_pool_spend_maturity_distance(BlockHeight::new(1));
 
         let pool_id = PoolId::new(H256::zero());
         let staked_atoms = rng.gen_range(100..1000);
@@ -348,7 +349,7 @@ mod tests {
             .consensus_upgrades(NetUpgrades::regtest_with_pos())
             .build();
         let required_maturity_distance =
-            chain_config.spend_share_maturity_distance(BlockHeight::new(1));
+            chain_config.staking_pool_spend_maturity_distance(BlockHeight::new(1));
 
         let delegation_id = DelegationId::new(H256::zero());
         let delegated_atoms = rng.gen_range(100..1000);
@@ -493,7 +494,7 @@ mod tests {
             .consensus_upgrades(NetUpgrades::regtest_with_pos())
             .build();
         let required_maturity_distance =
-            chain_config.decommission_pool_maturity_distance(BlockHeight::new(1));
+            chain_config.staking_pool_spend_maturity_distance(BlockHeight::new(1));
 
         let pool_id = PoolId::new(H256::zero());
         let staked_atoms = rng.gen_range(100..1000);
@@ -610,8 +611,8 @@ mod tests {
             ConsensusUpgrade::PoS {
                 initial_difficulty: None,
                 config: PoSChainConfigBuilder::new_for_unit_test()
-                    .decommission_maturity_distance(required_decommission_maturity.into())
-                    .spend_share_maturity_distance(required_spend_share_maturity.into())
+                    .staking_pool_spend_maturity_distance(required_decommission_maturity.into())
+                    .staking_pool_spend_maturity_distance(required_spend_share_maturity.into())
                     .build(),
             },
         )];

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/constraints_tests.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/constraints_tests.rs
@@ -84,7 +84,7 @@ fn timelock_constraints_on_decommission_in_tx(#[case] seed: Seed) {
         .consensus_upgrades(NetUpgrades::regtest_with_pos())
         .build();
     let required_maturity_distance =
-        chain_config.decommission_pool_maturity_distance(BlockHeight::new(1)).to_int() as u64;
+        chain_config.staking_pool_spend_maturity_distance(BlockHeight::new(1)).to_int() as u64;
 
     let mut rng = make_seedable_rng(seed);
     let number_of_inputs = rng.gen_range(0..10);
@@ -222,7 +222,7 @@ fn timelock_constraints_on_spend_share_in_tx(#[case] seed: Seed) {
         .consensus_upgrades(NetUpgrades::regtest_with_pos())
         .build();
     let required_maturity_distance =
-        chain_config.spend_share_maturity_distance(BlockHeight::new(1)).to_int() as u64;
+        chain_config.staking_pool_spend_maturity_distance(BlockHeight::new(1)).to_int() as u64;
 
     let mut rng = make_seedable_rng(seed);
     let number_of_outputs = rng.gen_range(0..10);

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -23,7 +23,8 @@ use crate::{
         },
         get_initial_randomness,
         pos::{
-            DEFAULT_BLOCK_COUNT_TO_AVERAGE, DEFAULT_MATURITY_DISTANCE, DEFAULT_TARGET_BLOCK_TIME,
+            DEFAULT_BLOCK_COUNT_TO_AVERAGE, DEFAULT_MATURITY_DISTANCE_V0,
+            DEFAULT_MATURITY_DISTANCE_V1, DEFAULT_TARGET_BLOCK_TIME,
         },
         pos_initial_difficulty,
         pow::PoWChainConfigBuilder,
@@ -90,8 +91,7 @@ impl ChainType {
                             config: PoSChainConfig::new(
                                 target_limit,
                                 target_block_time,
-                                DEFAULT_MATURITY_DISTANCE,
-                                DEFAULT_MATURITY_DISTANCE,
+                                DEFAULT_MATURITY_DISTANCE_V0,
                                 DEFAULT_BLOCK_COUNT_TO_AVERAGE,
                                 PerThousand::new(1).expect("must be valid"),
                                 PoSConsensusVersion::V0,
@@ -105,8 +105,7 @@ impl ChainType {
                             config: PoSChainConfig::new(
                                 target_limit,
                                 target_block_time,
-                                BlockDistance::new(7200),
-                                BlockDistance::new(7200),
+                                DEFAULT_MATURITY_DISTANCE_V1,
                                 DEFAULT_BLOCK_COUNT_TO_AVERAGE,
                                 PerThousand::new(1).expect("must be valid"),
                                 PoSConsensusVersion::V1,

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -529,26 +529,13 @@ impl ChainConfig {
 
     /// The minimum number of blocks required to be able to spend a utxo coming from a decommissioned pool
     #[must_use]
-    pub fn decommission_pool_maturity_distance(&self, block_height: BlockHeight) -> BlockDistance {
+    pub fn staking_pool_spend_maturity_distance(&self, block_height: BlockHeight) -> BlockDistance {
         match self.consensus_upgrades.consensus_status(block_height) {
             RequiredConsensus::IgnoreConsensus | RequiredConsensus::PoW(_) => {
                 self.empty_consensus_reward_maturity_distance
             }
             RequiredConsensus::PoS(status) => {
-                status.get_chain_config().decommission_maturity_distance()
-            }
-        }
-    }
-
-    /// The number of blocks required to pass before a delegation share can be spent after taking it out of the delegation account
-    #[must_use]
-    pub fn spend_share_maturity_distance(&self, block_height: BlockHeight) -> BlockDistance {
-        match self.consensus_upgrades.consensus_status(block_height) {
-            RequiredConsensus::IgnoreConsensus | RequiredConsensus::PoW(_) => {
-                self.empty_consensus_reward_maturity_distance
-            }
-            RequiredConsensus::PoS(status) => {
-                status.get_chain_config().spend_share_maturity_distance()
+                status.get_chain_config().staking_pool_spend_maturity_distance()
             }
         }
     }

--- a/common/src/chain/config/regtest_options.rs
+++ b/common/src/chain/config/regtest_options.rs
@@ -24,7 +24,7 @@ use crate::{
             Builder, ChainType, EmissionScheduleTabular,
         },
         pos::{
-            DEFAULT_BLOCK_COUNT_TO_AVERAGE, DEFAULT_MATURITY_DISTANCE, DEFAULT_TARGET_BLOCK_TIME,
+            DEFAULT_BLOCK_COUNT_TO_AVERAGE, DEFAULT_MATURITY_DISTANCE_V0, DEFAULT_TARGET_BLOCK_TIME,
         },
         pos_initial_difficulty, ConsensusUpgrade, Destination, NetUpgrades, PoSChainConfig,
         PoSConsensusVersion,
@@ -193,8 +193,7 @@ pub fn regtest_chain_config(options: &ChainConfigOptions) -> Result<ChainConfig>
                             config: PoSChainConfig::new(
                                 target_limit,
                                 target_block_time,
-                                DEFAULT_MATURITY_DISTANCE,
-                                DEFAULT_MATURITY_DISTANCE,
+                                DEFAULT_MATURITY_DISTANCE_V0,
                                 DEFAULT_BLOCK_COUNT_TO_AVERAGE,
                                 PerThousand::new(1).expect("must be valid"),
                                 PoSConsensusVersion::V0,
@@ -208,8 +207,7 @@ pub fn regtest_chain_config(options: &ChainConfigOptions) -> Result<ChainConfig>
                             config: PoSChainConfig::new(
                                 target_limit,
                                 target_block_time,
-                                DEFAULT_MATURITY_DISTANCE,
-                                DEFAULT_MATURITY_DISTANCE,
+                                DEFAULT_MATURITY_DISTANCE_V0,
                                 DEFAULT_BLOCK_COUNT_TO_AVERAGE,
                                 PerThousand::new(1).expect("must be valid"),
                                 PoSConsensusVersion::V1,

--- a/common/src/chain/pos/config.rs
+++ b/common/src/chain/pos/config.rs
@@ -42,7 +42,7 @@ impl PoSChainConfig {
     pub fn new(
         target_limit: Uint256,
         target_block_time: NonZeroU64,
-        decommission_maturity_distance: BlockDistance,
+        staking_pool_spend_maturity_distance: BlockDistance,
         block_count_to_average_for_blocktime: usize,
         difficulty_change_limit: PerThousand,
         consensus_version: PoSConsensusVersion,
@@ -52,7 +52,7 @@ impl PoSChainConfig {
         Self {
             target_limit,
             target_block_time,
-            staking_pool_spend_maturity_distance: decommission_maturity_distance,
+            staking_pool_spend_maturity_distance,
             block_count_to_average_for_blocktime,
             difficulty_change_limit,
             consensus_version,

--- a/common/src/chain/pos/config.rs
+++ b/common/src/chain/pos/config.rs
@@ -28,10 +28,8 @@ pub struct PoSChainConfig {
     target_limit: Uint256,
     /// Time interval in secs between the blocks targeted by the difficulty adjustment algorithm
     target_block_time: NonZeroU64,
-    /// The distance required to pass to allow spending the decommission pool
-    decommission_maturity_distance: BlockDistance,
-    /// The distance required to pass to allow spending delegation share
-    spend_share_maturity_distance: BlockDistance,
+    /// The distance required to pass to allow spending the decommission pool and spending delegation share
+    staking_pool_spend_maturity_distance: BlockDistance,
     /// Max number of blocks required to calculate average block time. Min is 2
     block_count_to_average_for_blocktime: usize,
     /// The limit on how much the difficulty can go up or down after each block
@@ -45,7 +43,6 @@ impl PoSChainConfig {
         target_limit: Uint256,
         target_block_time: NonZeroU64,
         decommission_maturity_distance: BlockDistance,
-        spend_share_maturity_distance: BlockDistance,
         block_count_to_average_for_blocktime: usize,
         difficulty_change_limit: PerThousand,
         consensus_version: PoSConsensusVersion,
@@ -55,8 +52,7 @@ impl PoSChainConfig {
         Self {
             target_limit,
             target_block_time,
-            decommission_maturity_distance,
-            spend_share_maturity_distance,
+            staking_pool_spend_maturity_distance: decommission_maturity_distance,
             block_count_to_average_for_blocktime,
             difficulty_change_limit,
             consensus_version,
@@ -71,12 +67,8 @@ impl PoSChainConfig {
         self.target_block_time
     }
 
-    pub fn decommission_maturity_distance(&self) -> BlockDistance {
-        self.decommission_maturity_distance
-    }
-
-    pub fn spend_share_maturity_distance(&self) -> BlockDistance {
-        self.spend_share_maturity_distance
+    pub fn staking_pool_spend_maturity_distance(&self) -> BlockDistance {
+        self.staking_pool_spend_maturity_distance
     }
 
     pub fn block_count_to_average_for_blocktime(&self) -> usize {

--- a/common/src/chain/pos/config_builder.rs
+++ b/common/src/chain/pos/config_builder.rs
@@ -25,8 +25,7 @@ use super::{config::PoSChainConfig, PoSConsensusVersion};
 pub struct PoSChainConfigBuilder {
     target_limit: Uint256,
     target_block_time: NonZeroU64,
-    decommission_maturity_distance: BlockDistance,
-    spend_share_maturity_distance: BlockDistance,
+    staking_pool_spend_maturity_distance: BlockDistance,
     block_count_to_average_for_blocktime: usize,
     difficulty_change_limit: PerThousand,
     consensus_version: PoSConsensusVersion,
@@ -37,8 +36,7 @@ impl PoSChainConfigBuilder {
         Self {
             target_limit: Uint256::MAX,
             target_block_time: NonZeroU64::new(2 * 60).expect("cannot be 0"),
-            decommission_maturity_distance: super::DEFAULT_MATURITY_DISTANCE,
-            spend_share_maturity_distance: super::DEFAULT_MATURITY_DISTANCE,
+            staking_pool_spend_maturity_distance: super::DEFAULT_MATURITY_DISTANCE_V0,
             block_count_to_average_for_blocktime: super::DEFAULT_BLOCK_COUNT_TO_AVERAGE,
             difficulty_change_limit: PerThousand::new(1).expect("must be valid"),
             consensus_version: PoSConsensusVersion::V1,
@@ -55,13 +53,8 @@ impl PoSChainConfigBuilder {
         self
     }
 
-    pub fn decommission_maturity_distance(mut self, value: BlockDistance) -> Self {
-        self.decommission_maturity_distance = value;
-        self
-    }
-
-    pub fn spend_share_maturity_distance(mut self, value: BlockDistance) -> Self {
-        self.spend_share_maturity_distance = value;
+    pub fn staking_pool_spend_maturity_distance(mut self, value: BlockDistance) -> Self {
+        self.staking_pool_spend_maturity_distance = value;
         self
     }
 
@@ -84,8 +77,7 @@ impl PoSChainConfigBuilder {
         PoSChainConfig::new(
             self.target_limit,
             self.target_block_time,
-            self.decommission_maturity_distance,
-            self.spend_share_maturity_distance,
+            self.staking_pool_spend_maturity_distance,
             self.block_count_to_average_for_blocktime,
             self.difficulty_change_limit,
             self.consensus_version,

--- a/common/src/chain/pos/mod.rs
+++ b/common/src/chain/pos/mod.rs
@@ -30,7 +30,8 @@ pub mod config;
 pub mod config_builder;
 
 pub const DEFAULT_BLOCK_COUNT_TO_AVERAGE: usize = 100;
-pub const DEFAULT_MATURITY_DISTANCE: BlockDistance = BlockDistance::new(2000);
+pub const DEFAULT_MATURITY_DISTANCE_V0: BlockDistance = BlockDistance::new(2000);
+pub const DEFAULT_MATURITY_DISTANCE_V1: BlockDistance = BlockDistance::new(7200);
 pub const DEFAULT_TARGET_BLOCK_TIME: NonZeroU64 = match NonZeroU64::new(2 * 60) {
     Some(v) => v,
     None => panic!("cannot be 0"),

--- a/common/src/chain/upgrades/consensus_upgrade.rs
+++ b/common/src/chain/upgrades/consensus_upgrade.rs
@@ -15,7 +15,7 @@
 
 use crate::chain::config::ChainType;
 use crate::chain::pos::{
-    DEFAULT_BLOCK_COUNT_TO_AVERAGE, DEFAULT_MATURITY_DISTANCE, DEFAULT_TARGET_BLOCK_TIME,
+    DEFAULT_BLOCK_COUNT_TO_AVERAGE, DEFAULT_MATURITY_DISTANCE_V0, DEFAULT_TARGET_BLOCK_TIME,
 };
 use crate::chain::pow::limit;
 use crate::chain::{pos_initial_difficulty, PoSChainConfig, PoSConsensusVersion};
@@ -133,8 +133,7 @@ impl NetUpgrades<ConsensusUpgrade> {
                     config: PoSChainConfig::new(
                         target_limit,
                         target_block_time,
-                        DEFAULT_MATURITY_DISTANCE,
-                        DEFAULT_MATURITY_DISTANCE,
+                        DEFAULT_MATURITY_DISTANCE_V0,
                         DEFAULT_BLOCK_COUNT_TO_AVERAGE,
                         PerThousand::new(1).expect("must be valid"),
                         PoSConsensusVersion::V1,

--- a/consensus/src/pos/effective_pool_balance.rs
+++ b/consensus/src/pos/effective_pool_balance.rs
@@ -210,7 +210,7 @@ fn effective_pool_balance_impl(
              Saturation level:    {pool_saturation_level}\n\
              Pledge influence:    {pledge_influence}\n\
              Final supply:        {final_supply_atoms}\n\
-             ---------------------------------------------\
+             ---------------------------------------------\n\
              Pool balance:        {pool_balance_atoms}\n\
              Capped pool balance: {sigma128}\n\
              Adjustment term:     {adjustment}\n\

--- a/consensus/src/pos/effective_pool_balance.rs
+++ b/consensus/src/pos/effective_pool_balance.rs
@@ -202,7 +202,7 @@ fn effective_pool_balance_impl(
         let pool_balance_atoms = pool_balance.into_atoms();
         let final_supply_atoms = final_supply.into_atoms();
 
-        log::debug!(
+        log::trace!(
             "---------------------------------------------\n\
              Done calculating the effective balance\n\
              ---------------------------------------------\n\

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -117,7 +117,7 @@ pub fn make_address_output_from_delegation(
 ) -> WalletResult<TxOutput> {
     let destination = address.decode_object(chain_config)?;
     let num_blocks_to_lock: i64 =
-        chain_config.spend_share_maturity_distance(current_block_height).into();
+        chain_config.staking_pool_spend_maturity_distance(current_block_height).into();
 
     Ok(TxOutput::LockThenTransfer(
         OutputValue::Coin(amount),
@@ -133,7 +133,7 @@ pub fn make_decomission_stake_pool_output(
     current_block_height: BlockHeight,
 ) -> WalletResult<TxOutput> {
     let num_blocks_to_lock: i64 =
-        chain_config.decommission_pool_maturity_distance(current_block_height).into();
+        chain_config.staking_pool_spend_maturity_distance(current_block_height).into();
 
     Ok(TxOutput::LockThenTransfer(
         OutputValue::Coin(amount),


### PR DESCRIPTION
The way timelocks processes timelocked outputs into block rewards depends on this distance, so it makes sense to unify them as it simplifies processing anyway.