### PR TITLE
Add account rename command to the wallet

### DIFF
--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -66,6 +66,11 @@ class CreatedBlockInfo:
     block_height: str
     pool_id: str
 
+@dataclass
+class AccountInfo:
+    index: int
+    name: Optional[str]
+
 class WalletCliController:
 
     def __init__(self, node, config, log, wallet_args: List[str] = [], chain_config_args: List[str] = []):
@@ -164,6 +169,12 @@ class WalletCliController:
     async def close_wallet(self) -> str:
         return await self._write_command("wallet-close\n")
 
+    async def wallet_info(self) -> List[AccountInfo]:
+        output = await self._write_command(f"wallet-info\n")
+        pattern = r"Account index: (\d+), Name: (.+)"
+        matches = re.findall(pattern, output)
+        return [AccountInfo(int(idx), name.strip('"') if name != "None" else None) for idx, name in matches]
+
     async def show_seed_phrase(self) -> Optional[str]:
         output = await self._write_command("wallet-show-seed-phrase\n")
         if output.startswith("The stored seed phrase is"):
@@ -192,6 +203,9 @@ class WalletCliController:
 
     async def create_new_account(self, name: Optional[str] = '') -> str:
         return await self._write_command(f"account-create {name}\n")
+
+    async def rename_account(self, name: Optional[str] = '') -> str:
+        return await self._write_command(f"account-rename {name}\n")
 
     async def select_account(self, account_index: int) -> str:
         return await self._write_command(f"account-select {account_index}\n")

--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -54,6 +54,11 @@ class CreatedBlockInfo:
     block_height: str
     pool_id: str
 
+@dataclass
+class AccountInfo:
+    index: int
+    name: Optional[str]
+
 class WalletRpcController:
 
     def __init__(self, node, config, log, wallet_args: List[str] = [], chain_config_args: List[str] = []):
@@ -67,13 +72,14 @@ class WalletRpcController:
     async def __aenter__(self):
         cookie_file = os.path.join(self.node.datadir, ".cookie")
 
+        port = 23034 + int(self.node.url.split(':')[3])
+        url = "127.0.0.1"
+        bind_addr = f"{url}:{port}"
         self.log.info(f"node url: {self.node.url}")
         wallet_rpc = os.path.join(self.config["environment"]["BUILDDIR"], "test_rpc_wallet"+self.config["environment"]["EXEEXT"] )
