### PR TITLE
Make cargo-deny install from locked crates

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Install rust clippy
         run: rustup component add clippy
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        run: cargo install cargo-deny --locked
       - name: Run checks
         run: ./do_checks.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,7 +65,7 @@ build:cargo:
 test:cargo_deny:
   stage: test_cargo_deny
   script:
-    - cargo install cargo-deny
+    - cargo install cargo-deny --locked
     - cargo deny check advisories licenses
 
 test:func:


### PR DESCRIPTION
This fixes a CI issue and reduces the likelihood that this happens again