### PR TITLE
Fix/api server json encodings

### DIFF
--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -117,6 +117,7 @@ impl<S: ApiServerStorage + Send + Sync> LocalBlockchainState for BlockchainState
                     &mut db_tx,
                     block_height,
                     tx.inputs(),
+                    tx.transaction().get_id(),
                 )
                 .await
                 .expect("Unable to update balances from inputs");
@@ -158,6 +159,7 @@ async fn update_address_tables_from_inputs<T: ApiServerStorageWrite>(
     db_tx: &mut T,
     block_height: BlockHeight,
     inputs: &[TxInput],
+    tx_id: Id<Transaction>,
 ) -> Result<(), ApiServerStorageError> {
     let mut address_transactions: BTreeMap<Address<Destination>, BTreeSet<Id<Transaction>>> =
         BTreeMap::new();
@@ -205,7 +207,7 @@ async fn update_address_tables_from_inputs<T: ApiServerStorageWrite>(
                                         address_transactions
                                             .entry(address.clone())
                                             .or_default()
-                                            .insert(transaction_id);
+                                            .insert(tx_id);
 
                                         match output_value {
                                             OutputValue::TokenV0(_)

--- a/api-server/stack-test-suite/tests/v1/block.rs
+++ b/api-server/stack-test-suite/tests/v1/block.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use api_web_server::api::json_helpers::{tx_to_json, txoutput_to_json};
+
 use super::*;
 
 #[tokio::test]
@@ -103,8 +105,15 @@ async fn ok(#[case] seed: Seed) {
                     "timestamp": block.timestamp(),
                 },
                 "body": {
-                    "reward": block.block_reward().outputs().iter().clone().collect::<Vec<_>>(),
-                    "transactions": block.transactions().iter().map(|tx| tx.transaction()).collect::<Vec<_>>(),
+                    "reward": block.block_reward()
+                        .outputs()
+                        .iter()
+                        .map(|out| txoutput_to_json(out, &chain_config))
+                        .collect::<Vec<_>>(),
+                    "transactions": block.transactions()
+                                        .iter()
+                                        .map(|tx| tx_to_json(tx.transaction(), &chain_config))
+                                        .collect::<Vec<_>>(),
                 },
             });
 
@@ -137,8 +146,15 @@ async fn ok(#[case] seed: Seed) {
                     "timestamp": block.timestamp(),
                 },
                 "body": {
-                    "reward": block.block_reward().outputs().iter().clone().collect::<Vec<_>>(),
-                    "transactions": block.transactions().iter().map(|tx| tx.transaction()).collect::<Vec<_>>(),
+                    "reward": block.block_reward()
+                        .outputs()
+                        .iter()
+                        .map(|out| txoutput_to_json(out, &chain_config))
+                        .collect::<Vec<_>>(),
+                    "transactions": block.transactions()
+                                        .iter()
+                                        .map(|tx| tx_to_json(tx.transaction(), &chain_config))
+                                        .collect::<Vec<_>>(),
                 },
             });
 

--- a/api-server/stack-test-suite/tests/v1/mod.rs
+++ b/api-server/stack-test-suite/tests/v1/mod.rs
@@ -31,7 +31,10 @@ use api_server_common::storage::{
     impls::in_memory::transactional::TransactionalApiServerInMemoryStorage,
     storage_api::{ApiServerStorageWrite, ApiServerTransactionRw, Transactional},
 };
-use api_web_server::{api::web_server, ApiServerWebServerState};
+use api_web_server::{
+    api::{json_helpers::txoutput_to_json, web_server},
+    ApiServerWebServerState,
+};
 use chainstate::BlockSource;
 use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::{
@@ -74,7 +77,10 @@ async fn chain_genesis() {
                     "block_id": expected_genesis.get_id(),
                     "fun_message": expected_genesis.fun_message(),
                     "timestamp": expected_genesis.timestamp(),
-                    "utxos": expected_genesis.utxos(),
+                    "utxos": expected_genesis.utxos()
+                             .iter()
+                             .map(|out| txoutput_to_json(out, &chain_config))
+                             .collect::<Vec<_>>(),
                 }));
 
                 let storage = TransactionalApiServerInMemoryStorage::new(&chain_config);

--- a/api-server/web-server/src/api/json_helpers.rs
+++ b/api-server/web-server/src/api/json_helpers.rs
@@ -15,7 +15,7 @@
 
 use common::{
     address::Address,
-    chain::{output_value::OutputValue, ChainConfig, TxOutput},
+    chain::{output_value::OutputValue, ChainConfig, Transaction, TxOutput},
     primitives::Amount,
 };
 use serde_json::json;
@@ -134,4 +134,17 @@ pub fn txoutput_to_json(out: &TxOutput, chain_config: &ChainConfig) -> serde_jso
             })
         }
     }
+}
+
+pub fn tx_to_json(tx: &Transaction, chain_config: &ChainConfig) -> serde_json::Value {
+    json!({
+    "version_byte": tx.version_byte(),
+    "is_replaceable": tx.is_replaceable(),
+    "flags": tx.flags(),
+    // TODO: add fee
+    "fee": amount_to_json(Amount::ZERO),
+    "inputs": tx.inputs(),
+    "outputs": tx.outputs()
+    .iter().map(|out| txoutput_to_json(out, chain_config)).collect::<Vec<_>>()
+    })
 }

--- a/api-server/web-server/src/api/v1.rs
+++ b/api-server/web-server/src/api/v1.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{
-    api::json_helpers::amount_to_json,
+    api::json_helpers::{amount_to_json, tx_to_json},
     error::{
         ApiServerWebServerClientError, ApiServerWebServerError, ApiServerWebServerServerError,
     },
@@ -119,7 +119,10 @@ pub async fn block<T: ApiServerStorage>(
             .iter()
             .map(|out| txoutput_to_json(out, &state.chain_config))
             .collect::<Vec<_>>(),
-        "transactions": block.transactions().iter().map(|tx| tx.transaction()).collect::<Vec<_>>(),
+        "transactions": block.transactions()
+                            .iter()
+                            .map(|tx| tx_to_json(tx.transaction(), &state.chain_config))
+                            .collect::<Vec<_>>(),
     },
     })))
 }
@@ -184,7 +187,10 @@ pub async fn chain_genesis<T: ApiServerStorage>(
         "block_id": genesis.get_id(),
         "fun_message": genesis.fun_message(),
         "timestamp": genesis.timestamp(),
-        "utxos": genesis.utxos(),
+        "utxos": genesis.utxos()
+                 .iter()
+                 .map(|out| txoutput_to_json(out, &state.chain_config))
+                 .collect::<Vec<_>>(),
     })))
 }
 


### PR DESCRIPTION
- fix wrong transaction ID in history
- add make_change_address function in wasm crypto
- fix the transaction output encodings in the block and genesis responses