### PR TITLE
wallet-rpc: Rename `amount_str` to `amount` for consistency

### DIFF
--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -203,7 +203,7 @@ Parameters:
 {
     "account": number,
     "address": string,
-    "amount_str": decimal string,
+    "amount": decimal string,
     "selected_utxo": {
         "id": EITHER OF
              1) { "Transaction": hex string }

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -239,7 +239,7 @@ trait WalletRpc {
         &self,
         account: AccountArg,
         address: String,
-        amount_str: DecimalAmount,
+        amount: DecimalAmount,
         selected_utxo: UtxoOutPoint,
         change_address: Option<String>,
         options: TransactionOptions,


### PR DESCRIPTION
No need for Hungarian notation here.