### PR TITLE
Fix unlocking of UTXOs in the API Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait",
  "bb8-postgres",
+ "chainstate",
  "chainstate-test-framework",
  "clap",
  "common",

--- a/api-server/api-server-common/Cargo.toml
+++ b/api-server/api-server-common/Cargo.toml
@@ -14,6 +14,7 @@ logging = { path = '../../logging'}
 pos-accounting = { path = '../../pos-accounting' }
 serialization = { path = "../../serialization" }
 mempool = { path = "../../mempool" }
+chainstate = { path = "../../chainstate" }
 
 async-trait.workspace = true
 bb8-postgres = "0.8"

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
@@ -139,6 +139,12 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRo<'t> {
         Ok(Some(self.transaction.get_storage_version()?))
     }
 
+    async fn get_latest_blocktimestamps(
+        &self,
+    ) -> Result<Vec<BlockTimestamp>, ApiServerStorageError> {
+        self.transaction.get_latest_blocktimestamps()
+    }
+
     async fn get_best_block(&self) -> Result<BlockAuxData, ApiServerStorageError> {
         self.transaction.get_best_block()
     }

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
@@ -277,6 +277,12 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRw<'t> {
         self.transaction.get_address_transactions(address)
     }
 
+    async fn get_latest_blocktimestamps(
+        &self,
+    ) -> Result<Vec<BlockTimestamp>, ApiServerStorageError> {
+        self.transaction.get_latest_blocktimestamps()
+    }
+
     async fn get_best_block(&self) -> Result<BlockAuxData, ApiServerStorageError> {
         self.transaction.get_best_block()
     }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
@@ -84,6 +84,15 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
         Ok(res)
     }
 
+    async fn get_latest_blocktimestamps(
+        &self,
+    ) -> Result<Vec<BlockTimestamp>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_latest_blocktimestamps().await?;
+
+        Ok(res)
+    }
+
     async fn get_best_block(&self) -> Result<BlockAuxData, ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_best_block().await?;

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
@@ -359,6 +359,15 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
         Ok(res)
     }
 
+    async fn get_latest_blocktimestamps(
+        &self,
+    ) -> Result<Vec<BlockTimestamp>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_latest_blocktimestamps().await?;
+
+        Ok(res)
+    }
+
     async fn get_best_block(&self) -> Result<BlockAuxData, ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_best_block().await?;

--- a/api-server/api-server-common/src/storage/storage_api/mod.rs
+++ b/api-server/api-server-common/src/storage/storage_api/mod.rs
@@ -293,6 +293,10 @@ pub trait ApiServerStorageRead: Sync {
 
     async fn get_best_block(&self) -> Result<BlockAuxData, ApiServerStorageError>;
 
+    async fn get_latest_blocktimestamps(
+        &self,
+    ) -> Result<Vec<BlockTimestamp>, ApiServerStorageError>;
+
     async fn get_block(
         &self,
         block_id: Id<Block>,

--- a/api-server/storage-test-suite/src/basic.rs
+++ b/api-server/storage-test-suite/src/basic.rs
@@ -117,6 +117,9 @@ where
             chain_config.genesis_block().timestamp()
         );
 
+        let timestamps = db_tx.get_latest_blocktimestamps().await.unwrap();
+        assert_eq!(timestamps, vec![chain_config.genesis_block().timestamp()]);
+
         {
             let random_block_id: Id<Block> = Id::<Block>::new(H256::random_using(&mut rng));
             let block = db_tx.get_block(random_block_id).await.unwrap();

--- a/chainstate/src/detail/median_time.rs
+++ b/chainstate/src/detail/median_time.rs
@@ -23,7 +23,7 @@ use common::{
 
 use chainstate_types::BlockIndexHistoryIterator;
 
-const MEDIAN_TIME_SPAN: usize = 11;
+pub const MEDIAN_TIME_SPAN: usize = 11;
 
 #[must_use]
 pub fn calculate_median_time_past<H: BlockIndexHandle>(
@@ -31,11 +31,14 @@ pub fn calculate_median_time_past<H: BlockIndexHandle>(
     starting_block: &Id<GenBlock>,
 ) -> BlockTimestamp {
     let iter = BlockIndexHistoryIterator::new(*starting_block, block_index_handle);
-    let time_values = iter
-        .take(MEDIAN_TIME_SPAN)
-        .map(|bi| bi.block_timestamp())
-        .sorted()
-        .collect::<Vec<_>>();
+    calculate_median_time_past_from_blocktimestamps(iter.map(|bi| bi.block_timestamp()))
+}
+
+#[must_use]
+pub fn calculate_median_time_past_from_blocktimestamps<I: Iterator<Item = BlockTimestamp>>(
+    blocktimestamps: I,
+) -> BlockTimestamp {
+    let time_values = blocktimestamps.take(MEDIAN_TIME_SPAN).sorted().collect::<Vec<_>>();
 
     time_values[time_values.len() / 2]
 }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -64,7 +64,10 @@ use utils::{
 };
 use utxo::UtxosDB;
 
-pub use self::{error::*, info::ChainInfo, median_time::calculate_median_time_past};
+pub use self::{
+    error::*, info::ChainInfo, median_time::calculate_median_time_past,
+    median_time::calculate_median_time_past_from_blocktimestamps, median_time::MEDIAN_TIME_SPAN,
+};
 pub use chainstate_types::Locator;
 pub use error::{
     BlockError, CheckBlockError, CheckBlockTransactionsError, DbCommittingContext,

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -35,10 +35,11 @@ pub use crate::{
     config::{ChainstateConfig, MaxTipAge},
     detail::{
         ban_score, block_invalidation::BlockInvalidatorError, calculate_median_time_past,
-        BlockError, BlockSource, ChainInfo, CheckBlockError, CheckBlockTransactionsError,
-        ConnectTransactionError, IOPolicyError, InitializationError, Locator, OrphanCheckError,
-        SpendStakeError, StorageCompatibilityCheckError, TokenIssuanceError, TokensError,
-        TransactionVerifierStorageError,
+        calculate_median_time_past_from_blocktimestamps, BlockError, BlockSource, ChainInfo,
+        CheckBlockError, CheckBlockTransactionsError, ConnectTransactionError, IOPolicyError,
+        InitializationError, Locator, OrphanCheckError, SpendStakeError,
+        StorageCompatibilityCheckError, TokenIssuanceError, TokensError,
+        TransactionVerifierStorageError, MEDIAN_TIME_SPAN,
     },
 };
 pub use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};


### PR DESCRIPTION
- use the median time when unlocking time locked UTXOs
- add test with locked UTXOs and reorg
- fix handling of locked outputs that are already unlocked when included