### PR TITLE
Bunch of small api-server/node fixes

### DIFF
--- a/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
@@ -344,6 +344,26 @@ impl ApiServerInMemoryStorage {
         Ok(())
     }
 
+    fn reinitialize_storage(
+        &mut self,
+        chain_config: &ChainConfig,
+    ) -> Result<(), ApiServerStorageError> {
+        self.block_table.clear();
+        self.block_aux_data_table.clear();
+        self.address_balance_table.clear();
+        self.address_transactions_table.clear();
+        self.delegation_table.clear();
+        self.main_chain_blocks_table.clear();
+        self.pool_data_table.clear();
+        self.transaction_table.clear();
+        self.utxo_table.clear();
+        self.address_utxos.clear();
+        self.fungible_token_issuances.clear();
+        self.nft_token_issuances.clear();
+
+        self.initialize_storage(chain_config)
+    }
+
     fn del_address_balance_above_height(
         &mut self,
         block_height: BlockHeight,

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
@@ -41,6 +41,13 @@ impl<'t> ApiServerStorageWrite for ApiServerInMemoryStorageTransactionalRw<'t> {
         self.transaction.initialize_storage(chain_config)
     }
 
+    async fn reinitialize_storage(
+        &mut self,
+        chain_config: &ChainConfig,
+    ) -> Result<(), ApiServerStorageError> {
+        self.transaction.reinitialize_storage(chain_config)
+    }
+
     async fn del_address_balance_above_height(
         &mut self,
         block_height: BlockHeight,

--- a/api-server/api-server-common/src/storage/impls/postgres/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/mod.rs
@@ -66,7 +66,7 @@ impl TransactionalApiServerPostgresStorage {
 
         let database_part = match database {
             Some(d) => format!("dbname={}", d),
-            None => "".to_string(),
+            None => format!("dbname=mintlayer-{}", chain_config.chain_type().name()),
         };
 
         let config_str =

--- a/api-server/api-server-common/src/storage/impls/postgres/queries.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/queries.rs
@@ -326,7 +326,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
         Ok(())
     }
 
-    pub async fn create_tables(&mut self) -> Result<(), ApiServerStorageError> {
+    async fn create_tables(&mut self) -> Result<(), ApiServerStorageError> {
         logging::log::info!("Creating database tables");
 
         self.just_execute(
@@ -462,6 +462,28 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
         Ok(())
     }
 
+    async fn drop_tables(&mut self) -> Result<(), ApiServerStorageError> {
+        logging::log::info!("Dropping database tables");
+
+        self.just_execute("DROP TABLE ml_misc_data;").await?;
+        self.just_execute("DROP TABLE ml_genesis;").await?;
+        self.just_execute("DROP TABLE ml_main_chain_blocks;").await?;
+        self.just_execute("DROP TABLE ml_blocks;").await?;
+        self.just_execute("DROP TABLE ml_transactions;").await?;
+        self.just_execute("DROP TABLE ml_address_balance;").await?;
+        self.just_execute("DROP TABLE ml_address_transactions;").await?;
+        self.just_execute("DROP TABLE ml_utxo;").await?;
+        self.just_execute("DROP TABLE ml_block_aux_data;").await?;
+        self.just_execute("DROP TABLE ml_pool_data;").await?;
+        self.just_execute("DROP TABLE ml_delegations;").await?;
+        self.just_execute("DROP TABLE ml_fungible_token;").await?;
+        self.just_execute("DROP TABLE ml_nft_issuance;").await?;
+
+        logging::log::info!("Done dropping database tables");
+
+        Ok(())
+    }
+
     pub async fn initialize_database(
         &mut self,
         chain_config: &ChainConfig,
@@ -488,6 +510,17 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
             )
             .await
             .map_err(|e| ApiServerStorageError::InitializationError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    pub async fn reinitialize_database(
+        &mut self,
+        chain_config: &ChainConfig,
+    ) -> Result<(), ApiServerStorageError> {
+        self.drop_tables().await?;
+
+        self.initialize_database(chain_config).await?;
 
         Ok(())
     }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
@@ -47,6 +47,16 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         Ok(())
     }
 
+    async fn reinitialize_storage(
+        &mut self,
+        chain_config: &ChainConfig,
+    ) -> Result<(), ApiServerStorageError> {
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        conn.reinitialize_database(chain_config).await?;
+
+        Ok(())
+    }
+
     async fn del_address_balance_above_height(
         &mut self,
         block_height: BlockHeight,

--- a/api-server/api-server-common/src/storage/storage_api/mod.rs
+++ b/api-server/api-server-common/src/storage/storage_api/mod.rs
@@ -287,6 +287,11 @@ pub trait ApiServerStorageWrite: ApiServerStorageRead {
         chain_config: &ChainConfig,
     ) -> Result<(), ApiServerStorageError>;
 
+    async fn reinitialize_storage(
+        &mut self,
+        chain_config: &ChainConfig,
+    ) -> Result<(), ApiServerStorageError>;
+
     async fn del_address_balance_above_height(
         &mut self,
         block_height: BlockHeight,

--- a/api-server/storage-test-suite/tests/postgres.rs
+++ b/api-server/storage-test-suite/tests/postgres.rs
@@ -30,6 +30,10 @@ async fn make_postgres_storage(chain_config: Arc<ChainConfig>) -> impl ApiServer
 
     let mut podman = containers::podman::Podman::new("MintlayerPostgresTest", container)
         .with_env("POSTGRES_HOST_AUTH_METHOD", "trust")
+        .with_env(
+            "POSTGRES_DB",
+            format!("mintlayer-{}", chain_config.chain_type().name()).as_str(),
+        )
         .with_port_mapping(None, 5432);
 
     podman.run();

--- a/node-daemon/src/main.rs
+++ b/node-daemon/src/main.rs
@@ -17,8 +17,16 @@ pub async fn run() -> anyhow::Result<()> {
     let opts = node_lib::Options::from_args(std::env::args_os());
     logging::init_logging();
     logging::log::info!("Command line options: {opts:?}");
-    let node = node_lib::setup(opts).await?;
-    node.main().await;
+    let setup_result = node_lib::setup(opts).await?;
+    match setup_result {
+        node_lib::NodeSetupResult::Node(node) => {
+            node.main().await;
+        }
+        node_lib::NodeSetupResult::DataDirCleanedUp => {
+            logging::log::info!("Data directory was cleaned up, please restart the node without `clean-data` argument");
+        }
+    };
+
     Ok(())
 }
 

--- a/node-gui/src/backend/mod.rs
+++ b/node-gui/src/backend/mod.rs
@@ -86,7 +86,14 @@ pub async fn node_initialize(_time_getter: TimeGetter) -> anyhow::Result<Backend
     logging::init_logging();
     logging::log::info!("Command line options: {opts:?}");
 
-    let node = node_lib::setup(opts).await?;
+    let setup_result = node_lib::setup(opts).await?;
+    let node = match setup_result {
+        node_lib::NodeSetupResult::Node(node) => node,
+        node_lib::NodeSetupResult::DataDirCleanedUp => {
+            // TODO: find more friendly way to report the message and shut down GUI
+            anyhow::bail!("Data directory was cleaned up, please restart the node without `clean-data` argument");
+        }
+    };
 
     let controller = node.controller().clone();
 

--- a/node-lib/src/lib.rs
+++ b/node-lib/src/lib.rs
@@ -29,7 +29,7 @@ pub use config_files::{
     NodeConfigFile, NodeTypeConfigFile, RpcConfigFile, StorageBackendConfigFile,
 };
 pub use options::{Command, Options, RunOptions};
-pub use runner::setup;
+pub use runner::{setup, NodeSetupResult};
 
 pub fn default_rpc_config(chain_config: &ChainConfig) -> RpcConfigFile {
     RpcConfigFile::with_run_options(

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -321,6 +321,11 @@ async fn start(
         return Ok(NodeSetupResult::DataDirCleanedUp);
     }
 
+    log::info!(
+        "Starting mintlayer-core version {}",
+        chain_config.software_version()
+    );
+
     log::info!("Starting with the following config:\n {node_config:#?}");
     let (manager, controller) = match initialize(
         chain_config.clone(),

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -51,6 +51,11 @@ use crate::{
 
 const LOCK_FILE_NAME: &str = ".lock";
 
+pub enum NodeSetupResult {
+    Node(Node),
+    DataDirCleanedUp,
+}
+
 pub struct Node {
     manager: subsystem::Manager,
     controller: NodeController,
@@ -223,7 +228,7 @@ async fn initialize(
 }
 
 /// Processes options and potentially runs the node.
-pub async fn setup(options: Options) -> Result<Node> {
+pub async fn setup(options: Options) -> Result<NodeSetupResult> {
     let command = options.command.clone().unwrap_or(Command::Testnet(RunOptions::default()));
     match command {
         Command::Mainnet(ref run_options) => {
@@ -293,7 +298,7 @@ async fn start(
     datadir_path_opt: &Option<PathBuf>,
     run_options: &RunOptions,
     chain_config: ChainConfig,
-) -> Result<Node> {
+) -> Result<NodeSetupResult> {
     if let Some(mock_time) = run_options.mock_time {
         set_mock_time(*chain_config.chain_type(), mock_time)?;
     }
@@ -313,6 +318,7 @@ async fn start(
             &data_dir,
             std::slice::from_ref(&data_dir.join(LOCK_FILE_NAME).as_path()),
         )?;
+        return Ok(NodeSetupResult::DataDirCleanedUp);
     }
 
     log::info!("Starting with the following config:\n {node_config:#?}");
@@ -348,11 +354,11 @@ async fn start(
         },
     };
 
-    Ok(Node {
+    Ok(NodeSetupResult::Node(Node {
         manager,
         controller,
         lock_file,
-    })
+    }))
 }
 
 #[cfg(test)]

--- a/test/src/bin/test_node.rs
+++ b/test/src/bin/test_node.rs
@@ -19,7 +19,13 @@ use std::env;
 async fn main() -> Result<(), node_lib::Error> {
     let opts = node_lib::Options::from_args(env::args_os());
     node_lib::init_logging(&opts);
-    let node = node_lib::setup(opts).await?;
+    let setup_result = node_lib::setup(opts).await?;
+    let node = match setup_result {
+        node_lib::NodeSetupResult::Node(node) => node,
+        node_lib::NodeSetupResult::DataDirCleanedUp => {
+            panic!("Data directory was cleaned up, please restart the node without `clean-data` argument");
+        }
+    };
     node.main().await;
     Ok(())
 }


### PR DESCRIPTION
- if api-server db version mismatch clean up the db
- api-server db should have default "mintlayer-{CHAIN_TYPE}" name
- if node-lib was provided with the `clean-data` argument it should exit after that
- software version should be printed on startup