### PR TITLE
Rework staker reward distribution

### DIFF
--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -32,7 +32,7 @@ use common::{
     },
     primitives::{id::WithId, Amount, BlockHeight, CoinOrTokenId, Fee, Id, Idable},
 };
-use pos_accounting::{make_delegation_id, PoolData};
+use pos_accounting::{make_delegation_id, PoSAccountingView, PoolData};
 use std::{
     collections::{BTreeMap, BTreeSet},
     ops::{Add, Sub},
@@ -539,14 +539,16 @@ async fn update_tables_from_consensus_data<T: ApiServerStorageWrite>(
                 .expect("Pool should exist");
 
             let delegation_shares = db_tx.get_pool_delegations(pool_id).await?;
-            let mut adapter = PoSAdapter::new(pool_id, pool_data, delegation_shares);
+            let mut adapter = PoSAdapter::new(pool_id, pool_data, &delegation_shares);
 
             distribute_pos_reward(&mut adapter, block.get_id(), pool_id, total_reward)
                 .expect("no error");
 
-            for (delegation_id, rewards, updated_delegation) in adapter.rewards_per_delegation() {
+            for (delegation_id, rewards) in adapter.rewards_per_delegation() {
+                let delegation = delegation_shares.get(delegation_id).expect("must exist").clone();
+                let updated_delegation = delegation.stake(*rewards);
                 db_tx
-                    .set_delegation_at_height(delegation_id, &updated_delegation, block_height)
+                    .set_delegation_at_height(*delegation_id, &updated_delegation, block_height)
                     .await?;
                 let address = Address::<Destination>::new(
                     &chain_config,
@@ -556,14 +558,14 @@ async fn update_tables_from_consensus_data<T: ApiServerStorageWrite>(
                 increase_address_amount(
                     db_tx,
                     &address,
-                    &rewards,
+                    rewards,
                     CoinOrTokenId::Coin,
                     block_height,
                 )
                 .await;
             }
 
-            let pool_data = adapter.get_pool_data_with_reward(pool_id).expect("must exist");
+            let pool_data = adapter.get_pool_data(pool_id).expect("no error").expect("must exist");
             db_tx.set_pool_data_at_height(pool_id, &pool_data, block_height).await?;
             let pool_reward = adapter.get_pool_reward(pool_id);
 

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -128,6 +128,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::MissingTxInputs => 100,
             ConnectTransactionError::UndoFetchFailure => 0,
             ConnectTransactionError::TxVerifierStorage => 0,
+            ConnectTransactionError::StakerRewardCalculationFailed(_, _) => 100,
             ConnectTransactionError::StakerRewardCannotExceedTotalReward(_, _, _, _) => 100,
             ConnectTransactionError::UnexpectedPoolId(_, _) => 100,
             ConnectTransactionError::DelegationsRewardSumFailed(_, _) => 100,

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -21,6 +21,7 @@ use tx_verifier::{
     timelock_check::OutputMaturityError,
     transaction_verifier::{
         signature_destination_getter::SignatureDestinationGetterError, IOPolicyError,
+        RewardDistributionError,
     },
 };
 
@@ -128,14 +129,8 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::MissingTxInputs => 100,
             ConnectTransactionError::UndoFetchFailure => 0,
             ConnectTransactionError::TxVerifierStorage => 0,
-            ConnectTransactionError::StakerRewardCalculationFailed(_, _) => 100,
-            ConnectTransactionError::StakerRewardCannotExceedTotalReward(_, _, _, _) => 100,
             ConnectTransactionError::UnexpectedPoolId(_, _) => 100,
-            ConnectTransactionError::DelegationsRewardSumFailed(_, _) => 100,
-            ConnectTransactionError::DelegationRewardOverflow(_, _, _, _) => 100,
-            ConnectTransactionError::DistributedDelegationsRewardExceedTotal(_, _, _, _) => 100,
             ConnectTransactionError::BlockRewardInputOutputMismatch(_, _) => 100,
-            ConnectTransactionError::TotalDelegationBalanceZero(_) => 0,
             ConnectTransactionError::DelegationDataNotFound(_) => 0,
             ConnectTransactionError::DestinationRetrievalError(err) => err.ban_score(),
             ConnectTransactionError::OutputTimelockError(err) => err.ban_score(),
@@ -153,8 +148,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::InsufficientCoinsFee(_, _) => 100,
             ConnectTransactionError::AttemptToSpendFrozenToken(_) => 100,
             ConnectTransactionError::PoolBalanceNotFound(_) => 100,
-            ConnectTransactionError::StakerRewardOverflow(_, _, _, _) => 100,
-            ConnectTransactionError::PoolBalanceIsZero(_) => 100,
+            ConnectTransactionError::RewardDistributionError(err) => err.ban_score(),
         }
     }
 }
@@ -535,6 +529,26 @@ impl BanScore for tokens_accounting::Error {
             tokens_accounting::Error::CannotUndoChangeAuthorityForFrozenToken(_) => 100,
             tokens_accounting::Error::ViewFail => 0,
             tokens_accounting::Error::StorageWrite => 0,
+        }
+    }
+}
+
+impl BanScore for RewardDistributionError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            RewardDistributionError::PoSAccountingError(err) => err.ban_score(),
+            RewardDistributionError::InvariantPoolBalanceIsZero(_) => 100,
+            RewardDistributionError::InvariantStakerBalanceGreaterThanPoolBalance(_, _, _) => 100,
+            RewardDistributionError::RewardAdditionError(_) => 100,
+            RewardDistributionError::TotalDelegationBalanceZero(_) => 100,
+            RewardDistributionError::PoolDataNotFound(_) => 0,
+            RewardDistributionError::PoolBalanceNotFound(_) => 0,
+            RewardDistributionError::StakerRewardCalculationFailed(_, _) => 100,
+            RewardDistributionError::StakerRewardCannotExceedTotalReward(_, _, _, _) => 100,
+            RewardDistributionError::DistributedDelegationsRewardExceedTotal(_, _, _, _) => 100,
+            RewardDistributionError::DelegationRewardOverflow(_, _, _, _) => 100,
+            RewardDistributionError::DelegationsRewardSumFailed(_, _) => 100,
+            RewardDistributionError::StakerRewardOverflow(_, _, _, _) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -128,7 +128,6 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::MissingTxInputs => 100,
             ConnectTransactionError::UndoFetchFailure => 0,
             ConnectTransactionError::TxVerifierStorage => 0,
-            ConnectTransactionError::StakerRewardCalculationFailed(_, _) => 100,
             ConnectTransactionError::StakerRewardCannotExceedTotalReward(_, _, _, _) => 100,
             ConnectTransactionError::UnexpectedPoolId(_, _) => 100,
             ConnectTransactionError::DelegationsRewardSumFailed(_, _) => 100,
@@ -152,6 +151,9 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::TotalFeeRequiredOverflow => 100,
             ConnectTransactionError::InsufficientCoinsFee(_, _) => 100,
             ConnectTransactionError::AttemptToSpendFrozenToken(_) => 100,
