### PR TITLE
Don't evict peers that have a block in-flight

### DIFF
--- a/p2p/src/peer_manager/peer_context.rs
+++ b/p2p/src/peer_manager/peer_context.rs
@@ -21,6 +21,7 @@ use utils::{bloom_filters::rolling_bloom_filter::RollingBloomFilter, set_flag::S
 
 use crate::{
     net::types::{PeerInfo, PeerRole},
+    sync::sync_status::PeerBlockSyncStatus,
     utils::rate_limiter::RateLimiter,
 };
 
@@ -75,4 +76,7 @@ pub struct PeerContext {
     pub last_tip_block_time: Option<Time>,
 
     pub last_tx_time: Option<Time>,
+
+    /// Certain information from the block sync manager that the peer manager may be interested in.
+    pub block_sync_status: PeerBlockSyncStatus,
 }

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -613,4 +613,19 @@ pub mod test_utils {
             rng,
         )
     }
+
+    pub fn make_non_colliding_addresses_for_peer_db_in_distinct_addr_groups<S: PeerDbStorage>(
+        peer_db: &PeerDb<S>,
+        count: usize,
+        rng: &mut impl Rng,
+    ) -> Vec<SocketAddress> {
+        make_non_colliding_addresses_in_distinct_addr_groups(
+            &[
+                peer_db.address_tables().new_addr_table(),
+                peer_db.address_tables().tried_addr_table(),
+            ],
+            count,
+            rng,
+        )
+    }
 }

--- a/p2p/src/peer_manager/peers_eviction/tests.rs
+++ b/p2p/src/peer_manager/peers_eviction/tests.rs
@@ -47,6 +47,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
                 peer_role: PeerRole::Inbound,
                 last_tip_block_time: None,
                 last_tx_time: None,
+                expecting_blocks_since: None,
             },],
             1
         ),
@@ -65,6 +66,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -74,6 +76,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -88,6 +91,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         },]
     );
 
@@ -103,6 +107,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -112,6 +117,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -126,6 +132,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         },]
     );
 
@@ -141,6 +148,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -150,6 +158,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -159,6 +168,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -173,6 +183,7 @@ fn test_filter_address_group(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         },]
     );
 }
@@ -198,6 +209,7 @@ fn test_ping(#[case] seed: Seed) {
                 peer_role: PeerRole::Inbound,
                 last_tip_block_time: None,
                 last_tx_time: None,
+                expecting_blocks_since: None,
             },],
             1
         ),
@@ -216,6 +228,7 @@ fn test_ping(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -225,6 +238,7 @@ fn test_ping(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -239,6 +253,7 @@ fn test_ping(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         },]
     );
 
@@ -254,6 +269,7 @@ fn test_ping(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -263,6 +279,7 @@ fn test_ping(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -272,6 +289,7 @@ fn test_ping(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -286,6 +304,7 @@ fn test_ping(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         },]
     );
 }
@@ -311,6 +330,7 @@ fn test_filter_by_last_block_time(#[case] seed: Seed) {
                 peer_role: PeerRole::Inbound,
                 last_tip_block_time: None,
                 last_tx_time: None,
+                expecting_blocks_since: None,
             },],
             1
         ),
@@ -329,6 +349,7 @@ fn test_filter_by_last_block_time(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -340,6 +361,7 @@ fn test_filter_by_last_block_time(#[case] seed: Seed) {
                             Duration::from_secs(10000000)
                         )),
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -354,6 +376,7 @@ fn test_filter_by_last_block_time(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         },]
     );
 
@@ -371,6 +394,7 @@ fn test_filter_by_last_block_time(#[case] seed: Seed) {
                             Duration::from_secs(10000000)
                         )),
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -382,6 +406,7 @@ fn test_filter_by_last_block_time(#[case] seed: Seed) {
                             Duration::from_secs(10000001)
                         )),
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -393,6 +418,7 @@ fn test_filter_by_last_block_time(#[case] seed: Seed) {
                             Duration::from_secs(10000002)
                         )),
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -407,6 +433,7 @@ fn test_filter_by_last_block_time(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: Some(Time::from_secs_since_epoch(10000000)),
             last_tx_time: None,
+            expecting_blocks_since: None,
         },]
     );
 }
@@ -432,6 +459,7 @@ fn test_filter_by_last_transaction_time(#[case] seed: Seed) {
                 peer_role: PeerRole::Inbound,
                 last_tip_block_time: None,
                 last_tx_time: None,
+                expecting_blocks_since: None,
             },],
             1
         ),
@@ -450,6 +478,7 @@ fn test_filter_by_last_transaction_time(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: Some(Time::from_secs_since_epoch(1000000)),
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -459,6 +488,7 @@ fn test_filter_by_last_transaction_time(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: None,
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -473,6 +503,7 @@ fn test_filter_by_last_transaction_time(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         },]
     );
 
@@ -488,6 +519,7 @@ fn test_filter_by_last_transaction_time(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: Some(Time::from_secs_since_epoch(10000000)),
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -497,6 +529,7 @@ fn test_filter_by_last_transaction_time(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: Some(Time::from_secs_since_epoch(10000001)),
+                        expecting_blocks_since: None,
                     },
                     EvictionCandidate {
                         age: Duration::ZERO,
@@ -506,6 +539,7 @@ fn test_filter_by_last_transaction_time(#[case] seed: Seed) {
                         peer_role: PeerRole::Inbound,
                         last_tip_block_time: None,
                         last_tx_time: Some(Time::from_secs_since_epoch(10000002)),
+                        expecting_blocks_since: None,
                     },
                 ],
                 &mut rng
@@ -520,6 +554,7 @@ fn test_filter_by_last_transaction_time(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: Some(Time::from_secs_since_epoch(10000000)),
+            expecting_blocks_since: None,
         },]
     );
 }
