### PR TITLE
Add pool ids when listing created blocks

### DIFF
--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -64,6 +64,7 @@ class DelegationData:
 class CreatedBlockInfo:
     block_id: str
     block_height: str
+    pool_id: str
 
 class WalletCliController:
 
@@ -337,9 +338,9 @@ class WalletCliController:
     async def list_created_blocks_ids(self) -> List[CreatedBlockInfo]:
         output =  await self._write_command("staking-list-created-block-ids\n")
         self.log.info(output)
-        pattern = r"\((\d+),\s*([0-9a-fA-F]+)\)"
+        pattern = r"\((\d+),\s*([0-9a-fA-F]+),\s*([a-zA-Z0-9]+)\)"
         matches = re.findall(pattern, output)
-        return [CreatedBlockInfo(block_id, block_height) for block_height, block_id in matches]
+        return [CreatedBlockInfo(block_id, block_height, pool_id) for block_height, block_id, pool_id in matches]
 
     async def create_delegation(self, address: str, pool_id: str) -> Optional[str]:
         output = await self._write_command(f"delegation-create {address} {pool_id}\n")

--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -52,6 +52,7 @@ class DelegationData:
 class CreatedBlockInfo:
     block_id: str
     block_height: str
+    pool_id: str
 
 class WalletRpcController:
 
@@ -254,7 +255,7 @@ class WalletRpcController:
 
     async def list_created_blocks_ids(self) -> List[CreatedBlockInfo]:
         output = self._write_command("staking_list_created_block_ids", [self.account])['result']
-        return [CreatedBlockInfo(block['id'], block['height']) for block in output]
+        return [CreatedBlockInfo(block['id'], block['height'], block['pool_id']) for block in output]
 
     async def create_delegation(self, address: str, pool_id: str) -> Optional[str]:
         return self._write_command("delegation_create", [self.account, address, pool_id, {'in_top_x_mb': 5}])['result']['delegation_id']

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1938,7 +1938,7 @@ impl Account {
         Ok(())
     }
 