+            ConnectTransactionError::PoolBalanceNotFound(_) => 100,
+            ConnectTransactionError::StakerRewardOverflow(_, _, _, _) => 100,
+            ConnectTransactionError::PoolBalanceIsZero(_) => 100,
         }
     }
 }

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -26,8 +26,8 @@ use common::{
         tokens::{
             make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0, TokenIssuanceVersion,
         },
-        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, Transaction, TxInput,
-        TxOutput, UtxoOutPoint,
+        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
+        Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Id, Idable},
 };
@@ -116,7 +116,10 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         common::chain::NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V0),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V0,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )
@@ -190,7 +193,10 @@ fn store_nft_v0(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         common::chain::NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V0),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V0,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )
@@ -369,7 +375,10 @@ fn store_aux_data_from_issue_nft(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V1,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/data_deposit.rs
+++ b/chainstate/test-suite/src/tests/data_deposit.rs
@@ -19,10 +19,10 @@ use chainstate::{
 };
 use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
-    output_value::OutputValue, signature::inputsig::InputWitness, tokens::TokenIssuanceVersion,
-    ChainstateUpgrade, Destination, OutPointSourceId, TxInput, TxOutput, UtxoOutPoint,
+    output_value::OutputValue, signature::inputsig::InputWitness, Destination, OutPointSourceId,
+    TxInput, TxOutput, UtxoOutPoint,
 };