@@ -546,6 +581,7 @@ fn test_find_group_most_connections(#[case] seed: Seed) {
             peer_role: PeerRole::Inbound,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         }]),
         Some(peer1)
     );
@@ -562,6 +598,7 @@ fn test_find_group_most_connections(#[case] seed: Seed) {
                     peer_role: PeerRole::Inbound,
                     last_tip_block_time: None,
                     last_tx_time: None,
+                    expecting_blocks_since: None,
                 },
                 EvictionCandidate {
                     age: Duration::ZERO,
@@ -571,6 +608,7 @@ fn test_find_group_most_connections(#[case] seed: Seed) {
                     peer_role: PeerRole::Inbound,
                     last_tip_block_time: None,
                     last_tx_time: None,
+                    expecting_blocks_since: None,
                 }
             ],
             &mut rng
@@ -589,6 +627,7 @@ fn test_find_group_most_connections(#[case] seed: Seed) {
                     peer_role: PeerRole::Inbound,
                     last_tip_block_time: None,
                     last_tx_time: None,
+                    expecting_blocks_since: None,
                 },
                 EvictionCandidate {
                     age: Duration::ZERO,
@@ -598,6 +637,7 @@ fn test_find_group_most_connections(#[case] seed: Seed) {
                     peer_role: PeerRole::Inbound,
                     last_tip_block_time: None,
                     last_tx_time: None,
+                    expecting_blocks_since: None,
                 },
                 EvictionCandidate {
                     age: Duration::ZERO,
@@ -607,6 +647,7 @@ fn test_find_group_most_connections(#[case] seed: Seed) {
                     peer_role: PeerRole::Inbound,
                     last_tip_block_time: None,
                     last_tx_time: None,
+                    expecting_blocks_since: None,
                 },
             ],
             &mut rng
@@ -624,6 +665,7 @@ fn random_eviction_candidate(rng: &mut impl Rng) -> EvictionCandidate {
         peer_role: PeerRole::Inbound,
         last_tip_block_time: None,
         last_tx_time: None,
+        expecting_blocks_since: None,
     }
 }
 
@@ -697,6 +739,7 @@ fn test_block_relay_eviction_young_old_peers(#[case] seed: Seed) {
     let peer2 = PeerId::new();
     let peer3 = PeerId::new();
 
+    let now = Time::from_secs_since_epoch(100000);
     let min_age = Duration::from_secs(5000);
     let config = config_with_block_relay_conn_limits(2, min_age);
 
@@ -709,6 +752,7 @@ fn test_block_relay_eviction_young_old_peers(#[case] seed: Seed) {
             peer_role: PeerRole::OutboundBlockRelay,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         }
     }
 
@@ -719,7 +763,7 @@ fn test_block_relay_eviction_young_old_peers(#[case] seed: Seed) {
         make_candidate(peer3, min_age - Duration::from_secs(1)),
     ];
     assert_eq!(
-        select_for_eviction_block_relay(shuffle_vec(candidates, &mut rng), &config),
+        select_for_eviction_block_relay(shuffle_vec(candidates, &mut rng), &config, now),
         None
     );
 
@@ -731,13 +775,13 @@ fn test_block_relay_eviction_young_old_peers(#[case] seed: Seed) {
     ];
     let candidates = shuffle_vec(candidates, &mut rng);
     assert_eq!(
-        select_for_eviction_block_relay(candidates.clone(), &config),
+        select_for_eviction_block_relay(candidates.clone(), &config, now),
         Some(peer3)
     );
 
     // But if the limits are lifted, no eviction happens.
     assert_eq!(
-        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits()),
+        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits(), now),
         None
     );
 }
