### PR TITLE
Include outbound manual connections in address group

### DIFF
--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -1218,12 +1218,7 @@ where
             match role {
                 PeerRole::Inbound => {}
                 PeerRole::OutboundManual => {
-                    // TODO: should we include manual peer connection in cur_outbound_conn_addr_groups,
-                    // in order to avoid opening new automatic connections to their address groups?
-                    // (Bitcoin does it).
-                    // See the TODO section of https://github.com/mintlayer/mintlayer-core/issues/832
-                    // Note that this change will require adjusting expected connections numbers
-                    // in the "discovered_node" tests.
+                    cur_outbound_conn_addr_groups.insert(addr_group);
                 }
                 PeerRole::OutboundFullRelay => {
                     cur_outbound_full_relay_conn_count += 1;

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -103,6 +103,21 @@ impl TestTransportChannel {
         MpscChannelTransport::new_with_addr_in_group(addr_group_idx, addr_group_bit_offset)
     }
 }
+
+pub fn make_transport_with_local_addr_in_group(
+    group_idx: u32,
+) -> <TestTransportChannel as TestTransportMaker>::Transport {
+    let group_bits = crate::peer_manager::address_groups::IPV4_GROUP_BYTES * 8;
+
+    TestTransportChannel::make_transport_with_local_addr_in_group(
+        // Make sure that the most significant byte of the address is non-zero
+        // (all 0.x.x.x addresses get into AddressGroup::Private, but we want all
+        // addresses to be in different address groups).
+        group_idx + (1 << (group_bits - 1)),
+        group_bits as u32,
+    )
+}
+
 pub struct TestTransportNoise {}
 
 impl TestTransportMaker for TestTransportNoise {

--- a/p2p/src/tests/peer_discovery_on_stale_tip.rs
+++ b/p2p/src/tests/peer_discovery_on_stale_tip.rs
@@ -29,11 +29,14 @@ use crate::{
     config::P2pConfig,
     net::types::PeerRole,
     peer_manager::{
-        self, address_groups::AddressGroup, PeerManagerConfig, PEER_MGR_DNS_RELOAD_INTERVAL,
+        address_groups::AddressGroup, PeerManagerConfig, PEER_MGR_DNS_RELOAD_INTERVAL,
         PEER_MGR_HEARTBEAT_INTERVAL_MAX,
     },
     sync::test_helpers::make_new_block,
-    testing_utils::{TestTransportChannel, TestTransportMaker, TEST_PROTOCOL_VERSION},
+    testing_utils::{
+        make_transport_with_local_addr_in_group, TestTransportChannel, TestTransportMaker,
+        TEST_PROTOCOL_VERSION,
+    },
     tests::helpers::{PeerManagerNotification, TestNode, TestNodeGroup},
 };
 
@@ -470,20 +473,6 @@ pub fn make_p2p_config(peer_manager_config: PeerManagerConfig) -> P2pConfig {
         user_agent: mintlayer_core_user_agent(),
         protocol_config: Default::default(),
     }
-}
-
-fn make_transport_with_local_addr_in_group(
-    group_idx: u32,
-) -> <TestTransportChannel as TestTransportMaker>::Transport {
-    let group_bits = peer_manager::address_groups::IPV4_GROUP_BYTES * 8;
-
-    TestTransportChannel::make_transport_with_local_addr_in_group(
-        // Make sure that the most significant byte of the address is non-zero
-        // (all 0.x.x.x addresses get into AddressGroup::Private, but we want all
-        // addresses to be in different address groups).
-        group_idx + (1 << (group_bits - 1)),
-        group_bits as u32,
-    )
 }
 
 async fn start_node(


### PR DESCRIPTION
> Currently when establishing a new automatic outbound connection we ignore addresses in address groups that already have an automatic outbound connection.
But should we also ignore those that have manual outbound connections?