-        wallet_args = ["--chain-type", "regtest", "--node-rpc-address", self.node.url.split("@")[1], "--node-cookie-file", cookie_file, "--rpc-no-authentication"] + self.wallet_args + self.chain_config_args
-        self.wallet_log_file = NamedTemporaryFile(prefix="wallet_stderr_", dir=os.path.dirname(self.node.datadir), delete=False)
-        self.wallet_commands_file = NamedTemporaryFile(prefix="wallet_commands_responses_", dir=os.path.dirname(self.node.datadir), delete=False)
-        url = "127.0.0.1"
-        port = 23034
+        wallet_args = ["--chain-type", "regtest", "--node-rpc-address", self.node.url.split("@")[1], "--node-cookie-file", cookie_file, "--rpc-bind-address", bind_addr, "--rpc-no-authentication"] + self.wallet_args + self.chain_config_args
+        self.wallet_log_file = NamedTemporaryFile(prefix="wallet_stderr_rpc_", dir=os.path.dirname(self.node.datadir), delete=False)
+        self.wallet_commands_file = NamedTemporaryFile(prefix="wallet_commands_responses_rpc_", dir=os.path.dirname(self.node.datadir), delete=False)
 
         self.process = await asyncio.create_subprocess_exec(
             wallet_rpc, *wallet_args,
@@ -128,7 +134,11 @@ class WalletRpcController:
         return "Success"
 
     async def close_wallet(self) -> str:
-        return self._write_command("wallet-close", [])
+        return self._write_command("wallet_close", [])['result']
+
+    async def wallet_info(self) -> List[AccountInfo]:
+        result = self._write_command("wallet_info", [])['result']
+        return [AccountInfo(idx, name) for idx, name in enumerate(result['account_names'])]
 
     async def get_best_block_height(self) -> str:
         return str(self._write_command("wallet_best_block", [{}])['result']['height'])
@@ -137,8 +147,12 @@ class WalletRpcController:
         return self._write_command("wallet_best_block", [{}])['result']['id']
 
     async def create_new_account(self, name: Optional[str] = None) -> str:
-        self._write_command("account_create", [name, {}])
-        return "Success"
+        result = self._write_command("account_create", [name, {}])['result']
+        return f"Success, the new account index is: {result['account']}"
+
+    async def rename_account(self, name: Optional[str] = None) -> str:
+        self._write_command("account_rename", [self.account, name, {}])
+        return "Success, the account name has been successfully renamed"
 
     async def select_account(self, account_index: int) -> str:
         self.account = {'account': account_index}
@@ -247,6 +261,10 @@ class WalletRpcController:
 
     async def decommission_stake_pool(self, pool_id: str, address: str) -> str:
         self._write_command("staking_decommission_pool", [self.account, pool_id, address, {'in_top_x_mb': 5}])['result']
+        return "The transaction was submitted successfully"
+
+    async def submit_transaction(self, transaction: str, do_not_store: bool = False) -> str:
+        self._write_command(f"node_submit_transaction", [transaction, do_not_store, {}])['result']
         return "The transaction was submitted successfully"
 
     async def list_pool_ids(self) -> List[PoolData]:

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -129,6 +129,8 @@ BASE_SCRIPTS = [
     'p2p_relay_transactions.py',
     'feature_db_reinit.py',
     'feature_lmdb_backend_test.py',
+    'wallet_account_info.py',
+    'wallet_account_info_rpc.py',
     'wallet_conflict.py',
     'wallet_list_txs.py',
     'wallet_sign_message.py',

--- a/test/functional/wallet_account_info.py
+++ b/test/functional/wallet_account_info.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Wallet account info test
+
+Check that:
+* We can create a new wallet,
+* get an address
+* send coins to the wallet's address
+* sync the wallet with the node
+* check balance
+* create a new account
+* rename the account
+* get wallet info
+"""
+
+import json
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.mintlayer import (make_tx, reward_input, tx_input, ATOMS_PER_COIN)
+from test_framework.util import assert_in, assert_equal
+from test_framework.mintlayer import mintlayer_hash, block_input_data_obj
+from test_framework.wallet_cli_controller import WalletCliController
+
+import asyncio
+import sys
+import random
+import string
+
+
+class WalletAccountInfo(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.wallet_controller = WalletCliController
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        relay_fee_rate = random.randint(1, 100_000_000)
+        self.extra_args = [[
+            "--blockprod-min-peers-to-produce-blocks=0",
+            f"--min-tx-relay-fee-rate={relay_fee_rate}",
+        ]]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.sync_all(self.nodes[0:1])
+
+    def generate_block(self):
+        node = self.nodes[0]
+
+        block_input_data = { "PoW": { "reward_destination": "AnyoneCanSpend" } }
+        block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
+
+        # create a new block, taking transactions from mempool
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
+        node.chainstate_submit_block(block)
+        block_id = node.chainstate_best_block_id()
+
+        # Wait for mempool to sync
+        self.wait_until(lambda: node.mempool_local_best_block_id() == block_id, timeout = 5)
+
+        return block_id
+
+    def run_test(self):
+        if 'win32' in sys.platform:
+            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+        asyncio.run(self.async_test())
+
+    async def async_test(self):
+        node = self.nodes[0]
+        async with self.wallet_controller(node, self.config, self.log) as wallet:
+            # new wallet
+            await wallet.create_wallet()
+
+            # check it is on genesis
+            best_block_height = await wallet.get_best_block_height()
+            self.log.info(f"best block height = {best_block_height}")
+            assert_equal(best_block_height, '0')
+
+            # new address
+            pub_key_bytes = await wallet.new_public_key()
+            assert_equal(len(pub_key_bytes), 33)
+
+            # Get chain tip
+            tip_id = node.chainstate_best_block_id()
+            self.log.debug(f'Tip: {tip_id}')
+
+            # Submit a valid transaction
+            coins_to_send = random.randint(2, 100)
+            output = {
+                    'Transfer': [ { 'Coin': coins_to_send * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+            }
+            encoded_tx, tx_id = make_tx([reward_input(tip_id)], [output], 0)
+            assert_in("The transaction was submitted successfully", await wallet.submit_transaction(encoded_tx))
+
+            assert node.mempool_contains_tx(tx_id)
+
+            self.generate_block() # Block 1
+            assert not node.mempool_contains_tx(tx_id)
+
+            # sync the wallet
+            assert_in("Success", await wallet.sync())
+
+            acc1_name = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(random.randint(1, 5)))
+            assert_in("Success, the new account index is: 1", await wallet.create_new_account(acc1_name))
+
+            info = await wallet.wallet_info()
+            assert_equal(2, len(info))
+            assert_equal(info[0].index, 0)
+            assert_equal(info[0].name, None)
+            assert_equal(info[1].index, 1)
+            assert_equal(info[1].name, acc1_name)
+
+            acc0_name = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(random.randint(1, 5)))
+            assert_in("Success, the account name has been successfully renamed", await wallet.rename_account(acc0_name))
+
+            info = await wallet.wallet_info()
+            assert_equal(2, len(info))
+            assert_equal(info[0].index, 0)
+            assert_equal(info[0].name, acc0_name)
+            assert_equal(info[1].index, 1)
+            assert_equal(info[1].name, acc1_name)
+
+
+if __name__ == '__main__':
+    WalletAccountInfo().main()
+

--- a/test/functional/wallet_account_info_rpc.py
+++ b/test/functional/wallet_account_info_rpc.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Wallet account info test
+
+Check that:
+* We can create a new wallet,
+* get an address
+* send coins to the wallet's address
+* sync the wallet with the node
+* check balance
+* create a new account
+* rename the account
+* get wallet info
+"""
+
+from wallet_account_info import WalletAccountInfo
+from test_framework.wallet_rpc_controller import WalletRpcController
+import random
+
+class WalletAccountInfoRpc(WalletAccountInfo):
+
+    def set_test_params(self):
+        self.wallet_controller = WalletRpcController
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        relay_fee_rate = random.randint(1, 100_000_000)
+        self.extra_args = [[
+            "--blockprod-min-peers-to-produce-blocks=0",
+            f"--min-tx-relay-fee-rate={relay_fee_rate}",
+        ]]
+
+    def run_test(self):
+        super().run_test()
+
+
+if __name__ == '__main__':
+    WalletAccountInfoRpc().main()
+

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1936,10 +1936,10 @@ impl Account {
         &mut self,
         name: Option<String>,
         db_tx: &mut impl WalletStorageWriteLocked,
-    ) -> WalletResult<()> {
+    ) -> WalletResult<(U31, &Option<String>)> {
         self.account_info.set_name(name);
         db_tx.set_account(&self.get_account_id(), &self.account_info)?;
-        Ok(())
+        Ok((self.account_index(), self.name()))
     }
 
     pub fn get_created_blocks(&self) -> Vec<(BlockHeight, Id<GenBlock>, PoolId)> {

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1936,10 +1936,10 @@ impl Account {
         &mut self,
         name: Option<String>,
         db_tx: &mut impl WalletStorageWriteLocked,
-    ) -> WalletResult<(U31, &Option<String>)> {
+    ) -> WalletResult<()> {
         self.account_info.set_name(name);
         db_tx.set_account(&self.get_account_id(), &self.account_info)?;
-        Ok((self.account_index(), self.name()))
+        Ok(())
     }
 
     pub fn get_created_blocks(&self) -> Vec<(BlockHeight, Id<GenBlock>, PoolId)> {

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -794,7 +794,7 @@ impl<B: storage::Backend> Wallet<B> {
         name: Option<String>,
     ) -> WalletResult<(U31, Option<String>)> {
         self.for_account_rw(account_index, |acc, db_tx| {
-            acc.set_name(name, db_tx).map(|(index, name)| (index, name.clone()))
+            acc.set_name(name, db_tx).map(|()| (acc.account_index(), acc.name().clone()))
         })
     }
 

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -788,6 +788,16 @@ impl<B: storage::Backend> Wallet<B> {
         Ok((next_account_index, name))
     }
 
+    pub fn set_account_name(
+        &mut self,
+        account_index: U31,
+        name: Option<String>,
+    ) -> WalletResult<(U31, Option<String>)> {
+        self.for_account_rw(account_index, |acc, db_tx| {
+            acc.set_name(name, db_tx).map(|(index, name)| (index, name.clone()))
+        })
+    }
+
     pub fn database(&self) -> &Store<B> {
         &self.db
     }

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -202,6 +202,21 @@ where
                 })
             }
 
+            ColdWalletCommand::WalletInfo => {
+                let info = self.non_empty_wallet().await?.wallet_info().await?;
+                let names = info
+                    .account_names
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, name)| {
+                        let name = name.map_or("None".into(), |name| format!("\"{name}\""));
+                        format!("Account index: {idx}, Name: {name}")
+                    })
+                    .join("\n");
+
+                Ok(ConsoleCommand::Print(format!("Wallet Accounts:\n{names}")))
+            }
+
             ColdWalletCommand::EncryptPrivateKeys { password } => {
                 self.non_empty_wallet().await?.encrypt_private_keys(password).await?;
 
@@ -564,6 +579,16 @@ where
                         "Success, the new account index is: {}",
                         new_acc.account,
                     ),
