### PR TITLE
fix list created blocks to show pools based on staker key

### DIFF
--- a/node-gui/src/backend/backend_impl.rs
+++ b/node-gui/src/backend/backend_impl.rs
@@ -777,7 +777,7 @@ impl Backend {
                 let pool_info_res = wallet_data
                     .controller
                     .readonly_controller(account_id.account_index())
-                    .get_pool_ids()
+                    .get_staking_pools()
                     .await;
                 match pool_info_res {
                     Ok(staking_balance) => {

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -372,7 +372,14 @@ class WalletCliController:
         return await self._write_command(f"node-submit-transaction {transaction} {store_tx}\n")
 
     async def list_pool_ids(self) -> List[PoolData]:
-        output = await self._write_command("staking-list-pool-ids\n", can_be_empty=True)
+        output = await self._write_command("staking-list-pools\n", can_be_empty=True)
+        self.log.info(f"pools: {output}");
+        pattern = r"Pool Id: ([a-zA-Z0-9]+), Pledge: (\d+[.]?\d+), Balance: (\d+[.]?\d+), Creation Block Height: (\d+), Timestamp: (\d+), Staker: ([a-zA-Z0-9]+), Decommission Key: ([a-zA-Z0-9]+), VRF Public Key: ([a-zA-Z0-9]+)"
+        matches = re.findall(pattern, output)
+        return [PoolData(pool_id, pledge, balance, int(height), timestamp, staker, decommission_key, vrf_public_key) for pool_id, pledge, balance, height, timestamp, staker, decommission_key, vrf_public_key in matches]
+
+    async def list_pools_for_decommission(self) -> List[PoolData]:
+        output = await self._write_command("staking-list-owned-pools-for-decommission\n", can_be_empty=True)
         self.log.info(f"pools: {output}");
         pattern = r"Pool Id: ([a-zA-Z0-9]+), Pledge: (\d+[.]?\d+), Balance: (\d+[.]?\d+), Creation Block Height: (\d+), Timestamp: (\d+), Staker: ([a-zA-Z0-9]+), Decommission Key: ([a-zA-Z0-9]+), VRF Public Key: ([a-zA-Z0-9]+)"
         matches = re.findall(pattern, output)

--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -281,7 +281,11 @@ class WalletRpcController:
         return "The transaction was submitted successfully"
 
     async def list_pool_ids(self) -> List[PoolData]:
-        pools = self._write_command("staking_list_pool_ids", [self.account])['result']
+        pools = self._write_command("staking_list_pools", [self.account])['result']
+        return [PoolData(pool['pool_id'], pool['pledge'], pool['balance']) for pool in pools]
+
+    async def list_pools_for_decommission(self) -> List[PoolData]:
+        pools = self._write_command("staking_list_owned_pools_for_decommission", [self.account])['result']
         return [PoolData(pool['pool_id'], pool['pledge'], pool['balance']) for pool in pools]
 
     async def list_created_blocks_ids(self) -> List[CreatedBlockInfo]:

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -476,7 +476,12 @@ class WalletDelegationsCLI(BitcoinTestFramework):
 
             assert_in("Success", await wallet.sync())
 
+            # the acc0 pool has been decommissioned so there are non left
             pools = await wallet.list_pool_ids()
+            assert_equal(len(pools), 0)
+
+            # but since acc1's pool has the decommissioning address from acc0
+            pools = await wallet.list_pools_for_decommission()
             assert_equal(len(pools), 1)
 
             balance = await wallet.get_balance("locked")

--- a/test/functional/wallet_delegations.py
+++ b/test/functional/wallet_delegations.py
@@ -377,9 +377,8 @@ class WalletDelegationsCLI(BitcoinTestFramework):
             assert_equal(len(delegations), 1)
             assert_equal(delegations[0].balance, '1000')
 
-            # create another pool in account 1
-            decommission_address_acc1 = await wallet.new_address()
-            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(40000, 0, 0.5, decommission_address_acc1))
+            # create another pool in account 1 with decommission_address from acc 0
+            assert_in("The transaction was submitted successfully", await wallet.create_stake_pool(40000, 0, 0.5, decommission_address))
 
             assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
             pools = await wallet.list_pool_ids()
@@ -469,13 +468,16 @@ class WalletDelegationsCLI(BitcoinTestFramework):
             address = await wallet.new_address()
             assert_in("The transaction was submitted successfully", await wallet.decommission_stake_pool(pool_id, address))
 
-            transactions = node.mempool_transactions()
-            block_height = await wallet.get_best_block_height()
-            self.gen_pos_block(transactions, int(block_height)+1, last_block_id)
+            assert_in("Success", await wallet.select_account(1))
+            assert_in("Staking started successfully", await wallet.start_staking())
+            tip_id = node.chainstate_best_block_id()
+            self.wait_until(lambda: node.chainstate_best_block_id() != tip_id, timeout = 5)
+            assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
+
             assert_in("Success", await wallet.sync())
 
             pools = await wallet.list_pool_ids()
-            assert_equal(len(pools), 0)
+            assert_equal(len(pools), 1)
 
             balance = await wallet.get_balance("locked")
             pattern = r"Coins amount: (\d{5,})"
@@ -494,6 +496,11 @@ class WalletDelegationsCLI(BitcoinTestFramework):
                     return block.block_id == block_id and str(block.block_height) == str(block_height) and block.pool_id == pool_id
 
                 assert(any([same_with_current(block) for block in created_block_ids]))
+
+            # check even though decommission_address is from acc0 it will list the created blocks for acc1's pool
+            assert_in("Success", await wallet.select_account(1))
+            created_block_ids = await wallet.list_created_blocks_ids()
+            assert_greater_than(len(created_block_ids), 0)
 
 
 if __name__ == '__main__':

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -1363,7 +1363,7 @@ impl OutputCache {
                     TxOutput::ProduceBlockFromStake(_, pool_id)
                     | TxOutput::CreateStakePool(pool_id, _) => {
                         self.pools.get(pool_id).and_then(|pool_data| {
-                            is_mine(&pool_data.decommission_key).then_some(*pool_id)
+                            is_mine(&pool_data.stake_destination).then_some(*pool_id)
                         })
                     }
                 }),

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -1207,10 +1207,21 @@ where
                 Ok(ConsoleCommand::Print(version.version))
             }
 
