### PR TITLE
Feature/api server locked utxos

### DIFF
--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
@@ -19,7 +19,7 @@ use common::{
     chain::{
         block::timestamp::BlockTimestamp,
         tokens::{NftIssuance, TokenId},
-        Block, DelegationId, Destination, GenBlock, PoolId, Transaction, TxOutput, UtxoOutPoint,
+        Block, DelegationId, Destination, PoolId, Transaction, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId, Id},
 };
@@ -44,6 +44,14 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRo<'t> {
         coin_or_token_id: CoinOrTokenId,
     ) -> Result<Option<Amount>, ApiServerStorageError> {
         self.transaction.get_address_balance(address, coin_or_token_id)
+    }
+
+    async fn get_address_locked_balance(
+        &self,
+        address: &str,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<Option<Amount>, ApiServerStorageError> {
+        self.transaction.get_address_locked_balance(address, coin_or_token_id)
     }
 
     async fn get_address_transactions(
@@ -131,7 +139,7 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRo<'t> {
         Ok(Some(self.transaction.get_storage_version()?))
     }
 
-    async fn get_best_block(&self) -> Result<(BlockHeight, Id<GenBlock>), ApiServerStorageError> {
+    async fn get_best_block(&self) -> Result<BlockAuxData, ApiServerStorageError> {
         self.transaction.get_best_block()
     }
 
@@ -168,6 +176,14 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRo<'t> {
         address: &str,
     ) -> Result<Vec<(UtxoOutPoint, TxOutput)>, ApiServerStorageError> {
         self.transaction.get_address_available_utxos(address)
+    }
+
+    async fn get_locked_utxos_until_now(
+        &self,
+        block_height: BlockHeight,
+        time_range: (BlockTimestamp, BlockTimestamp),
+    ) -> Result<Vec<(UtxoOutPoint, TxOutput)>, ApiServerStorageError> {
+        self.transaction.get_locked_utxos_until_now(block_height, time_range)
     }
 
     async fn get_delegations_from_address(

--- a/api-server/api-server-common/src/storage/impls/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const CURRENT_STORAGE_VERSION: u32 = 4;
+pub const CURRENT_STORAGE_VERSION: u32 = 5;
 
 pub mod in_memory;
 pub mod postgres;

--- a/api-server/api-server-common/src/storage/impls/postgres/queries.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/queries.rs
@@ -515,7 +515,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                     utxo bytea NOT NULL,
                     lock_until_block bigint,
                     lock_until_timestamp bigint,
-                    PRIMARY KEY outpoint
+                    PRIMARY KEY (outpoint)
                 );",
         )
         .await?;

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/mod.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use bb8_postgres::{bb8::PooledConnection, PostgresConnectionManager};
 use common::{
-    chain::{Block, ChainConfig, GenBlock, PoolId, Transaction},
+    chain::{Block, ChainConfig, PoolId, Transaction},
     primitives::{BlockHeight, Id},
 };
 use pos_accounting::PoolData;
@@ -88,9 +88,7 @@ impl<'a> ApiServerPostgresTransactionalRo<'a> {
         Ok(res)
     }
 
-    pub async fn get_best_block(
-        &mut self,
-    ) -> Result<(BlockHeight, Id<GenBlock>), ApiServerStorageError> {
+    pub async fn get_best_block(&mut self) -> Result<BlockAuxData, ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_best_block().await?;
 

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
@@ -17,7 +17,7 @@ use common::{
     chain::{
         block::timestamp::BlockTimestamp,
         tokens::{NftIssuance, TokenId},
-        DelegationId, Destination, GenBlock, PoolId, TxOutput,
+        DelegationId, Destination, PoolId, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId, Id},
 };
@@ -63,6 +63,17 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
         Ok(res)
     }
 
+    async fn get_address_locked_balance(
+        &self,
+        address: &str,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<Option<Amount>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_address_locked_balance(address, coin_or_token_id).await?;
+
+        Ok(res)
+    }
+
     async fn get_address_transactions(
         &self,
         address: &str,
@@ -73,7 +84,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
         Ok(res)
     }
 
-    async fn get_best_block(&self) -> Result<(BlockHeight, Id<GenBlock>), ApiServerStorageError> {
+    async fn get_best_block(&self) -> Result<BlockAuxData, ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_best_block().await?;
 
@@ -236,6 +247,17 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
     ) -> Result<Vec<(UtxoOutPoint, TxOutput)>, ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_address_available_utxos(address).await?;