@@ -753,10 +797,16 @@ fn test_block_relay_eviction_no_blocks(#[case] seed: Seed) {
     let peer2 = PeerId::new();
     let peer3 = PeerId::new();
 
+    let now_as_secs = 100000;
+    let now = Time::from_secs_since_epoch(now_as_secs);
     let min_age = Duration::from_secs(5000);
     let config = config_with_block_relay_conn_limits(2, min_age);
 
-    fn make_candidate(peer_id: PeerId, last_tip_block_time_secs: Option<u64>) -> EvictionCandidate {
+    fn make_candidate(
+        peer_id: PeerId,
+        last_tip_block_time_secs: Option<u64>,
+        expecting_blocks_since_secs: Option<u64>,
+    ) -> EvictionCandidate {
         EvictionCandidate {
             age: Duration::from_secs(10000),
             peer_id,
@@ -765,24 +815,68 @@ fn test_block_relay_eviction_no_blocks(#[case] seed: Seed) {
             peer_role: PeerRole::OutboundBlockRelay,
             last_tip_block_time: last_tip_block_time_secs.map(Time::from_secs_since_epoch),
             last_tx_time: None,
+            expecting_blocks_since: expecting_blocks_since_secs.map(Time::from_secs_since_epoch),
         }
     }
 
-    // The peer that never sent us new blocks is evicted
+    // The peer that never sent us new blocks is evicted.
     let candidates = vec![
-        make_candidate(peer1, Some(10000)),
-        make_candidate(peer2, Some(20000)),
-        make_candidate(peer3, None),
+        make_candidate(peer1, Some(10000), None),
+        make_candidate(peer2, Some(20000), None),
+        make_candidate(peer3, None, None),
     ];
     let candidates = shuffle_vec(candidates, &mut rng);
     assert_eq!(
-        select_for_eviction_block_relay(candidates.clone(), &config),
+        select_for_eviction_block_relay(candidates.clone(), &config, now),
         Some(peer3)
     );
-
     // But if the limits are lifted, no eviction happens.
     assert_eq!(
-        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits()),
+        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits(), now),
+        None
+    );
+
+    // The previously evicted peer now has `expecting_blocks_since` within the limit;
+    // the next worst peer should be evicted instead.
+    let candidates = vec![
+        make_candidate(peer1, Some(10000), None),
+        make_candidate(peer2, Some(20000), None),
+        make_candidate(
+            peer3,
+            None,
+            Some(now_as_secs - BLOCK_EXPECTATION_MAX_DURATION.as_secs()),
+        ),
+    ];
+    let candidates = shuffle_vec(candidates, &mut rng);
+    assert_eq!(
+        select_for_eviction_block_relay(candidates.clone(), &config, now),
+        Some(peer1)
+    );
+    // But if the limits are lifted, no eviction happens.
+    assert_eq!(
+        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits(), now),
+        None
+    );
+
+    // The same peer now has `expecting_blocks_since` below the limit;
+    // this time it should be evicted.
+    let candidates = vec![
+        make_candidate(peer1, Some(10000), None),
+        make_candidate(peer2, Some(20000), None),
+        make_candidate(
+            peer3,
+            None,
+            Some(now_as_secs - BLOCK_EXPECTATION_MAX_DURATION.as_secs() - 1),
+        ),
+    ];
+    let candidates = shuffle_vec(candidates, &mut rng);
+    assert_eq!(
+        select_for_eviction_block_relay(candidates.clone(), &config, now),
+        Some(peer3)
+    );
+    // But if the limits are lifted, no eviction happens.
+    assert_eq!(
+        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits(), now),
         None
     );
 }
@@ -798,10 +892,16 @@ fn test_block_relay_eviction_old_blocks(#[case] seed: Seed) {
     let peer2 = PeerId::new();
     let peer3 = PeerId::new();
 
+    let now_as_secs = 100000;
+    let now = Time::from_secs_since_epoch(now_as_secs);
     let min_age = Duration::from_secs(5000);
     let config = config_with_block_relay_conn_limits(2, min_age);
 
-    fn make_candidate(peer_id: PeerId, last_tip_block_time_secs: u64) -> EvictionCandidate {
+    fn make_candidate(
+        peer_id: PeerId,
+        last_tip_block_time_secs: u64,
+        expecting_blocks_since_secs: Option<u64>,
+    ) -> EvictionCandidate {
         EvictionCandidate {
             age: Duration::from_secs(10000),
             peer_id,
@@ -810,24 +910,68 @@ fn test_block_relay_eviction_old_blocks(#[case] seed: Seed) {
             peer_role: PeerRole::OutboundBlockRelay,
             last_tip_block_time: Some(Time::from_secs_since_epoch(last_tip_block_time_secs)),
             last_tx_time: None,
+            expecting_blocks_since: expecting_blocks_since_secs.map(Time::from_secs_since_epoch),
         }
     }
 
-    // The peer that sent blocks a long time ago is evicted
+    // The peer that sent blocks a long time ago is evicted.
     let candidates = vec![
-        make_candidate(peer1, 10000),
-        make_candidate(peer2, 20000),
-        make_candidate(peer3, 30000),
+        make_candidate(peer1, 10000, None),
+        make_candidate(peer2, 20000, None),
+        make_candidate(peer3, 30000, None),
     ];
     let candidates = shuffle_vec(candidates, &mut rng);
     assert_eq!(
-        select_for_eviction_block_relay(candidates.clone(), &config),
+        select_for_eviction_block_relay(candidates.clone(), &config, now),
         Some(peer1)
     );
-
     // But if the limits are lifted, no eviction happens.
     assert_eq!(
-        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits()),
+        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits(), now),
+        None
+    );
+
+    // The previously evicted peer now has `expecting_blocks_since` within the limit;
+    // the next worst peer should be evicted instead.
+    let candidates = vec![
+        make_candidate(
+            peer1,
+            10000,
+            Some(now_as_secs - BLOCK_EXPECTATION_MAX_DURATION.as_secs()),
+        ),
+        make_candidate(peer2, 20000, None),
+        make_candidate(peer3, 30000, None),
+    ];
+    let candidates = shuffle_vec(candidates, &mut rng);
+    assert_eq!(
+        select_for_eviction_block_relay(candidates.clone(), &config, now),
+        Some(peer2)
+    );
+    // But if the limits are lifted, no eviction happens.
+    assert_eq!(
+        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits(), now),
+        None
+    );
+
+    // The same peer now has `expecting_blocks_since` below the limit;
+    // this time it should be evicted.
+    let candidates = vec![
+        make_candidate(
+            peer1,
+            10000,
+            Some(now_as_secs - BLOCK_EXPECTATION_MAX_DURATION.as_secs() - 1),
+        ),
+        make_candidate(peer2, 20000, None),
+        make_candidate(peer3, 30000, None),
+    ];
+    let candidates = shuffle_vec(candidates, &mut rng);
+    assert_eq!(
+        select_for_eviction_block_relay(candidates.clone(), &config, now),
+        Some(peer1)
+    );
+    // But if the limits are lifted, no eviction happens.
+    assert_eq!(
+        select_for_eviction_block_relay(candidates, &config_with_no_outbound_conn_limits(), now),
         None
     );
 }
