### PR TITLE
Tokens fees testnet fork

### DIFF
--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -438,7 +438,8 @@ async fn tx_fees<T: ApiServerStorageWrite>(
     )
     .expect("valid block");
     let outputs_accumulator =
-        ConstrainedValueAccumulator::from_outputs(chain_config, tx.outputs()).expect("valid block");
+        ConstrainedValueAccumulator::from_outputs(chain_config, block_height, tx.outputs())
+            .expect("valid block");
     let consumed_accumulator =
         inputs_accumulator.satisfy_with(outputs_accumulator).expect("valid block");
     Ok(consumed_accumulator)

--- a/chainstate/constraints-value-accumulator/src/tests/constraints_tests.rs
+++ b/chainstate/constraints-value-accumulator/src/tests/constraints_tests.rs
@@ -94,7 +94,7 @@ fn allow_fees_from_decommission(#[case] seed: Seed) {
     .unwrap();
 
     let outputs_accumulator =
-        ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+        ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs).unwrap();
 
     let accumulated_fee = inputs_accumulator
         .satisfy_with(outputs_accumulator)
@@ -150,7 +150,7 @@ fn allow_fees_from_spend_share(#[case] seed: Seed) {
     .unwrap();
 
     let outputs_accumulator =
-        ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+        ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs).unwrap();
 
     let accumulated_fee = inputs_accumulator
         .satisfy_with(outputs_accumulator)
@@ -224,7 +224,8 @@ fn no_timelock_outputs_on_decommission(#[case] seed: Seed) {
         .unwrap();
 
         let outputs_accumulator =
-            ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+            ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs)
+                .unwrap();
 
         let result = inputs_accumulator.satisfy_with(outputs_accumulator);
         assert_eq!(
@@ -251,7 +252,8 @@ fn no_timelock_outputs_on_decommission(#[case] seed: Seed) {
         .unwrap();
 
         let outputs_accumulator =
-            ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+            ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs)
+                .unwrap();
 
         inputs_accumulator.satisfy_with(outputs_accumulator).unwrap();
     }
@@ -331,7 +333,7 @@ fn try_to_unlock_coins_with_smaller_timelock(#[case] seed: Seed) {
     .unwrap();
 
     let outputs_accumulator =
-        ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+        ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs).unwrap();
 
     let result = inputs_accumulator.satisfy_with(outputs_accumulator);
 
@@ -370,7 +372,8 @@ fn try_to_unlock_coins_with_smaller_timelock(#[case] seed: Seed) {
         .unwrap();
 
         let outputs_accumulator =
-            ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+            ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs)
+                .unwrap();
 
         inputs_accumulator.satisfy_with(outputs_accumulator).unwrap();
     }
@@ -464,7 +467,7 @@ fn check_timelock_saturation(#[case] seed: Seed) {
     .unwrap();
 
     let outputs_accumulator =
-        ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+        ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs).unwrap();
 
     let result = inputs_accumulator.satisfy_with(outputs_accumulator);
     assert_eq!(
@@ -496,7 +499,7 @@ fn check_timelock_saturation(#[case] seed: Seed) {
     .unwrap();
 
     let outputs_accumulator =
-        ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+        ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs).unwrap();
 
     let accumulated_fee = inputs_accumulator
         .satisfy_with(outputs_accumulator)
@@ -575,7 +578,8 @@ fn try_to_overspend_on_spending_delegation(#[case] seed: Seed) {
         .unwrap();
 
         let outputs_accumulator =
-            ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+            ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs)
+                .unwrap();
 
         let result = inputs_accumulator.satisfy_with(outputs_accumulator);
         assert_eq!(
@@ -611,7 +615,8 @@ fn try_to_overspend_on_spending_delegation(#[case] seed: Seed) {
         .unwrap();
 
         let outputs_accumulator =
-            ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+            ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs)
+                .unwrap();
 
         inputs_accumulator.satisfy_with(outputs_accumulator).unwrap();
     }

--- a/chainstate/constraints-value-accumulator/src/tests/homomorphism.rs
+++ b/chainstate/constraints-value-accumulator/src/tests/homomorphism.rs
@@ -227,7 +227,8 @@ fn accumulators_homomorphism(#[case] seed: Seed) {
             .cloned()
             .collect::<Vec<TxOutput>>();
         let outputs_accumulator =
-            ConstrainedValueAccumulator::from_outputs(&chain_config, &outputs).unwrap();
+            ConstrainedValueAccumulator::from_outputs(&chain_config, block_height, &outputs)
+                .unwrap();
 
         inputs_accumulator.satisfy_with(outputs_accumulator).unwrap()
     };
@@ -243,9 +244,12 @@ fn accumulators_homomorphism(#[case] seed: Seed) {
         )
         .unwrap();
 
-        let decommission_outputs_accumulator =
-            ConstrainedValueAccumulator::from_outputs(&chain_config, decommission_tx.outputs())
-                .unwrap();
+        let decommission_outputs_accumulator = ConstrainedValueAccumulator::from_outputs(
+            &chain_config,
+            block_height,
+            decommission_tx.outputs(),
+        )
+        .unwrap();
 
         let spend_share_inputs_accumulator = ConstrainedValueAccumulator::from_inputs(
             &chain_config,
@@ -257,9 +261,12 @@ fn accumulators_homomorphism(#[case] seed: Seed) {
         )
         .unwrap();
 
-        let spend_share_outputs_accumulator =
-            ConstrainedValueAccumulator::from_outputs(&chain_config, spend_share_tx.outputs())
-                .unwrap();
+        let spend_share_outputs_accumulator = ConstrainedValueAccumulator::from_outputs(
+            &chain_config,
+            block_height,
+            spend_share_tx.outputs(),
+        )
+        .unwrap();
 
         decommission_inputs_accumulator
             .satisfy_with(decommission_outputs_accumulator)

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -25,8 +25,8 @@ use common::{
         output_value::OutputValue,
         tokens::{make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0},
         ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersionVersion, Transaction, TxInput, TxOutput,
-        UtxoOutPoint,
+        TokenIssuanceVersion, TokensFeeVersionVersion, TokensTickerMaxLengthVersion, Transaction,
+        TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Id, Idable},
 };
@@ -119,6 +119,7 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersionVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -197,6 +198,7 @@ fn store_nft_v0(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersionVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -376,11 +378,7 @@ fn store_aux_data_from_issue_nft(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(
-                                TokenIssuanceVersion::V1,
-                                RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
-                            ),
+                            ChainstateUpgrade::latest(),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -378,7 +378,12 @@ fn store_aux_data_from_issue_nft(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::latest(),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V1,
+                                RewardDistributionVersion::V1,
+                                TokensFeeVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -23,11 +23,10 @@ use chainstate_test_framework::{
 use common::{
     chain::{
         output_value::OutputValue,
-        tokens::{
-            make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0, TokenIssuanceVersion,
-        },
+        tokens::{make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0},
         ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        Transaction, TxInput, TxOutput, UtxoOutPoint,
+        TokenIssuanceVersion, TokensFeeVersionVersion, Transaction, TxInput, TxOutput,
+        UtxoOutPoint,
     },
     primitives::{Amount, Id, Idable},
 };
@@ -119,6 +118,7 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
+                                TokensFeeVersionVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -196,6 +196,7 @@ fn store_nft_v0(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
+                                TokensFeeVersionVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -378,6 +379,7 @@ fn store_aux_data_from_issue_nft(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
+                                TokensFeeVersionVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -25,8 +25,8 @@ use common::{
         output_value::OutputValue,
         tokens::{make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0},
         ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersionVersion, TokensTickerMaxLengthVersion, Transaction,
-        TxInput, TxOutput, UtxoOutPoint,
+        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, Transaction, TxInput,
+        TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Id, Idable},
 };
@@ -118,7 +118,7 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
+                                TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
@@ -197,7 +197,7 @@ fn store_nft_v0(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
+                                TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                             ),
                         )])

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -28,8 +28,8 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         tokens::{make_token_id, TokenData, TokenId},
-        ChainstateUpgrade, Destination, OutPointSourceId, TokenIssuanceVersion,
-        TokensFeeVersionVersion, TxInput, TxOutput,
+        ChainstateUpgrade, Destination, OutPointSourceId, TokenIssuanceVersion, TokensFeeVersion,
+        TxInput, TxOutput,
     },
     primitives::{Amount, Idable},
 };
@@ -55,7 +55,7 @@ fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramewor
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V0,
                             RewardDistributionVersion::V1,
-                            TokensFeeVersionVersion::V1,
+                            TokensFeeVersion::V1,
                             TokensTickerMaxLengthVersion::V1,
                         ),
                     )])
@@ -959,7 +959,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
+                                TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
@@ -1018,7 +1018,7 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                 ChainstateUpgrade::new(
                                     TokenIssuanceVersion::V0,
                                     RewardDistributionVersion::V1,
-                                    TokensFeeVersionVersion::V1,
+                                    TokensFeeVersion::V1,
                                     TokensTickerMaxLengthVersion::V1,
                                 ),
                             ),
