### PR TITLE
Fix waiting for CLI wallet to start

### DIFF
--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -100,7 +100,17 @@ class WalletCliController:
         )
 
         # read any initial input from the wallet
-        (await self._read_available_output(can_be_empty=True, timeout=0.1)).strip()
+        open_wallet = "--wallet-file" in self.wallet_args
+        num_acc_to_start_staking = sum([1 for arg in self.wallet_args if arg == "--start-staking-for-account"])
+        if open_wallet:
+            output = await self._read_available_output(can_be_empty=False)
+            # wait for the wallet to be loaded
+            while "Wallet loaded successfully" not in output:
+                output += await self._read_available_output(can_be_empty=False)
+
+            # wait for all the accounts to start staking
+            while output.count("Staking started successfully") != num_acc_to_start_staking:
+                output += await self._read_available_output(can_be_empty=False)
 
         return self
 

--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -26,6 +26,8 @@ from tempfile import NamedTemporaryFile
 
 from typing import Optional, List, Tuple, Union
 
+from test_framework.util import rpc_port
+
 ONE_MB = 2**20
 READ_TIMEOUT_SEC = 30
 DEFAULT_ACCOUNT_INDEX = 0
@@ -73,7 +75,7 @@ class WalletRpcController:
     async def __aenter__(self):
         cookie_file = os.path.join(self.node.datadir, ".cookie")
 
-        port = 23034 + int(self.node.url.split(':')[3])
+        port = rpc_port(10)
         url = "127.0.0.1"
         bind_addr = f"{url}:{port}"
         self.log.info(f"node url: {self.node.url}")


### PR DESCRIPTION
Wait for CLI wallet to open and start staking in the functional tests, before sending and reading output from commands