### PR TITLE
common: Move Amount-related types into a subfolder

### DIFF
--- a/accounting/src/delta/combine.rs
+++ b/accounting/src/delta/combine.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::primitives::{signed_amount::SignedAmount, Amount};
+use common::primitives::{amount::SignedAmount, Amount};
 
 use crate::{error::Error, DataDelta};
 
@@ -77,7 +77,7 @@ pub mod test {
     use crate::DataDelta;
 
     use super::*;
-    use common::primitives::{amount::UnsignedIntType, signed_amount::SignedIntType};
+    use common::primitives::amount::{signed::SignedIntType, UnsignedIntType};
 
     use rstest::rstest;
 

--- a/accounting/src/delta/delta_amount_collection.rs
+++ b/accounting/src/delta/delta_amount_collection.rs
@@ -15,7 +15,7 @@
 
 use std::{collections::BTreeMap, ops::Neg};
 
-use common::primitives::{signed_amount::SignedAmount, Amount};
+use common::primitives::{amount::SignedAmount, Amount};
 
 use serialization::{Decode, Encode};
 

--- a/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
@@ -33,7 +33,7 @@ use common::{
         AccountCommand, AccountNonce, AccountType, Block, Destination, GenBlock, OutPointSourceId,
         SignedTransaction, Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
-    primitives::{signed_amount::SignedAmount, Amount, BlockHeight, CoinOrTokenId, Id, Idable},
+    primitives::{amount::SignedAmount, Amount, BlockHeight, CoinOrTokenId, Id, Idable},
 };
 use crypto::{
     key::{KeyKind, PrivateKey},

--- a/common/src/primitives/amount/decimal.rs
+++ b/common/src/primitives/amount/decimal.rs
@@ -17,7 +17,7 @@ use std::fmt::Write;
 
 use utils::ensure;
 
-pub use super::amount::{Amount, UnsignedIntType};
+use super::{Amount, UnsignedIntType};
 
 const TEN: UnsignedIntType = 10;
 

--- a/common/src/primitives/amount/mod.rs
+++ b/common/src/primitives/amount/mod.rs
@@ -1,0 +1,282 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// use only unsigned types
+// if you need a signed amount, we should create a separate type for it and implement proper conversion
+
+#![allow(clippy::eq_op)]
+
+use serialization::{Decode, Encode};
+use std::iter::Sum;
+
+pub mod decimal;
+pub mod signed;
+
+pub use decimal::{DecimalAmount, DisplayAmount};
+pub use signed::SignedAmount;
+
+pub type UnsignedIntType = u128;
+
+/// An unsigned fixed-point type for amounts
+/// The smallest unit of count is called an atom
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+#[must_use]
+pub struct Amount {
+    #[codec(compact)]
+    atoms: UnsignedIntType,
+}
+
+impl Amount {
+    pub const MAX: Self = Self::from_atoms(UnsignedIntType::MAX);
+    pub const ZERO: Self = Self::from_atoms(0);
+
+    pub const fn from_atoms(v: UnsignedIntType) -> Self {
+        Amount { atoms: v }
+    }
+
+    pub const fn into_atoms(&self) -> UnsignedIntType {
+        self.atoms
+    }
+
+    pub fn from_signed(amount: SignedAmount) -> Option<Self> {
+        let signed_atoms = amount.into_atoms();
+        let atoms: UnsignedIntType = signed_atoms.try_into().ok()?;
+        Some(Self::from_atoms(atoms))
+    }
+
+    pub fn into_signed(self) -> Option<SignedAmount> {
+        let atoms = self.atoms;
+        let signed_atoms: signed::SignedIntType = atoms.try_into().ok()?;
+        Some(SignedAmount::from_atoms(signed_atoms))
+    }
+
+    pub fn into_fixedpoint_str(self, decimals: u8) -> String {
+        DecimalAmount::from_amount_minimal(self, decimals).to_string()
+    }
+
+    pub fn from_fixedpoint_str(amount_str: &str, decimals: u8) -> Option<Self> {
+        amount_str.parse::<DecimalAmount>().ok()?.to_amount(decimals)
+    }
+
+    pub fn abs_diff(self, other: Amount) -> Amount {
+        if self > other {
+            (self - other).expect("cannot be negative")
+        } else {
+            (other - self).expect("cannot be negative")
+        }
+    }
+}
+
+impl std::ops::Add for Amount {
+    type Output = Option<Self>;
+
+    fn add(self, other: Self) -> Option<Self> {
+        self.atoms.checked_add(other.atoms).map(|n| Amount { atoms: n })
+    }
+}
+
+impl std::ops::Sub for Amount {
+    type Output = Option<Self>;
+
+    fn sub(self, other: Self) -> Option<Self> {
+        self.atoms.checked_sub(other.atoms).map(|n| Amount { atoms: n })
+    }
+}
+
+impl std::ops::Mul<UnsignedIntType> for Amount {
+    type Output = Option<Self>;
+
+    fn mul(self, other: UnsignedIntType) -> Option<Self> {
+        self.atoms.checked_mul(other).map(|n| Amount { atoms: n })
+    }
+}
+
+impl std::ops::Div<UnsignedIntType> for Amount {
+    type Output = Option<Amount>;
+
+    fn div(self, other: UnsignedIntType) -> Option<Amount> {
+        self.atoms.checked_div(other).map(|n| Amount { atoms: n })
+    }
+}
+
+impl std::ops::Rem<UnsignedIntType> for Amount {
+    type Output = Option<Self>;
+
+    fn rem(self, other: UnsignedIntType) -> Option<Self> {
+        self.atoms.checked_rem(other).map(|n| Amount { atoms: n })
+    }
+}
+
+impl std::ops::BitAnd for Amount {
+    type Output = Self;
+
+    fn bitand(self, other: Self) -> Self {
+        Amount {
+            atoms: self.atoms.bitand(other.atoms),
+        }
+    }
+}
+
+impl std::ops::BitAndAssign for Amount {
+    fn bitand_assign(&mut self, other: Self) {
+        self.atoms.bitand_assign(other.atoms)
+    }
+}
+
+impl std::ops::BitOr for Amount {
+    type Output = Self;
+
+    fn bitor(self, other: Self) -> Self {
+        Amount {
+            atoms: self.atoms.bitor(other.atoms),
+        }
+    }
+}
+
+impl std::ops::BitOrAssign for Amount {
+    fn bitor_assign(&mut self, other: Self) {
+        self.atoms.bitor_assign(other.atoms)
+    }
+}
+
+impl std::ops::BitXor for Amount {
+    type Output = Self;
+
+    fn bitxor(self, other: Self) -> Self {
+        Amount {
+            atoms: self.atoms.bitxor(other.atoms),
+        }
+    }
+}
+
+impl std::ops::BitXorAssign for Amount {
+    fn bitxor_assign(&mut self, other: Self) {
+        self.atoms.bitxor_assign(other.atoms)
+    }
+}
+
+impl std::ops::Not for Amount {
+    type Output = Self;
+
+    fn not(self) -> Self {
+        Amount {
+            atoms: self.atoms.not(),
+        }
+    }
+}
+
+impl std::ops::Shl<u32> for Amount {
+    type Output = Option<Self>;
+
+    fn shl(self, other: u32) -> Option<Self> {
+        self.atoms.checked_shl(other).map(|v| Amount { atoms: v })
+    }
+}
+
+impl std::ops::Shr<u32> for Amount {
+    type Output = Option<Self>;
+
+    fn shr(self, other: u32) -> Option<Self> {
+        self.atoms.checked_shr(other).map(|v| Amount { atoms: v })
+    }
+}
+
+impl Sum<Amount> for Option<Amount> {
+    fn sum<I>(mut iter: I) -> Self
+    where
+        I: Iterator<Item = Amount>,
+    {
+        iter.try_fold(Amount::ZERO, std::ops::Add::add)
+    }
+}
+
+impl rpc_description::HasValueHint for Amount {
+    const HINT: rpc_description::ValueHint =
+        rpc_description::ValueHint::Object(&[("atoms", &rpc_description::ValueHint::STRING)]);
+}
+
+#[macro_export]
+macro_rules! amount_sum {
+    ($arg_1:expr, $($arg_n:expr),+) => {{
+        let result = Some($arg_1);
+        $(
+            let result = match result {
+                Some(v) => v + $arg_n,
+                None => None,
+            };
+        )*
+        result
+    }}
+}
+
+mod json {
+    use super::{Amount, UnsignedIntType};
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(untagged)]
+    enum StringOrUint {
+        String(String),
+        UInt(UnsignedIntType),
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    pub struct JsonAmount {
+        atoms: StringOrUint,
+    }
+
+    impl From<Amount> for JsonAmount {
+        fn from(amount: Amount) -> Self {
+            JsonAmount {
+                atoms: StringOrUint::String(amount.atoms.to_string()),
+            }
+        }
+    }
+
+    impl TryFrom<JsonAmount> for Amount {
+        type Error = Box<dyn std::error::Error>;
+
+        fn try_from(json_amount: JsonAmount) -> Result<Self, Self::Error> {
+            let atoms: UnsignedIntType = match json_amount.atoms {
+                StringOrUint::String(s) => s.parse()?,
+                StringOrUint::UInt(atoms) => atoms,
+            };
+            Ok(Amount { atoms })
+        }
+    }
+}
+
+impl serde::Serialize for Amount {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let json_amount: json::JsonAmount = (*self).into();
+        json_amount.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Amount {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error;
+
+        let json_amount = json::JsonAmount::deserialize(deserializer)?;
+
+        let amount: Amount = json_amount
+            .try_into()
+            .map_err(|e| D::Error::custom(format!("Failed to parse json amount to Amount: {e}")))?;
+
+        Ok(amount)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/common/src/primitives/amount/signed.rs
+++ b/common/src/primitives/amount/signed.rs
@@ -17,7 +17,7 @@
 
 use std::iter::Sum;
 
-use super::{amount::UnsignedIntType, Amount};
+use super::{Amount, UnsignedIntType};
 
 use serialization::{Decode, Encode};
 

--- a/common/src/primitives/mod.rs
+++ b/common/src/primitives/mod.rs
@@ -15,7 +15,6 @@
 
 pub mod amount;
 pub mod compact;
-pub mod decimal_amount;
 pub mod encoding;
 pub mod error;
 pub mod height;
@@ -23,16 +22,14 @@ pub mod id;
 pub mod per_thousand;
 pub mod rational;
 pub mod semver;
-pub mod signed_amount;
 pub mod time;
 pub mod user_agent;
 pub mod version_tag;
 
 mod hash_encoded;
 
-pub use amount::Amount;
+pub use amount::{Amount, DecimalAmount, DisplayAmount};
 pub use compact::Compact;
-pub use decimal_amount::DecimalAmount;
 pub use encoding::{Bech32Error, DecodedArbitraryDataFromBech32};
 pub use height::{BlockCount, BlockDistance, BlockHeight};
 pub use id::{Id, Idable, H256};

--- a/mempool/src/error/mod.rs
+++ b/mempool/src/error/mod.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 
 use common::{
     chain::{GenBlock, Transaction},
-    primitives::{decimal_amount::DisplayAmount, Id, H256},
+    primitives::{amount::DisplayAmount, Id, H256},
 };
 
 use crate::pool::fee::Fee;

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -35,7 +35,7 @@ use common::{
         block::timestamp::BlockTimestamp, Block, ChainConfig, GenBlock, SignedTransaction,
         Transaction, TxInput,
     },
-    primitives::{amount::Amount, decimal_amount::DisplayAmount, time::Time, BlockHeight, Id},
+    primitives::{time::Time, Amount, BlockHeight, DisplayAmount, Id},
     time_getter::TimeGetter,
 };
 use logging::log;

--- a/pos-accounting/src/pool/delta/mod.rs
+++ b/pos-accounting/src/pool/delta/mod.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use accounting::{DeltaAmountCollection, DeltaDataUndoCollection};
 use common::{
     chain::{DelegationId, PoolId},
-    primitives::{signed_amount::SignedAmount, Amount, H256},
+    primitives::{amount::SignedAmount, Amount, H256},
 };
 use serialization::{Decode, Encode};
 

--- a/pos-accounting/src/pool/delta/view_impl.rs
+++ b/pos-accounting/src/pool/delta/view_impl.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use accounting::combine_amount_delta;
 use common::{
     chain::{DelegationId, PoolId},
-    primitives::{signed_amount::SignedAmount, Amount},
+    primitives::{amount::SignedAmount, Amount},
 };
 
 use crate::{

--- a/pos-accounting/src/pool/storage/mod.rs
+++ b/pos-accounting/src/pool/storage/mod.rs
@@ -22,7 +22,7 @@ use accounting::{
 use chainstate_types::storage_result;
 use common::{
     chain::{DelegationId, PoolId},
-    primitives::{signed_amount::SignedAmount, Amount},
+    primitives::{amount::SignedAmount, Amount},
 };
 
 use crate::{

--- a/pos-accounting/src/pool/tests/delta_tests.rs
+++ b/pos-accounting/src/pool/tests/delta_tests.rs
@@ -16,7 +16,7 @@
 use std::collections::BTreeMap;
 
 use accounting::{DataDelta, DeltaAmountCollection, DeltaDataCollection};
-use common::primitives::{signed_amount::SignedAmount, Amount};
+use common::primitives::{amount::SignedAmount, Amount};
 use rstest::rstest;
 use test_utils::random::{make_seedable_rng, Seed};
 

--- a/wallet/src/account/utxo_selector/mod.rs
+++ b/wallet/src/account/utxo_selector/mod.rs
@@ -20,7 +20,7 @@ pub use output_group::{OutputGroup, PayFee};
 
 use common::{
     chain::{TxInput, TxOutput},
-    primitives::{signed_amount::SignedAmount, Amount},
+    primitives::{amount::SignedAmount, Amount},
 };
 use crypto::random::{make_pseudo_rng, Rng, SliceRandom};
 use utils::ensure;


### PR DESCRIPTION
* Move all Amount-related types in `common/src/primitives/amount/`
* Move `Amount` tests into a separate file

Not much else.