-            WalletCommand::ListPoolIds => {
+            WalletCommand::ListPools => {
                 let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
                 let pool_ids: Vec<_> = wallet
-                    .list_pool_ids(selected_account)
+                    .list_staking_pools(selected_account)
+                    .await?
+                    .into_iter()
+                    .map(format_pool_info)
+                    .collect();
+                Ok(ConsoleCommand::Print(format!("{}\n", pool_ids.join("\n"))))
+            }
+
+            WalletCommand::ListOwnedPoolsForDecommission => {
+                let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
+                let pool_ids: Vec<_> = wallet
+                    .list_pools_for_decommission(selected_account)
                     .await?
                     .into_iter()
                     .map(format_pool_info)

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -511,9 +511,13 @@ pub enum WalletCommand {
         delegation_id: String,
     },
 
-    /// List ids of pools that are controlled by the selected account in this wallet
-    #[clap(name = "staking-list-pool-ids")]
-    ListPoolIds,
+    /// List staking pools that are controlled by the selected account in this wallet
+    #[clap(name = "staking-list-pools")]
+    ListPools,
+
+    /// List pools that can be decommissioned by the selected account in this wallet
+    #[clap(name = "staking-list-owned-pools-for-decommission")]
+    ListOwnedPoolsForDecommission,
 
     /// Start staking, assuming there are staking pools in the selected account in this wallet.
     #[clap(name = "staking-start")]

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -205,12 +205,27 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
         self.get_all_issued_vrf_public_keys()
     }
 
-    pub async fn get_pool_ids(
+    /// Get all pools owned by this account that can be used for staking
+    pub async fn get_staking_pools(
         &self,
+    ) -> Result<Vec<(PoolId, PoolData, Amount, Amount)>, ControllerError<T>> {
+        self.get_pools(WalletPoolsFilter::Stake).await
+    }
+
+    /// Get all pools that can be decommissioned by this account
+    pub async fn get_pools_for_decommission(
+        &self,
+    ) -> Result<Vec<(PoolId, PoolData, Amount, Amount)>, ControllerError<T>> {
+        self.get_pools(WalletPoolsFilter::Decommission).await
+    }
+
+    async fn get_pools(
+        &self,
+        filter: WalletPoolsFilter,
     ) -> Result<Vec<(PoolId, PoolData, Amount, Amount)>, ControllerError<T>> {
         let pools = self
             .wallet
-            .get_pool_ids(self.account_index, WalletPoolsFilter::All)
+            .get_pool_ids(self.account_index, filter)
             .map_err(ControllerError::WalletError)?;
 
         let tasks: FuturesUnordered<_> = pools

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -578,9 +578,19 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 
-    async fn list_pool_ids(&self, account_index: U31) -> Result<Vec<PoolInfo>, Self::Error> {
+    async fn list_staking_pools(&self, account_index: U31) -> Result<Vec<PoolInfo>, Self::Error> {
         self.wallet_rpc
-            .list_pool_ids(account_index)
+            .list_staking_pools(account_index)
+            .await
+            .map_err(WalletRpcHandlesClientError::WalletRpcError)
+    }
+
+    async fn list_pools_for_decommission(
+        &self,
+        account_index: U31,
+    ) -> Result<Vec<PoolInfo>, Self::Error> {
+        self.wallet_rpc
+            .list_pools_for_decommission(account_index)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -505,8 +505,17 @@ impl WalletInterface for ClientWalletRpc {
             .map_err(WalletRpcError::ResponseError)
     }
 
-    async fn list_pool_ids(&self, account_index: U31) -> Result<Vec<PoolInfo>, Self::Error> {
-        WalletRpcClient::list_pool_ids(&self.http_client, account_index.into())
+    async fn list_staking_pools(&self, account_index: U31) -> Result<Vec<PoolInfo>, Self::Error> {
+        WalletRpcClient::list_pools(&self.http_client, account_index.into())
+            .await
+            .map_err(WalletRpcError::ResponseError)
+    }
+
+    async fn list_pools_for_decommission(
+        &self,
+        account_index: U31,
+    ) -> Result<Vec<PoolInfo>, Self::Error> {
+        WalletRpcClient::list_pools_for_decommission(&self.http_client, account_index.into())
             .await
             .map_err(WalletRpcError::ResponseError)
     }

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -271,7 +271,12 @@ pub trait WalletInterface {
 
     async fn staking_status(&self, account_index: U31) -> Result<StakingStatus, Self::Error>;
 
-    async fn list_pool_ids(&self, account_index: U31) -> Result<Vec<PoolInfo>, Self::Error>;
+    async fn list_staking_pools(&self, account_index: U31) -> Result<Vec<PoolInfo>, Self::Error>;
+
+    async fn list_pools_for_decommission(
+        &self,
+        account_index: U31,
+    ) -> Result<Vec<PoolInfo>, Self::Error>;
 
     async fn stake_pool_balance(&self, pool_id: String) -> Result<StakePoolBalance, Self::Error>;
 

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -408,7 +408,28 @@ EITHER OF
      2) "NotStaking"
 ```
 
-### Method `staking_list_pool_ids`
+### Method `staking_list_pools`
+
+Parameters:
+```
+{ "account": number }
+```
+
+Returns:
+```
+[ {
+    "pool_id": string,
+    "pledge": decimal string,
+    "balance": decimal string,
+    "height": number,
+    "block_timestamp": { "timestamp": number },
+    "vrf_public_key": string,
+    "decommission_key": string,
+    "staker": string,
+}, .. ]
+```
+
+### Method `staking_list_owned_pools_for_decommission`
 
 Parameters:
 ```

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -314,8 +314,14 @@ trait WalletRpc {
     #[method(name = "staking_status")]
     async fn staking_status(&self, account: AccountArg) -> rpc::RpcResult<StakingStatus>;
 
-    #[method(name = "staking_list_pool_ids")]
-    async fn list_pool_ids(&self, account: AccountArg) -> rpc::RpcResult<Vec<PoolInfo>>;
+    #[method(name = "staking_list_pools")]
+    async fn list_pools(&self, account: AccountArg) -> rpc::RpcResult<Vec<PoolInfo>>;
+
+    #[method(name = "staking_list_owned_pools_for_decommission")]
+    async fn list_pools_for_decommission(
+        &self,
+        account: AccountArg,
+    ) -> rpc::RpcResult<Vec<PoolInfo>>;
 
     #[method(name = "staking_pool_balance")]
     async fn stake_pool_balance(&self, pool_id: String) -> rpc::RpcResult<StakePoolBalance>;

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -577,8 +577,15 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         rpc::handle_result(self.staking_status(account_arg.index::<N>()?).await)
     }
 
-    async fn list_pool_ids(&self, account_arg: AccountArg) -> rpc::RpcResult<Vec<PoolInfo>> {
-        rpc::handle_result(self.list_pool_ids(account_arg.index::<N>()?).await)
+    async fn list_pools(&self, account_arg: AccountArg) -> rpc::RpcResult<Vec<PoolInfo>> {
+        rpc::handle_result(self.list_staking_pools(account_arg.index::<N>()?).await)
+    }
+
+    async fn list_pools_for_decommission(
+        &self,
+        account_arg: AccountArg,
+    ) -> rpc::RpcResult<Vec<PoolInfo>> {
+        rpc::handle_result(self.list_pools_for_decommission(account_arg.index::<N>()?).await)
     }
 
     async fn list_delegation_ids(


### PR DESCRIPTION
- list created blocks if a pool with staking key from this wallet created it
- split list pool ids into 2 commands staking-list-pools which returns pools that can be staked and staking-list-owning-pools-for-decommission