### PR TITLE
Fix log coloring on Windows

### DIFF
--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -88,11 +88,28 @@ where
     });
 }
 
+fn can_use_coloring() -> bool {
+    if cfg!(windows) {
+        // Allow using colors if run in an MSYS console, which includes Git Bash
+        // (the value of the variable will differ depending on how the console was started,
+        // so we don't check it).
+        // Also note that though Cygwin technically supports ansi coloring, it only works
+        // in applications linked with cygwin.dll, so it makes no sense to check for it here
+        // (which doesn't seem to be possible anyway).
+        // Finally, we could enable ansi coloring for the traditional Windows console by using
+        // this crate - https://github.com/sunshowers-code/enable-ansi-support
+        // This will work only starting from Windows 10 though.
+        std::env::var("MSYSTEM").is_ok()
+    } else {
+        true
+    }
+}
+
 fn should_use_coloring(preferred_coloring: TextColoring, is_terminal: bool) -> bool {
     match preferred_coloring {
         TextColoring::On => true,
         TextColoring::Off => false,
-        TextColoring::Auto => is_terminal,
+        TextColoring::Auto => is_terminal && can_use_coloring(),
     }
 }
 

--- a/node-gui/src/main.rs
+++ b/node-gui/src/main.rs
@@ -13,6 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Windows only: prevent opening a console window when the GUI app is started.
+// Note that it's also supposed to detach the app from the console when it's being
+// launched from one, which is unfortunate, because it's useful to be able to run
+// the GUI app and still see the logs. However, for some reason this is not true
+// for MSYS console, which remains attached, so it's still possible to observe
+// the logs by using MSYS.
+#![windows_subsystem = "windows"]
+
 mod backend;
 mod main_window;
 mod widgets;

--- a/node-gui/src/main.rs
+++ b/node-gui/src/main.rs
@@ -13,14 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Windows only: prevent opening a console window when the GUI app is started.
-// Note that it's also supposed to detach the app from the console when it's being
-// launched from one, which is unfortunate, because it's useful to be able to run
-// the GUI app and still see the logs. However, for some reason this is not true
-// for MSYS console, which remains attached, so it's still possible to observe
-// the logs by using MSYS.
-#![windows_subsystem = "windows"]
-
 mod backend;
 mod main_window;
 mod widgets;


### PR DESCRIPTION
Disable log colouring on Windows unless we're run inside MSYS console.

This fixes #1445.

I also added `#![windows_subsystem = "windows"]` to node-gui to prevent it from opening a console window.
