### PR TITLE
Move transaction checks from chainstate to tx_verifier and use them in mempool

### DIFF
--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -23,6 +23,7 @@ use tx_verifier::{
         signature_destination_getter::SignatureDestinationGetterError, IOPolicyError,
         RewardDistributionError,
     },
+    CheckTransactionError,
 };
 
 use super::{
@@ -149,6 +150,7 @@ impl BanScore for ConnectTransactionError {
             ConnectTransactionError::AttemptToSpendFrozenToken(_) => 100,
             ConnectTransactionError::PoolBalanceNotFound(_) => 100,
             ConnectTransactionError::RewardDistributionError(err) => err.ban_score(),
+            ConnectTransactionError::CheckTransactionError(err) => err.ban_score(),
         }
     }
 }
@@ -244,8 +246,8 @@ impl BanScore for TokensError {
     fn ban_score(&self) -> u32 {
         match self {
             TokensError::StorageError(_) => 0,
-            TokensError::IssueError(_, _, _) => 100,
-            TokensError::MultipleTokenIssuanceInTransaction(_, _) => 100,
+            TokensError::IssueError(_, _) => 100,
+            TokensError::MultipleTokenIssuanceInTransaction(_) => 100,
             TokensError::CoinOrTokenOverflow(_) => 100,
             TokensError::InsufficientTokenFees(_) => 100,
             TokensError::TransferZeroTokens(_, _) => 100,
@@ -261,15 +263,23 @@ impl BanScore for TokensError {
 impl BanScore for CheckBlockTransactionsError {
     fn ban_score(&self) -> u32 {
         match self {
-            CheckBlockTransactionsError::PropertyQueryError(_) => 0,
-            CheckBlockTransactionsError::DuplicateInputInTransaction(_, _) => 100,
+            CheckBlockTransactionsError::CheckTransactionError(err) => err.ban_score(),
             CheckBlockTransactionsError::DuplicateInputInBlock(_) => 100,
-            CheckBlockTransactionsError::EmptyInputsInTransactionInBlock(_, _) => 100,
-            CheckBlockTransactionsError::TokensError(err) => err.ban_score(),
-            CheckBlockTransactionsError::InvalidWitnessCount => 100,
-            CheckBlockTransactionsError::NoSignatureDataNotAllowed(_, _) => 100,
-            CheckBlockTransactionsError::NoSignatureDataSizeTooLarge(_, _) => 100,
-            CheckBlockTransactionsError::DataDepositMaxSizeExceeded(_, _, _, _) => 100,
+        }
+    }
+}
+
+impl BanScore for CheckTransactionError {
+    fn ban_score(&self) -> u32 {
+        match self {
+            CheckTransactionError::PropertyQueryError(_) => 0,
+            CheckTransactionError::DuplicateInputInTransaction(_) => 100,
+            CheckTransactionError::EmptyInputsInTransaction(_) => 100,
+            CheckTransactionError::TokensError(err) => err.ban_score(),
+            CheckTransactionError::InvalidWitnessCount => 100,
+            CheckTransactionError::NoSignatureDataNotAllowed(_) => 100,
+            CheckTransactionError::NoSignatureDataSizeTooLarge(_, _) => 100,
+            CheckTransactionError::DataDepositMaxSizeExceeded(_, _, _) => 100,
         }
     }
 }

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -276,9 +276,9 @@ impl BanScore for CheckTransactionError {
             CheckTransactionError::DuplicateInputInTransaction(_) => 100,
             CheckTransactionError::EmptyInputsInTransaction(_) => 100,
             CheckTransactionError::TokensError(err) => err.ban_score(),
-            CheckTransactionError::InvalidWitnessCount => 100,
+            CheckTransactionError::InvalidWitnessCount(_) => 100,
             CheckTransactionError::NoSignatureDataNotAllowed(_) => 100,
-            CheckTransactionError::NoSignatureDataSizeTooLarge(_, _) => 100,
+            CheckTransactionError::NoSignatureDataSizeTooLarge(_, _, _) => 100,
             CheckTransactionError::DataDepositMaxSizeExceeded(_, _, _) => 100,
         }
     }

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -21,8 +21,7 @@ use super::{
     chainstateref::EpochSealError,
     orphan_blocks::OrphanAddError,
     transaction_verifier::{
-        error::{ConnectTransactionError, TokensError},
-        storage::TransactionVerifierStorageError,
+        error::ConnectTransactionError, storage::TransactionVerifierStorageError,
     },
 };
 use chainstate_storage::ChainstateStorageVersion;
@@ -30,7 +29,7 @@ use chainstate_types::{GetAncestorError, PropertyQueryError};
 use common::{
     chain::{
         block::{block_body::BlockMerkleTreeError, timestamp::BlockTimestamp},
-        Block, GenBlock, Transaction,
+        Block, GenBlock,
     },
     primitives::{BlockHeight, Id},
 };
@@ -150,25 +149,9 @@ pub enum CheckBlockError {
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum CheckBlockTransactionsError {
     #[error("Blockchain storage error: {0}")]
-    PropertyQueryError(#[from] PropertyQueryError),
-    #[error("Duplicate input in transaction {0} in block {1}")]
-    DuplicateInputInTransaction(Id<Transaction>, Id<Block>),
+    CheckTransactionError(#[from] tx_verifier::CheckTransactionError),
     #[error("Duplicate input in block")]
     DuplicateInputInBlock(Id<Block>),
-    #[error("Number of signatures differs from number of inputs")]
-    InvalidWitnessCount,
-    #[error("Empty inputs in transaction {0} found in block {1}")]
-    EmptyInputsInTransactionInBlock(Id<Transaction>, Id<Block>),
-    #[error("Tokens error: {0}")]
-    TokensError(TokensError),
-    #[error("No signature data size is too large: {0} > {1}")]
-    NoSignatureDataSizeTooLarge(usize, usize),
-    #[error("No signature data is not allowed. Found in transaction {0} and block {1}")]
-    NoSignatureDataNotAllowed(Id<Transaction>, Id<Block>),
-    #[error(
-        "Data deposit size {0} exceeded max allowed {1}. Found in transaction {2} and block {3}"
-    )]
-    DataDepositMaxSizeExceeded(usize, usize, Id<Transaction>, Id<Block>),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -148,9 +148,9 @@ pub enum CheckBlockError {
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum CheckBlockTransactionsError {
-    #[error("Blockchain storage error: {0}")]
+    #[error("Check transaction error: {0}")]
     CheckTransactionError(#[from] tx_verifier::CheckTransactionError),
-    #[error("Duplicate input in block")]
+    #[error("Duplicate input in block: {0}")]
     DuplicateInputInBlock(Id<Block>),
 }
 

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -24,7 +24,6 @@ pub mod block_checking;
 pub mod block_invalidation;
 pub mod bootstrap;
 pub mod query;
-pub mod tokens;
 pub mod tx_verification_strategy;
 
 use std::{collections::VecDeque, sync::Arc};
@@ -64,12 +63,7 @@ use utils::{
 };
 use utxo::UtxosDB;
 
-pub use self::{
-    error::*,
-    info::ChainInfo,
-    median_time::calculate_median_time_past,
-    tokens::{check_nft_issuance_data, check_tokens_issuance, is_rfc3986_valid_symbol},
-};
+pub use self::{error::*, info::ChainInfo, median_time::calculate_median_time_past};
 pub use chainstate_types::Locator;
 pub use error::{
     BlockError, CheckBlockError, CheckBlockTransactionsError, DbCommittingContext,

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -35,8 +35,7 @@ pub use crate::{
     config::{ChainstateConfig, MaxTipAge},
     detail::{
         ban_score, block_invalidation::BlockInvalidatorError, calculate_median_time_past,
-        check_nft_issuance_data, check_tokens_issuance, is_rfc3986_valid_symbol, BlockError,
-        BlockSource, ChainInfo, CheckBlockError, CheckBlockTransactionsError,
+        BlockError, BlockSource, ChainInfo, CheckBlockError, CheckBlockTransactionsError,
         ConnectTransactionError, IOPolicyError, InitializationError, Locator, OrphanCheckError,
         SpendStakeError, StorageCompatibilityCheckError, TokenIssuanceError, TokensError,
         TransactionVerifierStorageError,

--- a/chainstate/test-suite/src/tests/data_deposit.rs
+++ b/chainstate/test-suite/src/tests/data_deposit.rs
@@ -26,6 +26,7 @@ use common::primitives::{Amount, CoinOrTokenId, Idable};
 use crypto::random::Rng;
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
+use tx_verifier::CheckTransactionError;
 
 #[rstest]
 #[trace]
@@ -66,11 +67,12 @@ fn data_deposited_too_large(#[case] seed: Seed, #[case] expect_success: bool) {
 
             let expected_err = Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::DataDepositMaxSizeExceeded(
-                        deposited_data_len,
-                        tf.chain_config().data_deposit_max_size(),
-                        tx.transaction().get_id(),
-                        block.get_id(),
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::DataDepositMaxSizeExceeded(
+                            deposited_data_len,
+                            tf.chain_config().data_deposit_max_size(),
+                            tx.transaction().get_id(),
+                        ),
                     ),
                 )),
             ));

--- a/chainstate/test-suite/src/tests/double_spend_tests.rs
+++ b/chainstate/test-suite/src/tests/double_spend_tests.rs
@@ -29,6 +29,7 @@ use common::{
     primitives::{Amount, CoinOrTokenId, Id, Idable},
 };
 use crypto::random::SliceRandom;
+use tx_verifier::CheckTransactionError;
 
 // Process a block where the second transaction uses the first one as input.
 //
@@ -324,14 +325,12 @@ fn duplicate_input_in_the_same_tx(#[case] seed: Seed) {
         let second_tx_id = second_tx.transaction().get_id();
 
         let block = tf.make_block_builder().with_transactions(vec![first_tx, second_tx]).build();
-        let block_id = block.get_id();
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
                 CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::DuplicateInputInTransaction(
-                        second_tx_id,
-                        block_id
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::DuplicateInputInTransaction(second_tx_id,)
                     )
                 )
             ))
@@ -379,14 +378,12 @@ fn same_input_diff_sig_in_the_same_tx(#[case] seed: Seed) {
         let second_tx_id = second_tx.transaction().get_id();
 
         let block = tf.make_block_builder().with_transactions(vec![first_tx, second_tx]).build();
-        let block_id = block.get_id();
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
                 CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::DuplicateInputInTransaction(
-                        second_tx_id,
-                        block_id
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::DuplicateInputInTransaction(second_tx_id,)
                     )
                 )
             ))

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -42,6 +42,7 @@ use test_utils::{
     random::{make_seedable_rng, Seed},
     random_ascii_alphanumeric_string,
 };
+use tx_verifier::CheckTransactionError;
 
 fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramework {
     TestFramework::builder(rng)
@@ -223,8 +224,10 @@ fn multiple_token_issuance_in_one_tx(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(
-                        TokensError::MultipleTokenIssuanceInTransaction(_, _)
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(
+                            TokensError::MultipleTokenIssuanceInTransaction(_)
+                        )
                     )
                 ))
             ))

--- a/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
@@ -46,8 +46,11 @@ use test_utils::{
     random_ascii_alphanumeric_string, split_value,
 };
 use tokens_accounting::TokensAccountingStorageRead;
-use tx_verifier::transaction_verifier::{
-    error::TokenIssuanceError, signature_destination_getter::SignatureDestinationGetterError,
+use tx_verifier::{
+    transaction_verifier::{
+        error::TokenIssuanceError, signature_destination_getter::SignatureDestinationGetterError,
+    },
+    CheckTransactionError,
 };
 
 fn make_issuance(
@@ -282,16 +285,17 @@ fn token_issue_test(#[case] seed: Seed) {
             authority: Destination::AnyoneCanSpend,
             is_freezable: IsTokenFreezable::No,
         });
-        let (result, tx_id, block_id) = process_block_with_issuance(issuance);
+        let (result, tx_id, _) = process_block_with_issuance(issuance);
         assert_eq!(
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorInvalidTickerLength,
-                        tx_id,
-                        block_id
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorInvalidTickerLength,
+                            tx_id,
+                        ))
+                    )
                 ))
             ))
         );
