### PR TITLE
Wallet migration v7 add wallet type Cold/Hot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,7 @@ dependencies = [
  "tokio",
  "tower",
  "utils-networking",
+ "wallet-types",
 ]
 
 [[package]]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -136,6 +136,7 @@ BASE_SCRIPTS = [
     'wallet_sign_message.py',
     'wallet_sign_message_rpc.py',
     'wallet_cold_wallet_send.py',
+    'wallet_cold_wallet_send_rpc.py',
     'wallet_tx_compose.py',
     'wallet_data_deposit.py',
     'wallet_submit_tx.py',

--- a/test/functional/wallet_cold_wallet_send_rpc.py
+++ b/test/functional/wallet_cold_wallet_send_rpc.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Wallet cold wallet send request test
+
+Check that:
+* We can create a new cold wallet,
+* issue a new address
+* send some coins to that address
+* create a new hot wallet
+* from the hot wallet create a send request using the cold wallet's utxo
+* sign the new tx with the cold wallet
+* send it with the hot wallet
+"""
+
+
+from wallet_cold_wallet_send import WalletColdSend
+from test_framework.wallet_rpc_controller import WalletRpcController
+
+class WalletColdSendRpc(WalletColdSend):
+
+    def set_test_params(self):
+        self.wallet_controller = WalletRpcController
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[
+            "--blockprod-min-peers-to-produce-blocks=0",
+        ]]
+
+    def run_test(self):
+        super().run_test()
+
+
+if __name__ == '__main__':
+    WalletColdSendRpc().main()

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -227,7 +227,14 @@ fn verify_wallet_balance(
 
     // Loading a copy of the wallet from the same DB should be safe because loading is an R/O operation
     let db_copy = wallet.db.clone();
-    let wallet = Wallet::load_wallet(Arc::clone(chain_config), db_copy, None, |_| Ok(())).unwrap();
+    let wallet = Wallet::load_wallet(
+        Arc::clone(chain_config),
+        db_copy,
+        None,
+        |_| Ok(()),
+        WalletType::Hot,
+    )
+    .unwrap();
     let coin_balance = get_coin_balance(&wallet);
     // Check that the loaded wallet has the same balance
     assert_eq!(coin_balance, expected_balance);
@@ -251,8 +258,8 @@ fn create_wallet_with_mnemonic(
         mnemonic,
         None,
         StoreSeedPhrase::DoNotStore,
-        BlockHeight::new(0),
-        genesis_block_id,
+        (BlockHeight::new(0), genesis_block_id),
+        WalletType::Hot,
     )
     .unwrap()
 }
@@ -309,7 +316,13 @@ fn wallet_creation_in_memory() {
     let empty_db = create_wallet_in_memory().unwrap();
 
     // fail to load an empty wallet
-    match Wallet::load_wallet(Arc::clone(&chain_config), empty_db, None, |_| Ok(())) {
+    match Wallet::load_wallet(
+        Arc::clone(&chain_config),
+        empty_db,
+        None,
+        |_| Ok(()),
+        WalletType::Hot,
+    ) {
         Ok(_) => panic!("Wallet loading should fail"),
         Err(err) => assert_eq!(err, WalletError::WalletNotInitialized),
     }
@@ -319,7 +332,14 @@ fn wallet_creation_in_memory() {
     let initialized_db = wallet.db;
 
     // successfully load a wallet from initialized db
-    let _wallet = Wallet::load_wallet(chain_config, initialized_db, None, |_| Ok(())).unwrap();
+    let _wallet = Wallet::load_wallet(
+        chain_config,
+        initialized_db,
+        None,
+        |_| Ok(()),
+        WalletType::Hot,
+    )
+    .unwrap();
 }
 
 #[rstest]
@@ -353,8 +373,8 @@ fn wallet_migration_to_v2(#[case] seed: Seed) {
         MNEMONIC,
         None,
         StoreSeedPhrase::DoNotStore,
-        BlockHeight::new(0),
-        genesis_block_id,
+        (BlockHeight::new(0), genesis_block_id),
+        WalletType::Hot,
     )
     .unwrap();
     verify_wallet_balance(&chain_config, &wallet, genesis_amount);
@@ -398,8 +418,14 @@ fn wallet_migration_to_v2(#[case] seed: Seed) {
 
     let new_db = Store::new_from_dump(DefaultBackend::new_in_memory(), raw_db).unwrap();
 
-    let wallet =
-        Wallet::load_wallet(Arc::clone(&chain_config), new_db, password, |_| Ok(())).unwrap();
+    let wallet = Wallet::load_wallet(
+        Arc::clone(&chain_config),
+        new_db,
+        password,
+        |_| Ok(()),
+        WalletType::Hot,
+    )
+    .unwrap();
 
     // Migration has been done and new version is v2
     assert_eq!(
@@ -444,8 +470,8 @@ fn wallet_seed_phrase_retrieval(#[case] seed: Seed) {
         MNEMONIC,
         wallet_passphrase.as_ref().map(|p| p.as_ref()),
         StoreSeedPhrase::Store,
-        BlockHeight::new(0),
-        genesis_block_id,
+        (BlockHeight::new(0), genesis_block_id),
+        WalletType::Hot,
     )
     .unwrap();
 
@@ -533,8 +559,8 @@ fn wallet_seed_phrase_check_address() {
         MNEMONIC,
         wallet_passphrase.as_ref().map(|p| p.as_ref()),
         StoreSeedPhrase::Store,
-        BlockHeight::new(0),
-        genesis_block_id,
+        (BlockHeight::new(0), genesis_block_id),
+        WalletType::Hot,
     )
     .unwrap();
 
@@ -558,8 +584,8 @@ fn wallet_seed_phrase_check_address() {
         MNEMONIC,
         wallet_passphrase.as_ref().map(|p| p.as_ref()),
         StoreSeedPhrase::Store,
-        BlockHeight::new(0),
-        genesis_block_id,
+        (BlockHeight::new(0), genesis_block_id),
+        WalletType::Hot,
     )
     .unwrap();
 
@@ -876,7 +902,14 @@ fn test_wallet_accounts(
     assert_eq!(accounts, expected_accounts);
 
     let db_copy = wallet.db.clone();
-    let wallet = Wallet::load_wallet(Arc::clone(chain_config), db_copy, None, |_| Ok(())).unwrap();
+    let wallet = Wallet::load_wallet(
+        Arc::clone(chain_config),
+        db_copy,
+        None,
+        |_| Ok(()),
+        WalletType::Hot,
+    )
+    .unwrap();
     let accounts = wallet.account_indexes().cloned().collect::<Vec<_>>();
     assert_eq!(accounts, expected_accounts);
 }

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -29,8 +29,9 @@ use std::collections::BTreeMap;
 
 use wallet_types::{
     account_info::AccountVrfKeys, chain_info::ChainInfo, keys::RootKeys,
-    seed_phrase::SerializableSeedPhrase, AccountDerivationPathId, AccountId, AccountInfo,
-    AccountKeyPurposeId, AccountWalletCreatedTxId, AccountWalletTxId, KeychainUsageState, WalletTx,
+    seed_phrase::SerializableSeedPhrase, wallet_type::WalletType, AccountDerivationPathId,
+    AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletCreatedTxId, AccountWalletTxId,
+    KeychainUsageState, WalletTx,
 };
 
 /// Wallet Errors
@@ -63,6 +64,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub trait WalletStorageReadLocked {
     /// Get storage version
     fn get_storage_version(&self) -> Result<u32>;
+    fn get_wallet_type(&self) -> Result<WalletType>;
     fn get_chain_info(&self) -> Result<ChainInfo>;
     fn get_transaction(&self, id: &AccountWalletTxId) -> Result<Option<WalletTx>>;
     fn get_transactions(
@@ -114,6 +116,7 @@ pub trait WalletStorageEncryptionRead {
 pub trait WalletStorageWriteLocked: WalletStorageReadLocked {
     /// Set storage version
     fn set_storage_version(&mut self, version: u32) -> Result<()>;
+    fn set_wallet_type(&mut self, wallet_type: WalletType) -> Result<()>;
     fn set_chain_info(&mut self, chain_info: &ChainInfo) -> Result<()>;
     fn set_transaction(&mut self, id: &AccountWalletTxId, tx: &WalletTx) -> Result<()>;
     fn del_transaction(&mut self, id: &AccountWalletTxId) -> Result<()>;

--- a/wallet/types/src/wallet_type.rs
+++ b/wallet/types/src/wallet_type.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 RBB S.r.l
+// Copyright (c) 2024 RBB S.r.l
 // opensource@mintlayer.org
 // SPDX-License-Identifier: MIT
 // Licensed under the MIT License;
@@ -13,20 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod account_id;
-pub mod account_info;
-pub mod chain_info;
-pub mod keys;
-pub mod seed_phrase;
-pub mod utxo_types;
-pub mod wallet_tx;
-pub mod wallet_type;
-pub mod with_locked;
+use serialization::{Decode, Encode};
+use std::fmt::{Display, Formatter};
 
-pub use account_id::{
-    AccountDerivationPathId, AccountId, AccountKeyPurposeId, AccountWalletCreatedTxId,
-    AccountWalletTxId,
-};
-pub use account_info::AccountInfo;
-pub use keys::{KeyPurpose, KeychainUsageState, RootKeys};
-pub use wallet_tx::{BlockInfo, WalletTx};
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+pub enum WalletType {
+    #[codec(index = 0)]
+    Cold,
+    #[codec(index = 1)]
+    Hot,
+}
+
+impl Display for WalletType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hot => write!(f, "Hot"),
+            Self::Cold => write!(f, "Cold"),
+        }
+    }
+}

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -46,7 +46,7 @@ use test_utils::random::{make_seedable_rng, Seed};
 use tokio::sync::mpsc;
 use utils_networking::IpOrSocketAddress;
 use wallet::wallet_events::WalletEventsNoOp;
-use wallet_types::account_info::DEFAULT_ACCOUNT_INDEX;
+use wallet_types::{account_info::DEFAULT_ACCOUNT_INDEX, wallet_type::WalletType};
 
 use super::*;
 
@@ -201,6 +201,10 @@ impl MockNode {
 #[async_trait::async_trait]
 impl NodeInterface for MockNode {
     type Error = NodeRpcError;
+
+    fn is_cold_wallet_node(&self) -> WalletType {
+        WalletType::Hot
+    }
 
     async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error> {
         Ok(self.tf.lock().unwrap().chainstate.info().unwrap())

--- a/wallet/wallet-node-client/Cargo.toml
+++ b/wallet/wallet-node-client/Cargo.toml
@@ -21,6 +21,7 @@ rpc = { path = "../../rpc" }
 serialization = { path = "../../serialization" }
 subsystem = { path = "../../subsystem" }
 utils-networking = { path = "../../utils/networking" }
+wallet-types = { path = "../types" }
 
 async-trait.workspace = true
 base64.workspace = true

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -37,6 +37,7 @@ use p2p::{
 };
 use serialization::hex::HexError;
 use utils_networking::IpOrSocketAddress;
+use wallet_types::wallet_type::WalletType;
 
 use crate::node_traits::NodeInterface;
 
@@ -98,6 +99,10 @@ impl WalletHandlesClient {
 #[async_trait::async_trait]
 impl NodeInterface for WalletHandlesClient {
     type Error = WalletHandlesClientError;
+
+    fn is_cold_wallet_node(&self) -> WalletType {
+        WalletType::Hot
+    }
 
     async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error> {
         let result = self.chainstate.call(move |this| this.info()).await??;

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -31,10 +31,13 @@ use mempool::{tx_accumulator::PackingStrategy, tx_options::TxOptionsOverrides, F
 use p2p::types::{bannable_address::BannableAddress, socket_address::SocketAddress};
 pub use p2p::{interface::types::ConnectedPeer, types::peer_id::PeerId};
 use utils_networking::IpOrSocketAddress;
+use wallet_types::wallet_type::WalletType;
 
 #[async_trait::async_trait]
 pub trait NodeInterface {
     type Error: std::error::Error + Send + Sync + 'static;
+
+    fn is_cold_wallet_node(&self) -> WalletType;
 
     async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error>;
     async fn get_best_block_id(&self) -> Result<Id<GenBlock>, Self::Error>;

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -38,6 +38,7 @@ use p2p::{
 };
 use serialization::hex_encoded::HexEncoded;
 use utils_networking::IpOrSocketAddress;
+use wallet_types::wallet_type::WalletType;
 
 use crate::node_traits::NodeInterface;
 
@@ -46,6 +47,10 @@ use super::{NodeRpcClient, NodeRpcError};
 #[async_trait::async_trait]
 impl NodeInterface for NodeRpcClient {
     type Error = NodeRpcError;
+
+    fn is_cold_wallet_node(&self) -> WalletType {
+        WalletType::Hot
+    }
 
     async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error> {
         ChainstateRpcClient::info(&self.http_client)

--- a/wallet/wallet-node-client/src/rpc_client/cold_wallet_client.rs
+++ b/wallet/wallet-node-client/src/rpc_client/cold_wallet_client.rs
@@ -31,6 +31,7 @@ use p2p::{
     types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId},
 };
 use utils_networking::IpOrSocketAddress;
+use wallet_types::wallet_type::WalletType;
 
 use crate::node_traits::NodeInterface;
 
@@ -45,6 +46,10 @@ pub enum ColdWalletRpcError {
 #[async_trait::async_trait]
 impl NodeInterface for ColdWalletClient {
     type Error = ColdWalletRpcError;
+
+    fn is_cold_wallet_node(&self) -> WalletType {
+        WalletType::Cold
+    }
 
     async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error> {
         let genesis = self.chain_config.genesis_block();

--- a/wallet/wallet-rpc-lib/src/service/mod.rs
+++ b/wallet/wallet-rpc-lib/src/service/mod.rs
@@ -68,6 +68,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletService<N> {
                     chain_config.shallow_clone(),
                     wallet_file,
                     wallet_password,
+                    node_rpc.is_cold_wallet_node(),
                 )?
             };
 

--- a/wallet/wallet-rpc-lib/src/service/worker.rs
+++ b/wallet/wallet-rpc-lib/src/service/worker.rs
@@ -177,8 +177,13 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletWorker<N> {
             self.controller.is_none(),
             ControllerError::WalletFileAlreadyOpen
         );
-        let wallet =
-            WalletController::open_wallet(self.chain_config.clone(), wallet_path, password)?;
+
+        let wallet = WalletController::open_wallet(
+            self.chain_config.clone(),
+            wallet_path,
+            password,
+            self.node_rpc.is_cold_wallet_node(),
+        )?;
 
         let controller = WalletController::new(
             self.chain_config.clone(),
@@ -221,8 +226,8 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletWorker<N> {
                 mnemonic.clone(),
                 passphrase_ref,
                 whether_to_store_seed_phrase,
-                info.best_block_height,
-                info.best_block_id,
+                (info.best_block_height, info.best_block_id),
+                self.node_rpc.is_cold_wallet_node(),
             )
         } else {
             WalletController::recover_wallet(
@@ -231,6 +236,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletWorker<N> {
                 mnemonic.clone(),
                 passphrase_ref,
                 whether_to_store_seed_phrase,
+                self.node_rpc.is_cold_wallet_node(),
             )
         }
         .map_err(RpcError::Controller)?;

--- a/wallet/wallet-rpc-lib/tests/utils.rs
+++ b/wallet/wallet-rpc-lib/tests/utils.rs
@@ -33,6 +33,7 @@ pub use crypto::random::Rng;
 pub use rpc::test_support::{ClientT, Subscription, SubscriptionClientT};
 pub use serde_json::Value as JsonValue;
 pub use test_utils::random::{make_seedable_rng, Seed};
+use wallet_types::wallet_type::WalletType;
 
 pub const ACCOUNT0_ARG: AccountArg = AccountArg(0);
 pub const ACCOUNT1_ARG: AccountArg = AccountArg(1);
@@ -69,8 +70,8 @@ impl TestFramework {
                 wallet_test_node::MNEMONIC,
                 None,
                 wallet_types::seed_phrase::StoreSeedPhrase::DoNotStore,
-                BlockHeight::new(0),
-                chain_config.genesis_block_id(),
+                (BlockHeight::new(0), chain_config.genesis_block_id()),
+                WalletType::Hot,
             )
             .unwrap();
 


### PR DESCRIPTION
- store wallet type Cold/Hot in the wallet db file
- check wallet type on loading to prevent opening a Cold wallet in hot mode or reverse