### PR TITLE
Check for id mismatch on NFT issuance

### DIFF
--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -24,9 +24,9 @@ use common::{
     chain::{
         output_value::OutputValue,
         tokens::{make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0},
-        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, Transaction, TxInput,
-        TxOutput, UtxoOutPoint,
+        ChainstateUpgrade, Destination, NetUpgrades, NftIdMismatchCheck, OutPointSourceId,
+        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+        TokensTickerMaxLengthVersion, Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Id, Idable},
 };
@@ -120,6 +120,7 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),
@@ -199,6 +200,7 @@ fn store_nft_v0(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),
@@ -383,6 +385,7 @@ fn store_aux_data_from_issue_nft(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -21,7 +21,9 @@ use chainstate::{
 };
 use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::chain::tokens::{Metadata, NftIssuanceV0, TokenIssuanceV0, TokenTransfer};
-use common::chain::{RewardDistributionVersion, TokensTickerMaxLengthVersion, UtxoOutPoint};
+use common::chain::{
+    NftIdMismatchCheck, RewardDistributionVersion, TokensTickerMaxLengthVersion, UtxoOutPoint,
+};
 use common::primitives::{id, BlockHeight, Id};
 use common::{
     chain::{
@@ -57,6 +59,7 @@ fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramewor
                             RewardDistributionVersion::V1,
                             TokensFeeVersion::V1,
                             TokensTickerMaxLengthVersion::V1,
+                            NftIdMismatchCheck::Yes,
                         ),
                     )])
                     .unwrap(),
@@ -961,6 +964,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),
@@ -1020,6 +1024,7 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     RewardDistributionVersion::V1,
                                     TokensFeeVersion::V1,
                                     TokensTickerMaxLengthVersion::V1,
+                                    NftIdMismatchCheck::Yes,
                                 ),
                             ),
                             (
@@ -1029,6 +1034,7 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     RewardDistributionVersion::V1,
                                     TokensFeeVersion::V1,
                                     TokensTickerMaxLengthVersion::V1,
+                                    NftIdMismatchCheck::Yes,
                                 ),
                             ),
                         ])

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -17,8 +17,8 @@ use chainstate::{BlockError, ChainstateError, ConnectTransactionError, TokensErr
 use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
     output_value::OutputValue, signature::inputsig::InputWitness, tokens::make_token_id,
-    ChainstateUpgrade, Destination, RewardDistributionVersion, TokenIssuanceVersion,
-    TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    ChainstateUpgrade, Destination, NftIdMismatchCheck, RewardDistributionVersion,
+    TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
@@ -216,6 +216,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -22,8 +22,9 @@ use common::chain::{
     output_value::OutputValue,
     signature::inputsig::InputWitness,
     tokens::{is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0},
-    Block, ChainstateUpgrade, Destination, OutPointSourceId, RewardDistributionVersion,
-    TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    Block, ChainstateUpgrade, Destination, NftIdMismatchCheck, OutPointSourceId,
+    RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+    TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
 use crypto::random::{CryptoRng, Rng};
@@ -1670,6 +1671,7 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),
@@ -1729,6 +1731,7 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -21,8 +21,9 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         tokens::{make_token_id, NftIssuance, TokenId},
-        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+        ChainstateUpgrade, Destination, NetUpgrades, NftIdMismatchCheck, OutPointSourceId,
+        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+        TokensTickerMaxLengthVersion, TxInput, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId},
 };
