### PR TITLE
Introduce `DecimalAmount` and refactor wallet controller to use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7318,6 +7318,7 @@ dependencies = [
  "node-comm",
  "p2p-types",
  "rstest",
+ "serde",
  "serialization",
  "test-utils",
  "thiserror",

--- a/common/src/primitives/decimal_amount.rs
+++ b/common/src/primitives/decimal_amount.rs
@@ -1,0 +1,261 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Write;
+
+use utils::ensure;
+
+pub use super::amount::{Amount, UnsignedIntType};
+
+const TEN: UnsignedIntType = 10;
+
+/// Amount in fractional representation
+///
+/// Keeps track of the number of decimal digits that should be presented to the user. This is
+/// mostly for presentation purposes so does not define any arithmetic operations. Convert to
+/// `Amount` if arithmetic is needed.
+///
+/// Comparison operators are deliberately left out too. The reason is that there are two sensible
+/// ways to compare `DecimalAmount`s:
+/// 1. Compare the numerical values that they signify
+/// 2. Compare the implied textual representation, e.g. "1.0" and "1.000" are considered different
+/// The user is expected to convert to a number or a string before comparing to explicitly state
+/// which for of comparison is desired in any given situation.
+#[derive(Clone, Copy, Debug)]
+pub struct DecimalAmount {
+    mantissa: UnsignedIntType,
+    decimals: u8,
+}
+
+impl DecimalAmount {
+    pub const ZERO: Self = Self::from_uint_integral(0);
+
+    /// Convert from integer with no decimals
+    pub const fn from_uint_integral(number: u128) -> Self {
+        Self::from_uint_decimal(number, 0)
+    }
+
+    /// Convert from integer, interpreting the last N digits as the fractional part
+    pub const fn from_uint_decimal(mantissa: UnsignedIntType, decimals: u8) -> Self {
+        Self { mantissa, decimals }
+    }
+
+    /// Convert from amount, keeping all decimal digits
+    pub const fn from_amount_full(amount: Amount, decimals: u8) -> Self {
+        Self::from_uint_decimal(amount.into_atoms(), decimals)
+    }
+
+    /// Convert from amount, keeping as few decimal digits as possible (without losing precision)
+    pub const fn from_amount_minimal(amount: Amount, decimals: u8) -> Self {
+        Self::from_amount_full(amount, decimals).minimize()
+    }
+
+    /// Convert to amount using given number of decimals
+    pub fn to_amount(self, decimals: u8) -> Option<Amount> {
+        Some(Amount::from_atoms(self.with_decimals(decimals)?.mantissa))
+    }
+
+    /// Change the number of decimals. Can only increase decimals, otherwise we risk losing digits.
+    pub fn with_decimals(self, decimals: u8) -> Option<Self> {
+        let extra_decimals = decimals.checked_sub(self.decimals)?;
+        let mantissa = self.mantissa.checked_mul(TEN.checked_pow(extra_decimals as u32)?)?;
+        Some(Self::from_uint_decimal(mantissa, decimals))
+    }
+
+    /// Trim trailing zeroes in the fractional part
+    pub const fn minimize(mut self) -> Self {
+        while self.decimals > 0 && self.mantissa % TEN == 0 {
+            self.mantissa /= TEN;
+            self.decimals -= 1;
+        }
+        self
+    }
+
+    /// Check this is the same number presented with the same precision
+    pub fn is_same(&self, other: &Self) -> bool {
+        (self.mantissa, self.decimals) == (other.mantissa, other.decimals)
+    }
+}
+
+fn empty_to_zero(s: &str) -> &str {
+    match s {
+        "" => "0",
+        s => s,
+    }
+}
+
+impl std::str::FromStr for DecimalAmount {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ensure!(s.len() <= 100, ParseError::StringTooLong);
+
+        let s = s.trim_matches(' ');
+        let s = s.replace('_', "");
+        ensure!(!s.is_empty(), ParseError::EmptyString);
+
+        let (int_str, frac_str) = s.split_once('.').unwrap_or((&s, ""));
+
+        let mut chars = int_str.chars().chain(frac_str.chars());
+        ensure!(chars.all(|c| c.is_ascii_digit()), ParseError::IllegalChar);
+        ensure!(int_str.len() + frac_str.len() > 0, ParseError::NoDigits);
+
+        let int: UnsignedIntType = empty_to_zero(int_str).parse()?;
+        let frac: UnsignedIntType = empty_to_zero(frac_str).parse()?;
+
+        let decimals: u8 = frac_str.len().try_into().expect("Checked string length above");
+
+        let mantissa = TEN
+            .checked_pow(decimals as u32)
+            .and_then(|mul| int.checked_mul(mul))
+            .and_then(|shifted| shifted.checked_add(frac))
+            .ok_or(ParseError::OutOfRange)?;
+
+        Ok(Self::from_uint_decimal(mantissa, decimals))
+    }
+}
+
+impl std::fmt::Display for DecimalAmount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mantissa = self.mantissa;
+        let decimals = self.decimals as usize;
+
+        if decimals > 0 {
+            // Max string length: ceil(log10(u128::MAX)) + 1 for decimal point = 40
+            let mut buffer = String::with_capacity(40);
+            write!(&mut buffer, "{mantissa:0>width$}", width = decimals + 1)?;
+            assert!(buffer.len() > decimals);
+            buffer.insert(buffer.len() - decimals, '.');
+            f.pad(&buffer)
+        } else {
+            mantissa.fmt(f)
+        }
+    }
+}
+
+impl serde::Serialize for DecimalAmount {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+enum StringOrUint {
+    String(String),
+    UInt(u128),
+}
+
+impl<'de> serde::Deserialize<'de> for DecimalAmount {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        match StringOrUint::deserialize(deserializer)? {
+            StringOrUint::String(s) => s.parse().map_err(<D::Error as serde::de::Error>::custom),
+            StringOrUint::UInt(i) => Ok(Self::from_uint_integral(i)),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    #[error("Resulting number is too big")]
+    OutOfRange,
+
+    #[error("The number string is too long")]
+    StringTooLong,
+
+    #[error("Empty input")]
+    EmptyString,
+
+    #[error("Invalid character used in number")]
+    IllegalChar,
+
+    #[error("Number does not contain any digits")]
+    NoDigits,
+
+    #[error(transparent)]
+    IntParse(#[from] std::num::ParseIntError),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[rstest::rstest]
+    // Zero decimals
+    #[case("0", DecimalAmount::from_uint_integral(0))]
+    #[case("00", DecimalAmount::from_uint_integral(0))]
+    #[case("5", DecimalAmount::from_uint_integral(5))]
+    #[case("123", DecimalAmount::from_uint_integral(123))]
+    #[case("0123", DecimalAmount::from_uint_integral(123))]
+    #[case("55555", DecimalAmount::from_uint_integral(55555))]
+    #[case("9999", DecimalAmount::from_uint_integral(9999))]
+    #[case(
+        "340282366920938463463374607431768211455",
+        DecimalAmount::from_uint_integral(u128::MAX)
+    )]
+    // Trailing dot
+    #[case("0123.", DecimalAmount::from_uint_integral(123))]
+    #[case("55555.", DecimalAmount::from_uint_integral(55555))]
+    #[case("9999.", DecimalAmount::from_uint_integral(9999))]
+    #[case(
+        "340282366920938463463374607431768211455.",
+        DecimalAmount::from_uint_integral(u128::MAX)
+    )]
+    // One decimal
+    #[case("0.0", DecimalAmount::from_uint_decimal(0, 1))]
+    #[case("00.0", DecimalAmount::from_uint_decimal(0, 1))]
+    #[case("5.3", DecimalAmount::from_uint_decimal(53, 1))]
+    #[case("123.0", DecimalAmount::from_uint_decimal(1230, 1))]
+    #[case("0123.4", DecimalAmount::from_uint_decimal(1234, 1))]
+    #[case("55555.0", DecimalAmount::from_uint_decimal(555550, 1))]
+    #[case("9999.0", DecimalAmount::from_uint_decimal(99990, 1))]
+    #[case("0123.7", DecimalAmount::from_uint_decimal(1237, 1))]
+    #[case("55555.6", DecimalAmount::from_uint_decimal(555556, 1))]
+    #[case("9999.9", DecimalAmount::from_uint_decimal(99999, 1))]
+    #[case(
+        "34028236692093846346337460743176821.1455",
+        DecimalAmount::from_uint_decimal(u128::MAX, 4)
+    )]
+    fn parse_ok(#[case] s: &str, #[case] amt: DecimalAmount) {
+        assert!(amt.is_same(&s.parse().expect("parsing failed")));
+
+        let roundtrip = amt.to_string().parse().expect("parsing failed");
+        assert!(amt.is_same(&roundtrip));
+    }
+
+    #[rstest::rstest]
+    #[case("", ParseError::EmptyString)]
+    #[case("  ", ParseError::EmptyString)]
+    #[case(" _ _ ", ParseError::IllegalChar)]
+    #[case(".", ParseError::NoDigits)]
+    #[case("._", ParseError::NoDigits)]
+    #[case("_.", ParseError::NoDigits)]
+    #[case("_._", ParseError::NoDigits)]
+    #[case("_.___", ParseError::NoDigits)]
+    #[case("x", ParseError::IllegalChar)]
+    #[case("-", ParseError::IllegalChar)]
+    #[case("%", ParseError::IllegalChar)]
+    #[case("13.5e2", ParseError::IllegalChar)]
+    #[case("34028236692093846346337460743176821145.6", ParseError::OutOfRange)]
+    #[case("3.40282366920938463463374607431768211456", ParseError::OutOfRange)]
+    #[case(
+        "99999_99999_99999_99999_99999.99999_99999_99999_99999_99999",
+        ParseError::OutOfRange
+    )]
+    fn parse_err(#[case] s: &str, #[case] expected_err: ParseError) {
+        let err = s.parse::<DecimalAmount>().expect_err("parsing succeeded");
+        assert_eq!(err, expected_err);
+    }
+}