@@ -305,16 +309,17 @@ fn token_issue_test(#[case] seed: Seed) {
             authority: Destination::AnyoneCanSpend,
             is_freezable: IsTokenFreezable::No,
         });
-        let (result, tx_id, block_id) = process_block_with_issuance(issuance);
+        let (result, tx_id, _) = process_block_with_issuance(issuance);
         assert_eq!(
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorInvalidTickerLength,
-                        tx_id,
-                        block_id
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorInvalidTickerLength,
+                            tx_id,
+                        ))
+                    )
                 ))
             ))
         );
@@ -340,17 +345,18 @@ fn token_issue_test(#[case] seed: Seed) {
                     authority: Destination::AnyoneCanSpend,
                     is_freezable: IsTokenFreezable::No,
                 });
-                let (result, tx_id, block_id) = process_block_with_issuance(issuance);
+                let (result, tx_id, _) = process_block_with_issuance(issuance);
 
                 assert_eq!(
                     result,
                     Err(ChainstateError::ProcessBlockError(
                         BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                            CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                                TokenIssuanceError::IssueErrorTickerHasNoneAlphaNumericChar,
-                                tx_id,
-                                block_id
-                            ))
+                            CheckBlockTransactionsError::CheckTransactionError(
+                                CheckTransactionError::TokensError(TokensError::IssueError(
+                                    TokenIssuanceError::IssueErrorTickerHasNoneAlphaNumericChar,
+                                    tx_id,
+                                ))
+                            )
                         ))
                     ))
                 );
