### PR TITLE
Fix decommission request from TxOutput::ProduceBlockFromStake

### DIFF
--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -118,15 +118,15 @@ class WalletCliController:
 
     async def create_wallet(self, name: str = "wallet") -> str:
         wallet_file = os.path.join(self.node.datadir, name)
-        return await self._write_command(f"wallet-create {wallet_file} store-seed-phrase\n")
+        return await self._write_command(f"wallet-create \"{wallet_file}\" store-seed-phrase\n")
 
     async def open_wallet(self, name: str) -> str:
         wallet_file = os.path.join(self.node.datadir, name)
-        return await self._write_command(f"wallet-open {wallet_file}\n")
+        return await self._write_command(f"wallet-open \"{wallet_file}\"\n")
 
     async def recover_wallet(self, mnemonic: str, name: str = "recovered_wallet") -> str:
         wallet_file = os.path.join(self.node.datadir, name)
-        return await self._write_command(f"wallet-create {wallet_file} store-seed-phrase \"{mnemonic}\"\n")
+        return await self._write_command(f"wallet-create \"{wallet_file}\" store-seed-phrase \"{mnemonic}\"\n")
 
     async def close_wallet(self) -> str:
         return await self._write_command("wallet-close\n")
@@ -309,6 +309,9 @@ class WalletCliController:
 
     async def stop_staking(self) -> str:
         return await self._write_command(f"staking-stop\n")
