### PR TITLE
Transactions should be relayed with random delay

### DIFF
--- a/p2p/src/sync/peer_v2/mod.rs
+++ b/p2p/src/sync/peer_v2/mod.rs
@@ -16,3 +16,5 @@
 pub mod block_manager;
 pub mod requested_transactions;
 pub mod transaction_manager;
+
+mod pending_transactions;

--- a/p2p/src/sync/peer_v2/pending_transactions.rs
+++ b/p2p/src/sync/peer_v2/pending_transactions.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2021-2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{cmp::Reverse, collections::BinaryHeap, time::Duration};
+
+use common::{
+    chain::Transaction,
+    primitives::{Id, H256},
+    time_getter::TimeGetter,
+};
+
+use crate::Result;
+
+pub struct PendingTransactions {
+    time_getter: TimeGetter,
+    txs: BinaryHeap<Reverse<(Duration, Id<Transaction>)>>,
+}
+
+impl PendingTransactions {
+    pub fn new(time_getter: TimeGetter) -> Self {
+        Self {
+            time_getter,
+            txs: Default::default(),
+        }
+    }
+
+    pub fn push(&mut self, tx: Id<Transaction>, due_time: Duration) {
+        self.txs.push(Reverse((due_time, tx)));
+    }
+
+    pub async fn due(&mut self) -> Result<Id<Transaction>> {
+        if self.txs.is_empty() {
+            std::future::pending::<()>().await;
+            Ok(Id::<Transaction>::new(H256::zero())) // unreachable
+        } else {
+            let now = self.time_getter.get_time().as_duration_since_epoch();
+            let (due, _) = self.txs.peek().expect("cannot be empty").0;
+            if now < due {
+                tokio::time::sleep(due - now).await;
+            }
+
+            let (_, tx) = self.txs.pop().expect("cannot be empty").0;
+            Ok(tx)
+        }
+    }
+}

