### PR TITLE
Support all arguments for pool creation in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ The logging of mintlayer-core is configured via the `RUST_LOG` environment varia
 Here are the commands as recommended for different scenarios:
 
 For normal operation
-- Node daemon: `RUST_LOG=info cargo run --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
-- CLI Wallet:  `RUST_LOG=info cargo run --bin wallet-cli -- --network testnet 2>&1 | tee ../wallet-cli.log`
-- GUI:         `RUST_LOG=info cargo run --bin node-gui 2>&1 | tee ../node-gui.log`
+- Node daemon: `RUST_LOG=info cargo run --release --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
+- CLI Wallet:  `RUST_LOG=info cargo run --release --bin wallet-cli -- testnet 2>&1 | tee ../wallet-cli.log`
+- GUI:         `RUST_LOG=info cargo run --release --bin node-gui 2>&1 | tee ../node-gui.log`
 
 For heavy debugging operation
 - Node daemon: `RUST_LOG=debug cargo run --bin node-daemon -- testnet 2>&1 | tee ../mintlayer.log`
-- CLI Wallet:  `RUST_LOG=debug cargo run --bin wallet-cli -- --network testnet 2>&1 | tee ../wallet-cli.log`
+- CLI Wallet:  `RUST_LOG=debug cargo run --bin wallet-cli -- testnet 2>&1 | tee ../wallet-cli.log`
 - GUI:         `RUST_LOG=debug cargo run --bin node-gui 2>&1 | tee ../node-gui.log`

--- a/node-gui/src/backend/error.rs
+++ b/node-gui/src/backend/error.rs
@@ -29,4 +29,10 @@ pub enum BackendError {
     AddressError(String),
     #[error("Invalid amount: {0}")]
     InvalidAmount(String),
+    #[error("Invalid pledge amount: {0}")]
+    InvalidPledgeAmount(String),
+    #[error("Invalid cost per block amount: {0}")]
+    InvalidCostPerBlockAmount(String),
+    #[error("Failed to parse margin per thousand: {0}. The decimal must be in the range [0.001,1.000] or [0.1%,100%]")]
+    InvalidMarginPerThousand(String),
 }

--- a/node-gui/src/backend/messages.rs
+++ b/node-gui/src/backend/messages.rs
@@ -94,7 +94,10 @@ pub struct SendRequest {
 pub struct StakeRequest {
     pub wallet_id: WalletId,
     pub account_id: AccountId,
-    pub amount: String,
+    pub pledge_amount: String,
+    pub mpt: String,
+    pub cost_per_block: String,
+    pub decommission_address: String,
 }
 
 #[derive(Debug, Clone)]

--- a/node-gui/src/main_window/main_widget/tabs/wallet/mod.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/mod.rs
@@ -71,6 +71,9 @@ pub enum WalletMessage {
     SendSucceed,
 
     StakeAmountEdit(String),
+    MarginPerThousandEdit(String),
+    CostPerBlockEdit(String),
+    DecommissionAddressEdit(String),
     CreateStakingPool,
     CreateStakingPoolSucceed,
 
@@ -88,6 +91,9 @@ pub struct AccountState {
     send_amount: String,
     send_address: String,
     stake_amount: String,
+    margin_per_thousand: String,
+    cost_per_block_amount: String,
+    decommission_address: String,
 }
 
 pub struct WalletTab {
@@ -197,17 +203,36 @@ impl WalletTab {
                 self.account_state.stake_amount = value;
                 Command::none()
             }
+            WalletMessage::MarginPerThousandEdit(value) => {
+                self.account_state.margin_per_thousand = value;
+                Command::none()
+            }
+            WalletMessage::CostPerBlockEdit(value) => {
+                self.account_state.cost_per_block_amount = value;
+                Command::none()
+            }
+            WalletMessage::DecommissionAddressEdit(value) => {
+                self.account_state.decommission_address = value;
+                Command::none()
+            }
+
             WalletMessage::CreateStakingPool => {
                 let request = StakeRequest {
                     wallet_id: self.wallet_id,
                     account_id: self.selected_account,
-                    amount: self.account_state.stake_amount.clone(),
+                    pledge_amount: self.account_state.stake_amount.clone(),
+                    mpt: self.account_state.margin_per_thousand.clone(),
+                    cost_per_block: self.account_state.cost_per_block_amount.clone(),
+                    decommission_address: self.account_state.decommission_address.clone(),
                 };
                 backend_sender.send(BackendRequest::StakeAmount(request));
                 Command::none()
             }
             WalletMessage::CreateStakingPoolSucceed => {
                 self.account_state.stake_amount.clear();
+                self.account_state.margin_per_thousand.clear();
+                self.account_state.cost_per_block_amount.clear();
+                self.account_state.decommission_address.clear();
                 Command::none()
             }
             WalletMessage::ToggleStaking(enabled) => {
@@ -290,6 +315,9 @@ impl Tab for WalletTab {
                             &node_state.chain_config,
                             account,
                             &self.account_state.stake_amount,
+                            &self.account_state.margin_per_thousand,
+                            &self.account_state.cost_per_block_amount,
+                            &self.account_state.decommission_address,
                             still_syncing.clone(),
                         ),
                     };

--- a/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
@@ -28,6 +28,9 @@ pub fn view_stake(
     chain_config: &ChainConfig,
     account: &AccountInfo,
     stake_amount: &str,
+    mpt: &str,
+    cost_per_block: &str,
+    decommission_key: &str,
     still_syncing: Option<WalletMessage>,
 ) -> Element<'static, WalletMessage> {
     let field = |text: String| container(Text::new(text)).padding(5);
@@ -73,14 +76,24 @@ pub fn view_stake(
     };
 
     column![
-        row![
-            text_input("Pledge amount for the new staking pool", stake_amount)
-                .on_input(|value| { WalletMessage::StakeAmountEdit(value) })
-                .padding(15),
-            iced::widget::button(Text::new("Create staking pool"))
-                .padding(15)
-                .on_press(still_syncing.unwrap_or(WalletMessage::CreateStakingPool))
-        ],
+        text_input("Pledge amount for the new staking pool", stake_amount)
+            .on_input(|value| { WalletMessage::StakeAmountEdit(value) })
+            .padding(15),
+        text_input("Cost per block", cost_per_block)
+            .on_input(|value| { WalletMessage::CostPerBlockEdit(value) })
+            .padding(15),
+        text_input("Margin ratio per thousand. The decimal must be in the range [0.001,1.000] or [0.1%,100%]", mpt)
+            .on_input(|value| { WalletMessage::MarginPerThousandEdit(value) })
+            .padding(15),
+        text_input(
+            "Decommission address",
+            decommission_key
+        )
+        .on_input(|value| { WalletMessage::DecommissionAddressEdit(value) })
+        .padding(15),
+        iced::widget::button(Text::new("Create staking pool"))
+            .padding(15)
+            .on_press(still_syncing.unwrap_or(WalletMessage::CreateStakingPool)),
         staking_enabled_row.spacing(10).align_items(Alignment::Center),
         iced::widget::horizontal_rule(10),
         staking_balance_grid,


### PR DESCRIPTION
Now all arguments for pool creation can be provided from GUI.

P.S. added small change to the README file. --network flag is an error that people bump all the time. Also I think providing release command by default is the right thing to do

P.P.S added 2 tests to check create pool duplication error and decided to keep them around