-use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
+use common::primitives::{Amount, CoinOrTokenId, Idable};
 use crypto::random::Rng;
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
@@ -35,20 +35,7 @@ use test_utils::random::{make_seedable_rng, Seed};
 fn data_deposited_too_large(#[case] seed: Seed, #[case] expect_success: bool) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let mut tf = TestFramework::builder(&mut rng)
-            .with_chain_config(
-                common::chain::config::Builder::test_chain()
-                    .chainstate_upgrades(
-                        common::chain::NetUpgrades::initialize(vec![(
-                            BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
-                        )])
-                        .unwrap(),
-                    )
-                    .genesis_unittest(Destination::AnyoneCanSpend)
-                    .build(),
-            )
-            .build();
+        let mut tf = TestFramework::builder(&mut rng).build();
         let outpoint_source_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
         let mut rng = make_seedable_rng(seed);
 
@@ -109,20 +96,7 @@ fn data_deposit_insufficient_fee(
 ) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let mut tf = TestFramework::builder(&mut rng)
-            .with_chain_config(
-                common::chain::config::Builder::test_chain()
-                    .chainstate_upgrades(
-                        common::chain::NetUpgrades::initialize(vec![(
-                            BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
-                        )])
-                        .unwrap(),
-                    )
-                    .genesis_unittest(Destination::AnyoneCanSpend)
-                    .build(),
-            )
-            .build();
+        let mut tf = TestFramework::builder(&mut rng).build();
         let outpoint_source_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
         let mut rng = make_seedable_rng(seed);
 
@@ -198,20 +172,7 @@ fn data_deposit_insufficient_fee(
 fn data_deposit_output_attempt_spend(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let mut tf = TestFramework::builder(&mut rng)
-            .with_chain_config(
-                common::chain::config::Builder::test_chain()
-                    .chainstate_upgrades(
-                        common::chain::NetUpgrades::initialize(vec![(
-                            BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
-                        )])
-                        .unwrap(),
-                    )
-                    .genesis_unittest(Destination::AnyoneCanSpend)
-                    .build(),
-            )
-            .build();
+        let mut tf = TestFramework::builder(&mut rng).build();
         let outpoint_source_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
         let mut rng = make_seedable_rng(seed);
 

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -21,7 +21,7 @@ use chainstate::{
 };
 use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::chain::tokens::{Metadata, NftIssuanceV0, TokenIssuanceV0, TokenTransfer};
-use common::chain::UtxoOutPoint;
+use common::chain::{RewardDistributionVersion, UtxoOutPoint};
 use common::primitives::{id, BlockHeight, Id};
 use common::{
     chain::{
@@ -50,7 +50,10 @@ fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramewor
                 .chainstate_upgrades(
                     common::chain::NetUpgrades::initialize(vec![(
                         BlockHeight::zero(),
-                        ChainstateUpgrade::new(TokenIssuanceVersion::V0),
+                        ChainstateUpgrade::new(
+                            TokenIssuanceVersion::V0,
+                            RewardDistributionVersion::V1,
+                        ),
                     )])
                     .unwrap(),
                 )
@@ -947,7 +950,10 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         common::chain::NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V1,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )
@@ -1001,11 +1007,17 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                         common::chain::NetUpgrades::initialize(vec![
                             (
                                 BlockHeight::zero(),
-                                ChainstateUpgrade::new(TokenIssuanceVersion::V0),
+                                ChainstateUpgrade::new(
+                                    TokenIssuanceVersion::V0,
+                                    RewardDistributionVersion::V1,
+                                ),
                             ),
                             (
                                 BlockHeight::new(2),
-                                ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                                ChainstateUpgrade::new(
+                                    TokenIssuanceVersion::V1,
+                                    RewardDistributionVersion::V1,
+                                ),
                             ),
                         ])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -19,7 +19,7 @@ use common::chain::{
     output_value::OutputValue,
     signature::inputsig::InputWitness,
     tokens::{make_token_id, TokenIssuanceVersion},
-    ChainstateUpgrade, Destination, TxInput, TxOutput,
+    ChainstateUpgrade, Destination, RewardDistributionVersion, TxInput, TxOutput,
 };
 use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
@@ -212,7 +212,10 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         common::chain::NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V1,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -24,7 +24,7 @@ use common::chain::OutPointSourceId;
 use common::chain::{
     signature::inputsig::InputWitness,
     tokens::{make_token_id, Metadata, NftIssuance, NftIssuanceV0, TokenIssuanceVersion},
-    ChainstateUpgrade, Destination, TxInput, TxOutput,
+    ChainstateUpgrade, Destination, RewardDistributionVersion, TxInput, TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
 use crypto::random::{CryptoRng, Rng};
@@ -1626,7 +1626,10 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         common::chain::NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V1,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )
@@ -1679,7 +1682,10 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         common::chain::NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V1,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -21,7 +21,8 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         tokens::{make_token_id, NftIssuance, TokenId, TokenIssuanceVersion},
-        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, TxInput, TxOutput,
+        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
+        TxInput, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId},
 };
@@ -363,7 +364,10 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V1,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -20,7 +20,8 @@ use super::helpers::{
 use super::*;
 
 use chainstate_test_framework::{empty_witness, TestFramework, TestStore, TransactionBuilder};
-use common::chain::{AccountCommand, AccountNonce, AccountSpending};
+use common::chain::config::create_unit_test_config;
+use common::chain::{AccountCommand, AccountNonce, AccountSpending, RewardDistributionVersion};
 use common::{
     chain::{
         config::ChainType,
@@ -44,17 +45,7 @@ use tx_verifier::transaction_verifier::{TransactionSourceForConnect, Transaction
 fn setup(rng: &mut (impl Rng + CryptoRng)) -> (ChainConfig, InMemoryStorageWrapper, TestFramework) {
     let storage = TestStore::new_empty().unwrap();
 
-    let chain_config = common::chain::config::Builder::test_chain()
-        .chainstate_upgrades(
-            NetUpgrades::initialize(vec![(
-                BlockHeight::zero(),
-                ChainstateUpgrade::new(TokenIssuanceVersion::V1),
-            )])
-            .unwrap(),
-        )
-        .genesis_unittest(Destination::AnyoneCanSpend)
-        .build();
-
+    let chain_config = create_unit_test_config();
     let tf = TestFramework::builder(rng)
         .with_storage(storage.clone())
         .with_chain_config(chain_config.clone())
@@ -580,7 +571,10 @@ fn issue_fungible_token_v0(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         common::chain::NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V0),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V0,
+                                RewardDistributionVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/tx_verification_simulation.rs
+++ b/chainstate/test-suite/src/tests/tx_verification_simulation.rs
@@ -15,7 +15,6 @@
 
 use super::*;
 use chainstate_test_framework::TxVerificationStrategy;
-use common::chain::{tokens::TokenIssuanceVersion, ChainstateUpgrade, Destination, NetUpgrades};
 
 #[rstest]
 #[trace]
@@ -31,18 +30,6 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
                 max_tip_age: Default::default(),
             })
             .with_tx_verification_strategy(TxVerificationStrategy::Randomized(seed))
-            .with_chain_config(
-                common::chain::config::Builder::test_chain()
-                    .chainstate_upgrades(
-                        NetUpgrades::initialize(vec![(
-                            BlockHeight::zero(),
-                            ChainstateUpgrade::new(TokenIssuanceVersion::V1),
-                        )])
-                        .unwrap(),
-                    )
-                    .genesis_unittest(Destination::AnyoneCanSpend)
-                    .build(),
-            )
             .build();
 
         for _ in 0..rng.gen_range(10..max_blocks) {

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -104,8 +104,8 @@ pub enum ConnectTransactionError {
     StakerBalanceNotFound(PoolId),
     #[error("Data of pool {0} not found")]
     PoolDataNotFound(PoolId),
-    #[error("Failed to calculate reward for block {0} for staker of the pool {1}")]
-    StakerRewardCalculationFailed(Id<Block>, PoolId),
+    #[error("Balance of pool {0} not found")]
+    PoolBalanceNotFound(PoolId),
     #[error(
         "Reward in block {0} for the pool {1} staker which is {2:?} cannot be bigger than total reward {3:?}"
     )]
@@ -116,10 +116,14 @@ pub enum ConnectTransactionError {
     DelegationsRewardSumFailed(Id<Block>, PoolId),
     #[error("Reward for delegation {0} overflowed: {1:?}*{2:?}/{3:?}")]
     DelegationRewardOverflow(DelegationId, Amount, Amount, Amount),
+    #[error("Reward for staker {0} overflowed: {1:?}*{2:?}/{3:?}")]
+    StakerRewardOverflow(PoolId, Amount, Amount, Amount),
     #[error("Actually distributed delegation rewards {0} for pool {1} in block {2:?} is bigger then total delegations reward {3:?}")]
     DistributedDelegationsRewardExceedTotal(PoolId, Id<Block>, Amount, Amount),
     #[error("Total balance of delegations in pool {0} is zero")]
     TotalDelegationBalanceZero(PoolId),
+    #[error("Balance of pool {0} is zero")]
+    PoolBalanceIsZero(PoolId),
     #[error("Data for delegation {0} not found")]
     DelegationDataNotFound(DelegationId),
 

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -118,7 +118,7 @@ pub enum ConnectTransactionError {
     DelegationsRewardSumFailed(Id<Block>, PoolId),
     #[error("Reward for delegation {0} overflowed: {1:?}*{2:?}/{3:?}")]
     DelegationRewardOverflow(DelegationId, Amount, Amount, Amount),
-    #[error("Reward for staker {0} overflowed: {1:?}*{2:?}/{3:?}")]
+    #[error("Reward for staker {0} overflowed: {1:?}+{2:?}+{3:?}")]
     StakerRewardOverflow(PoolId, Amount, Amount, Amount),
     #[error("Actually distributed delegation rewards {0} for pool {1} in block {2:?} is bigger then total delegations reward {3:?}")]
     DistributedDelegationsRewardExceedTotal(PoolId, Id<Block>, Amount, Amount),

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -29,7 +29,7 @@ use thiserror::Error;
 use crate::timelock_check;
 
 use super::{
-    input_output_policy::IOPolicyError,
+    input_output_policy::IOPolicyError, reward_distribution,
     signature_destination_getter::SignatureDestinationGetterError,
     storage::TransactionVerifierStorageError,
 };
@@ -106,26 +106,8 @@ pub enum ConnectTransactionError {
     PoolDataNotFound(PoolId),
     #[error("Balance of pool {0} not found")]
     PoolBalanceNotFound(PoolId),
-    #[error("Failed to calculate reward for block {0} for staker of the pool {1}")]
-    StakerRewardCalculationFailed(Id<Block>, PoolId),
-    #[error(
-        "Reward in block {0} for the pool {1} staker which is {2:?} cannot be bigger than total reward {3:?}"
-    )]
-    StakerRewardCannotExceedTotalReward(Id<Block>, PoolId, Amount, Amount),
     #[error("Unexpected pool id in kernel {0} doesn't match pool id {1}")]
     UnexpectedPoolId(PoolId, PoolId),
-    #[error("Failed to sum block {0} reward for pool {1} delegations")]
-    DelegationsRewardSumFailed(Id<Block>, PoolId),
-    #[error("Reward for delegation {0} overflowed: {1:?}*{2:?}/{3:?}")]
-    DelegationRewardOverflow(DelegationId, Amount, Amount, Amount),
-    #[error("Reward for staker {0} overflowed: {1:?}+{2:?}+{3:?}")]
-    StakerRewardOverflow(PoolId, Amount, Amount, Amount),
-    #[error("Actually distributed delegation rewards {0} for pool {1} in block {2:?} is bigger then total delegations reward {3:?}")]
-    DistributedDelegationsRewardExceedTotal(PoolId, Id<Block>, Amount, Amount),
-    #[error("Total balance of delegations in pool {0} is zero")]
-    TotalDelegationBalanceZero(PoolId),
-    #[error("Balance of pool {0} is zero")]
-    PoolBalanceIsZero(PoolId),
     #[error("Data for delegation {0} not found")]
     DelegationDataNotFound(DelegationId),
 
@@ -168,6 +150,8 @@ pub enum ConnectTransactionError {
     InsufficientCoinsFee(Amount, Amount),
     #[error("Cannot perform any operations for frozen token {0}")]
     AttemptToSpendFrozenToken(TokenId),
+    #[error("Reward distribution error: {0}")]
+    RewardDistributionError(#[from] reward_distribution::RewardDistributionError),
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -106,6 +106,8 @@ pub enum ConnectTransactionError {
     PoolDataNotFound(PoolId),
     #[error("Balance of pool {0} not found")]
     PoolBalanceNotFound(PoolId),
+    #[error("Failed to calculate reward for block {0} for staker of the pool {1}")]
+    StakerRewardCalculationFailed(Id<Block>, PoolId),
     #[error(
         "Reward in block {0} for the pool {1} staker which is {2:?} cannot be bigger than total reward {3:?}"
     )]

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -57,7 +57,7 @@ use self::{
     utxos_undo_cache::{UtxosBlockUndoCache, UtxosBlockUndoEntry},
 };
 use ::utils::{ensure, shallow_clone::ShallowClone};
-pub use reward_distribution::distribute_pos_reward;
+pub use reward_distribution::{distribute_pos_reward, RewardDistributionError};
 
 use chainstate_types::BlockIndex;
 use common::{

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -877,11 +877,21 @@ where
                 let undos = {
                     let mut accounting_adapter =
                         self.pos_accounting_adapter.operations(TransactionSource::Chain(block_id));
+
+                    let reward_distribution_version = self
+                        .chain_config
+                        .as_ref()
+                        .chainstate_upgrades()
+                        .version_at_height(block_index.block_height())
+                        .1
+                        .reward_distribution_version();
+
                     let undos = reward_distribution::distribute_pos_reward(
                         &mut accounting_adapter,
                         block_id,
                         *pos_data.stake_pool_id(),
                         total_reward,
+                        reward_distribution_version,
                     )?;
 
                     AccountingBlockRewardUndo::new(undos)

--- a/chainstate/tx-verifier/src/transaction_verifier/reward_distribution.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/reward_distribution.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use crate::error::ConnectTransactionError;
 
 use common::{
-    chain::{Block, DelegationId, PoolId},
+    chain::{Block, DelegationId, PoolId, RewardDistributionVersion},
     primitives::{
         amount::UnsignedIntType as AmountUIntType, per_thousand::PerThousand, Amount, Id,
     },
@@ -37,6 +37,7 @@ pub fn distribute_pos_reward<
     block_id: Id<Block>,
     pool_id: PoolId,
     total_reward: Amount,
+    reward_distribution_version: RewardDistributionVersion,
 ) -> Result<Vec<U>, ConnectTransactionError> {
     let pool_data = accounting_adapter
         .get_pool_data(pool_id)?
@@ -45,14 +46,24 @@ pub fn distribute_pos_reward<
         .get_pool_balance(pool_id)?
         .ok_or(ConnectTransactionError::PoolBalanceNotFound(pool_id))?;
 
-    let staker_reward = calculate_staker_reward(
-        total_reward,
-        pool_balance,
-        pool_data.staker_balance()?,
-        pool_data.cost_per_block(),
-        pool_data.margin_ratio_per_thousand(),
-        pool_id,
-    )?;
+    let staker_reward = match reward_distribution_version {
+        RewardDistributionVersion::V0 => calculate_staker_reward_v0(
+            total_reward,
+            pool_data.cost_per_block(),
+            pool_data.margin_ratio_per_thousand(),
+        )
+        .ok_or(ConnectTransactionError::StakerRewardCalculationFailed(
+            block_id, pool_id,
+        ))?,
+        RewardDistributionVersion::V1 => calculate_staker_reward_v1(
+            total_reward,
+            pool_balance,
+            pool_data.staker_balance()?,
+            pool_data.cost_per_block(),
+            pool_data.margin_ratio_per_thousand(),
+            pool_id,
+        )?,
+    };
 
     let total_delegations_reward = (total_reward - staker_reward).ok_or(
         ConnectTransactionError::StakerRewardCannotExceedTotalReward(
@@ -108,7 +119,24 @@ pub fn distribute_pos_reward<
     Ok(undos)
 }
 
-fn calculate_staker_reward(
+fn calculate_staker_reward_v0(
+    total_reward: Amount,
+    cost_per_block: Amount,
+    mpt: PerThousand,
+) -> Option<Amount> {
+    let staker_reward = match total_reward - cost_per_block {
+        Some(v) => (v * mpt.value().into())
+            .and_then(|v| v / 1000)
+            .and_then(|v| v + cost_per_block)?,
+        // if cost per block > total reward then give the reward to staker
+        None => total_reward,
+    };
+
+    debug_assert!(staker_reward <= total_reward);
+    Some(staker_reward)
+}
+
+fn calculate_staker_reward_v1(
     total_reward: Amount,
     pool_balance: Amount,
     staker_balance: Amount,
@@ -273,7 +301,70 @@ mod tests {
     #[rstest]
     #[trace]
     #[case(Seed::from_entropy())]
-    fn calculate_staker_reward_test(#[case] seed: Seed) {
+    fn calculate_staker_reward_test_v0(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+
+        let reward = Amount::from_atoms(rng.gen_range(1..=100_000_000));
+        let cost_per_block = Amount::from_atoms(rng.gen_range(1..=reward.into_atoms()));
+        let cost_per_block_over_reward =
+            (reward + Amount::from_atoms(rng.gen_range(1..=100_000_000))).unwrap();
+        let mpt = PerThousand::new_from_rng(&mut rng);
+        let mpt_zero = PerThousand::new(0).unwrap();
+        let mpt_more_than_one = PerThousand::new(rng.gen_range(2..=1000)).unwrap();
+
+        assert!(calculate_staker_reward_v0(Amount::ZERO, Amount::ZERO, mpt_zero).is_some());
+        assert!(calculate_staker_reward_v0(Amount::ZERO, Amount::ZERO, mpt).is_some());
+        assert!(calculate_staker_reward_v0(reward, Amount::ZERO, mpt_zero).is_some());
+        assert!(calculate_staker_reward_v0(reward, Amount::ZERO, mpt).is_some());
+        assert!(calculate_staker_reward_v0(reward, Amount::ZERO, mpt_zero).is_some());
+        assert!(calculate_staker_reward_v0(reward, cost_per_block, mpt_zero).is_some());
+        assert!(calculate_staker_reward_v0(reward, cost_per_block, mpt).is_some());
+        // negative amount
+        assert_eq!(
+            calculate_staker_reward_v0(Amount::ZERO, cost_per_block, mpt_zero),
+            Some(Amount::ZERO)
+        );
+        // cost per block > reward
+        assert_eq!(
+            calculate_staker_reward_v0(reward, cost_per_block_over_reward, mpt_zero),
+            Some(reward)
+        );
+        // overflow
+        assert!(
+            calculate_staker_reward_v0(Amount::MAX, cost_per_block, mpt_more_than_one).is_none()
+        );
+
+        // arbitrary values
+        assert_eq!(
+            calculate_staker_reward_v0(
+                Amount::from_atoms(100),
+                Amount::from_atoms(10),
+                PerThousand::new(100).unwrap()
+            ),
+            Some(Amount::from_atoms(19))
+        );
+        assert_eq!(
+            calculate_staker_reward_v0(
+                Amount::from_atoms(1100),
+                Amount::from_atoms(100),
+                PerThousand::new(100).unwrap()
+            ),
+            Some(Amount::from_atoms(200))
+        );
+        assert_eq!(
+            calculate_staker_reward_v0(
+                Amount::from_atoms(10_000),
+                Amount::from_atoms(33),
+                PerThousand::new(111).unwrap()
+            ),
+            Some(Amount::from_atoms(1139))
+        );
+    }
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    fn calculate_staker_reward_test_v1(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
 
         let pool_id = new_pool_id(1);
@@ -289,7 +380,7 @@ mod tests {
         let mpt_more_than_one = PerThousand::new(rng.gen_range(2..=1000)).unwrap();
 
         assert_eq!(
-            calculate_staker_reward(
+            calculate_staker_reward_v1(
                 Amount::ZERO,
                 Amount::ZERO,
                 Amount::ZERO,
@@ -300,7 +391,7 @@ mod tests {
             Err(ConnectTransactionError::PoolBalanceIsZero(pool_id))
         );
         assert_eq!(
-            calculate_staker_reward(
+            calculate_staker_reward_v1(
                 reward,
                 Amount::ZERO,
                 Amount::ZERO,
@@ -310,7 +401,7 @@ mod tests {
             ),
             Err(ConnectTransactionError::PoolBalanceIsZero(pool_id))
         );
-        assert!(calculate_staker_reward(
+        assert!(calculate_staker_reward_v1(
             reward,
             pool_balance,
             staker_balance,
@@ -319,7 +410,7 @@ mod tests {
             pool_id
         )
         .is_ok());
-        assert!(calculate_staker_reward(
+        assert!(calculate_staker_reward_v1(
             reward,
             pool_balance,
             staker_balance,
@@ -328,7 +419,7 @@ mod tests {
             pool_id
         )
         .is_ok());
-        assert!(calculate_staker_reward(
+        assert!(calculate_staker_reward_v1(
             reward,
             pool_balance,
             Amount::ZERO,
@@ -339,7 +430,7 @@ mod tests {
         .is_ok());
         // negative amount
         assert_eq!(
-            calculate_staker_reward(
+            calculate_staker_reward_v1(
                 Amount::ZERO,
                 pool_balance,
                 staker_balance,
@@ -351,7 +442,7 @@ mod tests {
         );
         // cost per block > reward
         assert_eq!(
-            calculate_staker_reward(
+            calculate_staker_reward_v1(
                 reward,
                 pool_balance,
                 staker_balance,
@@ -362,7 +453,7 @@ mod tests {
             Ok(reward)
         );
         // overflow
-        assert!(calculate_staker_reward(
+        assert!(calculate_staker_reward_v1(
             Amount::MAX,
             pool_balance,
             staker_balance,
@@ -374,7 +465,7 @@ mod tests {
 
         // arbitrary values
         assert_eq!(
-            calculate_staker_reward(
+            calculate_staker_reward_v1(
                 Amount::from_atoms(100),
                 Amount::from_atoms(1000),
                 Amount::from_atoms(500),
@@ -385,7 +476,7 @@ mod tests {
             Ok(Amount::from_atoms(59))
         );
         assert_eq!(
-            calculate_staker_reward(
+            calculate_staker_reward_v1(
                 Amount::from_atoms(1100),
                 Amount::from_atoms(1000),
                 Amount::from_atoms(500),
@@ -396,7 +487,7 @@ mod tests {
             Ok(Amount::from_atoms(650))
         );
         assert_eq!(
-            calculate_staker_reward(
+            calculate_staker_reward_v1(
                 Amount::from_atoms(10_000),
                 Amount::from_atoms(700),
                 Amount::from_atoms(55),
@@ -415,8 +506,9 @@ mod tests {
     // Then undo everything and check that original state was restored.
     #[rstest]
     #[trace]
-    #[case(Seed::from_entropy())]
-    fn distribution_basic(#[case] seed: Seed) {
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V0)]
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V1)]
+    fn distribution_basic(#[case] seed: Seed, #[case] version: RewardDistributionVersion) {
         let mut rng = make_seedable_rng(seed);
         let block_id = Id::new(H256::random_using(&mut rng));
 
@@ -453,7 +545,11 @@ mod tests {
             PerThousand::new(100).unwrap(),
             Amount::from_atoms(50),
         );
-        let expected_staker_reward = Amount::from_atoms(278);
+
+        let expected_staker_reward = match version {
+            RewardDistributionVersion::V0 => Amount::from_atoms(150),
+            RewardDistributionVersion::V1 => Amount::from_atoms(278),
+        };
         let expected_pool_data_a = PoolData::new(
             Destination::AnyoneCanSpend,
             pledged_amount,
@@ -462,6 +558,14 @@ mod tests {
             PerThousand::new(100).unwrap(),
             Amount::from_atoms(50),
         );
+        let expected_delegation_a_1_reward = match version {
+            RewardDistributionVersion::V0 => Amount::from_atoms(300),
+            RewardDistributionVersion::V1 => Amount::from_atoms(257),
+        };
+        let expected_delegation_a_2_reward = match version {
+            RewardDistributionVersion::V0 => Amount::from_atoms(600),
+            RewardDistributionVersion::V1 => Amount::from_atoms(515),
+        };
 
         let mut store = InMemoryPoSAccounting::from_values(
             BTreeMap::from([(pool_id_a, pool_data.clone()), (pool_id_b, pool_data.clone())]),
@@ -498,24 +602,24 @@ mod tests {
             BTreeMap::from([
                 (
                     (pool_id_a, delegation_a_1),
-                    (delegation_a_1_amount + Amount::from_atoms(257)).unwrap(),
+                    (delegation_a_1_amount + expected_delegation_a_1_reward).unwrap(),
                 ),
                 ((pool_id_b, delegation_b_1), delegation_b_1_amount),
                 (
                     (pool_id_a, delegation_a_2),
-                    (delegation_a_2_amount + Amount::from_atoms(515)).unwrap(),
+                    (delegation_a_2_amount + expected_delegation_a_2_reward).unwrap(),
                 ),
                 ((pool_id_b, delegation_b_2), delegation_b_2_amount),
             ]),
             BTreeMap::from_iter([
                 (
                     delegation_a_1,
-                    (delegation_a_1_amount + Amount::from_atoms(257)).unwrap(),
+                    (delegation_a_1_amount + expected_delegation_a_1_reward).unwrap(),
                 ),
                 (delegation_b_1, delegation_b_1_amount),
                 (
                     delegation_a_2,
-                    (delegation_a_2_amount + Amount::from_atoms(515)).unwrap(),
+                    (delegation_a_2_amount + expected_delegation_a_2_reward).unwrap(),
                 ),
                 (delegation_b_2, delegation_b_2_amount),
             ]),
@@ -530,7 +634,14 @@ mod tests {
         let all_undos = {
             let mut accounting_adapter =
                 accounting_adapter.operations(TransactionSource::Chain(block_id));
-            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id_a, reward).unwrap()
+            distribute_pos_reward(
+                &mut accounting_adapter,
+                block_id,
+                pool_id_a,
+                reward,
+                version,
+            )
+            .unwrap()
         };
 
         let (consumed, _) = accounting_adapter.consume();
@@ -558,8 +669,9 @@ mod tests {
     // Check distribution properties.
     #[rstest]
     #[trace]
-    #[case(Seed::from_entropy())]
-    fn distribution_properties(#[case] seed: Seed) {
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V0)]
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V1)]
+    fn distribution_properties(#[case] seed: Seed, #[case] version: RewardDistributionVersion) {
         let mut rng = make_seedable_rng(seed);
         let block_id = Id::new(H256::random_using(&mut rng));
 
@@ -583,8 +695,11 @@ mod tests {
         let reward = Amount::from_atoms(rng.gen_range(0..100_000_000));
         let cost_per_block = Amount::from_atoms(rng.gen_range(0..reward.into_atoms()));
         let mpt = PerThousand::new_from_rng(&mut rng);
-        let total_delegation_reward = (reward
-            - calculate_staker_reward(
+        let staker_reward = match version {
+            RewardDistributionVersion::V0 => {
+                calculate_staker_reward_v0(reward, cost_per_block, mpt).unwrap()
+            }
+            RewardDistributionVersion::V1 => calculate_staker_reward_v1(
                 reward,
                 original_pool_balance,
                 original_pledged_amount,
@@ -592,8 +707,9 @@ mod tests {
                 mpt,
                 pool_id,
             )
-            .unwrap())
-        .unwrap();
+            .unwrap(),
+        };
+        let total_delegation_reward = (reward - staker_reward).unwrap();
 
         let delegation_data = DelegationData::new(pool_id, Destination::AnyoneCanSpend);
 
@@ -628,7 +744,8 @@ mod tests {
         {
             let mut accounting_adapter =
                 accounting_adapter.operations(TransactionSource::Chain(block_id));
-            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id, reward).unwrap()
+            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id, reward, version)
+                .unwrap()
         };
 
         let staker_reward = accounting_adapter
@@ -705,8 +822,12 @@ mod tests {
     // Check that if delegation is present but its balance is 0 then all the reward goes to staker
     #[rstest]
     #[trace]
-    #[case(Seed::from_entropy())]
-    fn total_delegations_balance_zero(#[case] seed: Seed) {
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V0)]
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V1)]
+    fn total_delegations_balance_zero(
+        #[case] seed: Seed,
+        #[case] version: RewardDistributionVersion,
+    ) {
         let mut rng = make_seedable_rng(seed);
         let block_id = Id::new(H256::random_using(&mut rng));
 
@@ -755,7 +876,8 @@ mod tests {
         {
             let mut accounting_adapter =
                 accounting_adapter.operations(TransactionSource::Chain(block_id));
-            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id, reward).unwrap()
+            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id, reward, version)
+                .unwrap()
         };
 
         let expected_store = InMemoryPoSAccounting::from_values(
@@ -775,8 +897,12 @@ mod tests {
     // Check that staker can set its reward to 100% and the reward goes entirely to the staker
     #[rstest]
     #[trace]
-    #[case(Seed::from_entropy())]
-    fn total_delegations_reward_zero(#[case] seed: Seed) {
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V0)]
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V1)]
+    fn total_delegations_reward_zero(
+        #[case] seed: Seed,
+        #[case] version: RewardDistributionVersion,
+    ) {
         let mut rng = make_seedable_rng(seed);
         let block_id = Id::new(H256::random_using(&mut rng));
 
@@ -825,7 +951,8 @@ mod tests {
         {
             let mut accounting_adapter =
                 accounting_adapter.operations(TransactionSource::Chain(block_id));
-            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id, reward).unwrap()
+            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id, reward, version)
+                .unwrap()
         };
 
         let expected_store = InMemoryPoSAccounting::from_values(
@@ -845,8 +972,9 @@ mod tests {
     // Check that if there are no delegations then the whole reward goes to the staker
     #[rstest]
     #[trace]
-    #[case(Seed::from_entropy())]
-    fn no_delegations(#[case] seed: Seed) {
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V0)]
+    #[case(Seed::from_entropy(), RewardDistributionVersion::V1)]
+    fn no_delegations(#[case] seed: Seed, #[case] version: RewardDistributionVersion) {
         let mut rng = make_seedable_rng(seed);
         let block_id = Id::new(H256::random_using(&mut rng));
         let pool_id = new_pool_id(1);
@@ -890,7 +1018,8 @@ mod tests {
         {
             let mut accounting_adapter =
                 accounting_adapter.operations(TransactionSource::Chain(block_id));
-            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id, reward).unwrap()
+            distribute_pos_reward(&mut accounting_adapter, block_id, pool_id, reward, version)
+                .unwrap()
         };
 
         let expected_store = InMemoryPoSAccounting::from_values(

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -30,7 +30,7 @@ use crate::{
         pow::PoWChainConfigBuilder,
         tokens::TokenIssuanceVersion,
         ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
-        PoSChainConfig, PoSConsensusVersion, PoWChainConfig,
+        PoSChainConfig, PoSConsensusVersion, PoWChainConfig, RewardDistributionVersion,
     },
     primitives::{
         id::WithId, per_thousand::PerThousand, semver::SemVer, Amount, BlockCount, BlockDistance,
@@ -42,6 +42,8 @@ use crypto::key::hdkd::child_number::ChildNumber;
 
 // The fork, at which we upgrade consensus to dis-incentivize large pools + enable tokens v1
 const CHAINSTATE_AND_TOKEN_FORK_HEIGHT: BlockHeight = BlockHeight::new(78440);
+// The fork, at which we upgrade chainstate to distribute reward to staker proportionally to its balance
+const CHAINSTATE_STAKER_REWARD_FORK_HEIGHT: BlockHeight = BlockHeight::new(138244);
 
 impl ChainType {
     fn default_genesis_init(&self) -> GenesisBlockInit {
@@ -125,7 +127,7 @@ impl ChainType {
             ChainType::Mainnet | ChainType::Regtest | ChainType::Signet => {
                 let upgrades = vec![(
                     BlockHeight::new(0),
-                    ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                    ChainstateUpgrade::new(TokenIssuanceVersion::V1, RewardDistributionVersion::V1),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
@@ -133,11 +135,24 @@ impl ChainType {
                 let upgrades = vec![
                     (
                         BlockHeight::new(0),
-                        ChainstateUpgrade::new(TokenIssuanceVersion::V0),
+                        ChainstateUpgrade::new(
+                            TokenIssuanceVersion::V0,
+                            RewardDistributionVersion::V0,
+                        ),
                     ),
                     (
                         CHAINSTATE_AND_TOKEN_FORK_HEIGHT,
-                        ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                        ChainstateUpgrade::new(
+                            TokenIssuanceVersion::V1,
+                            RewardDistributionVersion::V0,
+                        ),
+                    ),
+                    (
+                        CHAINSTATE_STAKER_REWARD_FORK_HEIGHT,
+                        ChainstateUpgrade::new(
+                            TokenIssuanceVersion::V1,
+                            RewardDistributionVersion::V1,
+                        ),
                     ),
                 ];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -41,9 +41,9 @@ use crate::{
 use crypto::key::hdkd::child_number::ChildNumber;
 
 // The fork, at which we upgrade consensus to dis-incentivize large pools + enable tokens v1
-const CHAINSTATE_AND_TOKEN_FORK_HEIGHT: BlockHeight = BlockHeight::new(78440);
+const TESTNET_TOKEN_FORK_HEIGHT: BlockHeight = BlockHeight::new(78440);
 // The fork, at which we upgrade chainstate to distribute reward to staker proportionally to its balance
-const CHAINSTATE_STAKER_REWARD_FORK_HEIGHT: BlockHeight = BlockHeight::new(138244);
+const TESTNET_STAKER_REWARD_FORK_HEIGHT: BlockHeight = BlockHeight::new(138244);
 
 impl ChainType {
     fn default_genesis_init(&self) -> GenesisBlockInit {
@@ -103,7 +103,7 @@ impl ChainType {
                         },
                     ),
                     (
-                        CHAINSTATE_AND_TOKEN_FORK_HEIGHT,
+                        TESTNET_TOKEN_FORK_HEIGHT,
                         ConsensusUpgrade::PoS {
                             initial_difficulty: None,
                             config: PoSChainConfig::new(
@@ -141,14 +141,14 @@ impl ChainType {
                         ),
                     ),
                     (
-                        CHAINSTATE_AND_TOKEN_FORK_HEIGHT,
+                        TESTNET_TOKEN_FORK_HEIGHT,
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V0,
                         ),
                     ),
                     (
-                        CHAINSTATE_STAKER_REWARD_FORK_HEIGHT,
+                        TESTNET_STAKER_REWARD_FORK_HEIGHT,
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V1,

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -45,6 +45,7 @@ use self::checkpoints::Checkpoints;
 use self::emission_schedule::DEFAULT_INITIAL_MINT;
 use super::output_value::OutputValue;
 use super::tokens::TokenIssuanceVersion;
+use super::RewardDistributionVersion;
 use super::{stakelock::StakePoolData, RequiredConsensus};
 use super::{ChainstateUpgrade, ConsensusUpgrade};
 
@@ -744,7 +745,7 @@ pub fn create_unit_test_config_builder() -> Builder {
         .chainstate_upgrades(
             NetUpgrades::initialize(vec![(
                 BlockHeight::zero(),
-                ChainstateUpgrade::new(TokenIssuanceVersion::V1),
+                ChainstateUpgrade::new(TokenIssuanceVersion::V1, RewardDistributionVersion::V1),
             )])
             .expect("cannot fail"),
         )

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -17,20 +17,37 @@ use crate::chain::tokens::TokenIssuanceVersion;
 
 use super::Activate;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+pub enum RewardDistributionVersion {
+    /// Initial distribution implementation
+    V0,
+    /// Distribute reward to staker proportional to its balance
+    V1,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ChainstateUpgrade {
     token_issuance_version: TokenIssuanceVersion,
+    reward_distribution_version: RewardDistributionVersion,
 }
 
 impl ChainstateUpgrade {
-    pub fn new(token_issuance_version: TokenIssuanceVersion) -> Self {
+    pub fn new(
+        token_issuance_version: TokenIssuanceVersion,
+        reward_distribution_version: RewardDistributionVersion,
+    ) -> Self {
         Self {
             token_issuance_version,
+            reward_distribution_version,
         }
     }
 
     pub fn token_issuance_version(&self) -> TokenIssuanceVersion {
         self.token_issuance_version
+    }
+
+    pub fn reward_distribution_version(&self) -> RewardDistributionVersion {
+        self.reward_distribution_version
     }
 }
 

--- a/common/src/chain/upgrades/mod.rs
+++ b/common/src/chain/upgrades/mod.rs
@@ -17,7 +17,7 @@ mod chainstate_upgrade;
 mod consensus_upgrade;
 mod netupgrade;
 
-pub use chainstate_upgrade::ChainstateUpgrade;
+pub use chainstate_upgrade::{ChainstateUpgrade, RewardDistributionVersion};
 pub use consensus_upgrade::{ConsensusUpgrade, PoSStatus, PoWStatus, RequiredConsensus};
 pub use netupgrade::{Activate, NetUpgrades};
 

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -135,6 +135,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::AttemptToSpendBurnedAmount => 100,
             ConnectTransactionError::BurnAmountSumError(_) => 100,
             ConnectTransactionError::SpendStakeError(_) => 100,
+            ConnectTransactionError::StakerRewardCalculationFailed(_, _) => 100,
             ConnectTransactionError::StakerRewardCannotExceedTotalReward(_, _, _, _) => 100,
             ConnectTransactionError::UnexpectedPoolId(_, _) => 100,
             ConnectTransactionError::NotEnoughPledgeToCreateStakePool(_, _, _) => 100,

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -135,7 +135,6 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::AttemptToSpendBurnedAmount => 100,
             ConnectTransactionError::BurnAmountSumError(_) => 100,
             ConnectTransactionError::SpendStakeError(_) => 100,
-            ConnectTransactionError::StakerRewardCalculationFailed(_, _) => 100,
             ConnectTransactionError::StakerRewardCannotExceedTotalReward(_, _, _, _) => 100,
             ConnectTransactionError::UnexpectedPoolId(_, _) => 100,
             ConnectTransactionError::NotEnoughPledgeToCreateStakePool(_, _, _) => 100,
@@ -166,6 +165,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::AccountingBlockUndoError(_) => 0,
             ConnectTransactionError::StakerBalanceNotFound(_) => 0,
             ConnectTransactionError::PoolDataNotFound(_) => 0,
+            ConnectTransactionError::PoolBalanceNotFound(_) => 0,
             ConnectTransactionError::StorageError(_) => 0,
             ConnectTransactionError::UndoFetchFailure => 0,
             ConnectTransactionError::TxVerifierStorage => 0,
@@ -173,6 +173,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::MissingMempoolTxsUndo => 0,
             ConnectTransactionError::DelegationsRewardSumFailed(_, _) => 0,
             ConnectTransactionError::DelegationRewardOverflow(_, _, _, _) => 0,
+            ConnectTransactionError::StakerRewardOverflow(_, _, _, _) => 0,
             ConnectTransactionError::DistributedDelegationsRewardExceedTotal(_, _, _, _) => 0,
             ConnectTransactionError::BlockRewardInputOutputMismatch(_, _) => 0,
             ConnectTransactionError::TotalDelegationBalanceZero(_) => 0,
@@ -181,6 +182,7 @@ impl MempoolBanScore for ConnectTransactionError {
             ConnectTransactionError::FailedToIncrementAccountNonce => 0,
             ConnectTransactionError::TokensAccountingBlockUndoError(_) => 0,
             ConnectTransactionError::AttemptToSpendFrozenToken(_) => 0,
+            ConnectTransactionError::PoolBalanceIsZero(_) => 0,
         }
     }
 }

--- a/mempool/src/pool/orphans/detect.rs
+++ b/mempool/src/pool/orphans/detect.rs
@@ -68,7 +68,6 @@ impl OrphanType {
             | CTE::SpendStakeError(_)
             | CTE::StakerBalanceNotFound(_)
             | CTE::PoolDataNotFound(_)
-            | CTE::StakerRewardCalculationFailed(_, _)
             | CTE::StakerRewardCannotExceedTotalReward(..)
             | CTE::UnexpectedPoolId(_, _)
             | CTE::DelegationsRewardSumFailed(..)
@@ -91,6 +90,9 @@ impl OrphanType {
             | CTE::InsufficientCoinsFee(_, _)
             | CTE::AttemptToSpendFrozenToken(_)
             | CTE::ConstrainedValueAccumulatorError(_, _)
+            | CTE::PoolBalanceNotFound(_)
+            | CTE::StakerRewardOverflow(_, _, _, _)
+            | CTE::PoolBalanceIsZero(_)
             | CTE::IOPolicyError(_, _) => None,
         }
     }

--- a/mempool/src/pool/orphans/detect.rs
+++ b/mempool/src/pool/orphans/detect.rs
@@ -68,13 +68,7 @@ impl OrphanType {
             | CTE::SpendStakeError(_)
             | CTE::StakerBalanceNotFound(_)
             | CTE::PoolDataNotFound(_)
-            | CTE::StakerRewardCalculationFailed(_, _)
-            | CTE::StakerRewardCannotExceedTotalReward(..)
             | CTE::UnexpectedPoolId(_, _)
-            | CTE::DelegationsRewardSumFailed(..)
-            | CTE::DelegationRewardOverflow(..)
-            | CTE::DistributedDelegationsRewardExceedTotal(..)
-            | CTE::TotalDelegationBalanceZero(_)
             | CTE::UndoFetchFailure
             | CTE::TxVerifierStorage
             | CTE::DestinationRetrievalError(_)
@@ -92,8 +86,7 @@ impl OrphanType {
             | CTE::AttemptToSpendFrozenToken(_)
             | CTE::ConstrainedValueAccumulatorError(_, _)
             | CTE::PoolBalanceNotFound(_)
-            | CTE::StakerRewardOverflow(_, _, _, _)
-            | CTE::PoolBalanceIsZero(_)
+            | CTE::RewardDistributionError(_)
             | CTE::IOPolicyError(_, _) => None,
         }
     }

--- a/mempool/src/pool/orphans/detect.rs
+++ b/mempool/src/pool/orphans/detect.rs
@@ -68,6 +68,7 @@ impl OrphanType {
             | CTE::SpendStakeError(_)
             | CTE::StakerBalanceNotFound(_)
             | CTE::PoolDataNotFound(_)
+            | CTE::StakerRewardCalculationFailed(_, _)
             | CTE::StakerRewardCannotExceedTotalReward(..)
             | CTE::UnexpectedPoolId(_, _)
             | CTE::DelegationsRewardSumFailed(..)

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -326,7 +326,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             assert_in("Success", await wallet.select_account(1))
             acc1_address = await wallet.new_address()
             assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
-            assert_in("The transaction was submitted successfully", await wallet.send_to_address(acc1_address, 100))
+            assert_in("The transaction was submitted successfully", await wallet.send_to_address(acc1_address, 5000))
             assert_in("Success", await wallet.select_account(1))
             transactions = node.mempool_transactions()
 
@@ -353,7 +353,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             delegations = await wallet.list_delegation_ids()
             assert_equal(len(delegations), 0)
 
-            assert_in("Success", await wallet.stake_delegation(10, delegation_id))
+            assert_in("Success", await wallet.stake_delegation(1000, delegation_id))
             transactions2 = node.mempool_transactions()
             for tx in transactions2:
                 if tx not in transactions:
@@ -365,7 +365,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
 
             delegations = await wallet.list_delegation_ids()
             assert_equal(len(delegations), 1)
-            assert_equal(delegations[0].balance, 10)
+            assert_equal(delegations[0].balance, 1000)
 
             assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
             created_block_ids = await wallet.list_created_blocks_ids()

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -300,23 +300,28 @@ pub enum WalletCommand {
     /// and will be capable of taking delegations from other users and staking.
     /// The decommission key is the key that can decommission the pool.
     /// Cost per block, and margin ratio are parameters that control how delegators receive rewards.
-    /// The cost per block is an amount in coins to be subtracted from the total rewards in a block,
+    /// The cost per block is an amount in coins to be subtracted from the total rewards in a block first,
     /// and handed to the staking pool. After subtracting the cost per block, a fraction equal to
     /// margin ratio is taken from what is left, and given to the staking pool. Finally, what is left
-    /// is distributed among stakers, pro-rata, based on their delegation amounts.
+    /// is distributed among delegators, pro-rata, based on their delegation amounts.
     #[clap(name = "staking-create-pool")]
     CreateStakePool {
         /// The amount to be pledged to the pool. There is a minimum to be accepted.
         /// This amount, and the rewards gained by the pool, CANNOT be taken out without decommissioning the pool.
         /// If you'd like to withdraw rewards, consider creating a pool and delegating to yourself.
         /// Delegators have no restrictions on withdrawals.
+        /// The likelihood to win block rewards, by creating blocks while staking, is proportional to how much the pool owns,
+        /// up to a maximum, to discourage heavy centralization of power.
         amount: String,
 
-        /// An amount in coins to be subtracted from the total rewards in a block and handed to the pool.
+        /// An amount in coins to be subtracted from the total rewards in a block and handed to the staker
+        /// as a constant/fixed cost for running the pool.
         cost_per_block: String,
 
-        /// After subtracting "cost per block" from the reward, this ratio is taken from the rewards and is handed to the pool.
+        /// After subtracting "cost per block" from the reward, this ratio is taken from the rewards and is handed to the staker.
         /// What is left is distributed among delegators, pro-rata, based on their delegation amounts.
+        /// The amount here is written as a percentage with per-mill accuracy. For example, 0.1% is valid,
+        /// and is equivalent to 0.001. Also 5% is valid and is equivalent to 0.05.
         margin_ratio_per_thousand: String,
 
         /// The key that can decommission the pool. It's recommended to keep the decommission key in a cold storage.


### PR DESCRIPTION
Staker should get reward proportional to its balance.

Now if the total reward is T the process is as follows:

1. Subtract cost-per-block from T, what’s left is U
2. Split U pro-rata among delegators and staker, give the staker his amount, and what’s for delegators goes to the next step, call it X
3. Multiple X by margin ratio, give the result to the staker, and the rest is distributed among delegators, pro-rata.