### PR TITLE
Make local socket address available in the peer manager

### DIFF
--- a/dns_server/src/crawler_p2p/crawler_manager/mod.rs
+++ b/dns_server/src/crawler_p2p/crawler_manager/mod.rs
@@ -230,27 +230,44 @@ where
                 self.handle_conn_message(peer_id, message);
             }
             ConnectivityEvent::OutboundAccepted {
-                address,
+                peer_address,
+                bind_address: _,
                 peer_info,
-                receiver_address: _,
+                node_address_as_seen_by_peer: _,
             } => {
                 // Allow reading input messages from the connected peer
                 self.conn.accept(peer_info.peer_id).expect("accept must succeed");
 
-                self.send_crawler_event(CrawlerEvent::Connected { peer_info, address });
+                self.send_crawler_event(CrawlerEvent::Connected {
+                    peer_info,
+                    address: peer_address,
+                });
             }
             ConnectivityEvent::InboundAccepted {
-                address: _,
+                peer_address: _,
+                bind_address: _,
                 peer_info: _,
-                receiver_address: _,
+                node_address_as_seen_by_peer: _,
             } => {
                 unreachable!("unexpected inbound connection");
             }
-            ConnectivityEvent::ConnectionError { address, error } => {
-                self.send_crawler_event(CrawlerEvent::ConnectionError { address, error });
+            ConnectivityEvent::ConnectionError {
+                peer_address,
+                error,
+            } => {
+                self.send_crawler_event(CrawlerEvent::ConnectionError {
+                    address: peer_address,
+                    error,
+                });
             }
-            ConnectivityEvent::MisbehavedOnHandshake { address, error } => {
-                self.send_crawler_event(CrawlerEvent::MisbehavedOnHandshake { address, error });
+            ConnectivityEvent::MisbehavedOnHandshake {
+                peer_address,
+                error,
+            } => {
+                self.send_crawler_event(CrawlerEvent::MisbehavedOnHandshake {
+                    address: peer_address,
+                    error,
+                });
             }
             ConnectivityEvent::ConnectionClosed { peer_id } => {
                 self.send_crawler_event(CrawlerEvent::Disconnected { peer_id });

--- a/p2p/src/net/default_backend/transport/buffered_transcoder.rs
+++ b/p2p/src/net/default_backend/transport/buffered_transcoder.rs
@@ -30,7 +30,7 @@ pub struct BufferedTranscoder<S> {
     message_codec: MessageCodec<Message>,
 }
 
-impl<S: AsyncWrite + AsyncRead + Unpin> BufferedTranscoder<S> {
+impl<S> BufferedTranscoder<S> {
     pub fn new(stream: S, max_message_size: usize) -> BufferedTranscoder<S> {
         let message_codec = MessageCodec::new(max_message_size);
         BufferedTranscoder {
@@ -40,6 +40,15 @@ impl<S: AsyncWrite + AsyncRead + Unpin> BufferedTranscoder<S> {
         }
     }
 
+    /// The inner stream. This is only accessible as an immutable reference, so it'll allow
+    /// to read some additional info that the concrete stream might provide, but won't allow
+    /// reading or writing the actual stream data.
+    pub fn inner_stream(&self) -> &S {
+        &self.stream
+    }
+}
+
+impl<S: AsyncWrite + AsyncRead + Unpin> BufferedTranscoder<S> {
     pub async fn send(&mut self, msg: Message) -> Result<()> {
         let mut buf = BytesMut::new();
         self.message_codec.encode(msg, &mut buf)?;

--- a/p2p/src/net/default_backend/transport/impls/socks5.rs
+++ b/p2p/src/net/default_backend/transport/impls/socks5.rs
@@ -23,7 +23,9 @@ use tokio_socks::tcp::Socks5Stream;
 
 use crate::{
     error::{DialError, P2pError},
-    net::default_backend::transport::{PeerStream, TransportListener, TransportSocket},
+    net::default_backend::transport::{
+        ConnectedSocketInfo, PeerStream, TransportListener, TransportSocket,
+    },
     Result,
 };
 
@@ -98,3 +100,13 @@ impl TransportListener for Socks5TransportListener {
 pub type Socks5TransportStream = Socks5Stream<TcpStream>;
 
 impl PeerStream for Socks5TransportStream {}
+
+impl ConnectedSocketInfo for Socks5TransportStream {
+    fn local_address(&self) -> crate::Result<SocketAddress> {
+        Ok(SocketAddress::new(TcpStream::local_addr(self)?))
+    }
+
+    fn remote_address(&self) -> crate::Result<SocketAddress> {
+        Ok(SocketAddress::new(TcpStream::peer_addr(self)?))
+    }
+}

--- a/p2p/src/net/default_backend/transport/impls/stream_adapter/identity.rs
+++ b/p2p/src/net/default_backend/transport/impls/stream_adapter/identity.rs
@@ -15,7 +15,10 @@
 
 use futures::future::{ready, BoxFuture};
 
-use crate::net::{default_backend::transport::PeerStream, types::Role};
+use crate::net::{
+    default_backend::transport::{ConnectedSocketInfo, PeerStream},
+    types::Role,
+};
 
 use super::StreamAdapter;
 
@@ -29,7 +32,7 @@ impl IdentityStreamAdapter {
 }
 
 /// A StreamAdapter that does nothing with no handshake (Identity operation on data that goes through it)
-impl<T: PeerStream + 'static> StreamAdapter<T> for IdentityStreamAdapter {
+impl<T: PeerStream + ConnectedSocketInfo + 'static> StreamAdapter<T> for IdentityStreamAdapter {
     type Stream = T;
 
     fn handshake(&self, base: T, _role: Role) -> BoxFuture<'static, crate::Result<Self::Stream>> {

--- a/p2p/src/net/default_backend/transport/impls/stream_adapter/traits.rs
+++ b/p2p/src/net/default_backend/transport/impls/stream_adapter/traits.rs
@@ -16,13 +16,16 @@
 use futures::future::BoxFuture;
 
 use crate::{
-    net::{default_backend::transport::PeerStream, types::Role},
+    net::{
+        default_backend::transport::{ConnectedSocketInfo, PeerStream},
+        types::Role,
+    },
     Result,
 };
 
 /// Represents a stream that requires a handshake to function (such as encrypted streams)
 pub trait StreamAdapter<T>: Clone + Send + Sync + 'static {
-    type Stream: PeerStream;
+    type Stream: PeerStream + ConnectedSocketInfo;
 
     /// Wraps base async stream into AsyncRead/AsyncWrite stream that may implement encryption.
     fn handshake(&self, base: T, role: Role) -> BoxFuture<'static, Result<Self::Stream>>;

--- a/p2p/src/net/default_backend/transport/mod.rs
+++ b/p2p/src/net/default_backend/transport/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
         wrapped_transport::wrapped_socket::WrappedTransportSocket,
     },
     tcp::TcpTransportSocket,
-    traits::{PeerStream, TransportListener, TransportSocket},
+    traits::{ConnectedSocketInfo, PeerStream, TransportListener, TransportSocket},
 };
 
 pub type NoiseTcpTransport =

--- a/p2p/src/net/default_backend/transport/traits/listener.rs
+++ b/p2p/src/net/default_backend/transport/traits/listener.rs
@@ -18,12 +18,16 @@ use p2p_types::socket_address::SocketAddress;
 
 use crate::Result;
 
+use super::{ConnectedSocketInfo, PeerStream};
+
 /// An abstraction layer over a potential inbound network connection (acceptor in boost terminology).
 #[async_trait]
 pub trait TransportListener: Send {
-    type Stream;
+    type Stream: PeerStream + ConnectedSocketInfo;
 
     /// Accepts a new inbound connection.
+    ///
+    /// The returned address is the same as the one returned by `Stream::remote_address`.
     async fn accept(&mut self) -> Result<(Self::Stream, SocketAddress)>;
 
     /// Returns the local address of the listener.

--- a/p2p/src/net/default_backend/transport/traits/mod.rs
+++ b/p2p/src/net/default_backend/transport/traits/mod.rs
@@ -18,5 +18,5 @@ mod socket;
 mod stream;
 
 pub use listener::TransportListener;
-pub use socket::TransportSocket;
+pub use socket::{ConnectedSocketInfo, TransportSocket};
 pub use stream::PeerStream;

--- a/p2p/src/net/default_backend/transport/traits/socket.rs
+++ b/p2p/src/net/default_backend/transport/traits/socket.rs
@@ -31,11 +31,20 @@ pub trait TransportSocket: Send + Sync + 'static {
     type Listener: TransportListener<Stream = Self::Stream>;
 
     /// A messages stream.
-    type Stream: PeerStream;
+    type Stream: PeerStream + ConnectedSocketInfo;
 
     /// Creates a new listener bound to the specified address.
     async fn bind(&self, address: Vec<SocketAddress>) -> Result<Self::Listener>;
 
     /// Returns a future that opens a connection to the given address.
     fn connect(&self, address: SocketAddress) -> BoxFuture<'static, Result<Self::Stream>>;
+}
+
+/// Additional information for a connected socket.
+pub trait ConnectedSocketInfo {
+    /// Local socket address.
+    fn local_address(&self) -> crate::Result<SocketAddress>;
+
+    /// Remote socket address.
+    fn remote_address(&self) -> crate::Result<SocketAddress>;
 }

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -89,7 +89,7 @@ pub enum PeerEvent {
         common_services: Services,
         user_agent: UserAgent,
         software_version: SemVer,
-        receiver_address: Option<PeerAddress>,
+        node_address_as_seen_by_peer: Option<PeerAddress>,
 
         /// For outbound connections that is what we sent.
         /// For inbound connections that is what was received from remote peer.
@@ -129,7 +129,7 @@ pub enum HandshakeMessage {
         user_agent: UserAgent,
         software_version: SemVer,
 
-        /// Socket address of the remote peer as seen by this node (addr_you in bitcoin)
+        /// Socket address of the remote peer as seen by the sending node (addr_you in bitcoin)
         receiver_address: Option<PeerAddress>,
 
         current_time: P2pTimestamp,
@@ -145,7 +145,7 @@ pub enum HandshakeMessage {
         user_agent: UserAgent,
         software_version: SemVer,
 
-        /// Socket address of the remote peer as seen by this node (addr_you in bitcoin)
+        /// Socket address of the remote peer as seen by the sending node (addr_you in bitcoin)
         receiver_address: Option<PeerAddress>,
 
         current_time: P2pTimestamp,

--- a/p2p/src/net/types.rs
+++ b/p2p/src/net/types.rs
@@ -61,6 +61,15 @@ impl PeerRole {
         PeerRole::OutboundBlockRelay,
         PeerRole::OutboundManual,
     ];
+
+    pub fn is_outbound(&self) -> bool {
+        use PeerRole::*;
+
+        match self {
+            Inbound => false,
+            OutboundFullRelay | OutboundBlockRelay | OutboundManual | Feeler => true,
+        }
+    }
 }
 
 /// Peer information learned during handshaking
@@ -125,25 +134,31 @@ pub enum ConnectivityEvent {
     /// Outbound connection accepted
     OutboundAccepted {
         /// Peer address
-        address: SocketAddress,
+        peer_address: SocketAddress,
+
+        /// Bind address of this node's side of the connection.
+        bind_address: SocketAddress,
 
         /// Peer information
         peer_info: PeerInfo,
 
         /// Socket address of this node as seen by remote peer
-        receiver_address: Option<PeerAddress>,
+        node_address_as_seen_by_peer: Option<PeerAddress>,
     },
 
     /// Inbound connection received
     InboundAccepted {
         /// Peer address
-        address: SocketAddress,
+        peer_address: SocketAddress,
+
+        /// Bind address of this node's side of the connection.
+        bind_address: SocketAddress,
 
         /// Peer information
         peer_info: PeerInfo,
 
         /// Socket address of this node as seen by remote peer
-        receiver_address: Option<PeerAddress>,
+        node_address_as_seen_by_peer: Option<PeerAddress>,
     },
 
     /// Outbound connection failed
@@ -152,7 +167,7 @@ pub enum ConnectivityEvent {
     // during handshake, an additional MisbehavedOnHandshake event will be produced.
     ConnectionError {
         /// Address that was dialed
-        address: SocketAddress,
+        peer_address: SocketAddress,
 
         /// Error that occurred
         error: P2pError,
@@ -184,7 +199,7 @@ pub enum ConnectivityEvent {
     // that happen during handshake as well.
     MisbehavedOnHandshake {
         /// Peer's address
-        address: SocketAddress,
+        peer_address: SocketAddress,
 
         /// Error that occurred
         error: P2pError,

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -385,14 +385,14 @@ where
 
     /// Discover public addresses for this node after a new outbound connection is made
     ///
-    /// *receiver_address* is this host socket address as seen and reported by remote peer.
+    /// `node_address_as_seen_by_peer` is this host socket address as seen and reported by remote peer.
     /// This should work for hosts with public IPs and for hosts behind NAT with port forwarding (same port is assumed).
     /// This won't work for majority of nodes but that should be accepted.
     fn discover_own_address(
         &mut self,
         peer_role: PeerRole,
         common_services: Services,
-        receiver_address: Option<PeerAddress>,
+        node_address_as_seen_by_peer: Option<PeerAddress>,
     ) -> Option<SocketAddress> {
         let discover = match peer_role {
             PeerRole::Inbound | PeerRole::OutboundBlockRelay | PeerRole::Feeler => false,
@@ -404,7 +404,7 @@ where
             return None;
         }
 
-        let receiver_address = receiver_address?;
+        let node_address_as_seen_by_peer = node_address_as_seen_by_peer?;
 
         // Take IP and use port numbers from all listening sockets (with same IP version)
         let discovered_own_addresses = self
@@ -412,23 +412,23 @@ where
             .local_addresses()
             .iter()
             .map(SocketAddress::as_peer_address)
-            .filter_map(
-                |listening_address| match (&receiver_address, listening_address) {
-                    (PeerAddress::Ip4(receiver), PeerAddress::Ip4(listener)) => {
+            .filter_map(|listening_address| {
+                match (&node_address_as_seen_by_peer, listening_address) {
+                    (PeerAddress::Ip4(seen_by_peer), PeerAddress::Ip4(listening)) => {
                         Some(PeerAddress::Ip4(PeerAddressIp4 {
-                            ip: receiver.ip,
-                            port: listener.port,
+                            ip: seen_by_peer.ip,
+                            port: listening.port,
                         }))
                     }
-                    (PeerAddress::Ip6(receiver), PeerAddress::Ip6(listener)) => {
+                    (PeerAddress::Ip6(seen_by_peer), PeerAddress::Ip6(listening)) => {
                         Some(PeerAddress::Ip6(PeerAddressIp6 {
-                            ip: receiver.ip,
-                            port: listener.port,
+                            ip: seen_by_peer.ip,
+                            port: listening.port,
                         }))
                     }
                     _ => None,
-                },
-            )
+                }
+            })
             .filter_map(|address| {
                 SocketAddress::from_peer_address(
                     &address,
@@ -528,11 +528,11 @@ where
         );
 
         if let Some(o) = self.observer.as_mut() {
-            o.on_peer_ban_score_adjustment(peer.address, peer.score)
+            o.on_peer_ban_score_adjustment(peer.peer_address, peer.score)
         }
 
         if peer.score >= *self.p2p_config.ban_threshold {
-            let address = peer.address.as_bannable();
+            let address = peer.peer_address.as_bannable();
             self.ban(address);
         }
     }
@@ -570,7 +570,7 @@ where
             .peers
             .values()
             .filter_map(|peer| {
-                if peer.address.as_bannable() == address {
+                if peer.peer_address.as_bannable() == address {
                     Some(peer.info.peer_id)
                 } else {
                     None
@@ -871,19 +871,20 @@ where
     /// by the node as result of the peer manager maintenance.
     fn try_accept_connection(
         &mut self,
-        address: SocketAddress,
+        peer_address: SocketAddress,
+        bind_address: SocketAddress,
         peer_role: PeerRole,
         info: PeerInfo,
-        receiver_address: Option<PeerAddress>,
+        node_address_as_seen_by_peer: Option<PeerAddress>,
     ) -> crate::Result<()> {
         let peer_id = info.peer_id;
 
-        self.validate_connection(&address, peer_role, &info)?;
+        self.validate_connection(&peer_address, peer_role, &info)?;
 
         self.peer_connectivity_handle.accept(peer_id)?;
 
         log::info!(
-            "new peer accepted, peer_id: {peer_id}, address: {address:?}, role: {peer_role:?}, protocol_version: {:?}",
+            "new peer accepted, peer_id: {peer_id}, address: {peer_address:?}, role: {peer_role:?}, protocol_version: {:?}",
             info.protocol_version
         );
 
@@ -912,13 +913,17 @@ where
             &mut make_pseudo_rng(),
         );
 
-        let discovered_own_address =
-            self.discover_own_address(peer_role, info.common_services, receiver_address);
+        let discovered_own_address = self.discover_own_address(
+            peer_role,
+            info.common_services,
+            node_address_as_seen_by_peer,
+        );
 
         let peer = PeerContext {
             created_at: self.time_getter.get_time(),
             info,
-            address,
+            peer_address,
+            bind_address,
             peer_role,
             score: 0,
             sent_ping: None,
@@ -938,14 +943,8 @@ where
         let old_value = self.peers.insert(peer_id, peer);
         assert!(old_value.is_none());
 
-        match peer_role {
-            PeerRole::Inbound => {}
-            PeerRole::OutboundFullRelay
-            | PeerRole::OutboundBlockRelay
-            | PeerRole::OutboundManual
-            | PeerRole::Feeler => {
-                self.peerdb.outbound_peer_connected(address);
-            }
+        if peer_role.is_outbound() {
+            self.peerdb.outbound_peer_connected(peer_address);
         }
 
         if peer_role == PeerRole::OutboundBlockRelay {
@@ -957,7 +956,7 @@ where
                     | PeerRole::OutboundFullRelay
                     | PeerRole::OutboundManual
                     | PeerRole::Feeler => None,
-                    PeerRole::OutboundBlockRelay => Some(peer.address),
+                    PeerRole::OutboundBlockRelay => Some(peer.peer_address),
                 })
                 // Note: there may be more than outbound_block_relay_count block relay connections
                 // at a given moment, but the extra ones will soon be evicted. Since connections
@@ -968,7 +967,7 @@ where
         }
 
         if let Some(o) = self.observer.as_mut() {
-            o.on_connection_accepted(address, peer_role)
+            o.on_connection_accepted(peer_address, peer_role)
         }
 
         Ok(())
@@ -991,17 +990,18 @@ where
 
     fn accept_connection(
         &mut self,
-        address: SocketAddress,
+        peer_address: SocketAddress,
+        bind_address: SocketAddress,
         role: Role,
         info: PeerInfo,
-        receiver_address: Option<PeerAddress>,
+        node_address_as_seen_by_peer: Option<PeerAddress>,
     ) {
         let peer_id = info.peer_id;
 
         let (peer_role, response) = match role {
             Role::Inbound => (PeerRole::Inbound, None),
             Role::Outbound => {
-                let pending_connect = self.pending_outbound_connects.remove(&address).expect(
+                let pending_connect = self.pending_outbound_connects.remove(&peer_address).expect(
                     "the address must be present in pending_outbound_connects (accept_connection)",
                 );
                 let role = Self::determine_outbound_peer_role(&pending_connect);
@@ -1018,7 +1018,13 @@ where
             }
         };
 
-        let accept_res = self.try_accept_connection(address, peer_role, info, receiver_address);
+        let accept_res = self.try_accept_connection(
+            peer_address,
+            bind_address,
+            peer_role,
+            info,
+            node_address_as_seen_by_peer,
+        );
 
         if let Err(accept_err) = &accept_res {
             log::debug!("connection rejected for peer {peer_id}: {accept_err}");
@@ -1038,14 +1044,8 @@ where
                 log::error!("disconnect failed unexpectedly: {err:?}");
             }
 
-            match peer_role {
-                PeerRole::Inbound => {}
-                PeerRole::OutboundFullRelay
-                | PeerRole::OutboundBlockRelay
-                | PeerRole::OutboundManual
-                | PeerRole::Feeler => {
-                    self.peerdb.report_outbound_failure(address);
-                }
+            if peer_role.is_outbound() {
+                self.peerdb.report_outbound_failure(peer_address);
             }
         }
 
@@ -1096,17 +1096,11 @@ where
             log::info!(
                 "peer disconnected, peer_id: {}, address: {:?}",
                 peer.info.peer_id,
-                peer.address
+                peer.peer_address
             );
 
-            match peer.peer_role {
-                PeerRole::Inbound => {}
-                PeerRole::OutboundFullRelay
-                | PeerRole::OutboundBlockRelay
-                | PeerRole::OutboundManual
-                | PeerRole::Feeler => {
-                    self.peerdb.outbound_peer_disconnected(peer.address);
-                }
+            if peer.peer_role.is_outbound() {
+                self.peerdb.outbound_peer_disconnected(peer.peer_address);
             }
 
             if let Some(PendingDisconnect {
@@ -1116,15 +1110,11 @@ where
             {
                 match peerdb_action {
                     PeerDisconnectionDbAction::Keep => {}
-                    PeerDisconnectionDbAction::RemoveIfOutbound => match peer.peer_role {
-                        PeerRole::Inbound => {}
-                        PeerRole::OutboundFullRelay
-                        | PeerRole::OutboundBlockRelay
-                        | PeerRole::OutboundManual
-                        | PeerRole::Feeler => {
-                            self.peerdb.remove_outbound_address(&peer.address);
+                    PeerDisconnectionDbAction::RemoveIfOutbound => {
+                        if peer.peer_role.is_outbound() {
+                            self.peerdb.remove_outbound_address(&peer.peer_address);
                         }
-                    },
+                    }
                 }
 
                 if let Some(response_sender) = response_sender {
@@ -1165,7 +1155,8 @@ where
             let role = Self::determine_outbound_peer_role(pending_conn);
             (*addr, role)
         });
-        let connected = self.peers.values().map(|peer_ctx| (peer_ctx.address, peer_ctx.peer_role));
+        let connected =
+            self.peers.values().map(|peer_ctx| (peer_ctx.peer_address, peer_ctx.peer_role));
         connected.chain(pending)
     }
 
@@ -1541,30 +1532,50 @@ where
                 self.handle_incoming_message(peer_id, message);
             }
             ConnectivityEvent::InboundAccepted {
-                address,
+                peer_address,
+                bind_address,
                 peer_info,
-                receiver_address,
+                node_address_as_seen_by_peer,
             } => {
-                self.accept_connection(address, Role::Inbound, peer_info, receiver_address);
+                self.accept_connection(
+                    peer_address,
+                    bind_address,
+                    Role::Inbound,
+                    peer_info,
+                    node_address_as_seen_by_peer,
+                );
             }
             ConnectivityEvent::OutboundAccepted {
-                address,
+                peer_address,
+                bind_address,
                 peer_info,
-                receiver_address,
+                node_address_as_seen_by_peer,
             } => {
-                self.accept_connection(address, Role::Outbound, peer_info, receiver_address);
+                self.accept_connection(
+                    peer_address,
+                    bind_address,
+                    Role::Outbound,
+                    peer_info,
+                    node_address_as_seen_by_peer,
+                );
             }
             ConnectivityEvent::ConnectionClosed { peer_id } => {
                 self.connection_closed(peer_id);
             }
-            ConnectivityEvent::ConnectionError { address, error } => {
-                self.handle_outbound_error(address, error);
+            ConnectivityEvent::ConnectionError {
+                peer_address,
+                error,
+            } => {
+                self.handle_outbound_error(peer_address, error);
             }
             ConnectivityEvent::Misbehaved { peer_id, error } => {
                 self.adjust_peer_score(peer_id, error.ban_score());
             }
-            ConnectivityEvent::MisbehavedOnHandshake { address, error } => {
-                self.adjust_peer_score_on_failed_handshake(address, error.ban_score());
+            ConnectivityEvent::MisbehavedOnHandshake {
+                peer_address,
+                error,
+            } => {
+                self.adjust_peer_score_on_failed_handshake(peer_address, error.ban_score());
             }
         }
     }
@@ -1581,7 +1592,7 @@ where
             .values()
             .map(|context| ConnectedPeer {
                 peer_id: context.info.peer_id,
-                address: context.address,
+                address: context.peer_address,
                 peer_role: context.peer_role,
                 ban_score: context.score,
                 user_agent: context.info.user_agent.to_string(),
@@ -1606,19 +1617,15 @@ where
     }
 
     fn is_address_connected(&self, address: &SocketAddress) -> bool {
-        self.peers.values().any(|peer| peer.address == *address)
+        self.peers.values().any(|peer| peer.peer_address == *address)
     }
 
     /// The number of active inbound peers (all inbound connected peers that are not in `pending_disconnects`)
     fn inbound_peer_count(&self) -> usize {
         self.peers
             .iter()
-            .filter(|(peer_id, peer)| match peer.peer_role {
-                PeerRole::Inbound => !self.pending_disconnects.contains_key(peer_id),
-                PeerRole::OutboundFullRelay
-                | PeerRole::OutboundBlockRelay
-                | PeerRole::OutboundManual
-                | PeerRole::Feeler => false,
+            .filter(|(peer_id, peer)| {
+                !peer.peer_role.is_outbound() && !self.pending_disconnects.contains_key(peer_id)
             })
             .count()
     }
@@ -1865,7 +1872,7 @@ where
             }
 
             // Advertise local address regularly
-            while next_time_resend_own_address < now {
+            while next_time_resend_own_address <= now {
                 self.resend_own_address_randomly();
 
                 // Pick a random outbound peer to resend the listening address to.

--- a/p2p/src/peer_manager/peer_context.rs
+++ b/p2p/src/peer_manager/peer_context.rs
@@ -37,7 +37,10 @@ pub struct PeerContext {
     pub info: PeerInfo,
 
     /// Peer's address
-    pub address: SocketAddress,
+    pub peer_address: SocketAddress,
+
+    /// Bind address of this node's side of the connection.
+    pub bind_address: SocketAddress,
 
     pub peer_role: PeerRole,
 

--- a/p2p/src/peer_manager/peers_eviction/mod.rs
+++ b/p2p/src/peer_manager/peers_eviction/mod.rs
@@ -85,7 +85,7 @@ impl EvictionCandidate {
             age: now.saturating_sub(peer.created_at),
             peer_id: peer.info.peer_id,
             net_group_keyed: NetGroupKeyed(random_state.get_hash(
-                &AddressGroup::from_peer_address(&peer.address.as_peer_address()),
+                &AddressGroup::from_peer_address(&peer.peer_address.as_peer_address()),
             )),
             ping_min: peer.ping_min.map_or(i64::MAX, |val| val.as_micros() as i64),
             peer_role: peer.peer_role,

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -69,7 +69,13 @@ where
     )
     .await;
     let peer_id = peer_info.peer_id;
-    pm2.accept_connection(address, Role::Inbound, peer_info, None);
+    pm2.accept_connection(
+        address,
+        pm2.peer_connectivity_handle.local_addresses()[0],
+        Role::Inbound,
+        peer_info,
+        None,
+    );
 
     pm2.adjust_peer_score(peer_id, 1000);
     let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
@@ -121,7 +127,13 @@ where
     )
     .await;
     let peer_id = peer_info.peer_id;
-    pm2.accept_connection(address, Role::Inbound, peer_info, None);
+    pm2.accept_connection(
+        address,
+        pm2.peer_connectivity_handle.local_addresses()[0],
+        Role::Inbound,
+        peer_info,
+        None,
+    );
 
     pm2.adjust_peer_score(peer_id, 1000);
     let addr1 = pm1.peer_connectivity_handle.local_addresses()[0].clone().as_bannable();
@@ -181,7 +193,13 @@ where
     )
     .await;
     let peer_id = peer_info1.peer_id;
-    pm2.accept_connection(address, Role::Inbound, peer_info1, None);
+    pm2.accept_connection(
+        address,
+        pm2.peer_connectivity_handle.local_addresses()[0],
+        Role::Inbound,
+        peer_info1,
+        None,
+    );
 
     let remote_addr = pm1.peer_connectivity_handle.local_addresses()[0];
 
@@ -244,6 +262,7 @@ where
         // invalid magic bytes
         let peer_id = PeerId::new();
         let res = peer_manager.try_accept_connection(
+            TestAddressMaker::new_random_address(),
             TestAddressMaker::new_random_address(),
             peer_role,
             net::types::PeerInfo {
@@ -364,6 +383,7 @@ async fn inbound_connection_invalid_magic_noise() {
 fn ban_and_disconnect() {
     type TestNetworkingService = DefaultNetworkingService<TcpTransportSocket>;
 
+    let bind_address = TestTransportTcp::make_address();
     let chain_config = Arc::new(config::create_mainnet());
     let p2p_config = Arc::new(test_p2p_config());
     let (cmd_sender, mut cmd_receiver) = tokio::sync::mpsc::unbounded_channel();
@@ -393,7 +413,7 @@ fn ban_and_disconnect() {
         user_agent: mintlayer_core_user_agent(),
         common_services: NodeType::Full.into(),
     };
-    pm.accept_connection(address_1, Role::Inbound, peer_info, None);
+    pm.accept_connection(address_1, bind_address, Role::Inbound, peer_info, None);
     assert_eq!(pm.peers.len(), 1);
 
     // Peer is accepted by the peer manager

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -55,7 +55,7 @@ use super::peerdb::storage::PeerDbStorage;
 
 async fn make_peer_manager_custom<T>(
     transport: T::Transport,
-    addr: SocketAddress,
+    bind_address: SocketAddress,
     chain_config: Arc<common::chain::ChainConfig>,
     p2p_config: Arc<P2pConfig>,
     time_getter: TimeGetter,
@@ -74,7 +74,7 @@ where
     let (subscribers_sender, subscribers_receiver) = mpsc::unbounded_channel();
     let (conn, _, _, _) = T::start(
         transport,
-        vec![addr],
+        vec![bind_address],
         Arc::clone(&chain_config),
         Arc::clone(&p2p_config),
         time_getter.clone(),
@@ -106,7 +106,7 @@ where
 
 async fn make_peer_manager<T>(
     transport: T::Transport,
-    addr: SocketAddress,
+    bind_address: SocketAddress,
     chain_config: Arc<common::chain::ChainConfig>,
 ) -> (
     PeerManager<T, impl PeerDbStorage>,
@@ -121,7 +121,7 @@ where
     let (peer_manager, _peer_mgr_event_sender, shutdown_sender, subscribers_sender) =
         make_peer_manager_custom::<T>(
             transport,
-            addr,
+            bind_address,
             chain_config,
             p2p_config,
             Default::default(),

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -33,7 +33,9 @@ use crate::{
         tests::{send_and_sync, utils::cmd_to_peer_man_msg},
         PeerManager,
     },
-    testing_utils::{peerdb_inmemory_store, TEST_PROTOCOL_VERSION},
+    testing_utils::{
+        peerdb_inmemory_store, TestTransportMaker, TestTransportTcp, TEST_PROTOCOL_VERSION,
+    },
     types::peer_id::PeerId,
     PeerManagerEvent,
 };
@@ -73,8 +75,12 @@ async fn ping_timeout() {
     let (_peer_mgr_event_sender, peer_mgr_event_receiver) =
         tokio::sync::mpsc::unbounded_channel::<PeerManagerEvent>();
     let time_getter = P2pBasicTestTimeGetter::new();
-    let connectivity_handle =
-        ConnectivityHandle::<TestNetworkingService>::new(vec![], cmd_sender, conn_event_receiver);
+    let bind_address = TestTransportTcp::make_address();
+    let connectivity_handle = ConnectivityHandle::<TestNetworkingService>::new(
+        vec![bind_address],
+        cmd_sender,
+        conn_event_receiver,
+    );
 
     let peer_manager = PeerManager::<TestNetworkingService, _>::new(
         Arc::clone(&chain_config),
@@ -93,7 +99,8 @@ async fn ping_timeout() {
     // Notify about new inbound connection
     conn_event_sender
         .send(ConnectivityEvent::InboundAccepted {
-            address: "123.123.123.123:12345".parse().unwrap(),
+            peer_address: "123.123.123.123:12345".parse().unwrap(),
+            bind_address,
             peer_info: PeerInfo {
                 peer_id: PeerId::new(),
                 protocol_version: TEST_PROTOCOL_VERSION,
@@ -102,7 +109,7 @@ async fn ping_timeout() {
                 user_agent: p2p_config.user_agent.clone(),
                 common_services: NodeType::Full.into(),
             },
-            receiver_address: None,
+            node_address_as_seen_by_peer: None,
         })
         .unwrap();
 

--- a/p2p/src/tests/helpers/mod.rs
+++ b/p2p/src/tests/helpers/mod.rs
@@ -112,7 +112,7 @@ impl TestPeersInfo {
 
         for ctx in contexts.values() {
             info.insert(
-                ctx.address,
+                ctx.peer_address,
                 TestPeerInfo {
                     info: ctx.info.clone(),
                     role: ctx.peer_role,


### PR DESCRIPTION
This is needed for the other PR, related to AddrListResponse caching (https://github.com/mintlayer/mintlayer-core/pull/1403)

I also did some renaming and minor cleanup.