@@ -371,16 +377,17 @@ fn token_issue_test(#[case] seed: Seed) {
                 authority: Destination::AnyoneCanSpend,
                 is_freezable: IsTokenFreezable::No,
             });
-            let (result, tx_id, block_id) = process_block_with_issuance(issuance);
+            let (result, tx_id, _) = process_block_with_issuance(issuance);
             assert_eq!(
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorTooManyDecimals,
-                            tx_id,
-                            block_id
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::IssueErrorTooManyDecimals,
+                                tx_id,
+                            ))
+                        )
                     ))
                 ))
             );
@@ -400,16 +407,17 @@ fn token_issue_test(#[case] seed: Seed) {
                 authority: Destination::AnyoneCanSpend,
                 is_freezable: IsTokenFreezable::No,
             });
-            let (result, tx_id, block_id) = process_block_with_issuance(issuance);
+            let (result, tx_id, _) = process_block_with_issuance(issuance);
             assert_eq!(
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorIncorrectMetadataURI,
-                            tx_id,
-                            block_id
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::IssueErrorIncorrectMetadataURI,
+                                tx_id,
+                            ))
+                        )
                     ))
                 ))
             );
@@ -424,16 +432,17 @@ fn token_issue_test(#[case] seed: Seed) {
             authority: Destination::AnyoneCanSpend,
             is_freezable: IsTokenFreezable::No,
         });
-        let (result, tx_id, block_id) = process_block_with_issuance(issuance);
+        let (result, tx_id, _) = process_block_with_issuance(issuance);
         assert_eq!(
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorIncorrectMetadataURI,
-                        tx_id,
-                        block_id
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorIncorrectMetadataURI,
+                            tx_id,
+                        ))
+                    )
                 ))
             ))
         );
@@ -3798,19 +3807,19 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
             .build();
         let tx_id = tx.transaction().get_id();
         let block = tf.make_block_builder().add_transaction(tx).build();
-        let block_id = block.get_id();
         let res = tf.process_block(block, chainstate::BlockSource::Local);
 
         assert_eq!(
             res.unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
-                    TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorTickerHasNoneAlphaNumericChar,
-                        tx_id,
-                        block_id
+                CheckBlockError::CheckTransactionFailed(
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorTickerHasNoneAlphaNumericChar,
+                            tx_id,
+                        ))
                     )
-                ))
+                )
             ))
         );
 

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -14,17 +14,19 @@
 // limitations under the License.
 
 use chainstate::{
-    is_rfc3986_valid_symbol, BlockError, ChainstateError, CheckBlockError,
-    CheckBlockTransactionsError, ConnectTransactionError, TokensError,
+    BlockError, ChainstateError, CheckBlockError, CheckBlockTransactionsError,
+    ConnectTransactionError, TokensError,
 };
 use chainstate_test_framework::{TestFramework, TransactionBuilder};
