### PR TITLE
Add inspect transaction command to the wallet

### DIFF
--- a/common/src/chain/transaction/signed_transaction.rs
+++ b/common/src/chain/transaction/signed_transaction.rs
@@ -46,6 +46,10 @@ impl SignedTransaction {
         &self.transaction
     }
 
+    pub fn take_transaction(self) -> Transaction {
+        self.transaction
+    }
+
     pub fn version_byte(&self) -> u8 {
         self.transaction.version_byte()
     }

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -227,6 +227,9 @@ class WalletCliController:
         except:
             return out
 
+    async def inspect_transaction(self, tx: str) -> str:
+        return await self._write_command(f"transaction-inspect {tx}\n")
+
     async def get_raw_signed_transaction(self, tx_id: str) -> str:
         return await self._write_command(f"transaction-get-signed-raw {tx_id}\n")
 

--- a/test/functional/wallet_tx_compose.py
+++ b/test/functional/wallet_tx_compose.py
@@ -195,6 +195,7 @@ class WalletComposeTransaction(BitcoinTestFramework):
             encoded_tx = output.split('\n')[1]
             output = await wallet.sign_raw_transaction(encoded_tx)
             assert_in("The transaction has been fully signed and is ready to be broadcast to network.", output)
+            signed_tx2 = output.split('\n')[2]
 
             transactions = node.mempool_transactions()
             assert_in(signed_tx, transactions)
@@ -209,6 +210,18 @@ class WalletComposeTransaction(BitcoinTestFramework):
             await wallet.select_account(1)
             assert_in(f"Coins amount: {num_outputs * coins_to_send + coins_to_send-1}", await wallet.get_balance())
             assert_equal(num_outputs + 1, len(await wallet.list_utxos()))
+
+            assert_in("The transaction was submitted successfully", await wallet.submit_transaction(signed_tx2))
+            self.generate_block()
+
+            # even though the UTXOs are spent and can't be found in the Node's chainstate they can be found in the wallet's cache
+            assert_in("Success", await wallet.sync())
+            output = await wallet.inspect_transaction(signed_tx2)
+            assert_in(f"Transfer({acc1_address}, 0.1)", output)
+            assert_in(f"Could not calcualte fees", output)
+            assert_in(f"number of inputs: 1", output)
+            assert_in(f"total signatures 1", output)
+            assert_in(f"The signatures could not be verified because the UTXOs were spend or not found", output)
 
 
 if __name__ == '__main__':

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -156,6 +156,10 @@ impl PartiallySignedTransaction {
         &self.tx
     }
 
+    pub fn take_tx(self) -> Transaction {
+        self.tx
+    }
+
     pub fn input_utxos(&self) -> &[Option<TxOutput>] {
         self.input_utxos.as_ref()
     }

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -33,7 +33,7 @@ use wallet::{account::PartiallySignedTransaction, version::get_version};
 use wallet_rpc_client::wallet_rpc_traits::{PartialOrSignedTx, WalletInterface};
 use wallet_rpc_lib::types::{
     Balances, ComposedTransaction, ControllerConfig, CreatedWallet, InsepectTransaction,
-    NewTransaction, NftMetadata, SignatureStats, TokenMetadata,
+    NewTransaction, NftMetadata, SignatureStats, TokenMetadata, ValidatedSignatures,
 };
 
 use crate::errors::WalletCliError;
