### PR TITLE
wallet-rpc: Make command line args consistent with other executables

### DIFF
--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -80,7 +80,7 @@ class WalletRpcController:
         bind_addr = f"{url}:{port}"
         self.log.info(f"node url: {self.node.url}")
         wallet_rpc = os.path.join(self.config["environment"]["BUILDDIR"], "test_rpc_wallet"+self.config["environment"]["EXEEXT"] )
-        wallet_args = ["--chain-type", "regtest", "--node-rpc-address", self.node.url.split("@")[1], "--node-cookie-file", cookie_file, "--rpc-bind-address", bind_addr, "--rpc-no-authentication"] + self.wallet_args + self.chain_config_args
+        wallet_args = ["regtest", "--node-rpc-address", self.node.url.split("@")[1], "--node-cookie-file", cookie_file, "--rpc-bind-address", bind_addr, "--rpc-no-authentication"] + self.wallet_args + self.chain_config_args
         self.wallet_log_file = NamedTemporaryFile(prefix="wallet_stderr_rpc_", dir=os.path.dirname(self.node.datadir), delete=False)
         self.wallet_commands_file = NamedTemporaryFile(prefix="wallet_commands_responses_rpc_", dir=os.path.dirname(self.node.datadir), delete=False)
 

--- a/wallet/wallet-rpc-lib/src/config.rs
+++ b/wallet/wallet-rpc-lib/src/config.rs
@@ -45,19 +45,18 @@ impl WalletServiceConfig {
         chain_type: ChainType,
         wallet_file: Option<PathBuf>,
         start_staking_for_account: Vec<U31>,
-        chain_config_options: ChainConfigOptions,
-    ) -> anyhow::Result<Self> {
-        let chain_config = match chain_type {
-            ChainType::Regtest => Arc::new(regtest_chain_config(&chain_config_options)?),
-            _ => Arc::new(common::chain::config::Builder::new(chain_type).build()),
-        };
-        Ok(Self {
-            chain_config,
+    ) -> Self {
+        Self {
+            chain_config: Arc::new(common::chain::config::Builder::new(chain_type).build()),
             wallet_file,
             start_staking_for_account,
             node_rpc_address: None,
             node_credentials: RpcAuthData::None,
-        })
+        }
+    }
+
+    pub fn with_regtest_options(self, options: ChainConfigOptions) -> anyhow::Result<Self> {
+        Ok(self.with_custom_chain_config(Arc::new(regtest_chain_config(&options)?)))
     }
 
     pub fn with_custom_chain_config(mut self, chain_config: Arc<ChainConfig>) -> Self {

--- a/wallet/wallet-rpc-lib/tests/utils.rs
+++ b/wallet/wallet-rpc-lib/tests/utils.rs
@@ -103,16 +103,12 @@ impl TestFramework {
 
         // Start the wallet service
         let (wallet_service, rpc_server) = {
-            let ws_config = WalletServiceConfig::new(
-                chain_type,
-                Some(wallet_path),
-                vec![],
-                chain_config_options,
-            )
-            .unwrap()
-            .with_custom_chain_config(chain_config)
-            .with_node_rpc_address(node_rpc_addr.to_string())
-            .with_username_and_password(RPC_USERNAME.to_string(), RPC_PASSWORD.to_string());
+            let ws_config = WalletServiceConfig::new(chain_type, Some(wallet_path), vec![])
+                .with_regtest_options(chain_config_options)
+                .unwrap()
+                .with_custom_chain_config(chain_config)
+                .with_node_rpc_address(node_rpc_addr.to_string())
+                .with_username_and_password(RPC_USERNAME.to_string(), RPC_PASSWORD.to_string());
             let bind_addr = "127.0.0.1:0".parse().unwrap();
             let rpc_config = wallet_rpc_lib::config::WalletRpcConfig {
                 bind_addr,


### PR DESCRIPTION
Network type is a subcommand rather than a switch like in other tools like the node binary etc.