+
+        Ok(res)
+    }
+
+    async fn get_locked_utxos_until_now(
+        &self,
+        block_height: BlockHeight,
+        time_range: (BlockTimestamp, BlockTimestamp),
+    ) -> Result<Vec<(UtxoOutPoint, TxOutput)>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_locked_utxos_until_now(block_height, time_range).await?;
 
         Ok(res)
     }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
@@ -19,8 +19,7 @@ use common::{
     chain::{
         block::timestamp::BlockTimestamp,
         tokens::{NftIssuance, TokenId},
-        Block, ChainConfig, DelegationId, Destination, GenBlock, PoolId, Transaction, TxOutput,
-        UtxoOutPoint,
+        Block, ChainConfig, DelegationId, Destination, PoolId, Transaction, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId, Id},
 };
@@ -31,7 +30,7 @@ use crate::storage::{
     storage_api::{
         block_aux_data::{BlockAuxData, BlockWithExtraData},
         ApiServerStorageError, ApiServerStorageRead, ApiServerStorageWrite, BlockInfo, Delegation,
-        FungibleTokenData, PoolBlockStats, TransactionInfo, Utxo,
+        FungibleTokenData, LockedUtxo, PoolBlockStats, TransactionInfo, Utxo,
     },
 };
 
@@ -69,6 +68,16 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         Ok(())
     }
 
+    async fn del_address_locked_balance_above_height(
+        &mut self,
+        block_height: BlockHeight,
+    ) -> Result<(), ApiServerStorageError> {
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        conn.del_address_locked_balance_above_height(block_height).await?;
+
+        Ok(())
+    }
+
     async fn del_address_transactions_above_height(
         &mut self,
         block_height: BlockHeight,
@@ -88,6 +97,20 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
     ) -> Result<(), ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.set_address_balance_at_height(address, amount, coin_or_token_id, block_height)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn set_address_locked_balance_at_height(
+        &mut self,
+        address: &str,
+        amount: Amount,
+        coin_or_token_id: CoinOrTokenId,
+        block_height: BlockHeight,
+    ) -> Result<(), ApiServerStorageError> {
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        conn.set_address_locked_balance_at_height(address, amount, coin_or_token_id, block_height)
             .await?;
 
         Ok(())
@@ -210,12 +233,35 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
         Ok(())
     }
 
+    async fn set_locked_utxo_at_height(
+        &mut self,
+        outpoint: UtxoOutPoint,
+        utxo: LockedUtxo,
+        address: &str,
+        block_height: BlockHeight,
+    ) -> Result<(), ApiServerStorageError> {
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        conn.set_locked_utxo_at_height(outpoint, utxo, address, block_height).await?;
+
+        Ok(())
+    }
+
     async fn del_utxo_above_height(
         &mut self,
         block_height: BlockHeight,
     ) -> Result<(), ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.del_utxo_above_height(block_height).await?;
+
+        Ok(())
+    }
+
+    async fn del_locked_utxo_above_height(
+        &mut self,
+        block_height: BlockHeight,
+    ) -> Result<(), ApiServerStorageError> {
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        conn.del_locked_utxo_above_height(block_height).await?;
 
         Ok(())
     }
@@ -292,6 +338,17 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
         Ok(res)
     }
 
+    async fn get_address_locked_balance(
+        &self,
+        address: &str,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<Option<Amount>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_address_locked_balance(address, coin_or_token_id).await?;
+
+        Ok(res)
+    }
+
     async fn get_address_transactions(
         &self,
         address: &str,
@@ -302,7 +359,7 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
         Ok(res)
     }
 
-    async fn get_best_block(&self) -> Result<(BlockHeight, Id<GenBlock>), ApiServerStorageError> {
+    async fn get_best_block(&self) -> Result<BlockAuxData, ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_best_block().await?;
 
@@ -461,6 +518,17 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
     ) -> Result<Vec<(UtxoOutPoint, TxOutput)>, ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_address_available_utxos(address).await?;
+
+        Ok(res)
+    }
+
+    async fn get_locked_utxos_until_now(
+        &self,
+        block_height: BlockHeight,
+        time_range: (BlockTimestamp, BlockTimestamp),
+    ) -> Result<Vec<(UtxoOutPoint, TxOutput)>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_locked_utxos_until_now(block_height, time_range).await?;
 
         Ok(res)
     }

