### PR TITLE
Add a check for NFT issuance data in the wallet

### DIFF
--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -168,7 +168,7 @@ pub enum TokenIssuanceError {
     IssueErrorInvalidNameLength,
     #[error("Invalid ticker length")]
     IssueErrorInvalidTickerLength,
-    #[error("Invalid ticker length")]
+    #[error("Invalid description length")]
     IssueErrorInvalidDescriptionLength,
     #[error("Invalid character in token ticker")]
     IssueErrorTickerHasNoneAlphaNumericChar,

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -232,12 +232,12 @@ class WalletCliController:
                             icon_uri: Optional[str] = '',
                             media_uri: Optional[str] = '',
                             additional_metadata_uri: Optional[str] = ''):
-        output = await self._write_command(f"token-nft-issue-new {destination_address} {media_hash} {name} {description} {ticker} {creator} {icon_uri} {media_uri} {additional_metadata_uri}\n")
+        output = await self._write_command(f'token-nft-issue-new {destination_address} {media_hash} {name} {description} "{ticker}" {creator} {icon_uri} {media_uri} {additional_metadata_uri}\n')
         if output.startswith("A new NFT has been issued with ID"):
-            return output[output.find(':')+2:]
+            return output[output.find(':')+2:], None
 
         self.log.error(f"err: {output}")
-        return None
+        return None, output
 
     async def create_stake_pool(self,
                                 amount: int,

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -122,7 +122,7 @@ class WalletTokens(BitcoinTestFramework):
             assert err is not None
             assert_in("Invalid ticker length", err)
             # non alphanumeric
-            invalid_ticker = "asd" + random.choice(string.punctuation)
+            invalid_ticker = "asd" + random.choice(r"#$%&'()*+,-./:;<=>?@[\]^_`{|}~")
             token_id, err = await wallet.issue_new_token("asd#", 2, "http://uri", address)
             assert token_id is None
             assert err is not None

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -17,6 +17,7 @@ mod output_cache;
 pub mod transaction_list;
 mod utxo_selector;
 
+use chainstate::check_nft_issuance_data;
 use common::address::pubkeyhash::PublicKeyHash;
 use common::chain::block::timestamp::BlockTimestamp;
 use common::chain::{AccountCommand, AccountOutPoint, AccountSpending, TransactionCreationError};
@@ -726,14 +727,17 @@ impl Account {
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
+        let nft_issuance = NftIssuanceV0 {
+            metadata: nft_issue_arguments.metadata,
+        };
+        check_nft_issuance_data(&self.chain_config, &nft_issuance)?;
+
         // the first UTXO is needed in advance to issue a new nft, so just make a dummy one
         // and then replace it with when we can calculate the pool_id
         let dummy_token_id = TokenId::new(H256::zero());
         let dummy_issuance_output = TxOutput::IssueNft(
             dummy_token_id,
-            Box::new(NftIssuance::V0(NftIssuanceV0 {
-                metadata: nft_issue_arguments.metadata,
-            })),
+            Box::new(NftIssuance::V0(nft_issuance)),
             nft_issue_arguments.destination,
         );
 


### PR DESCRIPTION
Check NFT issuance in the wallet before sending it to the mempool same as token issuance