### PR TITLE
Support reorg in simulation test

### DIFF
--- a/chainstate/test-suite/src/tests/tx_verification_simulation.rs
+++ b/chainstate/test-suite/src/tests/tx_verification_simulation.rs
@@ -15,6 +15,7 @@
 
 use super::*;
 use chainstate_test_framework::TxVerificationStrategy;
+use common::primitives::Idable;
 
 #[rstest]
 #[trace]
@@ -41,5 +42,12 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
 
             block_builder.build_and_process().unwrap().unwrap();
         }
+        let best_block_id = tf.best_block_id();
+
+        // create longer chain to trigger reorg and disconnect all the random txs
+        let genesis = &tf.genesis().get_id().into();
+        let new_best_block_id = tf.create_chain(genesis, max_blocks, &mut rng).unwrap();
+        assert_ne!(best_block_id, tf.best_block_id());
+        assert_eq!(new_best_block_id, tf.best_block_id());
     });
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/pos_accounting_undo_cache/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/pos_accounting_undo_cache/mod.rs
@@ -130,9 +130,7 @@ impl PoSAccountingBlockUndoCache {
             Entry::Vacant(_) => fetcher_func(*tx_source)?,
             Entry::Occupied(entry) => match entry.get() {
                 CachedOperation::Write(undo) | CachedOperation::Read(undo) => Some(undo.clone()),
-                CachedOperation::Erase => panic!(
-                    "Attempt to undo pos a transaction for a block that has been fully disconnected."
-                ),
+                CachedOperation::Erase => None,
             },
         };
 

--- a/chainstate/tx-verifier/src/transaction_verifier/tokens_accounting_undo_cache/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tokens_accounting_undo_cache/mod.rs
@@ -103,9 +103,7 @@ impl TokensAccountingBlockUndoCache {
             Entry::Vacant(_) => fetcher_func(*tx_source)?,
             Entry::Occupied(entry) => match entry.get() {
                 CachedOperation::Write(undo) | CachedOperation::Read(undo) => Some(undo.clone()),
-                CachedOperation::Erase => panic!(
-                    "Attempt to undo tokens in a transaction for a block that has been fully disconnected."
-                ),
+                CachedOperation::Erase => None,
             },
         };
 


### PR DESCRIPTION
I chose the most straight-forward approach for reorgs which is after random chain is generated in simulation another longer chain is created from genesis. This will disconnect all random blocks and transactions ensuring it works correctly with all possible combinations.

Initially we discussed the approach with multiple branches but I don't see why it's beneficial given the complexity of such an implementation.