@@ -937,21 +937,43 @@ where
             WalletCommand::InspectTransaction { transaction } => {
                 let InsepectTransaction {
                     tx,
-                    fees,
-                    signatures:
+                    stats:
                         SignatureStats {
                             num_inputs,
-                            num_valid_signatures,
-                            num_invalid_signatures,
+                            total_signatures,
+                            validated_signatures,
                         },
+                    fees,
                 } = self.non_empty_wallet().await?.transaction_inspect(transaction).await?;
 
-                let missing_signatures = num_inputs - num_valid_signatures - num_invalid_signatures;
                 let summary = tx.take().text_summary(chain_config);
-                let mut output_str = format!("{summary}\n\
-                    number of inputs: {num_inputs} of which {num_valid_signatures} have valid signatures, {num_invalid_signatures} with invalid signatures and {missing_signatures} missing signatures\n"
-                );
-                format_fees(&mut output_str, fees, chain_config);
+                let mut output_str = format!("{summary}\n");
+                if let Some(ValidatedSignatures {
+                    num_valid_signatures,
+                    num_invalid_signatures,
+                }) = validated_signatures
+                {
+                    let missing_signatures = num_inputs - total_signatures;
+                    writeln!(
+                        output_str,
+                        "number of inputs: {num_inputs} and total signatures {total_signatures}, of which {num_valid_signatures} have valid signatures, {num_invalid_signatures} with invalid signatures and {missing_signatures} missing signatures\n"
+                    )
+                    .expect("Writing to a memory buffer should not fail");
+                } else {
+                    let missing_signatures = num_inputs - total_signatures;
+                    writeln!(
+                        output_str,
+                        "number of inputs: {num_inputs} and total signatures {total_signatures} with {missing_signatures} missing signatures\nThe signatures could not be verified because the UTXOs were spend or not found"
+                    )
+                    .expect("Writing to a memory buffer should not fail");
+                }
+
+                if let Some(fees) = fees {
+                    format_fees(&mut output_str, fees, chain_config);
+                } else {
+                    writeln!(output_str, "Could not calcualte fees")
+                        .expect("Writing to a memory buffer should not fail");
+                }
 
                 Ok(ConsoleCommand::Print(output_str))
             }

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -421,6 +421,13 @@ pub enum WalletCommand {
         change_address: Option<String>,
     },
 
+    /// Print the summary of the transaction
+    #[clap(name = "transaction-inspect")]
+    InspectTransaction {
+        /// Hex encoded transaction or PartiallySignedTransaction.
+        transaction: String,
+    },
+
     /// Store data on the blockchain, the data is provided as hex encoded string.
     /// Note that there is a high fee for storing data on the blockchain.
     #[clap(name = "address-deposit-data")]

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -24,7 +24,11 @@ pub mod types;
 const NORMAL_DELAY: Duration = Duration::from_secs(1);
 const ERROR_DELAY: Duration = Duration::from_secs(10);
 
-use futures::{never::Never, stream::FuturesUnordered, TryStreamExt};
+use futures::{
+    never::Never,
+    stream::{FuturesOrdered, FuturesUnordered},
+    TryStreamExt,
+};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
@@ -33,7 +37,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use types::{Balances, WalletInfo};
+use types::{Balances, InsepectTransaction, SignatureStats, TransactionToInspect, WalletInfo};
 
 use read::ReadOnlyController;
 use sync::InSync;
@@ -42,9 +46,13 @@ use synced_controller::SyncedController;
 use common::{
     address::AddressError,
     chain::{
+        signature::{
+            inputsig::{standard_signature::StandardInputSignature, InputWitness},
+            sighash::signature_hash,
+        },
         tokens::{RPCTokenInfo, TokenId},
-        Block, ChainConfig, GenBlock, PoolId, SignedTransaction, Transaction, TxInput, TxOutput,
-        UtxoOutPoint,
+        Block, ChainConfig, Destination, GenBlock, PoolId, SignedTransaction, Transaction, TxInput,
+        TxOutput, UtxoOutPoint,
     },
     primitives::{
         time::{get_time, Time},
@@ -621,6 +629,150 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         )
     }
 