@@ -843,6 +987,7 @@ fn test_full_relay_eviction_young_old_peers(#[case] seed: Seed) {
     let peer2 = PeerId::new();
     let peer3 = PeerId::new();
 
+    let now = Time::from_secs_since_epoch(100000);
     let min_age = Duration::from_secs(5000);
     let config = config_with_full_relay_conn_limits(2, min_age);
 
@@ -855,6 +1000,7 @@ fn test_full_relay_eviction_young_old_peers(#[case] seed: Seed) {
             peer_role: PeerRole::OutboundFullRelay,
             last_tip_block_time: None,
             last_tx_time: None,
+            expecting_blocks_since: None,
         }
     }
 
@@ -865,7 +1011,7 @@ fn test_full_relay_eviction_young_old_peers(#[case] seed: Seed) {
         make_candidate(peer3, min_age - Duration::from_secs(1)),
     ];
     assert_eq!(
-        select_for_eviction_full_relay(shuffle_vec(candidates, &mut rng), &config),
+        select_for_eviction_full_relay(shuffle_vec(candidates, &mut rng), &config, now),
         None
     );
 
@@ -877,13 +1023,13 @@ fn test_full_relay_eviction_young_old_peers(#[case] seed: Seed) {
     ];
     let candidates = shuffle_vec(candidates, &mut rng);
     assert_eq!(
-        select_for_eviction_full_relay(candidates.clone(), &config),
+        select_for_eviction_full_relay(candidates.clone(), &config, now),
         Some(peer3)
     );
 
     // But if the limits are lifted, no eviction happens.
     assert_eq!(
-        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits()),
+        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits(), now),
         None
     );
 }
@@ -899,10 +1045,16 @@ fn test_full_relay_eviction_no_blocks(#[case] seed: Seed) {
     let peer2 = PeerId::new();
     let peer3 = PeerId::new();
 
+    let now_as_secs = 100000;
+    let now = Time::from_secs_since_epoch(now_as_secs);
     let min_age = Duration::from_secs(5000);
     let config = config_with_full_relay_conn_limits(2, min_age);
 
-    fn make_candidate(peer_id: PeerId, last_tip_block_time_secs: Option<u64>) -> EvictionCandidate {
+    fn make_candidate(
+        peer_id: PeerId,
+        last_tip_block_time_secs: Option<u64>,
+        expecting_blocks_since_secs: Option<u64>,
+    ) -> EvictionCandidate {
         EvictionCandidate {
             age: Duration::from_secs(10000),
             peer_id,
@@ -911,24 +1063,68 @@ fn test_full_relay_eviction_no_blocks(#[case] seed: Seed) {
             peer_role: PeerRole::OutboundFullRelay,
             last_tip_block_time: last_tip_block_time_secs.map(Time::from_secs_since_epoch),
             last_tx_time: None,
+            expecting_blocks_since: expecting_blocks_since_secs.map(Time::from_secs_since_epoch),
         }
     }
 
-    // The peer that never sent us new blocks is evicted
+    // The peer that never sent us new blocks is evicted.
     let candidates = vec![
-        make_candidate(peer1, Some(10000)),
-        make_candidate(peer2, Some(20000)),
-        make_candidate(peer3, None),
+        make_candidate(peer1, Some(10000), None),
+        make_candidate(peer2, Some(20000), None),
+        make_candidate(peer3, None, None),
     ];
     let candidates = shuffle_vec(candidates, &mut rng);
     assert_eq!(
-        select_for_eviction_full_relay(candidates.clone(), &config),
+        select_for_eviction_full_relay(candidates.clone(), &config, now),
         Some(peer3)
     );
-
     // But if the limits are lifted, no eviction happens.
     assert_eq!(
-        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits()),
+        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits(), now),
+        None
+    );
+
+    // The previously evicted peer now has `expecting_blocks_since` within the limit;
+    // the next worst peer should be evicted instead.
+    let candidates = vec![
+        make_candidate(peer1, Some(10000), None),
+        make_candidate(peer2, Some(20000), None),
+        make_candidate(
+            peer3,
+            None,
+            Some(now_as_secs - BLOCK_EXPECTATION_MAX_DURATION.as_secs()),
+        ),
+    ];
+    let candidates = shuffle_vec(candidates, &mut rng);
+    assert_eq!(
+        select_for_eviction_full_relay(candidates.clone(), &config, now),
+        Some(peer1)
+    );
+    // But if the limits are lifted, no eviction happens.
+    assert_eq!(
+        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits(), now),
+        None
+    );
+
+    // The same peer now has `expecting_blocks_since` below the limit;
+    // this time it should be evicted.
+    let candidates = vec![
+        make_candidate(peer1, Some(10000), None),
+        make_candidate(peer2, Some(20000), None),
+        make_candidate(
+            peer3,
+            None,
+            Some(now_as_secs - BLOCK_EXPECTATION_MAX_DURATION.as_secs() - 1),
+        ),
+    ];
+    let candidates = shuffle_vec(candidates, &mut rng);
+    assert_eq!(
+        select_for_eviction_full_relay(candidates.clone(), &config, now),
+        Some(peer3)
+    );
+    // But if the limits are lifted, no eviction happens.
+    assert_eq!(
+        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits(), now),
         None
     );
 }