+                })
+            }
+
+            WalletCommand::RenameAccount { name } => {
+                let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
+                wallet.rename_account(selected_account, name).await?;
+
+                Ok(ConsoleCommand::SetStatus {
+                    status: self.repl_status().await?,
+                    print_message: "Success, the account name has been successfully renamed".into(),
                 })
             }
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -254,8 +254,8 @@ pub enum WalletCommand {
     #[clap(name = "account-create")]
     CreateNewAccount { name: Option<String> },
 
-    /// Renames the selected account with an optional name, if the name is not specified it will
-    /// remove any existing name for the account.
+    /// Renames the selected account with an optional name.
+    /// If the name is not specified, it will remove any existing name for the account.
     #[clap(name = "account-rename")]
     RenameAccount { name: Option<String> },
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -73,6 +73,10 @@ pub enum ColdWalletCommand {
     #[clap(name = "wallet-close")]
     CloseWallet,
 
+    /// Check the current wallet's number of accounts and their names
+    #[clap(name = "wallet-info")]
+    WalletInfo,
+
     /// Encrypts the private keys with a new password, expects the wallet to be unlocked
     #[clap(name = "wallet-encrypt-private-keys")]
     EncryptPrivateKeys {
@@ -249,6 +253,11 @@ pub enum WalletCommand {
     /// Returns an error if the last created account does not have a transaction history.
     #[clap(name = "account-create")]
     CreateNewAccount { name: Option<String> },
+
+    /// Renames the selected account with an optional name, if the name is not specified it will
+    /// remove any existing name for the account.
+    #[clap(name = "account-rename")]
+    RenameAccount { name: Option<String> },
 
     /// Switch to a given wallet account.
     #[clap(name = "account-select")]

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -509,6 +509,16 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         self.wallet.create_next_account(name).map_err(ControllerError::WalletError)
     }
 
+    pub fn update_account_name(
+        &mut self,
+        account_index: U31,
+        name: Option<String>,
+    ) -> Result<(U31, Option<String>), ControllerError<T>> {
+        self.wallet
+            .set_account_name(account_index, name)
+            .map_err(ControllerError::WalletError)
+    }
+
     pub fn stop_staking(&mut self, account_index: U31) -> Result<(), ControllerError<T>> {
         log::info!("Stop staking, account_index: {}", account_index);
         self.staking_started.remove(&account_index);

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -230,6 +230,17 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 
+    async fn rename_account(
+        &self,
+        account_index: U31,
+        name: Option<String>,
+    ) -> Result<NewAccountInfo, Self::Error> {
+        self.wallet_rpc
+            .update_account_name(account_index, name)
+            .await
+            .map_err(WalletRpcHandlesClientError::WalletRpcError)
+    }
+
     async fn get_issued_addresses(
         &self,
         account_index: U31,

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -184,6 +184,16 @@ impl WalletInterface for ClientWalletRpc {
             .map_err(WalletRpcError::ResponseError)
     }
 
+    async fn rename_account(
+        &self,
+        account_index: U31,
+        name: Option<String>,
+    ) -> Result<NewAccountInfo, Self::Error> {
+        WalletRpcClient::rename_account(&self.http_client, account_index.into(), name, EmptyArgs {})
+            .await
+            .map_err(WalletRpcError::ResponseError)
+    }
+
     async fn get_issued_addresses(
         &self,
         account_index: U31,

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -96,6 +96,12 @@ pub trait WalletInterface {
 
     async fn create_account(&self, name: Option<String>) -> Result<NewAccountInfo, Self::Error>;
 
+    async fn rename_account(
+        &self,
+        account_index: U31,
+        name: Option<String>,
+    ) -> Result<NewAccountInfo, Self::Error>;
+
     async fn get_issued_addresses(
         &self,
         options: U31,

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -107,6 +107,14 @@ trait WalletRpc {
         options: EmptyArgs,
     ) -> rpc::RpcResult<NewAccountInfo>;
 
+    #[method(name = "account_rename")]
+    async fn rename_account(
+        &self,
+        account_index: AccountIndexArg,
+        name: Option<String>,
+        options: EmptyArgs,
+    ) -> rpc::RpcResult<NewAccountInfo>;
+
     #[method(name = "address_show")]
     async fn get_issued_addresses(
         &self,

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -201,6 +201,16 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         Ok(NewAccountInfo::new(num, name))
     }
 
+    pub async fn update_account_name(
+        &self,
+        account_index: U31,
+        name: Option<String>,
+    ) -> WRpcResult<NewAccountInfo, N> {
+        let (num, name) =
+            self.wallet.call(move |w| w.update_account_name(account_index, name)).await??;
+        Ok(NewAccountInfo::new(num, name))
+    }
+
     pub async fn issue_address(&self, account_index: U31) -> WRpcResult<AddressInfo, N> {
         let config = ControllerConfig { in_top_x_mb: 5 }; // irrelevant for issuing addresses
         let (child_number, destination) = self

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -167,6 +167,15 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         rpc::handle_result(self.create_account(name).await)
     }
 
+    async fn rename_account(
+        &self,
+        account_index: AccountIndexArg,
+        name: Option<String>,
+        _options: EmptyArgs,
+    ) -> rpc::RpcResult<NewAccountInfo> {
+        rpc::handle_result(self.update_account_name(account_index.index::<N>()?, name).await)
+    }
+
     async fn issue_address(&self, account_index: AccountIndexArg) -> rpc::RpcResult<AddressInfo> {
         rpc::handle_result(self.issue_address(account_index.index::<N>()?).await)
     }


### PR DESCRIPTION
- Add account-rename command to rename an existing account
- Add wallet-info command that returns the wallet's account names
- fix RPC wallet functional tests to start with different port