@@ -370,6 +371,7 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -22,7 +22,7 @@ use super::*;
 use chainstate_test_framework::{empty_witness, TestFramework, TestStore, TransactionBuilder};
 use common::chain::config::create_unit_test_config;
 use common::chain::{
-    AccountCommand, AccountNonce, AccountSpending, RewardDistributionVersion,
+    AccountCommand, AccountNonce, AccountSpending, NftIdMismatchCheck, RewardDistributionVersion,
     TokensTickerMaxLengthVersion,
 };
 use common::{
@@ -580,6 +580,7 @@ fn issue_fungible_token_v0(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
+                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -192,6 +192,8 @@ pub enum TokenIssuanceError {
     MediaHashTooShort,
     #[error("The media hash is too long")]
     MediaHashTooLong,
+    #[error("Token id {0} from issuance does not match calculated token id {1}")]
+    TokenIdMismatch(TokenId, TokenId),
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -777,11 +777,17 @@ where
         let block_id = tx_source.chain_block_index().map(|c| *c.block_id());
 
         // Register tokens if tx has issuance data
-        self.token_issuance_cache.register(block_id, tx.transaction(), |id| {
-            self.storage
-                .get_token_aux_data(id)
-                .map_err(|_| ConnectTransactionError::TxVerifierStorage)
-        })?;
+        self.token_issuance_cache.register(
+            self.chain_config.as_ref(),
+            tx_source.expected_block_height(),
+            block_id,
+            tx.transaction(),
+            |id| {
+                self.storage
+                    .get_token_aux_data(id)
+                    .map_err(|_| ConnectTransactionError::TxVerifierStorage)
+            },
+        )?;
 
         // check for attempted money printing and invalid inputs/outputs combinations
         let fee = input_output_policy::check_tx_inputs_outputs_policy(

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -29,8 +29,9 @@ use crate::{
         pos_initial_difficulty,
         pow::PoWChainConfigBuilder,
         ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
-        PoSChainConfig, PoSConsensusVersion, PoWChainConfig, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion,
+        NftIdMismatchCheck, PoSChainConfig, PoSConsensusVersion, PoWChainConfig,
+        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+        TokensTickerMaxLengthVersion,
     },
     primitives::{
         id::WithId, per_thousand::PerThousand, semver::SemVer, Amount, BlockCount, BlockDistance,
@@ -158,6 +159,7 @@ impl ChainType {
                         RewardDistributionVersion::V1,
                         TokensFeeVersion::V1,
                         TokensTickerMaxLengthVersion::V1,
+                        NftIdMismatchCheck::Yes,
                     ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
@@ -170,6 +172,7 @@ impl ChainType {
                         RewardDistributionVersion::V1,
                         TokensFeeVersion::V1,
                         TokensTickerMaxLengthVersion::V1,
+                        NftIdMismatchCheck::Yes,
                     ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
@@ -183,6 +186,7 @@ impl ChainType {
                             RewardDistributionVersion::V0,
                             TokensFeeVersion::V0,
                             TokensTickerMaxLengthVersion::V0,
+                            NftIdMismatchCheck::No,
                         ),
                     ),
                     (
@@ -192,6 +196,7 @@ impl ChainType {
                             RewardDistributionVersion::V0,
                             TokensFeeVersion::V0,
                             TokensTickerMaxLengthVersion::V0,
+                            NftIdMismatchCheck::No,
                         ),
                     ),
                     (
@@ -201,6 +206,7 @@ impl ChainType {
                             RewardDistributionVersion::V1,
                             TokensFeeVersion::V1,
                             TokensTickerMaxLengthVersion::V1,
+                            NftIdMismatchCheck::Yes,
                         ),
                     ),
                 ];

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -44,6 +44,7 @@ use crypto::key::hdkd::{child_number::ChildNumber, u31::U31};
 use self::checkpoints::Checkpoints;
 use self::emission_schedule::DEFAULT_INITIAL_MINT;
 use super::output_value::OutputValue;
+use super::NftIdMismatchCheck;
 use super::TokensTickerMaxLengthVersion;
 use super::{stakelock::StakePoolData, RequiredConsensus};
 use super::{ChainstateUpgrade, ConsensusUpgrade};
@@ -812,6 +813,7 @@ pub fn create_unit_test_config_builder() -> Builder {
                     RewardDistributionVersion::V1,
                     TokensFeeVersion::V1,
                     TokensTickerMaxLengthVersion::V1,
+                    NftIdMismatchCheck::Yes,
                 ),
             )])
             .expect("cannot fail"),

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -47,12 +47,19 @@ pub enum TokensTickerMaxLengthVersion {
     V1,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+pub enum NftIdMismatchCheck {
+    Yes,
+    No,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ChainstateUpgrade {
     token_issuance_version: TokenIssuanceVersion,
     reward_distribution_version: RewardDistributionVersion,
     tokens_fee_version: TokensFeeVersion,
     tokens_ticker_length_version: TokensTickerMaxLengthVersion,
+    nft_id_mismatch_check: NftIdMismatchCheck,
 }
 
 impl ChainstateUpgrade {
@@ -61,12 +68,14 @@ impl ChainstateUpgrade {
         reward_distribution_version: RewardDistributionVersion,
         tokens_fee_version: TokensFeeVersion,
         tokens_ticker_length_version: TokensTickerMaxLengthVersion,
+        nft_id_mismatch_check: NftIdMismatchCheck,
     ) -> Self {
         Self {
             token_issuance_version,
             reward_distribution_version,
             tokens_fee_version,
             tokens_ticker_length_version,
+            nft_id_mismatch_check,
         }
     }
 
@@ -84,6 +93,10 @@ impl ChainstateUpgrade {
 
     pub fn tokens_ticker_length_version(&self) -> TokensTickerMaxLengthVersion {
         self.tokens_ticker_length_version
+    }
+
+    pub fn nft_id_mismatch_check(&self) -> NftIdMismatchCheck {
+        self.nft_id_mismatch_check
     }
 }
 

--- a/common/src/chain/upgrades/mod.rs
+++ b/common/src/chain/upgrades/mod.rs
@@ -18,8 +18,8 @@ mod consensus_upgrade;
 mod netupgrade;
 
 pub use chainstate_upgrade::{
-    ChainstateUpgrade, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
-    TokensTickerMaxLengthVersion,
+    ChainstateUpgrade, NftIdMismatchCheck, RewardDistributionVersion, TokenIssuanceVersion,
+    TokensFeeVersion, TokensTickerMaxLengthVersion,
 };
 pub use consensus_upgrade::{ConsensusUpgrade, PoSStatus, PoWStatus, RequiredConsensus};
 pub use netupgrade::{Activate, NetUpgrades};


### PR DESCRIPTION
NFT's id is both calculated from `input0_outpoint` and provided as a parameter in `TxOutput::NftIssuance(id, _, _)`. 
The check that these ids match was missing.
