### PR TITLE
Fix for the spurious failure of the test 'block_responses_in_wrong_order'

### DIFF
--- a/p2p/types/src/ip_or_socket_address.rs
+++ b/p2p/types/src/ip_or_socket_address.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 /// IP or socket address
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IpOrSocketAddress {
     Ip(IpAddr),
     Socket(SocketAddr),


### PR DESCRIPTION
This is the failure - https://github.com/mintlayer/mintlayer-core/actions/runs/6856218144/job/18642973987#step:7:1

Basically what happened is that `assert_no_peer_manager_event` would miss an event that it was supposed to consume due to the build being slow and then that event would be catched by `receive_adjust_peer_score_event` instead.
The solution is, instead of using `assert_no_peer_manager_event`, to wait for specific events that can happen at that point.