### PR TITLE
Implement AddrListResponse caching

### DIFF
--- a/p2p/src/peer_manager/addr_list_response_cache.rs
+++ b/p2p/src/peer_manager/addr_list_response_cache.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2021-2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::BTreeMap,
+    hash::{Hash, Hasher},
+    time::Duration,
+};
+
+use common::primitives::time::Time;
+use crypto::random::{make_pseudo_rng, Rng};
+use p2p_types::socket_address::SocketAddress;
+
+use super::{peer_context::PeerContext, peerdb::salt::Salt};
+
+use crate::types::peer_address::PeerAddress;
+
+/// A cache for addresses to return in an AddrListResponse. Its purpose is to make it harder
+/// for an attacker to scrape the addresses in PeerDb, which in turn will make it harder
+/// to learn the topology of the p2p network.
+///
+/// The idea is to remember the addresses in the first AddrListResponse and return the same list
+/// to all peers until its expiration time is reached. This way, even if the attacker connects
+/// to the node multiple times, it won't learn any additional addresses from this.
+/// There is a caveat though - if the node has multiple listening addresses, this straightforward
+/// approach will allow the attacker to identify them as belonging to the same node. So instead
+/// of one address list we cache multiple lists indexed by an id that is produced by hashing
+/// the local address.
+pub struct AddrListResponseCache {
+    cache: BTreeMap<CacheId, CacheEntry>,
+    salt: Salt,
+}
+
+impl AddrListResponseCache {
+    pub fn new(salt: Salt) -> Self {
+        Self {
+            cache: BTreeMap::new(),
+            salt,
+        }
+    }
+
+    pub fn get_or_create<F>(&mut self, peer_ctx: &PeerContext, now: Time, create: F) -> &Addresses
+    where
+        F: FnOnce() -> Addresses,
+    {
+        use std::collections::btree_map::Entry;
+
+        let id = self.calc_id(peer_ctx);
+
+        let cache_entry = match self.cache.entry(id) {
+            Entry::Vacant(entry) => entry.insert(CacheEntry {
+                addresses: create(),
+                expiration_time: Self::new_expiration_time_from_now(now),
+            }),
+            Entry::Occupied(mut entry) => {
+                if entry.get().expiration_time <= now {
+                    *entry.get_mut() = CacheEntry {
+                        addresses: create(),
+                        expiration_time: Self::new_expiration_time_from_now(now),
+                    };
+                }
+                entry.into_mut()
+            }
+        };
+
+        &cache_entry.addresses
+    }
+
+    fn calc_id(&self, peer_ctx: &PeerContext) -> CacheId {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        let bind_addr = peer_ctx.bind_address.socket_addr();
+
+        self.salt.hash(&mut hasher);
+        bind_addr.ip().hash(&mut hasher);
+
+        // Note: for outbound connections, the local port shouldn't be included in the hash,
+        // because it's randomly generated for each connection.
+        // However, we don't expect outbound peers here, because addr list requests from them
+        // are never handled.
+        debug_assert!(!peer_ctx.peer_role.is_outbound());
+        bind_addr.port().hash(&mut hasher);
+
+        get_network(peer_ctx.peer_address).hash(&mut hasher);
+
+        hasher.finish()
+    }
+
+    fn new_expiration_time_from_now(now: Time) -> Time {
+        let min_secs = EXPIRATION_INTERVAL_MIN.as_secs();
+        let max_secs = EXPIRATION_INTERVAL_MAX.as_secs();
+        let secs = make_pseudo_rng().gen_range(min_secs..=max_secs);
+        (now + Duration::from_secs(secs)).expect("Unexpected time overflow")
+    }
+}
+
+// Note: in bitcoin they use 24h interval (+-3h), which seems too big.
+const EXPIRATION_INTERVAL_MEAN_SECS: u64 = 60 * 60;
+pub const EXPIRATION_INTERVAL_MIN: Duration =
+    Duration::from_secs(EXPIRATION_INTERVAL_MEAN_SECS * 9 / 10);
+pub const EXPIRATION_INTERVAL_MAX: Duration =
+    Duration::from_secs(EXPIRATION_INTERVAL_MEAN_SECS * 11 / 10);
+
+type CacheId = u64;
+type Addresses = Vec<PeerAddress>;
+
+struct CacheEntry {
+    addresses: Addresses,
+    expiration_time: Time,
+}
+
+#[derive(Hash)]
+enum Network {
+    IpV4,
+    IpV6,
+}
+
+fn get_network(addr: SocketAddress) -> Network {
+    match addr.socket_addr().ip() {
+        std::net::IpAddr::V4(_) => Network::IpV4,
+        std::net::IpAddr::V6(addr_v6) => {
+            // TODO: in bitcoin, they also handle a bunch of other IPv6 address types that can
+            // be translated to IPv4, see CNetAddr::HasLinkedIPv4. Probably, we need to handle
+            // them too.
+            if addr_v6.to_ipv4().is_some() {
+                Network::IpV4
+            } else {
+                Network::IpV6
+            }
+        }
+    }
+}

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -15,6 +15,7 @@
 
 //! Peer manager
 
+mod addr_list_response_cache;
 pub mod address_groups;
 pub mod dns_seed;
 pub mod peer_context;
