### PR TITLE
Include caller info in tap_error_log's messages

### DIFF
--- a/utils/build.rs
+++ b/utils/build.rs
@@ -18,6 +18,13 @@ use std::path::{PathBuf, MAIN_SEPARATOR};
 fn main() {
     let manifest_dir =
         std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is missing or invalid");
+    // Note: there is no point in allowing non-utf-8 strings here, because we won't be able
+    // to propagate them further anyway.
+    // Also note that if we tried accessing CARGO_MANIFEST_DIR directly from the code via env!
+    // and it wasn't Unicode, the compilation would fail anyway, complaining that the env var
+    // is not defined.
+    let manifest_dir = manifest_dir.to_str().expect("CARGO_MANIFEST_DIR is not a Unicode string");
+
     let ws_root_dir = {
         let mut path_buf = PathBuf::new();
         path_buf.push(manifest_dir);
@@ -27,7 +34,7 @@ fn main() {
 
     println!(
         "cargo:rustc-env=WORKSPACE_PATH={}{}",
-        ws_root_dir.to_string_lossy(),
+        ws_root_dir.to_str().expect("ws_root_dir must be Unicode"),
         MAIN_SEPARATOR
     );
 }

--- a/utils/build.rs
+++ b/utils/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 RBB S.r.l
+// Copyright (c) 2021-2024 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,30 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod array_2d;
-pub mod atomics;
-pub mod blockuntilzero;
-pub mod bloom_filters;
-pub mod clap_utils;
-pub mod config_setting;
-pub mod const_value;
-pub mod cookie;
-pub mod counttracker;
-pub mod default_data_dir;
-pub mod ensure;
-pub mod eventhandler;
-pub mod exp_rand;
-pub mod graph_traversals;
-pub mod maybe_encrypted;
-pub mod newtype;
-pub mod once_destructor;
-pub mod qrcode;
-pub mod rust_backtrace;
-pub mod set_flag;
-pub mod shallow_clone;
-pub mod tap_error_log;
-pub mod try_as;
-pub mod workspace_path;
+use std::path::{PathBuf, MAIN_SEPARATOR};
 
-mod concurrency_impl;
-pub use concurrency_impl::*;
+fn main() {
+    let manifest_dir =
+        std::env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is missing or invalid");
+    let ws_root_dir = {
+        let mut path_buf = PathBuf::new();
+        path_buf.push(manifest_dir);
+        path_buf.pop();
+        path_buf
+    };
+
+    println!(
+        "cargo:rustc-env=WORKSPACE_PATH={}{}",
+        ws_root_dir.to_string_lossy(),
+        MAIN_SEPARATOR
+    );
+}

--- a/utils/src/workspace_path.rs
+++ b/utils/src/workspace_path.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Return the path to the workspace, as it was recorded on the build machine. The path has
+/// a trailing path separator.
+///
+/// Note that the path is produced by the build script using PathBuf::to_string_lossy, so if it
+/// contained non-Unicode characters, this value will be an approximation rather than the exact
+/// path itself.
+pub fn workspace_path() -> &'static str {
+    env!("WORKSPACE_PATH")
+}
+
+/// Given a path to a source file, such as one obtained from std::panic::Location::file(),
+/// try to make it relative to the workspace; if that is impossible for any reason,
+/// return the original path.
+///
+/// The purpose of this function is to shorten file paths before printing them to the log.
+pub fn relative_src_file_path(src_file_path: &str) -> &str {
+    // Note: the passed path may have been retrieved from std::panic::Location; if so,
+    // it's not suitable for passing to Path::new (according to the docs), so we avoid that.
+    src_file_path.strip_prefix(workspace_path()).unwrap_or(src_file_path)
+}


### PR DESCRIPTION
Here `tap_error_log::LogError`'s function use `#[track_caller]` to get the location of their call and print it to the log as well.

An example of the output (to get it, I simulated a `BlockError::BlockAlreadyExists` error for 0-id block):
```
2024-02-28T08:24:14.309088Z ERROR process_block{block_id=4cbc…7c6d}: LogError: Block 0000…0000 already exists (chainstate/src/detail/mod.rs:404:10)
```

Here the `process_block{block_id=4cbc…7c6d}` part comes from `tracing::instrument` (PR #1600) and `(chainstate/src/detail/mod.rs:404:10)` is the caller location info that this PR adds.

P.S. in order to shorten the paths (make them relative to the workspace dir), I had to introduce a build script in `utils`, where I obtain the workspace dir.