### PR TITLE
p2p, mempool: Introduce transaction submission options

### DIFF
--- a/mempool/src/event.rs
+++ b/mempool/src/event.rs
@@ -20,6 +20,7 @@ use common::{
 
 use crate::{
     error::{Error, MempoolBanScore},
+    tx_options::TxRelayPolicy,
     tx_origin::TxOrigin,
 };
 
@@ -28,24 +29,31 @@ use crate::{
 pub struct TransactionProcessed {
     tx_id: Id<Transaction>,
     origin: TxOrigin,
+    relay_policy: TxRelayPolicy,
     result: crate::Result<()>,
 }
 
 impl TransactionProcessed {
-    fn new(tx_id: Id<Transaction>, origin: TxOrigin, result: crate::Result<()>) -> Self {
+    fn new(
+        tx_id: Id<Transaction>,
+        origin: TxOrigin,
+        relay_policy: TxRelayPolicy,
+        result: crate::Result<()>,
+    ) -> Self {
         Self {
             tx_id,
             origin,
+            relay_policy,
             result,
         }
     }
 
-    pub fn accepted(tx_id: Id<Transaction>, origin: TxOrigin) -> Self {
-        Self::new(tx_id, origin, Ok(()))
+    pub fn accepted(tx_id: Id<Transaction>, relay_policy: TxRelayPolicy, origin: TxOrigin) -> Self {
+        Self::new(tx_id, origin, relay_policy, Ok(()))
     }
 
     pub fn rejected(tx_id: Id<Transaction>, err: Error, origin: TxOrigin) -> Self {
-        Self::new(tx_id, origin, Err(err))
+        Self::new(tx_id, origin, TxRelayPolicy::DontRelay, Err(err))
     }
 
     pub fn result(&self) -> &crate::Result<()> {
@@ -66,6 +74,10 @@ impl TransactionProcessed {
 
     pub fn origin(&self) -> TxOrigin {
         self.origin
+    }
+
+    pub fn relay_policy(&self) -> TxRelayPolicy {
+        self.relay_policy
     }
 }
 

--- a/mempool/src/interface/mempool_interface.rs
+++ b/mempool/src/interface/mempool_interface.rs
@@ -18,7 +18,7 @@ use crate::{
     event::MempoolEvent,
     tx_accumulator::{PackingStrategy, TransactionAccumulator},
     tx_origin::{LocalTxOrigin, RemoteTxOrigin},
-    FeeRate, MempoolMaxSize, TxStatus,
+    FeeRate, MempoolMaxSize, TxOptions, TxStatus,
 };
 use common::{
     chain::{GenBlock, SignedTransaction, Transaction},
@@ -32,6 +32,7 @@ pub trait MempoolInterface: Send + Sync {
         &mut self,
         tx: SignedTransaction,
         origin: RemoteTxOrigin,
+        options: TxOptions,
     ) -> Result<TxStatus, Error>;
 
     /// Add a local transaction
@@ -39,6 +40,7 @@ pub trait MempoolInterface: Send + Sync {
         &mut self,
         tx: SignedTransaction,
         origin: LocalTxOrigin,
+        options: TxOptions,
     ) -> Result<(), Error>;
 
     /// Get all transactions from mempool

--- a/mempool/src/interface/mempool_interface_impl.rs
+++ b/mempool/src/interface/mempool_interface_impl.rs
@@ -19,7 +19,7 @@ use crate::{
     pool::memory_usage_estimator::StoreMemoryUsageEstimator,
     tx_accumulator::{PackingStrategy, TransactionAccumulator},
     tx_origin::{LocalTxOrigin, RemoteTxOrigin},
-    FeeRate, MempoolInterface, MempoolMaxSize, TxStatus,
+    FeeRate, MempoolInterface, MempoolMaxSize, TxOptions, TxStatus,
 };
 use common::{
     chain::{ChainConfig, GenBlock, SignedTransaction, Transaction},
@@ -127,8 +127,15 @@ impl MempoolInterface for MempoolImpl {
         &mut self,
         tx: SignedTransaction,
         origin: LocalTxOrigin,
+        options: TxOptions,
     ) -> Result<(), Error> {
-        let status = self.mempool.add_transaction(tx, origin.into(), &mut self.work_queue)?;
+        let status = self.mempool.add_transaction_with_options(
+            tx,
+            origin.into(),
+            options,
+            &mut self.work_queue,
+        )?;
+
         // TODO The following assertion could be avoided by parametrizing the above
         // `add_transaction` by the origin type and have the return type depend on it.
         assert_eq!(status, TxStatus::InMempool);
@@ -139,8 +146,10 @@ impl MempoolInterface for MempoolImpl {
         &mut self,
         tx: SignedTransaction,
         origin: RemoteTxOrigin,
+        options: TxOptions,
     ) -> Result<TxStatus, Error> {
-        self.mempool.add_transaction(tx, origin.into(), &mut self.work_queue)
+        self.mempool
+            .add_transaction_with_options(tx, origin.into(), options, &mut self.work_queue)
     }
 
     fn get_all(&self) -> Vec<SignedTransaction> {

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -17,7 +17,7 @@
 
 pub use config::MempoolMaxSize;
 pub use interface::{make_mempool, MempoolInterface};
-pub use mempool_types::{tx_origin, TxStatus};
+pub use mempool_types::{tx_options, tx_origin, TxOptions, TxStatus};
 
 mod config;
 pub mod error;

--- a/mempool/src/pool/entry.rs
+++ b/mempool/src/pool/entry.rs
@@ -21,7 +21,7 @@ use common::{
     primitives::{Id, Idable},
 };
 
-use super::{Fee, Time, TxOrigin};
+use super::{Fee, Time, TxOptions, TxOrigin};
 use crate::tx_origin::IsOrigin;
 
 /// A dependency of a transaction on a previous account state.
@@ -104,11 +104,17 @@ pub struct TxEntry<O = TxOrigin> {
     creation_time: Time,
     encoded_size: usize,
     origin: O,
+    options: TxOptions,
 }
 
 impl<O: IsOrigin> TxEntry<O> {
     /// Create a new mempool transaction entry
-    pub fn new(transaction: SignedTransaction, creation_time: Time, origin: O) -> Self {
+    pub fn new(
+        transaction: SignedTransaction,
+        creation_time: Time,
+        origin: O,
+        options: TxOptions,
+    ) -> Self {
         let tx_id = transaction.transaction().get_id();
         let encoded_size = serialization::Encode::encoded_size(&transaction);
         Self {
@@ -117,6 +123,7 @@ impl<O: IsOrigin> TxEntry<O> {
             creation_time,
             encoded_size,
             origin,
+            options,
         }
     }
 
@@ -143,6 +150,11 @@ impl<O: IsOrigin> TxEntry<O> {
     /// Where we got this transaction
     pub fn origin(&self) -> O {
         self.origin
+    }
+
+    /// Get transaction processing options
+    pub fn options(&self) -> &TxOptions {
+        &self.options
     }
 
     /// Dependency graph edges this entry requires
@@ -179,6 +191,7 @@ impl<O: IsOrigin> TxEntry<O> {
                     creation_time,
                     encoded_size,
                     origin: _,
+                    options,
                 } = self;
 
                 Ok(TxEntry {
@@ -187,6 +200,7 @@ impl<O: IsOrigin> TxEntry<O> {
                     creation_time,
                     encoded_size,
                     origin,
+                    options,
                 })
             }
             Err(err) => Err((self, err)),

--- a/mempool/src/pool/orphans/test.rs
+++ b/mempool/src/pool/orphans/test.rs
@@ -82,11 +82,13 @@ fn random_tx_entry(rng: &mut impl Rng) -> TxEntry {
     let transaction = SignedTransaction::new(transaction, signatures).unwrap();
     let insertion_time = Duration::from_secs(rng.gen());
     let origin = random_peer_origin(rng);
+    let options = crate::TxOptions::default_for(origin.into());
 
     TxEntry::new(
         transaction,
         Time::from_duration_since_epoch(insertion_time),
         origin,
+        options,
     )
 }
 

--- a/mempool/src/pool/store/mod.rs
+++ b/mempool/src/pool/store/mod.rs
@@ -581,7 +581,9 @@ impl TxMempoolEntry {
         creation_time: Time,
     ) -> Result<TxMempoolEntry, MempoolPolicyError> {
         use crate::tx_origin::LocalTxOrigin;
-        let entry = TxEntry::new(tx, creation_time, LocalTxOrigin::Mempool.into());
+        let origin = LocalTxOrigin::Mempool.into();
+        let options = crate::TxOptions::default_for(origin);
+        let entry = TxEntry::new(tx, creation_time, origin, options);
         Self::new(TxEntryWithFee::new(entry, fee), parents, ancestors)
     }
 

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -268,7 +268,8 @@ pub fn generate_transaction_graph(
         );
 
         let origin = RemoteTxOrigin::new(p2p_types::PeerId::from_u64(1)).into();
-        let entry = TxEntry::new(tx, time, origin);
+        let options = crate::TxOptions::default_for(origin);
+        let entry = TxEntry::new(tx, time, origin, options);
         TxEntryWithFee::new(entry, Fee::new(Amount::from_atoms(total)))
     })
 }

--- a/mempool/types/src/lib.rs
+++ b/mempool/types/src/lib.rs
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod tx_options;
 pub mod tx_origin;
 mod tx_status;
 
+pub use tx_options::TxOptions;
 pub use tx_status::TxStatus;

--- a/mempool/types/src/tx_options.rs
+++ b/mempool/types/src/tx_options.rs
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::tx_origin::{LocalTxOrigin, TxOrigin};
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug, serde::Serialize, serde::Deserialize, Default)]
+pub enum TxTrustPolicy {
+    /// Mempool policy checks are bypassed for this transaction
+    Trusted,
+
+    /// Transaction is subject to all the usual mempool policy checks.
+    #[default]
+    Untrusted,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum TxRelayPolicy {
+    /// Transaction should be relayed by p2p if checks pass
+    DoRelay,
+
+    /// Transaction should not be relayed to peers, keeping it local
+    DontRelay,
+}
+
+/// Options specifying how should a transaction be handled by mempool and p2p.
+// Can be extended further with custom eviction policies, tx orphan pool policies, etc.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct TxOptions {
+    /// What checks to apply to the transaction
+    trust_policy: TxTrustPolicy,
+
+    /// Whether the transaction should be relayed
+    relay_policy: TxRelayPolicy,
+}
+
+impl TxOptions {
+    /// Default options for given transaction origin
+    pub const fn default_for(origin: TxOrigin) -> Self {
+        let trust_policy = TxTrustPolicy::Untrusted;
+
+        let relay_policy = match origin {
+            TxOrigin::Local(origin) => match origin {
+                LocalTxOrigin::Mempool => TxRelayPolicy::DontRelay,
+                LocalTxOrigin::P2p => TxRelayPolicy::DoRelay,
+                LocalTxOrigin::PastBlock => TxRelayPolicy::DontRelay,
+            },
+            TxOrigin::Remote(_) => TxRelayPolicy::DoRelay,
+        };
+
+        TxOptions {
+            trust_policy,
+            relay_policy,
+        }
+    }
+
+    /// Apply given user-specified overrides to the options
+    pub const fn with_overrides(mut self, overrides: TxOptionsOverrides) -> Self {
+        if let Some(trust_policy) = overrides.trust_policy {
+            self.trust_policy = trust_policy;
+        }
+
+        self
+    }
+
+    pub fn trust_policy(&self) -> TxTrustPolicy {
+        self.trust_policy
+    }
+
+    pub fn relay_policy(&self) -> TxRelayPolicy {
+        self.relay_policy
+    }
+}
+
+/// Mechanism to apply user-specified overrides to [TxOptions].
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Default)]
+#[serde(default)]
+pub struct TxOptionsOverrides {
+    /// Override transaction trust policy.
+    trust_policy: Option<TxTrustPolicy>,
+}

--- a/mempool/types/src/tx_origin.rs
+++ b/mempool/types/src/tx_origin.rs
@@ -25,16 +25,6 @@ pub enum TxOrigin {
     Remote(RemoteTxOrigin),
 }
 
-impl TxOrigin {
-    /// Should this transaction be passed on to peers once accepted?
-    pub fn should_propagate(self) -> bool {
-        match self {
-            Self::Local(origin) => origin.should_propagate(),
-            Self::Remote(origin) => origin.should_propagate(),
-        }
-    }
-}
-
 impl From<LocalTxOrigin> for TxOrigin {
     fn from(value: LocalTxOrigin) -> Self {
         Self::Local(value)
@@ -60,16 +50,6 @@ pub enum LocalTxOrigin {
     PastBlock,
 }
 
-impl LocalTxOrigin {
-    pub fn should_propagate(self) -> bool {
-        match self {
-            LocalTxOrigin::Mempool => false,
-            LocalTxOrigin::P2p => true,
-            LocalTxOrigin::PastBlock => false,
-        }
-    }
-}
-
 /// Transaction was received from a peer.
 ///
 /// If it eventually turns out to be valid, it should be propagated further to other peers.
@@ -80,10 +60,6 @@ pub struct RemoteTxOrigin(PeerId);
 impl RemoteTxOrigin {
     pub const fn new(peer_id: PeerId) -> Self {
         Self(peer_id)
-    }
-
-    pub fn should_propagate(self) -> bool {
-        true
     }
 
     pub const fn peer_id(self) -> PeerId {

--- a/mocks/src/mempool.rs
+++ b/mocks/src/mempool.rs
@@ -26,7 +26,7 @@ use mempool::{
     event::MempoolEvent,
     tx_accumulator::{PackingStrategy, TransactionAccumulator},
     tx_origin::{LocalTxOrigin, RemoteTxOrigin},
-    FeeRate, MempoolInterface, MempoolMaxSize, TxStatus,
+    FeeRate, MempoolInterface, MempoolMaxSize, TxOptions, TxStatus,
 };
 
 mockall::mock! {
@@ -36,13 +36,15 @@ mockall::mock! {
         fn add_transaction_local(
             &mut self,
             tx: SignedTransaction,
-            origin: LocalTxOrigin
+            origin: LocalTxOrigin,
+            options: TxOptions,
         ) -> Result<(), Error>;
 
         fn add_transaction_remote(
             &mut self,
             tx: SignedTransaction,
             origin: RemoteTxOrigin,
+            options: TxOptions,
         ) -> Result<TxStatus, Error>;
 
         fn get_all(&self) -> Vec<SignedTransaction>;

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -16,6 +16,7 @@
 use std::sync::Arc;
 
 use common::chain::SignedTransaction;
+use mempool::tx_options::TxOptionsOverrides;
 use p2p_types::{
     bannable_address::BannableAddress, ip_or_socket_address::IpOrSocketAddress,
     p2p_event::P2pEvent, socket_address::SocketAddress,
@@ -39,7 +40,11 @@ pub trait P2pInterface: Send + Sync {
     async fn add_reserved_node(&mut self, addr: IpOrSocketAddress) -> crate::Result<()>;
     async fn remove_reserved_node(&mut self, addr: IpOrSocketAddress) -> crate::Result<()>;
 
-    async fn submit_transaction(&mut self, tx: SignedTransaction) -> crate::Result<()>;
+    async fn submit_transaction(
+        &mut self,
+        tx: SignedTransaction,
+        options: TxOptionsOverrides,
+    ) -> crate::Result<()>;
 
     fn subscribe_to_events(
         &mut self,

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -19,6 +19,7 @@ use std::{
 };
 
 use common::chain::SignedTransaction;
+use mempool::tx_options::TxOptionsOverrides;
 use p2p_types::{
     bannable_address::BannableAddress, ip_or_socket_address::IpOrSocketAddress,
     socket_address::SocketAddress,
@@ -70,8 +71,12 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
         self.deref_mut().remove_reserved_node(addr).await
     }
 
-    async fn submit_transaction(&mut self, tx: SignedTransaction) -> crate::Result<()> {
-        self.deref_mut().submit_transaction(tx).await
+    async fn submit_transaction(
+        &mut self,
+        tx: SignedTransaction,
+        options: TxOptionsOverrides,
+    ) -> crate::Result<()> {
+        self.deref_mut().submit_transaction(tx, options).await
     }
 
     fn subscribe_to_events(

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use common::chain::SignedTransaction;
+use mempool::tx_options::TxOptionsOverrides;
 use p2p_types::{
     bannable_address::BannableAddress, ip_or_socket_address::IpOrSocketAddress,
     socket_address::SocketAddress,
@@ -67,7 +68,11 @@ trait P2pRpc {
 
     /// Submits a transaction to mempool, and if it is valid, broadcasts it to the network.
     #[method(name = "submit_transaction")]
-    async fn submit_transaction(&self, tx: HexEncoded<SignedTransaction>) -> RpcResult<()>;
+    async fn submit_transaction(
+        &self,
+        tx: HexEncoded<SignedTransaction>,
+        options: TxOptionsOverrides,
+    ) -> RpcResult<()>;
 }
 
 #[async_trait::async_trait]
@@ -122,8 +127,14 @@ impl P2pRpcServer for super::P2pHandle {
         rpc::handle_result(res)
     }
 
-    async fn submit_transaction(&self, tx: HexEncoded<SignedTransaction>) -> RpcResult<()> {
-        let res = self.call_async_mut(move |this| this.submit_transaction(tx.take())).await;
+    async fn submit_transaction(
+        &self,
+        tx: HexEncoded<SignedTransaction>,
+        options: TxOptionsOverrides,
+    ) -> RpcResult<()> {
+        let res = self
+            .call_async_mut(move |this| this.submit_transaction(tx.take(), options))
+            .await;
         rpc::handle_result(res)
     }
 }

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -322,11 +322,15 @@ where
 
         match tx_proc_event.result() {
             Ok(()) => {
-                if origin.should_propagate() {
-                    log::info!("Broadcasting transaction {tx_id} originating in {origin}");
-                    self.send_local_event(&LocalEvent::MempoolNewTx(tx_id));
-                } else {
-                    log::trace!("Not propagating transaction {tx_id} originating in {origin}");
+                use mempool::tx_options::TxRelayPolicy;
+                match tx_proc_event.relay_policy() {
+                    TxRelayPolicy::DoRelay => {
+                        log::info!("Broadcasting transaction {tx_id} originating in {origin}");
+                        self.send_local_event(&LocalEvent::MempoolNewTx(tx_id));
+                    }
+                    TxRelayPolicy::DontRelay => {
+                        log::trace!("Not propagating transaction {tx_id} originating in {origin}");
+                    }
                 }
             }
             Err(_) => match origin {

--- a/p2p/src/sync/peer_v1.rs
+++ b/p2p/src/sync/peer_v1.rs
@@ -34,7 +34,7 @@ use common::{
     time_getter::TimeGetter,
 };
 use logging::log;
-use mempool::MempoolHandle;
+use mempool::{MempoolHandle, TxOptions};
 use utils::const_value::ConstValue;
 use utils::sync::Arc;
 
@@ -891,10 +891,11 @@ where
 
         if let Some(transaction) = tx {
             let origin = mempool::tx_origin::RemoteTxOrigin::new(self.id());
+            let options = TxOptions::default_for(origin.into());
             let txid = transaction.transaction().get_id();
             let tx_status = self
                 .mempool_handle
-                .call_mut(move |m| m.add_transaction_remote(transaction, origin))
+                .call_mut(move |m| m.add_transaction_remote(transaction, origin, options))
                 .await??;
             match tx_status {
                 mempool::TxStatus::InMempool => {

--- a/p2p/src/sync/peer_v2/transaction_manager.rs
+++ b/p2p/src/sync/peer_v2/transaction_manager.rs
@@ -26,7 +26,7 @@ use common::{
     time_getter::TimeGetter,
 };
 use logging::log;
-use mempool::MempoolHandle;
+use mempool::{MempoolHandle, TxOptions};
 use utils::const_value::ConstValue;
 use utils::sync::Arc;
 
@@ -258,10 +258,11 @@ where
 
         if let Some(transaction) = tx {
             let origin = mempool::tx_origin::RemoteTxOrigin::new(self.id());
+            let options = TxOptions::default_for(origin.into());
             let txid = transaction.transaction().get_id();
             let tx_status = self
                 .mempool_handle
-                .call_mut(move |m| m.add_transaction_remote(transaction, origin))
+                .call_mut(move |m| m.add_transaction_remote(transaction, origin, options))
                 .await??;
             match tx_status {
                 mempool::TxStatus::InMempool => {

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -491,9 +491,13 @@ async fn transaction_sequence_via_orphan_pool(#[case] seed: Seed) {
         let tx1_id = tx1.transaction().get_id();
         txs.insert(tx1_id, tx1.clone());
 
+        let origin = RemoteTxOrigin::new(peer_id);
+        let options0 = mempool::TxOptions::default_for(origin.into());
+        let options1 = options0.clone();
+
         let res = node
             .mempool()
-            .call_mut(move |m| m.add_transaction_remote(tx1, RemoteTxOrigin::new(peer_id)))
+            .call_mut(move |m| m.add_transaction_remote(tx1, origin, options0))
             .await
             .unwrap();
         assert_eq!(res, Ok(mempool::TxStatus::InOrphanPool));
@@ -504,7 +508,7 @@ async fn transaction_sequence_via_orphan_pool(#[case] seed: Seed) {
 
         let res = node
             .mempool()
-            .call_mut(move |m| m.add_transaction_remote(tx0, RemoteTxOrigin::new(peer_id)))
+            .call_mut(move |m| m.add_transaction_remote(tx0, origin, options1))
             .await
             .unwrap();
         assert_eq!(res, Ok(mempool::TxStatus::InMempool));

--- a/test/functional/blockprod_generate_blocks_all_sources.py
+++ b/test/functional/blockprod_generate_blocks_all_sources.py
@@ -79,7 +79,7 @@ class GenerateBlocksFromAllSourcesTest(BitcoinTestFramework):
                     utxo = tx_input(utxo_id, utxo_index)
                     (tx, tx_id) = make_tx([utxo], [100])
 
-                    node.mempool_submit_transaction(tx)
+                    node.mempool_submit_transaction(tx, {})
 
                     if include_mempool:
                         missing_transactions.append(tx_id)
@@ -108,7 +108,7 @@ class GenerateBlocksFromAllSourcesTest(BitcoinTestFramework):
                         (tx, tx_id) = make_tx([utxo], [100])
 
                         missing_transactions.append(tx_id)
-                        node.mempool_submit_transaction(tx)
+                        node.mempool_submit_transaction(tx, {})
                         assert(node.mempool_contains_tx(tx_id))
 
                         transaction_ids.append(tx_id)
@@ -126,7 +126,7 @@ class GenerateBlocksFromAllSourcesTest(BitcoinTestFramework):
                         (tx, tx_id) = make_tx([utxo], [100])
 
                         missing_transactions.append(tx_id)
-                        node.mempool_submit_transaction(tx)
+                        node.mempool_submit_transaction(tx, {})
                         assert(node.mempool_contains_tx(tx_id))
 
                         packing_strategy = "FillSpaceFromMempool"

--- a/test/functional/mempool_basic_reorg.py
+++ b/test/functional/mempool_basic_reorg.py
@@ -52,7 +52,7 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         self.log.debug("Encoded tx3 {}: {}".format(tx3_id, tx3))
 
         # Submit the first transaction
-        node.mempool_submit_transaction(tx1)
+        node.mempool_submit_transaction(tx1, {})
         assert node.mempool_contains_tx(tx1_id)
         assert not node.mempool_contains_tx(tx2_id)
         assert not node.mempool_contains_tx(tx3_id)
@@ -75,8 +75,8 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         assert not node.mempool_contains_tx(tx3_id)
 
         # Submit the other two transactions
-        node.mempool_submit_transaction(tx2)
-        node.mempool_submit_transaction(tx3)
+        node.mempool_submit_transaction(tx2, {})
+        node.mempool_submit_transaction(tx3, {})
         assert not node.mempool_contains_tx(tx1_id)
         assert node.mempool_contains_tx(tx2_id)
         assert node.mempool_contains_tx(tx3_id)

--- a/test/functional/mempool_eviction.py
+++ b/test/functional/mempool_eviction.py
@@ -48,9 +48,9 @@ class MempoolTxEvictionTest(BitcoinTestFramework):
         (tx3, tx3_id) = make_tx([ tx_input(tx2_id) ], [ 800_000 ] )
 
         # Submit the transactions
-        node.mempool_submit_transaction(tx1)
-        node.mempool_submit_transaction(tx2)
-        node.mempool_submit_transaction(tx3)
+        node.mempool_submit_transaction(tx1, {})
+        node.mempool_submit_transaction(tx2, {})
+        node.mempool_submit_transaction(tx3, {})
         assert node.mempool_contains_tx(tx1_id)
         assert node.mempool_contains_tx(tx2_id)
         assert node.mempool_contains_tx(tx3_id)
@@ -62,7 +62,7 @@ class MempoolTxEvictionTest(BitcoinTestFramework):
         assert not node.mempool_contains_tx(tx3_id)
 
         # Try to re-add the transaction, check it failed
-        assert_raises_rpc_error(None, "fee threshold not met", node.mempool_submit_transaction, tx3)
+        assert_raises_rpc_error(None, "fee threshold not met", node.mempool_submit_transaction, tx3, {})
 
         # Set the mempool limit to evict the second last transaction too
         node.mempool_set_max_size(node.mempool_memory_usage() - 1)
@@ -73,8 +73,8 @@ class MempoolTxEvictionTest(BitcoinTestFramework):
         # Reset the mempool size to fit all transactions. Submit the missing transactions again
         # in the opposite order, check they both make their way in.
         node.mempool_set_max_size(300_000_000)
-        assert_raises_rpc_error(None, "Orphans not supported", node.mempool_submit_transaction, tx3)
-        node.mempool_submit_transaction(tx2)
+        assert_raises_rpc_error(None, "Orphans not supported", node.mempool_submit_transaction, tx3, {})
+        node.mempool_submit_transaction(tx2, {})
         assert node.mempool_contains_tx(tx1_id)
         assert node.mempool_contains_tx(tx2_id)
         assert not node.mempool_contains_tx(tx3_id)
@@ -86,13 +86,13 @@ class MempoolTxEvictionTest(BitcoinTestFramework):
 
         # Add a transaction that pays two outputs
         (tx1, tx1_id) = make_tx([ reward_input(genesis_id) ], [ 100_000_000, 100_000_000 ])
-        node.mempool_submit_transaction(tx1)
+        node.mempool_submit_transaction(tx1, {})
 
         # Add two transactions with CPFP semantics
         (tx2a, tx2a_id) = make_tx([ tx_input(tx1_id) ], [ 99_000_000 ])
         (tx3a, tx3a_id) = make_tx([ tx_input(tx2a_id) ], [ 90_000_000 ])
-        node.mempool_submit_transaction(tx2a)
-        node.mempool_submit_transaction(tx3a)
+        node.mempool_submit_transaction(tx2a, {})
+        node.mempool_submit_transaction(tx3a, {})
 
         # Limit the mempool size so no more transactions fit
         node.mempool_set_max_size(node.mempool_memory_usage())
@@ -102,7 +102,7 @@ class MempoolTxEvictionTest(BitcoinTestFramework):
 
         # Add a transaction that pays higher fees than the previous two, so both need to be evicted
         (tx2b, tx2b_id) = make_tx([ tx_input(tx1_id, index = 1) ], [ 50_000_000, 5_000_000 ])
-        node.mempool_submit_transaction(tx2b)
+        node.mempool_submit_transaction(tx2b, {})
         assert node.mempool_contains_tx(tx1_id)
         assert node.mempool_contains_tx(tx2b_id)
         assert not node.mempool_contains_tx(tx2a_id)

--- a/test/functional/mempool_ibd.py
+++ b/test/functional/mempool_ibd.py
@@ -69,7 +69,7 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         self.log.debug("Encoded tx1 {}: {}".format(tx1_id, tx1))
 
         # The transaction should be rejected because of IBD
-        assert_raises_rpc_error(None, IBD_ERR, node.mempool_submit_transaction, tx1)
+        assert_raises_rpc_error(None, IBD_ERR, node.mempool_submit_transaction, tx1, {})
         assert not node.mempool_contains_tx(tx1_id)
 
         # Produce a block but wait over a day to submit it
@@ -78,7 +78,7 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         self.submit_block(block1)
 
         # The transaction should still be rejected because of IBD
-        assert_raises_rpc_error(None, IBD_ERR, node.mempool_submit_transaction, tx1)
+        assert_raises_rpc_error(None, IBD_ERR, node.mempool_submit_transaction, tx1, {})
         assert not node.mempool_contains_tx(tx1_id)
 
         # Produce a block but don't wait too long before submission
@@ -89,7 +89,7 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         self.log.debug("Chain info 2: {}".format(node.chainstate_info()))
 
         # The transaction should now be accepted
-        node.mempool_submit_transaction(tx1)
+        node.mempool_submit_transaction(tx1, {})
         assert node.mempool_contains_tx(tx1_id)
 
 if __name__ == '__main__':

--- a/test/functional/mempool_local_orphan_rejected.py
+++ b/test/functional/mempool_local_orphan_rejected.py
@@ -48,19 +48,19 @@ class MempoolLocalOrphanSubmissionTest(BitcoinTestFramework):
         (tx2, tx2_id) = make_tx([ tx_input(tx1_id) ], [ 900_000 ] )
 
         # Submit tx2 first, check it is rejected since local txs should not be orphans
-        assert_raises_rpc_error(None, 'originating at local node', node.mempool_submit_transaction, tx2)
+        assert_raises_rpc_error(None, 'originating at local node', node.mempool_submit_transaction, tx2, {})
         assert not node.mempool_contains_tx(tx2_id)
         self.wait_until(lambda: not node.mempool_contains_orphan_tx(tx2_id), timeout = 5)
 
         # Submit the first transaction now
-        node.mempool_submit_transaction(tx1)
+        node.mempool_submit_transaction(tx1, {})
         assert node.mempool_contains_tx(tx1_id)
         assert not node.mempool_contains_tx(tx2_id)
         self.wait_until(lambda: not node.mempool_contains_orphan_tx(tx1_id), timeout = 5)
         self.wait_until(lambda: not node.mempool_contains_orphan_tx(tx2_id), timeout = 5)
 
         # Check local submission of the second transaction has not been blocked
-        node.mempool_submit_transaction(tx2)
+        node.mempool_submit_transaction(tx2, {})
         assert node.mempool_contains_tx(tx2_id)
 
 

--- a/test/functional/mempool_orphan_peer_disconnected.py
+++ b/test/functional/mempool_orphan_peer_disconnected.py
@@ -48,8 +48,8 @@ class MempoolOrphanFromDisconnectedPeerTest(BitcoinTestFramework):
         (tx2, tx2_id) = make_tx([ tx_input(tx1_id) ], [ 900_000 ] )
 
         # Submit two transactions that build on top of each other but only propagate the second one
-        node0.mempool_submit_transaction(tx1)
-        node0.p2p_submit_transaction(tx2)
+        node0.mempool_submit_transaction(tx1, {})
+        node0.p2p_submit_transaction(tx2, {})
 
         # Check the node gets the orphan transaction
         self.wait_until(lambda: node1.mempool_contains_orphan_tx(tx2_id), timeout = 5)

--- a/test/functional/mempool_submit_tx.py
+++ b/test/functional/mempool_submit_tx.py
@@ -65,7 +65,7 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         tx_id = scalecodec.ScaleBytes(mintlayer_hash(base_tx_obj.encode(tx).data)).to_hex()[2:]
         self.log.debug("Encoded transaction {}: {}".format(tx_id, encoded_tx))
 
-        assert_raises_rpc_error(None, "Transaction has no inputs", node.mempool_submit_transaction, encoded_tx)
+        assert_raises_rpc_error(None, "Transaction has no inputs", node.mempool_submit_transaction, encoded_tx, {})
         assert not node.mempool_contains_tx(tx_id)
 
         # Submit a valid transaction
@@ -93,7 +93,7 @@ class MempoolTxSubmissionTest(BitcoinTestFramework):
         tx_id = scalecodec.ScaleBytes(mintlayer_hash(base_tx_obj.encode(tx).data)).to_hex()[2:]
         self.log.debug("Encoded transaction {}: {}".format(tx_id, encoded_tx))
 
-        node.mempool_submit_transaction(encoded_tx)
+        node.mempool_submit_transaction(encoded_tx, {})
         assert node.mempool_contains_tx(tx_id)
 
 

--- a/test/functional/mempool_timelocked_tx.py
+++ b/test/functional/mempool_timelocked_tx.py
@@ -77,11 +77,11 @@ class MempoolTimelockedTxTest(BitcoinTestFramework):
         self.log.debug("Encoded tx3 {}: {}".format(tx3_id, tx3))
 
         # Submit the transactions
-        node.mempool_submit_transaction(tx0)
-        node.mempool_submit_transaction(tx1)
-        node.mempool_submit_transaction(tx3)
+        node.mempool_submit_transaction(tx0, {})
+        node.mempool_submit_transaction(tx1, {})
+        node.mempool_submit_transaction(tx3, {})
         # Cannot submit tx2 yet, it spends and unconfirmed time-locked output
-        assert_raises_rpc_error(None, "Timelock rules violated", node.mempool_submit_transaction, tx2)
+        assert_raises_rpc_error(None, "Timelock rules violated", node.mempool_submit_transaction, tx2, {})
 
         assert node.mempool_contains_tx(tx0_id)
         assert node.mempool_contains_tx(tx1_id)
@@ -96,7 +96,7 @@ class MempoolTimelockedTxTest(BitcoinTestFramework):
         assert not node.mempool_contains_tx(tx3_id)
 
         # We can now submit tx2
-        node.mempool_submit_transaction(tx2)
+        node.mempool_submit_transaction(tx2, {})
         assert not node.mempool_contains_tx(tx0_id)
         assert node.mempool_contains_tx(tx1_id)
         assert node.mempool_contains_tx(tx2_id)

--- a/test/functional/p2p_relay_transactions.py
+++ b/test/functional/p2p_relay_transactions.py
@@ -60,7 +60,7 @@ class RelayTransactions(BitcoinTestFramework):
         encoded_tx = signed_tx_obj.encode(signed_tx).to_hex()[2:]
         tx_id = scalecodec.ScaleBytes(mintlayer_hash(base_tx_obj.encode(tx).data)).to_hex()[2:]
 
-        assert_raises_rpc_error(None, "Transaction has no inputs", self.nodes[0].p2p_submit_transaction, encoded_tx)
+        assert_raises_rpc_error(None, "Transaction has no inputs", self.nodes[0].p2p_submit_transaction, encoded_tx, {})
         assert not self.nodes[0].mempool_contains_tx(tx_id)
         assert not self.nodes[1].mempool_contains_tx(tx_id)
 
@@ -89,7 +89,7 @@ class RelayTransactions(BitcoinTestFramework):
         encoded_tx = signed_tx_obj.encode(signed_tx).to_hex()[2:]
         tx_id = scalecodec.ScaleBytes(mintlayer_hash(base_tx_obj.encode(tx).data)).to_hex()[2:]
 
-        self.nodes[0].p2p_submit_transaction(encoded_tx)
+        self.nodes[0].p2p_submit_transaction(encoded_tx, {})
         assert self.nodes[0].mempool_contains_tx(tx_id)
         self.assert_mempool_contains_tx(1, tx_id)
 

--- a/test/functional/wallet_conflict.py
+++ b/test/functional/wallet_conflict.py
@@ -107,7 +107,7 @@ class WalletConflictTransaction(BitcoinTestFramework):
 
             assert_in("No transaction found", await wallet.get_transaction(tx_id))
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             self.generate_block()

--- a/test/functional/wallet_data_deposit.py
+++ b/test/functional/wallet_data_deposit.py
@@ -97,7 +97,7 @@ class WalletDataDeposit(BitcoinTestFramework):
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             self.generate_block() # Block 1

--- a/test/functional/wallet_generate_addresses.py
+++ b/test/functional/wallet_generate_addresses.py
@@ -121,7 +121,7 @@ class WalletAddressGenerator(BitcoinTestFramework):
 
             self.log.debug(f"Encoded transaction {tx_id}: {encoded_tx}")
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/test/functional/wallet_get_address_usage.py
+++ b/test/functional/wallet_get_address_usage.py
@@ -103,7 +103,7 @@ class WalletGetAddressUsage(BitcoinTestFramework):
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             self.generate_block() # Block 1

--- a/test/functional/wallet_high_fee.py
+++ b/test/functional/wallet_high_fee.py
@@ -114,7 +114,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
             self.log.debug(f"Encoded transaction {tx_id}: {encoded_tx}")
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1
@@ -137,7 +137,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             transactions = node.test_functions_generate_transactions(tx_id, 25, total - 300, 300)
             for idx, encoded_tx in enumerate(transactions):
                 self.log.info(f"submitting tx {idx}")
-                node.mempool_submit_transaction(encoded_tx)
+                node.mempool_submit_transaction(encoded_tx, {})
 
             # try to send 9 out of 10 to itself, 1 coin should not be enough to pay the high fee
             address = await wallet.new_address()

--- a/test/functional/wallet_nfts.py
+++ b/test/functional/wallet_nfts.py
@@ -94,7 +94,7 @@ class WalletNfts(BitcoinTestFramework):
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/test/functional/wallet_recover_accounts.py
+++ b/test/functional/wallet_recover_accounts.py
@@ -101,7 +101,7 @@ class WalletRecoverAccounts(BitcoinTestFramework):
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/test/functional/wallet_select_utxos.py
+++ b/test/functional/wallet_select_utxos.py
@@ -101,7 +101,7 @@ class WalletSubmitTransactionSpecificUtxo(BitcoinTestFramework):
                 }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [make_output(pk) for pk in addresses], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/test/functional/wallet_submit_tx.py
+++ b/test/functional/wallet_submit_tx.py
@@ -101,7 +101,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
             assert_in("No transaction found", await wallet.get_transaction(tx_id))
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -97,7 +97,7 @@ class WalletTokens(BitcoinTestFramework):
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/test/functional/wallet_tokens_change_authority.py
+++ b/test/functional/wallet_tokens_change_authority.py
@@ -98,7 +98,7 @@ class WalletTokens(BitcoinTestFramework):
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/test/functional/wallet_tokens_change_supply.py
+++ b/test/functional/wallet_tokens_change_supply.py
@@ -96,7 +96,7 @@ class WalletTokens(BitcoinTestFramework):
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/test/functional/wallet_tokens_freeze.py
+++ b/test/functional/wallet_tokens_freeze.py
@@ -98,7 +98,7 @@ class WalletTokens(BitcoinTestFramework):
             }
             encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
 
-            node.mempool_submit_transaction(encoded_tx)
+            node.mempool_submit_transaction(encoded_tx, {})
             assert node.mempool_contains_tx(tx_id)
 
             block_id = self.generate_block() # Block 1

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -241,7 +241,11 @@ impl NodeInterface for WalletHandlesClient {
     }
 
     async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
-        Ok(self.p2p.call_async_mut(move |this| this.submit_transaction(tx)).await??)
+        let options = mempool::tx_options::TxOptionsOverrides::default();
+        Ok(self
+            .p2p
+            .call_async_mut(move |this| this.submit_transaction(tx, options))
+            .await??)
     }
 
     async fn node_shutdown(&self) -> Result<(), Self::Error> {

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -184,7 +184,8 @@ impl NodeInterface for NodeRpcClient {
             .map_err(NodeRpcError::ResponseError)
     }
     async fn submit_transaction(&self, tx: SignedTransaction) -> Result<(), Self::Error> {
-        let status = P2pRpcClient::submit_transaction(&self.http_client, tx.into())
+        let options = mempool::tx_options::TxOptionsOverrides::default();
+        let status = P2pRpcClient::submit_transaction(&self.http_client, tx.into(), options)
             .await
             .map_err(NodeRpcError::ResponseError)?;
         Ok(status)


### PR DESCRIPTION
* Add an argument to transaction submission RPCs specifying options how should the transaction be processed which is extensible in a backwards compatible way.
* Currently, it only supports passing trusted mode flag to the RPC which is intended to disable various mempool policy checks.
* The flag itself is not currently properly implemented.
* Refactor existing code to take transaction processing options.