### PR TITLE
Fix `ConnectTransactionError::MissingTransactionNonce`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7167,6 +7167,7 @@ dependencies = [
  "crypto",
  "fallible-iterator 0.3.0",
  "itertools 0.12.0",
+ "logging",
  "mockall",
  "pos-accounting",
  "replace_with",

--- a/chainstate/tx-verifier/Cargo.toml
+++ b/chainstate/tx-verifier/Cargo.toml
@@ -14,6 +14,7 @@ common = {path = '../../common'}
 consensus = {path = '../../consensus'}
 constraints-value-accumulator = {path = '../constraints-value-accumulator'}
 crypto = {path = '../../crypto'}
+logging = { path = "../../logging" }
 pos-accounting = {path = '../../pos-accounting'}
 serialization = { path = "../../serialization" }
 tokens-accounting = {path = '../../tokens-accounting'}

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -439,12 +439,8 @@ where
                             ConnectTransactionError::DelegationDataNotFound(delegation_id),
                         )?;
                     if !accounting_view.pool_exists(*delegation_data.source_pool())? {
-                        // clear the nonce
-                        self.account_nonce.insert(
-                            AccountType::Delegation(delegation_id),
-                            CachedOperation::Erase,
-                        );
-
+                        // When deleting a delegation nonce value is preserved in the db
+                        // in case reorg happens so we don't have to restore it
                         Some(
                             self.pos_accounting_adapter
                                 .operations(tx_source)

--- a/chainstate/tx-verifier/src/transaction_verifier/pos_accounting_delta_adapter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/pos_accounting_delta_adapter.rs
@@ -21,6 +21,7 @@ use common::{
     chain::{PoolId, UtxoOutPoint},
     primitives::Amount,
 };
+use logging::log;
 use pos_accounting::{
     DeltaMergeUndo, FlushablePoSAccountingView, PoSAccountingDelta, PoSAccountingDeltaData,
     PoSAccountingOperations, PoSAccountingUndo, PoSAccountingView, PoolData,
@@ -159,6 +160,8 @@ impl<'a, P: PoSAccountingView> PoSAccountingOperations<PoSAccountingUndo>
         pool_id: PoolId,
         pool_data: PoolData,
     ) -> Result<PoSAccountingUndo, pos_accounting::Error> {
+        log::debug!("Creating a pool: {}", pool_id);
+
         let mut delta = PoSAccountingDelta::new(&self.adapter.accounting_delta);
         let undo = delta.create_pool(pool_id, pool_data)?;
 
@@ -171,6 +174,8 @@ impl<'a, P: PoSAccountingView> PoSAccountingOperations<PoSAccountingUndo>
         &mut self,
         pool_id: PoolId,
     ) -> Result<PoSAccountingUndo, pos_accounting::Error> {
+        log::debug!("Decommissioning a pool: {}", pool_id);
+
         let mut delta = PoSAccountingDelta::new(&self.adapter.accounting_delta);
 
         let undo = delta.decommission_pool(pool_id)?;
@@ -205,6 +210,8 @@ impl<'a, P: PoSAccountingView> PoSAccountingOperations<PoSAccountingUndo>
         let (delegation_id, undo) =
             delta.create_delegation_id(target_pool, spend_key, input0_outpoint)?;
 
+        log::debug!("Creating a delegation: {}", delegation_id);
+
         self.merge_delta(delta.consume())?;
 
         Ok((delegation_id, undo))
@@ -214,6 +221,8 @@ impl<'a, P: PoSAccountingView> PoSAccountingOperations<PoSAccountingUndo>
         &mut self,
         delegation_id: common::chain::DelegationId,
     ) -> Result<PoSAccountingUndo, pos_accounting::Error> {
+        log::debug!("Deleting a delegation: {}", delegation_id);
+
         let mut delta = PoSAccountingDelta::new(&self.adapter.accounting_delta);
 
         let undo = delta.delete_delegation_id(delegation_id)?;
@@ -228,6 +237,12 @@ impl<'a, P: PoSAccountingView> PoSAccountingOperations<PoSAccountingUndo>
         delegation_target: common::chain::DelegationId,
         amount_to_delegate: Amount,
     ) -> Result<PoSAccountingUndo, pos_accounting::Error> {
+        log::debug!(
+            "Delegating {:?} coins to {}",
+            amount_to_delegate,
+            delegation_target
+        );
+
         let mut delta = PoSAccountingDelta::new(&self.adapter.accounting_delta);
 
         let undo = delta.delegate_staking(delegation_target, amount_to_delegate)?;
@@ -242,6 +257,12 @@ impl<'a, P: PoSAccountingView> PoSAccountingOperations<PoSAccountingUndo>
         delegation_id: common::chain::DelegationId,
         amount: Amount,
     ) -> Result<PoSAccountingUndo, pos_accounting::Error> {
+        log::debug!(
+            "Spending {:?} coins from delegation {}",
+            amount,
+            delegation_id
+        );
+
         let mut delta = PoSAccountingDelta::new(&self.adapter.accounting_delta);
 
         let undo = delta.spend_share_from_delegation_id(delegation_id, amount)?;


### PR DESCRIPTION
When we spend from delegation we increment nonces: 1 -> 2 -> 3
When we undo such txs we decrement nonces.

But if we spend the delegation entirely and the pool is decommissioned we delete nonce from db: 1->2->3->None
Now if we want to undo that last transaction we need to read the nonce and decrement it, but it’s not in the db because we deleted it.

The simplest solution would be to not delete nonces from the db.

