### PR TITLE
Decommission pool request

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ The logging of mintlayer-core is configured via the `RUST_LOG` environment varia
 Here are the commands as recommended for different scenarios:
 
 For normal operation
-- Node daemon: `RUST_LOG=info cargo run --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
-- CLI Wallet:  `RUST_LOG=info cargo run --bin wallet-cli -- --network testnet 2>&1 | tee ../wallet-cli.log`
-- GUI:         `RUST_LOG=info cargo run --bin node-gui 2>&1 | tee ../node-gui.log`
+- Node daemon: `RUST_LOG=info cargo run --release --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
+- CLI Wallet:  `RUST_LOG=info cargo run --release --bin wallet-cli -- testnet 2>&1 | tee ../wallet-cli.log`
+- GUI:         `RUST_LOG=info cargo run --release --bin node-gui 2>&1 | tee ../node-gui.log`
 
 For heavy debugging operation
 - Node daemon: `RUST_LOG=debug cargo run --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
-- CLI Wallet:  `RUST_LOG=debug cargo run --bin wallet-cli -- --network testnet 2>&1 | tee ../wallet-cli.log`
+- CLI Wallet:  `RUST_LOG=debug cargo run --bin wallet-cli -- testnet 2>&1 | tee ../wallet-cli.log`
 - GUI:         `RUST_LOG=debug cargo run --bin node-gui 2>&1 | tee ../node-gui.log`

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -428,7 +428,7 @@ fn fee_from_decommissioning_stake_pool(#[case] seed: Seed) {
             required_maturity_distance.to_int()..(required_maturity_distance.to_int() * 2),
         );
 
-        let decomission_outputs =
+        let decommission_outputs =
             test_utils::split_value(&mut rng, amount_to_stake.into_atoms() / 2)
                 .into_iter()
                 .map(|value| {
@@ -447,7 +447,7 @@ fn fee_from_decommissioning_stake_pool(#[case] seed: Seed) {
                 TxInput::from_utxo(stake_pool_tx_id.into(), 0),
                 empty_witness(&mut rng),
             )
-            .with_outputs(decomission_outputs)
+            .with_outputs(decommission_outputs)
             .build();
 
         let mut verifier = TransactionVerifier::new(&storage, &chain_config);

--- a/node-gui/src/backend/backend_impl.rs
+++ b/node-gui/src/backend/backend_impl.rs
@@ -408,11 +408,21 @@ impl Backend {
         let amount = parse_coin_amount(&self.chain_config, &amount)
             .ok_or(BackendError::InvalidAmount(amount))?;
 
+        // TODO: decommission address should be passed here as an argument
+        let (_, decommission_addr) = self
+            .synced_wallet_controller(wallet_id, account_id.account_index())
+            .await?
+            .new_address()
+            .map_err(|e| BackendError::WalletError(e.to_string()))?;
+        let decommission_key = decommission_addr
+            .decode_object(&self.chain_config)
+            .map_err(|e| BackendError::AddressError(e.to_string()))?;
+
         self.synced_wallet_controller(wallet_id, account_id.account_index())
             .await?
             .create_stake_pool_tx(
                 amount,
-                None,
+                decommission_key,
                 // TODO: get value from gui
                 PerThousand::new(10).expect("Must not fail"),
                 Amount::ZERO,

--- a/node-gui/src/backend/error.rs
+++ b/node-gui/src/backend/error.rs
@@ -29,4 +29,10 @@ pub enum BackendError {
     AddressError(String),
     #[error("Invalid amount: {0}")]
     InvalidAmount(String),
+    #[error("Invalid pledge amount: {0}")]
+    InvalidPledgeAmount(String),
+    #[error("Invalid cost per block amount: {0}")]
+    InvalidCostPerBlockAmount(String),
+    #[error("Failed to parse margin per thousand: {0}. The decimal must be in the range [0.001,1.000] or [0.1%,100%]")]
+    InvalidMarginPerThousand(String),
 }

--- a/node-gui/src/backend/messages.rs
+++ b/node-gui/src/backend/messages.rs
@@ -94,7 +94,10 @@ pub struct SendRequest {
 pub struct StakeRequest {
     pub wallet_id: WalletId,
     pub account_id: AccountId,
-    pub amount: String,
+    pub pledge_amount: String,
+    pub mpt: String,
+    pub cost_per_block: String,
+    pub decommission_address: String,
 }
 
 #[derive(Debug, Clone)]

--- a/node-gui/src/main_window/main_widget/tabs/wallet/mod.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/mod.rs
@@ -71,6 +71,9 @@ pub enum WalletMessage {
     SendSucceed,
 
     StakeAmountEdit(String),
+    MarginPerThousandEdit(String),
+    CostPerBlockEdit(String),
+    DecommissionAddressEdit(String),
     CreateStakingPool,
     CreateStakingPoolSucceed,
 
@@ -88,6 +91,9 @@ pub struct AccountState {
     send_amount: String,
     send_address: String,
     stake_amount: String,
+    margin_per_thousand: String,
+    cost_per_block_amount: String,
+    decommission_address: String,
 }
 
 pub struct WalletTab {
@@ -197,17 +203,36 @@ impl WalletTab {
                 self.account_state.stake_amount = value;
                 Command::none()
             }
+            WalletMessage::MarginPerThousandEdit(value) => {
+                self.account_state.margin_per_thousand = value;
+                Command::none()
+            }
+            WalletMessage::CostPerBlockEdit(value) => {
+                self.account_state.cost_per_block_amount = value;
+                Command::none()
+            }
+            WalletMessage::DecommissionAddressEdit(value) => {
+                self.account_state.decommission_address = value;
+                Command::none()
+            }
+
             WalletMessage::CreateStakingPool => {
                 let request = StakeRequest {
                     wallet_id: self.wallet_id,
                     account_id: self.selected_account,
-                    amount: self.account_state.stake_amount.clone(),
+                    pledge_amount: self.account_state.stake_amount.clone(),
+                    mpt: self.account_state.margin_per_thousand.clone(),
+                    cost_per_block: self.account_state.cost_per_block_amount.clone(),
+                    decommission_address: self.account_state.decommission_address.clone(),
                 };
                 backend_sender.send(BackendRequest::StakeAmount(request));
                 Command::none()
             }
             WalletMessage::CreateStakingPoolSucceed => {
                 self.account_state.stake_amount.clear();
+                self.account_state.margin_per_thousand.clear();
+                self.account_state.cost_per_block_amount.clear();
+                self.account_state.decommission_address.clear();
                 Command::none()
             }
             WalletMessage::ToggleStaking(enabled) => {
@@ -290,6 +315,9 @@ impl Tab for WalletTab {
                             &node_state.chain_config,
                             account,
                             &self.account_state.stake_amount,
+                            &self.account_state.margin_per_thousand,
+                            &self.account_state.cost_per_block_amount,
+                            &self.account_state.decommission_address,
                             still_syncing.clone(),
                         ),
                     };

--- a/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
@@ -28,6 +28,9 @@ pub fn view_stake(
     chain_config: &ChainConfig,
     account: &AccountInfo,
     stake_amount: &str,
+    mpt: &str,
+    cost_per_block: &str,
+    decommission_key: &str,
     still_syncing: Option<WalletMessage>,
 ) -> Element<'static, WalletMessage> {
     let field = |text: String| container(Text::new(text)).padding(5);
@@ -73,14 +76,24 @@ pub fn view_stake(
     };
 
     column![
-        row![
-            text_input("Pledge amount for the new staking pool", stake_amount)
-                .on_input(|value| { WalletMessage::StakeAmountEdit(value) })
-                .padding(15),
-            iced::widget::button(Text::new("Create staking pool"))
-                .padding(15)
-                .on_press(still_syncing.unwrap_or(WalletMessage::CreateStakingPool))
-        ],
+        text_input("Pledge amount for the new staking pool", stake_amount)
+            .on_input(|value| { WalletMessage::StakeAmountEdit(value) })
+            .padding(15),
+        text_input("Cost per block", cost_per_block)
+            .on_input(|value| { WalletMessage::CostPerBlockEdit(value) })
+            .padding(15),
+        text_input("Margin ratio per thousand. The decimal must be in the range [0.001,1.000] or [0.1%,100%]", mpt)
+            .on_input(|value| { WalletMessage::MarginPerThousandEdit(value) })
+            .padding(15),
+        text_input(
+            "Decommission address",
+            decommission_key
+        )
+        .on_input(|value| { WalletMessage::DecommissionAddressEdit(value) })
+        .padding(15),
+        iced::widget::button(Text::new("Create staking pool"))
+            .padding(15)
+            .on_press(still_syncing.unwrap_or(WalletMessage::CreateStakingPool)),
         staking_enabled_row.spacing(10).align_items(Alignment::Center),
         iced::widget::horizontal_rule(10),
         staking_balance_grid,

--- a/test/functional/test_framework/mintlayer.py
+++ b/test/functional/test_framework/mintlayer.py
@@ -28,7 +28,6 @@ block_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('BlockV1'
 outpoint_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('OutPoint')
 signed_tx_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('SignedTransaction')
 vec_output_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('Vec<TxOutput>')
-destination_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('Destination')
 
 
 def mintlayer_hash(data):
@@ -161,14 +160,3 @@ def make_delegation_id(outpoint):
 
     # Truncate output to match Rust's split()
     return hex_to_dec_array(blake2b_hasher.hexdigest()[:64])
-
-def destination_from_pub_key(pub_key_bytes):
-    return {
-        "PublicKey": {
-            "key": {
-                "Secp256k1Schnorr": {
-                    "pubkey_data": hex_to_dec_array(pub_key_bytes.hex()),
-                },
-            },
-        }
-    }

--- a/test/functional/test_framework/mintlayer.py
+++ b/test/functional/test_framework/mintlayer.py
@@ -28,6 +28,7 @@ block_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('BlockV1'
 outpoint_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('OutPoint')
 signed_tx_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('SignedTransaction')
 vec_output_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('Vec<TxOutput>')
+destination_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('Destination')
 
 
 def mintlayer_hash(data):
@@ -160,3 +161,14 @@ def make_delegation_id(outpoint):
 
     # Truncate output to match Rust's split()
     return hex_to_dec_array(blake2b_hasher.hexdigest()[:64])
+
+def destination_from_pub_key(pub_key_bytes):
+    return {
+        "PublicKey": {
+            "key": {
+                "Secp256k1Schnorr": {
+                    "pubkey_data": hex_to_dec_array(pub_key_bytes.hex()),
+                },
+            },
+        }
+    }

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -238,8 +238,8 @@ class WalletCliController:
                                 amount: int,
                                 cost_per_block: int,
                                 margin_ratio_per_thousand: float,
-                                decommission_key: Optional[str] = '') -> str:
-        return await self._write_command(f"staking-create-pool {amount} {cost_per_block} {margin_ratio_per_thousand} {decommission_key}\n")
+                                decommission_addr: Optional[str] = '') -> str:
+        return await self._write_command(f"staking-create-pool {amount} {cost_per_block} {margin_ratio_per_thousand} {decommission_addr}\n")
 
     async def decommission_stake_pool(self, pool_id: str) -> str:
         return await self._write_command(f"staking-decommission-pool {pool_id}\n")

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -240,6 +240,15 @@ class WalletCliController:
     async def decommission_stake_pool(self, pool_id: str) -> str:
         return await self._write_command(f"staking-decommission-pool {pool_id}\n")
 
+    async def decommission_stake_pool_request(self, pool_id: str) -> str:
+        return await self._write_command(f"staking-decommission-pool-request {pool_id}\n")
+
+    async def sign_raw_transaction(self, transaction: str) -> str:
+        return await self._write_command(f"node-sign-raw-transaction {transaction}\n")
+
+    async def submit_transaction(self, transaction: str) -> str:
+        return await self._write_command(f"node-submit-transaction {transaction}\n")
+
     async def list_pool_ids(self) -> List[PoolData]:
         output = await self._write_command("staking-list-pool-ids\n")
         pattern = r'Pool Id: ([a-zA-Z0-9]+), Balance: (\d+),'

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -106,9 +106,13 @@ class WalletCliController:
         await self.process.stdin.drain()
         return await self._read_available_output()
 
-    async def create_wallet(self) -> str:
-        wallet_file = os.path.join(self.node.datadir, "wallet")
+    async def create_wallet(self, name: str = "wallet") -> str:
+        wallet_file = os.path.join(self.node.datadir, name)
         return await self._write_command(f"wallet-create {wallet_file} store-seed-phrase\n")
+
+    async def open_wallet(self, name: str) -> str:
+        wallet_file = os.path.join(self.node.datadir, name)
+        return await self._write_command(f"wallet-open {wallet_file}\n")
 
     async def recover_wallet(self, mnemonic: str) -> str:
         wallet_file = os.path.join(self.node.datadir, "recovered_wallet")
@@ -244,7 +248,7 @@ class WalletCliController:
         return await self._write_command(f"staking-decommission-pool-request {pool_id}\n")
 
     async def sign_raw_transaction(self, transaction: str) -> str:
-        return await self._write_command(f"node-sign-raw-transaction {transaction}\n")
+        return await self._write_command(f"account-sign-raw-transaction {transaction}\n")
 
     async def submit_transaction(self, transaction: str) -> str:
         return await self._write_command(f"node-submit-transaction {transaction}\n")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -142,6 +142,7 @@ BASE_SCRIPTS = [
     'wallet_nfts.py',
     'wallet_delegations.py',
     'wallet_delegations_rpc.py',
+    'wallet_decommission_request.py',
     'wallet_high_fee.py',
     'wallet_generate_addresses.py',
     'wallet_set_lookahead_size.py',

--- a/test/functional/wallet_decommission_request.py
+++ b/test/functional/wallet_decommission_request.py
@@ -34,15 +34,12 @@ from test_framework.mintlayer import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mintlayer import (make_tx, reward_input)
 from test_framework.util import assert_equal, assert_in
-from test_framework.mintlayer import block_input_data_obj
+from test_framework.mintlayer import block_input_data_obj, destination_obj, destination_from_pub_key
 from test_framework.wallet_cli_controller import DEFAULT_ACCOUNT_INDEX, WalletCliController
 
-import scalecodec
 import asyncio
 import sys
 import time
-
-pub_key_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('PublicKey')
 
 GENESIS_POOL_ID = "123c4c600097c513e088b9be62069f0c74c7671c523c8e3469a1c3f14b7ea2c4"
 GENESIS_STAKE_PRIVATE_KEY = "8717e6946febd3a33ccdc3f3a27629ec80c33461c33a0fc56b4836fcedd26638"
@@ -159,6 +156,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
                 },
             },
         }
+
     def run_test(self):
         if 'win32' in sys.platform:
             asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
@@ -245,7 +243,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             await wallet.create_wallet("cold_wallet")
 
             decommission_pub_key_bytes = await wallet.new_public_key()
-            decommission_pub_key_encoded = pub_key_obj.encode(self.public_key(decommission_pub_key_bytes.hex())).to_hex()[2:]
+            decommission_pub_key_encoded = destination_obj.encode(destination_from_pub_key(decommission_pub_key_bytes)).to_hex()[2:]
 
         decommission_req = ""
 

--- a/test/functional/wallet_decommission_request.py
+++ b/test/functional/wallet_decommission_request.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Wallet decommission request test
+
+Check that:
+* We can create a new wallet,
+* create 2 accounts
+* generate decommission keys from account1
+* create a stake pool from account0 and provide decommission keys from account1
+* create a decommission request from account0
+* sign decommission request from account1 and submit a tx with it
+* check that the pool was decommissioned
+"""
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.mintlayer import (
+    block_input_data_obj,
+    ATOMS_PER_COIN,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.mintlayer import (make_tx, reward_input)
+from test_framework.util import assert_equal, assert_in
+from test_framework.mintlayer import block_input_data_obj
+from test_framework.wallet_cli_controller import DEFAULT_ACCOUNT_INDEX, WalletCliController
+
+import scalecodec
+import asyncio
+import sys
+import time
+
+pub_key_obj = scalecodec.base.RuntimeConfiguration().create_scale_object('PublicKey')
+
+GENESIS_POOL_ID = "123c4c600097c513e088b9be62069f0c74c7671c523c8e3469a1c3f14b7ea2c4"
+GENESIS_STAKE_PRIVATE_KEY = "8717e6946febd3a33ccdc3f3a27629ec80c33461c33a0fc56b4836fcedd26638"
+GENESIS_STAKE_PUBLIC_KEY = "03c53526caf73cd990148e127cb57249a5e266d78df23968642c976a532197fdaa"
+GENESIS_VRF_PUBLIC_KEY = "fa2f59dc7a7e176058e4f2d155cfa03ee007340e0285447892158823d332f744"
+
+GENESIS_VRF_PRIVATE_KEY = (
+    "3fcf7b813bec2a293f574b842988895278b396dd72471de2583b242097a59f06"
+    "e9f3cd7b78d45750afd17292031373fddb5e7a8090db51221038f5e05f29998e"
+)
+
+GENESIS_POOL_ID_ADDR = "rpool1zg7yccqqjlz38cyghxlxyp5lp36vwecu2g7gudrf58plzjm75tzq99fr6v"
+
+class WalletSubmitTransaction(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[
+            "--chain-pos-netupgrades=true",
+            "--blockprod-min-peers-to-produce-blocks=0",
+        ]]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.sync_all(self.nodes[0:1])
+
+    def assert_chain(self, block, previous_tip):
+        assert_equal(block["header"]["header"]["prev_block_id"][2:], previous_tip)
+
+    def assert_height(self, expected_height, expected_block):
+        block_id = self.nodes[0].chainstate_block_id_at_height(expected_height)
+        block = self.nodes[0].chainstate_get_block(block_id)
+        assert_equal(block, expected_block)
+
+    def assert_pos_consensus(self, block):
+        if block["header"]["header"]["consensus_data"].get("PoS") is None:
+            raise AssertionError("Block {} was not PoS".format(block))
+
+    def assert_tip(self, expected_block):
+        tip = self.nodes[0].chainstate_best_block_id()
+        block = self.nodes[0].chainstate_get_block(tip)
+        assert_equal(block, expected_block)
+
+    def block_height(self, n):
+        tip = self.nodes[n].chainstate_best_block_id()
+        return self.nodes[n].chainstate_block_height_in_main_chain(tip)
+
+    def generate_block(self, expected_height, block_input_data, transactions):
+        previous_block_id = self.nodes[0].chainstate_best_block_id()
+
+        fill_mode = 'LeaveEmptySpace'
+        # Block production may fail if the Job Manager found a new tip, so try and sleep
+        for _ in range(5):
+            try:
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], fill_mode)
+                break
+            except JSONRPCException:
+                block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], fill_mode)
+                time.sleep(1)
+
+        block_hex_array = bytearray.fromhex(block_hex)
+        # block = ScaleDecoder.get_decoder_class('BlockV1', ScaleBytes(block_hex_array)).decode()
+
+        self.nodes[0].chainstate_submit_block(block_hex)
+
+        self.assert_tip(block_hex)
+        self.assert_height(expected_height, block_hex)
+        # self.assert_pos_consensus(block)
+        # self.assert_chain(block, previous_block_id)
+
+    def genesis_pool_id(self):
+        return self.hex_to_dec_array(GENESIS_POOL_ID)
+
+    def hex_to_dec_array(self, hex_string):
+        return [int(hex_string[i:i+2], 16) for i in range(0, len(hex_string), 2)]
+
+    def previous_block_id(self):
+        previous_block_id = self.nodes[0].chainstate_best_block_id()
+        return self.hex_to_dec_array(previous_block_id)
+
+    def private_key(self, stake_private_key):
+        return {
+            "key": {
+                "Secp256k1Schnorr": {
+                    "data": self.hex_to_dec_array(stake_private_key),
+                },
+            },
+        }
+
+    def public_key(self, stake_public_key):
+        return {
+            "key": {
+                "Secp256k1Schnorr": {
+                    "pubkey_data": self.hex_to_dec_array(stake_public_key),
+                },
+            },
+        }
+
+    def vrf_private_key(self, vrf_private_key):
+        return {
+            "key": {
+                "Schnorrkel": {
+                    "key": self.hex_to_dec_array(vrf_private_key),
+                },
+            },
+        }
+
+    def vrf_public_key(self, vrf_public_key):
+        return {
+            "key": {
+                "Schnorrkel": {
+                    "key": self.hex_to_dec_array(vrf_public_key),
+                },
+            },
+        }
+    def run_test(self):
+        if 'win32' in sys.platform:
+            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+        asyncio.run(self.async_test())
+
+    def setup_pool_and_transfer(self, transactions):
+        block_input_data = block_input_data_obj.encode({
+            "PoS": {
+                "stake_private_key": self.private_key(GENESIS_STAKE_PRIVATE_KEY),
+                "vrf_private_key": self.vrf_private_key(GENESIS_VRF_PRIVATE_KEY),
+                "pool_id": self.genesis_pool_id(),
+                "kernel_inputs": [
+                        {
+                            "Utxo": {
+                                "id": {
+                                    "BlockReward": self.previous_block_id()
+                                },
+                                "index": 1,
+                            },
+                        },
+                ],
+                 "kernel_input_utxo": [
+                    {
+                        "CreateStakePool": [
+                            self.genesis_pool_id(),
+                            {
+                                "value": 40_000*ATOMS_PER_COIN,
+                                "staker": {
+                                    "PublicKey": self.public_key(GENESIS_STAKE_PUBLIC_KEY),
+                                },
+                                "vrf_public_key": self.vrf_public_key(GENESIS_VRF_PUBLIC_KEY),
+                                "decommission_key": {
+                                    "PublicKey": self.public_key(GENESIS_STAKE_PUBLIC_KEY),
+                                },
+                                "margin_ratio_per_thousand": 1000,
+                                "cost_per_block" : "0"
+                            },
+                        ],
+                    }
+                ],
+            }
+        }).to_hex()[2:]
+
+        self.generate_block(1, block_input_data, transactions)
+
+    def gen_pos_block(self, transactions, block_height, block_id=None):
+        block_id = self.previous_block_id() if block_id is None else block_id
+        block_input_data = block_input_data_obj.encode({
+            "PoS": {
+                "stake_private_key": self.private_key(GENESIS_STAKE_PRIVATE_KEY),
+                "vrf_private_key": self.vrf_private_key(GENESIS_VRF_PRIVATE_KEY),
+                "pool_id": self.genesis_pool_id(),
+                "kernel_inputs": [
+                        {
+                            "Utxo": {
+                                "id": {
+                                    "BlockReward": block_id
+                                },
+                                "index": 0,
+                            },
+                        },
+                ],
+                 "kernel_input_utxo": [
+                    {
+                        "ProduceBlockFromStake": [
+                            {
+                                "PublicKey": self.public_key(GENESIS_STAKE_PUBLIC_KEY),
+                            },
+                            self.genesis_pool_id(),
+                        ],
+                    }
+                ],
+            }
+        }).to_hex()[2:]
+
+        self.generate_block(block_height, block_input_data, transactions)
+
+    async def async_test(self):
+        node = self.nodes[0]
+        async with WalletCliController(node, self.config, self.log, chain_config_args=["--chain-pos-netupgrades", "true"]) as wallet:
+            # new hot wallet
+            await wallet.create_wallet()
+
+            # check it is on genesis
+            best_block_height = await wallet.get_best_block_height()
+            self.log.info(f"best block height = {best_block_height}")
+            assert_equal(best_block_height, '0')
+
+            # new address
+            pub_key_bytes = await wallet.new_public_key()
+            assert_equal(len(pub_key_bytes), 33)
+
+            # Get chain tip
+            tip_id = node.chainstate_best_block_id()
+            self.log.debug(f'Tip: {tip_id}')
+
+            # Submit a valid transaction
+            output = {
+                    'Transfer': [ { 'Coin': 50_000 * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+            }
+            encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
+            self.log.debug(f"Encoded transaction {tx_id}: {encoded_tx}")
+
+
+            self.setup_pool_and_transfer([encoded_tx])
+
+            # sync the wallet
+            assert_in("Success", await wallet.sync())
+
+            # check wallet best block if it is synced
+            best_block_height = await wallet.get_best_block_height()
+            assert_in(best_block_height, '1')
+
+            balance = await wallet.get_balance()
+            assert_in("Coins amount: 50000", balance)
+
+            # create new account that would hold decommission key
+            assert_in("Success", await wallet.create_new_account())
+            assert_in("Success", await wallet.select_account(1))
+            acc1_address = await wallet.new_address()
+            decommission_pub_key_bytes = await wallet.new_public_key()
+            decommission_pub_key_encoded  = pub_key_obj.encode(self.public_key(decommission_pub_key_bytes.hex())).to_hex()[2:]
+
+            assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
+            assert_in("The transaction was submitted successfully", await wallet.send_to_address(acc1_address, 100))
+            assert_in("Success", await wallet.select_account(1))
+            transactions = node.mempool_transactions()
+
+            assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
+
+            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(40000, 0, 0.5, decommission_pub_key_encoded))
+            transactions2 = node.mempool_transactions()
+            for tx in transactions2:
+                if tx not in transactions:
+                    transactions.append(tx)
+
+            self.gen_pos_block(transactions, 2)
+            assert_in("Success", await wallet.sync())
+
+            pools = await wallet.list_pool_ids()
+            assert_equal(len(pools), 1)
+            assert_equal(pools[0].balance, 40000)
+
+            # create decommission request
+            decommission_req_output = await wallet.decommission_stake_pool_request(pools[0].pool_id)
+            decommission_req = decommission_req_output.split('\n')[1]
+
+            # switch accounts and sign decommission request
+            assert_in("Success", await wallet.select_account(1))
+            decommission_signed_tx_output = await wallet.sign_raw_transaction(decommission_req)
+            decommission_signed_tx = decommission_signed_tx_output.split('\n')[1]
+            assert_in("The transaction was submitted successfully", await wallet.submit_transaction(decommission_signed_tx))
+
+            self.gen_pos_block(node.mempool_transactions(), 3)
+            assert_in("Success", await wallet.sync())
+
+            pools = await wallet.list_pool_ids()
+            assert_equal(len(pools), 0)
+
+
+if __name__ == '__main__':
+    WalletSubmitTransaction().main()

--- a/test/functional/wallet_decommission_request.py
+++ b/test/functional/wallet_decommission_request.py
@@ -298,7 +298,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
             # create decommission request
             decommission_req_output = await wallet.decommission_stake_pool_request(pools[0].pool_id)
-            decommission_req = decommission_req_output.split('\n')[1]
+            decommission_req = decommission_req_output.split('\n')[2]
 
             # try to sign decommission request from hot wallet
             assert_in("Wallet error: Wallet error: Input cannot be signed",
@@ -313,7 +313,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
             # sign decommission request
             decommission_signed_tx_output = await wallet.sign_raw_transaction(decommission_req)
-            decommission_signed_tx = decommission_signed_tx_output.split('\n')[1]
+            decommission_signed_tx = decommission_signed_tx_output.split('\n')[2]
 
         async with WalletCliController(node, self.config, self.log, chain_config_args=["--chain-pos-netupgrades", "true"]) as wallet:
             # open hot wallet

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -43,7 +43,7 @@ from scalecodec.base import ScaleBytes
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mintlayer import (make_tx, reward_input)
 from test_framework.util import assert_equal, assert_greater_than, assert_in
-from test_framework.mintlayer import mintlayer_hash, block_input_data_obj, destination_obj, destination_from_pub_key
+from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
 from test_framework.wallet_cli_controller import DEFAULT_ACCOUNT_INDEX, WalletCliController
 
 import asyncio
@@ -324,9 +324,6 @@ class WalletDelegationsCLI(BitcoinTestFramework):
             balance = await wallet.get_balance()
             assert_in("Coins amount: 50000", balance)
 
-            decommission_pub_key_bytes = await wallet.new_public_key()
-            decommission_pub_key_encoded = destination_obj.encode(destination_from_pub_key(decommission_pub_key_bytes)).to_hex()[2:]
-
             assert_in("Success", await wallet.create_new_account())
             assert_in("Success", await wallet.select_account(1))
             acc1_address = await wallet.new_address()
@@ -336,7 +333,8 @@ class WalletDelegationsCLI(BitcoinTestFramework):
             transactions = node.mempool_transactions()
 
             assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
-            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(40000, 0, 0.5, decommission_pub_key_encoded))
+            decommission_address = await wallet.new_address()
+            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(40000, 0, 0.5, decommission_address))
             transactions2 = node.mempool_transactions()
             for tx in transactions2:
                 if tx not in transactions:

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -43,7 +43,7 @@ from scalecodec.base import ScaleBytes
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.mintlayer import (make_tx, reward_input)
 from test_framework.util import assert_equal, assert_greater_than, assert_in
-from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
+from test_framework.mintlayer import mintlayer_hash, block_input_data_obj, destination_obj, destination_from_pub_key
 from test_framework.wallet_cli_controller import DEFAULT_ACCOUNT_INDEX, WalletCliController
 
 import asyncio
@@ -207,6 +207,7 @@ class WalletDelegationsCLI(BitcoinTestFramework):
                 },
             },
         }
+
     def run_test(self):
         if 'win32' in sys.platform:
             asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
@@ -323,6 +324,9 @@ class WalletDelegationsCLI(BitcoinTestFramework):
             balance = await wallet.get_balance()
             assert_in("Coins amount: 50000", balance)
 
+            decommission_pub_key_bytes = await wallet.new_public_key()
+            decommission_pub_key_encoded = destination_obj.encode(destination_from_pub_key(decommission_pub_key_bytes)).to_hex()[2:]
+
             assert_in("Success", await wallet.create_new_account())
             assert_in("Success", await wallet.select_account(1))
             acc1_address = await wallet.new_address()
@@ -332,7 +336,7 @@ class WalletDelegationsCLI(BitcoinTestFramework):
             transactions = node.mempool_transactions()
 
             assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
-            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(40000, 0, 0.5))
+            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(40000, 0, 0.5, decommission_pub_key_encoded))
             transactions2 = node.mempool_transactions()
             for tx in transactions2:
                 if tx not in transactions:

--- a/test/functional/wallet_get_address_usage.py
+++ b/test/functional/wallet_get_address_usage.py
@@ -25,9 +25,9 @@ Check that:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mintlayer import (ATOMS_PER_COIN, make_tx, reward_input, tx_input)
+from test_framework.mintlayer import (ATOMS_PER_COIN, make_tx, reward_input, destination_from_pub_key)
 from test_framework.util import assert_in, assert_equal
-from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
+from test_framework.mintlayer import block_input_data_obj, destination_obj
 from test_framework.wallet_cli_controller import WalletCliController
 
 import asyncio
@@ -62,6 +62,7 @@ class WalletGetAddressUsage(BitcoinTestFramework):
         self.wait_until(lambda: node.mempool_local_best_block_id() == block_id, timeout = 5)
 
         return block_id
+
 
     def run_test(self):
         if 'win32' in sys.platform:
@@ -134,14 +135,17 @@ class WalletGetAddressUsage(BitcoinTestFramework):
             for (line, expected_line) in zip(output.split(), expected_output.split()):
                 assert_equal(line, expected_line)
 
+            decommission_pub_key_bytes = await wallet.new_public_key()
+            decommission_pub_key_encoded = destination_obj.encode(destination_from_pub_key(decommission_pub_key_bytes)).to_hex()[2:]
+
             for _ in range(100):
-                assert_in("Not enough funds", await wallet.create_stake_pool(stake_pool_amount + 1, 0, 0.5))
+                assert_in("Not enough funds", await wallet.create_stake_pool(stake_pool_amount + 1, 0, 0.5, decommission_pub_key_encoded))
 
             output = await wallet.get_addresses_usage()
             for (line, expected_line) in zip(output.split(), expected_output.split()):
                 assert_equal(line, expected_line)
 
-            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(stake_pool_amount, 0, 0.5))
+            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(stake_pool_amount, 0, 0.5, decommission_pub_key_encoded))
 
             expected_output = """+-------+----------------------------------------------+--------------------------------+
 | Index | Address                                      | Is used in transaction history |

--- a/test/functional/wallet_get_address_usage.py
+++ b/test/functional/wallet_get_address_usage.py
@@ -25,9 +25,9 @@ Check that:
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mintlayer import (ATOMS_PER_COIN, make_tx, reward_input, destination_from_pub_key)
+from test_framework.mintlayer import (ATOMS_PER_COIN, make_tx, reward_input)
 from test_framework.util import assert_in, assert_equal
-from test_framework.mintlayer import block_input_data_obj, destination_obj
+from test_framework.mintlayer import block_input_data_obj
 from test_framework.wallet_cli_controller import WalletCliController
 
 import asyncio
@@ -135,17 +135,16 @@ class WalletGetAddressUsage(BitcoinTestFramework):
             for (line, expected_line) in zip(output.split(), expected_output.split()):
                 assert_equal(line, expected_line)
 
-            decommission_pub_key_bytes = await wallet.new_public_key()
-            decommission_pub_key_encoded = destination_obj.encode(destination_from_pub_key(decommission_pub_key_bytes)).to_hex()[2:]
+            decommission_address = await wallet.new_address()
 
             for _ in range(100):
-                assert_in("Not enough funds", await wallet.create_stake_pool(stake_pool_amount + 1, 0, 0.5, decommission_pub_key_encoded))
+                assert_in("Not enough funds", await wallet.create_stake_pool(stake_pool_amount + 1, 0, 0.5, decommission_address))
 
             output = await wallet.get_addresses_usage()
             for (line, expected_line) in zip(output.split(), expected_output.split()):
                 assert_equal(line, expected_line)
 
-            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(stake_pool_amount, 0, 0.5, decommission_pub_key_encoded))
+            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(stake_pool_amount, 0, 0.5, decommission_address))
 
             expected_output = """+-------+----------------------------------------------+--------------------------------+
 | Index | Address                                      | Is used in transaction history |

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -100,6 +100,14 @@ impl PartiallySignedTransaction {
         Self { tx, witnesses }
     }
 
+    pub fn count_inputs(&self) -> usize {
+        self.tx.inputs().len()
+    }
+
+    pub fn count_completed_signatures(&self) -> usize {
+        self.witnesses.iter().filter(|w| w.is_some()).count()
+    }
+
     pub fn is_fully_signed(&self) -> bool {
         self.witnesses.iter().all(|w| w.is_some())
     }

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -125,7 +125,7 @@ pub fn make_address_output_from_delegation(
     ))
 }
 
-pub fn make_decomission_stake_pool_output(
+pub fn make_decommission_stake_pool_output(
     chain_config: &ChainConfig,
     destination: Destination,
     amount: Amount,
@@ -276,7 +276,7 @@ impl SendRequest {
     }
 }
 
-pub fn get_tx_output_destination(txo: &TxOutput) -> Option<&Destination> {
+pub fn get_reward_output_destination(txo: &TxOutput) -> Option<&Destination> {
     match txo {
         TxOutput::Transfer(_, d)
         | TxOutput::LockThenTransfer(_, d, _)
@@ -284,6 +284,21 @@ pub fn get_tx_output_destination(txo: &TxOutput) -> Option<&Destination> {
         | TxOutput::IssueNft(_, _, d)
         | TxOutput::ProduceBlockFromStake(d, _) => Some(d),
         TxOutput::CreateStakePool(_, data) => Some(data.staker()),
+        TxOutput::IssueFungibleToken(_)
+        | TxOutput::Burn(_)
+        | TxOutput::DelegateStaking(_, _)
+        | TxOutput::DataDeposit(_) => None,
+    }
+}
+
+pub fn get_tx_output_destination(txo: &TxOutput) -> Option<&Destination> {
+    match txo {
+        TxOutput::Transfer(_, d)
+        | TxOutput::LockThenTransfer(_, d, _)
+        | TxOutput::CreateDelegationId(d, _)
+        | TxOutput::IssueNft(_, _, d)
+        | TxOutput::ProduceBlockFromStake(d, _) => Some(d),
+        TxOutput::CreateStakePool(_, data) => Some(data.decommission_key()),
         TxOutput::IssueFungibleToken(_)
         | TxOutput::Burn(_)
         | TxOutput::DelegateStaking(_, _)

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -23,7 +23,6 @@ use common::chain::{
 };
 use common::primitives::per_thousand::PerThousand;
 use common::primitives::{Amount, BlockHeight};
-use crypto::key::PublicKey;
 use crypto::vrf::VRFPublicKey;
 use utils::ensure;
 
@@ -146,27 +145,24 @@ pub struct StakePoolDataArguments {
     pub amount: Amount,
     pub margin_ratio_per_thousand: PerThousand,
     pub cost_per_block: Amount,
+    pub decommission_key: Destination,
 }
 
 pub fn make_stake_output(
     pool_id: PoolId,
     arguments: StakePoolDataArguments,
-    staker: PublicKey,
-    decommission_key: PublicKey,
+    staker: Destination,
     vrf_public_key: VRFPublicKey,
-) -> WalletResult<TxOutput> {
-    let staker = Destination::PublicKey(staker);
-    let decommission_key = Destination::PublicKey(decommission_key);
-
+) -> TxOutput {
     let stake_data = StakePoolData::new(
         arguments.amount,
         staker,
         vrf_public_key,
-        decommission_key,
+        arguments.decommission_key,
         arguments.margin_ratio_per_thousand,
         arguments.cost_per_block,
     );
-    Ok(TxOutput::CreateStakePool(pool_id, stake_data.into()))
+    TxOutput::CreateStakePool(pool_id, stake_data.into())
 }
 
 pub fn make_data_deposit_output(

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1214,7 +1214,7 @@ impl<B: storage::Backend> Wallet<B> {
         &mut self,
         account_index: U31,
         tx: PartiallySignedTransaction,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<PartiallySignedTransaction> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
             account.sign_raw_transaction(tx, db_tx)
         })

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -183,11 +183,11 @@ pub enum WalletError {
     ReducedLookaheadSize(u32, u32),
     #[error("Wallet file {0} error: {1}")]
     WalletFileError(PathBuf, String),
-    #[error("Missing inputs signatures in a tx")]
-    InputsSignatureAreMissing,
-    #[error("Cannot use partially signed transaction in a decommission command")]
+    #[error("Failed to completely sign the decommission transaction. \
+            This wallet does not seem to have the decommission key. \
+            Consider using a decommission-request, and passing it to the wallet that has the decommission key")]
     PartiallySignedTransactionInDecommissionCommand,
-    #[error("Cannot use fully signed transaction in a decommission request")]
+    #[error("Failed to create decommission request as all the signatures are present. Use staking-decommission-pool command.")]
     FullySignedTransactionInDecommissionReq,
     #[error("Input cannot be signed")]
     InputCannotBeSigned,

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -189,6 +189,10 @@ pub enum WalletError {
     PartiallySignedTransactionInDecommissionCommand,
     #[error("Cannot use fully signed transaction in a decommission request")]
     FullySignedTransactionInDecommissionReq,
+    #[error("Input cannot be signed")]
+    InputCannotBeSigned,
+    #[error("Failed to convert partially signed tx to signed")]
+    FailedToConvertPartiallySignedTx(PartiallySignedTransaction),
 }
 
 /// Result type used for the wallet
@@ -1205,6 +1209,16 @@ impl<B: storage::Backend> Wallet<B> {
     ) -> WalletResult<PartiallySignedTransaction> {
         self.for_account_rw_unlocked(account_index, |account, db_tx| {
             account.decommission_stake_pool_request(db_tx, pool_id, pool_balance, current_fee_rate)
+        })
+    }
+
+    pub fn sign_raw_transaction(
+        &mut self,
+        account_index: U31,
+        tx: PartiallySignedTransaction,
+    ) -> WalletResult<SignedTransaction> {
+        self.for_account_rw_unlocked(account_index, |account, db_tx| {
+            account.sign_raw_transaction(tx, db_tx)
         })
     }
 

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1168,7 +1168,6 @@ impl<B: storage::Backend> Wallet<B> {
     pub fn create_stake_pool_tx(
         &mut self,
         account_index: U31,
-        decommission_key: Option<PublicKey>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         stake_pool_arguments: StakePoolDataArguments,
@@ -1178,7 +1177,6 @@ impl<B: storage::Backend> Wallet<B> {
             account.create_stake_pool_tx(
                 db_tx,
                 stake_pool_arguments,
-                decommission_key,
                 latest_median_time,
                 CurrentFeeRate {
                     current_fee_rate,

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -182,6 +182,8 @@ pub enum WalletError {
     ReducedLookaheadSize(u32, u32),
     #[error("Wallet file {0} error: {1}")]
     WalletFileError(PathBuf, String),
+    #[error("Cannot use partially signed transaction")]
+    PartiallySignedTransaction,
 }
 
 /// Result type used for the wallet

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -1294,16 +1294,18 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
 
     let pool_amount = block1_amount;
 
+    let decommission_key = wallet.get_new_public_key(DEFAULT_ACCOUNT_INDEX).unwrap();
+
     let stake_pool_transaction = wallet
         .create_stake_pool_tx(
             DEFAULT_ACCOUNT_INDEX,
-            None,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             StakePoolDataArguments {
                 amount: pool_amount,
                 margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
                 cost_per_block: Amount::ZERO,
+                decommission_key: Destination::PublicKey(decommission_key),
             },
         )
         .unwrap();
@@ -1389,13 +1391,13 @@ fn reset_keys_after_failed_transaction(#[case] seed: Seed) {
 
     let result = wallet.create_stake_pool_tx(
         DEFAULT_ACCOUNT_INDEX,
-        None,
         FeeRate::from_amount_per_kb(Amount::ZERO),
         FeeRate::from_amount_per_kb(Amount::ZERO),
         StakePoolDataArguments {
             amount: not_enough,
             margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
             cost_per_block: Amount::ZERO,
+            decommission_key: Destination::AnyoneCanSpend,
         },
     );
     // check that result is an error and we last issued address is still the same
@@ -1513,13 +1515,13 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
     let stake_pool_transaction = wallet
         .create_stake_pool_tx(
             DEFAULT_ACCOUNT_INDEX,
-            None,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             StakePoolDataArguments {
                 amount: pool_amount,
                 margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
                 cost_per_block: Amount::ZERO,
+                decommission_key: Destination::AnyoneCanSpend,
             },
         )
         .unwrap();
@@ -3555,3 +3557,5 @@ fn wallet_set_lookahead_size(#[case] seed: Seed) {
     assert_eq!(usage.last_used(), Some(last_used.try_into().unwrap()));
     assert_eq!(usage.last_issued(), Some(last_used.try_into().unwrap()));
 }
+
+//FIXME: tests for decommission request

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -3558,4 +3558,279 @@ fn wallet_set_lookahead_size(#[case] seed: Seed) {
     assert_eq!(usage.last_issued(), Some(last_used.try_into().unwrap()));
 }
 
-//FIXME: tests for decommission request
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn decommission_pool_wrong_account(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    let acc_0_index = DEFAULT_ACCOUNT_INDEX;
+    let acc_1_index = U31::ONE;
+
+    let mut wallet = create_wallet(chain_config.clone());
+
+    let coin_balance = get_coin_balance(&wallet);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
+    let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
+
+    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    assert!(pool_ids.is_empty());
+
+    let coin_balance = get_coin_balance(&wallet);
+    assert_eq!(coin_balance, block1_amount);
+
+    let pool_amount = block1_amount;
+
+    let res = wallet.create_next_account(Some("name".into())).unwrap();
+    assert_eq!(res, (U31::from_u32(1).unwrap(), Some("name".into())));
+
+    let decommission_key = wallet.get_new_public_key(acc_1_index).unwrap();
+
+    let stake_pool_transaction = wallet
+        .create_stake_pool_tx(
+            acc_0_index,
+            FeeRate::from_amount_per_kb(Amount::ZERO),
+            FeeRate::from_amount_per_kb(Amount::ZERO),
+            StakePoolDataArguments {
+                amount: pool_amount,
+                margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
+                cost_per_block: Amount::ZERO,
+                decommission_key: Destination::PublicKey(decommission_key),
+            },
+        )
+        .unwrap();
+    let _ = create_block(
+        &chain_config,
+        &mut wallet,
+        vec![stake_pool_transaction],
+        Amount::ZERO,
+        1,
+    );
+
+    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    assert_eq!(pool_ids.len(), 1);
+
+    // Try to decommission the pool with default account
+    let pool_id = pool_ids.first().unwrap().0;
+    let decommission_cmd_res = wallet.decommission_stake_pool(
+        acc_0_index,
+        pool_id,
+        pool_amount,
+        FeeRate::from_amount_per_kb(Amount::from_atoms(0)),
+    );
+    assert_eq!(
+        decommission_cmd_res.unwrap_err(),
+        WalletError::PartiallySignedTransactionInDecommissionCommand
+    );
+
+    // Decommission from the account that holds the key
+    let decommission_tx = wallet
+        .decommission_stake_pool(
+            acc_1_index,
+            pool_id,
+            pool_amount,
+            FeeRate::from_amount_per_kb(Amount::from_atoms(0)),
+        )
+        .unwrap();
+
+    let _ = create_block(
+        &chain_config,
+        &mut wallet,
+        vec![decommission_tx],
+        Amount::ZERO,
+        2,
+    );
+
+    let currency_balances = wallet
+        .get_balance(
+            acc_1_index,
+            UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::CreateStakePool,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap();
+    assert_eq!(
+        currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
+        pool_amount,
+    );
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn decommission_pool_request_wrong_account(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    let acc_0_index = DEFAULT_ACCOUNT_INDEX;
+    let acc_1_index = U31::ONE;
+
+    let mut wallet = create_wallet(chain_config.clone());
+
+    let coin_balance = get_coin_balance(&wallet);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
+    let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
+
+    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    assert!(pool_ids.is_empty());
+
+    let coin_balance = get_coin_balance(&wallet);
+    assert_eq!(coin_balance, block1_amount);
+
+    let pool_amount = block1_amount;
+
+    let res = wallet.create_next_account(Some("name".into())).unwrap();
+    assert_eq!(res, (U31::from_u32(1).unwrap(), Some("name".into())));
+
+    let decommission_key = wallet.get_new_public_key(acc_1_index).unwrap();
+
+    let stake_pool_transaction = wallet
+        .create_stake_pool_tx(
+            acc_0_index,
+            FeeRate::from_amount_per_kb(Amount::ZERO),
+            FeeRate::from_amount_per_kb(Amount::ZERO),
+            StakePoolDataArguments {
+                amount: pool_amount,
+                margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
+                cost_per_block: Amount::ZERO,
+                decommission_key: Destination::PublicKey(decommission_key),
+            },
+        )
+        .unwrap();
+    let _ = create_block(
+        &chain_config,
+        &mut wallet,
+        vec![stake_pool_transaction],
+        Amount::ZERO,
+        1,
+    );
+
+    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    assert_eq!(pool_ids.len(), 1);
+
+    // Try to create decommission request from account that holds the key
+    let pool_id = pool_ids.first().unwrap().0;
+    let decommission_req_res = wallet.decommission_stake_pool_request(
+        acc_1_index,
+        pool_id,
+        pool_amount,
+        FeeRate::from_amount_per_kb(Amount::from_atoms(0)),
+    );
+    assert_eq!(
+        decommission_req_res.unwrap_err(),
+        WalletError::FullySignedTransactionInDecommissionReq
+    );
+
+    let decommission_partial_tx = wallet
+        .decommission_stake_pool_request(
+            acc_0_index,
+            pool_id,
+            pool_amount,
+            FeeRate::from_amount_per_kb(Amount::from_atoms(0)),
+        )
+        .unwrap();
+    assert!(!decommission_partial_tx.is_fully_signed());
+    matches!(
+        decommission_partial_tx.into_signed_tx().unwrap_err(),
+        WalletError::FailedToConvertPartiallySignedTx(_)
+    );
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_mainnet());
+
+    let acc_0_index = DEFAULT_ACCOUNT_INDEX;
+    let acc_1_index = U31::ONE;
+
+    let mut wallet = create_wallet(chain_config.clone());
+
+    let coin_balance = get_coin_balance(&wallet);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
+    let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
+
+    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    assert!(pool_ids.is_empty());
+
+    let coin_balance = get_coin_balance(&wallet);
+    assert_eq!(coin_balance, block1_amount);
+
+    let pool_amount = block1_amount;
+
+    let res = wallet.create_next_account(Some("name".into())).unwrap();
+    assert_eq!(res, (U31::from_u32(1).unwrap(), Some("name".into())));
+
+    let decommission_key = wallet.get_new_public_key(acc_1_index).unwrap();
+
+    let stake_pool_transaction = wallet
+        .create_stake_pool_tx(
+            acc_0_index,
+            FeeRate::from_amount_per_kb(Amount::ZERO),
+            FeeRate::from_amount_per_kb(Amount::ZERO),
+            StakePoolDataArguments {
+                amount: pool_amount,
+                margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
+                cost_per_block: Amount::ZERO,
+                decommission_key: Destination::PublicKey(decommission_key),
+            },
+        )
+        .unwrap();
+    let _ = create_block(
+        &chain_config,
+        &mut wallet,
+        vec![stake_pool_transaction],
+        Amount::ZERO,
+        1,
+    );
+
+    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    assert_eq!(pool_ids.len(), 1);
+
+    let pool_id = pool_ids.first().unwrap().0;
+    let decommission_partial_tx = wallet
+        .decommission_stake_pool_request(
+            acc_0_index,
+            pool_id,
+            pool_amount,
+            FeeRate::from_amount_per_kb(Amount::from_atoms(0)),
+        )
+        .unwrap();
+
+    // Try to sign decommission request with wrong account
+    let sign_from_acc0_res =
+        wallet.sign_raw_transaction(acc_0_index, decommission_partial_tx.clone());
+    assert_eq!(
+        sign_from_acc0_res.unwrap_err(),
+        WalletError::InputCannotBeSigned
+    );
+
+    let signed_tx = wallet.sign_raw_transaction(acc_1_index, decommission_partial_tx).unwrap();
+
+    let _ = create_block(&chain_config, &mut wallet, vec![signed_tx], Amount::ZERO, 1);
+
+    let currency_balances = wallet
+        .get_balance(
+            acc_1_index,
+            UtxoType::Transfer | UtxoType::LockThenTransfer | UtxoType::CreateStakePool,
+            UtxoState::Confirmed.into(),
+            WithLocked::Unlocked,
+        )
+        .unwrap();
+    assert_eq!(
+        currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
+        pool_amount,
+    );
+}

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -3817,7 +3817,11 @@ fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
         WalletError::InputCannotBeSigned
     );
 
-    let signed_tx = wallet.sign_raw_transaction(acc_1_index, decommission_partial_tx).unwrap();
+    let signed_tx = wallet
+        .sign_raw_transaction(acc_1_index, decommission_partial_tx)
+        .unwrap()
+        .into_signed_tx()
+        .unwrap();
 
     let _ = create_block(&chain_config, &mut wallet, vec![signed_tx], Amount::ZERO, 1);
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -330,6 +330,13 @@ pub enum WalletCommand {
         pool_id: String,
     },
 
+    // FIXME: docs
+    #[clap(name = "staking-decommission-pool-request")]
+    DecommissionStakePoolRequest {
+        /// The pool id of the pool to be decommissioned.
+        pool_id: String,
+    },
+
     /// Create new wallet
     #[clap(name = "wallet-create")]
     CreateWallet {
@@ -1249,6 +1256,22 @@ impl CommandHandler {
                     .decommission_stake_pool(selected_account, pool_id, self.config)
                     .await?;
                 Ok(Self::tx_submitted_command())
+            }
+
+            WalletCommand::DecommissionStakePoolRequest { pool_id } => {
+                let pool_id = parse_pool_id(chain_config, pool_id.as_str())?;
+                let result = self
+                    .get_synced_controller()
+                    .await?
+                    .decommission_stake_pool_request(pool_id)
+                    .await
+                    .map_err(WalletCliError::Controller)?;
+                let output_str = format!(
+                    "Decommission transaction created.\
+                    Pass the following string into the wallet with private key to sign:\n{}",
+                    result.to_string()
+                );
+                Ok(ConsoleCommand::Print(output_str))
             }
 
             WalletCommand::DepositData { hex_data } => {

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -323,9 +323,7 @@ pub enum WalletCommand {
         margin_ratio_per_thousand: String,
 
         /// The key that can decommission the pool. It's recommended to keep the decommission key in a cold storage.
-        /// If not provided, the selected account in this wallet will control both decommission and staking.
-        /// This is NOT RECOMMENDED.
-        decommission_key: Option<HexEncoded<PublicKey>>,
+        decommission_key: String,
     },
 
     /// Decommission a staking pool, given its id. This assumes that the decommission key is owned

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -507,6 +507,10 @@ pub enum WalletCommand {
     #[clap(name = "node-best-block-height")]
     BestBlockHeight,
 
+    /// Returns the current best block timestamp
+    #[clap(name = "node-best-block-timestamp")]
+    BestBlockTimestamp,
+
     /// Get the block ID of the block at a given height
     #[clap(name = "node-block-id")]
     BlockId {
@@ -815,6 +819,15 @@ impl CommandHandler {
             WalletCommand::BestBlockHeight => {
                 let height = self.wallet_rpc.node_best_block_height().await?;
                 Ok(ConsoleCommand::Print(height.to_string()))
+            }
+
+            WalletCommand::BestBlockTimestamp => {
+                let timestamp = self.wallet_rpc.chainstate_info().await?.best_block_timestamp;
+                Ok(ConsoleCommand::Print(format!(
+                    "{} ({})",
+                    timestamp,
+                    timestamp.into_time().as_standard_printable_time()
+                )))
             }
 
             WalletCommand::BlockId { height } => {

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -921,9 +921,10 @@ impl CommandHandler {
                         let qr_code_string = qr_code.encode_to_console_string_with_defaults(1);
 
                         format!(
-                            "Transaction has been signed. \
-                             Pass the following string into the wallet to broadcast:\n{result_hex}\n\
-                             Or scan the Qr code with it:\n{qr_code_string}"
+                            "The transaction has been fully signed signed as is ready to be broadcast to network. \
+                             You can use the command `node-submit-transaction` in a wallet connected to the internet (this one or elsewhere). \
+                             Pass the following data to the wallet to broadcast:\n\n{result_hex}\n\n\
+                             Or scan the Qr code with it:\n\n{qr_code_string}"
                         )
                     }
                     Err(WalletError::FailedToConvertPartiallySignedTx(partially_signed_tx)) => {
@@ -935,9 +936,9 @@ impl CommandHandler {
                         let qr_code_string = qr_code.encode_to_console_string_with_defaults(1);
 
                         format!(
-                            "Not all transaction inputs have been signed. \
-                             Pass the following string into the wallet that has appropriate keys for the inputs to sign:\n{result_hex}\n\
-                             Or scan the Qr code with it:\n{qr_code_string}"
+                            "Not all transaction inputs have been signed. This wallet does not have all the keys for that.\
+                             Pass the following string into the wallet that has appropriate keys for the inputs to sign what is left:\n\n{result_hex}\n\n\
+                             Or scan the Qr code with it:\n\n{qr_code_string}"
                         )
                     }
                     Err(err) => {
@@ -1327,8 +1328,8 @@ impl CommandHandler {
 
                 let output_str = format!(
                     "Decommission transaction created. \
-                    Pass the following string into the wallet with private key to sign:\n{result_hex}\n\
-                    Or scan the Qr code with it:\n{qr_code_string}"
+                    Pass the following string into the wallet with private key to sign:\n\n{result_hex}\n\n\
+                    Or scan the Qr code with it:\n\n{qr_code_string}"
                 );
                 Ok(ConsoleCommand::Print(output_str))
             }

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -324,7 +324,7 @@ pub enum WalletCommand {
         margin_ratio_per_thousand: String,
 
         /// The key that can decommission the pool. It's recommended to keep the decommission key in a cold storage.
-        decommission_key: String,
+        decommission_address: String,
     },
 
     /// Decommission a staking pool, given its id. This assumes that the decommission key is owned
@@ -1263,7 +1263,7 @@ impl CommandHandler {
                 amount,
                 cost_per_block,
                 margin_ratio_per_thousand,
-                decommission_key,
+                decommission_address,
             } => {
                 let selected_account = self.get_selected_acc()?;
                 self.wallet_rpc
@@ -1272,7 +1272,7 @@ impl CommandHandler {
                         amount,
                         cost_per_block,
                         margin_ratio_per_thousand,
-                        decommission_key,
+                        decommission_address,
                         self.config,
                     )
                     .await?;

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -330,7 +330,9 @@ pub enum WalletCommand {
         pool_id: String,
     },
 
-    // FIXME: docs
+    /// Create a request to decommission a pool. This assumes that the decommission key is owned
+    /// by another wallet. The output of this command should be passed to SignRawTransaction for
+    /// signing.
     #[clap(name = "staking-decommission-pool-request")]
     DecommissionStakePoolRequest {
         /// The pool id of the pool to be decommissioned.
@@ -908,9 +910,9 @@ impl CommandHandler {
                     .await?;
 
                 let output_str = format!(
-                    "Transaction has been signed.\
+                    "Transaction has been signed. \
                     Pass the following string into the wallet to broadcast:\n{}",
-                    result.to_string()
+                    result
                 );
                 Ok(ConsoleCommand::Print(output_str))
             }
@@ -1287,9 +1289,9 @@ impl CommandHandler {
                     .decommission_stake_pool_request(selected_account, pool_id, self.config)
                     .await?;
                 let output_str = format!(
-                    "Decommission transaction created.\
+                    "Decommission transaction created. \
                     Pass the following string into the wallet with private key to sign:\n{}",
-                    result.to_string()
+                    result
                 );
                 Ok(ConsoleCommand::Print(output_str))
             }

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -79,6 +79,13 @@ pub enum WalletCommand {
         utxo_states: Vec<CliUtxoState>,
     },
 
+    /// Signs the inputs that are not yet signed
+    #[clap(name = "account-sign-raw-transaction")]
+    SignRawTransaction {
+        /// Hex encoded transaction.
+        transaction: HexEncoded<PartiallySignedTransaction>,
+    },
+
     /// Issue a new non-fungible token (NFT) from scratch
     #[clap(name = "token-nft-issue-new")]
     IssueNewNft {
@@ -483,13 +490,6 @@ pub enum WalletCommand {
     SubmitTransaction {
         /// Hex encoded transaction.
         transaction: HexEncoded<SignedTransaction>,
-    },
-
-    /// Submits a transaction to mempool, and if it is valid, broadcasts it to the network
-    #[clap(name = "node-sign-raw-transaction")]
-    SignRawTransaction {
-        /// Hex encoded transaction.
-        transaction: HexEncoded<PartiallySignedTransaction>,
     },
 
     /// Returns the current node's chainstate (block height information and more)
@@ -908,11 +908,12 @@ impl CommandHandler {
                     .wallet_rpc
                     .sign_raw_transaction(selected_account, transaction, self.config)
                     .await?;
+                let result_hex: HexEncoded<SignedTransaction> = result.into();
 
                 let output_str = format!(
                     "Transaction has been signed. \
                     Pass the following string into the wallet to broadcast:\n{}",
-                    result
+                    result_hex
                 );
                 Ok(ConsoleCommand::Print(output_str))
             }
@@ -1288,10 +1289,12 @@ impl CommandHandler {
                     .wallet_rpc
                     .decommission_stake_pool_request(selected_account, pool_id, self.config)
                     .await?;
+                let result_hex: HexEncoded<PartiallySignedTransaction> = result.into();
+
                 let output_str = format!(
                     "Decommission transaction created. \
                     Pass the following string into the wallet with private key to sign:\n{}",
-                    result
+                    result_hex
                 );
                 Ok(ConsoleCommand::Print(output_str))
             }

--- a/wallet/wallet-cli-lib/src/errors.rs
+++ b/wallet/wallet-cli-lib/src/errors.rs
@@ -17,6 +17,7 @@ use std::path::PathBuf;
 
 use crypto::key::hdkd::u31::U31;
 use utils::{cookie::LoadCookieError, qrcode::QrCodeError};
+use wallet::WalletError;
 use wallet_rpc_lib::RpcError;
 
 #[derive(thiserror::Error, Debug)]
@@ -55,4 +56,6 @@ pub enum WalletCliError {
     SerdeJsonFormatError(#[from] serde_json::Error),
     #[error("{0}")]
     WalletRpcError(#[from] RpcError),
+    #[error("Failed to convert to signed transaction: {0}")]
+    FailedToConvertToSignedTransaction(#[from] WalletError),
 }

--- a/wallet/wallet-cli-lib/src/errors.rs
+++ b/wallet/wallet-cli-lib/src/errors.rs
@@ -15,9 +15,8 @@
 
 use std::path::PathBuf;
 
-use common::address::AddressError;
 use crypto::key::hdkd::u31::U31;
-use utils::cookie::LoadCookieError;
+use utils::{cookie::LoadCookieError, qrcode::QrCodeError};
 use wallet_rpc_lib::RpcError;
 
 #[derive(thiserror::Error, Debug)]
@@ -48,8 +47,8 @@ pub enum WalletCliError {
     NoSelectedAccount,
     #[error("Account not found for index: {0}")]
     AccountNotFound(U31),
-    #[error("Address encoding error: {0}")]
-    AddressEncodingError(#[from] AddressError),
+    #[error("QR Code encoding error: {0}")]
+    QrCodeEncoding(#[from] QrCodeError),
     #[error("Retrieving addresses with usage failed for account {0}: {1}")]
     AddressesRetrievalFailed(U31, String),
     #[error("Error converting to json: {0}")]

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -38,7 +38,6 @@ use futures::{stream::FuturesUnordered, TryStreamExt};
 use logging::log;
 use mempool::FeeRate;
 use node_comm::node_traits::NodeInterface;
-use serialization::hex_encoded::HexEncoded;
 use wallet::{
     account::{PartiallySignedTransaction, UnconfirmedTokenInfo},
     send_request::{
@@ -584,7 +583,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     pub async fn decommission_stake_pool_request(
         &mut self,
         pool_id: PoolId,
-    ) -> Result<HexEncoded<PartiallySignedTransaction>, ControllerError<T>> {
+    ) -> Result<PartiallySignedTransaction, ControllerError<T>> {
         let staker_balance = self
             .rpc_client
             .get_staker_balance(pool_id)
@@ -604,7 +603,6 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
                 current_fee_rate,
             )
             .map_err(ControllerError::WalletError)
-            .map(|r| r.into())
     }
 
     pub fn start_staking(&mut self) -> Result<(), ControllerError<T>> {
@@ -623,11 +621,10 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     pub fn sign_raw_transaction(
         &mut self,
         tx: PartiallySignedTransaction,
-    ) -> Result<HexEncoded<SignedTransaction>, ControllerError<T>> {
+    ) -> Result<SignedTransaction, ControllerError<T>> {
         self.wallet
             .sign_raw_transaction(self.account_index, tx)
             .map_err(ControllerError::WalletError)
-            .map(|tx| tx.into())
     }
 
     async fn get_current_and_consolidation_fee_rate(

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -526,7 +526,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     pub async fn create_stake_pool_tx(
         &mut self,
         amount: Amount,
-        decommission_key: Option<PublicKey>,
+        decommission_key: Destination,
         margin_ratio_per_thousand: PerThousand,
         cost_per_block: Amount,
     ) -> Result<(), ControllerError<T>> {
@@ -537,13 +537,13 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
                   account_index: U31| {
                 wallet.create_stake_pool_tx(
                     account_index,
-                    decommission_key,
                     current_fee_rate,
                     consolidate_fee_rate,
                     StakePoolDataArguments {
                         amount,
                         margin_ratio_per_thousand,
                         cost_per_block,
+                        decommission_key,
                     },
                 )
             },

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -620,6 +620,16 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         Ok(())
     }
 
+    pub fn sign_raw_transaction(
+        &mut self,
+        tx: PartiallySignedTransaction,
+    ) -> Result<HexEncoded<SignedTransaction>, ControllerError<T>> {
+        self.wallet
+            .sign_raw_transaction(self.account_index, tx)
+            .map_err(ControllerError::WalletError)
+            .map(|tx| tx.into())
+    }
+
     async fn get_current_and_consolidation_fee_rate(
         &mut self,
     ) -> Result<(mempool::FeeRate, mempool::FeeRate), ControllerError<T>> {

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -621,7 +621,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     pub fn sign_raw_transaction(
         &mut self,
         tx: PartiallySignedTransaction,
-    ) -> Result<SignedTransaction, ControllerError<T>> {
+    ) -> Result<PartiallySignedTransaction, ControllerError<T>> {
         self.wallet
             .sign_raw_transaction(self.account_index, tx)
             .map_err(ControllerError::WalletError)

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -18,7 +18,6 @@ use common::{
     chain::{Block, GenBlock, SignedTransaction, Transaction},
     primitives::{BlockHeight, Id},
 };
-use crypto::key::PublicKey;
 use p2p_types::bannable_address::BannableAddress;
 use wallet_controller::ConnectedPeer;
 use wallet_types::with_locked::WithLocked;
@@ -138,7 +137,7 @@ trait WalletRpc {
         amount: DecimalAmount,
         cost_per_block: DecimalAmount,
         margin_ratio_per_thousand: String,
-        decommission_key: Option<HexEncoded<PublicKey>>,
+        decommission_address: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<()>;
 

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -314,7 +314,7 @@ impl WalletRpc {
         account_index: U31,
         tx: HexEncoded<PartiallySignedTransaction>,
         config: ControllerConfig,
-    ) -> WRpcResult<SignedTransaction> {
+    ) -> WRpcResult<PartiallySignedTransaction> {
         self.wallet
             .call_async(move |controller| {
                 Box::pin(async move {
@@ -322,7 +322,7 @@ impl WalletRpc {
                         .synced_controller(account_index, config)
                         .await?
                         .sign_raw_transaction(tx.take())?;
-                    Ok::<SignedTransaction, ControllerError<_>>(tx)
+                    Ok::<PartiallySignedTransaction, ControllerError<_>>(tx)
                 })
             })
             .await?

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -314,7 +314,7 @@ impl WalletRpc {
         account_index: U31,
         tx: HexEncoded<PartiallySignedTransaction>,
         config: ControllerConfig,
-    ) -> WRpcResult<HexEncoded<SignedTransaction>> {
+    ) -> WRpcResult<SignedTransaction> {
         self.wallet
             .call_async(move |controller| {
                 Box::pin(async move {
@@ -322,7 +322,7 @@ impl WalletRpc {
                         .synced_controller(account_index, config)
                         .await?
                         .sign_raw_transaction(tx.take())?;
-                    Ok::<HexEncoded<SignedTransaction>, ControllerError<_>>(tx)
+                    Ok::<SignedTransaction, ControllerError<_>>(tx)
                 })
             })
             .await?
@@ -454,7 +454,7 @@ impl WalletRpc {
         account_index: U31,
         pool_id: String,
         config: ControllerConfig,
-    ) -> WRpcResult<HexEncoded<PartiallySignedTransaction>> {
+    ) -> WRpcResult<PartiallySignedTransaction> {
         let pool_id = Address::from_str(&self.chain_config, &pool_id)
             .and_then(|addr| addr.decode_object(&self.chain_config))
             .map_err(|_| RpcError::InvalidPoolId)?;
@@ -467,7 +467,7 @@ impl WalletRpc {
                         .await?
                         .decommission_stake_pool_request(pool_id)
                         .await?;
-                    Ok::<HexEncoded<PartiallySignedTransaction>, ControllerError<_>>(tx)
+                    Ok::<PartiallySignedTransaction, ControllerError<_>>(tx)
                 })
             })
             .await?

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -19,7 +19,6 @@ use common::{
     chain::{tokens::IsTokenUnfreezable, Block, GenBlock, SignedTransaction, Transaction},
     primitives::{BlockHeight, Id, Idable, H256},
 };
-use crypto::key::PublicKey;
 use p2p_types::{
     bannable_address::BannableAddress, ip_or_socket_address::IpOrSocketAddress, PeerId,
 };
@@ -209,7 +208,7 @@ impl WalletRpcServer for WalletRpc {
         amount: DecimalAmount,
         cost_per_block: DecimalAmount,
         margin_ratio_per_thousand: String,
-        decommission_key: Option<HexEncoded<PublicKey>>,
+        decommission_address: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<()> {
         let config = ControllerConfig {
@@ -221,7 +220,7 @@ impl WalletRpcServer for WalletRpc {
                 amount,
                 cost_per_block,
                 margin_ratio_per_thousand,
-                decommission_key,
+                decommission_address,
                 config,
             )
             .await,


### PR DESCRIPTION
Adds functionality to partially sign transaction to be able to pass it to a cold wallet and sign there.

The process of decommissioning is as follows:
- create a pool from hot wallet with decommission key from cold wallet
- call `staking-decommission-pool-request` from hot wallet
- copy the output and paste it to `node-sign-raw-transaction` command in cold wallet
- copy the output and paste it to `node-submit-transaction` command in hot wallet to broadcast

TODOs:

- [x] generate qr for output
- [x] decommission key in create pool command should not be optional
- [x] make decommission key in create pool a destination with an address, instead of a public key