@@ -944,10 +1140,16 @@ fn test_full_relay_eviction_old_blocks(#[case] seed: Seed) {
     let peer2 = PeerId::new();
     let peer3 = PeerId::new();
 
+    let now_as_secs = 100000;
+    let now = Time::from_secs_since_epoch(now_as_secs);
     let min_age = Duration::from_secs(5000);
     let config = config_with_full_relay_conn_limits(2, min_age);
 
-    fn make_candidate(peer_id: PeerId, last_tip_block_time_secs: u64) -> EvictionCandidate {
+    fn make_candidate(
+        peer_id: PeerId,
+        last_tip_block_time_secs: u64,
+        expecting_blocks_since_secs: Option<u64>,
+    ) -> EvictionCandidate {
         EvictionCandidate {
             age: Duration::from_secs(10000),
             peer_id,
@@ -956,24 +1158,68 @@ fn test_full_relay_eviction_old_blocks(#[case] seed: Seed) {
             peer_role: PeerRole::OutboundFullRelay,
             last_tip_block_time: Some(Time::from_secs_since_epoch(last_tip_block_time_secs)),
             last_tx_time: None,
+            expecting_blocks_since: expecting_blocks_since_secs.map(Time::from_secs_since_epoch),
         }
     }
 
-    // The peer that sent blocks a long time ago is evicted
+    // The peer that sent blocks a long time ago is evicted.
     let candidates = vec![
-        make_candidate(peer1, 10000),
-        make_candidate(peer2, 20000),
-        make_candidate(peer3, 30000),
+        make_candidate(peer1, 10000, None),
+        make_candidate(peer2, 20000, None),
+        make_candidate(peer3, 30000, None),
     ];
     let candidates = shuffle_vec(candidates, &mut rng);
     assert_eq!(
-        select_for_eviction_full_relay(candidates.clone(), &config),
+        select_for_eviction_full_relay(candidates.clone(), &config, now),
         Some(peer1)
     );
-
     // But if the limits are lifted, no eviction happens.
     assert_eq!(
-        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits()),
+        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits(), now),
+        None
+    );
+
+    // The previously evicted peer now has `expecting_blocks_since` within the limit;
+    // the next worst peer should be evicted instead.
+    let candidates = vec![
+        make_candidate(
+            peer1,
+            10000,
+            Some(now_as_secs - BLOCK_EXPECTATION_MAX_DURATION.as_secs()),
+        ),
+        make_candidate(peer2, 20000, None),
+        make_candidate(peer3, 30000, None),
+    ];
+    let candidates = shuffle_vec(candidates, &mut rng);
+    assert_eq!(
+        select_for_eviction_full_relay(candidates.clone(), &config, now),
+        Some(peer2)
+    );
+    // But if the limits are lifted, no eviction happens.
+    assert_eq!(
+        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits(), now),
+        None
+    );
+
+    // The same peer now has `expecting_blocks_since` below the limit;
+    // this time it should be evicted.
+    let candidates = vec![
+        make_candidate(
+            peer1,
+            10000,
+            Some(now_as_secs - BLOCK_EXPECTATION_MAX_DURATION.as_secs() - 1),
+        ),
+        make_candidate(peer2, 20000, None),
+        make_candidate(peer3, 30000, None),
+    ];
+    let candidates = shuffle_vec(candidates, &mut rng);
+    assert_eq!(
+        select_for_eviction_full_relay(candidates.clone(), &config, now),
+        Some(peer1)
+    );
+    // But if the limits are lifted, no eviction happens.
+    assert_eq!(
+        select_for_eviction_full_relay(candidates, &config_with_no_outbound_conn_limits(), now),
         None
     );
 }

--- a/p2p/src/peer_manager/tests/addresses.rs
+++ b/p2p/src/peer_manager/tests/addresses.rs
@@ -46,7 +46,7 @@ use crate::{
         self,
         tests::{
             make_peer_manager_custom,
-            utils::{cmd_to_peer_man_msg, make_peer_info},
+            utils::{cmd_to_peer_man_msg, make_full_relay_peer_info},
         },
         OutboundConnectType, PeerManager, DNS_SEED_QUERY_INTERVAL,
     },
