### PR TITLE
P2p: prevent connecting to the same ip address multiple times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,6 +4364,7 @@ dependencies = [
  "jsonrpsee",
  "logging",
  "mempool",
+ "num",
  "num-derive",
  "num-traits",
  "once_cell",

--- a/node-lib/src/config_files/p2p.rs
+++ b/node-lib/src/config_files/p2p.rs
@@ -162,6 +162,8 @@ impl From<P2pConfigFile> for P2pConfig {
                 force_dns_query_if_no_global_addresses_known:
                     force_dns_query_if_no_global_addresses_known.into(),
 
+                allow_same_ip_connections: Default::default(),
+
                 peerdb_config: Default::default(),
             },
             protocol_config: Default::default(),

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -62,6 +62,7 @@ tokio = { workspace = true, default-features = false, features = ["io-util", "ma
 
 criterion.workspace = true
 ctor.workspace = true
+num.workspace = true
 portpicker.workspace = true
 rstest.workspace = true
 

--- a/p2p/benches/benches.rs
+++ b/p2p/benches/benches.rs
@@ -46,7 +46,9 @@ pub fn peer_db(c: &mut Criterion) {
         .collect::<BTreeSet<_>>();
 
     c.bench_function("PeerDb", |b| {
-        b.iter(|| peerdb.select_non_reserved_outbound_addresses(&outbound_addr_groups, 11))
+        b.iter(|| {
+            peerdb.select_non_reserved_outbound_addresses(&outbound_addr_groups, &|_| true, 11)
+        })
     });
 }
 

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -142,7 +142,7 @@ impl P2pBasicTestTimeGetter {
 }
 
 /// A timeout for blocking calls.
-pub const LONG_TIMEOUT: Duration = Duration::from_secs(600);
+pub const LONG_TIMEOUT: Duration = Duration::from_secs(30); // FIXME
 /// A short timeout for events that shouldn't occur.
 pub const SHORT_TIMEOUT: Duration = Duration::from_millis(500);
 

--- a/p2p/p2p-test-utils/src/lib.rs
+++ b/p2p/p2p-test-utils/src/lib.rs
@@ -142,7 +142,7 @@ impl P2pBasicTestTimeGetter {
 }
 
 /// A timeout for blocking calls.
-pub const LONG_TIMEOUT: Duration = Duration::from_secs(30); // FIXME
+pub const LONG_TIMEOUT: Duration = Duration::from_secs(600);
 /// A short timeout for events that shouldn't occur.
 pub const SHORT_TIMEOUT: Duration = Duration::from_millis(500);
 

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use p2p_types::services::Services;
+use p2p_types::{services::Services, socket_address::SocketAddress, PeerId};
 use thiserror::Error;
 
 use chainstate::{ban_score::BanScore, ChainstateError};
@@ -24,7 +24,7 @@ use common::{
 use mempool::error::{Error as MempoolError, MempoolBanScore};
 use utils::try_as::TryAsRef;
 
-use crate::{peer_manager::peerdb, protocol::ProtocolVersion};
+use crate::{net::types::PeerRole, peer_manager::peerdb, protocol::ProtocolVersion};
 
 /// Errors related to invalid data/peer information that results in connection getting closed
 /// and the peer getting banned.
@@ -74,8 +74,18 @@ pub enum ProtocolError {
 pub enum PeerError {
     #[error("Peer doesn't exist")]
     PeerDoesntExist,
-    #[error("Peer already exists")]
-    PeerAlreadyExists,
+    #[error("Peer {0} already exists")]
+    PeerAlreadyExists(PeerId),
+    #[error(
+        "Rejecting {new_peer_role:?} connection to {new_peer_addr:?} \
+             because we already have {existing_peer_role:?} connection to {existing_peer_addr:?}"
+    )]
+    AlreadyConnected {
+        existing_peer_addr: SocketAddress,
+        existing_peer_role: PeerRole,
+        new_peer_addr: SocketAddress,
+        new_peer_role: PeerRole,
+    },
     #[error("Address {0} is banned")]
     BannedAddress(String),
     #[error("PeerManager has too many peers")]

--- a/p2p/src/net/types.rs
+++ b/p2p/src/net/types.rs
@@ -25,6 +25,7 @@ use p2p_types::socket_address::SocketAddress;
 use tokio::sync::mpsc::Receiver;
 
 use crate::{
+    error::ProtocolError,
     message::{BlockSyncMessage, PeerManagerMessage, TransactionSyncMessage},
     protocol::SupportedProtocolVersion,
     types::{peer_address::PeerAddress, peer_id::PeerId},
@@ -121,8 +122,18 @@ pub struct PeerInfo {
 
 impl PeerInfo {
     pub fn is_compatible(&self, chain_config: &ChainConfig) -> bool {
-        // Check node version here if necessary
-        self.network == *chain_config.magic_bytes()
+        self.check_compatibility(chain_config).is_ok()
+    }
+
+    pub fn check_compatibility(&self, chain_config: &ChainConfig) -> crate::Result<()> {
+        if self.network != *chain_config.magic_bytes() {
+            Err(P2pError::ProtocolError(ProtocolError::DifferentNetwork(
+                *chain_config.magic_bytes(),
+                self.network,
+            )))
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/p2p/src/net/types.rs
+++ b/p2p/src/net/types.rs
@@ -44,21 +44,25 @@ pub enum Role {
 }
 
 // TODO: Rename to ConnectionType
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub enum PeerRole {
     Inbound,
     OutboundFullRelay,
     OutboundBlockRelay,
+    OutboundReserved,
     OutboundManual,
     Feeler,
 }
 
 // TODO: Use something like enum_iterator
 impl PeerRole {
-    pub const ALL: [PeerRole; 4] = [
+    pub const ALL: [PeerRole; 5] = [
         PeerRole::Inbound,
         PeerRole::OutboundFullRelay,
         PeerRole::OutboundBlockRelay,
+        PeerRole::OutboundReserved,
         PeerRole::OutboundManual,
     ];
 
@@ -67,7 +71,18 @@ impl PeerRole {
 
         match self {
             Inbound => false,
-            OutboundFullRelay | OutboundBlockRelay | OutboundManual | Feeler => true,
+            OutboundFullRelay | OutboundBlockRelay | OutboundReserved | OutboundManual | Feeler => {
+                true
+            }
+        }
+    }
+
+    pub fn is_outbound_manual(&self) -> bool {
+        use PeerRole::*;
+
+        match self {
+            OutboundManual => true,
+            Inbound | OutboundFullRelay | OutboundBlockRelay | OutboundReserved | Feeler => false,
         }
     }
 }

--- a/p2p/src/peer_manager/peerdb/config.rs
+++ b/p2p/src/peer_manager/peerdb/config.rs
@@ -22,7 +22,7 @@ make_config_setting!(NewAddrTableBucketCount, usize, 1024);
 make_config_setting!(TriedAddrTableBucketCount, usize, 256);
 make_config_setting!(AddrTablesBucketSize, usize, 64);
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct PeerDbConfig {
     /// Bucket count for the "new" address table.
     pub new_addr_table_bucket_count: NewAddrTableBucketCount,

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -322,11 +322,7 @@ impl<S: PeerDbStorage> PeerDb<S> {
                     .addresses
                     .get(addr)
                     .expect("reserved nodes must always be in the addresses map");
-                if address_data.connect_now(now) && additional_filter(addr) {
-                    Some(*addr)
-                } else {
-                    None
-                }
+                (address_data.connect_now(now) && additional_filter(addr)).then_some(*addr)
             })
             .collect()
     }

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -237,7 +237,7 @@ impl<S: PeerDbStorage> PeerDb<S> {
                 addr_data.connect_now(now)
                     && !cur_outbound_conn_addr_groups
                         .contains(&AddressGroup::from_peer_address(&addr.as_peer_address()))
-                    && additional_filter(*addr)
+                    && additional_filter(addr)
                     && !addr_data.reserved()
                     && !self.banned_addresses.contains_key(&addr.as_bannable())
             }

--- a/p2p/src/peer_manager/peerdb/tests.rs
+++ b/p2p/src/peer_manager/peerdb/tests.rs
@@ -555,6 +555,7 @@ fn new_tried_addr_selection_frequency() {
                 let count_to_select = rng.gen_range(count_to_select_range.clone());
                 let selected_addrs = peerdb.select_non_reserved_outbound_addresses_with_rng(
                     &empty_addr_groups_set,
+                    &|_| true,
                     count_to_select,
                     &mut rng,
                 );

--- a/p2p/src/peer_manager/peers_eviction/tests.rs
+++ b/p2p/src/peer_manager/peers_eviction/tests.rs
@@ -1249,6 +1249,7 @@ fn config_with_block_relay_conn_limits(
         enable_feeler_connections: Default::default(),
         feeler_connections_interval: Default::default(),
         force_dns_query_if_no_global_addresses_known: Default::default(),
+        allow_same_ip_connections: Default::default(),
         peerdb_config: Default::default(),
     }
 }
@@ -1278,6 +1279,7 @@ fn config_with_full_relay_conn_limits(
         enable_feeler_connections: Default::default(),
         feeler_connections_interval: Default::default(),
         force_dns_query_if_no_global_addresses_known: Default::default(),
+        allow_same_ip_connections: Default::default(),
         peerdb_config: Default::default(),
     }
 }
@@ -1304,6 +1306,7 @@ fn config_with_no_outbound_conn_limits() -> PeerManagerConfig {
         enable_feeler_connections: Default::default(),
         feeler_connections_interval: Default::default(),
         force_dns_query_if_no_global_addresses_known: Default::default(),
+        allow_same_ip_connections: Default::default(),
         peerdb_config: Default::default(),
     }
 }

--- a/p2p/src/peer_manager/tests/eviction.rs
+++ b/p2p/src/peer_manager/tests/eviction.rs
@@ -125,6 +125,7 @@ mod dont_evict_if_blocks_in_flight {
                 main_loop_tick_interval: Default::default(),
                 feeler_connections_interval: Default::default(),
                 force_dns_query_if_no_global_addresses_known: Default::default(),
+                allow_same_ip_connections: Default::default(),
             },
             ping_check_period: Duration::ZERO.into(),
 

--- a/p2p/src/peer_manager/tests/peer_types.rs
+++ b/p2p/src/peer_manager/tests/peer_types.rs
@@ -118,8 +118,12 @@ fn validate_services() {
                     assert_eq!(res, Err(P2pError::PeerError(PeerError::EmptyServices)));
                 } else {
                     let expected_services: Option<Services> = match peer_role {
-                        PeerRole::Inbound | PeerRole::OutboundManual | PeerRole::Feeler => {
-                            // Inbound, OutboundManual and Feeler peers are allowed to nodes with any combination of services
+                        PeerRole::Inbound
+                        | PeerRole::OutboundReserved
+                        | PeerRole::OutboundManual
+                        | PeerRole::Feeler => {
+                            // Inbound, OutboundReserved, OutboundManual and Feeler connections
+                            // are allowed to nodes with any combination of services.
                             None
                         }
                         PeerRole::OutboundFullRelay => match node_type {

--- a/p2p/src/peer_manager/tests/utils.rs
+++ b/p2p/src/peer_manager/tests/utils.rs
@@ -28,10 +28,12 @@ use crate::{
     message::PeerManagerMessage,
     net::{
         default_backend::types::{CategorizedMessage, Command},
-        types::PeerInfo,
+        types::{ConnectivityEvent, PeerInfo},
     },
+    peer_manager::PeerManagerInterface,
     testing_utils::TEST_PROTOCOL_VERSION,
     tests::helpers::PeerManagerNotification,
+    PeerManagerEvent,
 };
 
 pub fn cmd_to_peer_man_msg(cmd: Command) -> (PeerId, PeerManagerMessage) {
@@ -117,6 +119,26 @@ pub fn expect_cmd_connect_to(cmd: &Command, expected_address: &SocketAddress) {
     }
 }
 
+/// Send a ConnectivityEvent simulating a connection being accepted by the backend.
+pub fn inbound_block_relay_peer_accepted_by_backend(
+    conn_event_sender: &mpsc::UnboundedSender<ConnectivityEvent>,
+    peer_address: SocketAddress,
+    bind_address: SocketAddress,
+    chain_config: &ChainConfig,
+) -> PeerId {
+    let peer_id = PeerId::new();
+    conn_event_sender
+        .send(ConnectivityEvent::InboundAccepted {
+            peer_address,
+            bind_address,
+            peer_info: make_block_relay_peer_info(peer_id, chain_config),
+            node_address_as_seen_by_peer: None,
+        })
+        .unwrap();
+
+    peer_id
+}
+
 pub async fn wait_for_heartbeat(
     peer_mgr_notification_receiver: &mut mpsc::UnboundedReceiver<PeerManagerNotification>,
 ) {
@@ -125,4 +147,48 @@ pub async fn wait_for_heartbeat(
         &PeerManagerNotification::Heartbeat,
     )
     .await;
+}
+
+pub async fn query_peer_manager<F, R>(
+    peer_mgr_event_sender: &mpsc::UnboundedSender<PeerManagerEvent>,
+    query_func: F,
+) -> R
+where
+    F: FnOnce(&dyn PeerManagerInterface) -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let (response_sender, mut response_receiver) = mpsc::unbounded_channel();
+
+    peer_mgr_event_sender
+        .send(PeerManagerEvent::GenericQuery(Box::new(
+            move |peer_mgr: &dyn PeerManagerInterface| {
+                let res = query_func(peer_mgr);
+                response_sender.send(res).unwrap();
+            },
+        )))
+        .unwrap();
+
+    response_receiver.recv().await.unwrap()
+}
+
+pub async fn mutate_peer_manager<F, R>(
+    peer_mgr_event_sender: &mpsc::UnboundedSender<PeerManagerEvent>,
+    mut_func: F,
+) -> R
+where
+    F: FnOnce(&mut dyn PeerManagerInterface) -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let (response_sender, mut response_receiver) = mpsc::unbounded_channel();
+
+    peer_mgr_event_sender
+        .send(PeerManagerEvent::GenericMut(Box::new(
+            move |peer_mgr: &mut dyn PeerManagerInterface| {
+                let res = mut_func(peer_mgr);
+                response_sender.send(res).unwrap();
+            },
+        )))
+        .unwrap();
+
+    response_receiver.recv().await.unwrap()
 }

--- a/p2p/src/peer_manager_event.rs
+++ b/p2p/src/peer_manager_event.rs
@@ -23,7 +23,7 @@ use p2p_types::{
 };
 
 use crate::{
-    interface::types::ConnectedPeer, peer_manager::PeerManagerQueryInterface,
+    interface::types::ConnectedPeer, peer_manager::PeerManagerInterface,
     sync::sync_status::PeerBlockSyncStatus, types::peer_id::PeerId, utils::oneshot_nofail,
 };
 
@@ -104,14 +104,26 @@ pub enum PeerManagerEvent {
     Unban(BannableAddress, oneshot_nofail::Sender<crate::Result<()>>),
 
     GenericQuery(Box<dyn PeerManagerQueryFunc>),
+    #[cfg(test)]
+    GenericMut(Box<dyn PeerManagerMutFunc>),
 }
 
-pub trait PeerManagerQueryFunc: FnOnce(&dyn PeerManagerQueryInterface) + Send {}
+pub trait PeerManagerQueryFunc: FnOnce(&dyn PeerManagerInterface) + Send {}
 
-impl<F> PeerManagerQueryFunc for F where F: FnOnce(&dyn PeerManagerQueryInterface) + Send {}
+impl<F> PeerManagerQueryFunc for F where F: FnOnce(&dyn PeerManagerInterface) + Send {}
 
 impl std::fmt::Debug for dyn PeerManagerQueryFunc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "DisplayFunction")
+        write!(f, "PeerManagerQueryFunc")
+    }
+}
+
+pub trait PeerManagerMutFunc: FnOnce(&mut dyn PeerManagerInterface) + Send {}
+
+impl<F> PeerManagerMutFunc for F where F: FnOnce(&mut dyn PeerManagerInterface) + Send {}
+
+impl std::fmt::Debug for dyn PeerManagerMutFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PeerManagerMutFunc")
     }
 }

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -356,7 +356,8 @@ impl TestNode {
                     | PeerManagerEvent::ListBanned(_)
                     | PeerManagerEvent::Ban(_, _)
                     | PeerManagerEvent::Unban(_, _)
-                    | PeerManagerEvent::GenericQuery(_) => {
+                    | PeerManagerEvent::GenericQuery(_)
+                    | PeerManagerEvent::GenericMut(_) => {
                         panic!("Unexpected peer manager event: {peer_event:?}");
                     }
                     PeerManagerEvent::NewTipReceived { .. }
@@ -626,6 +627,7 @@ pub enum PeerManagerEventDesc {
     Ban(BannableAddress),
     Unban(BannableAddress),
     GenericQuery,
+    GenericMut,
 }
 
 impl From<&PeerManagerEvent> for PeerManagerEventDesc {
@@ -673,6 +675,7 @@ impl From<&PeerManagerEvent> for PeerManagerEventDesc {
             PeerManagerEvent::Ban(addr, _) => PeerManagerEventDesc::Ban(*addr),
             PeerManagerEvent::Unban(addr, _) => PeerManagerEventDesc::Unban(*addr),
             PeerManagerEvent::GenericQuery(_) => PeerManagerEventDesc::GenericQuery,
+            PeerManagerEvent::GenericMut(_) => PeerManagerEventDesc::GenericMut,
         }
     }
 }

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -322,7 +322,8 @@ impl TestNodeGroup {
                         | PeerManagerEvent::ListBanned(_)
                         | PeerManagerEvent::Ban(_, _)
                         | PeerManagerEvent::Unban(_, _)
-                        | PeerManagerEvent::GenericQuery(_) => {
+                        | PeerManagerEvent::GenericQuery(_)
+                        | PeerManagerEvent::GenericMut(_) => {
                             panic!("Unexpected peer manager event: {peer_event:?}");
                         }
                         PeerManagerEvent::NewTipReceived { .. }

--- a/p2p/src/testing_utils.rs
+++ b/p2p/src/testing_utils.rs
@@ -336,6 +336,7 @@ pub fn test_p2p_config_with_peer_db_config(peerdb_config: PeerDbConfig) -> P2pCo
         enable_feeler_connections: Default::default(),
         feeler_connections_interval: Default::default(),
         force_dns_query_if_no_global_addresses_known: Default::default(),
+        allow_same_ip_connections: Default::default(),
     })
 }
 

--- a/p2p/src/tests/correct_handshake.rs
+++ b/p2p/src/tests/correct_handshake.rs
@@ -23,7 +23,7 @@ use crate::{
         transport::{BufferedTranscoder, TransportListener, TransportSocket},
         types::{HandshakeMessage, Message, P2pTimestamp},
     },
-    peer_manager::PeerManagerQueryInterface,
+    peer_manager::PeerManagerInterface,
     testing_utils::{
         test_p2p_config, TestTransportChannel, TestTransportMaker, TestTransportNoise,
         TestTransportTcp, TEST_PROTOCOL_VERSION,

--- a/p2p/src/tests/helpers/test_node_group.rs
+++ b/p2p/src/tests/helpers/test_node_group.rs
@@ -20,7 +20,10 @@ use p2p_test_utils::{P2pBasicTestTimeGetter, SHORT_TIMEOUT};
 use p2p_types::socket_address::SocketAddress;
 use tokio::time;
 
-use crate::{config::P2pConfig, net::default_backend::transport::TransportSocket};
+use crate::{
+    config::P2pConfig,
+    net::{default_backend::transport::TransportSocket, types::PeerRole},
+};
 
 use super::test_node::TestNode;
 
@@ -53,6 +56,7 @@ where
         self.nodes[0].time_getter()
     }
 
+    #[allow(unused)]
     pub fn p2p_config(&self) -> &P2pConfig {
         self.nodes[0].p2p_config()
     }
@@ -61,6 +65,21 @@ where
         self.nodes.iter().map(|node| *node.local_address()).collect()
     }
 
+    pub async fn count_connections_by_role(&self, peer_role: PeerRole) -> Vec<usize> {
+        let mut result = Vec::with_capacity(self.nodes.len());
+
+        for node in &self.nodes {
+            let peers_info = node.get_peers_info().await.info;
+            let count =
+                peers_info.iter().filter(|(_, peer_info)| peer_info.role == peer_role).count();
+
+            result.push(count);
+        }
+
+        result
+    }
+
+    #[allow(unused)]
     pub async fn assert_outbound_conn_count_maximums_reached(&self) {
         for node in &self.nodes {
             node.assert_outbound_conn_count_maximums_reached().await;

--- a/p2p/src/tests/misbehavior.rs
+++ b/p2p/src/tests/misbehavior.rs
@@ -25,7 +25,7 @@ use crate::{
         transport::{BufferedTranscoder, TransportSocket},
         types::{HandshakeMessage, Message, P2pTimestamp},
     },
-    peer_manager::PeerManagerQueryInterface,
+    peer_manager::PeerManagerInterface,
     testing_utils::{
         test_p2p_config, TestTransportChannel, TestTransportMaker, TestTransportNoise,
         TestTransportTcp, TEST_PROTOCOL_VERSION,

--- a/p2p/src/tests/peer_discovery_on_stale_tip.rs
+++ b/p2p/src/tests/peer_discovery_on_stale_tip.rs
@@ -185,6 +185,8 @@ async fn peer_discovery_on_stale_tip_impl(
     let full_relay_conn_cnt_after_wait =
         node_group.count_connections_by_role(PeerRole::OutboundFullRelay).await;
 
+    // Note that the "extra" connections may be dropped and re-established at any time, so we have
+    // to "ignore" them by clamping the connection counts to outbound_full_relay_conn_count.
     let full_relay_conn_cnt_before_wait: Vec<_> = full_relay_conn_cnt_before_wait
         .iter()
         .map(|cnt| num::clamp(*cnt, 0, outbound_full_relay_conn_count))

--- a/p2p/src/tests/peer_discovery_on_stale_tip.rs
+++ b/p2p/src/tests/peer_discovery_on_stale_tip.rs
@@ -21,7 +21,7 @@ use common::{
     primitives::{user_agent::mintlayer_core_user_agent, Idable},
 };
 use logging::log;
-use p2p_test_utils::{run_with_timeout, P2pBasicTestTimeGetter};
+use p2p_test_utils::{run_with_timeout, P2pBasicTestTimeGetter, SHORT_TIMEOUT};
 use p2p_types::socket_address::SocketAddress;
 use test_utils::random::Seed;
 
@@ -120,6 +120,7 @@ async fn peer_discovery_on_stale_tip_impl(
         enable_feeler_connections: Default::default(),
         feeler_connections_interval: Default::default(),
         force_dns_query_if_no_global_addresses_known: Default::default(),
+        allow_same_ip_connections: Default::default(),
 
         peerdb_config: Default::default(),
     };
@@ -170,15 +171,32 @@ async fn peer_discovery_on_stale_tip_impl(
 
     time_getter.advance_time(peer_manager::DNS_SEED_QUERY_INTERVAL);
 
-    // Wait until the maximum number of outbound connections is established.
-    wait_for_max_outbound_connections(&node_group).await;
+    // Wait until the maximum number of connections is established.
+    wait_for_max_cross_connections(&node_group).await;
+    let full_relay_conn_cnt_before_wait =
+        node_group.count_connections_by_role(PeerRole::OutboundFullRelay).await;
 
     // Advance the time by 1 hour
     log::debug!("Advancing time by 1 hour");
     time_getter.advance_time(Duration::from_secs(60 * 60));
+    tokio::time::sleep(SHORT_TIMEOUT).await;
 
-    // All the connections must still be in place
-    node_group.assert_outbound_conn_count_maximums_reached().await;
+    // Non-extra full relay connections must still be in place.
+    let full_relay_conn_cnt_after_wait =
+        node_group.count_connections_by_role(PeerRole::OutboundFullRelay).await;
+
+    let full_relay_conn_cnt_before_wait: Vec<_> = full_relay_conn_cnt_before_wait
+        .iter()
+        .map(|cnt| num::clamp(*cnt, 0, outbound_full_relay_conn_count))
+        .collect();
+    let full_relay_conn_cnt_after_wait: Vec<_> = full_relay_conn_cnt_after_wait
+        .iter()
+        .map(|cnt| num::clamp(*cnt, 0, outbound_full_relay_conn_count))
+        .collect();
+    assert_eq!(
+        full_relay_conn_cnt_after_wait,
+        full_relay_conn_cnt_before_wait
+    );
 
     // Start a new node that would produce a block.
     let new_node_idx = node_group.nodes().len() + 1;
@@ -282,6 +300,7 @@ async fn new_full_relay_connections_on_stale_tip_impl(seed: Seed) {
         outbound_block_relay_connection_min_age: Default::default(),
         feeler_connections_interval: Default::default(),
         force_dns_query_if_no_global_addresses_known: Default::default(),
+        allow_same_ip_connections: Default::default(),
         peerdb_config: Default::default(),
     };
     let main_node_p2p_config = Arc::new(make_p2p_config(main_node_peer_mgr_config));
@@ -308,6 +327,7 @@ async fn new_full_relay_connections_on_stale_tip_impl(seed: Seed) {
         outbound_full_relay_connection_min_age: Default::default(),
         feeler_connections_interval: Default::default(),
         force_dns_query_if_no_global_addresses_known: Default::default(),
+        allow_same_ip_connections: Default::default(),
         peerdb_config: Default::default(),
     };
     let extra_nodes_p2p_config = Arc::new(make_p2p_config(extra_nodes_peer_mgr_config));
@@ -506,27 +526,16 @@ async fn start_node(
     node
 }
 
-async fn wait_for_max_outbound_connections(node_group: &TestNodeGroup<Transport>) {
-    for node in node_group.nodes() {
-        let mut outbound_full_relay_peers_count = 0;
-        let mut outbound_block_relay_peers_count = 0;
-        while outbound_full_relay_peers_count
-            < *node_group.p2p_config().peer_manager_config.outbound_full_relay_count
-            || outbound_block_relay_peers_count
-                < *node_group.p2p_config().peer_manager_config.outbound_block_relay_count
-        {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let peers_info = node.get_peers_info().await;
-            outbound_full_relay_peers_count =
-                peers_info.count_peers_by_role(PeerRole::OutboundFullRelay);
-            outbound_block_relay_peers_count =
-                peers_info.count_peers_by_role(PeerRole::OutboundBlockRelay);
+async fn wait_for_max_cross_connections(node_group: &TestNodeGroup<Transport>) {
+    for node in node_group.nodes().iter() {
+        let mut peers_count = node.get_peers_info().await.info.len();
 
+        while peers_count < node_group.nodes().len() - 1 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
             node_group.time_getter().advance_time(peer_manager::HEARTBEAT_INTERVAL_MAX);
+            peers_count = node.get_peers_info().await.info.len();
         }
     }
-
-    node_group.assert_outbound_conn_count_maximums_reached().await;
 }
 
 async fn wait_for_connections_to_impl(


### PR DESCRIPTION
Previously, we would allow connecting to a peer unless we're already connected to the same socket address (i.e. both the ip address and port are the same). And because inbound connections have some random port number, a socket address of an inbound peer is always different from a socket address of an outbound one. So it was common to have "double" connections, where peer A would connect to peer B and then peer B would connect to peer A, despite the fact that it already has an inbound connection from peer A. 

Now we also check whether ip addresses are the same. The logic is:
1) Inbound connections are allowed no matter what.
2) An outbound connection is not allowed if we already have an inbound connection from the same ip address, unless the outbound connection is a manual one.