+    pub async fn inspect_transaction(
+        &self,
+        tx: TransactionToInspect,
+    ) -> Result<InsepectTransaction, ControllerError<T>> {
+        let result = match tx {
+            TransactionToInspect::Tx(tx) => self.inspect_tx(tx).await?,
+            TransactionToInspect::Partial(ptx) => self.inspect_partial_tx(ptx).await?,
+            TransactionToInspect::Signed(stx) => self.inspect_signed_tx(stx).await?,
+        };
+
+        Ok(result)
+    }
+
+    async fn inspect_signed_tx(
+        &self,
+        stx: SignedTransaction,
+    ) -> Result<InsepectTransaction, ControllerError<T>> {
+        let tasks: FuturesOrdered<_> =
+            stx.inputs().iter().map(|input| self.fetch_opt_utxo(input)).collect();
+        let input_utxos: Vec<Option<TxOutput>> = tasks.try_collect().await?;
+        let only_input_utxos: Vec<_> = input_utxos.clone().into_iter().flatten().collect();
+        let fees = self.get_fees(&only_input_utxos, stx.outputs()).await?;
+
+        let inputs_utxos_refs: Vec<_> = input_utxos.iter().map(|out| out.as_ref()).collect();
+        let destinations = inputs_utxos_refs
+            .iter()
+            .map(|txo| {
+                txo.map(|txo| {
+                    get_tx_output_destination(txo, &|_| None).ok_or_else(|| {
+                        WalletError::UnsupportedTransactionOutput(Box::new(txo.clone()))
+                    })
+                })
+                .transpose()
+            })
+            .collect::<Result<Vec<_>, WalletError>>()
+            .map_err(ControllerError::WalletError)?;
+        let num_valid_signatures = stx
+            .signatures()
+            .iter()
+            .enumerate()
+            .zip(destinations)
+            .filter(|((input_num, w), d)| match (w, d) {
+                (InputWitness::NoSignature(_), None) => true,
+                (InputWitness::NoSignature(_), Some(_)) => false,
+                (InputWitness::Standard(_), None) => false,
+                (InputWitness::Standard(sig), Some(dest)) => self.verify_tx_signature(
+                    sig,
+                    stx.transaction(),
+                    &inputs_utxos_refs,
+                    *input_num,
+                    dest,
+                ),
+            })
+            .count();
+        let num_inputs = stx.inputs().len();
+        let num_invalid_signatures = num_inputs - num_valid_signatures;
+        Ok(InsepectTransaction {
+            tx: stx.take_transaction().into(),
+            fees,
+            signatures: SignatureStats {
+                num_inputs,
+                num_valid_signatures,
+                num_invalid_signatures,
+            },
+        })
+    }
+
+    async fn inspect_partial_tx(
+        &self,
+        ptx: PartiallySignedTransaction,
+    ) -> Result<InsepectTransaction, ControllerError<T>> {
+        let input_utxos: Vec<_> = ptx.input_utxos().iter().flatten().cloned().collect();
+        let fees = self.get_fees(&input_utxos, ptx.tx().outputs()).await?;
+        let inputs_utxos_refs: Vec<_> = ptx.input_utxos().iter().map(|out| out.as_ref()).collect();
+        let signatures_status: Vec<_> = ptx
+            .witnesses()
+            .iter()
+            .enumerate()
+            .zip(ptx.destinations())
+            .filter_map(|((input_num, w), d)| match (w, d) {
+                (Some(InputWitness::NoSignature(_)), None) => Some(true),
+                (Some(InputWitness::NoSignature(_)), Some(_)) => Some(false),
+                (Some(InputWitness::Standard(_)), None) => None,
+                (Some(InputWitness::Standard(sig)), Some(dest)) => Some(self.verify_tx_signature(
+                    sig,
+                    ptx.tx(),
+                    &inputs_utxos_refs,
+                    input_num,
+                    dest,
+                )),
+                (None, _) => None,
+            })
+            .collect();
+        let num_valid_signatures = signatures_status.iter().copied().filter(|x| *x).count();
+        let num_invalid_signatures = signatures_status.iter().copied().filter(|x| !*x).count();
+        let num_inputs = ptx.count_inputs();
+        Ok(InsepectTransaction {
+            tx: ptx.take_tx().into(),
+            fees,
+            signatures: SignatureStats {
+                num_inputs,
+                num_valid_signatures,
+                num_invalid_signatures,
+            },
+        })
+    }
+
+    async fn inspect_tx(&self, tx: Transaction) -> Result<InsepectTransaction, ControllerError<T>> {
+        let inputs: Vec<_> = tx
+            .inputs()
+            .iter()
+            .filter_map(|inp| match inp {
+                TxInput::Utxo(utxo) => Some(utxo.clone()),
+                TxInput::Account(_) => None,
+                TxInput::AccountCommand(_, _) => None,
+            })
+            .collect();
+        let input_utxos = self.fetch_utxos(&inputs).await?;
+        let fees = self.get_fees(&input_utxos, tx.outputs()).await?;
+        let num_inputs = tx.inputs().len();
+        Ok(InsepectTransaction {
+            tx: tx.into(),
+            fees,
+            signatures: SignatureStats {
+                num_inputs,
+                num_valid_signatures: 0,
+                num_invalid_signatures: 0,
+            },
+        })
+    }
+
+    fn verify_tx_signature(
+        &self,
+        sig: &StandardInputSignature,
+        tx: &Transaction,
+        inputs_utxos_refs: &[Option<&TxOutput>],
+        input_num: usize,
+        dest: &Destination,
+    ) -> bool {
+        signature_hash(sig.sighash_type(), tx, inputs_utxos_refs, input_num)
+            .and_then(|sighash| sig.verify_signature(&self.chain_config, dest, &sighash))
+            .is_ok()
+    }
+
     pub async fn compose_transaction(
         &self,
         inputs: Vec<UtxoOutPoint>,
@@ -628,8 +780,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         only_transaction: bool,
     ) -> Result<(TransactionToSign, Balances), ControllerError<T>> {
         let input_utxos = self.fetch_utxos(&inputs).await?;
-        let fees = self.get_fees(&input_utxos, &outputs)?;
-        let fees = into_balances(&self.rpc_client, &self.chain_config, fees).await?;
+        let fees = self.get_fees(&input_utxos, &outputs).await?;
 
         let num_inputs = inputs.len();
         let inputs = inputs.into_iter().map(TxInput::Utxo).collect();
@@ -664,11 +815,11 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         Ok((tx, fees))
     }
 