@@ -677,7 +677,7 @@ async fn accept_outbound_connection(
         .send(ConnectivityEvent::OutboundAccepted {
             peer_address: *peer_address,
             bind_address: *local_bind_address,
-            peer_info: make_peer_info(peer_id, chain_config),
+            peer_info: make_full_relay_peer_info(peer_id, chain_config),
             node_address_as_seen_by_peer: None,
         })
         .unwrap();

--- a/p2p/src/peer_manager/tests/eviction.rs
+++ b/p2p/src/peer_manager/tests/eviction.rs
@@ -1,0 +1,316 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+
+use logging::log;
+use rstest::rstest;
+use test_utils::random::make_seedable_rng;
+use tokio::sync::mpsc;
+
+use p2p_test_utils::{expect_no_recv, expect_recv, P2pBasicTestTimeGetter};
+use test_utils::random::Seed;
+
+use crate::{
+    config::P2pConfig,
+    net::{
+        default_backend::{types::Command, ConnectivityHandle},
+        types::ConnectivityEvent,
+    },
+    peer_manager::{
+        dns_seed::DefaultDnsSeed,
+        peerdb::{self, config::PeerDbConfig, salt::Salt},
+        peers_eviction,
+        tests::utils::{expect_connect_cmd, make_block_relay_peer_info},
+        PeerManager, PeerManagerConfig,
+    },
+    sync::sync_status::PeerBlockSyncStatus,
+    testing_utils::{peerdb_inmemory_store, TestTransportMaker, TestTransportTcp},
+    tests::helpers::PeerManagerObserver,
+    types::peer_id::PeerId,
+};
+use common::{
+    chain::{config, Block},
+    primitives::{user_agent::mintlayer_core_user_agent, Id},
+    Uint256,
+};
+
+use crate::{
+    net::default_backend::{transport::TcpTransportSocket, DefaultNetworkingService},
+    peer_manager::{tests::utils::wait_for_heartbeat, HEARTBEAT_INTERVAL_MAX},
+    PeerManagerEvent,
+};
+
+// 1) Setup the peer manager so that it must open 3 block relay connections, 1 of which is
+// temporary; let it open the connections.
+// 2) Simulate new tip arrival from each peer with 1st peer's tip being the oldest.
+// 3) Based on the TestCase enum, make the peer manager expect (or not) a block from the 1st peer.
+// 4) Advance the time, so that the connections are mature enough for eviction to be possible.
+// The expected result depends on TestCase: if no block was expected from the 1st peer (NoBlocksInFlight),
+// it must be evicted. Same should happen if a block is expected, but the timeout has elapsed (BlockInFlightOld).
+// Otherwise (BlockInFlightRecent), the 2nd peer should be evicted instead.
+mod dont_evict_if_blocks_in_flight {
+    use super::*;
+
+    #[derive(Debug)]
+    enum TestCase {
+        NoBlocksInFlight,
+        BlockInFlightRecent,
+        BlockInFlightOld,
+    }
+
+    #[tracing::instrument(skip(seed))]
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test(
+        #[case] seed: Seed,
+        #[values(
+            TestCase::NoBlocksInFlight,
+            TestCase::BlockInFlightRecent,
+            TestCase::BlockInFlightOld
+        )]
+        test_case: TestCase,
+    ) {
+        type TestNetworkingService = DefaultNetworkingService<TcpTransportSocket>;
+
+        let mut rng = make_seedable_rng(seed);
+
+        let chain_config = Arc::new(config::create_unit_test_config());
+        // The age should be big enough to allow multiple heartbeats to pass before it may expire.
+        let min_connection_age = Duration::from_secs(60 * 60);
+
+        let p2p_config = Arc::new(P2pConfig {
+            peer_manager_config: PeerManagerConfig {
+                outbound_block_relay_count: 2.into(),
+                outbound_block_relay_extra_count: 1.into(),
+                outbound_block_relay_connection_min_age: min_connection_age.into(),
+
+                outbound_full_relay_count: 0.into(),
+                outbound_full_relay_extra_count: 0.into(),
+
+                enable_feeler_connections: false.into(),
+
+                peerdb_config: PeerDbConfig {
+                    salt: Some(Salt::new_random_with_rng(&mut rng)),
+
+                    new_addr_table_bucket_count: Default::default(),
+                    tried_addr_table_bucket_count: Default::default(),
+                    addr_tables_bucket_size: Default::default(),
+                },
+
+                preserved_inbound_count_address_group: Default::default(),
+                preserved_inbound_count_ping: Default::default(),
+                preserved_inbound_count_new_blocks: Default::default(),
+                preserved_inbound_count_new_transactions: Default::default(),
+
+                max_inbound_connections: Default::default(),
+
+                outbound_full_relay_connection_min_age: Default::default(),
+                stale_tip_time_diff: Default::default(),
+
+                main_loop_tick_interval: Default::default(),
+                feeler_connections_interval: Default::default(),
+                force_dns_query_if_no_global_addresses_known: Default::default(),
+            },
+            ping_check_period: Duration::ZERO.into(),
+
+            bind_addresses: Default::default(),
+            socks5_proxy: Default::default(),
+            disable_noise: Default::default(),
+            boot_nodes: Default::default(),
+            reserved_nodes: Default::default(),
+            whitelisted_addresses: Default::default(),
+            ban_threshold: Default::default(),
+            ban_duration: Default::default(),
+            outbound_connection_timeout: Default::default(),
+            ping_timeout: Default::default(),
+            peer_handshake_timeout: Default::default(),
+            max_clock_diff: Default::default(),
+            node_type: Default::default(),
+            allow_discover_private_ips: Default::default(),
+            user_agent: mintlayer_core_user_agent(),
+            sync_stalling_timeout: Default::default(),
+            protocol_config: Default::default(),
+        });
+
+        let bind_address = TestTransportTcp::make_address();
+        let (cmd_sender, mut cmd_receiver) = mpsc::unbounded_channel();
+        let (conn_event_sender, conn_event_receiver) = mpsc::unbounded_channel();
+        let (peer_mgr_event_sender, peer_mgr_event_receiver) =
+            mpsc::unbounded_channel::<PeerManagerEvent>();
+        let time_getter = P2pBasicTestTimeGetter::new();
+        let connectivity_handle = ConnectivityHandle::<TestNetworkingService>::new(
+            vec![],
+            cmd_sender,
+            conn_event_receiver,
+        );
+        let (peer_mgr_notification_sender, mut peer_mgr_notification_receiver) =
+            mpsc::unbounded_channel();
+        let peer_mgr_observer = Box::new(PeerManagerObserver::new(peer_mgr_notification_sender));
+
+        let mut peer_mgr = PeerManager::<TestNetworkingService, _>::new_generic(
+            Arc::clone(&chain_config),
+            Arc::clone(&p2p_config),
+            connectivity_handle,
+            peer_mgr_event_receiver,
+            time_getter.get_time_getter(),
+            peerdb_inmemory_store(),
+            Some(peer_mgr_observer),
+            Box::new(DefaultDnsSeed::new(
+                Arc::clone(&chain_config),
+                Arc::clone(&p2p_config),
+            )),
+        )
+        .unwrap();
+
+        let addr_count = 3;
+        let addresses =
+            peerdb::test_utils::make_non_colliding_addresses_for_peer_db_in_distinct_addr_groups(
+                &peer_mgr.peerdb,
+                addr_count,
+                &mut rng,
+            );
+        let mut addresses = BTreeSet::from_iter(addresses.into_iter());
+        for addr in &addresses {
+            peer_mgr.peerdb.peer_discovered(*addr);
+        }
+        let peer_mgr_join_handle = logging::spawn_in_current_span(async move {
+            let mut peer_mgr = peer_mgr;
+            let _ = peer_mgr.run_internal(None).await;
+            peer_mgr
+        });
+
+        let mut peer_ids = Vec::new();
+
+        log::debug!("Expecting outbound connection attempt #1");
+        let cmd = expect_recv!(cmd_receiver);
+        let peer1_addr = expect_connect_cmd(&cmd, &mut addresses);
+
+        log::debug!("Expecting outbound connection attempt #2");
+        let cmd = expect_recv!(cmd_receiver);
+        let peer2_addr = expect_connect_cmd(&cmd, &mut addresses);
+
+        log::debug!("Expecting outbound connection attempt #3");
+        let cmd = expect_recv!(cmd_receiver);
+        let peer3_addr = expect_connect_cmd(&cmd, &mut addresses);
+
+        for peer_addr in [peer1_addr, peer2_addr, peer3_addr] {
+            let peer_id = PeerId::new();
+            conn_event_sender
+                .send(ConnectivityEvent::OutboundAccepted {
+                    peer_address: peer_addr,
+                    bind_address,
+                    peer_info: make_block_relay_peer_info(peer_id, &chain_config),
+                    node_address_as_seen_by_peer: None,
+                })
+                .unwrap();
+
+            log::debug!("Expecting Command::Accept");
+            let cmd = expect_recv!(cmd_receiver);
+            assert_eq!(cmd, Command::Accept { peer_id });
+
+            peer_ids.push(peer_id);
+        }
+
+        // One unconditional heartbeat must have occurred early, skip it.
+        wait_for_heartbeat(&mut peer_mgr_notification_receiver).await;
+
+        // No other commands are sent immediately.
+        expect_no_recv!(cmd_receiver);
+
+        peer_mgr_event_sender
+            .send(PeerManagerEvent::NewTipReceived {
+                peer_id: peer_ids[0],
+                block_id: Id::<Block>::new(Uint256::from_u64(1).into()),
+            })
+            .unwrap();
+        time_getter.advance_time(HEARTBEAT_INTERVAL_MAX);
+        wait_for_heartbeat(&mut peer_mgr_notification_receiver).await;
+
+        time_getter.advance_time(Duration::from_secs(1));
+
+        peer_mgr_event_sender
+            .send(PeerManagerEvent::NewTipReceived {
+                peer_id: peer_ids[1],
+                block_id: Id::<Block>::new(Uint256::from_u64(2).into()),
+            })
+            .unwrap();
+        time_getter.advance_time(HEARTBEAT_INTERVAL_MAX);
+        wait_for_heartbeat(&mut peer_mgr_notification_receiver).await;
+
+        time_getter.advance_time(Duration::from_secs(1));
+
+        peer_mgr_event_sender
+            .send(PeerManagerEvent::NewTipReceived {
+                peer_id: peer_ids[2],
+                block_id: Id::<Block>::new(Uint256::from_u64(3).into()),
+            })
+            .unwrap();
+        time_getter.advance_time(HEARTBEAT_INTERVAL_MAX);
+        wait_for_heartbeat(&mut peer_mgr_notification_receiver).await;
+
+        let next_time_advancement = min_connection_age + Duration::from_secs(1);
+
+        let (expect_blocks_since, expected_peer_to_disconnect) = match test_case {
+            TestCase::NoBlocksInFlight => (None, peer_ids[0]),
+            TestCase::BlockInFlightRecent => {
+                let expect_blocks_since = (time_getter.get_time_getter().get_time()
+                    + (next_time_advancement - peers_eviction::BLOCK_EXPECTATION_MAX_DURATION
+                        + Duration::from_secs(1)))
+                .unwrap();
+
+                (Some(expect_blocks_since), peer_ids[1])
+            }
+            TestCase::BlockInFlightOld => {
+                let expect_blocks_since = (time_getter.get_time_getter().get_time()
+                    + (next_time_advancement
+                        - peers_eviction::BLOCK_EXPECTATION_MAX_DURATION
+                        - Duration::from_secs(1)))
+                .unwrap();
+
+                (Some(expect_blocks_since), peer_ids[0])
+            }
+        };
+
+        if let Some(expect_blocks_since) = expect_blocks_since {
+            peer_mgr_event_sender
+                .send(PeerManagerEvent::PeerBlockSyncStatusUpdate {
+                    peer_id: peer_ids[0],
+                    new_status: PeerBlockSyncStatus {
+                        expecting_blocks_since: Some(expect_blocks_since),
+                    },
+                })
+                .unwrap();
+        }
+
+        // Advance the time so that all connections become mature and can be evicted from now on.
+        time_getter.advance_time(next_time_advancement);
+
+        let cmd = expect_recv!(cmd_receiver);
+        assert_eq!(
+            cmd,
+            Command::Disconnect {
+                peer_id: expected_peer_to_disconnect
+            }
+        );
+
+        drop(conn_event_sender);
+        drop(peer_mgr_event_sender);
+
+        let _peer_mgr = peer_mgr_join_handle.await.unwrap();
+    }
+}