+
+    async def generate_block(self, transactions: [str]) -> str:
+        return await self._write_command(f"generate-block {transactions}\n")
 
     async def get_addresses_usage(self) -> str:
         return await self._write_command("address-show\n")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -113,7 +113,6 @@ BASE_SCRIPTS = [
     # vv Tests less than 2m vv
 
     # vv Tests less than 60s vv
-    'wallet_decommission_request.py',
 
     # vv Tests less than 30s vv
     'blockprod_generate_blocks_all_sources.py',
@@ -141,6 +140,7 @@ BASE_SCRIPTS = [
     'wallet_tokens_change_authority.py',
     'wallet_tokens_change_supply.py',
     'wallet_nfts.py',
+    'wallet_decommission_request.py',
     'wallet_delegations.py',
     'wallet_delegations_rpc.py',
     'wallet_high_fee.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -113,6 +113,7 @@ BASE_SCRIPTS = [
     # vv Tests less than 2m vv
 
     # vv Tests less than 60s vv
+    'wallet_decommission_request.py',
 
     # vv Tests less than 30s vv
     'blockprod_generate_blocks_all_sources.py',
@@ -142,7 +143,6 @@ BASE_SCRIPTS = [
     'wallet_nfts.py',
     'wallet_delegations.py',
     'wallet_delegations_rpc.py',
-    'wallet_decommission_request.py',
     'wallet_high_fee.py',
     'wallet_generate_addresses.py',
     'wallet_set_lookahead_size.py',

--- a/test/functional/wallet_decommission_request.py
+++ b/test/functional/wallet_decommission_request.py
@@ -320,11 +320,13 @@ class WalletDecommissionRequest(BitcoinTestFramework):
             pools = await wallet.list_pool_ids()
             assert_equal(len(pools), 0)
 
-if __name__ == '__main__':
-    tf1 = WalletDecommissionRequest()
-    tf1.use_wallet_to_produce_block = False
-    tf1.main(exit_on_success=False)
+# `use_wallet_to_produce_block` indicates whether a test should use a pool created by a wallet to produce block
+# `exit_on_success` indicates if the process should exit or continue and run next test case
+def wallet_decommission_request_test_case(use_wallet_to_produce_block, exit_on_success):
+    tf = WalletDecommissionRequest()
+    tf.use_wallet_to_produce_block = use_wallet_to_produce_block
+    tf.main(exit_on_success)
 
-    tf2 = WalletDecommissionRequest()
-    tf2.use_wallet_to_produce_block = True
-    tf2.main()
+if __name__ == '__main__':
+    wallet_decommission_request_test_case(False, False)
+    wallet_decommission_request_test_case(True, True)

--- a/test/functional/wallet_decommission_request.py
+++ b/test/functional/wallet_decommission_request.py
@@ -53,7 +53,7 @@ GENESIS_VRF_PRIVATE_KEY = (
 
 GENESIS_POOL_ID_ADDR = "rpool1zg7yccqqjlz38cyghxlxyp5lp36vwecu2g7gudrf58plzjm75tzq99fr6v"
 
-class WalletSubmitTransaction(BitcoinTestFramework):
+class WalletDecommissionRequest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -67,17 +67,10 @@ class WalletSubmitTransaction(BitcoinTestFramework):
         self.setup_nodes()
         self.sync_all(self.nodes[0:1])
 
-    def assert_chain(self, block, previous_tip):
-        assert_equal(block["header"]["header"]["prev_block_id"][2:], previous_tip)
-
     def assert_height(self, expected_height, expected_block):
         block_id = self.nodes[0].chainstate_block_id_at_height(expected_height)
         block = self.nodes[0].chainstate_get_block(block_id)
         assert_equal(block, expected_block)
-
-    def assert_pos_consensus(self, block):
-        if block["header"]["header"]["consensus_data"].get("PoS") is None:
-            raise AssertionError("Block {} was not PoS".format(block))
 
     def assert_tip(self, expected_block):
         tip = self.nodes[0].chainstate_best_block_id()
@@ -89,8 +82,6 @@ class WalletSubmitTransaction(BitcoinTestFramework):
         return self.nodes[n].chainstate_block_height_in_main_chain(tip)
 
     def generate_block(self, expected_height, block_input_data, transactions):
-        previous_block_id = self.nodes[0].chainstate_best_block_id()
-
         fill_mode = 'LeaveEmptySpace'
         # Block production may fail if the Job Manager found a new tip, so try and sleep
         for _ in range(5):
@@ -101,15 +92,10 @@ class WalletSubmitTransaction(BitcoinTestFramework):
                 block_hex = self.nodes[0].blockprod_generate_block(block_input_data, transactions, [], fill_mode)
                 time.sleep(1)
 
-        block_hex_array = bytearray.fromhex(block_hex)
-        # block = ScaleDecoder.get_decoder_class('BlockV1', ScaleBytes(block_hex_array)).decode()
-
         self.nodes[0].chainstate_submit_block(block_hex)
 
         self.assert_tip(block_hex)
         self.assert_height(expected_height, block_hex)
-        # self.assert_pos_consensus(block)
-        # self.assert_chain(block, previous_block_id)
 
     def genesis_pool_id(self):
         return self.hex_to_dec_array(GENESIS_POOL_ID)
@@ -293,6 +279,11 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             assert_equal(len(pools), 1)
             assert_equal(pools[0].balance, '40000')
 
+            if self.use_wallet_to_produce_block:
+                # produce block with the wallet so that utxo of a pool changes from CreateStakePool to ProduceBlockWithStakePool
+                # TODO: this is very slow but otherwise there is no way to sign block with wallet keys
+                await wallet.generate_block([])
+
             # try decommission from hot wallet
             assert (await wallet.decommission_stake_pool(pools[0].pool_id)).startswith("Wallet error: Wallet error: Failed to completely sign")
 
@@ -329,6 +320,11 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             pools = await wallet.list_pool_ids()
             assert_equal(len(pools), 0)
 
-
 if __name__ == '__main__':
-    WalletSubmitTransaction().main()
+    tf1 = WalletDecommissionRequest()
+    tf1.use_wallet_to_produce_block = False
+    tf1.main(exit_on_success=False)
+
+    tf2 = WalletDecommissionRequest()
+    tf2.use_wallet_to_produce_block = True
+    tf2.main()

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -212,14 +212,15 @@ fn sign_transaction(#[case] seed: Seed) {
 
     let tx = Transaction::new(0, inputs, outputs).unwrap();
 
-    let req = SendRequest::from_transaction(tx, utxos.clone()).unwrap();
+    let req = SendRequest::from_transaction(tx, utxos.clone(), &|_| None).unwrap();
 
     let sig_tx = account.sign_transaction_from_req(req, &db_tx).unwrap();
 
     let utxos_ref = utxos.iter().map(Some).collect::<Vec<_>>();
 
     for i in 0..sig_tx.inputs().len() {
-        let destination = get_tx_output_destination(utxos_ref[i].unwrap()).unwrap();
-        verify_signature(&config, destination, &sig_tx, &utxos_ref, i).unwrap();
+        let destination =
+            crate::get_tx_output_destination(utxos_ref[i].unwrap(), &|_| None).unwrap();
+        verify_signature(&config, &destination, &sig_tx, &utxos_ref, i).unwrap();
     }
 }

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -26,6 +26,7 @@ use common::primitives::{Amount, BlockHeight};
 use crypto::vrf::VRFPublicKey;
 use utils::ensure;
 
+use crate::account::PoolData;
 use crate::{WalletError, WalletResult};
 
 /// The `SendRequest` struct provides the necessary information to the wallet
@@ -195,11 +196,18 @@ impl SendRequest {
         }
     }
 
-    pub fn from_transaction(transaction: Transaction, utxos: Vec<TxOutput>) -> WalletResult<Self> {
+    pub fn from_transaction<'a, PoolDataGetter>(
+        transaction: Transaction,
+        utxos: Vec<TxOutput>,
+        pool_data_getter: &PoolDataGetter,
+    ) -> WalletResult<Self>
+    where
+        PoolDataGetter: Fn(&PoolId) -> Option<&'a PoolData>,
+    {
         let destinations = utxos
             .iter()
             .map(|utxo| {
-                get_tx_output_destination(utxo).cloned().ok_or_else(|| {
+                get_tx_output_destination(utxo, &pool_data_getter).ok_or_else(|| {
                     WalletError::UnsupportedTransactionOutput(Box::new(utxo.clone()))
                 })
             })
@@ -239,14 +247,18 @@ impl SendRequest {
         self
     }
 
-    pub fn with_inputs(
+    pub fn with_inputs<'a, PoolDataGetter>(
         mut self,
         utxos: impl IntoIterator<Item = (TxInput, TxOutput)>,
-    ) -> WalletResult<Self> {
+        pool_data_getter: &PoolDataGetter,
+    ) -> WalletResult<Self>
+    where
+        PoolDataGetter: Fn(&PoolId) -> Option<&'a PoolData>,
+    {
         for (outpoint, txo) in utxos {
             self.inputs.push(outpoint);
             self.destinations.push(
-                get_tx_output_destination(&txo).cloned().ok_or_else(|| {
+                get_tx_output_destination(&txo, &pool_data_getter).ok_or_else(|| {
                     WalletError::UnsupportedTransactionOutput(Box::new(txo.clone()))
                 })?,
             );
@@ -271,29 +283,22 @@ impl SendRequest {
     }
 }
 
-pub fn get_reward_output_destination(txo: &TxOutput) -> Option<&Destination> {
+pub fn get_tx_output_destination<'a, PoolDataGetter>(
+    txo: &TxOutput,
+    pool_data_getter: &PoolDataGetter,
+) -> Option<Destination>
+where
+    PoolDataGetter: Fn(&PoolId) -> Option<&'a PoolData>,
+{
     match txo {
         TxOutput::Transfer(_, d)
         | TxOutput::LockThenTransfer(_, d, _)
         | TxOutput::CreateDelegationId(d, _)
-        | TxOutput::IssueNft(_, _, d)
-        | TxOutput::ProduceBlockFromStake(d, _) => Some(d),
-        TxOutput::CreateStakePool(_, data) => Some(data.staker()),
-        TxOutput::IssueFungibleToken(_)
-        | TxOutput::Burn(_)
-        | TxOutput::DelegateStaking(_, _)
-        | TxOutput::DataDeposit(_) => None,
-    }
-}
-
-pub fn get_tx_output_destination(txo: &TxOutput) -> Option<&Destination> {
-    match txo {
-        TxOutput::Transfer(_, d)
-        | TxOutput::LockThenTransfer(_, d, _)
-        | TxOutput::CreateDelegationId(d, _)
-        | TxOutput::IssueNft(_, _, d)
-        | TxOutput::ProduceBlockFromStake(d, _) => Some(d),
-        TxOutput::CreateStakePool(_, data) => Some(data.decommission_key()),
+        | TxOutput::IssueNft(_, _, d) => Some(d.clone()),
+        TxOutput::ProduceBlockFromStake(_, pool_id) => {
+            pool_data_getter(pool_id).map(|pool_data| pool_data.decommission_key.clone())
+        }
+        TxOutput::CreateStakePool(_, data) => Some(data.decommission_key().clone()),
         TxOutput::IssueFungibleToken(_)
         | TxOutput::Burn(_)
         | TxOutput::DelegateStaking(_, _)

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -203,6 +203,14 @@ pub enum WalletError {
 /// Result type used for the wallet
 pub type WalletResult<T> = Result<T, WalletError>;
 
+/// Wallet tracks all pools that can be decommissioned or used for staking by the wallet.
+/// Filter allows to query for a specific set of pools.
+pub enum WalletPoolsFilter {
+    All,
+    Decommission,
+    Stake,
+}
+
 pub struct Wallet<B: storage::Backend> {
     chain_config: Arc<ChainConfig>,
     db: Store<B>,
@@ -857,8 +865,13 @@ impl<B: storage::Backend> Wallet<B> {
         })
     }
 
-    pub fn get_pool_ids(&self, account_index: U31) -> WalletResult<Vec<(PoolId, PoolData)>> {
-        let pool_ids = self.get_account(account_index)?.get_pool_ids();
+    pub fn get_pool_ids(
+        &self,
+        account_index: U31,
+        filter: WalletPoolsFilter,
+    ) -> WalletResult<Vec<(PoolId, PoolData)>> {
+        let db_tx = self.db.transaction_ro_unlocked()?;
+        let pool_ids = self.get_account(account_index)?.get_pool_ids(filter, &db_tx);
         Ok(pool_ids)
     }
 

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -1295,7 +1295,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
     let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
     let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
 
-    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert!(pool_ids.is_empty());
 
     let coin_balance = get_coin_balance(&wallet);
@@ -1340,7 +1340,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
         pool_amount
     );
 
-    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert_eq!(pool_ids.len(), 1);
 
     let (pool_id, pool_data) = pool_ids.first().unwrap();
@@ -1380,7 +1380,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
 
     scan_wallet(&mut wallet, BlockHeight::new(2), vec![block3.clone()]);
 
-    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert_eq!(pool_ids.len(), 1);
     let (_pool_id, pool_data) = pool_ids.first().unwrap();
     assert_eq!(
@@ -1390,7 +1390,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
 
     // do a reorg back to block 2
     scan_wallet(&mut wallet, BlockHeight::new(1), vec![block2.clone()]);
-    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert_eq!(pool_ids.len(), 1);
     let (pool_id, pool_data) = pool_ids.first().unwrap();
     assert_eq!(
@@ -1414,7 +1414,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
         Amount::ZERO,
         2,
     );
-    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert!(pool_ids.is_empty());
 
     let currency_balances = wallet
@@ -1571,7 +1571,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
     let block1_amount = (chain_config.min_stake_pool_pledge() + delegation_amount).unwrap();
     let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
 
-    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert!(pool_ids.is_empty());
 
     let coin_balance = get_coin_balance(&wallet);
@@ -1614,7 +1614,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
         block1_amount,
     );
 
-    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert_eq!(pool_ids.len(), 1);
 
     let pool_id = pool_ids.first().unwrap().0;
@@ -3652,7 +3652,7 @@ fn decommission_pool_wrong_account(#[case] seed: Seed) {
     let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
     let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
 
-    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    let pool_ids = wallet.get_pool_ids(acc_0_index, WalletPoolsFilter::All).unwrap();
     assert!(pool_ids.is_empty());
 
     let coin_balance = get_coin_balance(&wallet);
@@ -3686,7 +3686,7 @@ fn decommission_pool_wrong_account(#[case] seed: Seed) {
         1,
     );
 
-    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    let pool_ids = wallet.get_pool_ids(acc_0_index, WalletPoolsFilter::All).unwrap();
     assert_eq!(pool_ids.len(), 1);
 
     // Try to decommission the pool with default account
@@ -3753,7 +3753,7 @@ fn decommission_pool_request_wrong_account(#[case] seed: Seed) {
     let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
     let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
 
-    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    let pool_ids = wallet.get_pool_ids(acc_0_index, WalletPoolsFilter::All).unwrap();
     assert!(pool_ids.is_empty());
 
     let coin_balance = get_coin_balance(&wallet);
@@ -3787,7 +3787,7 @@ fn decommission_pool_request_wrong_account(#[case] seed: Seed) {
         1,
     );
 
-    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    let pool_ids = wallet.get_pool_ids(acc_0_index, WalletPoolsFilter::All).unwrap();
     assert_eq!(pool_ids.len(), 1);
 
     // Try to create decommission request from account that holds the key
@@ -3837,7 +3837,7 @@ fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
     let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
     let _ = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
 
-    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    let pool_ids = wallet.get_pool_ids(acc_0_index, WalletPoolsFilter::All).unwrap();
     assert!(pool_ids.is_empty());
 
     let coin_balance = get_coin_balance(&wallet);
@@ -3871,7 +3871,7 @@ fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
         1,
     );
 
-    let pool_ids = wallet.get_pool_ids(acc_0_index).unwrap();
+    let pool_ids = wallet.get_pool_ids(acc_0_index, WalletPoolsFilter::All).unwrap();
     assert_eq!(pool_ids.len(), 1);
 
     let pool_id = pool_ids.first().unwrap().0;
@@ -3936,7 +3936,7 @@ fn sign_decommission_pool_request_cold_wallet(#[case] seed: Seed) {
     let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
     let _ = create_block(&chain_config, &mut hot_wallet, vec![], block1_amount, 0);
 
-    let pool_ids = hot_wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = hot_wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert!(pool_ids.is_empty());
 
     let coin_balance = get_coin_balance(&hot_wallet);
@@ -3968,7 +3968,7 @@ fn sign_decommission_pool_request_cold_wallet(#[case] seed: Seed) {
         1,
     );
 
-    let pool_ids = hot_wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX).unwrap();
+    let pool_ids = hot_wallet.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
     assert_eq!(pool_ids.len(), 1);
 
     let pool_id = pool_ids.first().unwrap().0;
@@ -4008,4 +4008,90 @@ fn sign_decommission_pool_request_cold_wallet(#[case] seed: Seed) {
         currency_balances.get(&Currency::Coin).copied().unwrap_or(Amount::ZERO),
         pool_amount,
     );
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn filter_pools(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_regtest());
+
+    let mut wallet1 = create_wallet(chain_config.clone());
+
+    // create another wallet to store decommission key
+    let another_mnemonic =
+        "legal winner thank year wave sausage worth useful legal winner thank yellow";
+    let mut wallet2 = create_wallet_with_mnemonic(chain_config.clone(), another_mnemonic);
+    let decommission_key = wallet2.get_new_public_key(DEFAULT_ACCOUNT_INDEX).unwrap();
+
+    let coin_balance = get_coin_balance(&wallet1);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // Generate a new block which sends reward to the wallet
+    let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
+    let _ = create_block(&chain_config, &mut wallet1, vec![], block1_amount, 0);
+    let _ = create_block(&chain_config, &mut wallet2, vec![], block1_amount, 0);
+
+    let pool_ids = wallet1.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
+    assert!(pool_ids.is_empty());
+
+    let pool_ids = wallet2.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
+    assert!(pool_ids.is_empty());
+
+    let pool_amount = block1_amount;
+
+    let stake_pool_transaction = wallet1
+        .create_stake_pool_tx(
+            DEFAULT_ACCOUNT_INDEX,
+            FeeRate::from_amount_per_kb(Amount::ZERO),
+            FeeRate::from_amount_per_kb(Amount::ZERO),
+            StakePoolDataArguments {
+                amount: pool_amount,
+                margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
+                cost_per_block: Amount::ZERO,
+                decommission_key: Destination::PublicKey(decommission_key),
+            },
+        )
+        .unwrap();
+    // sync for wallet1
+    let _ = create_block(
+        &chain_config,
+        &mut wallet1,
+        vec![stake_pool_transaction.clone()],
+        Amount::ZERO,
+        1,
+    );
+    // sync for wallet2
+    let _ = create_block(
+        &chain_config,
+        &mut wallet2,
+        vec![stake_pool_transaction],
+        Amount::ZERO,
+        1,
+    );
+
+    // check wallet1 filter
+    let pool_ids = wallet1.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
+    assert_eq!(pool_ids.len(), 1);
+
+    let pool_ids = wallet1
+        .get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::Decommission)
+        .unwrap();
+    assert_eq!(pool_ids.len(), 0);
+
+    let pool_ids = wallet1.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::Stake).unwrap();
+    assert_eq!(pool_ids.len(), 1);
+
+    // check wallet2 filter
+    let pool_ids = wallet2.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::All).unwrap();
+    assert_eq!(pool_ids.len(), 1);
+
+    let pool_ids = wallet2
+        .get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::Decommission)
+        .unwrap();
+    assert_eq!(pool_ids.len(), 1);
+
+    let pool_ids = wallet2.get_pool_ids(DEFAULT_ACCOUNT_INDEX, WalletPoolsFilter::Stake).unwrap();
+    assert_eq!(pool_ids.len(), 0);
 }

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -60,7 +60,10 @@ pub use node_comm::node_traits::{ConnectedPeer, NodeInterface, PeerId};
 pub use node_comm::{
     handles_client::WalletHandlesClient, make_rpc_client, rpc_client::NodeRpcClient,
 };
-use wallet::{wallet_events::WalletEvents, DefaultWallet, WalletError, WalletResult};
+use wallet::{
+    wallet::WalletPoolsFilter, wallet_events::WalletEvents, DefaultWallet, WalletError,
+    WalletResult,
+};
 pub use wallet_types::{
     account_info::DEFAULT_ACCOUNT_INDEX,
     utxo_types::{UtxoState, UtxoStates, UtxoType, UtxoTypes},
@@ -429,8 +432,10 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         transaction_ids: Vec<Id<Transaction>>,
         packing_strategy: PackingStrategy,
     ) -> Result<Block, ControllerError<T>> {
-        let pools =
-            self.wallet.get_pool_ids(account_index).map_err(ControllerError::WalletError)?;
+        let pools = self
+            .wallet
+            .get_pool_ids(account_index, WalletPoolsFilter::Stake)
+            .map_err(ControllerError::WalletError)?;
 
         let mut last_error = ControllerError::NoStakingPool;
         for (pool_id, _) in pools {

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -31,6 +31,7 @@ use node_comm::node_traits::NodeInterface;
 use utils::tap_error_log::LogError;
 use wallet::{
     account::{transaction_list::TransactionList, Currency, DelegationData, PoolData},
+    wallet::WalletPoolsFilter,
     DefaultWallet,
 };
 use wallet_types::{
@@ -218,7 +219,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
     ) -> Result<Vec<(PoolId, PoolData, Amount)>, ControllerError<T>> {
         let pools = self
             .wallet
-            .get_pool_ids(self.account_index)
+            .get_pool_ids(self.account_index, WalletPoolsFilter::All)
             .map_err(ControllerError::WalletError)?;
 
         let tasks: FuturesUnordered<_> = pools

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -41,6 +41,7 @@ use wallet::{
         make_address_output, make_address_output_token, make_create_delegation_output,
         make_data_deposit_output, StakePoolDataArguments,
     },
+    wallet::WalletPoolsFilter,
     wallet_events::WalletEvents,
     DefaultWallet, WalletError, WalletResult,
 };
@@ -601,7 +602,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         // Make sure that account_index is valid and that pools exist
         let pool_ids = self
             .wallet
-            .get_pool_ids(self.account_index)
+            .get_pool_ids(self.account_index, WalletPoolsFilter::Stake)
             .map_err(ControllerError::WalletError)?;
         utils::ensure!(!pool_ids.is_empty(), ControllerError::NoStakingPool);
         log::info!("Start staking, account_index: {}", self.account_index);


### PR DESCRIPTION
Decommission request only worked if a pool is decommissioned from `TxOutput::StakePoolData` meaning it wasn't used for staking. If it was cold wallet couldn't sign it. The problem was that wallet needs to track pool utxo using both staker and decommission keys for both StakePoolData and ProduceBlockFromStake outputs.

UPD: now PartiallySignedTransaction provides all the information for a not-synced wallet to sign