@@ -1027,7 +1027,7 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                 ChainstateUpgrade::new(
                                     TokenIssuanceVersion::V1,
                                     RewardDistributionVersion::V1,
-                                    TokensFeeVersionVersion::V1,
+                                    TokensFeeVersion::V1,
                                     TokensTickerMaxLengthVersion::V1,
                                 ),
                             ),

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -27,8 +27,9 @@ use common::{
     chain::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
-        tokens::{make_token_id, TokenData, TokenId, TokenIssuanceVersion},
-        ChainstateUpgrade, Destination, OutPointSourceId, TxInput, TxOutput,
+        tokens::{make_token_id, TokenData, TokenId},
+        ChainstateUpgrade, Destination, OutPointSourceId, TokenIssuanceVersion,
+        TokensFeeVersionVersion, TxInput, TxOutput,
     },
     primitives::{Amount, Idable},
 };
@@ -54,6 +55,7 @@ fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramewor
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V0,
                             RewardDistributionVersion::V1,
+                            TokensFeeVersionVersion::V1,
                         ),
                     )])
                     .unwrap(),
@@ -956,6 +958,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
+                                TokensFeeVersionVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1013,6 +1016,7 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                 ChainstateUpgrade::new(
                                     TokenIssuanceVersion::V0,
                                     RewardDistributionVersion::V1,
+                                    TokensFeeVersionVersion::V1,
                                 ),
                             ),
                             (
@@ -1020,6 +1024,7 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                 ChainstateUpgrade::new(
                                     TokenIssuanceVersion::V1,
                                     RewardDistributionVersion::V1,
+                                    TokensFeeVersionVersion::V1,
                                 ),
                             ),
                         ])

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -21,7 +21,7 @@ use chainstate::{
 };
 use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::chain::tokens::{Metadata, NftIssuanceV0, TokenIssuanceV0, TokenTransfer};
-use common::chain::{RewardDistributionVersion, UtxoOutPoint};
+use common::chain::{RewardDistributionVersion, TokensTickerMaxLengthVersion, UtxoOutPoint};
 use common::primitives::{id, BlockHeight, Id};
 use common::{
     chain::{
@@ -56,6 +56,7 @@ fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramewor
                             TokenIssuanceVersion::V0,
                             RewardDistributionVersion::V1,
                             TokensFeeVersionVersion::V1,
+                            TokensTickerMaxLengthVersion::V1,
                         ),
                     )])
                     .unwrap(),
@@ -959,6 +960,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersionVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1017,6 +1019,7 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     TokenIssuanceVersion::V0,
                                     RewardDistributionVersion::V1,
                                     TokensFeeVersionVersion::V1,
+                                    TokensTickerMaxLengthVersion::V1,
                                 ),
                             ),
                             (
@@ -1025,6 +1028,7 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     TokenIssuanceVersion::V1,
                                     RewardDistributionVersion::V1,
                                     TokensFeeVersionVersion::V1,
+                                    TokensTickerMaxLengthVersion::V1,
                                 ),
                             ),
                         ])