@@ -74,6 +75,7 @@ use crate::{
 };
 
 use self::{
+    addr_list_response_cache::AddrListResponseCache,
     address_groups::AddressGroup,
     dns_seed::{DefaultDnsSeed, DnsSeed},
     peer_context::{PeerContext, SentPing},
@@ -179,9 +181,6 @@ const RESEND_OWN_ADDRESS_TO_PEER_PERIOD: Duration = Duration::from_secs(24 * 60 
 /// The interval at which to contact DNS seed servers.
 pub const PEER_MGR_DNS_RELOAD_INTERVAL: Duration = Duration::from_secs(60);
 
-/// How many addresses are allowed to be sent
-const MAX_ADDRESS_COUNT: usize = 1000;
-
 /// The maximum rate of address announcements the node will process from a peer (value as in Bitcoin Core).
 pub const MAX_ADDR_RATE_PER_SECOND: f64 = 0.1;
 /// Bucket size used to rate limit address announcements from a peer.
@@ -263,6 +262,9 @@ where
 
     peer_eviction_random_state: peers_eviction::RandomState,
 
+    /// Cached address list responses.
+    addr_list_response_cache: AddrListResponseCache,
+
     /// PeerManager's observer for use by tests.
     observer: Option<Box<dyn Observer + Send>>,
 
@@ -338,6 +340,7 @@ where
             time_getter.clone(),
             peerdb_storage,
         )?;
+        let salt = peerdb.salt();
         let now = time_getter.get_time();
         let next_feeler_connection_time =
             Self::choose_next_feeler_connection_time(&p2p_config, now);
@@ -356,6 +359,7 @@ where
             peerdb,
             subscribed_to_peer_addresses: BTreeSet::new(),
             peer_eviction_random_state: peers_eviction::RandomState::new(&mut rng),
+            addr_list_response_cache: AddrListResponseCache::new(salt),
             observer,
             dns_seed,
             init_time: now,
@@ -378,9 +382,8 @@ where
 
     /// Verify that the peer address has a public routable IP and any valid (non-zero) port.
     /// Private and local IPs are allowed if `allow_discover_private_ips` is true.
-    fn is_peer_address_valid(&self, address: &PeerAddress) -> bool {
-        SocketAddress::from_peer_address(address, *self.p2p_config.allow_discover_private_ips)
-            .is_some()
+    fn is_peer_address_valid(address: &PeerAddress, p2p_config: &P2pConfig) -> bool {
+        SocketAddress::from_peer_address(address, *p2p_config.allow_discover_private_ips).is_some()
     }
 
     /// Discover public addresses for this node after a new outbound connection is made
@@ -1112,7 +1115,7 @@ where
                     PeerDisconnectionDbAction::Keep => {}
                     PeerDisconnectionDbAction::RemoveIfOutbound => {
                         if peer.peer_role.is_outbound() {
-                            self.peerdb.remove_outbound_address(&peer.peer_address);
+                            self.peerdb.remove_address(&peer.peer_address);
                         }
                     }
                 }
@@ -1357,14 +1360,21 @@ where
             return;
         }
 
-        let addresses = self
-            .peerdb
-            .known_addresses()
-            .map(SocketAddress::as_peer_address)
-            .filter(|address| self.is_peer_address_valid(address))
-            .choose_multiple(&mut make_pseudo_rng(), MAX_ADDRESS_COUNT);
+        let max_addr_count = *self.p2p_config.protocol_config.max_addr_list_response_address_count;
 
-        assert!(addresses.len() <= MAX_ADDRESS_COUNT);
+        let now = self.time_getter.get_time();
+        let addresses = self
+            .addr_list_response_cache
+            .get_or_create(peer, now, || {
+                self.peerdb
+                    .known_addresses()
+                    .map(SocketAddress::as_peer_address)
+                    .filter(|address| Self::is_peer_address_valid(address, &self.p2p_config))
+                    .choose_multiple(&mut make_pseudo_rng(), max_addr_count)
+            })
+            .clone();
+
+        assert!(addresses.len() <= max_addr_count);
 
         Self::send_peer_message(
             &mut self.peer_connectivity_handle,
@@ -1383,7 +1393,8 @@ where
             .get_mut(&peer_id)
             .ok_or(P2pError::PeerError(PeerError::PeerDoesntExist))?;
         ensure!(
-            addresses.len() <= MAX_ADDRESS_COUNT,
+            addresses.len()
+                <= *self.p2p_config.protocol_config.max_addr_list_response_address_count,
             P2pError::ProtocolError(ProtocolError::AddressListLimitExceeded)
         );
         ensure!(

--- a/p2p/src/peer_manager/peerdb/address_tables/table.rs
+++ b/p2p/src/peer_manager/peerdb/address_tables/table.rs
@@ -13,26 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::{btree_map, BTreeMap},
-    hash::{Hash, Hasher},
-};
+use std::collections::{btree_map, BTreeMap};
 
 use p2p_types::socket_address::SocketAddress;
 use utils::array_2d::Array2d;
 
-use crate::peer_manager::address_groups::AddressGroup;
+use crate::peer_manager::{address_groups::AddressGroup, peerdb::salt::calc_hash64};
 
-use super::RandomKey;
-
-/// Calculate hash of a 'single' value.
-///
-/// Note: if multiple values are required to produce a single hash, pass them as a tuple.
-pub fn calc_hash<T: Hash>(val: &T) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    val.hash(&mut hasher);
-    hasher.finish()
-}
+use super::Salt;
 
 const BUCKETS_PER_GROUP: u64 = 8;
 