--- a/common/src/primitives/mod.rs
+++ b/common/src/primitives/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod amount;
 pub mod compact;
+pub mod decimal_amount;
 pub mod encoding;
 pub mod error;
 pub mod height;
@@ -31,6 +32,7 @@ mod hash_encoded;
 
 pub use amount::Amount;
 pub use compact::Compact;
+pub use decimal_amount::DecimalAmount;
 pub use encoding::{Bech32Error, DecodedArbitraryDataFromBech32};
 pub use height::{BlockCount, BlockDistance, BlockHeight};
 pub use id::{Id, Idable, H256};

--- a/wallet/wallet-cli-lib/src/commands/helper_types.rs
+++ b/wallet/wallet-cli-lib/src/commands/helper_types.rs
@@ -285,10 +285,6 @@ pub fn print_coin_amount(chain_config: &ChainConfig, value: Amount) -> String {
     value.into_fixedpoint_str(chain_config.coin_decimals())
 }
 
-pub fn print_token_amount(token_number_of_decimals: u8, value: Amount) -> String {
-    value.into_fixedpoint_str(token_number_of_decimals)
-}
-
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/wallet/wallet-controller/Cargo.toml
+++ b/wallet/wallet-controller/Cargo.toml
@@ -24,9 +24,10 @@ wallet-types = { path = "../types" }
 
 async-trait.workspace = true
 bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