--- a/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
@@ -257,7 +257,8 @@ fn token_issue_test(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let genesis_source_id: OutPointSourceId = tf.genesis().get_id().into();
 
-        let token_max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let token_max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let token_max_dec_count = tf.chainstate.get_chain_config().token_max_dec_count();
         let token_max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
 
@@ -3798,7 +3799,8 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let genesis_block_id = tf.best_block_id();
 
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         // Try not ascii alphanumeric ticker
         let c = test_utils::get_random_non_ascii_alphanumeric_byte(&mut rng);

--- a/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
@@ -33,7 +33,7 @@ use common::{
         AccountCommand, AccountNonce, AccountType, Block, Destination, GenBlock, OutPointSourceId,
         SignedTransaction, Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
-    primitives::{signed_amount::SignedAmount, Amount, CoinOrTokenId, Id, Idable},
+    primitives::{signed_amount::SignedAmount, Amount, BlockHeight, CoinOrTokenId, Id, Idable},
 };
 use crypto::{
     key::{KeyKind, PrivateKey},
@@ -125,7 +125,8 @@ fn mint_tokens_in_block(
     amount_to_mint: Amount,
     produce_change: bool,
 ) -> (Id<Block>, Id<Transaction>) {
-    let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+    let token_supply_change_fee =
+        tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
     let nonce = BlockchainStorageRead::get_account_nonce_count(
         &tf.storage.transaction_ro().unwrap(),
@@ -182,7 +183,8 @@ fn unmint_tokens_in_block(
     utxo_to_pay_fee: UtxoOutPoint,
     amount_to_unmint: Amount,
 ) -> (Id<Block>, Id<Transaction>) {
-    let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+    let token_supply_change_fee =
+        tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
     let nonce = BlockchainStorageRead::get_account_nonce_count(
         &tf.storage.transaction_ro().unwrap(),
@@ -608,7 +610,8 @@ fn mint_unmint_fixed_supply(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let mut nonce = AccountNonce::new(0);
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let total_supply = Amount::from_atoms(rng.gen_range(2..100_000_000));
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
@@ -1232,7 +1235,8 @@ fn mint_unlimited_supply(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let amount_to_mint = Amount::from_atoms(rng.gen_range(1..=i128::MAX as u128));
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
@@ -1317,7 +1321,8 @@ fn mint_unlimited_supply_max(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let max_amount_to_mint = Amount::from_atoms(i128::MAX as u128);
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
@@ -2086,7 +2091,8 @@ fn check_lockable_supply(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let mut nonce = AccountNonce::new(0);
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
             &mut rng,
@@ -2296,7 +2302,8 @@ fn try_lock_twice(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let mut nonce = AccountNonce::new(0);
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
             &mut rng,
@@ -2483,7 +2490,8 @@ fn mint_fee(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let some_amount = Amount::from_atoms(rng.gen_range(100..100_000));
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
@@ -2577,7 +2585,8 @@ fn unmint_fee(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let some_amount = Amount::from_atoms(rng.gen_range(100..100_000));
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
@@ -2676,7 +2685,8 @@ fn lock_supply_fee(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
             &mut rng,
@@ -2904,7 +2914,8 @@ fn issue_and_mint_same_block(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let genesis_source_id: OutPointSourceId = tf.genesis().get_id().into();
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
         let amount_to_mint = Amount::from_atoms(rng.gen_range(1..100_000));
         let token_id = make_token_id(&[TxInput::from_utxo(genesis_source_id.clone(), 0)]).unwrap();
 
@@ -3118,7 +3129,8 @@ fn reorg_test_2_tokens(#[case] seed: Seed) {
 
         let amount_to_mint_1 = Amount::from_atoms(rng.gen_range(2..100_000_000));
         let amount_to_mint_2 = Amount::from_atoms(rng.gen_range(2..100_000_000));
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         // create another block with 2 outputs to use them on tokens issuance and get 2 distinct token ids
         let tx_a = TransactionBuilder::new()
@@ -3345,7 +3357,8 @@ fn check_signature_on_unmint(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
         let genesis_block_id = tf.genesis().get_id();
 
         let (controller_sk, controller_pk) =
@@ -3670,7 +3683,8 @@ fn mint_with_timelock(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let amount_to_mint =
             Amount::from_atoms(rng.gen_range(2..SignedAmount::MAX.into_atoms() as u128));
@@ -3857,7 +3871,8 @@ fn token_issue_mint_and_data_deposit_not_enough_fee(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
         let token_issuance_fee = tf.chainstate.get_chain_config().fungible_token_issuance_fee();
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
         let data_deposit_fee = tf.chainstate.get_chain_config().data_deposit_fee();
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
@@ -3959,7 +3974,8 @@ fn check_freezable_supply(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let token_supply_change_fee = tf.chainstate.get_chain_config().token_supply_change_fee();
+        let token_supply_change_fee =
+            tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
             &mut rng,
@@ -4220,7 +4236,7 @@ fn token_freeze_fee(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let ok_fee = tf.chainstate.get_chain_config().token_freeze_fee();
+        let ok_fee = tf.chainstate.get_chain_config().token_freeze_fee(BlockHeight::zero());
         let not_ok_fee = (ok_fee - Amount::from_atoms(1)).unwrap();
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
@@ -4307,7 +4323,7 @@ fn token_unfreeze_fee(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let ok_fee = tf.chainstate.get_chain_config().token_freeze_fee();
+        let ok_fee = tf.chainstate.get_chain_config().token_freeze_fee(BlockHeight::zero());
         let not_ok_fee = (ok_fee - Amount::from_atoms(1)).unwrap();
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
@@ -4421,7 +4437,8 @@ fn check_signature_on_freeze_unfreeze(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
-        let token_freeze_fee = tf.chainstate.get_chain_config().token_freeze_fee();
+        let token_freeze_fee =
+            tf.chainstate.get_chain_config().token_freeze_fee(BlockHeight::zero());
         let genesis_block_id = tf.genesis().get_id();
 
         let (controller_sk, controller_pk) =
@@ -4646,7 +4663,9 @@ fn check_signature_on_change_authority(#[case] seed: Seed) {
                 InputWitness::NoSignature(None),
             )
             .add_output(TxOutput::Transfer(
-                OutputValue::Coin(tf.chain_config().token_change_authority_fee()),
+                OutputValue::Coin(
+                    tf.chain_config().token_change_authority_fee(BlockHeight::zero()),
+                ),
                 Destination::AnyoneCanSpend,
             ))
             .build();
@@ -4943,8 +4962,9 @@ fn check_change_authority_for_frozen_token(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
 
-        let unfreeze_fee = tf.chain_config().token_freeze_fee();
-        let change_authority_fee = tf.chain_config().token_change_authority_fee();
+        let unfreeze_fee = tf.chain_config().token_freeze_fee(BlockHeight::zero());
+        let change_authority_fee =
+            tf.chain_config().token_change_authority_fee(BlockHeight::zero());
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
             &mut rng,
@@ -5074,7 +5094,7 @@ fn change_authority_fee(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
 
         let token_change_authority_fee =
-            tf.chainstate.get_chain_config().token_change_authority_fee();
+            tf.chainstate.get_chain_config().token_change_authority_fee(BlockHeight::zero());
 
         let (token_id, _, utxo_with_change) = issue_token_from_genesis(
             &mut rng,

--- a/chainstate/test-suite/src/tests/homomorphism.rs
+++ b/chainstate/test-suite/src/tests/homomorphism.rs
@@ -154,7 +154,9 @@ fn tokens_homomorphism(#[case] seed: Seed) {
                 random_token_issuance_v1(tf.chain_config().as_ref(), &mut rng),
             ))))
             .add_output(TxOutput::Transfer(
-                OutputValue::Coin(tf.chainstate.get_chain_config().token_supply_change_fee()),
+                OutputValue::Coin(
+                    tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero()),
+                ),
                 Destination::AnyoneCanSpend,
             ))
             .build();

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -18,7 +18,7 @@ use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
     output_value::OutputValue, signature::inputsig::InputWitness, tokens::make_token_id,
     ChainstateUpgrade, Destination, RewardDistributionVersion, TokenIssuanceVersion,
-    TokensFeeVersionVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
@@ -214,7 +214,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
+                                TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                             ),
                         )])

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -18,7 +18,7 @@ use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
     output_value::OutputValue, signature::inputsig::InputWitness, tokens::make_token_id,
     ChainstateUpgrade, Destination, RewardDistributionVersion, TokenIssuanceVersion,
-    TokensFeeVersionVersion, TxInput, TxOutput,
+    TokensFeeVersionVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
@@ -215,6 +215,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersionVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -16,10 +16,9 @@
 use chainstate::{BlockError, ChainstateError, ConnectTransactionError, TokensError};
 use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
-    output_value::OutputValue,
-    signature::inputsig::InputWitness,
-    tokens::{make_token_id, TokenIssuanceVersion},
-    ChainstateUpgrade, Destination, RewardDistributionVersion, TxInput, TxOutput,
+    output_value::OutputValue, signature::inputsig::InputWitness, tokens::make_token_id,
+    ChainstateUpgrade, Destination, RewardDistributionVersion, TokenIssuanceVersion,
+    TokensFeeVersionVersion, TxInput, TxOutput,
 };
 use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
@@ -42,7 +41,7 @@ fn nft_burn_invalid_amount(#[case] seed: Seed) {
             make_token_id(&[TxInput::from_utxo(genesis_outpoint_id.clone(), 0)]).unwrap();
 
         let chain_config = tf.chainstate.get_chain_config();
-        let token_min_issuance_fee = chain_config.nft_issuance_fee();
+        let token_min_issuance_fee = chain_config.nft_issuance_fee(BlockHeight::zero());
 
         // Issuance
         let tx = TransactionBuilder::new()
@@ -123,7 +122,7 @@ fn nft_burn_valid_case(#[case] seed: Seed) {
             make_token_id(&[TxInput::from_utxo(genesis_outpoint_id.clone(), 0)]).unwrap();
 
         let chain_config = tf.chainstate.get_chain_config();
-        let token_min_issuance_fee = chain_config.nft_issuance_fee();
+        let token_min_issuance_fee = chain_config.nft_issuance_fee(BlockHeight::zero());
 
         // Issuance
         let tx = TransactionBuilder::new()
@@ -215,6 +214,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
+                                TokensFeeVersionVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -224,7 +224,8 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
             )
             .build();
 
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
 
         let tx = TransactionBuilder::new()
             .add_input(

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -21,12 +21,9 @@ use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
     output_value::OutputValue,
     signature::inputsig::InputWitness,
-    tokens::{
-        is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0,
-        TokenIssuanceVersion,
-    },
-    Block, ChainstateUpgrade, Destination, OutPointSourceId, RewardDistributionVersion, TxInput,
-    TxOutput,
+    tokens::{is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0},
+    Block, ChainstateUpgrade, Destination, OutPointSourceId, RewardDistributionVersion,
+    TokenIssuanceVersion, TokensFeeVersionVersion, TxInput, TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
 use crypto::random::{CryptoRng, Rng};
@@ -791,7 +788,8 @@ fn nft_icon_uri_empty(#[case] seed: Seed) {
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
         let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
 
         let metadata = Metadata {
             creator: Some(random_creator(&mut rng)),
@@ -1019,7 +1017,8 @@ fn nft_metadata_uri_empty(#[case] seed: Seed) {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
         let outpoint_source_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
         let token_id = make_token_id(&[TxInput::from_utxo(outpoint_source_id.clone(), 0)]).unwrap();
 
         // Metadata URI is empty
@@ -1254,7 +1253,8 @@ fn nft_media_uri_empty(#[case] seed: Seed) {
         let outpoint_source_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
         let token_id = make_token_id(&[TxInput::from_utxo(outpoint_source_id.clone(), 0)]).unwrap();
 
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
 
         // Media URI is empty
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
@@ -1412,7 +1412,8 @@ fn new_block_with_media_hash(
     let description = random_ascii_alphanumeric_string(rng, 1..max_desc_len).into_bytes();
     let ticker = random_ascii_alphanumeric_string(rng, 1..max_ticker_len).into_bytes();
     let genesis_id = tf.genesis().get_id();
-    let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+    let token_min_issuance_fee =
+        tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
     let token_id = make_token_id(&[TxInput::from_utxo(genesis_id.into(), 0)]).unwrap();
 
     tf.make_block_builder()
@@ -1577,7 +1578,8 @@ fn nft_valid_case(#[case] seed: Seed) {
         let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let valid_rfc3986_uri =
             b"https://something.com/?a:b.c_d-e~f!g/h?I#J[K]L@M$N&O/P'Q(R)S*T+U,V;W=Xyz".to_vec();
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
 
         let metadata = Metadata {
             creator: Some(random_creator(&mut rng)),
@@ -1648,6 +1650,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
+                                TokensFeeVersionVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1657,7 +1660,8 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
             )
             .build();
 
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
 
         let tx = TransactionBuilder::new()
             .add_input(
@@ -1704,6 +1708,7 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
+                                TokensFeeVersionVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1714,7 +1719,8 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
             .build();
         let genesis_block_id = tf.best_block_id();
 
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
         let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -23,7 +23,7 @@ use common::chain::{
     signature::inputsig::InputWitness,
     tokens::{is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0},
     Block, ChainstateUpgrade, Destination, OutPointSourceId, RewardDistributionVersion,
-    TokenIssuanceVersion, TokensFeeVersionVersion, TxInput, TxOutput,
+    TokenIssuanceVersion, TokensFeeVersionVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
 use crypto::random::{CryptoRng, Rng};
@@ -49,7 +49,8 @@ fn nft_name_too_long(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -120,7 +121,8 @@ fn nft_empty_name(#[case] seed: Seed) {
         let token_id = make_token_id(&[TxInput::from_utxo(outpoint_source_id.clone(), 0)]).unwrap();
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -188,7 +190,8 @@ fn nft_invalid_name(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         // try all possible chars for name and ensure everything fails except for alphanumeric chars
         for c in u8::MIN..u8::MAX {
@@ -267,7 +270,8 @@ fn nft_ticker_too_long(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         let result = tf
             .make_block_builder()
@@ -408,7 +412,8 @@ fn nft_invalid_ticker(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         // try all possible chars for ticker and ensure everything fails except for alphanumeric chars
         for c in u8::MIN..u8::MAX {
@@ -487,7 +492,8 @@ fn nft_description_too_long(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         let result = tf
             .make_block_builder()
@@ -559,7 +565,8 @@ fn nft_empty_description(#[case] seed: Seed) {
         let token_id = make_token_id(&[TxInput::from_utxo(outpoint_source_id.clone(), 0)]).unwrap();
 
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         let result = tf
             .make_block_builder()
@@ -628,7 +635,8 @@ fn nft_invalid_description(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         // try all possible chars for description and ensure everything fails except for alphanumeric chars
         for c in u8::MIN..u8::MAX {
@@ -708,7 +716,8 @@ fn nft_icon_uri_too_long(#[case] seed: Seed) {
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -786,7 +795,8 @@ fn nft_icon_uri_empty(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         let token_min_issuance_fee =
             tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
@@ -856,7 +866,8 @@ fn nft_icon_uri_invalid(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
 
         // try all possible chars for icon_uri and ensure everything fails except for alphanumeric chars
@@ -943,7 +954,8 @@ fn nft_metadata_uri_too_long(#[case] seed: Seed) {
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -1024,7 +1036,8 @@ fn nft_metadata_uri_empty(#[case] seed: Seed) {
         // Metadata URI is empty
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let metadata = Metadata {
             creator: Some(random_creator(&mut rng)),
             name: random_ascii_alphanumeric_string(&mut rng, 1..max_name_len).into_bytes(),
@@ -1090,7 +1103,8 @@ fn nft_metadata_uri_invalid(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
 
         // try all possible chars for additional_metadata_uri and ensure everything fails except for alphanumeric chars
@@ -1177,7 +1191,8 @@ fn nft_media_uri_too_long(#[case] seed: Seed) {
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -1259,7 +1274,8 @@ fn nft_media_uri_empty(#[case] seed: Seed) {
         // Media URI is empty
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let metadata = Metadata {
             creator: Some(random_creator(&mut rng)),
             name: random_ascii_alphanumeric_string(&mut rng, 1..max_name_len).into_bytes(),
@@ -1326,7 +1342,8 @@ fn nft_media_uri_invalid(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
 
         // try all possible chars for media_uri and ensure everything fails except for alphanumeric chars
@@ -1407,7 +1424,7 @@ fn new_block_with_media_hash(
 ) -> Block {
     let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
     let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-    let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+    let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
     let name = random_ascii_alphanumeric_string(rng, 1..max_name_len).into_bytes();
     let description = random_ascii_alphanumeric_string(rng, 1..max_desc_len).into_bytes();
     let ticker = random_ascii_alphanumeric_string(rng, 1..max_ticker_len).into_bytes();
@@ -1575,7 +1592,8 @@ fn nft_valid_case(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
         let valid_rfc3986_uri =
             b"https://something.com/?a:b.c_d-e~f!g/h?I#J[K]L@M$N&O/P'Q(R)S*T+U,V;W=Xyz".to_vec();
         let token_min_issuance_fee =
@@ -1651,6 +1669,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersionVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1709,6 +1728,7 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersionVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1723,7 +1743,8 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
             tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
+        let max_ticker_len =
+            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
 
         // Try not ascii alphanumeric name
         let c = test_utils::get_random_non_ascii_alphanumeric_byte(&mut rng);

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -23,7 +23,7 @@ use common::chain::{
     signature::inputsig::InputWitness,
     tokens::{is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0},
     Block, ChainstateUpgrade, Destination, OutPointSourceId, RewardDistributionVersion,
-    TokenIssuanceVersion, TokensFeeVersionVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
 use crypto::random::{CryptoRng, Rng};
@@ -1668,7 +1668,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
+                                TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
@@ -1727,7 +1727,7 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
+                                TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                             ),
                         )])

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -22,7 +22,7 @@ use common::{
         tokens::{make_token_id, NftIssuance},
         Destination, OutPointSourceId, TxInput, TxOutput, UtxoOutPoint,
     },
-    primitives::{Amount, Idable},
+    primitives::{Amount, BlockHeight, Idable},
 };
 use rstest::rstest;
 use test_utils::{
@@ -49,7 +49,8 @@ fn reorg_and_try_to_double_spend_nfts(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
 
         // Issue a new NFT
         let genesis_outpoint_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -20,9 +20,9 @@ use common::{
     chain::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
-        tokens::{make_token_id, NftIssuance, TokenId, TokenIssuanceVersion},
+        tokens::{make_token_id, NftIssuance, TokenId},
         ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        TxInput, TxOutput,
+        TokenIssuanceVersion, TokensFeeVersionVersion, TxInput, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId},
 };
@@ -183,7 +183,8 @@ fn spend_different_nft_than_one_in_input(#[case] seed: Seed) {
 
         // Issuance a few different NFT
         let genesis_outpoint_id = OutPointSourceId::BlockReward(tf.genesis().get_id().into());
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
         let first_token_id =
             make_token_id(&[TxInput::from_utxo(genesis_outpoint_id.clone(), 0)]).unwrap();
 
@@ -367,6 +368,7 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
+                                TokensFeeVersionVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -379,7 +381,8 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
         let token_id =
             make_token_id(&[TxInput::from_utxo(genesis_outpoint_id.clone(), 0)]).unwrap();
 
-        let token_min_issuance_fee = tf.chainstate.get_chain_config().nft_issuance_fee();
+        let token_min_issuance_fee =
+            tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
 
         let nft_issuance = random_nft_issuance(tf.chainstate.get_chain_config(), &mut rng);
 

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -21,7 +21,8 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         tokens::{make_token_id, NftIssuance, TokenId},
-        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, TxInput, TxOutput,
+        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
+        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId},
 };
@@ -364,7 +365,12 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::latest(),
+                            ChainstateUpgrade::new(
+                                TokenIssuanceVersion::V1,
+                                RewardDistributionVersion::V1,
+                                TokensFeeVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
+                            ),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -21,8 +21,7 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         tokens::{make_token_id, NftIssuance, TokenId},
-        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersionVersion, TxInput, TxOutput,
+        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, TxInput, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId},
 };
@@ -365,11 +364,7 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
                     .chainstate_upgrades(
                         NetUpgrades::initialize(vec![(
                             BlockHeight::zero(),
-                            ChainstateUpgrade::new(
-                                TokenIssuanceVersion::V1,
-                                RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
-                            ),
+                            ChainstateUpgrade::latest(),
                         )])
                         .unwrap(),
                     )

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -21,6 +21,7 @@ use chainstate_storage::TipStorageTag;
 use chainstate_test_framework::{
     anyonecanspend_address, empty_witness, get_output_value, TestFramework, TransactionBuilder,
 };
+use common::primitives::BlockHeight;
 use common::{
     chain::{
         output_value::OutputValue,
@@ -203,7 +204,9 @@ fn stake_pool_and_mint_tokens_same_tx(#[case] seed: Seed) {
                 anyonecanspend_address(),
             ))
             .add_output(TxOutput::Transfer(
-                OutputValue::Coin(tf.chainstate.get_chain_config().token_supply_change_fee()),
+                OutputValue::Coin(
+                    tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero()),
+                ),
                 Destination::AnyoneCanSpend,
             ))
             .build();

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -21,7 +21,10 @@ use super::*;
 
 use chainstate_test_framework::{empty_witness, TestFramework, TestStore, TransactionBuilder};
 use common::chain::config::create_unit_test_config;
-use common::chain::{AccountCommand, AccountNonce, AccountSpending, RewardDistributionVersion};
+use common::chain::{
+    AccountCommand, AccountNonce, AccountSpending, RewardDistributionVersion,
+    TokensTickerMaxLengthVersion,
+};
 use common::{
     chain::{
         config::ChainType,
@@ -576,6 +579,7 @@ fn issue_fungible_token_v0(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersionVersion::V1,
+                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -35,7 +35,7 @@ use common::{
             TokenTotalSupply,
         },
         ChainConfig, ChainstateUpgrade, Destination, NetUpgrades, TokenIssuanceVersion,
-        TokensFeeVersionVersion, TxInput, TxOutput, UtxoOutPoint,
+        TokensFeeVersion, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Fee, Idable},
 };
@@ -578,7 +578,7 @@ fn issue_fungible_token_v0(#[case] seed: Seed) {
                             ChainstateUpgrade::new(
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
-                                TokensFeeVersionVersion::V1,
+                                TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                             ),
                         )])

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -18,9 +18,9 @@ use common::{
     chain::{
         block::{Block, GenBlock},
         signature::TransactionSigError,
-        tokens::{TokenId, TokenIssuanceVersion},
-        AccountNonce, AccountType, DelegationId, OutPointSourceId, PoolId, Transaction,
-        UtxoOutPoint,
+        tokens::TokenId,
+        AccountNonce, AccountType, DelegationId, OutPointSourceId, PoolId, TokenIssuanceVersion,
+        Transaction, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId, Id},
 };

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/mod.rs
@@ -18,8 +18,9 @@ use common::{
         block::{BlockRewardTransactable, ConsensusData},
         output_value::OutputValue,
         signature::Signable,
-        tokens::{get_tokens_issuance_count, TokenId, TokenIssuanceVersion},
-        Block, ChainConfig, DelegationId, PoolId, Transaction, TxInput, TxOutput,
+        tokens::{get_tokens_issuance_count, TokenId},
+        Block, ChainConfig, DelegationId, PoolId, TokenIssuanceVersion, Transaction, TxInput,
+        TxOutput,
     },
     primitives::{Amount, BlockHeight, Fee, Id, Idable, Subsidy},
 };
@@ -105,13 +106,14 @@ pub fn check_reward_inputs_outputs_policy(
                 )
                 .ok_or(ConnectTransactionError::RewardAdditionError(block_id))?;
 
-                let outputs_accumulator = ConstrainedValueAccumulator::from_outputs(
-                    chain_config,
-                    outputs,
-                )
-                .map_err(|e| {
-                    ConnectTransactionError::ConstrainedValueAccumulatorError(e, block_id.into())
-                })?;
+                let outputs_accumulator =
+                    ConstrainedValueAccumulator::from_outputs(chain_config, block_height, outputs)
+                        .map_err(|e| {
+                            ConnectTransactionError::ConstrainedValueAccumulatorError(
+                                e,
+                                block_id.into(),
+                            )
+                        })?;
 
                 inputs_accumulator.satisfy_with(outputs_accumulator).map_err(|e| {
                     ConnectTransactionError::ConstrainedValueAccumulatorError(e, block_id.into())
@@ -205,10 +207,11 @@ pub fn check_tx_inputs_outputs_policy(
         ConnectTransactionError::ConstrainedValueAccumulatorError(e, tx.get_id().into())
     })?;
 
-    let outputs_accumulator = ConstrainedValueAccumulator::from_outputs(chain_config, tx.outputs())
-        .map_err(|e| {
-            ConnectTransactionError::ConstrainedValueAccumulatorError(e, tx.get_id().into())
-        })?;
+    let outputs_accumulator =
+        ConstrainedValueAccumulator::from_outputs(chain_config, block_height, tx.outputs())
+            .map_err(|e| {
+                ConnectTransactionError::ConstrainedValueAccumulatorError(e, tx.get_id().into())
+            })?;
 
     let consumed_accumulator =
         inputs_accumulator.satisfy_with(outputs_accumulator).map_err(|e| {

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -772,7 +772,11 @@ where
         tx: &SignedTransaction,
         median_time_past: &BlockTimestamp,
     ) -> Result<AccumulatedFee, ConnectTransactionError> {
-        check_transaction::check_transaction(self.chain_config.as_ref(), tx)?;
+        check_transaction::check_transaction(
+            self.chain_config.as_ref(),
+            tx_source.expected_block_height(),
+            tx,
+        )?;
 
         let block_id = tx_source.chain_block_index().map(|c| *c.block_id());
 

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -68,9 +68,9 @@ use common::{
         output_value::OutputValue,
         signature::Signable,
         signed_transaction::SignedTransaction,
-        tokens::{make_token_id, TokenIssuanceVersion},
+        tokens::make_token_id,
         AccountCommand, AccountNonce, AccountSpending, AccountType, Block, ChainConfig,
-        DelegationId, GenBlock, Transaction, TxInput, TxOutput, UtxoOutPoint,
+        DelegationId, GenBlock, TokenIssuanceVersion, Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{id::WithId, Amount, BlockHeight, Fee, Id, Idable},
 };

--- a/chainstate/tx-verifier/src/transaction_verifier/tokens_check/check_utils.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tokens_check/check_utils.rs
@@ -15,7 +15,10 @@
 
 use crate::error::TokenIssuanceError;
 
-use common::chain::{tokens::is_rfc3986_valid_symbol, ChainConfig};
+use common::{
+    chain::{tokens::is_rfc3986_valid_symbol, ChainConfig},
+    primitives::BlockHeight,
+};
 use utils::ensure;
 
 fn check_is_text_ascii_alphanumeric(str: &[u8]) -> bool {
@@ -46,11 +49,12 @@ pub fn check_media_hash(chain_config: &ChainConfig, hash: &[u8]) -> Result<(), T
 
 pub fn check_token_ticker(
     chain_config: &ChainConfig,
+    block_height: BlockHeight,
     ticker: &[u8],
 ) -> Result<(), TokenIssuanceError> {
     // Check length
     ensure!(
-        ticker.len() <= chain_config.token_max_ticker_len() && !ticker.is_empty(),
+        ticker.len() <= chain_config.token_max_ticker_len(block_height) && !ticker.is_empty(),
         TokenIssuanceError::IssueErrorInvalidTickerLength
     );
 

--- a/chainstate/tx-verifier/src/transaction_verifier/tokens_check/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tokens_check/mod.rs
@@ -17,9 +17,12 @@ use self::check_utils::check_media_hash;
 
 use crate::error::TokenIssuanceError;
 
-use common::chain::{
-    tokens::{NftIssuanceV0, TokenIssuance},
-    ChainConfig,
+use common::{
+    chain::{
+        tokens::{NftIssuanceV0, TokenIssuance},
+        ChainConfig,
+    },
+    primitives::BlockHeight,
 };
 use serialization::{DecodeAll, Encode};
 use utils::ensure;
@@ -28,9 +31,10 @@ mod check_utils;
 
 pub fn check_nft_issuance_data(
     chain_config: &ChainConfig,
+    block_height: BlockHeight,
     issuance: &NftIssuanceV0,
 ) -> Result<(), TokenIssuanceError> {
-    check_utils::check_token_ticker(chain_config, &issuance.metadata.ticker)?;
+    check_utils::check_token_ticker(chain_config, block_height, &issuance.metadata.ticker)?;
     check_utils::check_nft_name(chain_config, &issuance.metadata.name)?;
     check_utils::check_nft_description(chain_config, &issuance.metadata.description)?;
 
@@ -79,12 +83,17 @@ pub fn check_nft_issuance_data(
 
 pub fn check_tokens_issuance(
     chain_config: &ChainConfig,
+    block_height: BlockHeight,
     issuance: &TokenIssuance,
 ) -> Result<(), TokenIssuanceError> {
     match issuance {
         TokenIssuance::V1(issuance_data) => {
             // Check token ticker
-            check_utils::check_token_ticker(chain_config, &issuance_data.token_ticker)?;
+            check_utils::check_token_ticker(
+                chain_config,
+                block_height,
+                &issuance_data.token_ticker,
+            )?;
 
             // Check decimals
             ensure!(

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -30,7 +30,7 @@ use crate::{
         pow::PoWChainConfigBuilder,
         ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
         PoSChainConfig, PoSConsensusVersion, PoWChainConfig, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersionVersion,
+        TokenIssuanceVersion, TokensFeeVersionVersion, TokensTickerMaxLengthVersion,
     },
     primitives::{
         id::WithId, per_thousand::PerThousand, semver::SemVer, Amount, BlockCount, BlockDistance,
@@ -42,8 +42,8 @@ use crypto::key::hdkd::child_number::ChildNumber;
 
 // The fork, at which we upgrade consensus to dis-incentivize large pools + enable tokens v1
 const TESTNET_TOKEN_FORK_HEIGHT: BlockHeight = BlockHeight::new(78440);
-// The fork, at which we upgrade chainstate to distribute reward to staker proportionally to its balance
-// and also changed various tokens fees
+// The fork, at which we upgrade chainstate to distribute reward to staker proportionally to its balance,
+// changed various tokens fees and also increased max ticker length for tokens
 const TESTNET_STAKER_REWARD_AND_TOKENS_FEE_FORK_HEIGHT: BlockHeight = BlockHeight::new(138244);
 
 impl ChainType {
@@ -151,25 +151,11 @@ impl ChainType {
     fn default_chainstate_upgrades(&self) -> NetUpgrades<ChainstateUpgrade> {
         match self {
             ChainType::Mainnet => {
-                let upgrades = vec![(
-                    BlockHeight::new(0),
-                    ChainstateUpgrade::new(
-                        TokenIssuanceVersion::V1,
-                        RewardDistributionVersion::V1,
-                        TokensFeeVersionVersion::V1,
-                    ),
-                )];
+                let upgrades = vec![(BlockHeight::new(0), ChainstateUpgrade::latest())];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
             ChainType::Regtest | ChainType::Signet => {
-                let upgrades = vec![(
-                    BlockHeight::new(0),
-                    ChainstateUpgrade::new(
-                        TokenIssuanceVersion::V1,
-                        RewardDistributionVersion::V1,
-                        TokensFeeVersionVersion::V1,
-                    ),
-                )];
+                let upgrades = vec![(BlockHeight::new(0), ChainstateUpgrade::latest())];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
             ChainType::Testnet => {
@@ -180,6 +166,7 @@ impl ChainType {
                             TokenIssuanceVersion::V0,
                             RewardDistributionVersion::V0,
                             TokensFeeVersionVersion::V0,
+                            TokensTickerMaxLengthVersion::V0,
                         ),
                     ),
                     (
@@ -188,6 +175,7 @@ impl ChainType {
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V0,
                             TokensFeeVersionVersion::V0,
+                            TokensTickerMaxLengthVersion::V0,
                         ),
                     ),
                     (
@@ -196,6 +184,7 @@ impl ChainType {
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V1,
                             TokensFeeVersionVersion::V1,
+                            TokensTickerMaxLengthVersion::V1,
                         ),
                     ),
                 ];
@@ -259,7 +248,6 @@ pub struct Builder {
     data_deposit_fee: Amount,
     token_max_uri_len: usize,
     token_max_dec_count: u8,
-    token_max_ticker_len: usize,
     token_max_name_len: usize,
     token_max_description_len: usize,
     token_min_hash_len: usize,
@@ -307,7 +295,6 @@ impl Builder {
             data_deposit_fee: super::DATA_DEPOSIT_FEE,
             token_max_uri_len: super::TOKEN_MAX_URI_LEN,
             token_max_dec_count: super::TOKEN_MAX_DEC_COUNT,
-            token_max_ticker_len: super::TOKEN_MAX_TICKER_LEN,
             token_max_name_len: super::TOKEN_MAX_NAME_LEN,
             token_max_description_len: super::TOKEN_MAX_DESCRIPTION_LEN,
             token_min_hash_len: super::TOKEN_MIN_HASH_LEN,
@@ -357,7 +344,6 @@ impl Builder {
             data_deposit_fee,
             token_max_uri_len,
             token_max_dec_count,
-            token_max_ticker_len,
             token_max_name_len,
             token_max_description_len,
             token_min_hash_len,
@@ -441,7 +427,6 @@ impl Builder {
             data_deposit_fee,
             token_max_uri_len,
             token_max_dec_count,
-            token_max_ticker_len,
             empty_consensus_reward_maturity_block_count,
             token_max_name_len,
             token_max_description_len,

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -151,11 +151,27 @@ impl ChainType {
     fn default_chainstate_upgrades(&self) -> NetUpgrades<ChainstateUpgrade> {
         match self {
             ChainType::Mainnet => {
-                let upgrades = vec![(BlockHeight::new(0), ChainstateUpgrade::latest())];
+                let upgrades = vec![(
+                    BlockHeight::new(0),
+                    ChainstateUpgrade::new(
+                        TokenIssuanceVersion::V1,
+                        RewardDistributionVersion::V1,
+                        TokensFeeVersion::V1,
+                        TokensTickerMaxLengthVersion::V1,
+                    ),
+                )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
             ChainType::Regtest | ChainType::Signet => {
-                let upgrades = vec![(BlockHeight::new(0), ChainstateUpgrade::latest())];
+                let upgrades = vec![(
+                    BlockHeight::new(0),
+                    ChainstateUpgrade::new(
+                        TokenIssuanceVersion::V1,
+                        RewardDistributionVersion::V1,
+                        TokensFeeVersion::V1,
+                        TokensTickerMaxLengthVersion::V1,
+                    ),
+                )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
             ChainType::Testnet => {

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -28,9 +28,9 @@ use crate::{
         },
         pos_initial_difficulty,
         pow::PoWChainConfigBuilder,
-        tokens::TokenIssuanceVersion,
         ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
         PoSChainConfig, PoSConsensusVersion, PoWChainConfig, RewardDistributionVersion,
+        TokenIssuanceVersion, TokensFeeVersionVersion,
     },
     primitives::{
         id::WithId, per_thousand::PerThousand, semver::SemVer, Amount, BlockCount, BlockDistance,
@@ -43,7 +43,8 @@ use crypto::key::hdkd::child_number::ChildNumber;
 // The fork, at which we upgrade consensus to dis-incentivize large pools + enable tokens v1
 const TESTNET_TOKEN_FORK_HEIGHT: BlockHeight = BlockHeight::new(78440);
 // The fork, at which we upgrade chainstate to distribute reward to staker proportionally to its balance
-const TESTNET_STAKER_REWARD_FORK_HEIGHT: BlockHeight = BlockHeight::new(138244);
+// and also changed various tokens fees
+const TESTNET_STAKER_REWARD_AND_TOKENS_FEE_FORK_HEIGHT: BlockHeight = BlockHeight::new(138244);
 
 impl ChainType {
     fn default_genesis_init(&self) -> GenesisBlockInit {
@@ -152,14 +153,22 @@ impl ChainType {
             ChainType::Mainnet => {
                 let upgrades = vec![(
                     BlockHeight::new(0),
-                    ChainstateUpgrade::new(TokenIssuanceVersion::V1, RewardDistributionVersion::V1),
+                    ChainstateUpgrade::new(
+                        TokenIssuanceVersion::V1,
+                        RewardDistributionVersion::V1,
+                        TokensFeeVersionVersion::V1,
+                    ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
             ChainType::Regtest | ChainType::Signet => {
                 let upgrades = vec![(
                     BlockHeight::new(0),
-                    ChainstateUpgrade::new(TokenIssuanceVersion::V1, RewardDistributionVersion::V1),
+                    ChainstateUpgrade::new(
+                        TokenIssuanceVersion::V1,
+                        RewardDistributionVersion::V1,
+                        TokensFeeVersionVersion::V1,
+                    ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
@@ -170,6 +179,7 @@ impl ChainType {
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V0,
                             RewardDistributionVersion::V0,
+                            TokensFeeVersionVersion::V0,
                         ),
                     ),
                     (
@@ -177,13 +187,15 @@ impl ChainType {
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V0,
+                            TokensFeeVersionVersion::V0,
                         ),
                     ),
                     (
-                        TESTNET_STAKER_REWARD_FORK_HEIGHT,
+                        TESTNET_STAKER_REWARD_AND_TOKENS_FEE_FORK_HEIGHT,
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V1,
+                            TokensFeeVersionVersion::V1,
                         ),
                     ),
                 ];
@@ -245,11 +257,6 @@ pub struct Builder {
     emission_schedule: EmissionScheduleInit,
     data_deposit_max_size: usize,
     data_deposit_fee: Amount,
-    fungible_token_issuance_fee: Amount,
-    nft_issuance_fee: Amount,
-    token_supply_change_fee: Amount,
-    token_freeze_fee: Amount,
-    token_change_authority_fee: Amount,
     token_max_uri_len: usize,
     token_max_dec_count: u8,
     token_max_ticker_len: usize,
@@ -267,30 +274,6 @@ impl Builder {
     pub fn new(chain_type: ChainType) -> Self {
         let target_block_spacing = super::DEFAULT_TARGET_BLOCK_SPACING;
         let consensus_upgrades = chain_type.default_consensus_upgrades(target_block_spacing);
-
-        let nft_issuance_fee = if chain_type == ChainType::Testnet {
-            super::TESTNET_NFT_ISSUANCE_FEE
-        } else {
-            super::MAINNET_NFT_ISSUANCE_FEE
-        };
-
-        let token_supply_change_fee = if chain_type == ChainType::Testnet {
-            super::TESTNET_TOKEN_SUPPLY_CHANGE_FEE
-        } else {
-            super::MAINNET_TOKEN_SUPPLY_CHANGE_FEE
-        };
-
-        let token_freeze_fee = if chain_type == ChainType::Testnet {
-            super::TESTNET_TOKEN_FREEZE_FEE
-        } else {
-            super::MAINNET_TOKEN_FREEZE_FEE
-        };
-
-        let token_change_authority_fee = if chain_type == ChainType::Testnet {
-            super::TESTNET_TOKEN_CHANGE_AUTHORITY_FEE
-        } else {
-            super::MAINNET_TOKEN_CHANGE_AUTHORITY_FEE
-        };
 
         Self {
             chain_type,
@@ -322,11 +305,6 @@ impl Builder {
             chainstate_upgrades: chain_type.default_chainstate_upgrades(),
             data_deposit_max_size: super::DATA_DEPOSIT_MAX_SIZE,
             data_deposit_fee: super::DATA_DEPOSIT_FEE,
-            fungible_token_issuance_fee: super::FUNGIBLE_TOKEN_ISSUANCE_FEE,
-            nft_issuance_fee,
-            token_supply_change_fee,
-            token_freeze_fee,
-            token_change_authority_fee,
             token_max_uri_len: super::TOKEN_MAX_URI_LEN,
             token_max_dec_count: super::TOKEN_MAX_DEC_COUNT,
             token_max_ticker_len: super::TOKEN_MAX_TICKER_LEN,
@@ -377,11 +355,6 @@ impl Builder {
             chainstate_upgrades,
             data_deposit_max_size,
             data_deposit_fee,
-            fungible_token_issuance_fee,
-            nft_issuance_fee,
-            token_supply_change_fee,
-            token_freeze_fee,
-            token_change_authority_fee,
             token_max_uri_len,
             token_max_dec_count,
             token_max_ticker_len,
@@ -466,11 +439,6 @@ impl Builder {
             chainstate_upgrades,
             data_deposit_max_size,
             data_deposit_fee,
-            fungible_token_issuance_fee,
-            nft_issuance_fee,
-            token_supply_change_fee,
-            token_freeze_fee,
-            token_change_authority_fee,
             token_max_uri_len,
             token_max_dec_count,
             token_max_ticker_len,

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -30,7 +30,7 @@ use crate::{
         pow::PoWChainConfigBuilder,
         ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
         PoSChainConfig, PoSConsensusVersion, PoWChainConfig, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersionVersion, TokensTickerMaxLengthVersion,
+        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion,
     },
     primitives::{
         id::WithId, per_thousand::PerThousand, semver::SemVer, Amount, BlockCount, BlockDistance,
@@ -165,7 +165,7 @@ impl ChainType {
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V0,
                             RewardDistributionVersion::V0,
-                            TokensFeeVersionVersion::V0,
+                            TokensFeeVersion::V0,
                             TokensTickerMaxLengthVersion::V0,
                         ),
                     ),
@@ -174,7 +174,7 @@ impl ChainType {
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V0,
-                            TokensFeeVersionVersion::V0,
+                            TokensFeeVersion::V0,
                             TokensTickerMaxLengthVersion::V0,
                         ),
                     ),
@@ -183,7 +183,7 @@ impl ChainType {
                         ChainstateUpgrade::new(
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V1,
-                            TokensFeeVersionVersion::V1,
+                            TokensFeeVersion::V1,
                             TokensTickerMaxLengthVersion::V1,
                         ),
                     ),

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -47,7 +47,7 @@ use super::output_value::OutputValue;
 use super::TokensTickerMaxLengthVersion;
 use super::{stakelock::StakePoolData, RequiredConsensus};
 use super::{ChainstateUpgrade, ConsensusUpgrade};
-use super::{RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersionVersion};
+use super::{RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion};
 
 const DEFAULT_MAX_FUTURE_BLOCK_TIME_OFFSET: Duration = Duration::from_secs(120);
 const DEFAULT_TARGET_BLOCK_SPACING: Duration = Duration::from_secs(120);
@@ -508,8 +508,8 @@ impl ChainConfig {
     pub fn nft_issuance_fee(&self, height: BlockHeight) -> Amount {
         let fee_version = self.chainstate_upgrades.version_at_height(height).1.tokens_fee_version();
         match fee_version {
-            TokensFeeVersionVersion::V0 => NFT_ISSUANCE_FEE_V0,
-            TokensFeeVersionVersion::V1 => NFT_ISSUANCE_FEE_V1,
+            TokensFeeVersion::V0 => NFT_ISSUANCE_FEE_V0,
+            TokensFeeVersion::V1 => NFT_ISSUANCE_FEE_V1,
         }
     }
 
@@ -517,8 +517,8 @@ impl ChainConfig {
     pub fn token_supply_change_fee(&self, height: BlockHeight) -> Amount {
         let fee_version = self.chainstate_upgrades.version_at_height(height).1.tokens_fee_version();
         match fee_version {
-            TokensFeeVersionVersion::V0 => TOKEN_SUPPLY_CHANGE_FEE_V0,
-            TokensFeeVersionVersion::V1 => TOKEN_SUPPLY_CHANGE_FEE_V1,
+            TokensFeeVersion::V0 => TOKEN_SUPPLY_CHANGE_FEE_V0,
+            TokensFeeVersion::V1 => TOKEN_SUPPLY_CHANGE_FEE_V1,
         }
     }
 
@@ -526,8 +526,8 @@ impl ChainConfig {
     pub fn token_freeze_fee(&self, height: BlockHeight) -> Amount {
         let fee_version = self.chainstate_upgrades.version_at_height(height).1.tokens_fee_version();
         match fee_version {
-            TokensFeeVersionVersion::V0 => TOKEN_FREEZE_FEE_V0,
-            TokensFeeVersionVersion::V1 => TOKEN_FREEZE_FEE_V1,
+            TokensFeeVersion::V0 => TOKEN_FREEZE_FEE_V0,
+            TokensFeeVersion::V1 => TOKEN_FREEZE_FEE_V1,
         }
     }
 
@@ -535,8 +535,8 @@ impl ChainConfig {
     pub fn token_change_authority_fee(&self, height: BlockHeight) -> Amount {
         let fee_version = self.chainstate_upgrades.version_at_height(height).1.tokens_fee_version();
         match fee_version {
-            TokensFeeVersionVersion::V0 => TOKEN_CHANGE_AUTHORITY_FEE_V0,
-            TokensFeeVersionVersion::V1 => TOKEN_CHANGE_AUTHORITY_FEE_V1,
+            TokensFeeVersion::V0 => TOKEN_CHANGE_AUTHORITY_FEE_V0,
+            TokensFeeVersion::V1 => TOKEN_CHANGE_AUTHORITY_FEE_V1,
         }
     }
 
@@ -810,7 +810,7 @@ pub fn create_unit_test_config_builder() -> Builder {
                 ChainstateUpgrade::new(
                     TokenIssuanceVersion::V1,
                     RewardDistributionVersion::V1,
-                    TokensFeeVersionVersion::V1,
+                    TokensFeeVersion::V1,
                     TokensTickerMaxLengthVersion::V1,
                 ),
             )])

--- a/common/src/chain/tokens/issuance.rs
+++ b/common/src/chain/tokens/issuance.rs
@@ -17,14 +17,6 @@ use super::Destination;
 use crate::primitives::Amount;
 use serialization::{Decode, Encode};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
-pub enum TokenIssuanceVersion {
-    /// Initial issuance implementation
-    V0,
-    /// Enable modifying token supply
-    V1,
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, serde::Serialize)]
 pub enum TokenTotalSupply {
     #[codec(index = 0)]

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -32,7 +32,7 @@ pub enum RewardDistributionVersion {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
-pub enum TokensFeeVersionVersion {
+pub enum TokensFeeVersion {
     /// Initial tokens fee values
     V0,
     /// Updated tokens fee values
@@ -51,7 +51,7 @@ pub enum TokensTickerMaxLengthVersion {
 pub struct ChainstateUpgrade {
     token_issuance_version: TokenIssuanceVersion,
     reward_distribution_version: RewardDistributionVersion,
-    tokens_fee_version: TokensFeeVersionVersion,
+    tokens_fee_version: TokensFeeVersion,
     tokens_ticker_length_version: TokensTickerMaxLengthVersion,
 }
 
@@ -59,7 +59,7 @@ impl ChainstateUpgrade {
     pub fn new(
         token_issuance_version: TokenIssuanceVersion,
         reward_distribution_version: RewardDistributionVersion,
-        tokens_fee_version: TokensFeeVersionVersion,
+        tokens_fee_version: TokensFeeVersion,
         tokens_ticker_length_version: TokensTickerMaxLengthVersion,
     ) -> Self {
         Self {
@@ -74,7 +74,7 @@ impl ChainstateUpgrade {
         ChainstateUpgrade::new(
             TokenIssuanceVersion::V1,
             RewardDistributionVersion::V1,
-            TokensFeeVersionVersion::V1,
+            TokensFeeVersion::V1,
             TokensTickerMaxLengthVersion::V1,
         )
     }
@@ -87,7 +87,7 @@ impl ChainstateUpgrade {
         self.reward_distribution_version
     }
 
-    pub fn tokens_fee_version(&self) -> TokensFeeVersionVersion {
+    pub fn tokens_fee_version(&self) -> TokensFeeVersion {
         self.tokens_fee_version
     }
 

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -39,11 +39,20 @@ pub enum TokensFeeVersionVersion {
     V1,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+pub enum TokensTickerMaxLengthVersion {
+    /// Initial tokens ticker max length values
+    V0,
+    /// Updated tokens ticker max length values
+    V1,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ChainstateUpgrade {
     token_issuance_version: TokenIssuanceVersion,
     reward_distribution_version: RewardDistributionVersion,
     tokens_fee_version: TokensFeeVersionVersion,
+    tokens_ticker_length_version: TokensTickerMaxLengthVersion,
 }
 
 impl ChainstateUpgrade {
@@ -51,12 +60,23 @@ impl ChainstateUpgrade {
         token_issuance_version: TokenIssuanceVersion,
         reward_distribution_version: RewardDistributionVersion,
         tokens_fee_version: TokensFeeVersionVersion,
+        tokens_ticker_length_version: TokensTickerMaxLengthVersion,
     ) -> Self {
         Self {
             token_issuance_version,
             reward_distribution_version,
             tokens_fee_version,
+            tokens_ticker_length_version,
         }
+    }
+
+    pub fn latest() -> Self {
+        ChainstateUpgrade::new(
+            TokenIssuanceVersion::V1,
+            RewardDistributionVersion::V1,
+            TokensFeeVersionVersion::V1,
+            TokensTickerMaxLengthVersion::V1,
+        )
     }
 
     pub fn token_issuance_version(&self) -> TokenIssuanceVersion {
@@ -69,6 +89,10 @@ impl ChainstateUpgrade {
 
     pub fn tokens_fee_version(&self) -> TokensFeeVersionVersion {
         self.tokens_fee_version
+    }
+
+    pub fn tokens_ticker_length_version(&self) -> TokensTickerMaxLengthVersion {
+        self.tokens_ticker_length_version
     }
 }
 

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -70,15 +70,6 @@ impl ChainstateUpgrade {
         }
     }
 
-    pub fn latest() -> Self {
-        ChainstateUpgrade::new(
-            TokenIssuanceVersion::V1,
-            RewardDistributionVersion::V1,
-            TokensFeeVersion::V1,
-            TokensTickerMaxLengthVersion::V1,
-        )
-    }
-
     pub fn token_issuance_version(&self) -> TokenIssuanceVersion {
         self.token_issuance_version
     }

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -13,9 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::chain::tokens::TokenIssuanceVersion;
-
 use super::Activate;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+pub enum TokenIssuanceVersion {
+    /// Initial issuance implementation
+    V0,
+    /// Enable modifying token supply
+    V1,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 pub enum RewardDistributionVersion {
@@ -25,20 +31,31 @@ pub enum RewardDistributionVersion {
     V1,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+pub enum TokensFeeVersionVersion {
+    /// Initial tokens fee values
+    V0,
+    /// Updated tokens fee values
+    V1,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ChainstateUpgrade {
     token_issuance_version: TokenIssuanceVersion,
     reward_distribution_version: RewardDistributionVersion,
+    tokens_fee_version: TokensFeeVersionVersion,
 }
 
 impl ChainstateUpgrade {
     pub fn new(
         token_issuance_version: TokenIssuanceVersion,
         reward_distribution_version: RewardDistributionVersion,
+        tokens_fee_version: TokensFeeVersionVersion,
     ) -> Self {
         Self {
             token_issuance_version,
             reward_distribution_version,
+            tokens_fee_version,
         }
     }
 
@@ -48,6 +65,10 @@ impl ChainstateUpgrade {
 
     pub fn reward_distribution_version(&self) -> RewardDistributionVersion {
         self.reward_distribution_version
+    }
+
+    pub fn tokens_fee_version(&self) -> TokensFeeVersionVersion {
+        self.tokens_fee_version
     }
 }
 

--- a/common/src/chain/upgrades/mod.rs
+++ b/common/src/chain/upgrades/mod.rs
@@ -17,7 +17,9 @@ mod chainstate_upgrade;
 mod consensus_upgrade;
 mod netupgrade;
 
-pub use chainstate_upgrade::{ChainstateUpgrade, RewardDistributionVersion};
+pub use chainstate_upgrade::{
+    ChainstateUpgrade, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersionVersion,
+};
 pub use consensus_upgrade::{ConsensusUpgrade, PoSStatus, PoWStatus, RequiredConsensus};
 pub use netupgrade::{Activate, NetUpgrades};
 

--- a/common/src/chain/upgrades/mod.rs
+++ b/common/src/chain/upgrades/mod.rs
@@ -18,7 +18,7 @@ mod consensus_upgrade;
 mod netupgrade;
 
 pub use chainstate_upgrade::{
-    ChainstateUpgrade, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersionVersion,
+    ChainstateUpgrade, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
     TokensTickerMaxLengthVersion,
 };
 pub use consensus_upgrade::{ConsensusUpgrade, PoSStatus, PoWStatus, RequiredConsensus};

--- a/common/src/chain/upgrades/mod.rs
+++ b/common/src/chain/upgrades/mod.rs
@@ -19,6 +19,7 @@ mod netupgrade;
 
 pub use chainstate_upgrade::{
     ChainstateUpgrade, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersionVersion,
+    TokensTickerMaxLengthVersion,
 };
 pub use consensus_upgrade::{ConsensusUpgrade, PoSStatus, PoWStatus, RequiredConsensus};
 pub use netupgrade::{Activate, NetUpgrades};

--- a/test-utils/src/nft_utils.rs
+++ b/test-utils/src/nft_utils.rs
@@ -23,7 +23,7 @@ use common::{
         },
         Destination,
     },
-    primitives::Amount,
+    primitives::{Amount, BlockHeight},
 };
 use crypto::key::{KeyKind, PrivateKey};
 use crypto::random::{CryptoRng, Rng};
@@ -35,7 +35,7 @@ pub fn random_creator(rng: &mut (impl Rng + CryptoRng)) -> TokenCreator {
 }
 
 pub fn random_token_issuance(chain_config: &ChainConfig, rng: &mut impl Rng) -> TokenIssuanceV0 {
-    let max_ticker_len = chain_config.token_max_ticker_len();
+    let max_ticker_len = chain_config.token_max_ticker_len(BlockHeight::zero());
     let max_dec_count = chain_config.token_max_dec_count();
     let max_uri_len = chain_config.token_max_uri_len();
 
@@ -48,7 +48,7 @@ pub fn random_token_issuance(chain_config: &ChainConfig, rng: &mut impl Rng) -> 
 }
 
 pub fn random_token_issuance_v1(chain_config: &ChainConfig, rng: &mut impl Rng) -> TokenIssuanceV1 {
-    let max_ticker_len = chain_config.token_max_ticker_len();
+    let max_ticker_len = chain_config.token_max_ticker_len(BlockHeight::zero());
     let max_dec_count = chain_config.token_max_dec_count();
     let max_uri_len = chain_config.token_max_uri_len();
 
@@ -68,7 +68,7 @@ pub fn random_nft_issuance(
 ) -> NftIssuanceV0 {
     let max_desc_len = chain_config.token_max_description_len();
     let max_name_len = chain_config.token_max_name_len();
-    let max_ticker_len = chain_config.token_max_ticker_len();
+    let max_ticker_len = chain_config.token_max_ticker_len(BlockHeight::zero());
 
     NftIssuanceV0 {
         metadata: Metadata {

--- a/test/functional/wallet_nfts.py
+++ b/test/functional/wallet_nfts.py
@@ -116,7 +116,7 @@ class WalletNfts(BitcoinTestFramework):
 
             # invalid ticker
             # > max len
-            invalid_ticker = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(random.randint(6, 10)))
+            invalid_ticker = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(random.randint(13, 20)))
             nft_id, err = await wallet.issue_new_nft(address, "123456", "Name", "SomeNFT", invalid_ticker)
             assert nft_id is None
             assert err is not None

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -116,7 +116,7 @@ class WalletTokens(BitcoinTestFramework):
 
             # invalid ticker
             # > max len
-            invalid_ticker = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(random.randint(6, 10)))
+            invalid_ticker = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(random.randint(13, 20)))
             token_id, err = await wallet.issue_new_token(invalid_ticker, 2, "http://uri", address)
             assert token_id is None
             assert err is not None

--- a/test/functional/wallet_tokens_change_supply.py
+++ b/test/functional/wallet_tokens_change_supply.py
@@ -115,7 +115,7 @@ class WalletTokens(BitcoinTestFramework):
 
             # invalid ticker
             # > max len
-            token_id, err = await wallet.issue_new_token("asdddd", 2, "http://uri", address)
+            token_id, err = await wallet.issue_new_token("aaabbbcccddde", 2, "http://uri", address)
             assert token_id is None
             assert err is not None
             assert_in("Invalid ticker length", err)

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -733,7 +733,11 @@ impl Account {
         let nft_issuance = NftIssuanceV0 {
             metadata: nft_issue_arguments.metadata,
         };
-        tx_verifier::check_nft_issuance_data(&self.chain_config, &nft_issuance)?;
+        tx_verifier::check_nft_issuance_data(
+            &self.chain_config,
+            self.account_info.best_block_height().next_height(),
+            &nft_issuance,
+        )?;
 
         // the first UTXO is needed in advance to issue a new nft, so just make a dummy one
         // and then replace it with when we can calculate the pool_id

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -72,8 +72,9 @@ pub fn make_address_output_token(
 pub fn make_issue_token_outputs(
     token_issuance: TokenIssuance,
     chain_config: &ChainConfig,
+    block_height: BlockHeight,
 ) -> WalletResult<Vec<TxOutput>> {
-    tx_verifier::check_tokens_issuance(chain_config, &token_issuance)?;
+    tx_verifier::check_tokens_issuance(chain_config, block_height, &token_issuance)?;
     let issuance_output = TxOutput::IssueFungibleToken(Box::new(token_issuance));
 
     Ok(vec![issuance_output])

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1202,7 +1202,11 @@ impl<B: storage::Backend> Wallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<(TokenId, SignedTransaction)> {
-        let outputs = make_issue_token_outputs(token_issuance, self.chain_config.as_ref())?;
+        let outputs = make_issue_token_outputs(
+            token_issuance,
+            self.chain_config.as_ref(),
+            self.get_best_block_for_account(account_index)?.1.next_height(),
+        )?;
 
         let tx = self.create_transaction_to_addresses(
             account_index,

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -1801,7 +1801,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let issuance_fee = if issue_fungible_token {
         chain_config.fungible_token_issuance_fee()
     } else {
-        chain_config.nft_issuance_fee()
+        chain_config.nft_issuance_fee(BlockHeight::zero())
     };
 
     // Generate a new block which sends reward to the wallet
@@ -1810,7 +1810,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             .unwrap();
 
     if issue_fungible_token {
-        block1_amount = (block1_amount + chain_config.token_supply_change_fee()).unwrap();
+        block1_amount =
+            (block1_amount + chain_config.token_supply_change_fee(BlockHeight::zero())).unwrap();
     }
 
     let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
@@ -1910,7 +1911,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let mut expected_amount = ((block1_amount * 2).unwrap() - issuance_fee).unwrap();
 
     if issue_fungible_token {
-        expected_amount = (expected_amount - chain_config.token_supply_change_fee()).unwrap();
+        expected_amount =
+            (expected_amount - chain_config.token_supply_change_fee(BlockHeight::zero())).unwrap();
     }
 
     assert_eq!(coin_balance, expected_amount);
@@ -1952,7 +1954,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     let (coin_balance, token_balances) = get_currency_balances(&wallet);
     let mut expected_amount = ((block1_amount * 3).unwrap() - issuance_fee).unwrap();
     if issue_fungible_token {
-        expected_amount = (expected_amount - chain_config.token_supply_change_fee()).unwrap();
+        expected_amount =
+            (expected_amount - chain_config.token_supply_change_fee(BlockHeight::zero())).unwrap();
     }
     assert_eq!(coin_balance, expected_amount,);
     assert!(token_balances.len() <= 1);
@@ -2046,7 +2049,7 @@ fn check_tokens_v0_are_ignored(#[case] seed: Seed) {
         )
         .unwrap();
 
-    let block2_amount = chain_config.token_supply_change_fee();
+    let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
     let _ = create_block(
         &chain_config,
         &mut wallet,
@@ -2102,7 +2105,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
         )
         .unwrap();
 
-    let block2_amount = chain_config.token_supply_change_fee();
+    let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
     let _ = create_block(
         &chain_config,
         &mut wallet,
@@ -2384,7 +2387,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
         )
         .unwrap();
 
-    let block2_amount = chain_config.token_supply_change_fee();
+    let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
     let _ = create_block(
         &chain_config,
         &mut wallet,
@@ -2630,7 +2633,7 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
         )
         .unwrap();
 
-    let block2_amount = chain_config.token_supply_change_fee();
+    let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
 
     let _ = create_block(
         &chain_config,
@@ -2818,7 +2821,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
         )
         .unwrap();
 
-    let block2_amount = chain_config.token_supply_change_fee();
+    let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
 
     let _ = create_block(
         &chain_config,


### PR DESCRIPTION
New fork for testnet at height 138244 now includes the following changes:
- new fees for tokens operations
- max ticker length increased to 12

Other networks don't fork and just use new values