@@ -51,30 +39,25 @@ pub struct Table {
     /// to override it for testing.
     id_max: EntryId,
     /// Arbitrary value; this is used as an additional "key" to randomize bucket selection.
-    random_key: RandomKey,
+    salt: Salt,
     /// This is used to turn off consistency checks, which can be too heavy for some tests.
     #[cfg(test)]
     should_check_consistency: bool,
 }
 
 impl Table {
-    pub fn new(bucket_count: usize, bucket_size: usize, random_key: RandomKey) -> Self {
-        Self::new_generic(bucket_count, bucket_size, random_key, EntryId::MAX)
+    pub fn new(bucket_count: usize, bucket_size: usize, salt: Salt) -> Self {
+        Self::new_generic(bucket_count, bucket_size, salt, EntryId::MAX)
     }
 
-    fn new_generic(
-        bucket_count: usize,
-        bucket_size: usize,
-        random_key: RandomKey,
-        id_max: EntryId,
-    ) -> Self {
+    fn new_generic(bucket_count: usize, bucket_size: usize, salt: Salt, id_max: EntryId) -> Self {
         assert!(id_max as usize >= bucket_count * bucket_size);
 
         Self {
             // Fill "buckets" with "id_max" initially.
             buckets: Array2d::new(bucket_count, bucket_size, id_max),
             addresses: BTreeMap::new(),
-            random_key,
+            salt,
             id_max,
             #[cfg(test)]
             should_check_consistency: true,
@@ -91,18 +74,18 @@ impl Table {
     // addresses from the same addr group will end up in the same bucket.
     // Should we do something similar?
     fn bucket_idx(&self, addr: &SocketAddress) -> usize {
-        let addr_hash = calc_hash(&(self.random_key, addr));
+        let addr_hash = calc_hash64(&(self.salt, addr));
         let addr_group = AddressGroup::from_peer_address(&addr.as_peer_address());
 
         // Note: addresses from a certain address group can be spread over at most BUCKETS_PER_GROUP
         // buckets.
-        let final_hash = calc_hash(&(self.random_key, addr_group, addr_hash % BUCKETS_PER_GROUP));
+        let final_hash = calc_hash64(&(self.salt, addr_group, addr_hash % BUCKETS_PER_GROUP));
 
         (final_hash % self.buckets.rows_count() as u64) as usize
     }
 
     fn bucket_pos(&self, addr: &SocketAddress, bucket_idx: usize) -> usize {
-        let hash = calc_hash(&(self.random_key, addr, bucket_idx));
+        let hash = calc_hash64(&(self.salt, addr, bucket_idx));
         (hash % self.buckets.cols_count() as u64) as usize
     }
 
@@ -376,7 +359,7 @@ mod tests {
     #[case(Seed::from_entropy())]
     fn basic_test(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
-        let mut table = Table::new_generic(2, 2, RandomKey(0), 4);
+        let mut table = Table::new_generic(2, 2, Salt::from_u64(0), 4);
 
         let addr = make_random_address(&mut rng);
         let colliding_addr = make_colliding_address(&table, &addr);
@@ -418,7 +401,7 @@ mod tests {
     #[case(Seed::from_entropy())]
     fn test_replace(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
-        let mut table = Table::new_generic(2, 2, RandomKey(0), 4);
+        let mut table = Table::new_generic(2, 2, Salt::from_u64(0), 4);
 
         let addr = make_random_address(&mut rng);
         let colliding_addr = make_colliding_address(&table, &addr);
@@ -446,7 +429,7 @@ mod tests {
     #[case(Seed::from_entropy())]
     fn test_replace_if(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
-        let mut table = Table::new_generic(2, 2, RandomKey(0), 4);
+        let mut table = Table::new_generic(2, 2, Salt::from_u64(0), 4);
 
         let addr = make_random_address(&mut rng);
         let colliding_addr = make_colliding_address(&table, &addr);
@@ -504,7 +487,7 @@ mod tests {
     #[case(Seed::from_entropy())]
     fn test_full_table(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
-        let mut table = Table::new_generic(2, 2, RandomKey(0), 4);
+        let mut table = Table::new_generic(2, 2, Salt::from_u64(0), 4);
 
         let addrs = make_non_colliding_addresses(&table, 4, &mut rng);
 
@@ -521,7 +504,7 @@ mod tests {
     #[case(Seed::from_entropy())]
     fn test_id_rebuilding(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
-        let mut table = Table::new_generic(2, 2, RandomKey(0), 4);
+        let mut table = Table::new_generic(2, 2, Salt::from_u64(0), 4);
 
         let addrs = make_non_colliding_addresses(&table, 2, &mut rng);
 

--- a/p2p/src/peer_manager/peerdb/config.rs
+++ b/p2p/src/peer_manager/peerdb/config.rs
@@ -15,7 +15,7 @@
 
 use utils::make_config_setting;
 
-use super::address_tables;
+use super::salt::Salt;
 
 // TODO: do we need the tables to be this big?
 make_config_setting!(NewAddrTableBucketCount, usize, 1024);
@@ -30,6 +30,6 @@ pub struct PeerDbConfig {
     pub tried_addr_table_bucket_count: TriedAddrTableBucketCount,
     /// Address table bucket size.
     pub addr_tables_bucket_size: AddrTablesBucketSize,
-    /// The initial value for the address tables' random key.
-    pub addr_tables_initial_random_key: Option<address_tables::RandomKey>,
+    /// The initial value for the peer db's salt.
+    pub salt: Option<Salt>,
 }

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -27,6 +27,7 @@
 pub mod address_data;
 pub mod address_tables;
 pub mod config;
+pub mod salt;
 pub mod storage;
 pub mod storage_impl;
 mod storage_load;
@@ -46,6 +47,7 @@ use crate::config::P2pConfig;
 use self::{
     address_data::{AddressData, AddressStateTransitionTo},
     address_tables::AddressTables,
+    salt::Salt,
     storage::{KnownAddressState, PeerDbStorage, PeerDbStorageWrite},
     storage_load::LoadedStorage,
 };
@@ -86,6 +88,8 @@ pub struct PeerDb<S> {
     time_getter: TimeGetter,
 
     storage: S,
+
+    salt: Salt,
 }
 
 impl<S: PeerDbStorage> PeerDb<S> {
@@ -100,7 +104,7 @@ impl<S: PeerDbStorage> PeerDb<S> {
             known_addresses,
             banned_addresses,
             anchor_addresses,
-            addr_tables_random_key,
+            salt,
         } = LoadedStorage::load_storage(&storage, &p2p_config.peer_manager_config.peerdb_config)?;
 
         let reserved_nodes = p2p_config
@@ -117,10 +121,8 @@ impl<S: PeerDbStorage> PeerDb<S> {
 
         let now = time_getter.get_time();
         let mut addresses = BTreeMap::new();
-        let mut address_tables = AddressTables::new(
-            addr_tables_random_key,
-            &p2p_config.peer_manager_config.peerdb_config,
-        );
+        let mut address_tables =
+            AddressTables::new(salt, &p2p_config.peer_manager_config.peerdb_config);
 
         for (addr, state) in &known_addresses {
             match *state {
@@ -179,7 +181,12 @@ impl<S: PeerDbStorage> PeerDb<S> {
             p2p_config,
             time_getter,
             storage,
+            salt,
         })
+    }
+
+    pub fn salt(&self) -> Salt {
+        self.salt
     }
 
     /// Iterator of all known addresses.
@@ -386,7 +393,7 @@ impl<S: PeerDbStorage> PeerDb<S> {
         self.change_address_state(address, AddressStateTransitionTo::Disconnected);
     }
 
-    pub fn remove_outbound_address(&mut self, address: &SocketAddress) {
+    pub fn remove_address(&mut self, address: &SocketAddress) {
         if !self.reserved_nodes.contains(address) {
             self.addresses.remove(address);
         }
@@ -568,6 +575,11 @@ impl<S: PeerDbStorage> PeerDb<S> {
     #[cfg(test)]
     pub fn address_tables(&self) -> &AddressTables {
         &self.address_tables
+    }
+
+    #[cfg(test)]
+    pub fn address_tables_mut(&mut self) -> &mut AddressTables {
+        &mut self.address_tables
     }
 }
 

--- a/p2p/src/peer_manager/peerdb/salt.rs
+++ b/p2p/src/peer_manager/peerdb/salt.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2021-2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::hash::{Hash, Hasher};
+
+use crypto::random::{make_pseudo_rng, Rng};
+use serialization::{Decode, Encode};
+
+/// A random number that is generated once and then mixed into certain hashes in the peer manager.
+#[derive(Debug, Hash, Encode, Decode, Copy, Clone)]
+pub struct Salt(u64);
+
+impl Salt {
+    pub fn from_u64(val: u64) -> Self {
+        Self(val)
+    }
+
+    pub fn new_random() -> Self {
+        Self::new_random_with_rng(&mut make_pseudo_rng())
+    }
+
+    pub fn new_random_with_rng<R: Rng>(rng: &mut R) -> Self {
+        Self(rng.gen::<u64>())
+    }
+
+    pub fn mix_with<T: Hash>(&self, data: T) -> Self {
+        Self(calc_hash64(&(self.0, data)))
+    }
+}
+
+/// Calculate a 64-bit non-cryptographic hash of a 'single' value.
+///
+/// Note: if multiple values are required to produce a single hash, pass them as a tuple.
+pub fn calc_hash64<T: Hash>(val: &T) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    val.hash(&mut hasher);
+    hasher.finish()
+}

--- a/p2p/src/peer_manager/peerdb/storage.rs
+++ b/p2p/src/peer_manager/peerdb/storage.rs
@@ -19,7 +19,7 @@ use serialization::{Decode, Encode};
 
 use crate::peer_manager::peerdb_common::{TransactionRo, TransactionRw, Transactional};
 
-use super::address_tables;
+use super::salt::Salt;
 
 #[derive(Debug, derive_more::Display, Clone, Copy, Encode, Decode, Eq, PartialEq)]
 pub struct StorageVersion(u32);
@@ -41,7 +41,7 @@ pub enum KnownAddressState {
 pub trait PeerDbStorageRead {
     fn get_version(&self) -> crate::Result<Option<StorageVersion>>;
 
-    fn get_addr_tables_random_key(&self) -> crate::Result<Option<address_tables::RandomKey>>;
+    fn get_salt(&self) -> crate::Result<Option<Salt>>;
 
     fn get_known_addresses(&self) -> crate::Result<Vec<(SocketAddress, KnownAddressState)>>;
 
@@ -53,7 +53,7 @@ pub trait PeerDbStorageRead {
 pub trait PeerDbStorageWrite {
     fn set_version(&mut self, version: StorageVersion) -> crate::Result<()>;
 
-    fn set_addr_tables_random_key(&mut self, key: address_tables::RandomKey) -> crate::Result<()>;
+    fn set_salt(&mut self, salt: Salt) -> crate::Result<()>;
 
     // Note: the "add" methods below will overwrite the existing value if it's present.
 

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -35,7 +35,7 @@ use crate::{
     peer_manager::{
         peerdb::{
             address_data::{self, PURGE_REACHABLE_FAIL_COUNT, PURGE_UNREACHABLE_TIME},
-            address_tables::RandomKey,
+            salt::Salt,
             storage::{KnownAddressState, PeerDbStorageRead},
         },
         peerdb_common::Transactional,
@@ -215,7 +215,7 @@ fn anchor_peers() {
     assert_addr_consistency(&peerdb);
 }
 
-// Call 'remove_outbound_address' on new and tried addresses, check that the db is
+// Call 'remove_address' on new and tried addresses, check that the db is
 // in consistent state.
 #[tracing::instrument(skip(seed))]
 #[rstest]
@@ -231,7 +231,7 @@ fn remove_addr(#[case] seed: Seed) {
         addr_tables_bucket_size: 10.into(),
         new_addr_table_bucket_count: 10.into(),
         tried_addr_table_bucket_count: 10.into(),
-        addr_tables_initial_random_key: Some(RandomKey::new_random_with_rng(&mut rng)),
+        salt: Some(Salt::new_random_with_rng(&mut rng)),
     }));
 
     let mut peerdb = PeerDb::new(
@@ -264,7 +264,7 @@ fn remove_addr(#[case] seed: Seed) {
     }
 
     for addr in new_addrs_to_remove.iter().chain(tried_addrs_to_remove.iter()) {
-        peerdb.remove_outbound_address(addr);
+        peerdb.remove_address(addr);
     }
 
     let new_addrs_remaining = new_addr_table(&peerdb).addr_iter().copied().collect::<BTreeSet<_>>();
@@ -291,7 +291,7 @@ fn remove_unreachable(#[case] seed: Seed) {
         addr_tables_bucket_size: 10.into(),
         new_addr_table_bucket_count: 10.into(),
         tried_addr_table_bucket_count: 10.into(),
-        addr_tables_initial_random_key: Some(RandomKey::new_random_with_rng(&mut rng)),
+        salt: Some(Salt::new_random_with_rng(&mut rng)),
     }));
 
     let mut peerdb = PeerDb::new(
@@ -386,7 +386,7 @@ fn new_addr_count_limit(#[case] seed: Seed, #[values(true, false)] use_reserved_
         addr_tables_bucket_size: bucket_size.into(),
         new_addr_table_bucket_count: bucket_count.into(),
         tried_addr_table_bucket_count: bucket_count.into(),
-        addr_tables_initial_random_key: Some(RandomKey::new_random_with_rng(&mut rng)),
+        salt: Some(Salt::new_random_with_rng(&mut rng)),
     }));
 
     let mut peerdb = PeerDb::new(
@@ -445,7 +445,7 @@ fn tried_addr_count_limit(#[case] seed: Seed, #[values(true, false)] use_reserve
         addr_tables_bucket_size: bucket_size.into(),
         new_addr_table_bucket_count: bucket_count.into(),
         tried_addr_table_bucket_count: bucket_count.into(),
-        addr_tables_initial_random_key: Some(RandomKey::new_random_with_rng(&mut rng)),
+        salt: Some(Salt::new_random_with_rng(&mut rng)),
     }));
 
     let mut peerdb = PeerDb::new(
@@ -509,7 +509,7 @@ fn new_tried_addr_selection_frequency() {
                 addr_tables_bucket_size: bucket_size.into(),
                 new_addr_table_bucket_count: bucket_count.into(),
                 tried_addr_table_bucket_count: bucket_count.into(),
-                addr_tables_initial_random_key: Some(RandomKey::new_random_with_rng(&mut rng)),
+                salt: Some(Salt::new_random_with_rng(&mut rng)),
             }));
 
             let mut peerdb = PeerDb::new(

--- a/p2p/src/peer_manager/tests/addr_list_response_caching.rs
+++ b/p2p/src/peer_manager/tests/addr_list_response_caching.rs
@@ -1,0 +1,464 @@
+// Copyright (c) 2021-2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+    sync::Arc,
+};
+
+use rstest::rstest;
+
+use common::{
+    chain::{self, ChainConfig},
+    primitives::user_agent::mintlayer_core_user_agent,
+};
+use crypto::random::Rng;
+use p2p_test_utils::{expect_recv, P2pBasicTestTimeGetter};
+use p2p_types::{peer_address::PeerAddress, socket_address::SocketAddress};
+use test_utils::{
+    assert_matches_return_val,
+    random::{make_seedable_rng, Seed},
+};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use crate::{
+    config::{NodeType, P2pConfig},
+    message::AddrListResponse,
+    net::{
+        default_backend::{
+            transport::TcpTransportSocket,
+            types::{Command, Message},
+            ConnectivityHandle, DefaultNetworkingService,
+        },
+        types::{PeerInfo, Role},
+        ConnectivityService, NetworkingService,
+    },
+    peer_manager::{
+        addr_list_response_cache,
+        peerdb::{
+            address_tables::table::test_utils::make_non_colliding_addresses,
+            storage::PeerDbStorage, storage_impl::PeerDbStorageImpl,
+        },
+        PeerManager,
+    },
+    protocol::ProtocolConfig,
+    testing_utils::{peerdb_inmemory_store, TestAddressMaker, TEST_PROTOCOL_VERSION},
+    types::peer_id::PeerId,
+    PeerManagerEvent,
+};
+
+// Note: addr list requests are only handled for inbound peers, so we only test this variant.
+
+type TestNetworkingService = DefaultNetworkingService<TcpTransportSocket>;
+type TestPeerManager = PeerManager<
+    DefaultNetworkingService<TcpTransportSocket>,
+    PeerDbStorageImpl<storage::inmemory::InMemory>,
+>;
+
+#[tracing::instrument(skip(seed))]
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn basic_test(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let bind_address12 = TestAddressMaker::new_random_address_with_rng(&mut rng);
+    let bind_address3 = TestAddressMaker::new_random_address_with_rng(&mut rng);
+
+    let chain_config = Arc::new(chain::config::create_mainnet());
+    let p2p_config = Arc::new(make_p2p_config());
+    let time_getter = P2pBasicTestTimeGetter::new();
+
+    let (mut peer_mgr, mut cmd_receiver) =
+        setup_peer_mgr(&chain_config, &p2p_config, &time_getter, &mut rng);
+
+    let peer1_address = TestAddressMaker::new_random_address_with_rng(&mut rng);
+    let (peer1_id, peer1_info) = make_new_peer(&chain_config);
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer1_address,
+        bind_address12,
+        &peer1_info,
+    )
+    .await;
+    assert_eq!(peer_mgr.peers.len(), 1);
+
+    peer_mgr.handle_addr_list_request(peer1_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let addresses_for_peer1 = expect_addresses_from(cmd, peer1_id);
+
+    // Remove the addresses from the db
+    for address in &addresses_for_peer1 {
+        peer_mgr.peerdb.remove_address(
+            &SocketAddress::from_peer_address(address, *p2p_config.allow_discover_private_ips)
+                .unwrap(),
+        );
+    }
+
+    // Close and re-open the connection to peer1.
+    peer_mgr.connection_closed(peer1_id);
+    assert_eq!(peer_mgr.peers.len(), 0);
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer1_address,
+        bind_address12,
+        &peer1_info,
+    )
+    .await;
+    assert_eq!(peer_mgr.peers.len(), 1);
+
+    // Addr list request should return the same list.
+    peer_mgr.handle_addr_list_request(peer1_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let addresses_for_peer1_again = expect_addresses_from(cmd, peer1_id);
+    assert_eq!(addresses_for_peer1, addresses_for_peer1_again);
+
+    // Accept connection from another peer with the same bind address.
+    let peer2_address = TestAddressMaker::new_random_address_with_rng(&mut rng);
+    let (peer2_id, peer2_info) = make_new_peer(&chain_config);
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer2_address,
+        bind_address12,
+        &peer2_info,
+    )
+    .await;
+    assert_eq!(peer_mgr.peers.len(), 2);
+
+    // Addr list request should return the same list.
+    peer_mgr.handle_addr_list_request(peer2_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let addresses_for_peer2 = expect_addresses_from(cmd, peer2_id);
+    assert_eq!(addresses_for_peer1, addresses_for_peer2);
+
+    // Accept connection from another peer with a different bind address.
+    let peer3_address = TestAddressMaker::new_random_address_with_rng(&mut rng);
+    let (peer3_id, peer3_info) = make_new_peer(&chain_config);
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer3_address,
+        bind_address3,
+        &peer3_info,
+    )
+    .await;
+    assert_eq!(peer_mgr.peers.len(), 3);
+
+    // Addr list request should be different this time.
+    peer_mgr.handle_addr_list_request(peer3_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let addresses_for_peer3 = expect_addresses_from(cmd, peer3_id);
+    assert_ne!(addresses_for_peer3, addresses_for_peer1);
+
+    // Advance the time, so that the cache expires.
+    time_getter.advance_time(addr_list_response_cache::EXPIRATION_INTERVAL_MAX);
+
+    // Close and re-open the connections, using the samer bind addresses.
+    peer_mgr.connection_closed(peer1_id);
+    peer_mgr.connection_closed(peer2_id);
+    peer_mgr.connection_closed(peer3_id);
+    assert_eq!(peer_mgr.peers.len(), 0);
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer1_address,
+        bind_address12,
+        &peer1_info,
+    )
+    .await;
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer2_address,
+        bind_address12,
+        &peer2_info,
+    )
+    .await;
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer3_address,
+        bind_address3,
+        &peer3_info,
+    )
+    .await;
+    assert_eq!(peer_mgr.peers.len(), 3);
+
+    // Addr list requests should return a new list.
+    peer_mgr.handle_addr_list_request(peer1_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let addresses_for_peer1_after_cache_exp_time = expect_addresses_from(cmd, peer1_id);
+    assert_ne!(
+        addresses_for_peer1,
+        addresses_for_peer1_after_cache_exp_time
+    );
+
+    peer_mgr.handle_addr_list_request(peer2_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let addresses_for_peer2_after_cache_exp_time = expect_addresses_from(cmd, peer2_id);
+    assert_ne!(
+        addresses_for_peer2,
+        addresses_for_peer2_after_cache_exp_time
+    );
+
+    peer_mgr.handle_addr_list_request(peer3_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let addresses_for_peer3_after_cache_exp_time = expect_addresses_from(cmd, peer3_id);
+    assert_ne!(
+        addresses_for_peer3,
+        addresses_for_peer2_after_cache_exp_time
+    );
+
+    // Still, the new lists should be equal for peers 1 and 2 but different for peer 3.
+    assert_eq!(
+        addresses_for_peer1_after_cache_exp_time,
+        addresses_for_peer2_after_cache_exp_time
+    );
+    assert_ne!(
+        addresses_for_peer1_after_cache_exp_time,
+        addresses_for_peer3_after_cache_exp_time
+    );
+}
+
+#[tracing::instrument(skip(seed))]
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn different_network_test(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let bind_address = TestAddressMaker::new_random_address_with_rng(&mut rng);
+
+    let chain_config = Arc::new(chain::config::create_mainnet());
+    let p2p_config = Arc::new(make_p2p_config());
+    let time_getter = P2pBasicTestTimeGetter::new();
+
+    let (mut peer_mgr, mut cmd_receiver) =
+        setup_peer_mgr(&chain_config, &p2p_config, &time_getter, &mut rng);
+
+    let peer_ip_addr_v4 = TestAddressMaker::new_random_ipv4_addr_with_rng(&mut rng);
+    let peer_address_v4 =
+        SocketAddress::new(SocketAddr::new(IpAddr::V4(peer_ip_addr_v4), rng.gen()));
+    let peer_address_v4_as_v6 = SocketAddress::new(SocketAddr::new(
+        IpAddr::V6(peer_ip_addr_v4.to_ipv6_compatible()),
+        rng.gen(),
+    ));
+
+    let peer_address_v6 = {
+        // It looks like all v6 addresses that somehow correspond to a v4 address start with a zero byte or with 0x20.
+        // So, use anything that is not zero or 0x20.
+        let segments = [
+            0xFFFF_u16,
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+        ];
+        let addr: Ipv6Addr = segments.into();
+        SocketAddress::new(SocketAddr::new(IpAddr::V6(addr), rng.gen()))
+    };
+
+    let (peer_id, peer_info) = make_new_peer(&chain_config);
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer_address_v4,
+        bind_address,
+        &peer_info,
+    )
+    .await;
+
+    peer_mgr.handle_addr_list_request(peer_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let addresses = expect_addresses_from(cmd, peer_id);
+
+    peer_mgr.connection_closed(peer_id);
+
+    // Remove the addresses from the db
+    for address in &addresses {
+        peer_mgr.peerdb.remove_address(
+            &SocketAddress::from_peer_address(address, *p2p_config.allow_discover_private_ips)
+                .unwrap(),
+        );
+    }
+
+    // Close and re-open the connection using peer_address_v4_as_v6.
+    peer_mgr.connection_closed(peer_id);
+
+    // Recreate peer id and info, just in case.
+    let (peer_id, peer_info) = make_new_peer(&chain_config);
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer_address_v4_as_v6,
+        bind_address,
+        &peer_info,
+    )
+    .await;
+
+    // Addr list request should return the same list.
+    peer_mgr.handle_addr_list_request(peer_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let new_addresses = expect_addresses_from(cmd, peer_id);
+    assert_eq!(addresses, new_addresses);
+
+    // Close and re-open the connection using peer_address_v6.
+    peer_mgr.connection_closed(peer_id);
+
+    // Recreate peer id and info, just in case.
+    let (peer_id, peer_info) = make_new_peer(&chain_config);
+    accept_conn(
+        &mut peer_mgr,
+        &mut cmd_receiver,
+        peer_address_v6,
+        bind_address,
+        &peer_info,
+    )
+    .await;
+
+    // Addr list request should return a different list.
+    peer_mgr.handle_addr_list_request(peer_id);
+    let cmd = expect_recv!(cmd_receiver);
+    let new_addresses = expect_addresses_from(cmd, peer_id);
+    assert_ne!(addresses, new_addresses);
+}
+
+fn make_p2p_config() -> P2pConfig {
+    P2pConfig {
+        protocol_config: ProtocolConfig {
+            // Note: with the default value we'd have to switch off the extra test checks
+            // in address tables, because the test would take forever to complete.
+            max_addr_list_response_address_count: 10.into(),
+
+            msg_header_count_limit: Default::default(),
+            max_request_blocks_count: Default::default(),
+            msg_max_locator_count: Default::default(),
+            max_message_size: Default::default(),
+            max_peer_tx_announcements: Default::default(),
+        },
+
+        bind_addresses: Default::default(),
+        socks5_proxy: Default::default(),
+        disable_noise: Default::default(),
+        boot_nodes: Default::default(),
+        reserved_nodes: Default::default(),
+        ban_threshold: Default::default(),
+        ban_duration: Default::default(),
+        outbound_connection_timeout: Default::default(),
+        ping_check_period: Default::default(),
+        ping_timeout: Default::default(),
+        peer_handshake_timeout: Default::default(),
+        max_clock_diff: Default::default(),
+        node_type: Default::default(),
+        allow_discover_private_ips: Default::default(),
+        user_agent: mintlayer_core_user_agent(),
+        sync_stalling_timeout: Default::default(),
+        peer_manager_config: Default::default(),
+    }
+}
+
+fn setup_peer_mgr(
+    chain_config: &Arc<ChainConfig>,
+    p2p_config: &Arc<P2pConfig>,
+    time_getter: &P2pBasicTestTimeGetter,
+    rng: &mut impl Rng,
+) -> (TestPeerManager, UnboundedReceiver<Command>) {
+    let (cmd_sender, cmd_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let (_conn_event_sender, conn_event_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let (_peer_mgr_event_sender, peer_mgr_event_receiver) =
+        tokio::sync::mpsc::unbounded_channel::<PeerManagerEvent>();
+    let connectivity_handle = ConnectivityHandle::<TestNetworkingService>::new(
+        // Note: technically, we should pass the bind addresses here, but since we don't
+        // establish real connections, it doesn't really matter.
+        vec![],
+        cmd_sender,
+        conn_event_receiver,
+    );
+
+    let mut peer_mgr = PeerManager::<TestNetworkingService, _>::new(
+        Arc::clone(chain_config),
+        Arc::clone(p2p_config),
+        connectivity_handle,
+        peer_mgr_event_receiver,
+        time_getter.get_time_getter(),
+        peerdb_inmemory_store(),
+    )
+    .unwrap();
+
+    let addresses_in_db = make_non_colliding_addresses(
+        peer_mgr.peerdb.address_tables().new_addr_table(),
+        *p2p_config.protocol_config.max_addr_list_response_address_count * 10,
+        rng,
+    );
+
+    for address in addresses_in_db {
+        peer_mgr.peerdb.peer_discovered(address);
+    }
+
+    (peer_mgr, cmd_receiver)
+}
+
+fn make_new_peer(chain_config: &ChainConfig) -> (PeerId, PeerInfo) {
+    let id = PeerId::new();
+    let info = PeerInfo {
+        peer_id: id,
+        protocol_version: TEST_PROTOCOL_VERSION,
+        network: *chain_config.magic_bytes(),
+        software_version: *chain_config.software_version(),
+        user_agent: mintlayer_core_user_agent(),
+        common_services: NodeType::Full.into(),
+    };
+    (id, info)
+}
+
+fn expect_addresses_from(cmd: Command, expected_peer_id: PeerId) -> Vec<PeerAddress> {
+    assert_matches_return_val!(
+        cmd,
+        Command::SendMessage {
+            peer_id,
+            message: Message::AddrListResponse(AddrListResponse { addresses }),
+        } if peer_id == expected_peer_id,
+        addresses
+    )
+}
+
+async fn accept_conn<T, S>(
+    peer_mgr: &mut PeerManager<T, S>,
+    cmd_receiver: &mut UnboundedReceiver<Command>,
+    peer_addr: SocketAddress,
+    bind_addr: SocketAddress,
+    peer_info: &PeerInfo,
+) where
+    T: NetworkingService + 'static,
+    T::ConnectivityHandle: ConnectivityService<T>,
+    S: PeerDbStorage,
+{
+    peer_mgr.accept_connection(peer_addr, bind_addr, Role::Inbound, peer_info.clone(), None);
+    let cmd = expect_recv!(cmd_receiver);
+    assert_eq!(
+        cmd,
+        Command::Accept {
+            peer_id: peer_info.peer_id
+        }
+    );
+}

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -1296,7 +1296,7 @@ async fn feeler_connections_test_impl(seed: Seed) {
 mod feeler_connections_test_utils {
     use common::chain::ChainConfig;
 
-    use crate::peer_manager::peerdb::{address_tables, storage::PeerDbStorage, PeerDb};
+    use crate::peer_manager::peerdb::{salt::Salt, storage::PeerDbStorage, PeerDb};
 
     use super::*;
 
@@ -1312,9 +1312,7 @@ mod feeler_connections_test_utils {
                 feeler_connections_interval: feeler_connections_interval.into(),
 
                 peerdb_config: PeerDbConfig {
-                    addr_tables_initial_random_key: Some(
-                        address_tables::RandomKey::new_random_with_rng(rng),
-                    ),
+                    salt: Some(Salt::new_random_with_rng(rng)),
 
                     new_addr_table_bucket_count: Default::default(),
                     tried_addr_table_bucket_count: Default::default(),

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod addr_list_response_caching;
 mod addresses;
 mod ban;
 mod connections;

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -84,6 +84,7 @@ make_config_setting!(RequestedBlocksLimit, usize, 500);
 make_config_setting!(MaxMessageSize, usize, 10 * 1024 * 1024);
 make_config_setting!(MaxPeerTxAnnouncements, usize, 5000);
 make_config_setting!(MaxUnconnectedHeaders, usize, 10);
+make_config_setting!(MaxAddrListResponseAddressCount, usize, 1000);
 
 /// Protocol configuration. These values are supposed to be modified in tests only.
 ///
@@ -101,6 +102,8 @@ pub struct ProtocolConfig {
     pub msg_header_count_limit: HeaderLimit,
     /// The maximum number of blocks that can be requested from a single peer.
     pub max_request_blocks_count: RequestedBlocksLimit,
+    /// The maximum number of addresses that a single AddrListResponse may contain.
+    pub max_addr_list_response_address_count: MaxAddrListResponseAddressCount,
 
     // "Soft" limits:
     /// The maximum number of elements in a locator.
@@ -109,7 +112,4 @@ pub struct ProtocolConfig {
     pub max_message_size: MaxMessageSize,
     /// The maximum number of announcements (hashes) for which we haven't receive transactions.
     pub max_peer_tx_announcements: MaxPeerTxAnnouncements,
-    /// The maximum number of singular unconnected headers that a V1 peer can send before
-    /// it will be considered malicious.
-    pub max_singular_unconnected_headers: MaxUnconnectedHeaders,
 }

--- a/p2p/src/sync/tests/block_announcement.rs
+++ b/p2p/src/sync/tests/block_announcement.rs
@@ -517,10 +517,10 @@ async fn send_headers_connected_to_previously_sent_headers(#[case] seed: Seed) {
                 max_request_blocks_count: 1.into(),
 
                 msg_header_count_limit: Default::default(),
+                max_addr_list_response_address_count: Default::default(),
                 msg_max_locator_count: Default::default(),
                 max_message_size: Default::default(),
                 max_peer_tx_announcements: Default::default(),
-                max_singular_unconnected_headers: Default::default(),
             },
 
             bind_addresses: Default::default(),
@@ -620,10 +620,10 @@ async fn send_headers_connected_to_block_which_is_being_downloaded(#[case] seed:
                 max_request_blocks_count: 1.into(),
 
                 msg_header_count_limit: Default::default(),
+                max_addr_list_response_address_count: Default::default(),
                 msg_max_locator_count: Default::default(),
                 max_message_size: Default::default(),
                 max_peer_tx_announcements: Default::default(),
-                max_singular_unconnected_headers: Default::default(),
             },
 
             bind_addresses: Default::default(),
@@ -720,10 +720,10 @@ async fn correct_pending_headers_update(#[case] seed: Seed) {
                 max_request_blocks_count: 2.into(),
 
                 msg_header_count_limit: Default::default(),
+                max_addr_list_response_address_count: Default::default(),
                 msg_max_locator_count: Default::default(),
                 max_message_size: Default::default(),
                 max_peer_tx_announcements: Default::default(),
-                max_singular_unconnected_headers: Default::default(),
             },
 
             bind_addresses: Default::default(),

--- a/p2p/src/sync/tests/network_sync.rs
+++ b/p2p/src/sync/tests/network_sync.rs
@@ -49,10 +49,10 @@ async fn basic(#[case] seed: Seed) {
                 msg_header_count_limit: 10.into(),
                 max_request_blocks_count: 5.into(),
 
+                max_addr_list_response_address_count: Default::default(),
                 msg_max_locator_count: Default::default(),
                 max_message_size: Default::default(),
                 max_peer_tx_announcements: Default::default(),
-                max_singular_unconnected_headers: Default::default(),
             },
 
             bind_addresses: Default::default(),
@@ -287,10 +287,10 @@ async fn block_announcement_disconnected_headers(#[case] seed: Seed) {
                 msg_header_count_limit: (MAX_REQUEST_BLOCKS_COUNT * 2).into(),
                 max_request_blocks_count: MAX_REQUEST_BLOCKS_COUNT.into(),
 
+                max_addr_list_response_address_count: Default::default(),
                 msg_max_locator_count: Default::default(),
                 max_message_size: Default::default(),
                 max_peer_tx_announcements: Default::default(),
-                max_singular_unconnected_headers: Default::default(),
             },
 
             bind_addresses: Default::default(),

--- a/p2p/src/sync/tests/tx_announcement.rs
+++ b/p2p/src/sync/tests/tx_announcement.rs
@@ -223,10 +223,10 @@ async fn too_many_announcements(#[case] seed: Seed) {
                 max_peer_tx_announcements: 1.into(),
 
                 msg_header_count_limit: Default::default(),
-                msg_max_locator_count: Default::default(),
                 max_request_blocks_count: Default::default(),
+                max_addr_list_response_address_count: Default::default(),
+                msg_max_locator_count: Default::default(),
                 max_message_size: Default::default(),
-                max_singular_unconnected_headers: Default::default(),
             },
 
             bind_addresses: Default::default(),

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -17,7 +17,7 @@
 
 use std::{
     fmt::Debug,
-    net::{IpAddr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
 
@@ -121,17 +121,25 @@ impl TestTransportMaker for TestTransportNoise {
 pub struct TestAddressMaker {}
 
 impl TestAddressMaker {
+    pub fn new_random_ipv6_addr_with_rng(rng: &mut impl Rng) -> Ipv6Addr {
+        Ipv6Addr::new(
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+        )
+    }
+
+    pub fn new_random_ipv4_addr_with_rng(rng: &mut impl Rng) -> Ipv4Addr {
+        Ipv4Addr::new(rng.gen(), rng.gen(), rng.gen(), rng.gen())
+    }
+
     pub fn new_random_address_with_rng(rng: &mut impl Rng) -> SocketAddress {
-        let ip = Ipv6Addr::new(
-            rng.gen(),
-            rng.gen(),
-            rng.gen(),
-            rng.gen(),
-            rng.gen(),
-            rng.gen(),
-            rng.gen(),
-            rng.gen(),
-        );
+        let ip = Self::new_random_ipv6_addr_with_rng(rng);
         SocketAddress::new(SocketAddr::new(IpAddr::V6(ip), rng.gen()))
     }
 


### PR DESCRIPTION
This closes the "Address list responses are not cached to prevent fingerprinting" item in https://github.com/mintlayer/mintlayer-core/issues/832

I also renamed `RandomKey` from `address_tables` to `Salt` and put it into a separate file.