-    fn get_fees(
+    async fn get_fees(
         &self,
         inputs: &[TxOutput],
         outputs: &[TxOutput],
-    ) -> Result<BTreeMap<Currency, Amount>, ControllerError<T>> {
+    ) -> Result<Balances, ControllerError<T>> {
         let mut inputs = self.group_inputs(inputs)?;
         let outputs = self.group_outpus(outputs)?;
 
@@ -686,7 +837,8 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         }
         // add any leftover inputs
         fees.extend(inputs);
-        Ok(fees)
+
+        into_balances(&self.rpc_client, &self.chain_config, fees).await
     }
 
     fn group_outpus(
@@ -728,8 +880,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         &self,
         inputs: &[UtxoOutPoint],
     ) -> Result<Vec<TxOutput>, ControllerError<T>> {
-        let tasks: FuturesUnordered<_> =
-            inputs.iter().map(|input| self.fetch_utxo(input)).collect();
+        let tasks: FuturesOrdered<_> = inputs.iter().map(|input| self.fetch_utxo(input)).collect();
         let input_utxos: Vec<TxOutput> = tasks.try_collect().await?;
         Ok(input_utxos)
     }
@@ -748,6 +899,17 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
             .ok_or(ControllerError::WalletError(WalletError::CannotFindUtxo(
                 input.clone(),
             )))
+    }
+
+    async fn fetch_opt_utxo(
+        &self,
+        input: &TxInput,
+    ) -> Result<Option<TxOutput>, ControllerError<T>> {
+        match input {
+            TxInput::Utxo(utxo) => self.fetch_utxo(utxo).await.map(Some),
+            TxInput::Account(_) => Ok(None),
+            TxInput::AccountCommand(_, _) => Ok(None),
+        }
     }
 
     /// Synchronize the wallet in the background from the node's blockchain.

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -23,7 +23,9 @@ pub use balances::Balances;
 pub use block_info::{BlockInfo, CreatedBlockInfo};
 pub use common::primitives::DecimalAmount;
 use common::primitives::H256;
