### PR TITLE
wallet-rpc: Change format for passing an account to RPC

### DIFF
--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -144,17 +144,17 @@ class WalletRpcController:
         return [AccountInfo(idx, name) for idx, name in enumerate(result['account_names'])]
 
     async def get_best_block_height(self) -> str:
-        return str(self._write_command("wallet_best_block", [{}])['result']['height'])
+        return str(self._write_command("wallet_best_block", [])['result']['height'])
 
     async def get_best_block(self) -> str:
-        return self._write_command("wallet_best_block", [{}])['result']['id']
+        return self._write_command("wallet_best_block", [])['result']['id']
 
     async def create_new_account(self, name: Optional[str] = None) -> str:
-        result = self._write_command("account_create", [name, {}])['result']
+        result = self._write_command("account_create", [name])['result']
         return f"Success, the new account index is: {result['account']}"
 
     async def rename_account(self, name: Optional[str] = None) -> str:
-        self._write_command("account_rename", [self.account, name, {}])
+        self._write_command("account_rename", [self.account, name])
         return "Success, the account name has been successfully renamed"
 
     async def select_account(self, account_index: int) -> str:

--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -70,7 +70,7 @@ class WalletRpcController:
         self.config = config
         self.wallet_args = [arg for arg in wallet_args if arg != "--wallet-file"]
         self.chain_config_args = chain_config_args
-        self.account = {'account': DEFAULT_ACCOUNT_INDEX}
+        self.account = DEFAULT_ACCOUNT_INDEX
 
     async def __aenter__(self):
         cookie_file = os.path.join(self.node.datadir, ".cookie")
@@ -158,7 +158,7 @@ class WalletRpcController:
         return "Success, the account name has been successfully renamed"
 
     async def select_account(self, account_index: int) -> str:
-        self.account = {'account': account_index}
+        self.account = account_index
         return "Success"
 
     async def new_public_key(self) -> bytes:

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -37,10 +37,9 @@ use wallet_controller::{
 use wallet_rpc_lib::{
     types::{
         AddressInfo, AddressWithUsageInfo, BlockInfo, ComposedTransaction, CreatedWallet,
-        DelegationInfo, EmptyArgs, LegacyVrfPublicKeyInfo, NewAccountInfo, NewDelegation,
-        NewTransaction, NftMetadata, NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId,
-        StakePoolBalance, StakingStatus, TokenMetadata, TransactionOptions, TxOptionsOverrides,
-        VrfPublicKeyInfo,
+        DelegationInfo, LegacyVrfPublicKeyInfo, NewAccountInfo, NewDelegation, NewTransaction,
+        NftMetadata, NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId, StakePoolBalance,
+        StakingStatus, TokenMetadata, TransactionOptions, TxOptionsOverrides, VrfPublicKeyInfo,
     },
     WalletRpcClient,
 };
@@ -177,13 +176,13 @@ impl WalletInterface for ClientWalletRpc {
     }
 
     async fn best_block(&self) -> Result<BlockInfo, Self::Error> {
-        WalletRpcClient::best_block(&self.http_client, EmptyArgs {})
+        WalletRpcClient::best_block(&self.http_client)
             .await
             .map_err(WalletRpcError::ResponseError)
     }
 
     async fn create_account(&self, name: Option<String>) -> Result<NewAccountInfo, Self::Error> {
-        WalletRpcClient::create_account(&self.http_client, name, EmptyArgs {})
+        WalletRpcClient::create_account(&self.http_client, name)
             .await
             .map_err(WalletRpcError::ResponseError)
     }
@@ -193,7 +192,7 @@ impl WalletInterface for ClientWalletRpc {
         account_index: U31,
         name: Option<String>,
     ) -> Result<NewAccountInfo, Self::Error> {
-        WalletRpcClient::rename_account(&self.http_client, account_index.into(), name, EmptyArgs {})
+        WalletRpcClient::rename_account(&self.http_client, account_index.into(), name)
             .await
             .map_err(WalletRpcError::ResponseError)
     }

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -28,7 +28,7 @@ use wallet_types::with_locked::WithLocked;
 
 use crate::types::{
     AccountArg, AddressInfo, AddressWithUsageInfo, Balances, ComposedTransaction, CreatedWallet,
-    DecimalAmount, DelegationInfo, EmptyArgs, HexEncoded, JsonValue, LegacyVrfPublicKeyInfo,
+    DecimalAmount, DelegationInfo, HexEncoded, JsonValue, LegacyVrfPublicKeyInfo,
     MaybeSignedTransaction, NewAccountInfo, NewDelegation, NewTransaction, NftMetadata,
     NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId, StakePoolBalance, StakingStatus,
     TokenMetadata, TransactionOptions, TxOptionsOverrides, VrfPublicKeyInfo,
@@ -37,7 +37,7 @@ use crate::types::{
 #[rpc::rpc(server)]
 trait WalletEventsRpc {
     #[subscription(name = "subscribe_wallet_events", item = Event)]
-    async fn subscribe_wallet_events(&self, options: EmptyArgs) -> rpc::subscription::Reply;
+    async fn subscribe_wallet_events(&self) -> rpc::subscription::Reply;
 }
 
 #[rpc::rpc(server, client)]
@@ -98,21 +98,16 @@ trait WalletRpc {
     async fn lock_private_key_encryption(&self) -> rpc::RpcResult<()>;
 
     #[method(name = "wallet_best_block")]
-    async fn best_block(&self, options: EmptyArgs) -> rpc::RpcResult<BlockInfo>;
+    async fn best_block(&self) -> rpc::RpcResult<BlockInfo>;
 
     #[method(name = "account_create")]
-    async fn create_account(
-        &self,
-        name: Option<String>,
-        options: EmptyArgs,
-    ) -> rpc::RpcResult<NewAccountInfo>;
+    async fn create_account(&self, name: Option<String>) -> rpc::RpcResult<NewAccountInfo>;
 
     #[method(name = "account_rename")]
     async fn rename_account(
         &self,
         account: AccountArg,
         name: Option<String>,
-        options: EmptyArgs,
     ) -> rpc::RpcResult<NewAccountInfo>;
 
     #[method(name = "address_show")]

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -27,10 +27,10 @@ use wallet_controller::{
 use wallet_types::with_locked::WithLocked;
 
 use crate::types::{
-    AccountIndexArg, AddressInfo, AddressWithUsageInfo, Balances, ComposedTransaction,
-    CreatedWallet, DecimalAmount, DelegationInfo, EmptyArgs, HexEncoded, JsonValue,
-    LegacyVrfPublicKeyInfo, MaybeSignedTransaction, NewAccountInfo, NewDelegation, NewTransaction,
-    NftMetadata, NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId, StakePoolBalance, StakingStatus,
+    AccountArg, AddressInfo, AddressWithUsageInfo, Balances, ComposedTransaction, CreatedWallet,
+    DecimalAmount, DelegationInfo, EmptyArgs, HexEncoded, JsonValue, LegacyVrfPublicKeyInfo,
+    MaybeSignedTransaction, NewAccountInfo, NewDelegation, NewTransaction, NftMetadata,
+    NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId, StakePoolBalance, StakingStatus,
     TokenMetadata, TransactionOptions, TxOptionsOverrides, VrfPublicKeyInfo,
 };
 
@@ -110,7 +110,7 @@ trait WalletRpc {
     #[method(name = "account_rename")]
     async fn rename_account(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         name: Option<String>,
         options: EmptyArgs,
     ) -> rpc::RpcResult<NewAccountInfo>;
@@ -118,28 +118,28 @@ trait WalletRpc {
     #[method(name = "address_show")]
     async fn get_issued_addresses(
         &self,
-        options: AccountIndexArg,
+        account: AccountArg,
     ) -> rpc::RpcResult<Vec<AddressWithUsageInfo>>;
 
     #[method(name = "address_new")]
-    async fn issue_address(&self, account_index: AccountIndexArg) -> rpc::RpcResult<AddressInfo>;
+    async fn issue_address(&self, account: AccountArg) -> rpc::RpcResult<AddressInfo>;
 
     #[method(name = "address_reveal_public_key")]
     async fn reveal_public_key(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         address: String,
     ) -> rpc::RpcResult<PublicKeyInfo>;
 
     #[method(name = "account_balance")]
     async fn get_balance(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         with_locked: Option<WithLocked>,
     ) -> rpc::RpcResult<Balances>;
 
     #[method(name = "account_utxos")]
-    async fn get_utxos(&self, account_index: AccountIndexArg) -> rpc::RpcResult<Vec<JsonValue>>;
+    async fn get_utxos(&self, account: AccountArg) -> rpc::RpcResult<Vec<JsonValue>>;
 
     #[method(name = "node_submit_transaction")]
     async fn submit_raw_transaction(
@@ -152,7 +152,7 @@ trait WalletRpc {
     #[method(name = "address_send")]
     async fn send_coins(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         address: String,
         amount: DecimalAmount,
         selected_utxos: Vec<UtxoOutPoint>,
@@ -162,7 +162,7 @@ trait WalletRpc {
     #[method(name = "transaction_create_from_cold_input")]
     async fn transaction_from_cold_input(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         address: String,
         amount_str: DecimalAmount,
         selected_utxo: UtxoOutPoint,
@@ -177,7 +177,7 @@ trait WalletRpc {
     #[method(name = "staking_create_pool")]
     async fn create_stake_pool(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         amount: DecimalAmount,
         cost_per_block: DecimalAmount,
         margin_ratio_per_thousand: String,
@@ -188,7 +188,7 @@ trait WalletRpc {
     #[method(name = "staking_decommission_pool")]
     async fn decommission_stake_pool(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         pool_id: String,
         output_address: Option<String>,
         options: TransactionOptions,
@@ -197,7 +197,7 @@ trait WalletRpc {
     #[method(name = "staking_decommission_pool_request")]
     async fn decommission_stake_pool_request(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         pool_id: String,
         output_address: Option<String>,
         options: TransactionOptions,
@@ -206,7 +206,7 @@ trait WalletRpc {
     #[method(name = "delegation_create")]
     async fn create_delegation(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         address: String,
         pool_id: String,
         options: TransactionOptions,
@@ -215,7 +215,7 @@ trait WalletRpc {
     #[method(name = "delegation_stake")]
     async fn delegate_staking(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         amount: DecimalAmount,
         delegation_id: String,
         options: TransactionOptions,
@@ -224,7 +224,7 @@ trait WalletRpc {
     #[method(name = "delegation_withdraw")]
     async fn withdraw_from_delegation(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         address: String,
         amount: DecimalAmount,
         delegation_id: String,
@@ -232,55 +232,49 @@ trait WalletRpc {
     ) -> rpc::RpcResult<NewTransaction>;
 
     #[method(name = "staking_start")]
-    async fn start_staking(&self, account_index: AccountIndexArg) -> rpc::RpcResult<()>;
+    async fn start_staking(&self, account: AccountArg) -> rpc::RpcResult<()>;
 
     #[method(name = "staking_stop")]
-    async fn stop_staking(&self, account_index: AccountIndexArg) -> rpc::RpcResult<()>;
+    async fn stop_staking(&self, account: AccountArg) -> rpc::RpcResult<()>;
 
     #[method(name = "staking_status")]
-    async fn staking_status(&self, account_index: AccountIndexArg)
-        -> rpc::RpcResult<StakingStatus>;
+    async fn staking_status(&self, account: AccountArg) -> rpc::RpcResult<StakingStatus>;
 
     #[method(name = "staking_list_pool_ids")]
-    async fn list_pool_ids(&self, account_index: AccountIndexArg) -> rpc::RpcResult<Vec<PoolInfo>>;
+    async fn list_pool_ids(&self, account: AccountArg) -> rpc::RpcResult<Vec<PoolInfo>>;
 
     #[method(name = "staking_pool_balance")]
     async fn stake_pool_balance(&self, pool_id: String) -> rpc::RpcResult<StakePoolBalance>;
 
     #[method(name = "delegation_list_ids")]
-    async fn list_delegation_ids(
-        &self,
-        account_index: AccountIndexArg,
-    ) -> rpc::RpcResult<Vec<DelegationInfo>>;
+    async fn list_delegation_ids(&self, account: AccountArg)
+        -> rpc::RpcResult<Vec<DelegationInfo>>;
 
     #[method(name = "staking_list_created_block_ids")]
     async fn list_created_blocks_ids(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
     ) -> rpc::RpcResult<Vec<CreatedBlockInfo>>;
 
     #[method(name = "staking_new_vrf_public_key")]
-    async fn new_vrf_public_key(
-        &self,
-        account_index: AccountIndexArg,
-    ) -> rpc::RpcResult<VrfPublicKeyInfo>;
+    async fn new_vrf_public_key(&self, account: AccountArg) -> rpc::RpcResult<VrfPublicKeyInfo>;
 
     #[method(name = "staking_show_legacy_vrf_key")]
     async fn get_legacy_vrf_public_key(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
     ) -> rpc::RpcResult<LegacyVrfPublicKeyInfo>;
 
     #[method(name = "staking_show_vrf_public_keys")]
     async fn get_vrf_public_key(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
     ) -> rpc::RpcResult<Vec<VrfPublicKeyInfo>>;
 
     #[method(name = "token_nft_issue_new")]
     async fn issue_new_nft(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         destination_address: String,
         metadata: NftMetadata,
         options: TransactionOptions,
@@ -289,7 +283,7 @@ trait WalletRpc {
     #[method(name = "token_issue_new")]
     async fn issue_new_token(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         destination_address: String,
         metadata: TokenMetadata,
         options: TransactionOptions,
@@ -298,7 +292,7 @@ trait WalletRpc {
     #[method(name = "token_change_authority")]
     async fn change_token_authority(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         token_id: String,
         address: String,
         options: TransactionOptions,
@@ -307,7 +301,7 @@ trait WalletRpc {
     #[method(name = "token_mint")]
     async fn mint_tokens(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         token_id: String,
         address: String,
         amount: DecimalAmount,
@@ -317,7 +311,7 @@ trait WalletRpc {
     #[method(name = "token_unmint")]
     async fn unmint_tokens(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         token_id: String,
         amount: DecimalAmount,
         options: TransactionOptions,
@@ -326,7 +320,7 @@ trait WalletRpc {
     #[method(name = "token_lock_supply")]
     async fn lock_token_supply(
         &self,
-        account_index: AccountIndexArg,
+        account_index: AccountArg,
         token_id: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
@@ -334,7 +328,7 @@ trait WalletRpc {
     #[method(name = "token_freeze")]
     async fn freeze_token(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         token_id: String,
         is_unfreezable: bool,
         options: TransactionOptions,
@@ -343,7 +337,7 @@ trait WalletRpc {
     #[method(name = "token_unfreeze")]
     async fn unfreeze_token(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         token_id: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
@@ -351,7 +345,7 @@ trait WalletRpc {
     #[method(name = "token_send")]
     async fn send_tokens(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         token_id: String,
         address: String,
         amount: DecimalAmount,
@@ -361,7 +355,7 @@ trait WalletRpc {
     #[method(name = "address_deposit_data")]
     async fn deposit_data(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         data: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
@@ -422,20 +416,20 @@ trait WalletRpc {
     #[method(name = "transaction_abandon")]
     async fn abandon_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         transaction_id: HexEncoded<Id<Transaction>>,
     ) -> rpc::RpcResult<()>;
 
     #[method(name = "transaction_list_pending")]
     async fn list_pending_transactions(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
     ) -> rpc::RpcResult<Vec<Id<Transaction>>>;
 
     #[method(name = "transaction_list_by_address")]
     async fn list_transactions_by_address(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         address: Option<String>,
         limit: usize,
     ) -> rpc::RpcResult<Vec<TxInfo>>;
@@ -443,21 +437,21 @@ trait WalletRpc {
     #[method(name = "transaction_get")]
     async fn get_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         transaction_id: HexEncoded<Id<Transaction>>,
     ) -> rpc::RpcResult<serde_json::Value>;
 
     #[method(name = "transaction_get_raw")]
     async fn get_raw_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         transaction_id: HexEncoded<Id<Transaction>>,
     ) -> rpc::RpcResult<String>;
 
     #[method(name = "account_sign_raw_transaction")]
     async fn sign_raw_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         raw_tx: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<MaybeSignedTransaction>;
@@ -465,7 +459,7 @@ trait WalletRpc {
     #[method(name = "account_sign_challenge_plain")]
     async fn sign_challenge(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         challenge: String,
         address: String,
     ) -> rpc::RpcResult<String>;
@@ -473,7 +467,7 @@ trait WalletRpc {
     #[method(name = "account_sign_challenge_hex")]
     async fn sign_challenge_hex(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         challenge: String,
         address: String,
     ) -> rpc::RpcResult<String>;
@@ -497,7 +491,7 @@ trait WalletRpc {
     #[method(name = "transaction_get_signed_raw")]
     async fn get_raw_signed_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         transaction_id: HexEncoded<Id<Transaction>>,
     ) -> rpc::RpcResult<String>;
 
@@ -524,14 +518,14 @@ trait WalletRpc {
     #[method(name = "node_generate_block")]
     async fn node_generate_block(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         transactions: Vec<HexEncoded<SignedTransaction>>,
     ) -> rpc::RpcResult<()>;
 
     #[method(name = "node_generate_blocks")]
     async fn node_generate_blocks(
         &self,
-        account_index: AccountIndexArg,
+        account: AccountArg,
         block_count: u32,
     ) -> rpc::RpcResult<()>;
 

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -41,7 +41,7 @@ use crate::{
     rpc::{WalletEventsRpcServer, WalletRpc, WalletRpcServer},
     types::{
         AccountArg, AddressInfo, AddressWithUsageInfo, Balances, ComposedTransaction,
-        CreatedWallet, DecimalAmount, DelegationInfo, EmptyArgs, HexEncoded, JsonValue,
+        CreatedWallet, DecimalAmount, DelegationInfo, HexEncoded, JsonValue,
         LegacyVrfPublicKeyInfo, MaybeSignedTransaction, NewAccountInfo, NewDelegation,
         NewTransaction, NftMetadata, NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId,
         StakePoolBalance, StakingStatus, TokenMetadata, TransactionOptions, TxOptionsOverrides,
@@ -57,7 +57,6 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletEventsRpcSe
     async fn subscribe_wallet_events(
         &self,
         pending: rpc::subscription::Pending,
-        _options: EmptyArgs,
     ) -> rpc::subscription::Reply {
         let wallet_events = self.wallet.subscribe().await?;
         rpc::subscription::connect_broadcast(wallet_events, pending).await
@@ -155,15 +154,11 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         rpc::handle_result(self.lock_private_keys().await)
     }
 
-    async fn best_block(&self, _empty_args: EmptyArgs) -> rpc::RpcResult<BlockInfo> {
+    async fn best_block(&self) -> rpc::RpcResult<BlockInfo> {
         rpc::handle_result(self.best_block().await)
     }
 
-    async fn create_account(
-        &self,
-        name: Option<String>,
-        _empty_args: EmptyArgs,
-    ) -> rpc::RpcResult<NewAccountInfo> {
+    async fn create_account(&self, name: Option<String>) -> rpc::RpcResult<NewAccountInfo> {
         rpc::handle_result(self.create_account(name).await)
     }
 
@@ -171,7 +166,6 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         &self,
         account_arg: AccountArg,
         name: Option<String>,
-        _options: EmptyArgs,
     ) -> rpc::RpcResult<NewAccountInfo> {
         rpc::handle_result(self.update_account_name(account_arg.index::<N>()?, name).await)
     }

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -40,7 +40,7 @@ use wallet_types::{seed_phrase::StoreSeedPhrase, with_locked::WithLocked};
 use crate::{
     rpc::{WalletEventsRpcServer, WalletRpc, WalletRpcServer},
     types::{
-        AccountIndexArg, AddressInfo, AddressWithUsageInfo, Balances, ComposedTransaction,
+        AccountArg, AddressInfo, AddressWithUsageInfo, Balances, ComposedTransaction,
         CreatedWallet, DecimalAmount, DelegationInfo, EmptyArgs, HexEncoded, JsonValue,
         LegacyVrfPublicKeyInfo, MaybeSignedTransaction, NewAccountInfo, NewDelegation,
         NewTransaction, NftMetadata, NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId,
@@ -169,40 +169,40 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn rename_account(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         name: Option<String>,
         _options: EmptyArgs,
     ) -> rpc::RpcResult<NewAccountInfo> {
-        rpc::handle_result(self.update_account_name(account_index.index::<N>()?, name).await)
+        rpc::handle_result(self.update_account_name(account_arg.index::<N>()?, name).await)
     }
 
-    async fn issue_address(&self, account_index: AccountIndexArg) -> rpc::RpcResult<AddressInfo> {
-        rpc::handle_result(self.issue_address(account_index.index::<N>()?).await)
+    async fn issue_address(&self, account_arg: AccountArg) -> rpc::RpcResult<AddressInfo> {
+        rpc::handle_result(self.issue_address(account_arg.index::<N>()?).await)
     }
 
     async fn reveal_public_key(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         address: String,
     ) -> rpc::RpcResult<PublicKeyInfo> {
-        rpc::handle_result(self.find_public_key(account_index.index::<N>()?, address).await)
+        rpc::handle_result(self.find_public_key(account_arg.index::<N>()?, address).await)
     }
 
     async fn get_issued_addresses(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
     ) -> rpc::RpcResult<Vec<AddressWithUsageInfo>> {
-        rpc::handle_result(self.get_issued_addresses(account_index.index::<N>()?).await)
+        rpc::handle_result(self.get_issued_addresses(account_arg.index::<N>()?).await)
     }
 
     async fn get_balance(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         with_locked: Option<WithLocked>,
     ) -> rpc::RpcResult<Balances> {
         rpc::handle_result(
             self.get_balance(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 UtxoStates::ALL,
                 with_locked.unwrap_or(WithLocked::Unlocked),
             )
@@ -210,10 +210,10 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         )
     }
 
-    async fn get_utxos(&self, account_index: AccountIndexArg) -> rpc::RpcResult<Vec<JsonValue>> {
+    async fn get_utxos(&self, account_arg: AccountArg) -> rpc::RpcResult<Vec<JsonValue>> {
         let utxos = self
             .get_utxos(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 UtxoTypes::ALL,
                 UtxoStates::ALL,
                 WithLocked::Unlocked,
@@ -239,7 +239,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn send_coins(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         address: String,
         amount_str: DecimalAmount,
         selected_utxos: Vec<UtxoOutPoint>,
@@ -251,7 +251,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
         rpc::handle_result(
             self.send_coins(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 address,
                 amount_str,
                 selected_utxos,
@@ -263,7 +263,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn transaction_from_cold_input(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         address: String,
         amount_str: DecimalAmount,
         selected_utxo: UtxoOutPoint,
@@ -276,7 +276,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
         rpc::handle_result(
             self.request_send_coins(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 address,
                 amount_str,
                 selected_utxo,
@@ -300,7 +300,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn create_stake_pool(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         amount: DecimalAmount,
         cost_per_block: DecimalAmount,
         margin_ratio_per_thousand: String,
@@ -313,7 +313,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
         rpc::handle_result(
             self.create_stake_pool(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 amount,
                 cost_per_block,
                 margin_ratio_per_thousand,
@@ -326,7 +326,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn decommission_stake_pool(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         pool_id: String,
         output_address: Option<String>,
         options: TransactionOptions,
@@ -337,7 +337,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
         rpc::handle_result(
             self.decommission_stake_pool(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 pool_id,
                 output_address,
                 config,
@@ -348,7 +348,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn decommission_stake_pool_request(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         pool_id: String,
         output_address: Option<String>,
         options: TransactionOptions,
@@ -359,7 +359,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
         rpc::handle_result(
             self.decommission_stake_pool_request(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 pool_id,
                 output_address,
                 config,
@@ -371,7 +371,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn create_delegation(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         address: String,
         pool_id: String,
         options: TransactionOptions,
@@ -381,14 +381,14 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
             broadcast_to_mempool: true,
         };
         rpc::handle_result(
-            self.create_delegation(account_index.index::<N>()?, address, pool_id, config)
+            self.create_delegation(account_arg.index::<N>()?, address, pool_id, config)
                 .await,
         )
     }
 
     async fn delegate_staking(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         amount: DecimalAmount,
         delegation_id: String,
         options: TransactionOptions,
@@ -398,14 +398,14 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
             broadcast_to_mempool: true,
         };
         rpc::handle_result(
-            self.delegate_staking(account_index.index::<N>()?, amount, delegation_id, config)
+            self.delegate_staking(account_arg.index::<N>()?, amount, delegation_id, config)
                 .await,
         )
     }
 
     async fn withdraw_from_delegation(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         address: String,
         amount: DecimalAmount,
         delegation_id: String,
@@ -417,7 +417,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
         rpc::handle_result(
             self.withdraw_from_delegation(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 address,
                 amount,
                 delegation_id,
@@ -427,42 +427,39 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         )
     }
 
-    async fn start_staking(&self, account_index: AccountIndexArg) -> rpc::RpcResult<()> {
-        rpc::handle_result(self.start_staking(account_index.index::<N>()?).await)
+    async fn start_staking(&self, account_arg: AccountArg) -> rpc::RpcResult<()> {
+        rpc::handle_result(self.start_staking(account_arg.index::<N>()?).await)
     }
 
-    async fn stop_staking(&self, account_index: AccountIndexArg) -> rpc::RpcResult<()> {
-        rpc::handle_result(self.stop_staking(account_index.index::<N>()?).await)
+    async fn stop_staking(&self, account_arg: AccountArg) -> rpc::RpcResult<()> {
+        rpc::handle_result(self.stop_staking(account_arg.index::<N>()?).await)
     }
 
-    async fn staking_status(
-        &self,
-        account_index: AccountIndexArg,
-    ) -> rpc::RpcResult<StakingStatus> {
-        rpc::handle_result(self.staking_status(account_index.index::<N>()?).await)
+    async fn staking_status(&self, account_arg: AccountArg) -> rpc::RpcResult<StakingStatus> {
+        rpc::handle_result(self.staking_status(account_arg.index::<N>()?).await)
     }
 
-    async fn list_pool_ids(&self, account_index: AccountIndexArg) -> rpc::RpcResult<Vec<PoolInfo>> {
-        rpc::handle_result(self.list_pool_ids(account_index.index::<N>()?).await)
+    async fn list_pool_ids(&self, account_arg: AccountArg) -> rpc::RpcResult<Vec<PoolInfo>> {
+        rpc::handle_result(self.list_pool_ids(account_arg.index::<N>()?).await)
     }
 
     async fn list_delegation_ids(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
     ) -> rpc::RpcResult<Vec<DelegationInfo>> {
-        rpc::handle_result(self.list_delegation_ids(account_index.index::<N>()?).await)
+        rpc::handle_result(self.list_delegation_ids(account_arg.index::<N>()?).await)
     }
 
     async fn list_created_blocks_ids(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
     ) -> rpc::RpcResult<Vec<CreatedBlockInfo>> {
-        rpc::handle_result(self.list_created_blocks_ids(account_index.index::<N>()?).await)
+        rpc::handle_result(self.list_created_blocks_ids(account_arg.index::<N>()?).await)
     }
 
     async fn issue_new_nft(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         destination_address: String,
         metadata: NftMetadata,
         options: TransactionOptions,
@@ -474,7 +471,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
         rpc::handle_result(
             self.issue_new_nft(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 destination_address,
                 metadata.into_metadata(),
                 config,
@@ -485,7 +482,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn issue_new_token(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         destination_address: String,
         metadata: TokenMetadata,
         options: TransactionOptions,
@@ -499,7 +496,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         let is_freezable = metadata.is_freezable();
         rpc::handle_result(
             self.issue_new_token(
-                account_index.index::<N>()?,
+                account_arg.index::<N>()?,
                 metadata.number_of_decimals,
                 destination_address,
                 metadata.token_ticker.into_bytes(),
@@ -514,7 +511,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn change_token_authority(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         token_id: String,
         address: String,
         options: TransactionOptions,
@@ -525,14 +522,14 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
 
         rpc::handle_result(
-            self.change_token_authority(account_index.index::<N>()?, token_id, address, config)
+            self.change_token_authority(account_arg.index::<N>()?, token_id, address, config)
                 .await,
         )
     }
 
     async fn mint_tokens(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         token_id: String,
         address: String,
         amount: DecimalAmount,
@@ -544,20 +541,14 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
 
         rpc::handle_result(
-            self.mint_tokens(
-                account_index.index::<N>()?,
-                token_id,
-                address,
-                amount,
-                config,
-            )
-            .await,
+            self.mint_tokens(account_arg.index::<N>()?, token_id, address, amount, config)
+                .await,
         )
     }
 
     async fn unmint_tokens(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         token_id: String,
         amount: DecimalAmount,
         options: TransactionOptions,
@@ -568,13 +559,13 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
 
         rpc::handle_result(
-            self.unmint_tokens(account_index.index::<N>()?, token_id, amount, config).await,
+            self.unmint_tokens(account_arg.index::<N>()?, token_id, amount, config).await,
         )
     }
 
     async fn lock_token_supply(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         token_id: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
@@ -584,13 +575,13 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
 
         rpc::handle_result(
-            self.lock_token_supply(account_index.index::<N>()?, token_id, config).await,
+            self.lock_token_supply(account_arg.index::<N>()?, token_id, config).await,
         )
     }
 
     async fn freeze_token(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         token_id: String,
         is_unfreezable: bool,
         options: TransactionOptions,
@@ -607,19 +598,14 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
 
         rpc::handle_result(
-            self.freeze_token(
-                account_index.index::<N>()?,
-                token_id,
-                is_unfreezable,
-                config,
-            )
-            .await,
+            self.freeze_token(account_arg.index::<N>()?, token_id, is_unfreezable, config)
+                .await,
         )
     }
 
     async fn unfreeze_token(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         token_id: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
@@ -628,12 +614,12 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
             broadcast_to_mempool: true,
         };
 
-        rpc::handle_result(self.unfreeze_token(account_index.index::<N>()?, token_id, config).await)
+        rpc::handle_result(self.unfreeze_token(account_arg.index::<N>()?, token_id, config).await)
     }
 
     async fn send_tokens(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         token_id: String,
         address: String,
         amount: DecimalAmount,
@@ -645,20 +631,14 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
 
         rpc::handle_result(
-            self.send_tokens(
-                account_index.index::<N>()?,
-                token_id,
-                address,
-                amount,
-                config,
-            )
-            .await,
+            self.send_tokens(account_arg.index::<N>()?, token_id, address, amount, config)
+                .await,
         )
     }
 
     async fn deposit_data(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         data: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
@@ -668,7 +648,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         };
 
         let data = hex::decode(data).map_err(|_| RpcError::<N>::InvalidHexData)?;
-        rpc::handle_result(self.deposit_data(account_index.index::<N>()?, data, config).await)
+        rpc::handle_result(self.deposit_data(account_arg.index::<N>()?, data, config).await)
     }
 
     async fn stake_pool_balance(&self, pool_id: String) -> rpc::RpcResult<StakePoolBalance> {
@@ -681,23 +661,23 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn new_vrf_public_key(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
     ) -> rpc::RpcResult<VrfPublicKeyInfo> {
-        rpc::handle_result(self.issue_vrf_key(account_index.index::<N>()?).await)
+        rpc::handle_result(self.issue_vrf_key(account_arg.index::<N>()?).await)
     }
 
     async fn get_vrf_public_key(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
     ) -> rpc::RpcResult<Vec<VrfPublicKeyInfo>> {
-        rpc::handle_result(self.get_vrf_key_usage(account_index.index::<N>()?).await)
+        rpc::handle_result(self.get_vrf_key_usage(account_arg.index::<N>()?).await)
     }
 
     async fn get_legacy_vrf_public_key(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
     ) -> rpc::RpcResult<LegacyVrfPublicKeyInfo> {
-        rpc::handle_result(self.get_legacy_vrf_public_key(account_index.index::<N>()?).await)
+        rpc::handle_result(self.get_legacy_vrf_public_key(account_arg.index::<N>()?).await)
     }
 
     async fn node_version(&self) -> rpc::RpcResult<NodeVersion> {
@@ -772,21 +752,20 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn abandon_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         transaction_id: HexEncoded<Id<Transaction>>,
     ) -> rpc::RpcResult<()> {
         rpc::handle_result(
-            self.abandon_transaction(account_index.index::<N>()?, transaction_id.take())
-                .await,
+            self.abandon_transaction(account_arg.index::<N>()?, transaction_id.take()).await,
         )
     }
 
     async fn list_pending_transactions(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
     ) -> rpc::RpcResult<Vec<Id<Transaction>>> {
         rpc::handle_result(
-            self.pending_transactions(account_index.index::<N>()?)
+            self.pending_transactions(account_arg.index::<N>()?)
                 .await
                 .map(|txs| txs.into_iter().map(|tx| tx.get_id()).collect::<Vec<_>>()),
         )
@@ -794,22 +773,22 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn list_transactions_by_address(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         address: Option<String>,
         limit: usize,
     ) -> rpc::RpcResult<Vec<TxInfo>> {
         rpc::handle_result(
-            self.mainchain_transactions(account_index.index::<N>()?, address, limit).await,
+            self.mainchain_transactions(account_arg.index::<N>()?, address, limit).await,
         )
     }
 
     async fn get_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         transaction_id: HexEncoded<Id<Transaction>>,
     ) -> rpc::RpcResult<serde_json::Value> {
         rpc::handle_result(
-            self.get_transaction(account_index.index::<N>()?, transaction_id.take())
+            self.get_transaction(account_arg.index::<N>()?, transaction_id.take())
                 .await
                 .map(|tx| {
                     let str = JsonEncoded::new((tx.get_transaction(), tx.state())).to_string();
@@ -821,11 +800,11 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn get_raw_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         transaction_id: HexEncoded<Id<Transaction>>,
     ) -> rpc::RpcResult<String> {
         rpc::handle_result(
-            self.get_transaction(account_index.index::<N>()?, transaction_id.take())
+            self.get_transaction(account_arg.index::<N>()?, transaction_id.take())
                 .await
                 .map(|tx| HexEncode::hex_encode(tx.get_transaction())),
         )
@@ -833,11 +812,11 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn get_raw_signed_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         transaction_id: HexEncoded<Id<Transaction>>,
     ) -> rpc::RpcResult<String> {
         rpc::handle_result(
-            self.get_transaction(account_index.index::<N>()?, transaction_id.take())
+            self.get_transaction(account_arg.index::<N>()?, transaction_id.take())
                 .await
                 .map(|tx| HexEncode::hex_encode(tx.get_signed_transaction())),
         )
@@ -845,7 +824,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn sign_raw_transaction(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         raw_tx: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<MaybeSignedTransaction> {
@@ -854,7 +833,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
             broadcast_to_mempool: true,
         };
         rpc::handle_result(
-            self.sign_raw_transaction(account_index.index::<N>()?, raw_tx, config)
+            self.sign_raw_transaction(account_arg.index::<N>()?, raw_tx, config)
                 .await
                 .map(|tx| {
                     let is_complete = tx.is_fully_signed();
@@ -872,12 +851,12 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn sign_challenge(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         challenge: String,
         address: String,
     ) -> rpc::RpcResult<String> {
         rpc::handle_result(
-            self.sign_challenge(account_index.index::<N>()?, challenge.into_bytes(), address)
+            self.sign_challenge(account_arg.index::<N>()?, challenge.into_bytes(), address)
                 .await
                 .map(ArbitraryMessageSignature::to_hex),
         )
@@ -885,13 +864,13 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn sign_challenge_hex(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         challenge: String,
         address: String,
     ) -> rpc::RpcResult<String> {
         let challenge = hex::decode(challenge).map_err(|_| RpcError::<N>::InvalidHexData)?;
         rpc::handle_result(
-            self.sign_challenge(account_index.index::<N>()?, challenge, address)
+            self.sign_challenge(account_arg.index::<N>()?, challenge, address)
                 .await
                 .map(ArbitraryMessageSignature::to_hex),
         )
@@ -953,22 +932,22 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
 
     async fn node_generate_block(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         transactions: Vec<HexEncoded<SignedTransaction>>,
     ) -> rpc::RpcResult<()> {
         let transactions = transactions.into_iter().map(HexEncoded::take).collect();
         rpc::handle_result(
-            self.generate_block(account_index.index::<N>()?, transactions).await.map(|_| {}),
+            self.generate_block(account_arg.index::<N>()?, transactions).await.map(|_| {}),
         )
     }
 
     async fn node_generate_blocks(
         &self,
-        account_index: AccountIndexArg,
+        account_arg: AccountArg,
         block_count: u32,
     ) -> rpc::RpcResult<()> {
         rpc::handle_result(
-            self.generate_blocks(account_index.index::<N>()?, block_count).await.map(|_| {}),
+            self.generate_blocks(account_arg.index::<N>()?, block_count).await.map(|_| {}),
         )
     }
 

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -114,21 +114,17 @@ impl<N: NodeInterface> From<RpcError<N>> for rpc::Error {
 pub struct EmptyArgs {}
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
-pub struct AccountIndexArg {
-    pub account: u32,
-}
+pub struct AccountArg(pub u32);
 
-impl AccountIndexArg {
+impl AccountArg {
     pub fn index<N: NodeInterface>(&self) -> Result<U31, RpcError<N>> {
-        U31::from_u32(self.account).ok_or(RpcError::AcctIndexOutOfRange)
+        U31::from_u32(self.0).ok_or(RpcError::AcctIndexOutOfRange)
     }
 }
 
-impl From<U31> for AccountIndexArg {
-    fn from(value: U31) -> Self {
-        Self {
-            account: value.into_u32(),
-        }
+impl From<U31> for AccountArg {
+    fn from(idx: U31) -> Self {
+        Self(idx.into())
     }
 }
 

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -109,10 +109,6 @@ impl<N: NodeInterface> From<RpcError<N>> for rpc::Error {
     }
 }
 
-/// Struct representing empty arguments to RPC call, for forwards compatibility
-#[derive(Debug, Eq, PartialEq, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub struct EmptyArgs {}
-
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AccountArg(pub u32);
 

--- a/wallet/wallet-rpc-lib/tests/basic.rs
+++ b/wallet/wallet-rpc-lib/tests/basic.rs
@@ -27,10 +27,7 @@ use utils::{
     ACCOUNT1_ARG,
 };
 use wallet_rpc_lib::{
-    types::{
-        AddressInfo, Balances, BlockInfo, EmptyArgs, NewAccountInfo, NewTransaction,
-        TransactionOptions,
-    },
+    types::{AddressInfo, Balances, BlockInfo, NewAccountInfo, NewTransaction, TransactionOptions},
     TxState,
 };
 
@@ -48,7 +45,7 @@ async fn startup_shutdown(#[case] seed: Seed) {
     let rpc_client = tf.rpc_client_http();
     let genesis_id = tf.chain_config().genesis_block_id();
     let best_block: BlockInfo =
-        rpc_client.request("wallet_best_block", [EmptyArgs {}]).await.unwrap();
+        rpc_client.request("wallet_best_block", Vec::<u32>::new()).await.unwrap();
     assert_eq!(best_block.id, genesis_id);
     assert_eq!(best_block.height, BlockHeight::new(0));
 
@@ -108,10 +105,8 @@ async fn stake_and_send_coins_to_acct1(#[case] seed: Seed) {
     let addr_result: Result<AddressInfo, _> =
         wallet_rpc.request("address_new", [ACCOUNT1_ARG]).await;
     assert!(addr_result.is_err());
-    let new_acct: NewAccountInfo = wallet_rpc
-        .request("account_create", (None::<String>, EmptyArgs {}))
-        .await
-        .unwrap();
+    let new_acct: NewAccountInfo =
+        wallet_rpc.request("account_create", Vec::<u32>::new()).await.unwrap();
     assert_eq!(new_acct.account, 1);
     let acct1_addr: AddressInfo = wallet_rpc.request("address_new", [ACCOUNT1_ARG]).await.unwrap();
     log::debug!("acct1_addr: {acct1_addr:?}");
@@ -120,7 +115,7 @@ async fn stake_and_send_coins_to_acct1(#[case] seed: Seed) {
     let mut wallet_events: Subscription<JsonValue> = wallet_rpc
         .subscribe(
             "subscribe_wallet_events",
-            [EmptyArgs {}],
+            Vec::<u32>::new(),
             "unsubscribe_wallet_events",
         )
         .await

--- a/wallet/wallet-rpc-lib/tests/utils.rs
+++ b/wallet/wallet-rpc-lib/tests/utils.rs
@@ -25,9 +25,7 @@ use common::{
 };
 use test_utils::{test_dir::TestRoot, test_root};
 use wallet_controller::NodeRpcClient;
-use wallet_rpc_lib::{
-    config::WalletServiceConfig, types::AccountIndexArg, WalletHandle, WalletService,
-};
+use wallet_rpc_lib::{config::WalletServiceConfig, types::AccountArg, WalletHandle, WalletService};
 use wallet_test_node::{RPC_PASSWORD, RPC_USERNAME};
 
 pub use crypto::random::Rng;
@@ -35,8 +33,8 @@ pub use rpc::test_support::{ClientT, Subscription, SubscriptionClientT};
 pub use serde_json::Value as JsonValue;
 pub use test_utils::random::{make_seedable_rng, Seed};
 
-pub const ACCOUNT0_ARG: AccountIndexArg = AccountIndexArg { account: 0 };
-pub const ACCOUNT1_ARG: AccountIndexArg = AccountIndexArg { account: 1 };
+pub const ACCOUNT0_ARG: AccountArg = AccountArg(0);
+pub const ACCOUNT1_ARG: AccountArg = AccountArg(1);
 
 pub struct TestFramework {
     pub wallet_service: WalletService<NodeRpcClient>,


### PR DESCRIPTION
Change the account representation to be just number and rename `account_index` to just `account`. A hypothetical method accepting an account (number 3) and extra options (empty) will have its params passed like this:

* `"params": [3]`  in positional format
* `"params": {"account": 3}`  in named format