### PR TITLE
Add tooltips to staking tab

### DIFF
--- a/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
@@ -15,7 +15,7 @@
 
 use common::{address::Address, chain::ChainConfig};
 use iced::{
-    widget::{column, container, row, text_input, Text},
+    widget::{column, container, row, text_input, tooltip, tooltip::Position, Text},
     Alignment, Element,
 };
 use iced_aw::Grid;
@@ -23,6 +23,23 @@ use iced_aw::Grid;
 use crate::{backend::messages::AccountInfo, main_window::print_coin_amount};
 
 use super::WalletMessage;
+
+const PLEDGE_AMOUNT_TOOLTIP_TEXT: &str ="The amount to be pledged to the pool. There is a minimum to be accepted.\
+        This amount, and the rewards gained by the pool, CANNOT be taken out without decommissioning the pool.\
+        If you'd like to withdraw rewards, consider creating a pool and delegating to yourself.\
+        Delegators have no restrictions on withdrawals.\
+        The likelihood to win block rewards, by creating blocks while staking, is proportional to how much the pool owns,\
+        up to a maximum, to discourage heavy centralization of power.";
+
+const COST_PER_BLOCK_TOOLTIP_TEXT: &str = "An amount in coins to be subtracted from the total rewards in a block and handed to the staker\
+        as a constant/fixed cost for running the pool.";
+
+const MARGIN_PER_THOUSAND_TOOLTIP_TEXT: &str = "After subtracting \"cost per block\" from the reward, this ratio is taken from the rewards and is handed to the staker.\
+        What is left is distributed among delegators, pro-rata, based on their delegation amounts.\
+        The amount here is written as a percentage with per-mill accuracy. For example, 0.1% is valid,\
+        and is equivalent to 0.001. Also 5% is valid and is equivalent to 0.05.";
+
+const DECOMMISSION_ADDRESS_TOOLTIP_TEXT: &str = "The key that can decommission the pool. It's recommended to keep the decommission key in a cold storage.";
 
 pub fn view_stake(
     chain_config: &ChainConfig,
@@ -76,21 +93,54 @@ pub fn view_stake(
     };
 
     column![
-        text_input("Pledge amount for the new staking pool", stake_amount)
-            .on_input(|value| { WalletMessage::StakeAmountEdit(value) })
-            .padding(15),
-        text_input("Cost per block", cost_per_block)
-            .on_input(|value| { WalletMessage::CostPerBlockEdit(value) })
-            .padding(15),
-        text_input("Margin ratio per thousand. The decimal must be in the range [0.001,1.000] or [0.1%,100%]", mpt)
-            .on_input(|value| { WalletMessage::MarginPerThousandEdit(value) })
-            .padding(15),
-        text_input(
-            "Decommission address",
-            decommission_key
-        )
-        .on_input(|value| { WalletMessage::DecommissionAddressEdit(value) })
-        .padding(15),
+        row![
+            text_input("Pledge amount for the new staking pool", stake_amount)
+                .on_input(|value| { WalletMessage::StakeAmountEdit(value) })
+                .padding(15),
+            tooltip(
+                Text::new(iced_aw::Icon::Question.to_string()).font(iced_aw::ICON_FONT),
+                PLEDGE_AMOUNT_TOOLTIP_TEXT,
+                Position::Bottom)
+            .gap(10)
+            .style(iced::theme::Container::Box)
+        ],
+
+        row![
+            text_input("Cost per block", cost_per_block)
+                .on_input(|value| { WalletMessage::CostPerBlockEdit(value) })
+                .padding(15),
+            tooltip(
+                Text::new(iced_aw::Icon::Question.to_string()).font(iced_aw::ICON_FONT),
+                COST_PER_BLOCK_TOOLTIP_TEXT,
+                Position::Bottom)
+            .gap(10)
+            .style(iced::theme::Container::Box)
+        ],
+
+        row![
+            text_input("Margin ratio per thousand. The decimal must be in the range [0.001,1.000] or [0.1%,100%]", mpt)
+                .on_input(|value| { WalletMessage::MarginPerThousandEdit(value) })
+                .padding(15),
+            tooltip(
+                Text::new(iced_aw::Icon::Question.to_string()).font(iced_aw::ICON_FONT),
+                MARGIN_PER_THOUSAND_TOOLTIP_TEXT,
+                Position::Bottom)
+            .gap(10)
+            .style(iced::theme::Container::Box)
+        ],
+
+        row![
+            text_input("Decommission address", decommission_key)
+                .on_input(|value| { WalletMessage::DecommissionAddressEdit(value) })
+                .padding(15),
+            tooltip(
+                Text::new(iced_aw::Icon::Question.to_string()).font(iced_aw::ICON_FONT),
+                DECOMMISSION_ADDRESS_TOOLTIP_TEXT,
+                Position::Bottom)
+            .gap(10)
+            .style(iced::theme::Container::Box)
+        ],
+
         iced::widget::button(Text::new("Create staking pool"))
             .padding(15)
             .on_press(still_syncing.unwrap_or(WalletMessage::CreateStakingPool)),


### PR DESCRIPTION
On the staking tab if you hover over the question mark right to the input fields the tooltip with details appears. 
I added these icons to the right because tooltip over the input fields turned out to be pretty annoying.

<img width="1018" alt="Screenshot 2024-01-18 at 13 44 13" src="https://github.com/mintlayer/mintlayer-core/assets/105876856/18efc9d6-666f-4a45-a64b-7fe548b98dc4">