--- a/p2p/src/peer_manager/tests/mod.rs
+++ b/p2p/src/peer_manager/tests/mod.rs
@@ -17,6 +17,7 @@ mod addr_list_response_caching;
 mod addresses;
 mod ban;
 mod connections;
+mod eviction;
 mod peer_types;
 mod ping;
 mod utils;

--- a/p2p/src/peer_manager_event.rs
+++ b/p2p/src/peer_manager_event.rs
@@ -24,7 +24,7 @@ use p2p_types::{
 
 use crate::{
     interface::types::ConnectedPeer, peer_manager::PeerManagerQueryInterface,
-    types::peer_id::PeerId, utils::oneshot_nofail,
+    sync::sync_status::PeerBlockSyncStatus, types::peer_id::PeerId, utils::oneshot_nofail,
 };
 
 #[derive(Debug)]
@@ -87,6 +87,12 @@ pub enum PeerManagerEvent {
     NewValidTransactionReceived {
         peer_id: PeerId,
         txid: Id<Transaction>,
+    },
+
+    /// PeerBlockSyncStatus has changed for the specified peer.
+    PeerBlockSyncStatusUpdate {
+        peer_id: PeerId,
+        new_status: PeerBlockSyncStatus,
     },
 
     AddReserved(IpOrSocketAddress, oneshot_nofail::Sender<crate::Result<()>>),

--- a/p2p/src/sync/mod.rs
+++ b/p2p/src/sync/mod.rs
@@ -17,9 +17,10 @@
 //! to block announcement from peers and the announcement of blocks produced by this node).
 
 mod chainstate_handle;
+mod peer_activity;
 mod peer_common;
 mod peer_v2;
-mod types;
+pub mod sync_status;
 
 use std::collections::HashMap;
 

--- a/p2p/src/sync/peer_activity.rs
+++ b/p2p/src/sync/peer_activity.rs
@@ -30,11 +30,11 @@ impl PeerActivity {
         }
     }
 
-    pub fn expecting_headers_since(&mut self) -> Option<Time> {
+    pub fn expecting_headers_since(&self) -> Option<Time> {
         self.expecting_headers_since
     }
 
-    pub fn expecting_blocks_since(&mut self) -> Option<Time> {
+    pub fn expecting_blocks_since(&self) -> Option<Time> {
         self.expecting_blocks_since
     }
 

--- a/p2p/src/sync/sync_status.rs
+++ b/p2p/src/sync/sync_status.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::primitives::time::Time;
+
+/// Certain information about the current state of block syncing that other parts of p2p
+/// (namely, the peer manager) may be interested in.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PeerBlockSyncStatus {
+    pub expecting_blocks_since: Option<Time>,
+}
+
+impl PeerBlockSyncStatus {
+    pub fn new() -> Self {
+        Self {
+            expecting_blocks_since: None,
+        }
+    }
+}

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -304,7 +304,7 @@ impl TestNodeGroup {
         self.prevent_peer_manager_events = set;
     }
 
-    /// NewTipReceived/NewChainstateTip/NewValidTransactionReceived messages are ignored
+    /// The "informational" messages like NewTipReceived/NewChainstateTip etc are ignored.
     // TODO: Rename the function
     fn assert_no_peer_manager_events_if_needed(&mut self) {
         if self.prevent_peer_manager_events {
@@ -327,7 +327,8 @@ impl TestNodeGroup {
                         }
                         PeerManagerEvent::NewTipReceived { .. }
                         | PeerManagerEvent::NewChainstateTip(_)
-                        | PeerManagerEvent::NewValidTransactionReceived { .. } => {
+                        | PeerManagerEvent::NewValidTransactionReceived { .. }
+                        | PeerManagerEvent::PeerBlockSyncStatusUpdate { .. } => {
                             // Ignored
                         }
                     }


### PR DESCRIPTION
Peers from which a block was requested recently ("recently" meaning within the last 5 seconds) are now treated as if they've sent us a new tip just now; this way, peers can avoid eviction while they are sending us blocks.