--- a/api-server/api-server-common/src/storage/storage_api/block_aux_data.rs
+++ b/api-server/api-server-common/src/storage/storage_api/block_aux_data.rs
@@ -14,23 +14,23 @@
 // limitations under the License.
 
 use common::{
-    chain::{block::timestamp::BlockTimestamp, Block},
+    chain::{block::timestamp::BlockTimestamp, Block, GenBlock},
     primitives::{BlockHeight, Id},
 };
 use serialization::{Decode, Encode};
 
 use super::TxAdditionalInfo;
 
-#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Encode, Decode, PartialEq, Eq)]
 pub struct BlockAuxData {
-    block_id: Id<Block>,
+    block_id: Id<GenBlock>,
     block_height: BlockHeight,
     block_timestamp: BlockTimestamp,
 }
 
 impl BlockAuxData {
     pub fn new(
-        block_id: Id<Block>,
+        block_id: Id<GenBlock>,
         block_height: BlockHeight,
         block_timestamp: BlockTimestamp,
     ) -> Self {
@@ -41,7 +41,7 @@ impl BlockAuxData {
         }
     }
 
-    pub fn block_id(&self) -> Id<Block> {
+    pub fn block_id(&self) -> Id<GenBlock> {
         self.block_id
     }
 

--- a/api-server/scanner-lib/src/sync/tests.rs
+++ b/api-server/scanner-lib/src/sync/tests.rs
@@ -676,7 +676,7 @@ async fn sync_and_compare(
         .get_best_block()
         .await
         .unwrap()
-        .0;
+        .block_height();
     local_state.scan_blocks(block_height, vec![block]).await.unwrap();
 
     let node_data = tf.chainstate.get_stake_pool_data(pool_id).unwrap().unwrap();

--- a/api-server/stack-test-suite/tests/v1/address.rs
+++ b/api-server/stack-test-suite/tests/v1/address.rs
@@ -98,6 +98,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
                 let bob_address =
                     Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
                 let mut bob_balance = Amount::ZERO;
+                let mut bob_locked_balance = Amount::ZERO;
                 let mut bob_transaction_history: Vec<Id<Transaction>> = vec![];
 
                 // setup initial transaction
@@ -143,12 +144,16 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
 
                 let random_coin_amount1 = rng.gen_range(1..10);
                 let random_coin_amount2 = rng.gen_range(1..10);
+                let random_coin_amount3 = rng.gen_range(1..10);
 
                 alice_balance = (alice_balance - Amount::from_atoms(random_coin_amount1)).unwrap();
                 alice_balance = (alice_balance - Amount::from_atoms(random_coin_amount2)).unwrap();
+                alice_balance = (alice_balance - Amount::from_atoms(random_coin_amount3)).unwrap();
 
                 bob_balance = (bob_balance + Amount::from_atoms(random_coin_amount1)).unwrap();
                 bob_balance = (bob_balance + Amount::from_atoms(random_coin_amount2)).unwrap();
+                bob_locked_balance =
+                    (bob_locked_balance + Amount::from_atoms(random_coin_amount3)).unwrap();
 
                 let alice_tx_out =
                     TxOutput::Transfer(OutputValue::Coin(alice_balance), alice_destination.clone());
@@ -163,6 +168,12 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
                     bob_destination.clone(),
                 );
 
+                let bob_tx_out3 = TxOutput::LockThenTransfer(
+                    OutputValue::Coin(Amount::from_atoms(random_coin_amount3)),
+                    bob_destination.clone(),
+                    OutputTimeLock::ForBlockCount(10),
+                );
+
                 let transaction = TransactionBuilder::new()
                     .add_input(
                         TxInput::from_utxo(
@@ -174,6 +185,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
                     .add_output(alice_tx_out.clone())
                     .add_output(bob_tx_out1.clone())
                     .add_output(bob_tx_out2.clone())
+                    .add_output(bob_tx_out3.clone())
                     .build();
 
                 alice_transaction_history.push(transaction.transaction().get_id());
@@ -219,6 +231,249 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
                         bob_address.to_string(),
                         json!({
                         "coin_balance": amount_to_json(bob_balance),
+                        "locked_coin_balance": amount_to_json(bob_locked_balance),
+                        "transaction_history": bob_transaction_history,
+                                }),
+                    ),
+                ]);
+
+                chainstate_block_ids
+                    .iter()
+                    .map(|id| tf.block(tf.to_chain_block_id(id.into())))
+                    .collect::<Vec<_>>()
+            };
+
+            let storage = {
+                let mut storage = TransactionalApiServerInMemoryStorage::new(&chain_config);
+
+                let mut db_tx = storage.transaction_rw().await.unwrap();
+                db_tx.initialize_storage(&chain_config).await.unwrap();
+                db_tx.commit().await.unwrap();
+
+                storage
+            };
+
+            let chain_config = Arc::new(chain_config);
+
+            let mut local_node = BlockchainState::new(Arc::clone(&chain_config), storage);
+            local_node.scan_genesis(chain_config.genesis_block()).await.unwrap();
+            local_node.scan_blocks(BlockHeight::new(0), chainstate_blocks).await.unwrap();
+
+            ApiServerWebServerState {
+                db: Arc::new(local_node.storage().clone_storage().await),
+                chain_config: Arc::clone(&chain_config),
+                rpc: Arc::new(DummyRPC {}),
+                cached_values: Arc::new(CachedValues {
+                    feerate_points: RwLock::new((get_time(), vec![])),
+                }),
+                time_getter: Default::default(),
+            }
+        };
+
+        web_server(listener, web_server_state, true).await
+    });
+
+    for (address, expected_balance) in rx.await.unwrap() {
+        let url = format!("/api/v1/address/{address}");
+
+        // Given that the listener port is open, this will block until a
+        // response is made (by the web server, which takes the listener
+        // over)
+        let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            200,
+            "Failed getting address balance for {address}"
+        );
+
+        let body = response.text().await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(body, expected_balance);
+    }
+
+    task.abort();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test]
+async fn test_unlocking_for_locked_utxos(#[case] seed: Seed) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let web_server_state = {
+            let mut rng = make_seedable_rng(seed);
+            let chain_config = create_unit_test_config();
+
+            let chainstate_blocks = {
+                let mut tf = TestFramework::builder(&mut rng)
+                    .with_chain_config(chain_config.clone())
+                    .build();
+
+                // generate addresses
+
+                let (alice_sk, alice_pk) =
+                    PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+
+                let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
+                let alice_address =
+                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                let mut alice_balance = Amount::from_atoms(1_000_000);
+                let mut alice_transaction_history: Vec<Id<Transaction>> = vec![];
+
+                let (_bob_sk, bob_pk) =
+                    PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+
+                let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
+                let bob_address =
+                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                let mut bob_balance = Amount::ZERO;
+                let mut bob_locked_balance = Amount::ZERO;
+                let mut bob_transaction_history: Vec<Id<Transaction>> = vec![];
+
+                // setup initial transaction
+
+                let previous_tx_out =
+                    TxOutput::Transfer(OutputValue::Coin(alice_balance), alice_destination.clone());
+
+                let transaction = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(
+                            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+                            0,
+                        ),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(previous_tx_out.clone())
+                    .build();
+
+                alice_transaction_history.push(transaction.transaction().get_id());
+                let previous_transaction_id = transaction.transaction().get_id();
+
+                let mut previous_witness = InputWitness::Standard(
+                    StandardInputSignature::produce_uniparty_signature_for_input(
+                        &alice_sk,
+                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        alice_destination.clone(),
+                        &transaction,
+                        &[Some(&previous_tx_out)],
+                        0,
+                    )
+                    .unwrap(),
+                );
+
+                let mut chainstate_block_ids = vec![*tf
+                    .make_block_builder()
+                    .add_transaction(transaction.clone())
+                    .build_and_process()
+                    .unwrap()
+                    .unwrap()
+                    .block_id()];
+
+                // Generate two outputs for a single transaction
+
+                let random_coin_amount1 = rng.gen_range(1..10);
+                let random_coin_amount2 = rng.gen_range(1..10);
+                let random_coin_amount3 = rng.gen_range(1..10);
+
+                alice_balance = (alice_balance - Amount::from_atoms(random_coin_amount1)).unwrap();
+                alice_balance = (alice_balance - Amount::from_atoms(random_coin_amount2)).unwrap();
+                alice_balance = (alice_balance - Amount::from_atoms(random_coin_amount3)).unwrap();
+
+                bob_balance = (bob_balance + Amount::from_atoms(random_coin_amount1)).unwrap();
+                bob_balance = (bob_balance + Amount::from_atoms(random_coin_amount2)).unwrap();
+                bob_locked_balance =
+                    (bob_locked_balance + Amount::from_atoms(random_coin_amount3)).unwrap();
+
+                let alice_tx_out =
+                    TxOutput::Transfer(OutputValue::Coin(alice_balance), alice_destination.clone());
+
+                let bob_tx_out1 = TxOutput::Transfer(
+                    OutputValue::Coin(Amount::from_atoms(random_coin_amount1)),
+                    bob_destination.clone(),
+                );
+
+                let bob_tx_out2 = TxOutput::Transfer(
+                    OutputValue::Coin(Amount::from_atoms(random_coin_amount2)),
+                    bob_destination.clone(),
+                );
+
+                let bob_tx_out3 = TxOutput::LockThenTransfer(
+                    OutputValue::Coin(Amount::from_atoms(random_coin_amount3)),
+                    bob_destination.clone(),
+                    OutputTimeLock::ForBlockCount(1),
+                );
+
+                let transaction = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(
+                            OutPointSourceId::Transaction(previous_transaction_id),
+                            0,
+                        ),
+                        previous_witness.clone(),
+                    )
+                    .add_output(alice_tx_out.clone())
+                    .add_output(bob_tx_out1.clone())
+                    .add_output(bob_tx_out2.clone())
+                    .add_output(bob_tx_out3.clone())
+                    .build();
+
+                alice_transaction_history.push(transaction.transaction().get_id());
+                bob_transaction_history.push(transaction.transaction().get_id());
+
+                previous_witness = InputWitness::Standard(
+                    StandardInputSignature::produce_uniparty_signature_for_input(
+                        &alice_sk,
+                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        alice_destination.clone(),
+                        &transaction,
+                        &[Some(&previous_tx_out)],
+                        0,
+                    )
+                    .unwrap(),
+                );
+
+                let signed_transaction = SignedTransaction::new(
+                    transaction.transaction().clone(),
+                    vec![previous_witness.clone()],
+                )
+                .unwrap();
+
+                chainstate_block_ids.push(
+                    *tf.make_block_builder()
+                        .add_transaction(signed_transaction)
+                        .build_and_process()
+                        .unwrap()
+                        .unwrap()
+                        .block_id(),
+                );
+
+                // Add an empty block that to wait for the time lock to pass
+                chainstate_block_ids.push(
+                    *tf.make_block_builder().build_and_process().unwrap().unwrap().block_id(),
+                );
+
+                _ = tx.send([
+                    (
+                        alice_address.get().to_string(),
+                        json!({
+                        "coin_balance": amount_to_json(alice_balance),
+                        "locked_coin_balance": amount_to_json(Amount::ZERO),
+                        "transaction_history": alice_transaction_history,
+                                }),
+                    ),
+                    (
+                        bob_address.to_string(),
+                        json!({
+                        "coin_balance": amount_to_json((bob_balance + bob_locked_balance).unwrap()),
                         "locked_coin_balance": amount_to_json(Amount::ZERO),
                         "transaction_history": bob_transaction_history,
                                 }),

--- a/api-server/stack-test-suite/tests/v1/address.rs
+++ b/api-server/stack-test-suite/tests/v1/address.rs
@@ -211,6 +211,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
                         alice_address.get().to_string(),
                         json!({
                         "coin_balance": amount_to_json(alice_balance),
+                        "locked_coin_balance": amount_to_json(Amount::ZERO),
                         "transaction_history": alice_transaction_history,
                                 }),
                     ),
@@ -218,6 +219,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
                         bob_address.to_string(),
                         json!({
                         "coin_balance": amount_to_json(bob_balance),
+                        "locked_coin_balance": amount_to_json(Amount::ZERO),
                         "transaction_history": bob_transaction_history,
                                 }),
                     ),
@@ -432,6 +434,7 @@ async fn ok(#[case] seed: Seed) {
                         alice_address.get().to_string(),
                         json!({
                         "coin_balance": amount_to_json(alice_balance),
+                        "locked_coin_balance": amount_to_json(Amount::ZERO),
                         "transaction_history": alice_transaction_history,
                                 }),
                     ),
@@ -439,6 +442,7 @@ async fn ok(#[case] seed: Seed) {
                         bob_address.to_string(),
                         json!({
                         "coin_balance": amount_to_json(bob_balance),
+                        "locked_coin_balance": amount_to_json(Amount::ZERO),
                         "transaction_history": bob_transaction_history,
                                 }),
                     ),

--- a/api-server/stack-test-suite/tests/v1/transaction_merkle_path.rs
+++ b/api-server/stack-test-suite/tests/v1/transaction_merkle_path.rs
@@ -126,7 +126,7 @@ async fn get_block_failed(#[case] seed: Seed) {
                     .set_block_aux_data(
                         block_id,
                         &BlockAuxData::new(
-                            block_id,
+                            block_id.into(),
                             BlockHeight::new(rng.gen::<u32>() as u64),
                             BlockTimestamp::from_int_seconds(rng.gen::<u64>()),
                         ),

--- a/api-server/stack-test-suite/tests/v1/transactions.rs
+++ b/api-server/stack-test-suite/tests/v1/transactions.rs
@@ -111,7 +111,7 @@ async fn ok(#[case] seed: Seed) {
                             &chain_config,
                             BlockHeight::new(n_blocks as u64),
                             BlockAuxData::new(
-                                block_id,
+                                block_id.into(),
                                 BlockHeight::new((n_blocks - idx) as u64),
                                 block.timestamp(),
                             ),

--- a/api-server/storage-test-suite/src/basic.rs
+++ b/api-server/storage-test-suite/src/basic.rs
@@ -108,9 +108,13 @@ where
         let mut db_tx = storage.transaction_rw().await.unwrap();
 
         // should return genesis block id
-        let (height, block_id) = db_tx.get_best_block().await.unwrap();
-        assert_eq!(height, BlockHeight::new(0));
-        assert_eq!(block_id, chain_config.genesis_block_id());
+        let block_aux = db_tx.get_best_block().await.unwrap();
+        assert_eq!(block_aux.block_height(), BlockHeight::new(0));
+        assert_eq!(block_aux.block_id(), chain_config.genesis_block_id());
+        assert_eq!(
+            block_aux.block_timestamp(),
+            chain_config.genesis_block().timestamp()
+        );
 
         {
             let random_block_id: Id<Block> = Id::<Block>::new(H256::random_using(&mut rng));
@@ -204,7 +208,7 @@ where
                     .set_block_aux_data(
                         block_id,
                         &BlockAuxData::new(
-                            block_id,
+                            block_id.into(),
                             BlockHeight::new(block_height),
                             block.timestamp(),
                         ),
@@ -357,7 +361,8 @@ where
         let existing_block_id: Id<Block> = block_id;
         let height1_u64 = rng.gen_range::<u64, _>(1..i64::MAX as u64);
         let height1 = height1_u64.into();
-        let aux_data1 = BlockAuxData::new(existing_block_id, height1, random_block_timestamp);
+        let aux_data1 =
+            BlockAuxData::new(existing_block_id.into(), height1, random_block_timestamp);
         db_tx.set_block_aux_data(existing_block_id, &aux_data1).await.unwrap();
 
         let retrieved_aux_data = db_tx.get_block_aux_data(existing_block_id).await.unwrap();
@@ -367,7 +372,8 @@ where
         let height2_u64 = rng.gen_range::<u64, _>(1..i64::MAX as u64);
         let height2 = height2_u64.into();
         let random_block_timestamp = BlockTimestamp::from_int_seconds(rng.gen::<u64>());
-        let aux_data2 = BlockAuxData::new(existing_block_id, height2, random_block_timestamp);
+        let aux_data2 =
+            BlockAuxData::new(existing_block_id.into(), height2, random_block_timestamp);
         db_tx.set_block_aux_data(existing_block_id, &aux_data2).await.unwrap();
 
         let retrieved_aux_data = db_tx.get_block_aux_data(existing_block_id).await.unwrap();

--- a/common/src/chain/transaction/output/timelock.rs
+++ b/common/src/chain/transaction/output/timelock.rs
@@ -20,6 +20,7 @@ use crate::{chain::block::timestamp::BlockTimestamp, primitives::BlockHeight};
 #[derive(
     Debug,
     Clone,
+    Copy,
     Ord,
     PartialOrd,
     Eq,

--- a/mempool/src/pool/tests/accumulator.rs
+++ b/mempool/src/pool/tests/accumulator.rs
@@ -340,7 +340,7 @@ async fn timelocked(#[case] seed: Seed, #[case] timelock: OutputTimeLock, #[case
             .add_output(TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_atoms(900_000_000)),
                 Destination::AnyoneCanSpend,
-                timelock.clone(),
+                timelock,
             ))
             .build()
     };


### PR DESCRIPTION
- separate locked utxos into another table
- address endpoint returns 2 balances for unlocked and locked
- move locked utxos to the unlocked utxos when the lock period ends