-pub use transaction::{InsepectTransaction, SignatureStats, TransactionToInspect};
+pub use transaction::{
+    InsepectTransaction, SignatureStats, TransactionToInspect, ValidatedSignatures,
+};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WalletInfo {

--- a/wallet/wallet-controller/src/types/transaction.rs
+++ b/wallet/wallet-controller/src/types/transaction.rs
@@ -13,20 +13,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Support types for presenting data in user-facing settings
+use common::chain::{SignedTransaction, Transaction};
+use serialization::hex_encoded::HexEncoded;
+use wallet::account::PartiallySignedTransaction;
 
-mod balances;
-mod block_info;
-mod transaction;
+use super::Balances;
 
-pub use balances::Balances;
-pub use block_info::{BlockInfo, CreatedBlockInfo};
-pub use common::primitives::DecimalAmount;
-use common::primitives::H256;
-pub use transaction::{InsepectTransaction, SignatureStats, TransactionToInspect};
+pub enum TransactionToInspect {
+    Tx(Transaction),
+    Partial(PartiallySignedTransaction),
+    Signed(SignedTransaction),
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct WalletInfo {
-    pub wallet_id: H256,
-    pub account_names: Vec<Option<String>>,
+pub struct SignatureStats {
+    pub num_inputs: usize,
+    pub num_valid_signatures: usize,
+    pub num_invalid_signatures: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct InsepectTransaction {
+    pub tx: HexEncoded<Transaction>,
+    pub fees: Balances,
+    pub signatures: SignatureStats,
 }

--- a/wallet/wallet-controller/src/types/transaction.rs
+++ b/wallet/wallet-controller/src/types/transaction.rs
@@ -26,15 +26,21 @@ pub enum TransactionToInspect {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct SignatureStats {
-    pub num_inputs: usize,
+pub struct ValidatedSignatures {
     pub num_valid_signatures: usize,
     pub num_invalid_signatures: usize,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SignatureStats {
+    pub num_inputs: usize,
+    pub total_signatures: usize,
+    pub validated_signatures: Option<ValidatedSignatures>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct InsepectTransaction {
     pub tx: HexEncoded<Transaction>,
-    pub fees: Balances,
-    pub signatures: SignatureStats,
+    pub fees: Option<Balances>,
+    pub stats: SignatureStats,
 }

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -34,7 +34,7 @@ use wallet::{
     version::get_version,
 };
 use wallet_controller::{
-    types::{CreatedBlockInfo, WalletInfo},
+    types::{CreatedBlockInfo, InsepectTransaction, WalletInfo},
     ConnectedPeer, ControllerConfig,
 };
 use wallet_rpc_lib::{
@@ -342,6 +342,16 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
                 hex: HexEncoded::new(tx).to_string(),
                 fees,
             })
+            .map_err(WalletRpcHandlesClientError::WalletRpcError)
+    }
+
+    async fn transaction_inspect(
+        &self,
+        transaction: String,
+    ) -> Result<InsepectTransaction, Self::Error> {
+        self.wallet_rpc
+            .transaction_inspect(transaction)
+            .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -31,7 +31,7 @@ use serialization::DecodeAll;
 use utils_networking::IpOrSocketAddress;
 use wallet::account::{PartiallySignedTransaction, TxInfo};
 use wallet_controller::{
-    types::{Balances, CreatedBlockInfo, WalletInfo},
+    types::{Balances, CreatedBlockInfo, InsepectTransaction, WalletInfo},
     ConnectedPeer, ControllerConfig, UtxoStates, UtxoTypes,
 };
 use wallet_rpc_lib::{
@@ -287,6 +287,15 @@ impl WalletInterface for ClientWalletRpc {
         )
         .await
         .map_err(WalletRpcError::ResponseError)
+    }
+
+    async fn transaction_inspect(
+        &self,
+        transaction: String,
+    ) -> Result<InsepectTransaction, Self::Error> {
+        WalletRpcClient::transaction_inspect(&self.http_client, transaction)
+            .await
+            .map_err(WalletRpcError::ResponseError)
     }
 
     async fn create_stake_pool(

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -26,7 +26,7 @@ use serialization::hex_encoded::HexEncoded;
 use utils_networking::IpOrSocketAddress;
 use wallet::account::{PartiallySignedTransaction, TxInfo};
 use wallet_controller::{
-    types::{CreatedBlockInfo, WalletInfo},
+    types::{CreatedBlockInfo, InsepectTransaction, WalletInfo},
     ConnectedPeer, ControllerConfig,
 };
 use wallet_rpc_lib::types::{
@@ -183,6 +183,11 @@ pub trait WalletInterface {
         change_address: Option<String>,
         config: ControllerConfig,
     ) -> Result<ComposedTransaction, Self::Error>;
+
+    async fn transaction_inspect(
+        &self,
+        transaction: String,
+    ) -> Result<InsepectTransaction, Self::Error>;
 
     async fn create_stake_pool(
         &self,

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -21,7 +21,7 @@ use common::{
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress};
 use wallet::account::{PartiallySignedTransaction, TxInfo};
 use wallet_controller::{
-    types::{BlockInfo, CreatedBlockInfo, WalletInfo},
+    types::{BlockInfo, CreatedBlockInfo, InsepectTransaction, WalletInfo},
     ConnectedPeer,
 };
 use wallet_types::with_locked::WithLocked;
@@ -160,6 +160,10 @@ trait WalletRpc {
         change_address: Option<String>,
         options: TransactionOptions,
     ) -> rpc::RpcResult<ComposedTransaction>;
+
+    #[method(name = "transaction_inspect")]
+    async fn transaction_inspect(&self, transaction: String)
+        -> rpc::RpcResult<InsepectTransaction>;
 
     #[method(name = "staking_create_pool")]
     async fn create_stake_pool(

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -32,7 +32,7 @@ use wallet::{
     version::get_version,
 };
 use wallet_controller::{
-    types::{BlockInfo, CreatedBlockInfo, WalletInfo},
+    types::{BlockInfo, CreatedBlockInfo, InsepectTransaction, WalletInfo},
     ConnectedPeer, ControllerConfig, NodeInterface, UtxoStates, UtxoTypes,
 };
 use wallet_types::{seed_phrase::StoreSeedPhrase, with_locked::WithLocked};
@@ -278,6 +278,13 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
                 fees,
             }),
         )
+    }
+
+    async fn transaction_inspect(
+        &self,
+        transaction: String,
+    ) -> rpc::RpcResult<InsepectTransaction> {
+        rpc::handle_result(self.transaction_inspect(transaction).await)
     }
 
     async fn create_stake_pool(

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -38,7 +38,9 @@ pub use mempool_types::tx_options::TxOptionsOverrides;
 pub use serde_json::Value as JsonValue;
 pub use serialization::hex_encoded::HexEncoded;
 use wallet::account::PoolData;
-pub use wallet_controller::types::{Balances, BlockInfo, DecimalAmount};
+pub use wallet_controller::types::{
+    Balances, BlockInfo, DecimalAmount, InsepectTransaction, SignatureStats,
+};
 pub use wallet_controller::{ControllerConfig, NodeInterface};
 
 use crate::service::SubmitError;

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -39,7 +39,7 @@ pub use serde_json::Value as JsonValue;
 pub use serialization::hex_encoded::HexEncoded;
 use wallet::account::PoolData;
 pub use wallet_controller::types::{
-    Balances, BlockInfo, DecimalAmount, InsepectTransaction, SignatureStats,
+    Balances, BlockInfo, DecimalAmount, InsepectTransaction, SignatureStats, ValidatedSignatures,
 };
 pub use wallet_controller::{ControllerConfig, NodeInterface};
 


### PR DESCRIPTION
Add an inspect transaction command to the CLI and RPC wallet, prints the summary, fees and signature status of the transaction/partially signed transaction/signed transaction