### PR TITLE
remove pool and delegation balances from addr balances

### DIFF
--- a/api-server/scanner-lib/src/blockchain_state/adapter.rs
+++ b/api-server/scanner-lib/src/blockchain_state/adapter.rs
@@ -72,10 +72,6 @@ impl PoSAdapter {
         }
     }
 
-    pub fn get_pool_reward(&self, pool_id: PoolId) -> Amount {
-        self.pool_rewards.get(&pool_id).copied().unwrap_or(Amount::ZERO)
-    }
-
     pub fn rewards_per_delegation(&self) -> &Vec<(DelegationId, Amount)> {
         &self.delegation_rewards
     }


### PR DESCRIPTION
Don't increase or decrease the address balances of pool and delegation decommission keys.