### PR TITLE
Remove inputting the mnemonic in command line arguments

### DIFF
--- a/wallet/wallet-address-generator-lib/src/lib.rs
+++ b/wallet/wallet-address-generator-lib/src/lib.rs
@@ -68,7 +68,7 @@ pub struct CliArgs {
     pub network: Network,
 
     /// Number of addresses to generate and display
-    #[clap(long, default_value_t = 1)]
+    #[clap(long, short = 'n', default_value_t = 1)]
     pub address_count: u8,
 }
 

--- a/wallet/wallet-address-generator-lib/src/lib.rs
+++ b/wallet/wallet-address-generator-lib/src/lib.rs
@@ -70,18 +70,12 @@ pub struct CliArgs {
     /// Number of addresses to generate and display
     #[clap(long, default_value_t = 1)]
     pub address_count: u8,
-
-    /// Mnemonic phrase (12, 15, or 24 words as a single quoted argument). If not specified, a new mnemonic phrase is generated and printed.
-    #[clap(long)]
-    pub mnemonic: Option<String>,
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum CliError {
     #[error("Invalid input: {0}")]
     InvalidInput(String),
-    #[error("Invalid mnemonic: {0}")]
-    InvalidMnemonic(wallet_controller::mnemonic::Error),
     #[error("WalletError error: {0}")]
     WalletError(#[from] WalletError),
 }
@@ -95,7 +89,7 @@ pub fn run(args: CliArgs) -> Result<(), CliError> {
         ))
     );
 
-    let (root_key, seed_phrase) = root_key_and_mnemonic(&args.mnemonic)?;
+    let (root_key, seed_phrase) = root_key_and_mnemonic()?;
 
     let chain_config = Builder::new(args.network.into()).build();
 
@@ -109,9 +103,7 @@ pub fn run(args: CliArgs) -> Result<(), CliError> {
         args.network.to_string().to_uppercase()
     );
 
-    if let Some(mnemonic) = args.mnemonic {
-        println!("Using the seed phrase you provided to generate address(es): {mnemonic}");
-    } else {
+    {
         println!("No seed phrase provided. Generating a new one.");
         println!("WARNING: MAKE SURE TO WRITE DOWN YOUR SEED PHRASE AND KEEP IT SAFE!");
         println!("============================Seed phrase=============================");
@@ -170,15 +162,10 @@ fn to_receiving_pub_key(
 }
 
 /// Generate a new mnemonic and a root private key
-fn root_key_and_mnemonic(
-    mnemonic: &Option<String>,
-) -> Result<(ExtendedPrivateKey, String), CliError> {
+fn root_key_and_mnemonic() -> Result<(ExtendedPrivateKey, String), CliError> {
     let language = wallet::wallet::Language::English;
-    let mnemonic = match mnemonic {
-        Some(mnemonic) => wallet_controller::mnemonic::parse_mnemonic(language, mnemonic)
-            .map_err(CliError::InvalidMnemonic)?,
-        None => wallet_controller::mnemonic::generate_new_mnemonic(language),
-    };
+    let mnemonic = wallet_controller::mnemonic::generate_new_mnemonic(language);
+
     let (root_key, _root_vrf_key, _mnemonic) =
         MasterKeyChain::mnemonic_to_root_key(&mnemonic.to_string(), None)
             .map_err(WalletError::from)?;


### PR DESCRIPTION
This program should only be used for generating new mnemonics, not for inputting them. Besides, it's a security flaw because it encourages writing the mnemonics in command line arguments, which is a security risk due to them being saved in shell history.

If someone needs this functionality, they should use the cli wallet in cold mode.