### PR TITLE
Fix feeler_connections_test

### DIFF
--- a/p2p/src/peer_manager/peerdb/address_tables/table.rs
+++ b/p2p/src/peer_manager/peerdb/address_tables/table.rs
@@ -281,7 +281,7 @@ pub mod test_utils {
     }
 
     pub fn make_non_colliding_addresses(
-        table: &Table,
+        tables: &[&Table],
         count: usize,
         rng: &mut impl Rng,
     ) -> Vec<SocketAddress> {
@@ -290,11 +290,13 @@ pub mod test_utils {
         while map.len() < count {
             let addr = make_random_address(rng);
 
-            let bucket_idx = table.bucket_idx(&addr);
-            let bucket_pos = table.bucket_pos(&addr, bucket_idx);
+            for (table_idx, table) in tables.iter().enumerate() {
+                let bucket_idx = table.bucket_idx(&addr);
+                let bucket_pos = table.bucket_pos(&addr, bucket_idx);
 
-            if let Entry::Vacant(entry) = map.entry((bucket_idx, bucket_pos)) {
-                entry.insert(addr);
+                if let Entry::Vacant(entry) = map.entry((table_idx, bucket_idx, bucket_pos)) {
+                    entry.insert(addr);
+                }
             }
         }
 
@@ -496,7 +498,7 @@ mod tests {
         let mut rng = make_seedable_rng(seed);
         let mut table = Table::new_generic(2, 2, RandomKey(0), 4);
 
-        let addrs = make_non_colliding_addresses(&table, 4, &mut rng);
+        let addrs = make_non_colliding_addresses(&[&table], 4, &mut rng);
 
         assert_eq!(*table.get_or_create_entry(&addrs[0]), addrs[0]);
         assert_eq!(*table.get_or_create_entry(&addrs[1]), addrs[1]);
@@ -513,7 +515,7 @@ mod tests {
         let mut rng = make_seedable_rng(seed);
         let mut table = Table::new_generic(2, 2, RandomKey(0), 4);
 
-        let addrs = make_non_colliding_addresses(&table, 2, &mut rng);
+        let addrs = make_non_colliding_addresses(&[&table], 2, &mut rng);
 
         assert_eq!(table.next_id(), 0);
 

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -245,8 +245,9 @@ fn remove_addr(#[case] seed: Seed) {
 
     let addr_count = 10;
 
-    let new_addrs = make_non_colliding_addresses(new_addr_table(&peerdb), addr_count, &mut rng);
-    let tried_addrs = make_non_colliding_addresses(tried_addr_table(&peerdb), addr_count, &mut rng);
+    let new_addrs = make_non_colliding_addresses(&[new_addr_table(&peerdb)], addr_count, &mut rng);
+    let tried_addrs =
+        make_non_colliding_addresses(&[tried_addr_table(&peerdb)], addr_count, &mut rng);
 
     let (new_addrs_to_remove, new_addrs_to_keep) = split_in_two_sets(&new_addrs, &mut rng);
     let (tried_addrs_to_remove, tried_addrs_to_keep) = split_in_two_sets(&tried_addrs, &mut rng);
@@ -305,8 +306,9 @@ fn remove_unreachable(#[case] seed: Seed) {
 
     let addr_count = 10;
 
-    let new_addrs = make_non_colliding_addresses(new_addr_table(&peerdb), addr_count, &mut rng);
-    let tried_addrs = make_non_colliding_addresses(tried_addr_table(&peerdb), addr_count, &mut rng);
+    let new_addrs = make_non_colliding_addresses(&[new_addr_table(&peerdb)], addr_count, &mut rng);
+    let tried_addrs =
+        make_non_colliding_addresses(&[tried_addr_table(&peerdb)], addr_count, &mut rng);
     let tried_addrs_as_set = tried_addrs.iter().copied().collect::<BTreeSet<_>>();
 
     for addr in &new_addrs {


### PR DESCRIPTION
`make_non_colliding_addresses` can now accept multiple tables; the generated addresses won't collide when put into either of the tables.

`feeler_connections_test` now generates test addresses using `make_non_colliding_addresses` and passes both tables into it; this is needed because the test logic doesn't really expect the addresses to collide. E.g. the following could happen before the fix:
1) An address would collide with another one in the "new" table; so, the "new" table would be missing one of the addresses and a "sanity check" assertion at the beginning of the test would fail.
2) An address would collide with another one in the "tried" table; then, a previously "tried" address could be moved back into "new", so the assertions at the end of the test that expect the tables to be in certain state would fail. Also, an assertion could fire in the middle of the "main" loop if another attempt to connect to such an address was made.