### PR TITLE
Use PoS for simulation test

### DIFF
--- a/api-server/scanner-lib/src/sync/tests.rs
+++ b/api-server/scanner-lib/src/sync/tests.rs
@@ -580,12 +580,11 @@ async fn compare_pool_rewards_with_chainstate_real_state(#[case] seed: Seed) {
 
     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
     let block = tf
-        .make_pos_block_builder(&mut rng)
+        .make_pos_block_builder(
+            &mut rng,
+            Some((new_pool_id, new_staking_sk.clone(), new_vrf_sk.clone())),
+        )
         .with_parent(prev_block_hash.into())
-        .with_block_signing_key(new_staking_sk.clone())
-        .with_stake_spending_key(new_staking_sk)
-        .with_vrf_key(new_vrf_sk.clone())
-        .with_stake_pool(new_pool_id)
         .with_kernel_input(UtxoOutPoint::new(
             OutPointSourceId::Transaction(new_pool_tx_id),
             1,
@@ -1002,12 +1001,8 @@ fn create_block(
 ) -> Block {
     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
     let block = tf
-        .make_pos_block_builder(rng)
+        .make_pos_block_builder(rng, Some((pool_id, staking_sk.clone(), vrf_sk.clone())))
         .with_parent(prev_block_hash)
-        .with_block_signing_key(staking_sk.clone())
-        .with_stake_spending_key(staking_sk)
-        .with_vrf_key(vrf_sk.clone())
-        .with_stake_pool(pool_id)
         .with_transactions(transactions)
         .build();
     block

--- a/api-server/scanner-lib/src/sync/tests.rs
+++ b/api-server/scanner-lib/src/sync/tests.rs
@@ -363,7 +363,6 @@ async fn compare_pool_rewards_with_chainstate_real_state(#[case] seed: Seed) {
     let block = create_block(
         &mut tf,
         target_block_time,
-        &mut rng,
         prev_block_hash,
         staking_sk.clone(),
         vrf_sk.clone(),
@@ -392,7 +391,6 @@ async fn compare_pool_rewards_with_chainstate_real_state(#[case] seed: Seed) {
     let block = create_block(
         &mut tf,
         target_block_time,
-        &mut rng,
         prev_block_hash.into(),
         staking_sk.clone(),
         vrf_sk.clone(),
@@ -448,7 +446,6 @@ async fn compare_pool_rewards_with_chainstate_real_state(#[case] seed: Seed) {
     let block = create_block(
         &mut tf,
         target_block_time,
-        &mut rng,
         prev_block_hash.into(),
         staking_sk.clone(),
         vrf_sk.clone(),
@@ -477,7 +474,6 @@ async fn compare_pool_rewards_with_chainstate_real_state(#[case] seed: Seed) {
     let block = create_block(
         &mut tf,
         target_block_time,
-        &mut rng,
         prev_block_hash.into(),
         staking_sk.clone(),
         vrf_sk.clone(),
@@ -529,7 +525,6 @@ async fn compare_pool_rewards_with_chainstate_real_state(#[case] seed: Seed) {
     let block = create_block(
         &mut tf,
         target_block_time,
-        &mut rng,
         prev_block_hash.into(),
         staking_sk.clone(),
         vrf_sk.clone(),
@@ -580,11 +575,11 @@ async fn compare_pool_rewards_with_chainstate_real_state(#[case] seed: Seed) {
 
     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
     let block = tf
-        .make_pos_block_builder(
-            &mut rng,
-            Some((new_pool_id, new_staking_sk.clone(), new_vrf_sk.clone())),
-        )
+        .make_pos_block_builder()
         .with_parent(prev_block_hash.into())
+        .with_stake_spending_key(new_staking_sk)
+        .with_vrf_key(new_vrf_sk.clone())
+        .with_stake_pool(new_pool_id)
         .with_kernel_input(UtxoOutPoint::new(
             OutPointSourceId::Transaction(new_pool_tx_id),
             1,
@@ -988,11 +983,9 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
     drop(db_tx);
 }
 
-#[allow(clippy::too_many_arguments)]
 fn create_block(
     tf: &mut TestFramework,
     target_block_time: Duration,
-    rng: &mut (impl Rng + CryptoRng),
     prev_block_hash: Id<GenBlock>,
     staking_sk: PrivateKey,
     vrf_sk: VRFPrivateKey,
@@ -1001,8 +994,11 @@ fn create_block(
 ) -> Block {
     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
     let block = tf
-        .make_pos_block_builder(rng, Some((pool_id, staking_sk.clone(), vrf_sk.clone())))
+        .make_pos_block_builder()
         .with_parent(prev_block_hash)
+        .with_stake_spending_key(staking_sk)
+        .with_vrf_key(vrf_sk.clone())
+        .with_stake_pool(pool_id)
         .with_transactions(transactions)
         .build();
     block

--- a/api-server/stack-test-suite/tests/v1/block.rs
+++ b/api-server/stack-test-suite/tests/v1/block.rs
@@ -106,12 +106,11 @@ async fn ok(#[case] seed: Seed) {
                 .map(|_| {
                     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
                     let block = tf
-                        .make_pos_block_builder(&mut rng)
+                        .make_pos_block_builder(
+                            &mut rng,
+                            Some((pool_id, staking_sk.clone(), vrf_sk.clone())),
+                        )
                         .with_parent(prev_block_hash)
-                        .with_block_signing_key(staking_sk.clone())
-                        .with_stake_spending_key(staking_sk.clone())
-                        .with_vrf_key(vrf_sk.clone())
-                        .with_stake_pool(pool_id)
                         .build();
                     prev_block_hash = block.get_id().into();
                     tf.process_block(block.clone(), BlockSource::Local).unwrap();
@@ -172,12 +171,11 @@ async fn ok(#[case] seed: Seed) {
                 .map(|_| {
                     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
                     let block = tf
-                        .make_pos_block_builder(&mut rng)
+                        .make_pos_block_builder(
+                            &mut rng,
+                            Some((pool_id, staking_sk.clone(), vrf_sk.clone())),
+                        )
                         .with_parent(prev_block_hash)
-                        .with_block_signing_key(staking_sk.clone())
-                        .with_stake_spending_key(staking_sk.clone())
-                        .with_vrf_key(vrf_sk.clone())
-                        .with_stake_pool(pool_id)
                         .build();
                     prev_block_hash = block.get_id().into();
                     tf.process_block(block.clone(), BlockSource::Local).unwrap();

--- a/api-server/stack-test-suite/tests/v1/block.rs
+++ b/api-server/stack-test-suite/tests/v1/block.rs
@@ -106,11 +106,11 @@ async fn ok(#[case] seed: Seed) {
                 .map(|_| {
                     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
                     let block = tf
-                        .make_pos_block_builder(
-                            &mut rng,
-                            Some((pool_id, staking_sk.clone(), vrf_sk.clone())),
-                        )
+                        .make_pos_block_builder()
                         .with_parent(prev_block_hash)
+                        .with_stake_spending_key(staking_sk.clone())
+                        .with_vrf_key(vrf_sk.clone())
+                        .with_stake_pool(pool_id)
                         .build();
                     prev_block_hash = block.get_id().into();
                     tf.process_block(block.clone(), BlockSource::Local).unwrap();
@@ -171,11 +171,11 @@ async fn ok(#[case] seed: Seed) {
                 .map(|_| {
                     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
                     let block = tf
-                        .make_pos_block_builder(
-                            &mut rng,
-                            Some((pool_id, staking_sk.clone(), vrf_sk.clone())),
-                        )
+                        .make_pos_block_builder()
                         .with_parent(prev_block_hash)
+                        .with_stake_spending_key(staking_sk.clone())
+                        .with_vrf_key(vrf_sk.clone())
+                        .with_stake_pool(pool_id)
                         .build();
                     prev_block_hash = block.get_id().into();
                     tf.process_block(block.clone(), BlockSource::Local).unwrap();

--- a/api-server/stack-test-suite/tests/v1/block_header.rs
+++ b/api-server/stack-test-suite/tests/v1/block_header.rs
@@ -97,8 +97,11 @@ async fn ok(#[case] seed: Seed) {
             tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
 
             let block = tf
-                .make_pos_block_builder(&mut rng, Some((pool_id, staking_sk, vrf_sk.clone())))
+                .make_pos_block_builder()
                 .with_parent(prev_block_hash)
+                .with_stake_spending_key(staking_sk)
+                .with_vrf_key(vrf_sk.clone())
+                .with_stake_pool(pool_id)
                 .build();
             tf.process_block(block.clone(), BlockSource::Local).unwrap();
 

--- a/api-server/stack-test-suite/tests/v1/block_header.rs
+++ b/api-server/stack-test-suite/tests/v1/block_header.rs
@@ -97,12 +97,8 @@ async fn ok(#[case] seed: Seed) {
             tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
 
             let block = tf
-                .make_pos_block_builder(&mut rng)
+                .make_pos_block_builder(&mut rng, Some((pool_id, staking_sk, vrf_sk.clone())))
                 .with_parent(prev_block_hash)
-                .with_block_signing_key(staking_sk.clone())
-                .with_stake_spending_key(staking_sk)
-                .with_vrf_key(vrf_sk.clone())
-                .with_stake_pool(pool_id)
                 .build();
             tf.process_block(block.clone(), BlockSource::Local).unwrap();
 

--- a/api-server/stack-test-suite/tests/v1/pool_block_stats.rs
+++ b/api-server/stack-test-suite/tests/v1/pool_block_stats.rs
@@ -118,12 +118,11 @@ async fn ok(#[case] seed: Seed) {
                         tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
 
                         let block = tf
-                            .make_pos_block_builder(&mut rng)
+                            .make_pos_block_builder(
+                                &mut rng,
+                                Some((pool_id, staking_sk.clone(), vrf_sk.clone())),
+                            )
                             .with_parent(prev_block_hash)
-                            .with_block_signing_key(staking_sk.clone())
-                            .with_stake_spending_key(staking_sk.clone())
-                            .with_vrf_key(vrf_sk.clone())
-                            .with_stake_pool(pool_id)
                             .build();
                         tf.process_block(block.clone(), BlockSource::Local).unwrap();
 

--- a/api-server/stack-test-suite/tests/v1/pool_block_stats.rs
+++ b/api-server/stack-test-suite/tests/v1/pool_block_stats.rs
@@ -118,11 +118,11 @@ async fn ok(#[case] seed: Seed) {
                         tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
 
                         let block = tf
-                            .make_pos_block_builder(
-                                &mut rng,
-                                Some((pool_id, staking_sk.clone(), vrf_sk.clone())),
-                            )
+                            .make_pos_block_builder()
                             .with_parent(prev_block_hash)
+                            .with_stake_spending_key(staking_sk.clone())
+                            .with_vrf_key(vrf_sk.clone())
+                            .with_stake_pool(pool_id)
                             .build();
                         tf.process_block(block.clone(), BlockSource::Local).unwrap();
 

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -435,7 +435,7 @@ impl BanScore for pos_accounting::Error {
             E::InvariantErrorDelegationSharesAdditionUndoError => 100,
             E::InvariantErrorDelegationShareNotFound => 100,
             E::PledgeValueToSignedError => 100,
-            E::InvariantErrorDelegationUndoFailedDataNotFound => 100,
+            E::InvariantErrorDelegationUndoFailedDataNotFound(_) => 100,
             E::DuplicatesInDeltaAndUndo => 100,
             E::ViewFail => 0,
             E::IncreaseStakerRewardsOfNonexistingPool => 100,

--- a/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
+++ b/chainstate/src/detail/tx_verification_strategy/default_strategy.rs
@@ -126,6 +126,8 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config);
 
+        tx_verifier.disconnect_block_reward(block).log_err()?;
+
         block
             .transactions()
             .iter()
@@ -134,7 +136,6 @@ impl TransactionVerificationStrategy for DefaultTransactionVerificationStrategy 
                 tx_verifier.disconnect_transaction(&TransactionSource::Chain(block.get_id()), tx)
             })
             .log_err()?;
-        tx_verifier.disconnect_block_reward(block).log_err()?;
 
         tx_verifier.set_best_block(block.prev_block_id());
 

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -147,7 +147,7 @@ impl<'f> BlockBuilder<'f> {
                 None,
                 account_nonce_getter,
             )
-            .make(rng);
+            .make(rng, &mut self.framework.staking_pools);
 
         if !tx.inputs().is_empty() && !tx.outputs().is_empty() {
             // flush new tokens info to the in-memory store

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -144,6 +144,7 @@ impl<'f> BlockBuilder<'f> {
                 &utxo_set,
                 &self.tokens_accounting_store,
                 &self.pos_accounting_store,
+                None,
                 account_nonce_getter,
             )
             .make(rng);

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -19,6 +19,7 @@ use rstest::rstest;
 
 use crate::{
     pos_block_builder::PoSBlockBuilder,
+    staking_pools::StakingPools,
     utils::{outputs_from_block, outputs_from_genesis},
     BlockBuilder, TestChainstate, TestFrameworkBuilder, TestStore,
 };
@@ -49,7 +50,7 @@ pub struct TestFramework {
     // current time since epoch; if None, it means a custom TimeGetter was supplied and this is useless
     pub time_value: Option<Arc<SeqCstAtomicU64>>,
 
-    pub staking_pools: BTreeMap<PoolId, (PrivateKey, VRFPrivateKey)>,
+    pub staking_pools: StakingPools,
 }
 
 pub type BlockOutputs = BTreeMap<OutPointSourceId, Vec<TxOutput>>;

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -50,6 +50,7 @@ pub struct TestFramework {
     // current time since epoch; if None, it means a custom TimeGetter was supplied and this is useless
     pub time_value: Option<Arc<SeqCstAtomicU64>>,
 
+    // All pools from the tip that can be used for staking
     pub staking_pools: StakingPools,
 }
 

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -16,6 +16,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use crate::{
+    staking_pools::StakingPools,
     tx_verification_strategy::{
         DisposableTransactionVerificationStrategy, RandomizedTransactionVerificationStrategy,
     },
@@ -53,7 +54,7 @@ pub struct TestFrameworkBuilder {
     time_value: Option<Arc<SeqCstAtomicU64>>,
     tx_verification_strategy: TxVerificationStrategy,
     initial_time_since_genesis: u64,
-    staking_pools: BTreeMap<PoolId, (PrivateKey, VRFPrivateKey)>,
+    staking_pools: StakingPools,
 }
 
 impl TestFrameworkBuilder {
@@ -65,7 +66,7 @@ impl TestFrameworkBuilder {
         let time_getter = None;
         let time_value = None;
         let initial_time_since_genesis = 0;
-        let staking_pools = BTreeMap::new();
+        let staking_pools = StakingPools::new();
 
         assert_eq!(TxVerificationStrategy::VARIANT_COUNT, 3);
         let tx_verification_strategy = match rng.gen_range(0..3) {
@@ -165,7 +166,7 @@ impl TestFrameworkBuilder {
         mut self,
         staking_pools: BTreeMap<PoolId, (PrivateKey, VRFPrivateKey)>,
     ) -> Self {
-        self.staking_pools = staking_pools;
+        self.staking_pools = StakingPools::from_data(staking_pools);
         self
     }
 

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use chainstate::{BlockError, ChainstateConfig, DefaultTransactionVerificationStrategy};
 use common::{
-    chain::{ChainConfig, PoolId},
+    chain::{ChainConfig, PoolId, UtxoOutPoint},
     time_getter::TimeGetter,
 };
 use crypto::{
@@ -164,7 +164,7 @@ impl TestFrameworkBuilder {
 
     pub fn with_staking_pools(
         mut self,
-        staking_pools: BTreeMap<PoolId, (PrivateKey, VRFPrivateKey)>,
+        staking_pools: BTreeMap<PoolId, (PrivateKey, VRFPrivateKey, UtxoOutPoint)>,
     ) -> Self {
         self.staking_pools = StakingPools::from_data(staking_pools);
         self

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -20,6 +20,7 @@ mod framework;
 mod framework_builder;
 mod pos_block_builder;
 mod random_tx_maker;
+mod staking_pools;
 mod transaction_builder;
 mod tx_verification_strategy;
 mod utils;

--- a/chainstate/test-framework/src/pos_block_builder.rs
+++ b/chainstate/test-framework/src/pos_block_builder.rs
@@ -348,6 +348,7 @@ impl<'f> PoSBlockBuilder<'f> {
                 &utxo_set,
                 &self.tokens_accounting_store,
                 &self.pos_accounting_store,
+                Some(self.staking_pool),
                 account_nonce_getter,
             )
             .make(rng);

--- a/chainstate/test-framework/src/random_tx_maker.rs
+++ b/chainstate/test-framework/src/random_tx_maker.rs
@@ -212,6 +212,7 @@ impl<'a> RandomTxMaker<'a> {
         let tx = Transaction::new(0, inputs, outputs).unwrap();
         let tx_id = tx.get_id();
 
+        // after tx id is calculated kernel inputs for new pools can be propagated
         tx.outputs().iter().enumerate().for_each(|(i, output)| match output {
             TxOutput::Transfer(_, _)
             | TxOutput::LockThenTransfer(_, _, _)
@@ -724,6 +725,7 @@ impl<'a> RandomTxMaker<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn spend_output_value(
         &mut self,
         rng: &mut (impl Rng + CryptoRng),
@@ -731,13 +733,13 @@ impl<'a> RandomTxMaker<'a> {
         pos_accounting_cache: &mut (impl PoSAccountingView + PoSAccountingOperations<PoSAccountingUndo>),
         fee_input_to_change_supply: &mut Option<TxInput>,
         utxo_outpoint: UtxoOutPoint,
-        v: &OutputValue,
+        output_value: &OutputValue,
         num_inputs: usize,
     ) -> (Vec<TxInput>, Vec<TxOutput>) {
         let mut result_inputs = Vec::new();
         let mut result_outputs = Vec::new();
 
-        match v {
+        match output_value {
             OutputValue::Coin(coins) => {
                 // save utxo for a potential token supply change fee
                 if *coins

--- a/chainstate/test-framework/src/random_tx_maker.rs
+++ b/chainstate/test-framework/src/random_tx_maker.rs
@@ -483,7 +483,9 @@ impl<'a> RandomTxMaker<'a> {
                         }
                     };
                 }
-                TxOutput::CreateStakePool(pool_id, _) => {
+                TxOutput::CreateStakePool(pool_id, _)
+                | TxOutput::ProduceBlockFromStake(_, pool_id) => {
+                    // FIXME: there should be always at least one pool left
                     if rng.gen_bool(0.1) {
                         let staker_balance = pos_accounting_cache
                             .get_pool_data(*pool_id)
@@ -513,7 +515,6 @@ impl<'a> RandomTxMaker<'a> {
                     result_inputs.extend(new_inputs);
                     result_outputs.extend(new_outputs);
                 }
-                TxOutput::ProduceBlockFromStake(_, _) => unimplemented!(),
                 TxOutput::Burn(_)
                 | TxOutput::CreateDelegationId(_, _)
                 | TxOutput::DelegateStaking(_, _)

--- a/chainstate/test-framework/src/staking_pools.rs
+++ b/chainstate/test-framework/src/staking_pools.rs
@@ -19,6 +19,7 @@ use crate::random_tx_maker::StakingPoolsObserver;
 use common::chain::{PoolId, UtxoOutPoint};
 use crypto::{key::PrivateKey, vrf::VRFPrivateKey};
 
+/// Struct that holds possible pools and info required for staking
 pub struct StakingPools {
     staking_pools: BTreeMap<PoolId, (PrivateKey, VRFPrivateKey, UtxoOutPoint)>,
 }

--- a/chainstate/test-framework/src/staking_pools.rs
+++ b/chainstate/test-framework/src/staking_pools.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use crate::random_tx_maker::StakingPoolsObserver;
+use common::chain::PoolId;
+use crypto::{key::PrivateKey, vrf::VRFPrivateKey};
+
+pub struct StakingPools {
+    staking_pools: BTreeMap<PoolId, (PrivateKey, VRFPrivateKey)>,
+}
+
+impl StakingPools {
+    pub fn new() -> Self {
+        Self {
+            staking_pools: BTreeMap::new(),
+        }
+    }
+
+    pub fn from_data(staking_pools: BTreeMap<PoolId, (PrivateKey, VRFPrivateKey)>) -> Self {
+        Self { staking_pools }
+    }
+
+    pub fn staking_pools(&self) -> &BTreeMap<PoolId, (PrivateKey, VRFPrivateKey)> {
+        &self.staking_pools
+    }
+}
+
+impl StakingPoolsObserver for StakingPools {
+    fn on_pool_created(&mut self, pool_id: PoolId, staker_key: PrivateKey, vrf_sk: VRFPrivateKey) {
+        self.staking_pools.insert(pool_id, (staker_key, vrf_sk));
+    }
+
+    fn on_pool_decommissioned(&mut self, pool_id: PoolId) {
+        self.staking_pools.remove(&pool_id);
+    }
+}

--- a/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
+++ b/chainstate/test-framework/src/tx_verification_strategy/randomized_strategy.rs
@@ -263,6 +263,9 @@ impl RandomizedTransactionVerificationStrategy {
         <S as utxo::UtxosStorageRead>::Error: From<U::Error>,
     {
         let mut tx_verifier = tx_verifier_maker(storage_backend, chain_config);
+
+        tx_verifier.disconnect_block_reward(block).log_err()?;
+
         let mut tx_num = i32::try_from(block.transactions().len()).unwrap() - 1;
         while tx_num >= 0 {
             if self.rng.lock().unwrap().gen::<bool>() {
@@ -284,8 +287,6 @@ impl RandomizedTransactionVerificationStrategy {
                 tx_num -= 1;
             }
         }
-
-        tx_verifier.disconnect_block_reward(block).log_err()?;
 
         Ok(tx_verifier)
     }

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -161,7 +161,7 @@ pub fn create_chain_config_with_default_staking_pool(
         stake_amount,
         Destination::PublicKey(staking_pk.clone()),
         vrf_pk,
-        Destination::PublicKey(staking_pk),
+        Destination::AnyoneCanSpend,
         PerThousand::new(1000).unwrap(),
         Amount::ZERO,
     );

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -1756,7 +1756,7 @@ fn delegate_same_pool_as_staking(#[case] seed: Seed) {
 
     // Create alternative chain to trigger reorg
     tf.create_chain_pos(
-        &tf.chain_config().genesis_block_id().into(),
+        &tf.chain_config().genesis_block_id(),
         2,
         genesis_pool_id,
         &staker_sk,

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use std::{collections::BTreeMap, num::NonZeroU64};
+use std::num::NonZeroU64;
 
 use super::helpers::{
     new_pub_key_destination, pos::create_stake_pool_data_with_all_reward_to_staker,

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -42,23 +42,23 @@ fn stable_block_time(#[case] seed: Seed) {
     let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
     let (staking_sk, staking_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
 
-    let (config_builder, pool_id) =
+    let (chain_config_builder, genesis_pool_id) =
         chainstate_test_framework::create_chain_config_with_default_staking_pool(
             &mut rng, staking_pk, vrf_pk,
         );
-    let chain_config = config_builder.build();
+    let chain_config = chain_config_builder.build();
 
     let target_block_time = chain_config.target_block_spacing();
     let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
 
     for _i in 0..50 {
-        tf.make_pos_block_builder(
-            &mut rng,
-            Some((pool_id, staking_sk.clone(), vrf_sk.clone())),
-        )
-        .build_and_process()
-        .unwrap();
+        tf.make_pos_block_builder()
+            .with_stake_pool(genesis_pool_id)
+            .with_stake_spending_key(staking_sk.clone())
+            .with_vrf_key(vrf_sk.clone())
+            .build_and_process()
+            .unwrap();
     }
 }
 

--- a/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_retargeting_tests.rs
@@ -42,23 +42,23 @@ fn stable_block_time(#[case] seed: Seed) {
     let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
     let (staking_sk, staking_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
 
-    let chain_config = chainstate_test_framework::create_chain_config_with_default_staking_pool(
-        &mut rng, staking_pk, vrf_pk,
-    )
-    .0
-    .build();
+    let (config_builder, pool_id) =
+        chainstate_test_framework::create_chain_config_with_default_staking_pool(
+            &mut rng, staking_pk, vrf_pk,
+        );
+    let chain_config = config_builder.build();
 
     let target_block_time = chain_config.target_block_spacing();
     let mut tf = TestFramework::builder(&mut rng).with_chain_config(chain_config).build();
     tf.progress_time_seconds_since_epoch(target_block_time.as_secs());
 
     for _i in 0..50 {
-        tf.make_pos_block_builder(&mut rng)
-            .with_block_signing_key(staking_sk.clone())
-            .with_stake_spending_key(staking_sk.clone())
-            .with_vrf_key(vrf_sk.clone())
-            .build_and_process()
-            .unwrap();
+        tf.make_pos_block_builder(
+            &mut rng,
+            Some((pool_id, staking_sk.clone(), vrf_sk.clone())),
+        )
+        .build_and_process()
+        .unwrap();
     }
 }
 

--- a/chainstate/test-suite/src/tests/tx_verification_simulation.rs
+++ b/chainstate/test-suite/src/tests/tx_verification_simulation.rs
@@ -28,7 +28,6 @@ use crypto::{
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy(), 20, 50)]
-//#[case(1326317083504692347.into(), 20, 50)]
 fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_block: usize) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
@@ -116,7 +115,7 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
             tf2.progress_time_seconds_since_epoch(target_time.as_secs());
 
             // submit block to the original chain
-            tf.process_block(block, BlockSource::Local).unwrap();
+            tf.process_block(block, BlockSource::Peer).unwrap();
         }
 
         assert_ne!(old_best_block_id, tf.best_block_id());

--- a/chainstate/test-suite/src/tests/tx_verification_simulation.rs
+++ b/chainstate/test-suite/src/tests/tx_verification_simulation.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 use super::*;
 use common::{
-    chain::{ConsensusUpgrade, NetUpgrades, PoSChainConfigBuilder},
+    chain::{ConsensusUpgrade, NetUpgrades, PoSChainConfigBuilder, UtxoOutPoint},
     primitives::{BlockCount, Idable},
 };
 use crypto::{
@@ -28,6 +28,7 @@ use crypto::{
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy(), 20, 50)]
+#[case(1326317083504692347.into(), 20, 50)]
 fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_block: usize) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
@@ -35,7 +36,7 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
         let (vrf_sk, vrf_pk) = VRFPrivateKey::new_from_rng(&mut rng, VRFKeyKind::Schnorrkel);
         let (staking_sk, staking_pk) =
             PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
-        let (config_builder, genesis_pool) =
+        let (config_builder, genesis_pool_id) =
             chainstate_test_framework::create_chain_config_with_default_staking_pool(
                 &mut rng, staking_pk, vrf_pk,
             );
@@ -52,16 +53,20 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
         let consensus_upgrades = NetUpgrades::initialize(upgrades).expect("valid net-upgrades");
 
         let chain_config = config_builder.consensus_upgrades(consensus_upgrades).build();
+        let genesis_pool_outpoint = UtxoOutPoint::new(chain_config.genesis_block_id().into(), 1);
 
         let mut tf = TestFramework::builder(&mut rng)
             .with_chain_config(chain_config)
-            .with_staking_pools(BTreeMap::from_iter([(genesis_pool, (staking_sk, vrf_sk))]))
+            .with_staking_pools(BTreeMap::from_iter([(
+                genesis_pool_id,
+                (staking_sk.clone(), vrf_sk.clone(), genesis_pool_outpoint),
+            )]))
             .build();
         let target_time = tf.chain_config().target_block_spacing();
         tf.progress_time_seconds_since_epoch(target_time.as_secs());
 
         for _ in 0..rng.gen_range(10..max_blocks) {
-            let mut block_builder = tf.make_pos_block_builder(&mut rng, None);
+            let mut block_builder = tf.make_pos_block_builder().with_random_staking_pool(&mut rng);
 
             for _ in 0..rng.gen_range(10..max_tx_per_block) {
                 block_builder = block_builder.add_test_transaction(&mut rng);
@@ -74,8 +79,16 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
         let best_block_id = tf.best_block_id();
 
         // create longer chain to trigger reorg and disconnect all the random txs
-        let genesis = &tf.genesis().get_id().into();
-        let new_best_block_id = tf.create_chain_pos(genesis, max_blocks, &mut rng).unwrap();
+        let genesis_block_id = &tf.genesis().get_id().into();
+        let new_best_block_id = tf
+            .create_chain_pos(
+                genesis_block_id,
+                max_blocks,
+                genesis_pool_id,
+                &staking_sk,
+                &vrf_sk,
+            )
+            .unwrap();
         assert_ne!(best_block_id, tf.best_block_id());
         assert_eq!(new_best_block_id, tf.best_block_id());
     });

--- a/chainstate/tx-verifier/src/transaction_verifier/pos_accounting_delta_adapter.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/pos_accounting_delta_adapter.rs
@@ -210,7 +210,11 @@ impl<'a, P: PoSAccountingView> PoSAccountingOperations<PoSAccountingUndo>
         let (delegation_id, undo) =
             delta.create_delegation_id(target_pool, spend_key, input0_outpoint)?;
 
-        log::debug!("Creating a delegation: {}", delegation_id);
+        log::debug!(
+            "Creating a delegation: {} for pool {}",
+            delegation_id,
+            target_pool
+        );
 
         self.merge_delta(delta.consume())?;
 

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -300,7 +300,7 @@ impl MempoolBanScore for pos_accounting::Error {
             E::InvariantErrorDelegationBalanceAdditionUndoError => 0,
             E::InvariantErrorPoolBalanceAdditionUndoError => 0,
             E::InvariantErrorDelegationSharesAdditionUndoError => 0,
-            E::InvariantErrorDelegationUndoFailedDataNotFound => 0,
+            E::InvariantErrorDelegationUndoFailedDataNotFound(_) => 0,
             E::DuplicatesInDeltaAndUndo => 0,
             E::InvariantErrorIncreasePledgeUndoFailedPoolBalanceNotFound => 0,
             E::InvariantErrorIncreaseStakerRewardUndoFailedPoolBalanceNotFound => 0,

--- a/pos-accounting/src/error.rs
+++ b/pos-accounting/src/error.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common::chain::DelegationId;
+
 #[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub enum Error {
     #[error("Accounting storage error")]
@@ -83,8 +85,8 @@ pub enum Error {
     InvariantErrorDelegationShareNotFound,
     #[error("Failed to convert pledge value to signed")]
     PledgeValueToSignedError,
-    #[error("Delegation undo failed; data not found")]
-    InvariantErrorDelegationUndoFailedDataNotFound,
+    #[error("Delegation undo failed; data not found for {0}")]
+    InvariantErrorDelegationUndoFailedDataNotFound(DelegationId),
     #[error("Delta reverts merge failed due to duplicates")]
     DuplicatesInDeltaAndUndo,
     #[error("Increase staker rewards of nonexisting pool")]

--- a/pos-accounting/src/pool/delta/operator_impls.rs
+++ b/pos-accounting/src/pool/delta/operator_impls.rs
@@ -215,7 +215,9 @@ impl<P: PoSAccountingView> PoSAccountingOperations<PoSAccountingUndo> for PoSAcc
     ) -> Result<PoSAccountingUndo, Error> {
         let pool_id = *self
             .get_delegation_data(delegation_id)?
-            .ok_or(Error::InvariantErrorDelegationUndoFailedDataNotFound)?
+            .ok_or(Error::InvariantErrorDelegationUndoFailedDataNotFound(
+                delegation_id,
+            ))?
             .source_pool();
 
         self.sub_delegation_from_pool_share(pool_id, delegation_id, amount)?;
@@ -332,7 +334,9 @@ impl<P: PoSAccountingView> PoSAccountingDelta<P> {
     fn undo_delegate_staking(&mut self, undo_data: DelegateStakingUndo) -> Result<(), Error> {
         let pool_id = *self
             .get_delegation_data(undo_data.delegation_target)?
-            .ok_or(Error::InvariantErrorDelegationUndoFailedDataNotFound)?
+            .ok_or(Error::InvariantErrorDelegationUndoFailedDataNotFound(
+                undo_data.delegation_target,
+            ))?
             .source_pool();
 
         self.sub_delegation_from_pool_share(

--- a/pos-accounting/src/pool/storage/operator_impls.rs
+++ b/pos-accounting/src/pool/storage/operator_impls.rs
@@ -202,7 +202,9 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingOperations<PoS
     ) -> Result<PoSAccountingUndo, Error> {
         let pool_id = *self
             .get_delegation_data(delegation_id)?
-            .ok_or(Error::InvariantErrorDelegationUndoFailedDataNotFound)?
+            .ok_or(Error::InvariantErrorDelegationUndoFailedDataNotFound(
+                delegation_id,
+            ))?
             .source_pool();
 
         self.sub_delegation_from_pool_share(pool_id, delegation_id, amount)?;
@@ -325,7 +327,9 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingDB<S, T> {
     fn undo_delegate_staking(&mut self, undo_data: DelegateStakingUndo) -> Result<(), Error> {
         let pool_id = *self
             .get_delegation_data(undo_data.delegation_target)?
-            .ok_or(Error::InvariantErrorDelegationUndoFailedDataNotFound)?
+            .ok_or(Error::InvariantErrorDelegationUndoFailedDataNotFound(
+                undo_data.delegation_target,
+            ))?
             .source_pool();
 
         self.sub_delegation_from_pool_share(

--- a/pos-accounting/src/pool/tests/operations_tests.rs
+++ b/pos-accounting/src/pool/tests/operations_tests.rs
@@ -294,7 +294,7 @@ fn spend_share_unknown_id(#[case] seed: Seed) {
         let mut db = PoSAccountingDB::new(&mut storage);
         assert_eq!(
             db.spend_share_from_delegation_id(delegation_id, delegated_amount).unwrap_err(),
-            Error::InvariantErrorDelegationUndoFailedDataNotFound
+            Error::InvariantErrorDelegationUndoFailedDataNotFound(delegation_id)
         );
     }
 
@@ -305,7 +305,7 @@ fn spend_share_unknown_id(#[case] seed: Seed) {
             delta
                 .spend_share_from_delegation_id(delegation_id, delegated_amount)
                 .unwrap_err(),
-            Error::InvariantErrorDelegationUndoFailedDataNotFound
+            Error::InvariantErrorDelegationUndoFailedDataNotFound(delegation_id)
         );
     }
 }


### PR DESCRIPTION
Also changed the order in which reward and transactions are disconnected in block. It causes an error if delegation is created and staked to the same pool that is used for staking (see the test in `delegation_tests.rs`).