### PR TITLE
Fix wallet/freeze_and_unfreeze_tokens test

### DIFF
--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -2056,7 +2056,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
     let unconfirmed_token_info =
         wallet.get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, &token_info).unwrap();
 
-    let amount_to_mint = Amount::from_atoms(rng.gen_range(1..fixed_max_amount.into_atoms()));
+    let amount_to_mint = Amount::from_atoms(rng.gen_range(1..=fixed_max_amount.into_atoms()));
     let mint_tx = wallet
         .mint_tokens(
             DEFAULT_ACCOUNT_INDEX,


### PR DESCRIPTION
```
  FAIL [   0.059s] wallet wallet::tests::freeze_and_unfreeze_tokens::case_1

--- STDOUT:              wallet wallet::tests::freeze_and_unfreeze_tokens::case_1 ---

running 1 test
------------ TEST ARGUMENTS ------------
seed = Seed(7036335168113488306)
-------------- TEST START --------------
test wallet::tests::freeze_and_unfreeze_tokens::case_1 ... FAILED

failures:

failures:
    wallet::tests::freeze_and_unfreeze_tokens::case_1

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 52 filtered out; finished in 0.06s


--- STDERR:              wallet wallet::tests::freeze_and_unfreeze_tokens::case_1 ---
thread 'wallet::tests::freeze_and_unfreeze_tokens::case_1' panicked at /home/mintlayer/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/rng.rs:134:9:
cannot sample empty range
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```