-    pub fn get_created_blocks(&self) -> Vec<(BlockHeight, Id<GenBlock>)> {
+    pub fn get_created_blocks(&self) -> Vec<(BlockHeight, Id<GenBlock>, PoolId)> {
         self.output_cache
             .get_created_blocks(|destination| self.is_mine_or_watched_destination(destination))
     }

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -950,7 +950,7 @@ impl<B: storage::Backend> Wallet<B> {
     pub fn get_created_blocks(
         &self,
         account_index: U31,
-    ) -> WalletResult<Vec<(BlockHeight, Id<GenBlock>)>> {
+    ) -> WalletResult<Vec<(BlockHeight, Id<GenBlock>, PoolId)>> {
         let block_ids = self.get_account(account_index)?.get_created_blocks();
         Ok(block_ids)
     }

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -1093,20 +1093,17 @@ where
 
             WalletCommand::ListCreatedBlocksIds => {
                 let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
-                let mut block_ids = wallet
-                    .list_created_blocks_ids(selected_account)
-                    .await?
-                    .into_iter()
-                    .map(|block_info| (block_info.height.into_int(), *block_info.id.as_hash()))
-                    .collect::<Vec<_>>();
-                block_ids.sort_by(|(a0, _), (a1, _)| a0.cmp(a1));
+                let mut block_ids = wallet.list_created_blocks_ids(selected_account).await?;
+                block_ids.sort_by_key(|x| x.height);
                 let result = block_ids
                     .into_iter()
-                    .map(|(h, id)| {
-                        let id = id_to_hex_string(id);
-                        format!("({h}, {id})")
+                    .map(|block_info| {
+                        let id = id_to_hex_string(*block_info.id.as_hash());
+                        let h = block_info.height.into_int();
+                        let pool_id = block_info.pool_id;
+                        format!("({h}, {id}, {pool_id})")
                     })
-                    .fold("".to_string(), |curr, v| curr + &v + "\n");
+                    .join("\n");
                 Ok(ConsoleCommand::Print(result))
             }
 

--- a/wallet/wallet-controller/src/types/block_info.rs
+++ b/wallet/wallet-controller/src/types/block_info.rs
@@ -19,6 +19,13 @@ use common::{
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CreatedBlockInfo {
+    pub id: Id<GenBlock>,
+    pub height: BlockHeight,
+    pub pool_id: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockInfo {
     pub id: Id<GenBlock>,
     pub height: BlockHeight,

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -19,7 +19,7 @@ mod balances;
 mod block_info;
 
 pub use balances::Balances;
-pub use block_info::BlockInfo;
+pub use block_info::{BlockInfo, CreatedBlockInfo};
 pub use common::primitives::DecimalAmount;
 use common::primitives::H256;
 

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -35,7 +35,10 @@ use wallet::{
     account::{PartiallySignedTransaction, TxInfo},
     version::get_version,
 };
-use wallet_controller::{types::WalletInfo, ConnectedPeer, ControllerConfig};
+use wallet_controller::{
+    types::{CreatedBlockInfo, WalletInfo},
+    ConnectedPeer, ControllerConfig,
+};
 use wallet_rpc_lib::{
     types::{
         AddressInfo, AddressWithUsageInfo, Balances, BlockInfo, ComposedTransaction, CreatedWallet,
@@ -553,7 +556,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
     async fn list_created_blocks_ids(
         &self,
         account_index: U31,
-    ) -> Result<Vec<BlockInfo>, Self::Error> {
+    ) -> Result<Vec<CreatedBlockInfo>, Self::Error> {
         self.wallet_rpc
             .list_created_blocks_ids(account_index)
             .await

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -33,7 +33,7 @@ use serialization::hex_encoded::HexEncoded;
 use serialization::DecodeAll;
 use wallet::account::{PartiallySignedTransaction, TxInfo};
 use wallet_controller::{
-    types::{Balances, WalletInfo},
+    types::{Balances, CreatedBlockInfo, WalletInfo},
     ConnectedPeer, ControllerConfig, UtxoStates, UtxoTypes,
 };
 use wallet_rpc_lib::{
@@ -465,7 +465,7 @@ impl WalletInterface for ClientWalletRpc {
     async fn list_created_blocks_ids(
         &self,
         account_index: U31,
-    ) -> Result<Vec<BlockInfo>, Self::Error> {
+    ) -> Result<Vec<CreatedBlockInfo>, Self::Error> {
         WalletRpcClient::list_created_blocks_ids(&self.http_client, account_index.into())
             .await
             .map_err(WalletRpcError::ResponseError)

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -27,7 +27,10 @@ use p2p_types::{
 };
 use serialization::hex_encoded::HexEncoded;
 use wallet::account::{PartiallySignedTransaction, TxInfo};
-use wallet_controller::{types::WalletInfo, ConnectedPeer, ControllerConfig};
+use wallet_controller::{
+    types::{CreatedBlockInfo, WalletInfo},
+    ConnectedPeer, ControllerConfig,
+};
 use wallet_rpc_lib::types::{
     AddressInfo, AddressWithUsageInfo, Balances, BlockInfo, ComposedTransaction, CreatedWallet,
     DelegationInfo, LegacyVrfPublicKeyInfo, NewAccountInfo, NewDelegation, NewTransaction,
@@ -252,7 +255,7 @@ pub trait WalletInterface {
     async fn list_created_blocks_ids(
         &self,
         account_index: U31,
-    ) -> Result<Vec<BlockInfo>, Self::Error>;
+    ) -> Result<Vec<CreatedBlockInfo>, Self::Error>;
 
     async fn new_vrf_public_key(&self, account_index: U31)
         -> Result<VrfPublicKeyInfo, Self::Error>;

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -21,7 +21,7 @@ use common::{
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress};
 use wallet::account::{PartiallySignedTransaction, TxInfo};
 use wallet_controller::{
-    types::{BlockInfo, WalletInfo},
+    types::{BlockInfo, CreatedBlockInfo, WalletInfo},
     ConnectedPeer,
 };
 use wallet_types::with_locked::WithLocked;
@@ -244,7 +244,7 @@ trait WalletRpc {
     async fn list_created_blocks_ids(
         &self,
         account_index: AccountIndexArg,
-    ) -> rpc::RpcResult<Vec<BlockInfo>>;
+    ) -> rpc::RpcResult<Vec<CreatedBlockInfo>>;
 
     #[method(name = "staking_new_vrf_public_key")]
     async fn new_vrf_public_key(

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -51,7 +51,7 @@ use common::{
 pub use interface::{WalletEventsRpcServer, WalletRpcClient, WalletRpcServer};
 pub use rpc::{rpc_creds::RpcCreds, Rpc};
 use wallet_controller::{
-    types::{Balances, BlockInfo, WalletInfo},
+    types::{Balances, BlockInfo, CreatedBlockInfo, WalletInfo},
     ConnectedPeer, ControllerConfig, ControllerError, NodeInterface, UtxoStates, UtxoTypes,
     DEFAULT_ACCOUNT_INDEX,
 };
@@ -1169,7 +1169,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
     pub async fn list_created_blocks_ids(
         &self,
         account_index: U31,
-    ) -> WRpcResult<Vec<BlockInfo>, N> {
+    ) -> WRpcResult<Vec<CreatedBlockInfo>, N> {
         self.wallet
             .call(move |controller| {
                 controller.readonly_controller(account_index).get_created_blocks()

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -34,7 +34,7 @@ use wallet::{
     version::get_version,
 };
 use wallet_controller::{
-    types::{BlockInfo, WalletInfo},
+    types::{BlockInfo, CreatedBlockInfo, WalletInfo},
     ConnectedPeer, ControllerConfig, NodeInterface, UtxoStates, UtxoTypes,
 };
 use wallet_types::{seed_phrase::StoreSeedPhrase, with_locked::WithLocked};
@@ -434,7 +434,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
     async fn list_created_blocks_ids(
         &self,
         account_index: AccountIndexArg,
-    ) -> rpc::RpcResult<Vec<BlockInfo>> {
+    ) -> rpc::RpcResult<Vec<CreatedBlockInfo>> {
         rpc::handle_result(self.list_created_blocks_ids(account_index.index::<N>()?).await)
     }
 


### PR DESCRIPTION
Pool ids are now listed along the block id and height when listing created blocks from the wallet