### PR TITLE
Introduce Rpc Amount types and use them in wallet rpc

### DIFF
--- a/build-tools/code-docs/build-rpc-docs.sh
+++ b/build-tools/code-docs/build-rpc-docs.sh
@@ -5,8 +5,26 @@ set -x
 [ -f 'Cargo.toml' ] || exit 1
 grep 'name = "mintlayer-core"' Cargo.toml || exit 1
 
-mkdir -p ./node-daemon/docs/
-cargo run -p gen-rpc-docs -- node > ./node-daemon/docs/RPC.md
+CHECK=false
+case "$1" in
+    --check) CHECK=true ;;
+    '') ;;
+    *) echo "Unrecognized argument '$1'" && exit 2 ;;
+esac
 
-mkdir -p ./wallet/wallet-rpc-daemon/docs/
-cargo run -p gen-rpc-docs -- wallet > ./wallet/wallet-rpc-daemon/docs/RPC.md
+TMP_DIR=./target/tmp/rpc-docs
+mkdir -p "$TMP_DIR"
+cargo run -p gen-rpc-docs -- node > "$TMP_DIR/NODE_RPC.md"
+cargo run -p gen-rpc-docs -- wallet > "$TMP_DIR/WALLET_RPC.md"
+
+NODE_DIR="./node-daemon/docs"
+WALLET_DIR="./wallet/wallet-rpc-daemon/docs"
+
+if $CHECK; then
+    diff "$TMP_DIR/NODE_RPC.md" "$NODE_DIR/RPC.md" || exit 1
+    diff "$TMP_DIR/WALLET_RPC.md" "$WALLET_DIR/RPC.md" || exit 1
+else
+    mkdir -p "$NODE_DIR" "$WALLET_DIR"
+    mv "$TMP_DIR/NODE_RPC.md" "$NODE_DIR/RPC.md"
+    mv "$TMP_DIR/WALLET_RPC.md" "$WALLET_DIR/RPC.md"
+fi

--- a/common/src/primitives/amount/decimal.rs
+++ b/common/src/primitives/amount/decimal.rs
@@ -145,46 +145,6 @@ impl std::fmt::Display for DecimalAmount {
     }
 }
 