-use common::chain::output_value::OutputValue;
-use common::chain::Block;
-use common::chain::OutPointSourceId;
 use common::chain::{
+    output_value::OutputValue,
     signature::inputsig::InputWitness,
-    tokens::{make_token_id, Metadata, NftIssuance, NftIssuanceV0, TokenIssuanceVersion},
-    ChainstateUpgrade, Destination, RewardDistributionVersion, TxInput, TxOutput,
+    tokens::{
+        is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0,
+        TokenIssuanceVersion,
+    },
+    Block, ChainstateUpgrade, Destination, OutPointSourceId, RewardDistributionVersion, TxInput,
+    TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
 use crypto::random::{CryptoRng, Rng};
@@ -36,7 +38,7 @@ use test_utils::{
     random::{make_seedable_rng, Seed},
     random_ascii_alphanumeric_string,
 };
-use tx_verifier::error::TokenIssuanceError;
+use tx_verifier::{error::TokenIssuanceError, CheckTransactionError};
 
 #[rstest]
 #[trace]
@@ -98,11 +100,12 @@ fn nft_name_too_long(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorInvalidNameLength,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorInvalidNameLength,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -164,11 +167,12 @@ fn nft_empty_name(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorInvalidNameLength,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorInvalidNameLength,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -241,11 +245,12 @@ fn nft_invalid_name(#[case] seed: Seed) {
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorNameHasNoneAlphaNumericChar,
-                            _,
-                            _
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::IssueErrorNameHasNoneAlphaNumericChar,
+                                _,
+                            ))
+                        )
                     ))
                 ))
             ));
@@ -314,11 +319,12 @@ fn nft_ticker_too_long(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorInvalidTickerLength,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorInvalidTickerLength,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -381,11 +387,12 @@ fn nft_empty_ticker(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorInvalidTickerLength,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorInvalidTickerLength,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -458,11 +465,12 @@ fn nft_invalid_ticker(#[case] seed: Seed) {
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorTickerHasNoneAlphaNumericChar,
-                            _,
-                            _
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::IssueErrorTickerHasNoneAlphaNumericChar,
+                                _,
+                            ))
+                        )
                     ))
                 ))
             ));
@@ -531,11 +539,12 @@ fn nft_description_too_long(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorInvalidDescriptionLength,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorInvalidDescriptionLength,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -598,11 +607,12 @@ fn nft_empty_description(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorInvalidDescriptionLength,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorInvalidDescriptionLength,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -675,11 +685,12 @@ fn nft_invalid_description(#[case] seed: Seed) {
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorDescriptionHasNoneAlphaNumericChar,
-                            _,
-                            _
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::IssueErrorDescriptionHasNoneAlphaNumericChar,
+                                _,
+                            ))
+                        )
                     ))
                 ))
             ));
@@ -754,11 +765,12 @@ fn nft_icon_uri_too_long(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorIncorrectIconURI,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorIncorrectIconURI,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -906,11 +918,12 @@ fn nft_icon_uri_invalid(#[case] seed: Seed) {
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorIncorrectIconURI,
-                            _,
-                            _
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::IssueErrorIncorrectIconURI,
+                                _,
+                            ))
+                        )
                     ))
                 ))
             ));
@@ -986,11 +999,12 @@ fn nft_metadata_uri_too_long(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorIncorrectMetadataURI,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorIncorrectMetadataURI,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -1137,11 +1151,12 @@ fn nft_metadata_uri_invalid(#[case] seed: Seed) {
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorIncorrectMetadataURI,
-                            _,
-                            _
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::IssueErrorIncorrectMetadataURI,
+                                _,
+                            ))
+                        )
                     ))
                 ))
             ));
@@ -1217,11 +1232,12 @@ fn nft_media_uri_too_long(#[case] seed: Seed) {
             result,
             Err(ChainstateError::ProcessBlockError(
                 BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorIncorrectMediaURI,
-                        _,
-                        _
-                    ))
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorIncorrectMediaURI,
+                            _,
+                        ))
+                    )
                 ))
             ))
         ));
@@ -1370,11 +1386,12 @@ fn nft_media_uri_invalid(#[case] seed: Seed) {
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorIncorrectMediaURI,
-                            _,
-                            _
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::IssueErrorIncorrectMediaURI,
+                                _,
+                            ))
+                        )
                     ))
                 ))
             ));
@@ -1450,11 +1467,12 @@ fn nft_media_hash_too_short(#[case] seed: Seed) {
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::MediaHashTooShort,
-                            _,
-                            _
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::MediaHashTooShort,
+                                _,
+                            ))
+                        )
                     ))
                 ))
             ));
@@ -1484,11 +1502,12 @@ fn nft_media_hash_too_long(#[case] seed: Seed) {
                 result,
                 Err(ChainstateError::ProcessBlockError(
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
-                        CheckBlockTransactionsError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::MediaHashTooLong,
-                            _,
-                            _
-                        ))
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            CheckTransactionError::TokensError(TokensError::IssueError(
+                                TokenIssuanceError::MediaHashTooLong,
+                                _,
+                            ))
+                        )
                     ))
                 ))
             ));
@@ -1732,19 +1751,19 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
             .build();
         let tx_id = tx.transaction().get_id();
         let block = tf.make_block_builder().add_transaction(tx).build();
-        let block_id = block.get_id();
         let res = tf.process_block(block, chainstate::BlockSource::Local);
 
         assert_eq!(
             res.unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
-                    TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorNameHasNoneAlphaNumericChar,
-                        tx_id,
-                        block_id
+                CheckBlockError::CheckTransactionFailed(
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorNameHasNoneAlphaNumericChar,
+                            tx_id,
+                        ))
                     )
-                ))
+                )
             ))
         );
 
@@ -1779,19 +1798,19 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
             .build();
         let tx_id = tx.transaction().get_id();
         let block = tf.make_block_builder().add_transaction(tx).build();
-        let block_id = block.get_id();
         let res = tf.process_block(block, chainstate::BlockSource::Local);
 
         assert_eq!(
             res.unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
-                    TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorDescriptionHasNoneAlphaNumericChar,
-                        tx_id,
-                        block_id
+                CheckBlockError::CheckTransactionFailed(
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorDescriptionHasNoneAlphaNumericChar,
+                            tx_id,
+                        ))
                     )
-                ))
+                )
             ))
         );
 
@@ -1827,19 +1846,19 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
             .build();
         let tx_id = tx.transaction().get_id();
         let block = tf.make_block_builder().add_transaction(tx).build();
