### PR TITLE
Enforce all rules of clippy with errors

### DIFF
--- a/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
@@ -223,7 +223,13 @@ impl ApiServerInMemoryStorage {
             .main_chain_blocks_table
             .iter()
             .rev()
-            .map(|(_, id)| self.block_table.get(id).unwrap().block.timestamp())
+            .map(|(_, id)| {
+                self.block_table
+                    .get(id)
+                    .expect("Block id must be present in block_table")
+                    .block
+                    .timestamp()
+            })
             .chain(std::iter::once(self.genesis_block.timestamp()))
             .take(chainstate::MEDIAN_TIME_SPAN)
             .collect())

--- a/do_checks.sh
+++ b/do_checks.sh
@@ -15,24 +15,24 @@ cargo clippy --all-features --workspace --all-targets -- \
     -D warnings \
     -A clippy::unnecessary_literal_unwrap \
     -A clippy::new_without_default \
-    -W clippy::implicit_saturating_sub \
-    -W clippy::implicit_clone \
-    -W clippy::map_unwrap_or \
-    -W clippy::unnested_or_patterns \
-    -W clippy::manual_assert \
-    -W clippy::unused_async \
-    -W clippy::mut_mut \
-    -W clippy::todo
+    -D clippy::implicit_saturating_sub \
+    -D clippy::implicit_clone \
+    -D clippy::map_unwrap_or \
+    -D clippy::unnested_or_patterns \
+    -D clippy::manual_assert \
+    -D clippy::unused_async \
+    -D clippy::mut_mut \
+    -D clippy::todo
 
 # Checks that only apply to production code
 cargo clippy --all-features --workspace --lib --bins --examples -- \
     -A clippy::all \
     -D clippy::float_arithmetic \
-    -W clippy::unwrap_used \
-    -W clippy::dbg_macro \
-    -W clippy::items_after_statements \
-    -W clippy::fallible_impl_from \
-    -W clippy::string_slice
+    -D clippy::unwrap_used \
+    -D clippy::dbg_macro \
+    -D clippy::items_after_statements \
+    -D clippy::fallible_impl_from \
+    -D clippy::string_slice
 
 # Install requirements with: pip install -r ./build-tools/codecheck/requirements.txt
 "$PYTHON" "$SCRIPT_DIR/build-tools/codecheck/codecheck.py"

--- a/utils/networking/src/network_address.rs
+++ b/utils/networking/src/network_address.rs
@@ -224,6 +224,8 @@ impl FromStr for NetworkAddressWithOptionalPort {
         // either 'NotIpAddressOrDomainName("[1")' or 'BadPortNumber("2:3:4:5:6:7:8]")'.
         // The former looks too cryptic, so we choose the latter.
         let port = if let Some(pos) = separator_pos {
+            // Note: the position "pos + separator_len" is guaranteed to be at a character boundary.
+            #[allow(clippy::string_slice)]
             let port_str = &s[pos + separator_len..];
             let port: u16 = port_str
                 .parse()
@@ -233,6 +235,8 @@ impl FromStr for NetworkAddressWithOptionalPort {
             None
         };
 
+        // Note: the position "separator_pos" is guaranteed to be at a character boundary.
+        #[allow(clippy::string_slice)]
         let addr_str = &s[..separator_pos.unwrap_or(s.len())];
         let address: NetworkAddress = addr_str.parse()?;
 

--- a/utils/networking/src/network_address_tests.rs
+++ b/utils/networking/src/network_address_tests.rs
@@ -156,6 +156,10 @@ fn network_address_with_optional_port_printing_parsing_with_port() {
         NetworkAddressParseError::BadPortNumber("foo".to_owned())
     );
 
+    // Ipv4 address with an empty port
+    let err = "1.2.3.4:".parse::<NetworkAddressWithOptionalPort>().unwrap_err();
+    assert_eq!(err, NetworkAddressParseError::BadPortNumber("".to_owned()));
+
     // Ipv4 address with a port out of range
     let err = "1.2.3.4:65536".parse::<NetworkAddressWithOptionalPort>().unwrap_err();
     assert_eq!(
@@ -180,6 +184,10 @@ fn network_address_with_optional_port_printing_parsing_with_port() {
         err,
         NetworkAddressParseError::BadPortNumber("foo".to_owned())
     );
+
+    // Ipv6 address with an empty port
+    let err = "[1:2:3:4:5:6:7:8]:".parse::<NetworkAddressWithOptionalPort>().unwrap_err();
+    assert_eq!(err, NetworkAddressParseError::BadPortNumber("".to_owned()));
 
     // Ipv6 address with a port out of range
     let err = "[1:2:3:4:5:6:7:8]:65536".parse::<NetworkAddressWithOptionalPort>().unwrap_err();
@@ -275,6 +283,10 @@ fn network_address_with_port_printing_parsing_with_port() {
         NetworkAddressParseError::BadPortNumber("foo".to_owned())
     );
 
+    // Ipv4 address with an empty port
+    let err = "1.2.3.4:".parse::<NetworkAddressWithPort>().unwrap_err();
+    assert_eq!(err, NetworkAddressParseError::BadPortNumber("".to_owned()));
+
     // Ipv4 address with a port out of range
     let err = "1.2.3.4:65536".parse::<NetworkAddressWithPort>().unwrap_err();
     assert_eq!(
@@ -299,6 +311,10 @@ fn network_address_with_port_printing_parsing_with_port() {
         err,
         NetworkAddressParseError::BadPortNumber("foo".to_owned())
     );
+
+    // Ipv6 address with an empty port
+    let err = "[1:2:3:4:5:6:7:8]:".parse::<NetworkAddressWithPort>().unwrap_err();
+    assert_eq!(err, NetworkAddressParseError::BadPortNumber("".to_owned()));
 
     // Ipv6 address with a port out of range
     let err = "[1:2:3:4:5:6:7:8]:65536".parse::<NetworkAddressWithPort>().unwrap_err();


### PR DESCRIPTION
Using only warnings is causing rules slipping