### PR TITLE
p2p: fix self-connect detection

### DIFF
--- a/build-tools/p2p-test/README.md
+++ b/build-tools/p2p-test/README.md
@@ -30,7 +30,7 @@ to shut down the containers.
 ```
 run_wallet_cmd.sh node_idx cmd [cmd_params...]
 ```
-Run the specified wallet-cli command on the specified node. E.g. `run_wallet_cmd.sh 1 connectedpeers` will print peer information for the 1st node.
+Run the specified wallet-cli command on the specified node. E.g. `run_wallet_cmd.sh 1 node-list-connected-peers` will print peer information for the 1st node.
 
 #### prune_node.sh
 ```

--- a/build-tools/p2p-test/print_connected_peers.sh
+++ b/build-tools/p2p-test/print_connected_peers.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 print_peers() {
     local node_id=$1
     echo "Node ${node_id}'s peers:"
-    "${SCRIPT_DIR}/run_wallet_cmd.sh" "$node_id" connectedpeersjson 2> /dev/null | \
+    "${SCRIPT_DIR}/run_wallet_cmd.sh" "$node_id" node-list-connected-peers-json 2> /dev/null | \
         jq -c '.[] | [.peer_id, .address, .software_version, .peer_role]'
     echo
 }

--- a/build-tools/p2p-test/run_wallet_cmd.sh
+++ b/build-tools/p2p-test/run_wallet_cmd.sh
@@ -11,7 +11,7 @@ if [[ $# -lt 2 ]]; then
     echo "Run a wallet command on the specified node"
     echo "Usage: $(basename "$0") container_idx wallet_cmd [wallet_cmd_params...]"
     echo "  node_idx - the index of the node, e.g. 1, 2, 3 etc"
-    echo "  wallet_cmd - the command to send to the wallet, e.g. connectedpeers"
+    echo "  wallet_cmd - the command to send to the wallet, e.g. node-list-connected-peers"
     echo "  wallet_cmd_params - optional parameters for the specified command"
     exit 1
 fi

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 
 use chainstate::ban_score::BanScore;
 use p2p_types::services::Services;
-use tokio::{sync::mpsc, time::timeout};
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::timeout,
+};
 
 use common::{chain::ChainConfig, primitives::time::Time, time_getter::TimeGetter};
 use logging::log;
@@ -36,7 +39,9 @@ use crate::{
 
 use super::{
     transport::BufferedTranscoder,
-    types::{CategorizedMessage, HandshakeMessage, HandshakeNonce, Message, P2pTimestamp},
+    types::{
+        peer_event, CategorizedMessage, HandshakeMessage, HandshakeNonce, Message, P2pTimestamp,
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -186,20 +191,33 @@ where
                 let common_protocol_version =
                     choose_common_protocol_version(protocol_version, self.node_protocol_version)?;
 
-                // Send PeerInfoReceived before sending handshake to remote peer!
-                // Backend is expected to receive PeerInfoReceived before outgoing connection has chance to complete handshake,
-                // It's required to reliably detect self-connects.
+                // Note: we send `PeerInfoReceived` to `Backend` before sending `HelloAck`
+                // to the remote peer. `Backend` expects to receive `PeerInfoReceived` before
+                // the outgoing connection has a chance to complete the handshake; specifically,
+                // it relies on this fact when detecting self-connections.
+                // Also note that we wait for the confirmation from `Backend` before sending
+                // `HelloAck` to the peer. Without it a race is possible during self-connection
+                // detection (which we've experienced in production), where the "outbound" part
+                // of a self-connection may still be able to complete the handshake before the
+                // "inbound" `PeerInfoReceived` manages to reach `Backend`.
+                let (confirmation_sender, confirmation_receiver) = oneshot::channel();
+
                 self.peer_event_sender
                     .send(PeerEvent::PeerInfoReceived {
-                        protocol_version: common_protocol_version,
-                        network,
-                        common_services,
-                        user_agent,
-                        software_version,
-                        node_address_as_seen_by_peer,
-                        handshake_nonce,
+                        info: peer_event::PeerInfo {
+                            protocol_version: common_protocol_version,
+                            network,
+                            common_services,
+                            user_agent,
+                            software_version,
+                            node_address_as_seen_by_peer,
+                            handshake_nonce,
+                        },
+                        confirmation_sender: Some(confirmation_sender),
                     })
                     .await?;
+
+                let _ = confirmation_receiver.await;
 
                 self.socket
                     .send(Message::Handshake(HandshakeMessage::HelloAck {
@@ -256,13 +274,16 @@ where
 
                 self.peer_event_sender
                     .send(PeerEvent::PeerInfoReceived {
-                        protocol_version: common_protocol_version,
-                        network,
-                        common_services,
-                        user_agent,
-                        software_version,
-                        node_address_as_seen_by_peer,
-                        handshake_nonce,
+                        info: peer_event::PeerInfo {
+                            protocol_version: common_protocol_version,
+                            network,
+                            common_services,
+                            user_agent,
+                            software_version,
+                            node_address_as_seen_by_peer,
+                            handshake_nonce,
+                        },
+                        confirmation_sender: None,
                     })
                     .await?;
             }
@@ -427,6 +448,46 @@ mod tests {
 
     const TEST_CHAN_BUF_SIZE: usize = 100;
 
+    async fn expect_peer_info_received(
+        peer_event_receiver: &mut mpsc::Receiver<PeerEvent>,
+        expected_info: &peer_event::PeerInfo,
+    ) {
+        let peer_event = peer_event_receiver.recv().await.unwrap();
+        match peer_event {
+            PeerEvent::PeerInfoReceived {
+                info,
+                confirmation_sender,
+            } => {
+                assert_eq!(&info, expected_info);
+
+                if let Some(confirmation_sender) = confirmation_sender {
+                    let _ = confirmation_sender.send(());
+                }
+            }
+            _ => {
+                panic!("Unexpected peer event: {peer_event:?}")
+            }
+        }
+    }
+
+    // Same as expect_peer_info_received, but we don't care about the actual info.
+    async fn expect_some_peer_info_received(peer_event_receiver: &mut mpsc::Receiver<PeerEvent>) {
+        let peer_event = peer_event_receiver.recv().await.unwrap();
+        match peer_event {
+            PeerEvent::PeerInfoReceived {
+                info: _,
+                confirmation_sender,
+            } => {
+                if let Some(confirmation_sender) = confirmation_sender {
+                    let _ = confirmation_sender.send(());
+                }
+            }
+            _ => {
+                panic!("Unexpected peer event: {peer_event:?}")
+            }
+        }
+    }
+
     async fn handshake_inbound<A, T>()
     where
         A: TestTransportMaker<Transport = T>,
@@ -475,10 +536,9 @@ mod tests {
             .await
             .is_ok());
 
-        let _peer = handle.await.unwrap();
-        assert_eq!(
-            peer_event_receiver.try_recv().unwrap(),
-            PeerEvent::PeerInfoReceived {
+        expect_peer_info_received(
+            &mut peer_event_receiver,
+            &peer_event::PeerInfo {
                 protocol_version: TEST_PROTOCOL_VERSION,
                 network: *chain_config.magic_bytes(),
                 common_services: [Service::Blocks, Service::Transactions].as_slice().into(),
@@ -486,8 +546,10 @@ mod tests {
                 software_version: *chain_config.software_version(),
                 node_address_as_seen_by_peer: None,
                 handshake_nonce: 123,
-            }
-        );
+            },
+        )
+        .await;
+        let _peer = handle.await.unwrap();
     }
 
     #[tracing::instrument]
@@ -558,10 +620,9 @@ mod tests {
             .await
             .is_ok());
 
-        let _peer = handle.await.unwrap();
-        assert_eq!(
-            peer_event_receiver.try_recv(),
-            Ok(PeerEvent::PeerInfoReceived {
+        expect_peer_info_received(
+            &mut peer_event_receiver,
+            &peer_event::PeerInfo {
                 protocol_version: TEST_PROTOCOL_VERSION,
                 network: *chain_config.magic_bytes(),
                 common_services: [Service::Blocks, Service::Transactions].as_slice().into(),
@@ -569,8 +630,10 @@ mod tests {
                 software_version: *chain_config.software_version(),
                 node_address_as_seen_by_peer: None,
                 handshake_nonce: 1,
-            })
-        );
+            },
+        )
+        .await;
+        let _peer = handle.await.unwrap();
     }
 
     #[tracing::instrument]
@@ -599,7 +662,7 @@ mod tests {
         let (socket1, socket2) = get_two_connected_sockets::<A, T>().await;
         let chain_config = Arc::new(common::chain::config::create_mainnet());
         let p2p_config = Arc::new(test_p2p_config());
-        let (peer_event_sender, _peer_event_receiver) = mpsc::channel(TEST_CHAN_BUF_SIZE);
+        let (peer_event_sender, mut peer_event_receiver) = mpsc::channel(TEST_CHAN_BUF_SIZE);
         let (_backend_event_sender, backend_event_receiver) = mpsc::unbounded_channel();
         let cur_time = Arc::new(SeqCstAtomicU64::new(123456));
         let time_getter = mocked_time_getter_seconds(Arc::clone(&cur_time));
@@ -636,6 +699,7 @@ mod tests {
             .await
             .is_ok());
 
+        expect_some_peer_info_received(&mut peer_event_receiver).await;
         assert_eq!(handle.await.unwrap(), Ok(()));
     }
 


### PR DESCRIPTION
This fixes self-connect detection by putting a one-shot `confirmation_sender` into `PeerEvent::PeerInfoReceived`. After sending a `PeerInfoReceived` event to `Backend` during an inbound connection handshake, `Peer` will wait on the corresponding receiver to make sure that the event is received by `Backend` before the "outbound" part of the connection has a chance to complete the handshake (which is relied upon by self-connect detection logic in `Backend`).

No new tests have been added for this, because the existing `self_connect` tests can reproduce the problem if they are made multi-threaded.

There is also some minor unrelated cleanup which I did while trying to reproduce the issue.