--- a/p2p/src/sync/peer_v2/pending_transactions.rs
+++ b/p2p/src/sync/peer_v2/pending_transactions.rs
@@ -43,10 +43,9 @@ impl PendingTransactions {
     pub async fn due(&self) {
         match self.txs.peek() {
             Some(item) => {
-                let now = Instant::now();
                 let (due, _) = item.0;
-                if now < due {
-                    tokio::time::sleep(due - now).await;
+                if Instant::now() < due {
+                    tokio::time::sleep_until(due).await;
                 }
             }
             None => std::future::pending().await,

--- a/p2p/src/sync/peer_v2/pending_transactions.rs
+++ b/p2p/src/sync/peer_v2/pending_transactions.rs
@@ -44,11 +44,115 @@ impl PendingTransactions {
         match self.txs.peek() {
             Some(item) => {
                 let (due, _) = item.0;
-                if Instant::now() < due {
-                    tokio::time::sleep_until(due).await;
-                }
+                tokio::time::sleep_until(due).await;
             }
             None => std::future::pending().await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    use common::primitives::H256;
+    use rstest::rstest;
+    use test_utils::random::{make_seedable_rng, Rng, Seed};
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn modification_test(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+
+        let tx1 = Id::<Transaction>::new(H256::random_using(&mut rng));
+        let tx2 = Id::<Transaction>::new(H256::random_using(&mut rng));
+        let tx3 = Id::<Transaction>::new(H256::random_using(&mut rng));
+
+        let instant1 = Instant::now() + Duration::from_secs(1);
+        let instant2 = Instant::now() + Duration::from_secs(2);
+        let instant3 = Instant::now() + Duration::from_secs(3);
+
+        let mut txs = PendingTransactions::new();
+        assert_eq!(None, txs.pop());
+
+        txs.push(tx3, instant3);
+        txs.push(tx1, instant1);
+        txs.push(tx2, instant2);
+
+        assert_eq!(Some(tx1), txs.pop());
+        assert_eq!(Some(tx2), txs.pop());
+        assert_eq!(Some(tx3), txs.pop());
+        assert_eq!(None, txs.pop());
+    }
+
+    #[tokio::test]
+    async fn due_test() {
+        let before = Instant::now();
+
+        let tx = Id::<Transaction>::new(H256::zero());
+        let due_instant = Instant::now() + Duration::from_secs(1);
+
+        let mut txs = PendingTransactions::new();
+        txs.push(tx, due_instant);
+
+        tokio::time::pause();
+        tokio::spawn(async {
+            tokio::time::advance(Duration::from_secs(1)).await;
+        });
+        txs.due().await;
+
+        let after = Instant::now();
+        assert!(after.duration_since(before) >= Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn due_from_the_past_test() {
+        let before = Instant::now();
+
+        let tx = Id::<Transaction>::new(H256::zero());
+        let due_instant = Instant::now();
+
+        let mut txs = PendingTransactions::new();
+        txs.push(tx, due_instant);
+
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        // due is in the past now
+        assert!(due_instant < Instant::now());
+
+        txs.due().await;
+
+        let after = Instant::now();
+        assert!(after.duration_since(before) >= Duration::from_secs(1));
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    #[tokio::test]
+    async fn due_pending_test(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+
+        tokio::time::pause();
+
+        // Spawn a task with a timeout
+        let timeout_duration = Duration::from_secs(rng.gen_range(1..120));
+        let test_task = tokio::spawn(async move {
+            let txs = PendingTransactions::new();
+            tokio::time::timeout(timeout_duration, txs.due()).await
+        });
+
+        // Advance time manually
+        tokio::time::advance(timeout_duration).await;
+
+        let result = test_task.await.unwrap();
+        assert!(
+            result.is_err(),
+            "The due method should not complete when the queue is empty."
+        );
     }
 }

--- a/p2p/src/sync/peer_v2/transaction_manager.rs
+++ b/p2p/src/sync/peer_v2/transaction_manager.rs
@@ -159,8 +159,10 @@ where
                     self.handle_local_event(event)?;
                 }
 
-                new_tx = self.pending_transactions.due() => {
-                    self.send_message(TransactionSyncMessage::NewTransaction(new_tx?))?;
+                _ = self.pending_transactions.due() => {
+                    if let Some(new_tx) = self.pending_transactions.pop(){
+                        self.send_message(TransactionSyncMessage::NewTransaction(new_tx))?;
+                    }
                 }
 
                 _ = maintenance_interval.tick() => {}

--- a/p2p/src/sync/peer_v2/transaction_manager.rs
+++ b/p2p/src/sync/peer_v2/transaction_manager.rs
@@ -75,7 +75,7 @@ pub struct PeerTransactionSyncManager<T: NetworkingService> {
     /// received a response yet.
     requested_transactions: RequestedTransactions,
     /// Txs aren't relayed immediately but rather put into a collection to be propagated later
-    /// with random delay to avoid tracking
+    /// with random delay to make tracing transactions' origin harder
     pending_transactions: PendingTransactions,
     /// SyncManager's observer for use by tests.
     observer: Option<BoxedObserver>,

--- a/p2p/src/sync/peer_v2/transaction_manager.rs
+++ b/p2p/src/sync/peer_v2/transaction_manager.rs
@@ -188,7 +188,7 @@ where
                 {
                     self.add_known_transaction(txid);
 
-                    // TODO: whitelisted peers can get txs without delay
+                    // TODO: whitelisted peers should get txs without delay
                     let now = Instant::now();
                     let delay = TX_RELAY_DELAY_INTERVAL
                         .mul_f64(utils::exp_rand::exponential_rand(&mut make_pseudo_rng()));

--- a/p2p/src/sync/peer_v2/transaction_manager.rs
+++ b/p2p/src/sync/peer_v2/transaction_manager.rs
@@ -52,6 +52,7 @@ use super::requested_transactions::RequestedTransactions;
 
 // TODO: add smaller interval for outbound connections
 pub const TX_RELAY_DELAY_INTERVAL: Duration = Duration::from_secs(5);
+pub const TX_RELAY_DELAY_INTERVAL_LIMIT: Duration = Duration::from_secs(10);
 
 // TODO: Take into account the chain work when syncing.
 /// Transaction sync manager.
@@ -182,9 +183,10 @@ where
                 self.send_message(TransactionSyncMessage::NewTransaction(txid))
             })?;
 
+            let limit = now + TX_RELAY_DELAY_INTERVAL_LIMIT;
             let delay = TX_RELAY_DELAY_INTERVAL
                 .mul_f64(utils::exp_rand::exponential_rand(&mut make_pseudo_rng()));
-            self.next_transaction_relay_time = now + delay;
+            self.next_transaction_relay_time = num_traits::clamp_max(now + delay, limit);
         }
         Ok(())
     }

--- a/p2p/src/sync/peer_v2/transaction_manager.rs
+++ b/p2p/src/sync/peer_v2/transaction_manager.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, time::Duration};
+use std::time::Duration;
 
 use crypto::random::make_pseudo_rng;
 use tokio::{
@@ -48,11 +48,12 @@ use crate::{
     MessagingService, PeerManagerEvent, Result,
 };
 
-use super::requested_transactions::RequestedTransactions;
+use super::{
+    pending_transactions::PendingTransactions, requested_transactions::RequestedTransactions,
+};
 
 // TODO: add smaller interval for outbound connections
 pub const TX_RELAY_DELAY_INTERVAL: Duration = Duration::from_secs(5);
-pub const TX_RELAY_DELAY_INTERVAL_LIMIT: Duration = Duration::from_secs(10);
 
 // TODO: Take into account the chain work when syncing.
 /// Transaction sync manager.
@@ -76,8 +77,7 @@ pub struct PeerTransactionSyncManager<T: NetworkingService> {
     requested_transactions: RequestedTransactions,
     /// Txs aren't relayed immediately but rather put into a collection to be propagated later
     /// with random delay to avoid tracking
-    transactions_to_relay: BTreeSet<Id<Transaction>>,
-    next_transaction_relay_time: std::time::Duration,
+    pending_transactions: PendingTransactions,
     /// SyncManager's observer for use by tests.
     observer: Option<BoxedObserver>,
 }
@@ -102,7 +102,6 @@ where
         observer: Option<BoxedObserver>,
     ) -> Self {
         let known_transactions = KnownTransactions::new();
-        let next_transaction_relay_time = time_getter.get_time().as_duration_since_epoch();
 
         Self {
             id: id.into(),
@@ -116,9 +115,8 @@ where
             sync_msg_receiver,
             local_event_receiver,
             known_transactions,
-            requested_transactions: RequestedTransactions::new(time_getter),
-            transactions_to_relay: Default::default(),
-            next_transaction_relay_time,
+            requested_transactions: RequestedTransactions::new(time_getter.clone()),
+            pending_transactions: PendingTransactions::new(time_getter),
             observer,
         }
     }
@@ -161,10 +159,12 @@ where
                     self.handle_local_event(event)?;
                 }
 
+                new_tx = self.pending_transactions.due() => {
+                    self.send_message(TransactionSyncMessage::NewTransaction(new_tx?))?;
+                }
+
                 _ = maintenance_interval.tick() => {}
             }
-
-            self.announce_transactions_if_needed()?;
 
             self.requested_transactions.purge_if_needed();
         }
@@ -172,23 +172,6 @@ where
 
     fn send_message(&mut self, message: TransactionSyncMessage) -> Result<()> {
         self.messaging_handle.send_transaction_sync_message(self.id(), message)
-    }
-
-    // TODO: whitelisted peers can get txs without delay
-    fn announce_transactions_if_needed(&mut self) -> Result<()> {
-        let now = self.time_getter.get_time().as_duration_since_epoch();
-        if now >= self.next_transaction_relay_time {
-            let ids = std::mem::take(&mut self.transactions_to_relay);
-            ids.into_iter().try_for_each(|txid| {
-                self.send_message(TransactionSyncMessage::NewTransaction(txid))
-            })?;
-
-            let limit = now + TX_RELAY_DELAY_INTERVAL_LIMIT;
-            let delay = TX_RELAY_DELAY_INTERVAL
-                .mul_f64(utils::exp_rand::exponential_rand(&mut make_pseudo_rng()));
-            self.next_transaction_relay_time = num_traits::clamp_max(now + delay, limit);
-        }
-        Ok(())
     }
 
     fn handle_local_event(&mut self, event: LocalEvent) -> Result<()> {
@@ -204,7 +187,12 @@ where
                     && self.common_services.has_service(Service::Transactions)
                 {
                     self.add_known_transaction(txid);
-                    self.transactions_to_relay.insert(txid);
+
+                    // TODO: whitelisted peers can get txs without delay
+                    let now = self.time_getter.get_time().as_duration_since_epoch();
+                    let delay = TX_RELAY_DELAY_INTERVAL
+                        .mul_f64(utils::exp_rand::exponential_rand(&mut make_pseudo_rng()));
+                    self.pending_transactions.push(txid, now + delay);
                 }
                 Ok(())
             }

--- a/test/functional/mempool_orphan_peer_disconnected.py
+++ b/test/functional/mempool_orphan_peer_disconnected.py
@@ -52,7 +52,7 @@ class MempoolOrphanFromDisconnectedPeerTest(BitcoinTestFramework):
         node0.p2p_submit_transaction(tx2, {})
 
         # Check the node gets the orphan transaction
-        self.wait_until(lambda: node1.mempool_contains_orphan_tx(tx2_id), timeout = 5)
+        self.wait_until(lambda: node1.mempool_contains_orphan_tx(tx2_id), timeout = 60)
 
         # Now disconnect the nodes and check the orphan is gone
         self.disconnect_nodes(0, 1)

--- a/test/functional/p2p_relay_transactions.py
+++ b/test/functional/p2p_relay_transactions.py
@@ -35,7 +35,8 @@ class RelayTransactions(BitcoinTestFramework):
         self.sync_all(self.nodes[0:2])
 
     def assert_mempool_contains_tx(self, n, tx_id):
-        for _ in range(5):
+        # there is random delay when relaying txs so we need to wait for a while
+        for _ in range(60):
             if self.nodes[n].mempool_contains_tx(tx_id):
                 break
             time.sleep(1)

--- a/test/functional/p2p_submit_orphan.py
+++ b/test/functional/p2p_submit_orphan.py
@@ -71,7 +71,7 @@ class MempoolOrphanSubmissionTest(BitcoinTestFramework):
         # Check both transactions have propagated to the last peer
         for node in self.nodes:
             has_txs = lambda: all(node.mempool_contains_tx(tx_id) for tx_id in [tx1_id, tx2_id])
-            self.wait_until(has_txs, timeout = 5)
+            self.wait_until(has_txs, timeout = 10)
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_submit_orphan.py
+++ b/test/functional/p2p_submit_orphan.py
@@ -71,7 +71,8 @@ class MempoolOrphanSubmissionTest(BitcoinTestFramework):
         # Check both transactions have propagated to the last peer
         for node in self.nodes:
             has_txs = lambda: all(node.mempool_contains_tx(tx_id) for tx_id in [tx1_id, tx2_id])
-            self.wait_until(has_txs, timeout = 10)
+            # there is random delay when relaying txs so we need to wait for a while
+            self.wait_until(has_txs, timeout = 60)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This prevents deanonymization