### PR TITLE
Remove the option not to specify the destination of the coins from decommission due to misunderstandings

### DIFF
--- a/node-lib/src/config_files/rpc.rs
+++ b/node-lib/src/config_files/rpc.rs
@@ -57,7 +57,7 @@ impl RpcConfigFile {
 
         let RpcConfigFile {
             bind_address,
-            rpc_enabled: http_enabled,
+            rpc_enabled,
             username,
             password,
             cookie_file,
@@ -66,9 +66,9 @@ impl RpcConfigFile {
         let bind_address = options
             .rpc_bind_address
             .unwrap_or_else(|| bind_address.unwrap_or(default_rpc_bind_address));
-        let http_enabled = options
+        let rpc_enabled = options
             .rpc_enabled
-            .unwrap_or_else(|| http_enabled.unwrap_or(DEFAULT_RPC_ENABLED));
+            .unwrap_or_else(|| rpc_enabled.unwrap_or(DEFAULT_RPC_ENABLED));
 
         let username = username.or(options.rpc_username.clone());
         let password = password.or(options.rpc_password.clone());
@@ -76,7 +76,7 @@ impl RpcConfigFile {
 
         RpcConfigFile {
             bind_address: Some(bind_address),
-            rpc_enabled: Some(http_enabled),
+            rpc_enabled: Some(rpc_enabled),
             username,
             password,
             cookie_file,

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -290,11 +290,11 @@ class WalletCliController:
                                 decommission_addr: str) -> str:
         return await self._write_command(f"staking-create-pool {amount} {cost_per_block} {margin_ratio_per_thousand} {decommission_addr}\n")
 
-    async def decommission_stake_pool(self, pool_id: str) -> str:
-        return await self._write_command(f"staking-decommission-pool {pool_id}\n")
+    async def decommission_stake_pool(self, pool_id: str, address: str) -> str:
+        return await self._write_command(f"staking-decommission-pool {pool_id} {address}\n")
 
-    async def decommission_stake_pool_request(self, pool_id: str) -> str:
-        return await self._write_command(f"staking-decommission-pool-request {pool_id}\n")
+    async def decommission_stake_pool_request(self, pool_id: str, address: str) -> str:
+        return await self._write_command(f"staking-decommission-pool-request {pool_id} {address}\n")
 
     async def sign_raw_transaction(self, transaction: str) -> str:
         return await self._write_command(f"account-sign-raw-transaction {transaction}\n")

--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -244,8 +244,8 @@ class WalletRpcController:
         self._write_command("staking_create_pool", [self.account, str(amount), str(cost_per_block), str(margin_ratio_per_thousand), decommission_key, {'in_top_x_mb': 5}])['result']
         return "The transaction was submitted successfully"
 
-    async def decommission_stake_pool(self, pool_id: str) -> str:
-        self._write_command("staking_decommission_pool", [self.account, pool_id, None, {'in_top_x_mb': 5}])['result']
+    async def decommission_stake_pool(self, pool_id: str, address: str) -> str:
+        self._write_command("staking_decommission_pool", [self.account, pool_id, address, {'in_top_x_mb': 5}])['result']
         return "The transaction was submitted successfully"
 
     async def list_pool_ids(self) -> List[PoolData]:

--- a/test/functional/wallet_decommission_genesis.py
+++ b/test/functional/wallet_decommission_genesis.py
@@ -316,7 +316,8 @@ class WalletDecommissionGenesis(BitcoinTestFramework):
             assert_equal(len(pools), 1)
             genesis_pool_balance = pools[0].balance
             # decommission from hot wallet
-            assert_in("The transaction was submitted successfully", await wallet.decommission_stake_pool(genesis_pool_id))
+            address = await wallet.new_address()
+            assert_in("The transaction was submitted successfully", await wallet.decommission_stake_pool(genesis_pool_id, address))
             transactions = node.mempool_transactions()
             assert_equal(len(transactions), 1)
 

--- a/test/functional/wallet_decommission_request.py
+++ b/test/functional/wallet_decommission_request.py
@@ -287,10 +287,11 @@ class WalletDecommissionRequest(BitcoinTestFramework):
                 assert_in("Success", await wallet.stop_staking())
 
             # try decommission from hot wallet
-            assert (await wallet.decommission_stake_pool(pools[0].pool_id)).startswith("Wallet error: Wallet error: Failed to completely sign")
+            address = await wallet.new_address()
+            assert (await wallet.decommission_stake_pool(pools[0].pool_id, address)).startswith("Wallet error: Wallet error: Failed to completely sign")
 
             # create decommission request
-            decommission_req_output = await wallet.decommission_stake_pool_request(pools[0].pool_id)
+            decommission_req_output = await wallet.decommission_stake_pool_request(pools[0].pool_id, address)
             decommission_req = decommission_req_output.split('\n')[2]
 
             # try to sign decommission request from hot wallet

--- a/test/functional/wallet_decommission_request.py
+++ b/test/functional/wallet_decommission_request.py
@@ -324,6 +324,10 @@ class WalletDecommissionRequest(BitcoinTestFramework):
             pools = await wallet.list_pool_ids()
             assert_equal(len(pools), 0)
 
+            # check the locked balance is equal to the genesis pool balance
+            locked_utxos = await wallet.list_utxos('all', with_locked='locked')
+            assert_equal(len(locked_utxos), 1)
+
 # `use_wallet_to_produce_block` indicates whether a test should use a pool created by a wallet to produce block
 # `exit_on_success` indicates if the process should exit or continue and run next test case
 def wallet_decommission_request_test_case(use_wallet_to_produce_block, exit_on_success):

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -440,7 +440,8 @@ class WalletDelegationsCLI(BitcoinTestFramework):
             assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
             assert_in("Success", await wallet.stop_staking())
             assert_in("Not staking", await wallet.staking_status())
-            assert_in("The transaction was submitted successfully", await wallet.decommission_stake_pool(pools[0].pool_id))
+            address = await wallet.new_address()
+            assert_in("The transaction was submitted successfully", await wallet.decommission_stake_pool(pools[0].pool_id, address))
 
             transactions = node.mempool_transactions()
             block_height = await wallet.get_best_block_height()

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -556,8 +556,7 @@ pub enum WalletCommand {
         /// Notice that this only works if the selected account in this wallet owns the decommission key.
         pool_id: String,
         /// The address that will be receiving the staker's balance (both pledge and proceeds from staking).
-        /// If not specified, a new receiving address will be created by this wallet's selected account
-        output_address: Option<String>,
+        output_address: String,
     },
 
     /// Create a request to decommission a pool. This assumes that the decommission key is owned
@@ -569,8 +568,7 @@ pub enum WalletCommand {
         /// The pool id of the pool to be decommissioned.
         pool_id: String,
         /// The address that will be receiving the staker's balance (both pledge and proceeds from staking).
-        /// If not specified, a new receiving address will be created by this wallet's selected account
-        output_address: Option<String>,
+        output_address: String,
     },
 
     /// Rescan the blockchain and re-detect all operations related to the selected account in this wallet
@@ -1859,7 +1857,12 @@ where
                 let selected_account = self.get_selected_acc()?;
                 let new_tx = self
                     .wallet_rpc
-                    .decommission_stake_pool(selected_account, pool_id, output_address, self.config)
+                    .decommission_stake_pool(
+                        selected_account,
+                        pool_id,
+                        Some(output_address),
+                        self.config,
+                    )
                     .await?;
                 Ok(Self::new_tx_submitted_command(new_tx))
             }
@@ -1874,7 +1877,7 @@ where
                     .decommission_stake_pool_request(
                         selected_account,
                         pool_id,
-                        output_address,
+                        Some(output_address),
                         self.config,
                     )
                     .await?;

--- a/wallet/wallet-cli-lib/tests/basic.rs
+++ b/wallet/wallet-cli-lib/tests/basic.rs
@@ -142,10 +142,11 @@ async fn produce_blocks_decommission_genesis_pool(#[case] seed: Seed) {
 
     // create the decommission request
     assert_eq!(test.exec("account-select 0"), "Success");
+    let address = test.exec("address-new");
     let pool_id: PoolId = H256::zero().into();
     let output = test.exec(&format!(
-        "staking-decommission-pool-request {}",
-        Address::new(&test.chain_config, &pool_id).unwrap()
+        "staking-decommission-pool-request {} {address}",
+        Address::new(&test.chain_config, &pool_id).unwrap(),
     ));
     let req = output.lines().nth(2).unwrap();
 


### PR DESCRIPTION
Seems that people are used to ignoring optionals. So, this parameter isn't optional anymore.