+futures = { workspace = true, default-features = false }
+serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }
-futures = { workspace = true, default-features = false }
 zeroize.workspace = true
 
 [dev-dependencies]

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -19,6 +19,7 @@ pub mod mnemonic;
 pub mod read;
 mod sync;
 pub mod synced_controller;
+pub mod types;
 
 const NORMAL_DELAY: Duration = Duration::from_secs(1);
 const ERROR_DELAY: Duration = Duration::from_secs(10);
@@ -359,13 +360,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         &self,
         token_id: TokenId,
     ) -> Result<RPCTokenInfo, ControllerError<T>> {
-        self.rpc_client
-            .get_token_info(token_id)
-            .await
-            .map_err(ControllerError::NodeCallError)?
-            .ok_or(ControllerError::WalletError(WalletError::UnknownTokenId(
-                token_id,
-            )))
+        fetch_token_info(&self.rpc_client, token_id).await
     }
 
     pub async fn generate_block_by_pool(
@@ -653,4 +648,17 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 .expect("Sleep intervals cannot be this large");
         }
     }
+}
+
+pub async fn fetch_token_info<T: NodeInterface>(
+    rpc_client: &T,
+    token_id: TokenId,
+) -> Result<RPCTokenInfo, ControllerError<T>> {
+    rpc_client
+        .get_token_info(token_id)
+        .await
+        .map_err(ControllerError::NodeCallError)?
+        .ok_or(ControllerError::WalletError(WalletError::UnknownTokenId(
+            token_id,
+        )))
 }

--- a/wallet/wallet-controller/src/types/balances.rs
+++ b/wallet/wallet-controller/src/types/balances.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use common::{chain::tokens::TokenId, primitives::DecimalAmount};
+
+/// Balances of coins and tokens
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Balances {
+    coins: DecimalAmount,
+    tokens: BTreeMap<TokenId, DecimalAmount>,
+}
+
+impl Balances {
+    pub fn new(coins: DecimalAmount, tokens: BTreeMap<TokenId, DecimalAmount>) -> Self {
+        Self { coins, tokens }
+    }
+
+    pub fn coins(&self) -> DecimalAmount {
+        self.coins
+    }
+
+    pub fn tokens(&self) -> &BTreeMap<TokenId, DecimalAmount> {
+        &self.tokens
+    }
+
+    pub fn token(&self, token_id: &TokenId) -> DecimalAmount {
+        self.tokens.get(token_id).copied().unwrap_or(DecimalAmount::ZERO)
+    }
+
+    pub fn into_coins_and_tokens(self) -> (DecimalAmount, BTreeMap<TokenId, DecimalAmount>) {
+        let Self { coins, tokens } = self;
+        (coins, tokens)
+    }
+}

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Support types for presenting data in user-facing settings
+
+mod balances;
+
+pub use balances::Balances;
+pub use common::primitives::DecimalAmount;


### PR DESCRIPTION
* Add `DecimalAmount` which is like `Amount` with formatting information (number of decimals)
  *  it can be printed and parsed to/from strings and supports serde
  * The printing/parsing of `Amount` was changed to use it under the hood
* Use that in the wallet controller for querying balances
* That will enable removing some duplication between the CLI frontend and RPC frontend