-impl serde::Serialize for DecimalAmount {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let amount = DecimalAmountSerde {
-            decimal: StringOrUint::String(self.to_string()),
-        };
-        amount.serialize(serializer)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for DecimalAmount {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        match DecimalAmountSerde::deserialize(deserializer)?.decimal {
-            StringOrUint::String(s) => s.parse().map_err(<D::Error as serde::de::Error>::custom),
-            StringOrUint::UInt(i) => Ok(Self::from_uint_integral(i)),
-        }
-    }
-}
-
-impl rpc_description::HasValueHint for DecimalAmount {
-    const HINT: rpc_description::ValueHint = DecimalAmountSerde::HINT;
-}
-
-#[derive(serde::Serialize, serde::Deserialize, rpc_description::HasValueHint)]
-struct DecimalAmountSerde {
-    decimal: StringOrUint,
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(untagged)]
-enum StringOrUint {
-    String(String),
-    UInt(u128),
-}
-
-impl rpc_description::HasValueHint for StringOrUint {
-    // While this supports strings and numbers, strings should be encouraged so only mention string
-    // in the value hint.
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::DECIMAL_STRING;
-}
-
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum ParseError {
     #[error("Resulting number is too big")]

--- a/common/src/primitives/amount/decimal.rs
+++ b/common/src/primitives/amount/decimal.rs
@@ -53,13 +53,13 @@ impl DecimalAmount {
     }
 
     /// Convert from amount, keeping all decimal digits
-    pub const fn from_amount_full(amount: Amount, decimals: u8) -> Self {
+    pub const fn from_amount_full_padding(amount: Amount, decimals: u8) -> Self {
         Self::from_uint_decimal(amount.into_atoms(), decimals)
     }
 
     /// Convert from amount, keeping as few decimal digits as possible (without losing precision)
-    pub const fn from_amount_minimal(amount: Amount, decimals: u8) -> Self {
-        Self::from_amount_full(amount, decimals).minimal()
+    pub const fn from_amount_no_padding(amount: Amount, decimals: u8) -> Self {
+        Self::from_amount_full_padding(amount, decimals).without_padding()
     }
 
     /// Convert to amount using given number of decimals
@@ -75,7 +75,7 @@ impl DecimalAmount {
     }
 
     /// Trim trailing zeroes in the fractional part
-    pub const fn minimal(mut self) -> Self {
+    pub const fn without_padding(mut self) -> Self {
         while self.decimals > 0 && self.mantissa % TEN == 0 {
             self.mantissa /= TEN;
             self.decimals -= 1;
@@ -200,7 +200,7 @@ impl DisplayAmount {
 
     /// Convert from [Amount], keeping all decimal digits
     pub const fn from_amount_full(amount: Amount, decimals: u8) -> Self {
-        Self(DecimalAmount::from_amount_full(amount, decimals))
+        Self(DecimalAmount::from_amount_full_padding(amount, decimals))
     }
 }
 

--- a/common/src/primitives/amount/mod.rs
+++ b/common/src/primitives/amount/mod.rs
@@ -82,7 +82,7 @@ impl Amount {
     }
 
     pub fn into_fixedpoint_str(self, decimals: u8) -> String {
-        DecimalAmount::from_amount_minimal(self, decimals).to_string()
+        DecimalAmount::from_amount_no_padding(self, decimals).to_string()
     }
 
     pub fn from_fixedpoint_str(amount_str: &str, decimals: u8) -> Option<Self> {

--- a/common/src/primitives/amount/mod.rs
+++ b/common/src/primitives/amount/mod.rs
@@ -18,13 +18,16 @@
 
 #![allow(clippy::eq_op)]
 
+use rpc_description::ValueHint as VH;
 use serialization::{Decode, Encode};
 use std::iter::Sum;
 
 pub mod decimal;
+pub mod rpc;
 pub mod signed;
 
 pub use decimal::{DecimalAmount, DisplayAmount};
+pub use rpc::{RpcAmountIn, RpcAmountOut};
 pub use signed::SignedAmount;
 
 pub type UnsignedIntType = u128;
@@ -203,8 +206,7 @@ impl Sum<Amount> for Option<Amount> {
 }
 
 impl rpc_description::HasValueHint for Amount {
-    const HINT: rpc_description::ValueHint =
-        rpc_description::ValueHint::Object(&[("atoms", &rpc_description::ValueHint::STRING)]);
+    const HINT: VH = VH::Object(&[("atoms", &VH::NUMBER_STRING)]);
 }
 
 #[macro_export]

--- a/common/src/primitives/amount/rpc.rs
+++ b/common/src/primitives/amount/rpc.rs
@@ -106,18 +106,18 @@ impl RpcAmountOut {
     }
 
     pub fn from_amount(amount: Amount, decimals: u8) -> Self {
-        Self::from_amount_minimal(amount, decimals)
+        Self::from_amount_no_padding(amount, decimals)
     }
 
     /// Construct from amount, keeping all decimal digits
-    pub fn from_amount_full(amount: Amount, decimals: u8) -> Self {
-        let decimal = DecimalAmount::from_amount_full(amount, decimals);
+    pub fn from_amount_full_padding(amount: Amount, decimals: u8) -> Self {
+        let decimal = DecimalAmount::from_amount_full_padding(amount, decimals);
         Self::new_internal(amount, decimal)
     }
 
     /// Construct from amount, keeping the minimal number of decimal places
-    pub fn from_amount_minimal(amount: Amount, decimals: u8) -> Self {
-        let decimal = DecimalAmount::from_amount_minimal(amount, decimals);
+    pub fn from_amount_no_padding(amount: Amount, decimals: u8) -> Self {
+        let decimal = DecimalAmount::from_amount_no_padding(amount, decimals);
         Self::new_internal(amount, decimal)
     }
 
@@ -174,7 +174,7 @@ mod tests {
     #[case(u128::MAX, 25)]
     fn rpc_amount_serde(#[case] atoms: u128, #[case] n_decimals: u8) {
         let atoms = Amount::from_atoms(atoms);
-        let decimal = DecimalAmount::from_amount_minimal(atoms, n_decimals);
+        let decimal = DecimalAmount::from_amount_no_padding(atoms, n_decimals);
 
         let decimal_str = decimal.to_string();
         let atoms_str = atoms.into_atoms().to_string();
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(serde_json::to_value(atoms_in).unwrap(), atoms_in_json);
         assert!(atoms_in.is_same(&serde_json::from_value(atoms_in_json).unwrap()));
 
-        let rpc_out = RpcAmountOut::from_amount_minimal(atoms, n_decimals);
+        let rpc_out = RpcAmountOut::from_amount_no_padding(atoms, n_decimals);
         let rpc_out_json = json!({ "atoms": atoms_str, "decimal": decimal_str });
         assert_eq!(serde_json::to_value(&rpc_out).unwrap(), rpc_out_json);
         assert!(rpc_out.is_same(&serde_json::from_value(rpc_out_json).unwrap()));

--- a/common/src/primitives/amount/rpc.rs
+++ b/common/src/primitives/amount/rpc.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rpc_description::{HasValueHint, ValueHint as VH};
+
+use super::{Amount, DecimalAmount};
+
+/// Amount type suitable for getting user input supporting both decimal and atom formats in Json.
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, HasValueHint)]
+pub struct RpcAmountIn(RpcAmountData);
+
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, HasValueHint)]
+#[serde(untagged)]
+enum RpcAmountData {
+    Decimal(DecimalAmount),
+    Atoms(Amount),
+}
+
+impl RpcAmountIn {
+    /// Construct from atoms
+    pub fn from_atoms(atoms: Amount) -> Self {
+        Self(RpcAmountData::Atoms(atoms))
+    }
+
+    /// Construct from decimal representation
+    pub fn from_decimal(decimal: DecimalAmount) -> Self {
+        Self(RpcAmountData::Decimal(decimal))
+    }
+
+    /// Convert to amount using given number of decimals
+    pub fn to_amount(self, decimals: u8) -> Option<Amount> {
+        match self.0 {
+            RpcAmountData::Decimal(amount) => amount.to_amount(decimals),
+            RpcAmountData::Atoms(amount) => Some(amount),
+        }
+    }
+
+    /// Check this is the same number presented in the same way
+    pub fn is_same(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (RpcAmountData::Decimal(a), RpcAmountData::Decimal(b)) => a.is_same(b),
+            (RpcAmountData::Decimal(_), RpcAmountData::Atoms(_)) => false,
+            (RpcAmountData::Atoms(_), RpcAmountData::Decimal(_)) => false,
+            (RpcAmountData::Atoms(a), RpcAmountData::Atoms(b)) => a == b,
+        }
+    }
+}
+
+impl From<Amount> for RpcAmountIn {
+    fn from(value: Amount) -> Self {
+        Self::from_atoms(value)
+    }
+}
+
+impl From<DecimalAmount> for RpcAmountIn {
+    fn from(value: DecimalAmount) -> Self {
+        Self::from_decimal(value)
+    }
+}
+
+/// Amount type suitable for presenting Amount to the user in Json format. It presents given amount
+/// in both decimal and atom formats.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RpcAmountOut {
+    #[serde(flatten)]
+    atoms: Amount,
+
+    #[serde(flatten)]
+    decimal: DecimalAmount,
+}
+
+impl RpcAmountOut {
+    pub const ZERO: Self = Self {
+        atoms: Amount::ZERO,
+        decimal: DecimalAmount::ZERO,
+    };
+
+    fn new_internal(atoms: Amount, decimal: DecimalAmount) -> Self {
+        Self { atoms, decimal }
+    }
+
+    pub fn from_amount(amount: Amount, decimals: u8) -> Self {
+        Self::from_amount_minimal(amount, decimals)
+    }
+
+    /// Construct from amount, keeping all decimal digits
+    pub fn from_amount_full(amount: Amount, decimals: u8) -> Self {
+        let decimal = DecimalAmount::from_amount_full(amount, decimals);
+        Self::new_internal(amount, decimal)
+    }
+
+    /// Construct from amount, keeping the minimal number of decimal places
+    pub fn from_amount_minimal(amount: Amount, decimals: u8) -> Self {
+        let decimal = DecimalAmount::from_amount_minimal(amount, decimals);
+        Self::new_internal(amount, decimal)
+    }
+
+    pub fn amount(&self) -> Amount {
+        self.atoms
+    }
+
+    pub fn decimal(&self) -> DecimalAmount {
+        self.decimal
+    }
+}
+
+impl HasValueHint for RpcAmountOut {
+    const HINT: VH = VH::Object(&[("atoms", &VH::NUMBER_STRING), ("decimal", &VH::DECIMAL_STRING)]);
+}

--- a/common/src/primitives/amount/serde_support.rs
+++ b/common/src/primitives/amount/serde_support.rs
@@ -1,0 +1,122 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::de::Error;
+
+use rpc_description::{HasValueHint, ValueHint as VH};
+
+use super::{Amount, DecimalAmount, UnsignedIntType as UInt};
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+enum StringOrUInt {
+    String(String),
+    UInt(UInt),
+}
+
+/// Atom-based string or int
+pub struct AtomsInner(Amount);
+
+impl serde::Serialize for AtomsInner {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.atoms.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AtomsInner {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let atoms = match StringOrUInt::deserialize(deserializer)? {
+            StringOrUInt::String(s) => s.parse().map_err(D::Error::custom)?,
+            StringOrUInt::UInt(u) => u,
+        };
+        Ok(Self(Amount::from_atoms(atoms)))
+    }
+}
+
+impl From<Amount> for AtomsInner {
+    fn from(value: Amount) -> Self {
+        Self(value)
+    }
+}
+
+impl From<AtomsInner> for Amount {
+    fn from(value: AtomsInner) -> Self {
+        value.0
+    }
+}
+
+/// Decimal string or int
+pub struct DecimalInner(DecimalAmount);
+
+impl serde::Serialize for DecimalInner {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DecimalInner {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let decimal = match StringOrUInt::deserialize(deserializer)? {
+            StringOrUInt::String(s) => s.parse().map_err(D::Error::custom)?,
+            StringOrUInt::UInt(u) => DecimalAmount::from_uint_integral(u),
+        };
+        Ok(Self(decimal))
+    }
+}
+
+impl From<DecimalAmount> for DecimalInner {
+    fn from(value: DecimalAmount) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DecimalInner> for DecimalAmount {
+    fn from(value: DecimalInner) -> Self {
+        value.0
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, HasValueHint)]
+pub struct AmountSerde {
+    pub atoms: AtomsInner,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, HasValueHint)]
+pub struct RpcAmountOutSerde {
+    pub atoms: AtomsInner,
+    pub decimal: DecimalInner,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RpcAmountInSerde {
+    Atoms(AtomsInner),
+    Decimal(DecimalInner),
+}
+
+impl HasValueHint for RpcAmountInSerde {
+    const HINT: VH = VH::Choice(&[
+        &VH::Object(&[("atoms", &AtomsInner::HINT)]),
+        &VH::Object(&[("decimal", &DecimalInner::HINT)]),
+    ]);
+}
+
+rpc_description::impl_value_hint!({
+    AtomsInner => VH::NUMBER_STRING;
+    DecimalInner => VH::DECIMAL_STRING;
+    Amount => AmountSerde::HINT;
+    super::RpcAmountIn => RpcAmountInSerde::HINT;
+    super::RpcAmountOut => RpcAmountOutSerde::HINT;
+});

--- a/common/src/primitives/amount/tests.rs
+++ b/common/src/primitives/amount/tests.rs
@@ -637,8 +637,8 @@ fn serde_serialization() {
     assert!(serialized.contains("\"123553758873844226\""));
     assert!(serialized.contains("\"atoms\""));
 
-    let deserialized = serde_json::from_str::<json::JsonAmount>(&serialized).unwrap();
-    assert_eq!(amount, deserialized.try_into().unwrap());
+    let deserialized = serde_json::from_str::<AmountSerde>(&serialized).unwrap();
+    assert_eq!(amount, deserialized.into());
 
     let deserialized_json_value = serde_json::from_str::<serde_json::Value>(&serialized).unwrap();
 
@@ -659,8 +659,8 @@ fn serde_serialization_randomized(#[case] seed: Seed) {
     assert!(serialized.contains(&format!("\"{}\"", amount.into_atoms())));
     assert!(serialized.contains("\"atoms\""));
 
-    let deserialized = serde_json::from_str::<json::JsonAmount>(&serialized).unwrap();
-    assert_eq!(amount, deserialized.try_into().unwrap());
+    let deserialized = serde_json::from_str::<AmountSerde>(&serialized).unwrap();
+    assert_eq!(amount, deserialized.into());
 
     let deserialized_json_value = serde_json::from_str::<serde_json::Value>(&serialized).unwrap();
 

--- a/node-daemon/docs/RPC.md
+++ b/node-daemon/docs/RPC.md
@@ -294,7 +294,7 @@ Parameters:
 Returns:
 ```
 EITHER OF
-     1) { "atoms": string }
+     1) { "atoms": number string }
      2) null
 ```
 
@@ -314,7 +314,7 @@ Parameters:
 Returns:
 ```
 EITHER OF
-     1) { "atoms": string }
+     1) { "atoms": number string }
      2) null
 ```
 
@@ -335,7 +335,7 @@ Parameters:
 Returns:
 ```
 EITHER OF
-     1) { "atoms": string }
+     1) { "atoms": number string }
      2) null
 ```
 
@@ -357,9 +357,9 @@ EITHER OF
             "token_ticker": [ number, .. ],
             "number_of_decimals": number,
             "metadata_uri": [ number, .. ],
-            "circulating_supply": { "atoms": string },
+            "circulating_supply": { "atoms": number string },
             "total_supply": EITHER OF
-                 1) { "Fixed": { "atoms": string } }
+                 1) { "Fixed": { "atoms": number string } }
                  2) "Lockable"
                  3) "Unlimited",
             "is_locked": bool,
@@ -655,7 +655,7 @@ Parameters:
 
 Returns:
 ```
-{ "amount_per_kb": { "atoms": string } }
+{ "amount_per_kb": { "atoms": number string } }
 ```
 
 ### Method `mempool_get_fee_rate_points`
@@ -672,7 +672,7 @@ Returns:
 ```
 [ [
     number,
-    { "amount_per_kb": { "atoms": string } },
+    { "amount_per_kb": { "atoms": number string } },
 ], .. ]
 ```
 

--- a/rpc/description/src/value_hint.rs
+++ b/rpc/description/src/value_hint.rs
@@ -53,6 +53,8 @@ impl ValueHint {
     pub const NULL: VH = VH::Prim("null");
     pub const NUMBER: VH = VH::Prim("number");
     pub const STRING: VH = VH::Prim("string");
+    pub const NUMBER_STRING: VH = VH::Prim("number string");
+    pub const DECIMAL_STRING: VH = VH::Prim("decimal string");
     pub const BECH32_STRING: VH = VH::Prim("bech32 string");
     pub const HEX_STRING: VH = VH::Prim("hex string");
     pub const GENERIC_OBJECT: VH = VH::Prim("object");

--- a/rpc/tests/basic/HINT_TAGGED.txt
+++ b/rpc/tests/basic/HINT_TAGGED.txt
@@ -1,0 +1,3 @@
+EITHER OF
+     1) { "Int": number }
+     2) { "String": string }

--- a/rpc/tests/basic/HINT_UNTAGGED.txt
+++ b/rpc/tests/basic/HINT_UNTAGGED.txt
@@ -1,0 +1,3 @@
+EITHER OF
+     1) number
+     2) string

--- a/rpc/tests/basic/desc.rs
+++ b/rpc/tests/basic/desc.rs
@@ -15,7 +15,7 @@
 
 //! RPC description tests
 
-use rpc::description::{Described, Module, ValueHint as VH};
+use rpc::description::{Described, HasValueHint, Module, ValueHint as VH};
 
 use expect_test::expect_file;
 
@@ -58,6 +58,33 @@ fn value_hint_render() {
     const HINT: VH = VH::Object(&[("auth", &AUTH_HINT), ("command", &COMMAND_HINT)]);
 
     expect_file!["./HINT_RENDER.md"].assert_eq(&format!("{HINT}\n"));
+}
+
+#[test]
+fn value_hint_tagged() {
+    #[derive(HasValueHint, serde::Serialize)]
+    #[allow(unused)]
+    enum Tagged {
+        Int(u64),
+        String(String),
+    }
+
+    let actual = Tagged::HINT.to_string();
+    expect_file!["./HINT_TAGGED.txt"].assert_eq(&actual);
+}
+
+#[test]
+fn value_hint_untagged() {
+    #[derive(HasValueHint, serde::Serialize)]
+    #[serde(untagged)]
+    #[allow(unused)]
+    enum Untagged {
+        Int(u64),
+        String(String),
+    }
+
+    let actual = Untagged::HINT.to_string();
+    expect_file!["./HINT_UNTAGGED.txt"].assert_eq(&actual);
 }
 
 #[test]

--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -193,11 +193,11 @@ class WalletRpcController:
         return self._write_command("transaction_get_signed_raw", [self.account, tx_id])['result']
 
     async def send_to_address(self, address: str, amount: int, selected_utxos: List[UtxoOutpoint] = []) -> str:
-        self._write_command("address_send", [self.account, address, str(amount), selected_utxos, {'in_top_x_mb': 5}])
+        self._write_command("address_send", [self.account, address, {'decimal': str(amount)}, selected_utxos, {'in_top_x_mb': 5}])
         return "The transaction was submitted successfully"
 
     async def send_tokens_to_address(self, token_id: str, address: str, amount: Union[float, str]):
-        return self._write_command("token_send", [self.account, token_id, address, amount, {'in_top_x_mb': 5}])['result']
+        return self._write_command("token_send", [self.account, token_id, address, {'decimal': amount}, {'in_top_x_mb': 5}])['result']
 
     async def issue_new_token(self,
                               token_ticker: str,
@@ -219,10 +219,10 @@ class WalletRpcController:
         return output
 
     async def mint_tokens(self, token_id: str, address: str, amount: int) -> str:
-        return self._write_command("token_mint", [self.account, token_id, address, amount, {'in_top_x_mb': 5}])['result']
+        return self._write_command("token_mint", [self.account, token_id, address, {'decimal': amount}, {'in_top_x_mb': 5}])['result']
 
     async def unmint_tokens(self, token_id: str, amount: int) -> str:
-        return self._write_command("token_mint", [self.account, token_id, amount, {'in_top_x_mb': 5}])['result']
+        return self._write_command("token_mint", [self.account, token_id, {'decimal': amount}, {'in_top_x_mb': 5}])['result']
 
     async def lock_token_supply(self, token_id: str) -> str:
         return self._write_command("token_lock_supply", [self.account, token_id, {'in_top_x_mb': 5}])['result']
@@ -269,7 +269,7 @@ class WalletRpcController:
                                 margin_ratio_per_thousand: float,
                                 decommission_key: Optional[str] = None) -> str:
         #decommission_key = decommission_key if decommission_key else 'NULL'
-        self._write_command("staking_create_pool", [self.account, str(amount), str(cost_per_block), str(margin_ratio_per_thousand), decommission_key, {'in_top_x_mb': 5}])['result']
+        self._write_command("staking_create_pool", [self.account, {'decimal': str(amount)}, {'decimal': str(cost_per_block)}, str(margin_ratio_per_thousand), decommission_key, {'in_top_x_mb': 5}])['result']
         return "The transaction was submitted successfully"
 
     async def decommission_stake_pool(self, pool_id: str, address: str) -> str:
@@ -282,7 +282,7 @@ class WalletRpcController:
 
     async def list_pool_ids(self) -> List[PoolData]:
         pools = self._write_command("staking_list_pools", [self.account])['result']
-        return [PoolData(pool['pool_id'], pool['pledge'], pool['balance']) for pool in pools]
+        return [PoolData(pool['pool_id'], pool['pledge']['decimal'], pool['balance']['decimal']) for pool in pools]
 
     async def list_pools_for_decommission(self) -> List[PoolData]:
         pools = self._write_command("staking_list_owned_pools_for_decommission", [self.account])['result']
@@ -296,12 +296,12 @@ class WalletRpcController:
         return self._write_command("delegation_create", [self.account, address, pool_id, {'in_top_x_mb': 5}])['result']['delegation_id']
 
     async def stake_delegation(self, amount: int, delegation_id: str) -> str:
-        self._write_command(f"delegation_stake", [self.account, str(amount), delegation_id, {'in_top_x_mb': 5}])['result']
+        self._write_command(f"delegation_stake", [self.account, {'decimal': str(amount)}, delegation_id, {'in_top_x_mb': 5}])['result']
         return "Success"
 
     async def list_delegation_ids(self) -> List[DelegationData]:
         delegations = self._write_command("delegation_list_ids", [self.account])['result']
-        return [DelegationData(delegation['delegation_id'], delegation['balance']) for delegation in delegations]
+        return [DelegationData(delegation['delegation_id'], delegation['balance']['decimal']) for delegation in delegations]
 
     async def deposit_data(self, data: str) -> str:
         return self._write_command("address_deposit_data", [self.account, data, {'in_top_x_mb': 5}])['result']
@@ -331,7 +331,7 @@ class WalletRpcController:
     async def get_balance(self, with_locked: str = 'unlocked', utxo_states: List[str] = ['confirmed']) -> str:
         with_locked = with_locked.capitalize()
         balances = self._write_command("account_balance", [self.account, with_locked])# {' '.join(utxo_states)})
-        return f"Coins amount: {balances['result']['coins']}"
+        return f"Coins amount: {balances['result']['coins']['decimal']}"
 
     async def list_pending_transactions(self) -> List[str]:
         output = self._write_command("transaction_list_pending", [self.account])['result']
@@ -377,7 +377,7 @@ class WalletRpcController:
 
     async def create_from_cold_address(self, address: str, amount: int, selected_utxo: UtxoOutpoint, change_address: Optional[str] = None) -> str:
         utxo = { "id": {"Transaction": selected_utxo.id}, "index": selected_utxo.index }
-        result = self._write_command("transaction_create_from_cold_input", [self.account, address, str(amount), utxo, change_address, {'in_top_x_mb': 5}])
+        result = self._write_command("transaction_create_from_cold_input", [self.account, address, {'decimal': str(amount)}, utxo, change_address, {'in_top_x_mb': 5}])
         if 'result' in result:
             return f"Send transaction created\n\n{result['result']['hex']}"
         else:

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -852,11 +852,13 @@ where
                     .await?
                     .into_coins_and_tokens();
 
+                let coins = coins.decimal();
                 let mut output = format!("Coins amount: {coins}\n");
 
                 for (token_id, amount) in tokens {
                     let token_id = Address::new(chain_config, &token_id)
                         .expect("Encoding token id should never fail");
+                    let amount = amount.decimal();
                     writeln!(&mut output, "Token: {token_id} amount: {amount}")
                         .expect("Writing to a memory buffer should not fail");
                 }
@@ -1236,7 +1238,10 @@ where
                     .await?
                     .into_iter()
                     .map(|info| {
-                        format_delegation_info(info.delegation_id, info.balance.to_string())
+                        format_delegation_info(
+                            info.delegation_id,
+                            info.balance.decimal().to_string(),
+                        )
                     })
                     .collect();
                 Ok(ConsoleCommand::Print(delegations.join("\n").to_string()))
@@ -1335,6 +1340,7 @@ where
 
 fn format_fees(output: &mut String, fees: Balances, chain_config: &ChainConfig) {
     let (coins, tokens) = fees.into_coins_and_tokens();
+    let coins = coins.decimal();
     writeln!(
         output,
         "Fees that will be paid by the transaction:\nCoins amount: {coins}\n"
@@ -1344,6 +1350,7 @@ fn format_fees(output: &mut String, fees: Balances, chain_config: &ChainConfig) 
     for (token_id, amount) in tokens {
         let token_id =
             Address::new(chain_config, &token_id).expect("Encoding token id should never fail");
+        let amount = amount.decimal();
         writeln!(output, "Token: {token_id} amount: {amount}")
             .expect("Writing to a memory buffer should not fail");
     }

--- a/wallet/wallet-cli-lib/src/commands/helper_types.rs
+++ b/wallet/wallet-cli-lib/src/commands/helper_types.rs
@@ -103,7 +103,7 @@ impl CliUtxoState {
 pub fn format_pool_info(pool_info: PoolInfo) -> String {
     format!(
         "Pool Id: {}, Pledge: {}, Balance: {}, Creation Block Height: {}, Timestamp: {}, Staker: {}, Decommission Key: {}, VRF Public Key: {}",
-        pool_info.pool_id, pool_info.pledge, pool_info.balance, pool_info.height, pool_info.block_timestamp, pool_info.staker, pool_info.decommission_key, pool_info.vrf_public_key
+        pool_info.pool_id, pool_info.pledge.decimal(), pool_info.balance.decimal(), pool_info.height, pool_info.block_timestamp, pool_info.staker, pool_info.decommission_key, pool_info.vrf_public_key
     )
 }
 
@@ -276,11 +276,10 @@ fn parse_fixed_token_supply<N: NodeInterface>(
 fn parse_token_amount<N: NodeInterface>(
     token_number_of_decimals: u8,
     value: &str,
-) -> Result<DecimalAmount, WalletCliError<N>> {
-    DecimalAmount::from_str(value)
-        .map_err(|err| WalletCliError::<N>::InvalidInput(err.to_string()))?
-        .with_decimals(token_number_of_decimals)
-        .ok_or_else(|| WalletCliError::<N>::InvalidInput(value.to_owned()))
+) -> Result<wallet_rpc_lib::types::RpcAmountIn, WalletCliError<N>> {
+    let amount = common::primitives::Amount::from_fixedpoint_str(value, token_number_of_decimals)
+        .ok_or_else(|| WalletCliError::<N>::InvalidInput(value.to_owned()))?;
+    Ok(amount.into())
 }
 
 #[cfg(test)]

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -1050,7 +1050,7 @@ pub async fn into_balances<T: NodeInterface>(
     mut balances: BTreeMap<Currency, Amount>,
 ) -> Result<Balances, ControllerError<T>> {
     let coins = balances.remove(&Currency::Coin).unwrap_or(Amount::ZERO);
-    let coins = RpcAmountOut::from_amount_minimal(coins, chain_config.coin_decimals());
+    let coins = RpcAmountOut::from_amount_no_padding(coins, chain_config.coin_decimals());
 
     let tasks: FuturesUnordered<_> = balances
         .into_iter()
@@ -1062,7 +1062,7 @@ pub async fn into_balances<T: NodeInterface>(
 
             fetch_token_info(rpc_client, token_id).await.map(|info| {
                 let decimals = info.token_number_of_decimals();
-                let amount = RpcAmountOut::from_amount_minimal(amount, decimals);
+                let amount = RpcAmountOut::from_amount_no_padding(amount, decimals);
                 (token_id, amount)
             })
         })

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -58,8 +58,9 @@ use common::{
         TxOutput, UtxoOutPoint,
     },
     primitives::{
+        amount::RpcAmountOut,
         time::{get_time, Time},
-        Amount, BlockHeight, DecimalAmount, Id, Idable,
+        Amount, BlockHeight, Id, Idable,
     },
 };
 use consensus::GenerateBlockInputData;
@@ -1049,7 +1050,7 @@ pub async fn into_balances<T: NodeInterface>(
     mut balances: BTreeMap<Currency, Amount>,
 ) -> Result<Balances, ControllerError<T>> {
     let coins = balances.remove(&Currency::Coin).unwrap_or(Amount::ZERO);
-    let coins = DecimalAmount::from_amount_minimal(coins, chain_config.coin_decimals());
+    let coins = RpcAmountOut::from_amount_minimal(coins, chain_config.coin_decimals());
 
     let tasks: FuturesUnordered<_> = balances
         .into_iter()
@@ -1061,7 +1062,7 @@ pub async fn into_balances<T: NodeInterface>(
 
             fetch_token_info(rpc_client, token_id).await.map(|info| {
                 let decimals = info.token_number_of_decimals();
-                let amount = DecimalAmount::from_amount_minimal(amount, decimals);
+                let amount = RpcAmountOut::from_amount_minimal(amount, decimals);
                 (token_id, amount)
             })
         })

--- a/wallet/wallet-controller/src/types/balances.rs
+++ b/wallet/wallet-controller/src/types/balances.rs
@@ -15,33 +15,33 @@
 
 use std::collections::BTreeMap;
 
-use common::{chain::tokens::TokenId, primitives::DecimalAmount};
+use common::{chain::tokens::TokenId, primitives::amount::RpcAmountOut};
 
 /// Balances of coins and tokens
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, rpc_description::HasValueHint)]
 pub struct Balances {
-    coins: DecimalAmount,
-    tokens: BTreeMap<TokenId, DecimalAmount>,
+    coins: RpcAmountOut,
+    tokens: BTreeMap<TokenId, RpcAmountOut>,
 }
 
 impl Balances {
-    pub fn new(coins: DecimalAmount, tokens: BTreeMap<TokenId, DecimalAmount>) -> Self {
+    pub fn new(coins: RpcAmountOut, tokens: BTreeMap<TokenId, RpcAmountOut>) -> Self {
         Self { coins, tokens }
     }
 
-    pub fn coins(&self) -> DecimalAmount {
-        self.coins
+    pub fn coins(&self) -> &RpcAmountOut {
+        &self.coins
     }
 
-    pub fn tokens(&self) -> &BTreeMap<TokenId, DecimalAmount> {
+    pub fn tokens(&self) -> &BTreeMap<TokenId, RpcAmountOut> {
         &self.tokens
     }
 
-    pub fn token(&self, token_id: &TokenId) -> DecimalAmount {
-        self.tokens.get(token_id).copied().unwrap_or(DecimalAmount::ZERO)
+    pub fn token(&self, token_id: &TokenId) -> &RpcAmountOut {
+        self.tokens.get(token_id).unwrap_or(&RpcAmountOut::ZERO)
     }
 
-    pub fn into_coins_and_tokens(self) -> (DecimalAmount, BTreeMap<TokenId, DecimalAmount>) {
+    pub fn into_coins_and_tokens(self) -> (RpcAmountOut, BTreeMap<TokenId, RpcAmountOut>) {
         let Self { coins, tokens } = self;
         (coins, tokens)
     }

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -22,7 +22,7 @@ mod transaction;
 
 pub use balances::Balances;
 pub use block_info::{BlockInfo, CreatedBlockInfo};
-pub use common::primitives::DecimalAmount;
+pub use common::primitives::amount::RpcAmountOut;
 use common::primitives::H256;
 pub use seed_phrase::SeedWithPassPhrase;
 pub use transaction::{

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -339,7 +339,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         &self,
         account_index: U31,
         address: String,
-        amount_str: DecimalAmount,
+        amount: DecimalAmount,
         selected_utxo: UtxoOutPoint,
         change_address: Option<String>,
         config: ControllerConfig,
@@ -348,7 +348,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
             .request_send_coins(
                 account_index,
                 address,
-                amount_str,
+                amount.into(),
                 selected_utxo,
                 change_address,
                 config,
@@ -437,7 +437,13 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         config: ControllerConfig,
     ) -> Result<NewTransaction, Self::Error> {
         self.wallet_rpc
-            .send_coins(account_index, address, amount, selected_utxos, config)
+            .send_coins(
+                account_index,
+                address,
+                amount.into(),
+                selected_utxos,
+                config,
+            )
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
@@ -480,8 +486,8 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         self.wallet_rpc
             .create_stake_pool(
                 account_index,
-                amount,
-                cost_per_block,
+                amount.into(),
+                cost_per_block.into(),
                 margin_ratio_per_thousand,
                 decommission_address,
                 config,
@@ -538,7 +544,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         config: ControllerConfig,
     ) -> Result<NewTransaction, Self::Error> {
         self.wallet_rpc
-            .delegate_staking(account_index, amount, delegation_id, config)
+            .delegate_staking(account_index, amount.into(), delegation_id, config)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
@@ -552,7 +558,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         config: ControllerConfig,
     ) -> Result<NewTransaction, Self::Error> {
         self.wallet_rpc
-            .withdraw_from_delegation(account_index, address, amount, delegation_id, config)
+            .withdraw_from_delegation(account_index, address, amount.into(), delegation_id, config)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
@@ -678,7 +684,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         metadata: TokenMetadata,
         config: ControllerConfig,
     ) -> Result<RpcTokenId, Self::Error> {
-        let token_supply = metadata.token_supply::<N>(self.wallet_rpc.chain_config())?;
+        let token_supply = metadata.token_supply()?;
         let is_freezable = metadata.is_freezable();
         self.wallet_rpc
             .issue_new_token(
@@ -717,7 +723,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         config: ControllerConfig,
     ) -> Result<NewTransaction, Self::Error> {
         self.wallet_rpc
-            .mint_tokens(account_index, token_id, address, amount, config)
+            .mint_tokens(account_index, token_id, address, amount.into(), config)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
@@ -730,7 +736,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         config: ControllerConfig,
     ) -> Result<NewTransaction, Self::Error> {
         self.wallet_rpc
-            .unmint_tokens(account_index, token_id, amount, config)
+            .unmint_tokens(account_index, token_id, amount.into(), config)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
@@ -786,7 +792,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         config: ControllerConfig,
     ) -> Result<NewTransaction, Self::Error> {
         self.wallet_rpc
-            .send_tokens(account_index, token_id, address, amount, config)
+            .send_tokens(account_index, token_id, address, amount.into(), config)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -271,7 +271,7 @@ impl WalletInterface for ClientWalletRpc {
             &self.http_client,
             account_index.into(),
             address,
-            amount,
+            amount.into(),
             selected_utxos,
             options,
         )
@@ -325,7 +325,7 @@ impl WalletInterface for ClientWalletRpc {
         &self,
         account_index: U31,
         address: String,
-        amount_str: DecimalAmount,
+        amount: DecimalAmount,
         selected_utxo: UtxoOutPoint,
         change_address: Option<String>,
         config: ControllerConfig,
@@ -337,7 +337,7 @@ impl WalletInterface for ClientWalletRpc {
             &self.http_client,
             account_index.into(),
             address,
-            amount_str,
+            amount.into(),
             selected_utxo,
             change_address,
             options,
@@ -370,8 +370,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::create_stake_pool(
             &self.http_client,
             account_index.into(),
-            amount,
-            cost_per_block,
+            amount.into(),
+            cost_per_block.into(),
             margin_ratio_per_thousand,
             decommission_address,
             options,
@@ -456,7 +456,7 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::delegate_staking(
             &self.http_client,
             account_index.into(),
-            amount,
+            amount.into(),
             delegation_id,
             options,
         )
@@ -479,7 +479,7 @@ impl WalletInterface for ClientWalletRpc {
             &self.http_client,
             account_index.into(),
             address,
-            amount,
+            amount.into(),
             delegation_id,
             options,
         )
@@ -650,7 +650,7 @@ impl WalletInterface for ClientWalletRpc {
             account_index.into(),
             token_id,
             address,
-            amount,
+            amount.into(),
             options,
         )
         .await
@@ -671,7 +671,7 @@ impl WalletInterface for ClientWalletRpc {
             &self.http_client,
             account_index.into(),
             token_id,
-            amount,
+            amount.into(),
             options,
         )
         .await
@@ -748,7 +748,7 @@ impl WalletInterface for ClientWalletRpc {
             account_index.into(),
             token_id,
             address,
-            amount,
+            amount.into(),
             options,
         )
         .await

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -104,8 +104,8 @@ Parameters:
 Returns:
 ```
 {
-    "coins": decimal string,
-    "tokens": { hex string: decimal string, .. },
+    "coins": { "decimal": decimal string },
+    "tokens": { hex string: { "decimal": decimal string }, .. },
 }
 ```
 
@@ -146,7 +146,7 @@ Parameters:
 {
     "account": number,
     "address": string,
-    "amount": decimal string,
+    "amount": { "decimal": decimal string },
     "selected_utxos": [ {
         "id": EITHER OF
              1) { "Transaction": hex string }
@@ -203,7 +203,7 @@ Parameters:
 {
     "account": number,
     "address": string,
-    "amount": decimal string,
+    "amount": { "decimal": decimal string },
     "selected_utxo": {
         "id": EITHER OF
              1) { "Transaction": hex string }
@@ -222,8 +222,8 @@ Returns:
 {
     "hex": string,
     "fees": {
-        "coins": decimal string,
-        "tokens": { hex string: decimal string, .. },
+        "coins": { "decimal": decimal string },
+        "tokens": { hex string: { "decimal": decimal string }, .. },
     },
 }
 ```
@@ -241,8 +241,8 @@ Returns:
     "tx": hex string,
     "fees": EITHER OF
          1) {
-                "coins": decimal string,
-                "tokens": { hex string: decimal string, .. },
+                "coins": { "decimal": decimal string },
+                "tokens": { hex string: { "decimal": decimal string }, .. },
             }
          2) null,
     "stats": {
@@ -264,8 +264,8 @@ Parameters:
 ```
 {
     "account": number,
-    "amount": decimal string,
-    "cost_per_block": decimal string,
+    "amount": { "decimal": decimal string },
+    "cost_per_block": { "decimal": decimal string },
     "margin_ratio_per_thousand": string,
     "decommission_address": string,
     "options": { "in_top_x_mb": number },
@@ -341,7 +341,7 @@ Parameters:
 ```
 {
     "account": number,
-    "amount": decimal string,
+    "amount": { "decimal": decimal string },
     "delegation_id": string,
     "options": { "in_top_x_mb": number },
 }
@@ -359,7 +359,7 @@ Parameters:
 {
     "account": number,
     "address": string,
-    "amount": decimal string,
+    "amount": { "decimal": decimal string },
     "delegation_id": string,
     "options": { "in_top_x_mb": number },
 }
@@ -440,8 +440,8 @@ Returns:
 ```
 [ {
     "pool_id": string,
-    "pledge": decimal string,
-    "balance": decimal string,
+    "pledge": { "decimal": decimal string },
+    "balance": { "decimal": decimal string },
     "height": number,
     "block_timestamp": { "timestamp": number },
     "vrf_public_key": string,
@@ -475,7 +475,7 @@ Returns:
 ```
 [ {
     "delegation_id": bech32 string,
-    "balance": decimal string,
+    "balance": { "decimal": decimal string },
 }, .. ]
 ```
 
@@ -544,7 +544,7 @@ Parameters:
         "number_of_decimals": number,
         "metadata_uri": string,
         "token_supply": EITHER OF
-             1) { "Fixed": decimal string }
+             1) { "Fixed": { "decimal": decimal string } }
              2) "Lockable"
              3) "Unlimited",
         "is_freezable": bool,
@@ -586,7 +586,7 @@ Parameters:
     "account": number,
     "token_id": string,
     "address": string,
-    "amount": decimal string,
+    "amount": { "decimal": decimal string },
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -603,7 +603,7 @@ Parameters:
 {
     "account": number,
     "token_id": string,
-    "amount": decimal string,
+    "amount": { "decimal": decimal string },
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -670,7 +670,7 @@ Parameters:
     "account": number,
     "token_id": string,
     "address": string,
-    "amount": decimal string,
+    "amount": { "decimal": decimal string },
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -1037,8 +1037,8 @@ Returns:
 {
     "hex": string,
     "fees": {
-        "coins": decimal string,
-        "tokens": { hex string: decimal string, .. },
+        "coins": { "decimal": decimal string },
+        "tokens": { hex string: { "decimal": decimal string }, .. },
     },
 }
 ```

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -153,8 +153,8 @@ Parameters:
     "account": number,
     "address": string,
     "amount": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "selected_utxos": [ {
         "id": EITHER OF
              1) { "Transaction": hex string }
@@ -212,8 +212,8 @@ Parameters:
     "account": number,
     "address": string,
     "amount": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "selected_utxo": {
         "id": EITHER OF
              1) { "Transaction": hex string }
@@ -287,11 +287,11 @@ Parameters:
 {
     "account": number,
     "amount": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "cost_per_block": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "margin_ratio_per_thousand": string,
     "decommission_address": string,
     "options": { "in_top_x_mb": number },
@@ -368,8 +368,8 @@ Parameters:
 {
     "account": number,
     "amount": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "delegation_id": string,
     "options": { "in_top_x_mb": number },
 }
@@ -388,8 +388,8 @@ Parameters:
     "account": number,
     "address": string,
     "amount": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "delegation_id": string,
     "options": { "in_top_x_mb": number },
 }
@@ -590,8 +590,8 @@ Parameters:
         "metadata_uri": string,
         "token_supply": EITHER OF
              1) { "Fixed": EITHER OF
-                     1) { "decimal": decimal string }
-                     2) { "atoms": number string } }
+                     1) { "atoms": number string }
+                     2) { "decimal": decimal string } }
              2) "Lockable"
              3) "Unlimited",
         "is_freezable": bool,
@@ -634,8 +634,8 @@ Parameters:
     "token_id": string,
     "address": string,
     "amount": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -653,8 +653,8 @@ Parameters:
     "account": number,
     "token_id": string,
     "amount": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -722,8 +722,8 @@ Parameters:
     "token_id": string,
     "address": string,
     "amount": EITHER OF
-         1) { "decimal": decimal string }
-         2) { "atoms": number string },
+         1) { "atoms": number string }
+         2) { "decimal": decimal string },
     "options": { "in_top_x_mb": number },
 }
 ```

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -104,8 +104,14 @@ Parameters:
 Returns:
 ```
 {
-    "coins": { "decimal": decimal string },
-    "tokens": { hex string: { "decimal": decimal string }, .. },
+    "coins": {
+        "atoms": number string,
+        "decimal": decimal string,
+    },
+    "tokens": { hex string: {
+        "atoms": number string,
+        "decimal": decimal string,
+    }, .. },
 }
 ```
 
@@ -146,7 +152,9 @@ Parameters:
 {
     "account": number,
     "address": string,
-    "amount": { "decimal": decimal string },
+    "amount": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
     "selected_utxos": [ {
         "id": EITHER OF
              1) { "Transaction": hex string }
@@ -203,7 +211,9 @@ Parameters:
 {
     "account": number,
     "address": string,
-    "amount": { "decimal": decimal string },
+    "amount": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
     "selected_utxo": {
         "id": EITHER OF
              1) { "Transaction": hex string }
@@ -222,8 +232,14 @@ Returns:
 {
     "hex": string,
     "fees": {
-        "coins": { "decimal": decimal string },
-        "tokens": { hex string: { "decimal": decimal string }, .. },
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { hex string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
     },
 }
 ```
@@ -241,8 +257,14 @@ Returns:
     "tx": hex string,
     "fees": EITHER OF
          1) {
-                "coins": { "decimal": decimal string },
-                "tokens": { hex string: { "decimal": decimal string }, .. },
+                "coins": {
+                    "atoms": number string,
+                    "decimal": decimal string,
+                },
+                "tokens": { hex string: {
+                    "atoms": number string,
+                    "decimal": decimal string,
+                }, .. },
             }
          2) null,
     "stats": {
@@ -264,8 +286,12 @@ Parameters:
 ```
 {
     "account": number,
-    "amount": { "decimal": decimal string },
-    "cost_per_block": { "decimal": decimal string },
+    "amount": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
+    "cost_per_block": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
     "margin_ratio_per_thousand": string,
     "decommission_address": string,
     "options": { "in_top_x_mb": number },
@@ -341,7 +367,9 @@ Parameters:
 ```
 {
     "account": number,
-    "amount": { "decimal": decimal string },
+    "amount": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
     "delegation_id": string,
     "options": { "in_top_x_mb": number },
 }
@@ -359,7 +387,9 @@ Parameters:
 {
     "account": number,
     "address": string,
-    "amount": { "decimal": decimal string },
+    "amount": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
     "delegation_id": string,
     "options": { "in_top_x_mb": number },
 }
@@ -419,8 +449,14 @@ Returns:
 ```
 [ {
     "pool_id": string,
-    "pledge": decimal string,
-    "balance": decimal string,
+    "pledge": {
+        "atoms": number string,
+        "decimal": decimal string,
+    },
+    "balance": {
+        "atoms": number string,
+        "decimal": decimal string,
+    },
     "height": number,
     "block_timestamp": { "timestamp": number },
     "vrf_public_key": string,
@@ -440,8 +476,14 @@ Returns:
 ```
 [ {
     "pool_id": string,
-    "pledge": { "decimal": decimal string },
-    "balance": { "decimal": decimal string },
+    "pledge": {
+        "atoms": number string,
+        "decimal": decimal string,
+    },
+    "balance": {
+        "atoms": number string,
+        "decimal": decimal string,
+    },
     "height": number,
     "block_timestamp": { "timestamp": number },
     "vrf_public_key": string,
@@ -475,7 +517,10 @@ Returns:
 ```
 [ {
     "delegation_id": bech32 string,
-    "balance": { "decimal": decimal string },
+    "balance": {
+        "atoms": number string,
+        "decimal": decimal string,
+    },
 }, .. ]
 ```
 
@@ -544,7 +589,9 @@ Parameters:
         "number_of_decimals": number,
         "metadata_uri": string,
         "token_supply": EITHER OF
-             1) { "Fixed": { "decimal": decimal string } }
+             1) { "Fixed": EITHER OF
+                     1) { "decimal": decimal string }
+                     2) { "atoms": number string } }
              2) "Lockable"
              3) "Unlimited",
         "is_freezable": bool,
@@ -586,7 +633,9 @@ Parameters:
     "account": number,
     "token_id": string,
     "address": string,
-    "amount": { "decimal": decimal string },
+    "amount": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -603,7 +652,9 @@ Parameters:
 {
     "account": number,
     "token_id": string,
-    "amount": { "decimal": decimal string },
+    "amount": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -670,7 +721,9 @@ Parameters:
     "account": number,
     "token_id": string,
     "address": string,
-    "amount": { "decimal": decimal string },
+    "amount": EITHER OF
+         1) { "decimal": decimal string }
+         2) { "atoms": number string },
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -1037,8 +1090,14 @@ Returns:
 {
     "hex": string,
     "fees": {
-        "coins": { "decimal": decimal string },
-        "tokens": { hex string: { "decimal": decimal string }, .. },
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { hex string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
     },
 }
 ```

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -28,10 +28,10 @@ use wallet_types::with_locked::WithLocked;
 
 use crate::types::{
     AccountArg, AddressInfo, AddressWithUsageInfo, Balances, ComposedTransaction, CreatedWallet,
-    DecimalAmount, DelegationInfo, HexEncoded, JsonValue, LegacyVrfPublicKeyInfo,
-    MaybeSignedTransaction, NewAccountInfo, NewDelegation, NewTransaction, NftMetadata,
-    NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId, StakePoolBalance, StakingStatus,
-    TokenMetadata, TransactionOptions, TxOptionsOverrides, VrfPublicKeyInfo,
+    DelegationInfo, HexEncoded, JsonValue, LegacyVrfPublicKeyInfo, MaybeSignedTransaction,
+    NewAccountInfo, NewDelegation, NewTransaction, NftMetadata, NodeVersion, PoolInfo,
+    PublicKeyInfo, RpcAmountIn, RpcTokenId, StakePoolBalance, StakingStatus, TokenMetadata,
+    TransactionOptions, TxOptionsOverrides, VrfPublicKeyInfo,
 };
 
 #[rpc::rpc(server)]
@@ -211,7 +211,7 @@ trait WalletRpc {
         &self,
         account: AccountArg,
         address: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         selected_utxos: Vec<UtxoOutPoint>,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
@@ -239,7 +239,7 @@ trait WalletRpc {
         &self,
         account: AccountArg,
         address: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         selected_utxo: UtxoOutPoint,
         change_address: Option<String>,
         options: TransactionOptions,
@@ -252,8 +252,8 @@ trait WalletRpc {
     async fn create_stake_pool(
         &self,
         account: AccountArg,
-        amount: DecimalAmount,
-        cost_per_block: DecimalAmount,
+        amount: RpcAmountIn,
+        cost_per_block: RpcAmountIn,
         margin_ratio_per_thousand: String,
         decommission_address: String,
         options: TransactionOptions,
@@ -290,7 +290,7 @@ trait WalletRpc {
     async fn delegate_staking(
         &self,
         account: AccountArg,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         delegation_id: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
@@ -300,7 +300,7 @@ trait WalletRpc {
         &self,
         account: AccountArg,
         address: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         delegation_id: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
@@ -369,7 +369,7 @@ trait WalletRpc {
         account: AccountArg,
         token_id: String,
         address: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
 
@@ -378,7 +378,7 @@ trait WalletRpc {
         &self,
         account: AccountArg,
         token_id: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
 
@@ -413,7 +413,7 @@ trait WalletRpc {
         account: AccountArg,
         token_id: String,
         address: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
 

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -41,11 +41,11 @@ use crate::{
     rpc::{ColdWalletRpcServer, WalletEventsRpcServer, WalletRpc, WalletRpcServer},
     types::{
         AccountArg, AddressInfo, AddressWithUsageInfo, Balances, ComposedTransaction,
-        CreatedWallet, DecimalAmount, DelegationInfo, HexEncoded, JsonValue,
-        LegacyVrfPublicKeyInfo, MaybeSignedTransaction, NewAccountInfo, NewDelegation,
-        NewTransaction, NftMetadata, NodeVersion, PoolInfo, PublicKeyInfo, RpcTokenId,
-        StakePoolBalance, StakingStatus, TokenMetadata, TransactionOptions, TxOptionsOverrides,
-        UtxoInfo, VrfPublicKeyInfo,
+        CreatedWallet, DelegationInfo, HexEncoded, JsonValue, LegacyVrfPublicKeyInfo,
+        MaybeSignedTransaction, NewAccountInfo, NewDelegation, NewTransaction, NftMetadata,
+        NodeVersion, PoolInfo, PublicKeyInfo, RpcAmountIn, RpcTokenId, StakePoolBalance,
+        StakingStatus, TokenMetadata, TransactionOptions, TxOptionsOverrides, UtxoInfo,
+        VrfPublicKeyInfo,
     },
     RpcError,
 };
@@ -338,7 +338,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         &self,
         account_arg: AccountArg,
         address: String,
-        amount_str: DecimalAmount,
+        amount: RpcAmountIn,
         selected_utxos: Vec<UtxoOutPoint>,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
@@ -350,7 +350,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
             self.send_coins(
                 account_arg.index::<N>()?,
                 address,
-                amount_str,
+                amount,
                 selected_utxos,
                 config,
             )
@@ -406,7 +406,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         &self,
         account_arg: AccountArg,
         address: String,
-        amount_str: DecimalAmount,
+        amount: RpcAmountIn,
         selected_utxo: UtxoOutPoint,
         change_address: Option<String>,
         options: TransactionOptions,
@@ -419,7 +419,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
             self.request_send_coins(
                 account_arg.index::<N>()?,
                 address,
-                amount_str,
+                amount,
                 selected_utxo,
                 change_address,
                 config,
@@ -439,8 +439,8 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
     async fn create_stake_pool(
         &self,
         account_arg: AccountArg,
-        amount: DecimalAmount,
-        cost_per_block: DecimalAmount,
+        amount: RpcAmountIn,
+        cost_per_block: RpcAmountIn,
         margin_ratio_per_thousand: String,
         decommission_address: String,
         options: TransactionOptions,
@@ -527,7 +527,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
     async fn delegate_staking(
         &self,
         account_arg: AccountArg,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         delegation_id: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
@@ -545,7 +545,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         &self,
         account_arg: AccountArg,
         address: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         delegation_id: String,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
@@ -637,7 +637,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
             broadcast_to_mempool: true,
         };
 
-        let token_supply = metadata.token_supply::<N>(&self.chain_config)?;
+        let token_supply = metadata.token_supply::<N>()?;
         let is_freezable = metadata.is_freezable();
         rpc::handle_result(
             self.issue_new_token(
@@ -677,7 +677,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         account_arg: AccountArg,
         token_id: String,
         address: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
         let config = ControllerConfig {
@@ -695,7 +695,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         &self,
         account_arg: AccountArg,
         token_id: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
         let config = ControllerConfig {
@@ -767,7 +767,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         account_arg: AccountArg,
         token_id: String,
         address: String,
-        amount: DecimalAmount,
+        amount: RpcAmountIn,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
         let config = ControllerConfig {

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -272,8 +272,8 @@ impl PoolInfo {
         chain_config: &ChainConfig,
     ) -> Self {
         let decimals = chain_config.coin_decimals();
-        let balance = RpcAmountOut::from_amount_minimal(balance, decimals);
-        let pledge = RpcAmountOut::from_amount_minimal(pledge, decimals);
+        let balance = RpcAmountOut::from_amount_no_padding(balance, decimals);
+        let pledge = RpcAmountOut::from_amount_no_padding(pledge, decimals);
 
         Self {
             pool_id: Address::new(chain_config, &pool_id).expect("addressable").to_string(),
@@ -319,7 +319,7 @@ impl rpc::description::HasValueHint for DelegationInfo {
 impl DelegationInfo {
     pub fn new(delegation_id: DelegationId, balance: Amount, chain_config: &ChainConfig) -> Self {
         let decimals = chain_config.coin_decimals();
-        let balance = RpcAmountOut::from_amount_minimal(balance, decimals);
+        let balance = RpcAmountOut::from_amount_no_padding(balance, decimals);
 
         Self {
             delegation_id: Address::new(chain_config, &delegation_id)


### PR DESCRIPTION
* `RpcAmountIn` used for RPC params and allows the user to pick whether to specify amount in decimal units or in atoms
* `RpcAmountOut` used for RPC return values gives the user the amount in both decimal units and in atoms
* Use the above types in the wallet RPC
* `HasValueHint` derive macro now supports `#[serde(flatten)]` on enums

TODO:
* [x] Some serialization / deserialization unit tests for the `RpcAmount*` types