-        let block_id = block.get_id();
         let res = tf.process_block(block, chainstate::BlockSource::Local);
 
         assert_eq!(
             res.unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                CheckBlockError::CheckTransactionFailed(CheckBlockTransactionsError::TokensError(
-                    TokensError::IssueError(
-                        TokenIssuanceError::IssueErrorTickerHasNoneAlphaNumericChar,
-                        tx_id,
-                        block_id
+                CheckBlockError::CheckTransactionFailed(
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        CheckTransactionError::TokensError(TokensError::IssueError(
+                            TokenIssuanceError::IssueErrorTickerHasNoneAlphaNumericChar,
+                            tx_id,
+                        ))
                     )
-                ))
+                )
             ))
         );
 

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -1109,14 +1109,12 @@ fn empty_inputs_in_tx(#[case] seed: Seed) {
         let first_tx_id = first_tx.transaction().get_id();
 
         let block = tf.make_block_builder().with_transactions(vec![first_tx]).build();
-        let block_id = block.get_id();
         assert_eq!(
             tf.process_block(block, BlockSource::Local).unwrap_err(),
             ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
                 CheckBlockError::CheckTransactionFailed(
-                    CheckBlockTransactionsError::EmptyInputsInTransactionInBlock(
-                        first_tx_id,
-                        block_id
+                    CheckBlockTransactionsError::CheckTransactionError(
+                        tx_verifier::CheckTransactionError::EmptyInputsInTransaction(first_tx_id,)
                     )
                 )
             ))

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -405,9 +405,11 @@ fn too_large_no_sig_data(#[case] seed: Seed, #[case] valid_size: bool) {
                     chainstate::ChainstateError::ProcessBlockError(
                         chainstate::BlockError::CheckBlockFailed(
                             chainstate::CheckBlockError::CheckTransactionFailed(
-                                chainstate::CheckBlockTransactionsError::NoSignatureDataSizeTooLarge(
-                                    max_no_sig_data_size + 1,
-                                    max_no_sig_data_size
+                                chainstate::CheckBlockTransactionsError::CheckTransactionError(
+                                    tx_verifier::CheckTransactionError::NoSignatureDataSizeTooLarge(
+                                        max_no_sig_data_size + 1,
+                                        max_no_sig_data_size
+                                    )
                                 )
                             )
                         )
@@ -480,18 +482,19 @@ fn no_sig_data_not_allowed(#[case] seed: Seed, #[case] data_allowed: bool) {
                         tf.process_block(block.clone(), chainstate::BlockSource::Local);
 
                     assert_eq!(
-                            process_result.unwrap_err(),
-                            chainstate::ChainstateError::ProcessBlockError(
-                                chainstate::BlockError::CheckBlockFailed(
-                                    chainstate::CheckBlockError::CheckTransactionFailed(
-                                        chainstate::CheckBlockTransactionsError::NoSignatureDataNotAllowed(
+                        process_result.unwrap_err(),
+                        chainstate::ChainstateError::ProcessBlockError(
+                            chainstate::BlockError::CheckBlockFailed(
+                                chainstate::CheckBlockError::CheckTransactionFailed(
+                                    chainstate::CheckBlockTransactionsError::CheckTransactionError(
+                                        tx_verifier::CheckTransactionError::NoSignatureDataNotAllowed(
                                             tx.transaction().get_id(),
-                                            block.get_id()
                                         )
                                     )
                                 )
                             )
-                        );
+                        )
+                    );
                 }
             }
         }

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -390,6 +390,7 @@ fn too_large_no_sig_data(#[case] seed: Seed, #[case] valid_size: bool) {
                     anyonecanspend_address(),
                 ))
                 .build();
+            let tx_id = tx.transaction().get_id();
 
             if valid_size {
                 let process_result =
@@ -408,7 +409,8 @@ fn too_large_no_sig_data(#[case] seed: Seed, #[case] valid_size: bool) {
                                 chainstate::CheckBlockTransactionsError::CheckTransactionError(
                                     tx_verifier::CheckTransactionError::NoSignatureDataSizeTooLarge(
                                         max_no_sig_data_size + 1,
-                                        max_no_sig_data_size
+                                        max_no_sig_data_size,
+                                        tx_id
                                     )
                                 )
                             )

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -419,7 +419,7 @@ fn fee_from_decommissioning_stake_pool(#[case] seed: Seed) {
             .unwrap();
 
         // use regtest with pos for new tx
-        let chain_config = common::chain::config::Builder::new(ChainType::Mainnet)
+        let chain_config = common::chain::config::Builder::new(ChainType::Regtest)
             .consensus_upgrades(NetUpgrades::regtest_with_pos())
             .build();
         let required_maturity_distance =
@@ -505,7 +505,7 @@ fn fee_from_spending_delegation_share(#[case] seed: Seed) {
             .unwrap();
 
         // use regtest with pos for new tx
-        let chain_config = common::chain::config::Builder::new(ChainType::Mainnet)
+        let chain_config = common::chain::config::Builder::new(ChainType::Regtest)
             .consensus_upgrades(NetUpgrades::regtest_with_pos())
             .build();
         let required_maturity_distance =

--- a/chainstate/tx-verifier/src/lib.rs
+++ b/chainstate/tx-verifier/src/lib.rs
@@ -16,11 +16,14 @@
 pub mod transaction_verifier;
 
 pub use transaction_verifier::{
+    check_transaction::{check_transaction, CheckTransactionError},
     error,
     flush::flush_to_storage,
     storage::{
         TransactionVerifierStorageError, TransactionVerifierStorageMut,
         TransactionVerifierStorageRef,
     },
-    timelock_check, TransactionSource, TransactionVerifier,
+    timelock_check,
+    tokens_check::{check_nft_issuance_data, check_tokens_issuance},
+    TransactionSource, TransactionVerifier,
 };

--- a/chainstate/tx-verifier/src/transaction_verifier/check_transaction.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/check_transaction.rs
@@ -1,0 +1,190 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+
+use chainstate_types::PropertyQueryError;
+use common::{
+    chain::{
+        signature::inputsig::InputWitness,
+        tokens::{get_tokens_issuance_count, NftIssuance},
+        ChainConfig, SignedTransaction, Transaction, TxOutput,
+    },
+    primitives::{Id, Idable},
+};
+use thiserror::Error;
+use utils::ensure;
+
+use crate::{
+    error::TokensError,
+    transaction_verifier::tokens_check::{check_nft_issuance_data, check_tokens_issuance},
+};
+
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+pub enum CheckTransactionError {
+    #[error("Blockchain storage error: {0}")]
+    PropertyQueryError(#[from] PropertyQueryError),
+    #[error("Duplicate input in transaction {0}")]
+    DuplicateInputInTransaction(Id<Transaction>),
+    #[error("Number of signatures differs from number of inputs")]
+    InvalidWitnessCount,
+    #[error("Empty inputs in transaction {0} found")]
+    EmptyInputsInTransaction(Id<Transaction>),
+    #[error("Tokens error: {0}")]
+    TokensError(TokensError),
+    #[error("No signature data size is too large: {0} > {1}")]
+    NoSignatureDataSizeTooLarge(usize, usize),
+    #[error("No signature data is not allowed. Found in transaction {0}")]
+    NoSignatureDataNotAllowed(Id<Transaction>),
+    #[error("Data deposit size {0} exceeded max allowed {1}. Found in transaction {2}")]
+    DataDepositMaxSizeExceeded(usize, usize, Id<Transaction>),
+}
+
+pub fn check_transaction(
+    chain_config: &ChainConfig,
+    tx: &SignedTransaction,
+) -> Result<(), CheckTransactionError> {
+    check_duplicate_inputs(tx)?;
+    check_witness_count(tx)?;
+    check_tokens_tx(chain_config, tx)?;
+    check_no_signature_size(chain_config, tx)?;
+    check_data_deposit_outputs(chain_config, tx)?;
+    Ok(())
+}
+
+fn check_duplicate_inputs(tx: &SignedTransaction) -> Result<(), CheckTransactionError> {
+    // check for duplicate inputs (see CVE-2018-17144)
+    ensure!(
+        !tx.inputs().is_empty(),
+        CheckTransactionError::EmptyInputsInTransaction(tx.transaction().get_id(),),
+    );
+
+    let mut tx_inputs = BTreeSet::new();
+    for input in tx.inputs() {
+        ensure!(
+            tx_inputs.insert(input),
+            CheckTransactionError::DuplicateInputInTransaction(tx.transaction().get_id(),)
+        );
+    }
+
+    Ok(())
+}
+
+fn check_witness_count(tx: &SignedTransaction) -> Result<(), CheckTransactionError> {
+    ensure!(
+        tx.inputs().len() == tx.signatures().len(),
+        CheckTransactionError::InvalidWitnessCount
+    );
+
+    Ok(())
+}
+
+fn check_tokens_tx(
+    chain_config: &ChainConfig,
+    tx: &SignedTransaction,
+) -> Result<(), CheckTransactionError> {
+    // We can't issue multiple tokens in a single tx
+    let issuance_count = get_tokens_issuance_count(tx.outputs());
+    ensure!(
+        issuance_count <= 1,
+        CheckTransactionError::TokensError(TokensError::MultipleTokenIssuanceInTransaction(
+            tx.transaction().get_id(),
+        ),)
+    );
+
+    // Check tokens
+    tx.outputs()
+        .iter()
+        .try_for_each(|output| match output {
+            TxOutput::IssueFungibleToken(issuance) => check_tokens_issuance(chain_config, issuance)
+                .map_err(|e| TokensError::IssueError(e, tx.transaction().get_id())),
+            TxOutput::IssueNft(_, issuance, _) => match issuance.as_ref() {
+                NftIssuance::V0(data) => check_nft_issuance_data(chain_config, data)
+                    .map_err(|e| TokensError::IssueError(e, tx.transaction().get_id())),
+            },
+            TxOutput::Transfer(_, _)
+            | TxOutput::LockThenTransfer(_, _, _)
+            | TxOutput::Burn(_)
+            | TxOutput::CreateStakePool(_, _)
+            | TxOutput::ProduceBlockFromStake(_, _)
+            | TxOutput::CreateDelegationId(_, _)
+            | TxOutput::DelegateStaking(_, _)
+            | TxOutput::DataDeposit(_) => Ok(()),
+        })
+        .map_err(CheckTransactionError::TokensError)?;
+
+    Ok(())
+}
+
+fn check_no_signature_size(
+    chain_config: &ChainConfig,
+    tx: &SignedTransaction,
+) -> Result<(), CheckTransactionError> {
+    for signature in tx.signatures() {
+        match signature {
+            InputWitness::NoSignature(data) => {
+                if !chain_config.data_in_no_signature_witness_allowed() && data.is_some() {
+                    return Err(CheckTransactionError::NoSignatureDataNotAllowed(
+                        tx.transaction().get_id(),
+                    ));
+                }
+
+                if let Some(inner_data) = data {
+                    ensure!(
+                        inner_data.len() <= chain_config.data_in_no_signature_witness_max_size(),
+                        CheckTransactionError::NoSignatureDataSizeTooLarge(
+                            inner_data.len(),
+                            chain_config.data_in_no_signature_witness_max_size(),
+                        )
+                    )
+                }
+            }
+            InputWitness::Standard(_) => (),
+        }
+    }
+
+    Ok(())
+}
+
+fn check_data_deposit_outputs(
+    chain_config: &ChainConfig,
+    tx: &SignedTransaction,
+) -> Result<(), CheckTransactionError> {
+    for output in tx.outputs() {
+        match output {
+            TxOutput::Transfer(..)
+            | TxOutput::LockThenTransfer(..)
+            | TxOutput::Burn(..)
+            | TxOutput::CreateStakePool(..)
+            | TxOutput::ProduceBlockFromStake(..)
+            | TxOutput::CreateDelegationId(..)
+            | TxOutput::DelegateStaking(..)
+            | TxOutput::IssueFungibleToken(..)
+            | TxOutput::IssueNft(..) => { /* Do nothing */ }
+            TxOutput::DataDeposit(v) => {
+                // Ensure the size of the data doesn't exceed the max allowed
+                if v.len() > chain_config.data_deposit_max_size() {
+                    return Err(CheckTransactionError::DataDepositMaxSizeExceeded(
+                        v.len(),
+                        chain_config.data_deposit_max_size(),
+                        tx.transaction().get_id(),
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -26,7 +26,7 @@ use common::{
 };
 use thiserror::Error;
 
-use crate::timelock_check;
+use crate::{timelock_check, CheckTransactionError};
 
 use super::{
     input_output_policy::IOPolicyError, reward_distribution,
@@ -152,6 +152,8 @@ pub enum ConnectTransactionError {
     AttemptToSpendFrozenToken(TokenId),
     #[error("Reward distribution error: {0}")]
     RewardDistributionError(#[from] reward_distribution::RewardDistributionError),
+    #[error("Check transaction error: {0}")]
+    CheckTransactionError(#[from] CheckTransactionError),
 }
 
 impl From<chainstate_storage::Error> for ConnectTransactionError {
@@ -196,10 +198,10 @@ pub enum TokenIssuanceError {
 pub enum TokensError {
     #[error("Blockchain storage error: {0}")]
     StorageError(#[from] chainstate_storage::Error),
-    #[error("Issuance error {0} in transaction {1} in block {2}")]
-    IssueError(TokenIssuanceError, Id<Transaction>, Id<Block>),
-    #[error("Too many tokens issuance in transaction {0} in block {1}")]
-    MultipleTokenIssuanceInTransaction(Id<Transaction>, Id<Block>),
+    #[error("Issuance error {0} in transaction {1}")]
+    IssueError(TokenIssuanceError, Id<Transaction>),
+    #[error("Too many tokens issuance in transaction {0}")]
+    MultipleTokenIssuanceInTransaction(Id<Transaction>),
     #[error("Coin or token overflow {0:?}")]
     CoinOrTokenOverflow(CoinOrTokenId),
     #[error("Insufficient token issuance fee in transaction {0}")]

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -22,12 +22,14 @@ mod token_issuance_cache;
 mod tokens_accounting_undo_cache;
 mod utxos_undo_cache;
 
+pub mod check_transaction;
 pub mod error;
 pub mod flush;
 pub mod hierarchy;
 pub mod signature_destination_getter;
 pub mod storage;
 pub mod timelock_check;
+pub mod tokens_check;
 
 mod tx_source;
 use constraints_value_accumulator::AccumulatedFee;
@@ -770,6 +772,8 @@ where
         tx: &SignedTransaction,
         median_time_past: &BlockTimestamp,
     ) -> Result<AccumulatedFee, ConnectTransactionError> {
+        check_transaction::check_transaction(self.chain_config.as_ref(), tx)?;
+
         let block_id = tx_source.chain_block_index().map(|c| *c.block_id());
 
         // Register tokens if tx has issuance data

--- a/chainstate/tx-verifier/src/transaction_verifier/tokens_check/check_utils.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tokens_check/check_utils.rs
@@ -13,17 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::chain::ChainConfig;
-use tx_verifier::error::TokenIssuanceError;
+use crate::error::TokenIssuanceError;
+
+use common::chain::{tokens::is_rfc3986_valid_symbol, ChainConfig};
 use utils::ensure;
 
 fn check_is_text_ascii_alphanumeric(str: &[u8]) -> bool {
     str.iter().all(|c| c.is_ascii_alphanumeric())
-}
-
-pub fn is_rfc3986_valid_symbol(ch: char) -> bool {
-    // RFC 3986 alphabet taken from https://www.rfc-editor.org/rfc/rfc3986#section-2.1
-    "%:/?#[]@!$&\'()*+,;=-._~".chars().any(|rfc1738_ch| ch == rfc1738_ch)
 }
 
 pub fn is_uri_valid(uri: &[u8]) -> bool {

--- a/chainstate/tx-verifier/src/transaction_verifier/tokens_check/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tokens_check/mod.rs
@@ -15,25 +15,24 @@
 
 use self::check_utils::check_media_hash;
 
+use crate::error::TokenIssuanceError;
+
 use common::chain::{
     tokens::{NftIssuanceV0, TokenIssuance},
     ChainConfig,
 };
 use serialization::{DecodeAll, Encode};
-use tx_verifier::error::TokenIssuanceError;
 use utils::ensure;
 
 mod check_utils;
-pub use check_utils::is_rfc3986_valid_symbol;
-use check_utils::{check_nft_description, check_nft_name, check_token_ticker, is_uri_valid};
 
 pub fn check_nft_issuance_data(
     chain_config: &ChainConfig,
     issuance: &NftIssuanceV0,
 ) -> Result<(), TokenIssuanceError> {
-    check_token_ticker(chain_config, &issuance.metadata.ticker)?;
-    check_nft_name(chain_config, &issuance.metadata.name)?;
-    check_nft_description(chain_config, &issuance.metadata.description)?;
+    check_utils::check_token_ticker(chain_config, &issuance.metadata.ticker)?;
+    check_utils::check_nft_name(chain_config, &issuance.metadata.name)?;
+    check_utils::check_nft_description(chain_config, &issuance.metadata.description)?;
 
     let icon_uri = Vec::<u8>::decode_all(&mut issuance.metadata.icon_uri.encode().as_slice())
         .map_err(|_| TokenIssuanceError::IssueErrorIncorrectIconURI)?;
@@ -43,7 +42,7 @@ pub fn check_nft_issuance_data(
             TokenIssuanceError::IssueErrorIncorrectIconURI
         );
         ensure!(
-            is_uri_valid(&icon_uri),
+            check_utils::is_uri_valid(&icon_uri),
             TokenIssuanceError::IssueErrorIncorrectIconURI
         );
     }
@@ -57,7 +56,7 @@ pub fn check_nft_issuance_data(
             TokenIssuanceError::IssueErrorIncorrectMetadataURI
         );
         ensure!(
-            is_uri_valid(&additional_metadata_uri),
+            check_utils::is_uri_valid(&additional_metadata_uri),
             TokenIssuanceError::IssueErrorIncorrectMetadataURI
         );
     }
@@ -70,7 +69,7 @@ pub fn check_nft_issuance_data(
             TokenIssuanceError::IssueErrorIncorrectMediaURI
         );
         ensure!(
-            is_uri_valid(&media_uri),
+            check_utils::is_uri_valid(&media_uri),
             TokenIssuanceError::IssueErrorIncorrectMediaURI
         );
     }
@@ -85,7 +84,7 @@ pub fn check_tokens_issuance(
     match issuance {
         TokenIssuance::V1(issuance_data) => {
             // Check token ticker
-            check_token_ticker(chain_config, &issuance_data.token_ticker)?;
+            check_utils::check_token_ticker(chain_config, &issuance_data.token_ticker)?;
 
             // Check decimals
             ensure!(
@@ -95,7 +94,7 @@ pub fn check_tokens_issuance(
 
             // Check URI
             ensure!(
-                is_uri_valid(&issuance_data.metadata_uri),
+                check_utils::is_uri_valid(&issuance_data.metadata_uri),
                 TokenIssuanceError::IssueErrorIncorrectMetadataURI
             );
 

--- a/common/src/chain/tokens/mod.rs
+++ b/common/src/chain/tokens/mod.rs
@@ -29,6 +29,11 @@ pub use rpc::*;
 pub use token_id::TokenId;
 pub use tokens_utils::*;
 
+pub fn is_rfc3986_valid_symbol(ch: char) -> bool {
+    // RFC 3986 alphabet taken from https://www.rfc-editor.org/rfc/rfc3986#section-2.1
+    "%:/?#[]@!$&\'()*+,;=-._~".chars().any(|rfc1738_ch| ch == rfc1738_ch)
+}
+
 /// The data that is created when a token is issued to track it (and to update it with ACL commands)
 #[derive(Debug, Clone, Encode, Decode, Eq, PartialEq)]
 pub struct TokenAuxiliaryData {

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -421,10 +421,10 @@ impl MempoolBanScore for CheckTransactionError {
         match self {
             CheckTransactionError::PropertyQueryError(_) => 0,
             CheckTransactionError::DuplicateInputInTransaction(_) => 100,
-            CheckTransactionError::InvalidWitnessCount => 100,
+            CheckTransactionError::InvalidWitnessCount(_) => 100,
             CheckTransactionError::EmptyInputsInTransaction(_) => 100,
             CheckTransactionError::TokensError(err) => err.mempool_ban_score(),
-            CheckTransactionError::NoSignatureDataSizeTooLarge(_, _) => 100,
+            CheckTransactionError::NoSignatureDataSizeTooLarge(_, _, _) => 100,
             CheckTransactionError::NoSignatureDataNotAllowed(_) => 100,
             CheckTransactionError::DataDepositMaxSizeExceeded(_, _, _) => 100,
         }

--- a/mempool/src/pool/orphans/detect.rs
+++ b/mempool/src/pool/orphans/detect.rs
@@ -87,6 +87,7 @@ impl OrphanType {
             | CTE::ConstrainedValueAccumulatorError(_, _)
             | CTE::PoolBalanceNotFound(_)
             | CTE::RewardDistributionError(_)
+            | CTE::CheckTransactionError(_)
             | CTE::IOPolicyError(_, _) => None,
         }
     }

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -17,7 +17,6 @@ mod output_cache;
 pub mod transaction_list;
 mod utxo_selector;
 
-use chainstate::check_nft_issuance_data;
 use common::address::pubkeyhash::PublicKeyHash;
 use common::chain::block::timestamp::BlockTimestamp;
 use common::chain::{AccountCommand, AccountOutPoint, AccountSpending, TransactionCreationError};
@@ -729,7 +728,7 @@ impl Account {
         let nft_issuance = NftIssuanceV0 {
             metadata: nft_issue_arguments.metadata,
         };
-        check_nft_issuance_data(&self.chain_config, &nft_issuance)?;
+        tx_verifier::check_nft_issuance_data(&self.chain_config, &nft_issuance)?;
 
         // the first UTXO is needed in advance to issue a new nft, so just make a dummy one
         // and then replace it with when we can calculate the pool_id

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -73,8 +73,7 @@ pub fn make_issue_token_outputs(
     token_issuance: TokenIssuance,
     chain_config: &ChainConfig,
 ) -> WalletResult<Vec<TxOutput>> {
-    chainstate::check_tokens_issuance(chain_config, &token_issuance)?;
-
+    tx_verifier::check_tokens_issuance(chain_config, &token_issuance)?;
     let issuance_output = TxOutput::IssueFungibleToken(Box::new(token_issuance));
 
     Ok(vec![issuance_output])


### PR DESCRIPTION
I moved the implementations, so Chainstate calls the same checks as before.

Not sure if I should remove tokens checks from wallet because it looked like a workaround but I might be wrong