### PR TITLE
P2p: inform peers about disconnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,7 @@ dependencies = [
  "hex",
  "itertools 0.12.1",
  "jsonrpsee",
+ "lazy_static",
  "logging",
  "mempool",
  "num",

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -29,6 +29,7 @@ use chainstate_types::{GetAncestorError, PropertyQueryError};
 use common::{
     chain::{
         block::{block_body::BlockMerkleTreeError, timestamp::BlockTimestamp},
+        config::MagicBytes,
         Block, GenBlock,
     },
     primitives::{BlockHeight, Id},
@@ -207,7 +208,7 @@ pub enum StorageCompatibilityCheckError {
     #[error(
         "Chain's config magic bytes do not match the one from database : expected `{0:?}`, actual `{1:?}`"
     )]
-    ChainConfigMagicBytesMismatch([u8; 4], [u8; 4]),
+    ChainConfigMagicBytesMismatch(MagicBytes, MagicBytes),
     #[error("Node's chain type doesn't match the one in the database : db `{0}`, app `{1}`")]
     ChainTypeMismatch(String, String),
 }

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -521,7 +521,7 @@ where
         &mut self,
         reader: std::io::BufReader<Box<dyn std::io::Read + Send + 'a>>,
     ) -> Result<(), ChainstateError> {
-        let magic_bytes = self.chainstate.chain_config().magic_bytes().to_vec();
+        let magic_bytes = *self.chainstate.chain_config().magic_bytes();
 
         let mut reader = reader;
 
@@ -532,7 +532,7 @@ where
         let mut block_processor = |block| self.chainstate.process_block(block, BlockSource::Local);
 
         import_bootstrap_stream(
-            &magic_bytes,
+            &magic_bytes.bytes(),
             &mut reader,
             &mut block_processor,
             &chainstate_config,
@@ -550,7 +550,7 @@ where
         let magic_bytes = self.chainstate.chain_config().magic_bytes();
         let mut writer = writer;
         export_bootstrap_stream(
-            magic_bytes,
+            &magic_bytes.bytes(),
             &mut writer,
             include_orphans,
             &self.chainstate.query().map_err(ChainstateError::from)?,

--- a/chainstate/storage/src/internal/store_tx/mod.rs
+++ b/chainstate/storage/src/internal/store_tx/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 mod well_known {
-    use common::chain::GenBlock;
+    use common::chain::{self, GenBlock};
 
     use super::{BlockHeight, ChainstateStorageVersion, Codec, Id};
 
@@ -51,7 +51,7 @@ mod well_known {
     declare_entry!(StoreVersion: ChainstateStorageVersion);
     declare_entry!(BestBlockId: Id<GenBlock>);
     declare_entry!(UtxosBestBlockId: Id<GenBlock>);
-    declare_entry!(MagicBytes: [u8; 4]);
+    declare_entry!(MagicBytes: chain::config::MagicBytes);
     declare_entry!(ChainType: String);
     declare_entry!(MinHeightForReorg: BlockHeight);
 }

--- a/chainstate/storage/src/internal/store_tx/read_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/read_impls.rs
@@ -20,7 +20,7 @@ use chainstate_types::{BlockIndex, EpochData, EpochStorageRead};
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockReward},
-        config::EpochIndex,
+        config::{EpochIndex, MagicBytes},
         tokens::{TokenAuxiliaryData, TokenId},
         AccountNonce, AccountType, Block, DelegationId, GenBlock, PoolId, Transaction,
         UtxoOutPoint,
@@ -91,7 +91,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRo<'st, B
     }
 
     #[log_error]
-    fn get_magic_bytes(&self) -> crate::Result<Option<[u8; 4]>> {
+    fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>> {
         self.read_value::<well_known::MagicBytes>()
     }
 
@@ -346,7 +346,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     }
 
     #[log_error]
-    fn get_magic_bytes(&self) -> crate::Result<Option<[u8; 4]>> {
+    fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>> {
         self.read_value::<well_known::MagicBytes>()
     }
 

--- a/chainstate/storage/src/internal/store_tx/write_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/write_impls.rs
@@ -18,7 +18,7 @@ use crate::{BlockchainStorageWrite, ChainstateStorageVersion, SealedStorageTag, 
 use chainstate_types::{BlockIndex, EpochData, EpochStorageWrite};
 use common::{
     chain::{
-        config::EpochIndex,
+        config::{EpochIndex, MagicBytes},
         tokens::{TokenAuxiliaryData, TokenId},
         AccountNonce, AccountType, Block, DelegationId, GenBlock, PoolId, Transaction,
         UtxoOutPoint,
@@ -41,7 +41,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
     }
 
     #[log_error]
-    fn set_magic_bytes(&mut self, bytes: &[u8; 4]) -> crate::Result<()> {
+    fn set_magic_bytes(&mut self, bytes: &MagicBytes) -> crate::Result<()> {
         self.write_value::<well_known::MagicBytes>(bytes)
     }
 

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -27,7 +27,7 @@ use chainstate_types::{BlockIndex, EpochStorageRead, EpochStorageWrite};
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockReward},
-        config::EpochIndex,
+        config::{EpochIndex, MagicBytes},
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::Transaction,
         AccountNonce, AccountType, Block, GenBlock,
@@ -68,7 +68,7 @@ pub trait BlockchainStorageRead:
     fn get_storage_version(&self) -> crate::Result<Option<ChainstateStorageVersion>>;
 
     /// Get magic bytes
-    fn get_magic_bytes(&self) -> crate::Result<Option<[u8; 4]>>;
+    fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>>;
 
     /// Get chain type name
     fn get_chain_type(&self) -> crate::Result<Option<String>>;
@@ -146,7 +146,7 @@ pub trait BlockchainStorageWrite:
     fn set_storage_version(&mut self, version: ChainstateStorageVersion) -> Result<()>;
 
     /// Set magic bytes
-    fn set_magic_bytes(&mut self, bytes: &[u8; 4]) -> Result<()>;
+    fn set_magic_bytes(&mut self, bytes: &MagicBytes) -> Result<()>;
 
     /// Set chain type name
     fn set_chain_type(&mut self, chain: &str) -> Result<()>;

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -21,7 +21,7 @@ use chainstate_types::{BlockIndex, EpochData, EpochStorageRead, EpochStorageWrit
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockReward},
-        config::EpochIndex,
+        config::{EpochIndex, MagicBytes},
         tokens::{TokenAuxiliaryData, TokenId},
         transaction::Transaction,
         AccountNonce, AccountType, Block, DelegationId, GenBlock, PoolId, UtxoOutPoint,
@@ -45,7 +45,7 @@ mockall::mock! {
 
     impl crate::BlockchainStorageRead for Store {
         fn get_storage_version(&self) -> crate::Result<Option<ChainstateStorageVersion>>;
-        fn get_magic_bytes(&self) -> crate::Result<Option<[u8; 4]>>;
+        fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>>;
         fn get_chain_type(&self) -> crate::Result<Option<String>>;
         fn get_best_block_id(&self) -> crate::Result<Option<Id<GenBlock>>>;
         fn get_block_index(&self, id: &Id<Block>) -> crate::Result<Option<BlockIndex>>;
@@ -153,7 +153,7 @@ mockall::mock! {
 
     impl crate::BlockchainStorageWrite for Store {
         fn set_storage_version(&mut self, version: ChainstateStorageVersion) -> crate::Result<()>;
-        fn set_magic_bytes(&mut self, bytes: &[u8; 4]) -> crate::Result<()>;
+        fn set_magic_bytes(&mut self, bytes: &MagicBytes) -> crate::Result<()>;
         fn set_chain_type(&mut self, chain: &str) -> crate::Result<()>;
         fn set_best_block_id(&mut self, id: &Id<GenBlock>) -> crate::Result<()>;
         fn set_block_index(&mut self, block_index: &BlockIndex) -> crate::Result<()>;
@@ -314,7 +314,7 @@ mockall::mock! {
 
     impl crate::BlockchainStorageRead for StoreTxRo {
         fn get_storage_version(&self) -> crate::Result<Option<ChainstateStorageVersion>>;
-        fn get_magic_bytes(&self) -> crate::Result<Option<[u8; 4]>>;
+        fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>>;
         fn get_chain_type(&self) -> crate::Result<Option<String>>;
         fn get_best_block_id(&self) -> crate::Result<Option<Id<GenBlock>>>;
         fn get_block_index(&self, id: &Id<Block>) -> crate::Result<Option<BlockIndex>>;
@@ -427,7 +427,7 @@ mockall::mock! {
 
     impl crate::BlockchainStorageRead for StoreTxRw {
         fn get_storage_version(&self) -> crate::Result<Option<ChainstateStorageVersion>>;
-        fn get_magic_bytes(&self) -> crate::Result<Option<[u8; 4]>>;
+        fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>>;
         fn get_chain_type(&self) -> crate::Result<Option<String>>;
         fn get_best_block_id(&self) -> crate::Result<Option<Id<GenBlock>>>;
         fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
@@ -529,7 +529,7 @@ mockall::mock! {
 
     impl crate::BlockchainStorageWrite for StoreTxRw {
         fn set_storage_version(&mut self, version: ChainstateStorageVersion) -> crate::Result<()>;
-        fn set_magic_bytes(&mut self, bytes: &[u8; 4]) -> crate::Result<()>;
+        fn set_magic_bytes(&mut self, bytes: &MagicBytes) -> crate::Result<()>;
         fn set_chain_type(&mut self, chain: &str) -> crate::Result<()>;
         fn set_best_block_id(&mut self, id: &Id<GenBlock>) -> crate::Result<()>;
         fn set_block_index(&mut self, block_index: &BlockIndex) -> crate::Result<()>;

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -41,6 +41,8 @@ use crate::{
 };
 use crypto::key::hdkd::child_number::ChildNumber;
 
+use super::MagicBytes;
+
 // The fork, at which we upgrade consensus to dis-incentivize large pools + enable tokens v1
 const TESTNET_TOKEN_FORK_HEIGHT: BlockHeight = BlockHeight::new(78440);
 // The fork, at which we upgrade chainstate to distribute reward to staker proportionally to its balance,
@@ -273,7 +275,7 @@ impl GenesisBlockInit {
 pub struct Builder {
     chain_type: ChainType,
     bip44_coin_type: ChildNumber,
-    magic_bytes: [u8; 4],
+    magic_bytes: MagicBytes,
     p2p_port: u16,
     dns_seeds: Vec<&'static str>,
     predefined_peer_addresses: Vec<SocketAddr>,
@@ -320,7 +322,7 @@ impl Builder {
             bip44_coin_type: chain_type.default_bip44_coin_type(),
             coin_decimals: CoinUnit::DECIMALS,
             coin_ticker: chain_type.coin_ticker(),
-            magic_bytes: chain_type.default_magic_bytes(),
+            magic_bytes: chain_type.magic_bytes(),
             p2p_port: chain_type.default_p2p_port(),
             dns_seeds: chain_type.dns_seeds(),
             predefined_peer_addresses: chain_type.predefined_peer_addresses(),
@@ -504,7 +506,7 @@ macro_rules! builder_method {
 impl Builder {
     builder_method!(chain_type: ChainType);
     builder_method!(bip44_coin_type: ChildNumber);
-    builder_method!(magic_bytes: [u8; 4]);
+    builder_method!(magic_bytes: MagicBytes);
     builder_method!(p2p_port: u16);
     builder_method!(dns_seeds: Vec<&'static str>);
     builder_method!(predefined_peer_addresses: Vec<SocketAddr>);

--- a/common/src/chain/config/regtest_options.rs
+++ b/common/src/chain/config/regtest_options.rs
@@ -21,7 +21,7 @@ use crate::{
     chain::{
         config::{
             regtest::{create_regtest_pos_genesis, create_regtest_pow_genesis},
-            Builder, ChainType, EmissionScheduleTabular,
+            Builder, ChainType, EmissionScheduleTabular, MagicBytes,
         },
         pos::{DEFAULT_BLOCK_COUNT_TO_AVERAGE, DEFAULT_MATURITY_BLOCK_COUNT_V0},
         pos_initial_difficulty, ConsensusUpgrade, Destination, NetUpgrades, PoSChainConfig,
@@ -135,13 +135,13 @@ pub fn regtest_chain_config_builder(options: &ChainConfigOptions) -> Result<Buil
         };
     }
 
-    let magic_bytes_from_string = |magic_string: String| -> Result<[u8; 4]> {
+    let magic_bytes_from_string = |magic_string: String| -> Result<MagicBytes> {
         ensure!(magic_string.len() == 4, "Invalid size of magic_bytes");
         let mut result: [u8; 4] = [0; 4];
         for (i, byte) in magic_string.bytes().enumerate() {
             result[i] = byte;
         }
-        Ok(result)
+        Ok(MagicBytes::new(result))
     };
     update_builder!(magic_bytes, magic_bytes_from_string, map_err);
     update_builder!(max_future_block_time_offset, Duration::from_secs);

--- a/dns-server/src/crawler_p2p/crawler/tests/mod.rs
+++ b/dns-server/src/crawler_p2p/crawler/tests/mod.rs
@@ -23,7 +23,7 @@ use std::{
 
 use chainstate::ban_score::BanScore;
 use common::{
-    chain::ChainConfig,
+    chain::{config::MagicBytes, ChainConfig},
     primitives::{time::Time, user_agent::mintlayer_core_user_agent},
 };
 use p2p::{
@@ -380,7 +380,7 @@ fn incompatible_node(#[case] seed: Seed) {
             peer_info: PeerInfo {
                 peer_id: peer1,
                 protocol_version: TEST_PROTOCOL_VERSION,
-                network: [255, 255, 255, 255],
+                network: MagicBytes::new([255, 255, 255, 255]),
                 software_version: *chain_config.software_version(),
                 user_agent: mintlayer_core_user_agent(),
                 common_services: NodeType::DnsServer.into(),

--- a/dns-server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
+++ b/dns-server/src/crawler_p2p/crawler_manager/tests/mock_manager.rs
@@ -32,6 +32,7 @@ use tokio::{
 use common::{chain::ChainConfig, primitives::time::Time, time_getter::TimeGetter};
 use p2p::{
     config::{NodeType, P2pConfig},
+    disconnection_reason::DisconnectionReason,
     error::{DialError, P2pError},
     message::{AnnounceAddrRequest, PeerManagerMessage},
     net::{
@@ -240,7 +241,11 @@ impl ConnectivityService<MockNetworkingService> for MockConnectivityHandle {
         Ok(())
     }
 
-    fn disconnect(&mut self, peer_id: PeerId) -> p2p::Result<()> {
+    fn disconnect(
+        &mut self,
+        peer_id: PeerId,
+        _reason: Option<DisconnectionReason>,
+    ) -> p2p::Result<()> {
         let address = *self
             .state
             .connected

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -146,7 +146,8 @@ async fn initialize(
                 | P2pError::InvalidConfigurationValue(_)
                 | P2pError::InvalidStorageState(_)
                 | P2pError::MempoolError(_)
-                | P2pError::MessageCodecError(_) => Err(err),
+                | P2pError::MessageCodecError(_)
+                | P2pError::ConnectionValidationFailed(_) => Err(err),
             },
         }
     }?;

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -32,6 +32,7 @@ futures.workspace = true
 hex.workspace = true
 itertools.workspace = true
 jsonrpsee = { workspace = true, features = ["macros"] }
+lazy_static.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
 once_cell.workspace = true

--- a/p2p/backend-test-suite/src/events.rs
+++ b/p2p/backend-test-suite/src/events.rs
@@ -107,7 +107,7 @@ where
         res => panic!("unexpected result: {res:?}"),
     }
 
-    service1.disconnect(info.peer_id).unwrap();
+    service1.disconnect(info.peer_id, None).unwrap();
     assert_eq!(
         timeout(Duration::from_secs(5), events_receiver.recv()).await.unwrap(),
         Some(P2pEvent::PeerDisconnected(info.peer_id))

--- a/p2p/src/disconnection_reason.rs
+++ b/p2p/src/disconnection_reason.rs
@@ -15,7 +15,7 @@
 
 use std::fmt::Display;
 
-use common::primitives::time::Time;
+use common::{chain::config::MagicBytes, primitives::time::Time};
 
 use p2p_types::services::Services;
 
@@ -36,14 +36,13 @@ pub enum DisconnectionReason {
     SyncRequestsIgnored,
     TooManyInboundPeersAndThisOneIsDiscouraged,
     TooManyInboundPeersAndCannotEvictAnyone,
-
     UnsupportedProtocol,
     TimeDiff {
         remote_time: Time,
         accepted_peer_time: std::ops::RangeInclusive<Time>,
     },
     DifferentNetwork {
-        our_network: [u8; 4],
+        our_network: MagicBytes,
     },
     NoCommonServices,
     InsufficientServices {
@@ -90,7 +89,7 @@ impl Display for DisconnectionReason {
                 remote_time, accepted_peer_time
             ),
             DisconnectionReason::DifferentNetwork { our_network } => {
-                write!(f, "Wrong network; out network is {our_network:?}")
+                write!(f, "Wrong network; out network is '{our_network}'")
             }
             DisconnectionReason::NoCommonServices => write!(f, "No common services"),
             DisconnectionReason::InsufficientServices { needed_services } => {

--- a/p2p/src/disconnection_reason.rs
+++ b/p2p/src/disconnection_reason.rs
@@ -162,9 +162,3 @@ impl DisconnectionReason {
         }
     }
 }
-
-// impl Display for DisconnectionReason {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         write!(f, "{}", self.description)
-//     }
-// }

--- a/p2p/src/disconnection_reason.rs
+++ b/p2p/src/disconnection_reason.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Display;
+
+use common::primitives::time::Time;
+
+use p2p_types::services::Services;
+
+use crate::{
+    error::{ConnectionValidationError, P2pError},
+    protocol::MIN_SUPPORTED_PROTOCOL_VERSION,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DisconnectionReason {
+    AddressBanned,
+    AddressDiscouraged,
+    PeerEvicted,
+    FeelerConnection,
+    ConnectionFromSelf,
+    ManualDisconnect,
+    PingIgnored,
+    SyncRequestsIgnored,
+    TooManyInboundPeersAndThisOneIsDiscouraged,
+    TooManyInboundPeersAndCannotEvictAnyone,
+
+    UnsupportedProtocol,
+    TimeDiff {
+        remote_time: Time,
+        accepted_peer_time: std::ops::RangeInclusive<Time>,
+    },
+    DifferentNetwork {
+        our_network: [u8; 4],
+    },
+    NoCommonServices,
+    InsufficientServices {
+        needed_services: Services,
+    },
+}
+
+impl Display for DisconnectionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DisconnectionReason::AddressBanned => write!(f, "Your address is banned"),
+            DisconnectionReason::AddressDiscouraged => write!(f, "Your address is discouraged"),
+            DisconnectionReason::PeerEvicted => write!(f, "You are evicted"),
+            DisconnectionReason::FeelerConnection => write!(f, "This was a feeler connection"),
+            DisconnectionReason::ConnectionFromSelf => {
+                write!(f, "We think you are a self-connection")
+            }
+            DisconnectionReason::ManualDisconnect => write!(f, "Manual disconnection"),
+            DisconnectionReason::PingIgnored => write!(f, "You ignore our ping requests"),
+            DisconnectionReason::SyncRequestsIgnored => write!(f, "You ignore our sync requests"),
+
+            DisconnectionReason::TooManyInboundPeersAndThisOneIsDiscouraged => {
+                write!(
+                    f,
+                    "Too many inbound connections and your address is discouraged"
+                )
+            }
+            DisconnectionReason::TooManyInboundPeersAndCannotEvictAnyone => {
+                write!(f, "Too many inbound connections, which can't be evicted")
+            }
+
+            DisconnectionReason::UnsupportedProtocol => write!(
+                f,
+                "Unsupported protocol version, out min version is {}",
+                *MIN_SUPPORTED_PROTOCOL_VERSION as u32
+            ),
+
+            DisconnectionReason::TimeDiff {
+                remote_time,
+                accepted_peer_time,
+            } => write!(
+                f,
+                "Your time {:?} is out of the acceptable range {:?}",
+                remote_time, accepted_peer_time
+            ),
+            DisconnectionReason::DifferentNetwork { our_network } => {
+                write!(f, "Wrong network; out network is {our_network:?}")
+            }
+            DisconnectionReason::NoCommonServices => write!(f, "No common services"),
+            DisconnectionReason::InsufficientServices { needed_services } => {
+                write!(f, "Insufficient services, we need {needed_services:?}")
+            }
+        }
+    }
+}
+
+impl DisconnectionReason {
+    pub fn from_result<T>(res: &crate::Result<T>) -> Option<Self> {
+        match res {
+            Ok(_) => None,
+            Err(err) => Self::from_error(err),
+        }
+    }
+
+    pub fn from_error(err: &P2pError) -> Option<Self> {
+        match err {
+            P2pError::ProtocolError(_)
+            | P2pError::DialError(_)
+            | P2pError::ChannelClosed
+            | P2pError::PeerError(_)
+            | P2pError::SubsystemFailure
+            | P2pError::ChainstateError(_)
+            | P2pError::StorageFailure(_)
+            | P2pError::NoiseHandshakeError(_)
+            | P2pError::InvalidConfigurationValue(_)
+            | P2pError::InvalidStorageState(_)
+            | P2pError::PeerDbStorageVersionMismatch { .. }
+            | P2pError::MempoolError(_)
+            | P2pError::MessageCodecError(_) => None,
+            P2pError::ConnectionValidationFailed(err) => match err {
+                ConnectionValidationError::UnsupportedProtocol {
+                    peer_protocol_version: _,
+                } => Some(Self::UnsupportedProtocol),
+                ConnectionValidationError::TimeDiff {
+                    remote_time,
+                    accepted_peer_time,
+                } => Some(Self::TimeDiff {
+                    remote_time: *remote_time,
+                    accepted_peer_time: accepted_peer_time.clone(),
+                }),
+                ConnectionValidationError::DifferentNetwork {
+                    our_network,
+                    their_network: _,
+                } => Some(Self::DifferentNetwork {
+                    our_network: *our_network,
+                }),
+                ConnectionValidationError::TooManyInboundPeersAndThisOneIsDiscouraged => {
+                    Some(Self::TooManyInboundPeersAndThisOneIsDiscouraged)
+                }
+                ConnectionValidationError::TooManyInboundPeersAndCannotEvictAnyone => {
+                    Some(Self::TooManyInboundPeersAndCannotEvictAnyone)
+                }
+                ConnectionValidationError::AddressBanned { address: _ } => {
+                    Some(Self::AddressBanned)
+                }
+                ConnectionValidationError::AddressDiscouraged { address: _ } => {
+                    Some(Self::AddressDiscouraged)
+                }
+                ConnectionValidationError::NoCommonServices => Some(Self::NoCommonServices),
+                ConnectionValidationError::InsufficientServices {
+                    needed_services,
+                    available_services: _,
+                } => Some(Self::InsufficientServices {
+                    needed_services: *needed_services,
+                }),
+            },
+        }
+    }
+}
+
+// impl Display for DisconnectionReason {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         write!(f, "{}", self.description)
+//     }
+// }

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 
 use chainstate::{ban_score::BanScore, ChainstateError};
 use common::{
-    chain::{Block, Transaction},
+    chain::{config::MagicBytes, Block, Transaction},
     primitives::{time::Time, Id},
 };
 use mempool::error::{Error as MempoolError, MempoolBanScore};
@@ -125,11 +125,11 @@ pub enum ConnectionValidationError {
         accepted_peer_time: std::ops::RangeInclusive<Time>,
     },
     #[error(
-        "Peer is in different network. Our network {our_network:?}, their network {their_network:?}"
+        "Peer is in different network. Our network is '{our_network}', their network is '{their_network}'"
     )]
     DifferentNetwork {
-        our_network: [u8; 4],
-        their_network: [u8; 4],
+        our_network: MagicBytes,
+        their_network: MagicBytes,
     },
     #[error("Too many peers")]
     TooManyInboundPeersAndThisOneIsDiscouraged,

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -24,6 +24,7 @@ use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress
 use utils_networking::IpOrSocketAddress;
 
 use crate::{
+    disconnection_reason::DisconnectionReason,
     error::P2pError,
     interface::{p2p_interface::P2pInterface, types::ConnectedPeer},
     net::NetworkingService,
@@ -53,6 +54,7 @@ where
             .send(PeerManagerEvent::Disconnect(
                 peer_id,
                 PeerDisconnectionDbAction::RemoveIfOutbound,
+                Some(DisconnectionReason::ManualDisconnect),
                 response_sender,
             ))
             .map_err(|_| P2pError::ChannelClosed)?;

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod ban_config;
 pub mod config;
+pub mod disconnection_reason;
 pub mod error;
 pub mod interface;
 pub mod message;

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -54,6 +54,7 @@ pub enum PeerManagerMessage {
     PingRequest(PingRequest),
     AddrListResponse(AddrListResponse),
     PingResponse(PingResponse),
+    WillDisconnect(WillDisconnectMessage),
 }
 
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
@@ -167,4 +168,11 @@ pub struct AddrListResponse {
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct PingResponse {
     pub nonce: u64,
+}
+
+// Note: 'reason' is a string here, because we want ot be able to add more reasons without upping
+// the protocol version.
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct WillDisconnectMessage {
+    pub reason: String,
 }

--- a/p2p/src/message.rs
+++ b/p2p/src/message.rs
@@ -170,7 +170,7 @@ pub struct PingResponse {
     pub nonce: u64,
 }
 
-// Note: 'reason' is a string here, because we want ot be able to add more reasons without upping
+// Note: 'reason' is a string here, because we want to be able to add more reasons without upping
 // the protocol version.
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct WillDisconnectMessage {

--- a/p2p/src/net/default_backend/default_networking_service.rs
+++ b/p2p/src/net/default_backend/default_networking_service.rs
@@ -41,7 +41,7 @@ use super::{backend::Backend, ConnectivityHandle, MessagingHandle, SyncingEventR
 // The preferred protocol version.
 // Note that we intentionally keep this constant private, because most of the code should
 // not depend on its value.
-const PREFERRED_PROTOCOL_VERSION: SupportedProtocolVersion = SupportedProtocolVersion::V2;
+const PREFERRED_PROTOCOL_VERSION: SupportedProtocolVersion = SupportedProtocolVersion::V3;
 
 // Some tests do need this value though in order to check the correct version selection.
 // So we make it available for them via a function with a test-specific name and under cfg(test).

--- a/p2p/src/net/default_backend/mod.rs
+++ b/p2p/src/net/default_backend/mod.rs
@@ -28,6 +28,7 @@ use logging::log;
 use p2p_types::{services::Services, socket_address::SocketAddress};
 
 use crate::{
+    disconnection_reason::DisconnectionReason,
     error::P2pError,
     message::{BlockSyncMessage, PeerManagerMessage, TransactionSyncMessage},
     net::{
@@ -120,10 +121,14 @@ where
         Ok(self.cmd_sender.send(types::Command::Accept { peer_id })?)
     }
 
-    fn disconnect(&mut self, peer_id: PeerId) -> crate::Result<()> {
+    fn disconnect(
+        &mut self,
+        peer_id: PeerId,
+        reason: Option<DisconnectionReason>,
+    ) -> crate::Result<()> {
         log::debug!("close connection with remote, peer_id: {peer_id}");
 
-        Ok(self.cmd_sender.send(types::Command::Disconnect { peer_id })?)
+        Ok(self.cmd_sender.send(types::Command::Disconnect { peer_id, reason })?)
     }
 
     fn send_message(&mut self, peer_id: PeerId, message: PeerManagerMessage) -> crate::Result<()> {

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -514,6 +514,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use common::chain::config::MagicBytes;
     use futures::FutureExt;
     use std::time::Duration;
     use test_utils::{
@@ -779,7 +780,7 @@ mod tests {
             .send(Message::Handshake(HandshakeMessage::Hello {
                 protocol_version: TEST_PROTOCOL_VERSION.into(),
                 software_version: *chain_config.software_version(),
-                network: [1, 2, 3, 4],
+                network: MagicBytes::new([1, 2, 3, 4]),
                 user_agent: p2p_config.user_agent.clone(),
                 services: [Service::Blocks, Service::Transactions].as_slice().into(),
                 receiver_address: None,

--- a/p2p/src/net/default_backend/tests.rs
+++ b/p2p/src/net/default_backend/tests.rs
@@ -279,7 +279,7 @@ where
             peer_info,
             node_address_as_seen_by_peer: _,
         } => {
-            conn2.disconnect(peer_info.peer_id).unwrap();
+            conn2.disconnect(peer_info.peer_id, None).unwrap();
         }
         _ => panic!("invalid event received, expected incoming connection"),
     }

--- a/p2p/src/net/default_backend/transport/buffered_transcoder.rs
+++ b/p2p/src/net/default_backend/transport/buffered_transcoder.rs
@@ -85,7 +85,10 @@ mod tests {
 
     use chainstate::Locator;
     use chainstate_test_framework::TestFramework;
-    use common::primitives::{semver::SemVer, Id};
+    use common::{
+        chain::config::MagicBytes,
+        primitives::{semver::SemVer, Id},
+    };
     use crypto::random::Rng;
     use p2p_types::services::Service;
     use test_utils::random::Seed;
@@ -122,7 +125,7 @@ mod tests {
         let messages = [
             Message::Handshake(HandshakeMessage::Hello {
                 protocol_version: ProtocolVersion::new(rng.gen()),
-                network: [rng.gen(), rng.gen(), rng.gen(), rng.gen()],
+                network: MagicBytes::new([rng.gen(), rng.gen(), rng.gen(), rng.gen()]),
                 services: [Service::Blocks].as_slice().into(),
                 user_agent: p2p_config.user_agent.clone(),
                 software_version: SemVer {
@@ -142,7 +145,7 @@ mod tests {
             }),
             Message::Handshake(HandshakeMessage::HelloAck {
                 protocol_version: ProtocolVersion::new(rng.gen()),
-                network: [rng.gen(), rng.gen(), rng.gen(), rng.gen()],
+                network: MagicBytes::new([rng.gen(), rng.gen(), rng.gen(), rng.gen()]),
                 services: [Service::Blocks].as_slice().into(),
                 user_agent: p2p_config.user_agent.clone(),
                 software_version: SemVer {

--- a/p2p/src/net/default_backend/types.rs
+++ b/p2p/src/net/default_backend/types.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc::Sender, oneshot};
 
 use common::{
-    chain::Transaction,
+    chain::{config::MagicBytes, Transaction},
     primitives::{semver::SemVer, time::Time, user_agent::UserAgent, Id},
 };
 use p2p_types::socket_address::SocketAddress;
@@ -83,6 +83,8 @@ impl P2pTimestamp {
 }
 
 pub mod peer_event {
+    use common::chain::config::MagicBytes;
+
     use super::*;
 
     /// The "peer info" from PeerEvent's perspective.
@@ -92,7 +94,7 @@ pub mod peer_event {
     #[derive(Debug, PartialEq, Eq)]
     pub struct PeerInfo {
         pub protocol_version: SupportedProtocolVersion,
-        pub network: [u8; 4],
+        pub network: MagicBytes,
         pub common_services: Services,
         pub user_agent: UserAgent,
         pub software_version: SemVer,
@@ -148,7 +150,7 @@ pub enum HandshakeMessage {
     #[codec(index = 0)]
     Hello {
         protocol_version: ProtocolVersion,
-        network: [u8; 4],
+        network: MagicBytes,
         services: Services,
         user_agent: UserAgent,
         software_version: SemVer,
@@ -164,7 +166,7 @@ pub enum HandshakeMessage {
     #[codec(index = 1)]
     HelloAck {
         protocol_version: ProtocolVersion,
-        network: [u8; 4],
+        network: MagicBytes,
         services: Services,
         user_agent: UserAgent,
         software_version: SemVer,

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -33,6 +33,7 @@ use utils::atomics::SeqCstAtomicBool;
 
 use crate::{
     config,
+    disconnection_reason::DisconnectionReason,
     message::{BlockSyncMessage, PeerManagerMessage, TransactionSyncMessage},
     types::peer_id::PeerId,
     P2pEventHandler,
@@ -104,7 +105,11 @@ where
     ///
     /// # Arguments
     /// `peer_id` - Peer ID of the remote node
-    fn disconnect(&mut self, peer_id: PeerId) -> crate::Result<()>;
+    fn disconnect(
+        &mut self,
+        peer_id: PeerId,
+        reason: Option<DisconnectionReason>,
+    ) -> crate::Result<()>;
 
     /// Sends a message to the given peer.
     fn send_message(&mut self, peer: PeerId, message: PeerManagerMessage) -> crate::Result<()>;

--- a/p2p/src/net/mod.rs
+++ b/p2p/src/net/mod.rs
@@ -105,6 +105,7 @@ where
     ///
     /// # Arguments
     /// `peer_id` - Peer ID of the remote node
+    /// `reason` - reason for the disconnection
     fn disconnect(
         &mut self,
         peer_id: PeerId,

--- a/p2p/src/net/types.rs
+++ b/p2p/src/net/types.rs
@@ -25,7 +25,7 @@ use p2p_types::socket_address::SocketAddress;
 use tokio::sync::mpsc::Receiver;
 
 use crate::{
-    error::ProtocolError,
+    error::ConnectionValidationError,
     message::{BlockSyncMessage, PeerManagerMessage, TransactionSyncMessage},
     protocol::SupportedProtocolVersion,
     types::{peer_address::PeerAddress, peer_id::PeerId},
@@ -127,10 +127,12 @@ impl PeerInfo {
 
     pub fn check_compatibility(&self, chain_config: &ChainConfig) -> crate::Result<()> {
         if self.network != *chain_config.magic_bytes() {
-            Err(P2pError::ProtocolError(ProtocolError::DifferentNetwork(
-                *chain_config.magic_bytes(),
-                self.network,
-            )))
+            Err(P2pError::ConnectionValidationFailed(
+                ConnectionValidationError::DifferentNetwork {
+                    our_network: *chain_config.magic_bytes(),
+                    their_network: self.network,
+                },
+            ))
         } else {
             Ok(())
         }

--- a/p2p/src/net/types.rs
+++ b/p2p/src/net/types.rs
@@ -18,7 +18,7 @@ pub use crate::types::services;
 use std::fmt::{Debug, Display};
 
 use common::{
-    chain::ChainConfig,
+    chain::{config::MagicBytes, ChainConfig},
     primitives::{semver::SemVer, user_agent::UserAgent},
 };
 use p2p_types::socket_address::SocketAddress;
@@ -106,7 +106,7 @@ pub struct PeerInfo {
     pub protocol_version: SupportedProtocolVersion,
 
     /// Peer network
-    pub network: [u8; 4],
+    pub network: MagicBytes,
 
     /// Peer software version
     pub software_version: SemVer,

--- a/p2p/src/peer_manager/tests/ban.rs
+++ b/p2p/src/peer_manager/tests/ban.rs
@@ -20,6 +20,7 @@ use rstest::rstest;
 use crate::{
     ban_config::BanConfig,
     config::P2pConfig,
+    disconnection_reason::DisconnectionReason,
     message::{AddrListRequest, AddrListResponse, AnnounceAddrRequest, PeerManagerMessage},
     net::{
         default_backend::types::{Command, Message},
@@ -187,7 +188,13 @@ async fn disconnect_manually_banned_peer(#[case] seed: Seed) {
     assert!(is_banned);
 
     let cmd = expect_recv!(cmd_receiver);
-    assert_eq!(cmd, Command::Disconnect { peer_id });
+    assert_eq!(
+        cmd,
+        Command::Disconnect {
+            peer_id,
+            reason: Some(DisconnectionReason::AddressBanned)
+        }
+    );
 
     wait_for_no_recv(&mut peer_mgr_notification_receiver).await;
 
@@ -254,7 +261,13 @@ async fn reject_incoming_connection_from_banned_peer(#[case] seed: Seed) {
         &chain_config,
     );
     let cmd = expect_recv!(cmd_receiver);
-    assert_eq!(cmd, Command::Disconnect { peer_id: peer1_id });
+    assert_eq!(
+        cmd,
+        Command::Disconnect {
+            peer_id: peer1_id,
+            reason: Some(DisconnectionReason::AddressBanned)
+        }
+    );
 
     // Connection from the normal peer is accepted.
     let peer2_id = inbound_block_relay_peer_accepted_by_backend(

--- a/p2p/src/peer_manager/tests/connections.rs
+++ b/p2p/src/peer_manager/tests/connections.rs
@@ -73,7 +73,9 @@ use crate::{
     utils::oneshot_nofail,
 };
 use common::{
-    chain::config, primitives::user_agent::mintlayer_core_user_agent, time_getter::TimeGetter,
+    chain::config::{self, MagicBytes},
+    primitives::user_agent::mintlayer_core_user_agent,
+    time_getter::TimeGetter,
 };
 use utils::atomics::SeqCstAtomicBool;
 
@@ -113,7 +115,7 @@ where
             net::types::PeerInfo {
                 peer_id,
                 protocol_version: TEST_PROTOCOL_VERSION,
-                network: [1, 2, 3, 4],
+                network: MagicBytes::new([1, 2, 3, 4]),
                 software_version: *config.software_version(),
                 user_agent: mintlayer_core_user_agent(),
                 common_services: [Service::Blocks, Service::Transactions, Service::PeerAddresses]
@@ -170,7 +172,7 @@ where
     let (mut pm2, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
         A::make_transport(),
         addr2,
-        Arc::new(config::Builder::test_chain().magic_bytes([1, 2, 3, 4]).build()),
+        Arc::new(config::Builder::test_chain().magic_bytes(MagicBytes::new([1, 2, 3, 4])).build()),
     )
     .await;
 
@@ -390,7 +392,7 @@ where
     let (mut pm2, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
         A::make_transport(),
         addr2,
-        Arc::new(config::Builder::test_chain().magic_bytes([1, 2, 3, 4]).build()),
+        Arc::new(config::Builder::test_chain().magic_bytes(MagicBytes::new([1, 2, 3, 4])).build()),
     )
     .await;
 
@@ -504,7 +506,7 @@ where
     let (mut pm2, _shutdown_sender, _subscribers_sender) = make_peer_manager::<T>(
         A::make_transport(),
         addr2,
-        Arc::new(config::Builder::test_chain().magic_bytes([1, 2, 3, 4]).build()),
+        Arc::new(config::Builder::test_chain().magic_bytes(MagicBytes::new([1, 2, 3, 4])).build()),
     )
     .await;
 
@@ -524,7 +526,7 @@ where
         ),
         Err(P2pError::ConnectionValidationFailed(
             ConnectionValidationError::DifferentNetwork {
-                our_network: [1, 2, 3, 4],
+                our_network: MagicBytes::new([1, 2, 3, 4]),
                 their_network: *config::create_unit_test_config().magic_bytes(),
             }
         ))

--- a/p2p/src/peer_manager/tests/eviction.rs
+++ b/p2p/src/peer_manager/tests/eviction.rs
@@ -24,6 +24,7 @@ use test_utils::random::Seed;
 
 use crate::{
     config::P2pConfig,
+    disconnection_reason::DisconnectionReason,
     net::default_backend::types::Command,
     peer_manager::{
         config::PeerManagerConfig,
@@ -280,7 +281,8 @@ mod dont_evict_if_blocks_in_flight {
         assert_eq!(
             cmd,
             Command::Disconnect {
-                peer_id: expected_peer_to_disconnect
+                peer_id: expected_peer_to_disconnect,
+                reason: Some(DisconnectionReason::PeerEvicted),
             }
         );
 

--- a/p2p/src/peer_manager/tests/ping.rs
+++ b/p2p/src/peer_manager/tests/ping.rs
@@ -21,6 +21,7 @@ use test_utils::{assert_matches, assert_matches_return_val};
 
 use crate::{
     config::{NodeType, P2pConfig},
+    disconnection_reason::DisconnectionReason,
     message::{PeerManagerMessage, PingRequest, PingResponse},
     net::{
         default_backend::{
@@ -153,7 +154,8 @@ async fn ping_timeout() {
     // PeerManager should ask backend to close connection
     let event = expect_recv!(cmd_receiver);
     match event {
-        Command::Disconnect { peer_id } => {
+        Command::Disconnect { peer_id, reason } => {
+            assert_eq!(reason, Some(DisconnectionReason::PingIgnored));
             conn_event_sender.send(ConnectivityEvent::ConnectionClosed { peer_id }).unwrap();
         }
         _ => panic!("unexpected event: {event:?}"),

--- a/p2p/src/peer_manager/tests/whitelist.rs
+++ b/p2p/src/peer_manager/tests/whitelist.rs
@@ -17,6 +17,7 @@ use std::{net::IpAddr, sync::Arc, time::Duration};
 
 use crate::{
     config::{NodeType, P2pConfig},
+    disconnection_reason::DisconnectionReason,
     net::{
         default_backend::{types::Command, ConnectivityHandle},
         types::{PeerInfo, PeerRole, Role},
@@ -331,7 +332,9 @@ fn manual_ban_overrides_whitelisting() {
 
     // Peer is disconnected by the peer manager
     match cmd_receiver.try_recv() {
-        Ok(Command::Disconnect { peer_id }) if peer_id == peer_id_1 => {}
+        Ok(Command::Disconnect { peer_id, reason }) if peer_id == peer_id_1 => {
+            assert_eq!(reason, Some(DisconnectionReason::AddressBanned));
+        }
         v => panic!("unexpected command: {v:?}"),
     }
 

--- a/p2p/src/peer_manager_event.rs
+++ b/p2p/src/peer_manager_event.rs
@@ -23,8 +23,9 @@ use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress
 use utils_networking::IpOrSocketAddress;
 
 use crate::{
-    interface::types::ConnectedPeer, peer_manager::PeerManagerInterface,
-    sync::sync_status::PeerBlockSyncStatus, types::peer_id::PeerId, utils::oneshot_nofail,
+    disconnection_reason::DisconnectionReason, interface::types::ConnectedPeer,
+    peer_manager::PeerManagerInterface, sync::sync_status::PeerBlockSyncStatus,
+    types::peer_id::PeerId, utils::oneshot_nofail,
 };
 
 #[derive(Debug)]
@@ -47,6 +48,7 @@ pub enum PeerManagerEvent {
     Disconnect(
         PeerId,
         PeerDisconnectionDbAction,
+        Option<DisconnectionReason>,
         oneshot_nofail::Sender<crate::Result<()>>,
     ),
 

--- a/p2p/src/sync/peer_common/mod.rs
+++ b/p2p/src/sync/peer_common/mod.rs
@@ -92,7 +92,8 @@ pub async fn handle_message_processing_result(
         | P2pError::PeerError(_)
         | P2pError::NoiseHandshakeError(_)
         | P2pError::InvalidConfigurationValue(_)
-        | P2pError::MessageCodecError(_)) => panic!("Unexpected error {e:?}"),
+        | P2pError::MessageCodecError(_)
+        | P2pError::ConnectionValidationFailed(_)) => panic!("Unexpected error {e:?}"),
 
         // Fatal errors, simply propagate them to stop the sync manager.
         // Note/TODO: due to how error types are currently organized, a storage error can

--- a/p2p/src/sync/peer_v2/block_manager.rs
+++ b/p2p/src/sync/peer_v2/block_manager.rs
@@ -36,6 +36,7 @@ use utils::sync::Arc;
 
 use crate::{
     config::P2pConfig,
+    disconnection_reason::DisconnectionReason,
     error::{P2pError, PeerError, ProtocolError},
     message::{BlockListRequest, BlockResponse, BlockSyncMessage, HeaderList, HeaderListRequest},
     net::{
@@ -898,6 +899,7 @@ where
         self.peer_mgr_event_sender.send(PeerManagerEvent::Disconnect(
             self.id(),
             PeerDisconnectionDbAction::Keep,
+            Some(DisconnectionReason::SyncRequestsIgnored),
             sender,
         ))?;
         receiver.await?.or_else(|e| match e {

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -277,7 +277,7 @@ impl TestNode {
         let future = async {
             loop {
                 match self.peer_manager_event_receiver.recv().await.unwrap() {
-                    PeerManagerEvent::Disconnect(peer_id, _peerdb_action, sender) => {
+                    PeerManagerEvent::Disconnect(peer_id, _peerdb_action, _, sender) => {
                         assert_eq!(id, peer_id);
                         sender.send(Ok(()));
                         break;
@@ -324,7 +324,9 @@ impl TestNode {
         time::timeout(SHORT_TIMEOUT, async {
             loop {
                 match self.peer_manager_event_receiver.recv().await.unwrap() {
-                    PeerManagerEvent::Disconnect(peer_id, _peerdb_action, _) if id == peer_id => {
+                    PeerManagerEvent::Disconnect(peer_id, _peerdb_action, _, _)
+                        if id == peer_id =>
+                    {
                         break;
                     }
                     _ => {}
@@ -344,7 +346,7 @@ impl TestNode {
                 let peer_event = self.peer_manager_event_receiver.recv().await.unwrap();
                 match peer_event {
                     PeerManagerEvent::Connect(_, _)
-                    | PeerManagerEvent::Disconnect(_, _, _)
+                    | PeerManagerEvent::Disconnect(_, _, _, _)
                     | PeerManagerEvent::GetPeerCount(_)
                     | PeerManagerEvent::GetBindAddresses(_)
                     | PeerManagerEvent::GetConnectedPeers(_)
@@ -636,7 +638,7 @@ impl From<&PeerManagerEvent> for PeerManagerEventDesc {
     fn from(event: &PeerManagerEvent) -> Self {
         match event {
             PeerManagerEvent::Connect(addr, _) => PeerManagerEventDesc::Connect(addr.clone()),
-            PeerManagerEvent::Disconnect(peer_id, _, _) => {
+            PeerManagerEvent::Disconnect(peer_id, _, _, _) => {
                 PeerManagerEventDesc::Disconnect(*peer_id)
             }
             PeerManagerEvent::GetPeerCount(_) => PeerManagerEventDesc::GetPeerCount,

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -312,7 +312,7 @@ impl TestNodeGroup {
                 if let Ok(peer_event) = data_item.node.peer_manager_event_receiver.try_recv() {
                     match peer_event {
                         PeerManagerEvent::Connect(_, _)
-                        | PeerManagerEvent::Disconnect(_, _, _)
+                        | PeerManagerEvent::Disconnect(_, _, _, _)
                         | PeerManagerEvent::GetPeerCount(_)
                         | PeerManagerEvent::GetBindAddresses(_)
                         | PeerManagerEvent::GetConnectedPeers(_)

--- a/p2p/src/tests/bad_time_diff.rs
+++ b/p2p/src/tests/bad_time_diff.rs
@@ -34,7 +34,10 @@ use crate::{
     tests::helpers::TestNode,
 };
 
-// In this test we want a version that would result in the WillDisconnect message being sent.
+// Check that a handshake is rejected if the time difference between the peers is too big.
+// Also check that the WillDisconnect message is sent in this case.
+
+// V3+ is needed for the WillDisconnect message to be sent.
 const TEST_PROTOCOL_VERSION: SupportedProtocolVersion = SupportedProtocolVersion::V3;
 
 async fn bad_time_diff_outgoing<TTM>()
@@ -132,16 +135,7 @@ where
     // The connection should be closed.
     msg_stream.recv().await.unwrap_err();
 
-    // Note: no peer discouragement  here, because peers are not banned during "manual outbound" connections.
-    let test_node_remnants = test_node.join().await;
-    assert_eq!(
-        test_node_remnants.peer_mgr.peerdb().list_discouraged().count(),
-        0
-    );
-    assert_eq!(
-        test_node_remnants.peer_mgr.peerdb().list_banned().count(),
-        0
-    );
+    test_node.join().await;
 }
 
 #[tracing::instrument]
@@ -247,16 +241,7 @@ where
     // The connection should be closed.
     msg_stream.recv().await.unwrap_err();
 
-    // Note: no peer discouragement here, because the TimeDiff error has zero ban score.
-    let test_node_remnants = test_node.join().await;
-    assert_eq!(
-        test_node_remnants.peer_mgr.peerdb().list_discouraged().count(),
-        0
-    );
-    assert_eq!(
-        test_node_remnants.peer_mgr.peerdb().list_banned().count(),
-        0
-    );
+    test_node.join().await;
 }
 
 #[tracing::instrument]

--- a/p2p/src/tests/bad_time_diff.rs
+++ b/p2p/src/tests/bad_time_diff.rs
@@ -1,0 +1,278 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{sync::Arc, time::Duration};
+
+use common::primitives::{time::Time, user_agent::mintlayer_core_user_agent};
+use p2p_test_utils::{run_with_timeout, P2pBasicTestTimeGetter};
+use test_utils::assert_matches;
+
+use crate::{
+    config::P2pConfig,
+    disconnection_reason::DisconnectionReason,
+    message::WillDisconnectMessage,
+    net::default_backend::{
+        transport::{BufferedTranscoder, TransportListener, TransportSocket},
+        types::{HandshakeMessage, Message, P2pTimestamp},
+    },
+    protocol::SupportedProtocolVersion,
+    testing_utils::{
+        TestTransportChannel, TestTransportMaker, TestTransportNoise, TestTransportTcp,
+    },
+    tests::helpers::TestNode,
+};
+
+// In this test we want a version that would result in the WillDisconnect message being sent.
+const TEST_PROTOCOL_VERSION: SupportedProtocolVersion = SupportedProtocolVersion::V3;
+
+async fn bad_time_diff_outgoing<TTM>()
+where
+    TTM: TestTransportMaker,
+    TTM::Transport: TransportSocket,
+{
+    let time_getter = P2pBasicTestTimeGetter::new();
+    let chain_config = Arc::new(common::chain::config::create_unit_test_config());
+    let max_clock_diff = Duration::from_secs(1);
+    let p2p_config = Arc::new(P2pConfig {
+        max_clock_diff: max_clock_diff.into(),
+
+        bind_addresses: Default::default(),
+        socks5_proxy: Default::default(),
+        disable_noise: Default::default(),
+        boot_nodes: Default::default(),
+        reserved_nodes: Default::default(),
+        whitelisted_addresses: Default::default(),
+        ban_config: Default::default(),
+        outbound_connection_timeout: Default::default(),
+        ping_check_period: Default::default(),
+        ping_timeout: Default::default(),
+        peer_handshake_timeout: Default::default(),
+        node_type: Default::default(),
+        allow_discover_private_ips: Default::default(),
+        user_agent: mintlayer_core_user_agent(),
+        sync_stalling_timeout: Default::default(),
+        peer_manager_config: Default::default(),
+        protocol_config: Default::default(),
+    });
+
+    let test_node = TestNode::<TTM::Transport>::start(
+        time_getter.clone(),
+        Arc::clone(&chain_config),
+        Arc::clone(&p2p_config),
+        TTM::make_transport(),
+        TTM::make_address(),
+        TEST_PROTOCOL_VERSION.into(),
+        None,
+    )
+    .await;
+
+    let transport = TTM::make_transport();
+    let mut listener = transport.bind(vec![TTM::make_address()]).await.unwrap();
+
+    let address = listener.local_addresses().unwrap()[0];
+    let connect_result_receiver = test_node.start_connecting(address);
+
+    let (stream, _) = listener.accept().await.unwrap();
+
+    let mut msg_stream =
+        BufferedTranscoder::new(stream, *p2p_config.protocol_config.max_message_size);
+
+    let msg = msg_stream.recv().await.unwrap();
+    assert_matches!(msg, Message::Handshake(HandshakeMessage::Hello { .. }));
+
+    let cur_time = time_getter.get_time_getter().get_time();
+    let peer_time =
+        P2pTimestamp::from_time(cur_time.saturating_duration_add(Duration::from_secs(1000)));
+
+    msg_stream
+        .send(Message::Handshake(HandshakeMessage::HelloAck {
+            protocol_version: TEST_PROTOCOL_VERSION.into(),
+            network: *chain_config.magic_bytes(),
+            user_agent: p2p_config.user_agent.clone(),
+            software_version: *chain_config.software_version(),
+            services: (*p2p_config.node_type).into(),
+            receiver_address: None,
+            current_time: peer_time,
+        }))
+        .await
+        .unwrap();
+
+    // connect_result should indicate a failed connection
+    let connect_result = connect_result_receiver.await.unwrap();
+    assert!(connect_result.is_err());
+
+    // WillDisconnect should be sent.
+    let msg = msg_stream.recv().await.unwrap();
+    assert_eq!(
+        msg,
+        Message::WillDisconnect(WillDisconnectMessage {
+            reason: (DisconnectionReason::TimeDiff {
+                remote_time: Time::from_duration_since_epoch(peer_time.as_duration_since_epoch()),
+                accepted_peer_time: std::ops::RangeInclusive::new(
+                    cur_time.saturating_duration_sub(max_clock_diff),
+                    cur_time.saturating_duration_add(max_clock_diff)
+                ),
+            })
+            .to_string()
+        })
+    );
+
+    // The connection should be closed.
+    msg_stream.recv().await.unwrap_err();
+
+    // Note: no peer discouragement  here, because peers are not banned during "manual outbound" connections.
+    let test_node_remnants = test_node.join().await;
+    assert_eq!(
+        test_node_remnants.peer_mgr.peerdb().list_discouraged().count(),
+        0
+    );
+    assert_eq!(
+        test_node_remnants.peer_mgr.peerdb().list_banned().count(),
+        0
+    );
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bad_time_diff_outgoing_tcp() {
+    run_with_timeout(bad_time_diff_outgoing::<TestTransportTcp>()).await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bad_time_diff_outgoing_channels() {
+    run_with_timeout(bad_time_diff_outgoing::<TestTransportChannel>()).await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bad_time_diff_outgoing_noise() {
+    run_with_timeout(bad_time_diff_outgoing::<TestTransportNoise>()).await;
+}
+
+async fn bad_time_diff_incoming<TTM>()
+where
+    TTM: TestTransportMaker,
+    TTM::Transport: TransportSocket,
+{
+    let time_getter = P2pBasicTestTimeGetter::new();
+    let chain_config = Arc::new(common::chain::config::create_unit_test_config());
+    let max_clock_diff = Duration::from_secs(1);
+    let p2p_config = Arc::new(P2pConfig {
+        max_clock_diff: max_clock_diff.into(),
+
+        bind_addresses: Default::default(),
+        socks5_proxy: Default::default(),
+        disable_noise: Default::default(),
+        boot_nodes: Default::default(),
+        reserved_nodes: Default::default(),
+        whitelisted_addresses: Default::default(),
+        ban_config: Default::default(),
+        outbound_connection_timeout: Default::default(),
+        ping_check_period: Default::default(),
+        ping_timeout: Default::default(),
+        peer_handshake_timeout: Default::default(),
+        node_type: Default::default(),
+        allow_discover_private_ips: Default::default(),
+        user_agent: mintlayer_core_user_agent(),
+        sync_stalling_timeout: Default::default(),
+        peer_manager_config: Default::default(),
+        protocol_config: Default::default(),
+    });
+
+    let test_node = TestNode::<TTM::Transport>::start(
+        time_getter.clone(),
+        Arc::clone(&chain_config),
+        Arc::clone(&p2p_config),
+        TTM::make_transport(),
+        TTM::make_address(),
+        TEST_PROTOCOL_VERSION.into(),
+        None,
+    )
+    .await;
+
+    let transport = TTM::make_transport();
+
+    let stream = transport.connect(*test_node.local_address()).await.unwrap();
+
+    let mut msg_stream =
+        BufferedTranscoder::new(stream, *p2p_config.protocol_config.max_message_size);
+
+    let cur_time = time_getter.get_time_getter().get_time();
+    let peer_time =
+        P2pTimestamp::from_time(cur_time.saturating_duration_add(Duration::from_secs(1000)));
+
+    msg_stream
+        .send(Message::Handshake(HandshakeMessage::Hello {
+            protocol_version: TEST_PROTOCOL_VERSION.into(),
+            network: *chain_config.magic_bytes(),
+            user_agent: p2p_config.user_agent.clone(),
+            software_version: *chain_config.software_version(),
+            services: (*p2p_config.node_type).into(),
+            receiver_address: None,
+            current_time: peer_time,
+            handshake_nonce: 0,
+        }))
+        .await
+        .unwrap();
+
+    // WillDisconnect should be sent.
+    let msg = msg_stream.recv().await.unwrap();
+    assert_eq!(
+        msg,
+        Message::WillDisconnect(WillDisconnectMessage {
+            reason: (DisconnectionReason::TimeDiff {
+                remote_time: Time::from_duration_since_epoch(peer_time.as_duration_since_epoch()),
+                accepted_peer_time: std::ops::RangeInclusive::new(
+                    cur_time.saturating_duration_sub(max_clock_diff),
+                    cur_time.saturating_duration_add(max_clock_diff)
+                ),
+            })
+            .to_string()
+        })
+    );
+
+    // The connection should be closed.
+    msg_stream.recv().await.unwrap_err();
+
+    // Note: no peer discouragement here, because the TimeDiff error has zero ban score.
+    let test_node_remnants = test_node.join().await;
+    assert_eq!(
+        test_node_remnants.peer_mgr.peerdb().list_discouraged().count(),
+        0
+    );
+    assert_eq!(
+        test_node_remnants.peer_mgr.peerdb().list_banned().count(),
+        0
+    );
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bad_time_diff_incoming_tcp() {
+    run_with_timeout(bad_time_diff_incoming::<TestTransportTcp>()).await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bad_time_diff_incoming_channels() {
+    run_with_timeout(bad_time_diff_incoming::<TestTransportChannel>()).await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bad_time_diff_incoming_noise() {
+    run_with_timeout(bad_time_diff_incoming::<TestTransportNoise>()).await;
+}

--- a/p2p/src/tests/correct_handshake.rs
+++ b/p2p/src/tests/correct_handshake.rs
@@ -96,6 +96,8 @@ where
 
     let bans_count = test_node_remnants.peer_mgr.peerdb().list_banned().count();
     assert_eq!(bans_count, 0);
+    let discouragements_count = test_node_remnants.peer_mgr.peerdb().list_discouraged().count();
+    assert_eq!(discouragements_count, 0);
 
     assert_eq!(test_node_remnants.peer_mgr.peers().len(), 1);
     let peer_score = test_node_remnants.peer_mgr.peers().first_key_value().unwrap().1.score;
@@ -176,6 +178,8 @@ where
 
     let bans_count = test_node_remnants.peer_mgr.peerdb().list_banned().count();
     assert_eq!(bans_count, 0);
+    let discouragements_count = test_node_remnants.peer_mgr.peerdb().list_discouraged().count();
+    assert_eq!(discouragements_count, 0);
 
     assert_eq!(test_node_remnants.peer_mgr.peers().len(), 1);
     let peer_score = test_node_remnants.peer_mgr.peers().first_key_value().unwrap().1.score;

--- a/p2p/src/tests/disconnect_on_will_disconnect_msg.rs
+++ b/p2p/src/tests/disconnect_on_will_disconnect_msg.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{sync::Arc, time::Duration};
+
+use chainstate::Locator;
+use p2p_test_utils::{run_with_timeout, P2pBasicTestTimeGetter};
+use test_utils::assert_matches;
+
+use crate::{
+    message::{HeaderList, HeaderListRequest, WillDisconnectMessage},
+    net::default_backend::{
+        transport::{BufferedTranscoder, TransportSocket},
+        types::{HandshakeMessage, Message, P2pTimestamp},
+    },
+    protocol::SupportedProtocolVersion,
+    testing_utils::{
+        test_p2p_config, TestTransportChannel, TestTransportMaker, TestTransportNoise,
+        TestTransportTcp,
+    },
+    tests::helpers::TestNode,
+};
+
+// In this test we want a version that would result in the WillDisconnect message being sent.
+const TEST_PROTOCOL_VERSION: SupportedProtocolVersion = SupportedProtocolVersion::V3;
+
+// Check that the node will also initiate disconnection when it receives the WillDisconnect message.
+async fn disconnect_on_will_disconnect_msg<TTM>()
+where
+    TTM: TestTransportMaker,
+    TTM::Transport: TransportSocket,
+{
+    let time_getter = P2pBasicTestTimeGetter::new();
+    let chain_config = Arc::new(common::chain::config::create_unit_test_config());
+    let p2p_config = Arc::new(test_p2p_config());
+
+    let test_node = TestNode::<TTM::Transport>::start(
+        time_getter.clone(),
+        Arc::clone(&chain_config),
+        Arc::clone(&p2p_config),
+        TTM::make_transport(),
+        TTM::make_address(),
+        TEST_PROTOCOL_VERSION.into(),
+        None,
+    )
+    .await;
+
+    let transport = TTM::make_transport();
+
+    let stream = transport.connect(*test_node.local_address()).await.unwrap();
+
+    let mut msg_stream =
+        BufferedTranscoder::new(stream, *p2p_config.protocol_config.max_message_size);
+
+    msg_stream
+        .send(Message::Handshake(HandshakeMessage::Hello {
+            protocol_version: TEST_PROTOCOL_VERSION.into(),
+            network: *chain_config.magic_bytes(),
+            user_agent: p2p_config.user_agent.clone(),
+            software_version: *chain_config.software_version(),
+            services: (*p2p_config.node_type).into(),
+            receiver_address: None,
+            current_time: P2pTimestamp::from_time(time_getter.get_time_getter().get_time()),
+            handshake_nonce: 0,
+        }))
+        .await
+        .unwrap();
+
+    let msg = msg_stream.recv().await.unwrap();
+    assert_matches!(msg, Message::Handshake(HandshakeMessage::HelloAck { .. }));
+
+    // Handshake has completed successfully; the node requests for headers.
+    let msg = msg_stream.recv().await.unwrap();
+    assert_matches!(msg, Message::HeaderListRequest(HeaderListRequest { .. }));
+
+    // The peer sends WillDisconnect, but then continues working as if nothing has happened.
+    msg_stream
+        .send(Message::WillDisconnect(WillDisconnectMessage {
+            reason: "foo".to_owned(),
+        }))
+        .await
+        .unwrap();
+
+    // The peer responds with a header list and sends its own header list request.
+    // Note that we don't check results of the send calls, because the connection may or may not
+    // be dropped by now by the node.
+    let _ = msg_stream.send(Message::HeaderList(HeaderList::new(vec![]))).await;
+    // Note: if we send HeaderListRequest right away, there's the chance that the message will be
+    // handled by the sync manager before the disconnection command reaches backend.
+    std::thread::sleep(Duration::from_secs(1));
+    let _ = msg_stream
+        .send(Message::HeaderListRequest(HeaderListRequest::new(
+            Locator::new(vec![]),
+        )))
+        .await;
+
+    // The node shouldn't respond with headers; instead, the connection should be closed.
+    msg_stream.recv().await.unwrap_err();
+
+    test_node.join().await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disconnect_on_will_disconnect_msg_tcp() {
+    run_with_timeout(disconnect_on_will_disconnect_msg::<TestTransportTcp>()).await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disconnect_on_will_disconnect_msg_channels() {
+    run_with_timeout(disconnect_on_will_disconnect_msg::<TestTransportChannel>()).await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disconnect_on_will_disconnect_msg_noise() {
+    run_with_timeout(disconnect_on_will_disconnect_msg::<TestTransportNoise>()).await;
+}

--- a/p2p/src/tests/disconnect_on_will_disconnect_msg.rs
+++ b/p2p/src/tests/disconnect_on_will_disconnect_msg.rs
@@ -94,10 +94,10 @@ where
         .unwrap();
 
     // The peer responds with a header list and sends its own header list request.
-    // Note that we don't check results of the send calls, because the connection may or may not
-    // be dropped by now by the node.
+    // Note that we don't check results of subsequent send calls, because the connection may be
+    // dropped by the node at any moment.
     let _ = msg_stream.send(Message::HeaderList(HeaderList::new(vec![]))).await;
-    // Note: if we send HeaderListRequest right away, there's the chance that the message will be
+    // Note: if we send HeaderListRequest right away, there's a chance that the message will be
     // handled by the sync manager before the disconnection command reaches backend.
     std::thread::sleep(Duration::from_secs(1));
     let _ = msg_stream

--- a/p2p/src/tests/incorrect_handshake.rs
+++ b/p2p/src/tests/incorrect_handshake.rs
@@ -149,7 +149,7 @@ where
     // we end the test.
     test_node.wait_for_ban_score_adjustment().await;
 
-    // The peer address should be banned.
+    // The peer address should be discouraged.
     let test_node_remnants = test_node.join().await;
     // TODO: check the actual address instead of the count, same in other places.
     assert!(test_node_remnants.peer_mgr.peerdb().list_discouraged().count() > 0);

--- a/p2p/src/tests/mod.rs
+++ b/p2p/src/tests/mod.rs
@@ -16,10 +16,13 @@
 //! A module for tests that behave like integration tests but still need access to private data
 //! via methods under #[cfg(test)],
 
+mod bad_time_diff;
 mod correct_handshake;
+mod disconnect_on_will_disconnect_msg;
 mod incorrect_handshake;
 mod misbehavior;
 mod peer_discovery_on_stale_tip;
+mod same_handshake_nonce;
 mod unsupported_version;
 
 pub mod helpers;

--- a/p2p/src/tests/same_handshake_nonce.rs
+++ b/p2p/src/tests/same_handshake_nonce.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use p2p_test_utils::{run_with_timeout, P2pBasicTestTimeGetter};
+use test_utils::assert_matches;
+
+use crate::{
+    disconnection_reason::DisconnectionReason,
+    message::WillDisconnectMessage,
+    net::default_backend::{
+        transport::{BufferedTranscoder, TransportListener, TransportSocket},
+        types::{HandshakeMessage, Message, P2pTimestamp},
+    },
+    protocol::SupportedProtocolVersion,
+    testing_utils::{
+        test_p2p_config, TestTransportChannel, TestTransportMaker, TestTransportNoise,
+        TestTransportTcp,
+    },
+    tests::helpers::TestNode,
+};
+
+// In this test we want a version that would result in the WillDisconnect message being sent.
+const TEST_PROTOCOL_VERSION: SupportedProtocolVersion = SupportedProtocolVersion::V3;
+
+// Simulate a self-connection by sending the same nonce in Hello. Check that the WillDisconnect
+// message is sent.
+async fn same_handshake_nonce<TTM>()
+where
+    TTM: TestTransportMaker,
+    TTM::Transport: TransportSocket,
+{
+    let time_getter = P2pBasicTestTimeGetter::new();
+    let chain_config = Arc::new(common::chain::config::create_unit_test_config());
+    let p2p_config = Arc::new(test_p2p_config());
+
+    let test_node = TestNode::<TTM::Transport>::start(
+        time_getter.clone(),
+        Arc::clone(&chain_config),
+        Arc::clone(&p2p_config),
+        TTM::make_transport(),
+        TTM::make_address(),
+        TEST_PROTOCOL_VERSION.into(),
+        None,
+    )
+    .await;
+
+    let transport = TTM::make_transport();
+    let mut listener = transport.bind(vec![TTM::make_address()]).await.unwrap();
+
+    let outgoing_conn_address = listener.local_addresses().unwrap()[0];
+    let _outgoing_connect_result_receiver = test_node.start_connecting(outgoing_conn_address);
+
+    let (outgoing_conn_stream, _) = listener.accept().await.unwrap();
+
+    let mut outgoing_conn_msg_stream = BufferedTranscoder::new(
+        outgoing_conn_stream,
+        *p2p_config.protocol_config.max_message_size,
+    );
+
+    let msg = outgoing_conn_msg_stream.recv().await.unwrap();
+    let Message::Handshake(HandshakeMessage::Hello {
+        protocol_version: _,
+        network: _,
+        services: _,
+        user_agent: _,
+        software_version: _,
+        receiver_address: _,
+        current_time: _,
+        handshake_nonce,
+    }) = msg
+    else {
+        panic!("Unexpected message: {msg:?}");
+    };
+    assert_matches!(msg, Message::Handshake(HandshakeMessage::Hello { .. }));
+
+    let incoming_conn_stream = transport.connect(*test_node.local_address()).await.unwrap();
+
+    let mut incoming_conn_msg_stream = BufferedTranscoder::new(
+        incoming_conn_stream,
+        *p2p_config.protocol_config.max_message_size,
+    );
+
+    incoming_conn_msg_stream
+        .send(Message::Handshake(HandshakeMessage::Hello {
+            protocol_version: TEST_PROTOCOL_VERSION.into(),
+            network: *chain_config.magic_bytes(),
+            user_agent: p2p_config.user_agent.clone(),
+            software_version: *chain_config.software_version(),
+            services: (*p2p_config.node_type).into(),
+            receiver_address: None,
+            current_time: P2pTimestamp::from_time(time_getter.get_time_getter().get_time()),
+            handshake_nonce,
+        }))
+        .await
+        .unwrap();
+
+    let msg = incoming_conn_msg_stream.recv().await.unwrap();
+    assert_matches!(msg, Message::Handshake(HandshakeMessage::HelloAck { .. }));
+
+    // WillDisconnect should be sent.
+    let msg = incoming_conn_msg_stream.recv().await.unwrap();
+    assert_eq!(
+        msg,
+        Message::WillDisconnect(WillDisconnectMessage {
+            reason: (DisconnectionReason::ConnectionFromSelf).to_string()
+        })
+    );
+
+    // The connection should be closed.
+    incoming_conn_msg_stream.recv().await.unwrap_err();
+
+    test_node.join().await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn same_handshake_nonce_tcp() {
+    run_with_timeout(same_handshake_nonce::<TestTransportTcp>()).await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn same_handshake_nonce_channels() {
+    run_with_timeout(same_handshake_nonce::<TestTransportChannel>()).await;
+}
+
+#[tracing::instrument]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn same_handshake_nonce_noise() {
+    run_with_timeout(same_handshake_nonce::<TestTransportNoise>()).await;
+}

--- a/p2p/src/tests/unsupported_version.rs
+++ b/p2p/src/tests/unsupported_version.rs
@@ -86,8 +86,12 @@ where
     // The connection should be closed.
     msg_stream.recv().await.unwrap_err();
 
-    // Note: no peer ban here, because peers are not banned during "manual outbound" connections.
+    // Note: no peer discouragement here, because peers are not banned during "manual outbound" connections.
     let test_node_remnants = test_node.join().await;
+    assert_eq!(
+        test_node_remnants.peer_mgr.peerdb().list_discouraged().count(),
+        0
+    );
     assert_eq!(
         test_node_remnants.peer_mgr.peerdb().list_banned().count(),
         0
@@ -157,8 +161,12 @@ where
     // The connection should be closed.
     msg_stream.recv().await.unwrap_err();
 
-    // Note: no peer ban here, because the UnsupportedProtocol error has zero ban score.
+    // Note: no peer discouragement here, because the UnsupportedProtocol error has zero ban score.
     let test_node_remnants = test_node.join().await;
+    assert_eq!(
+        test_node_remnants.peer_mgr.peerdb().list_discouraged().count(),
+        0
+    );
     assert_eq!(
         test_node_remnants.peer_mgr.peerdb().list_banned().count(),
         0

--- a/p2p/src/tests/unsupported_version.rs
+++ b/p2p/src/tests/unsupported_version.rs
@@ -86,7 +86,8 @@ where
     // The connection should be closed.
     msg_stream.recv().await.unwrap_err();
 
-    // Note: no peer discouragement here, because peers are not banned during "manual outbound" connections.
+    // Note: no peer discouragement here, because peers are not discouraged during
+    // "manual outbound" connections.
     let test_node_remnants = test_node.join().await;
     assert_eq!(
         test_node_remnants.peer_mgr.peerdb().list_discouraged().count(),

--- a/wallet/types/src/chain_info.rs
+++ b/wallet/types/src/chain_info.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{ChainConfig, GenBlock},
+    chain::{config::MagicBytes, ChainConfig, GenBlock},
     primitives::Id,
 };
 use serialization::{Decode, Encode};
@@ -23,7 +23,7 @@ use serialization::{Decode, Encode};
 pub struct ChainInfo {
     chain_type: String,
     genesis_block_id: Id<GenBlock>,
-    magic_bytes: [u8; 4],
+    magic_bytes: MagicBytes,
 }
 
 impl ChainInfo {
@@ -43,7 +43,7 @@ impl ChainInfo {
         self.genesis_block_id
     }
 
-    pub fn magic_bytes(&self) -> [u8; 4] {
+    pub fn magic_bytes(&self) -> MagicBytes {
         self.magic_bytes
     }
 


### PR DESCRIPTION
Functions/events that perform disconnection now accept an optional `DisconnectionReason`; if it's set, a `WillDisconnect` message will be sent to the peer before disconnecting if the peer has the appropriate protocol version.
The current protocol version has been upped to 3.

Also, I wrapped the "magic bytes" array that represents the network into a new-type `MagicBytes`; this is not really needed in this PR, but I wanted to implement `Display` for it to make log lines look nicer.