### PR TITLE
Don't add unconfirmed txs to all wallet accounts

### DIFF
--- a/test/functional/wallet_conflict.py
+++ b/test/functional/wallet_conflict.py
@@ -159,7 +159,7 @@ class WalletConflictTransaction(BitcoinTestFramework):
             transactions.remove(transfer_tx)
             freeze_tx = transactions[0]
 
-            assert_equal(2, len(await wallet.list_pending_transactions()))
+            assert_equal(1, len(await wallet.list_pending_transactions()))
 
 
             # try to send tokens again should fail as the tokens are already sent

--- a/test/functional/wallet_decommission_genesis.py
+++ b/test/functional/wallet_decommission_genesis.py
@@ -280,9 +280,12 @@ class WalletDecommissionGenesis(BitcoinTestFramework):
             assert_in("Success", await wallet.select_account(DEFAULT_ACCOUNT_INDEX))
             assert_in("The transaction was submitted successfully", await wallet.send_to_address(acc1_address, 45000))
 
+            transactions = node.mempool_transactions()
+            self.gen_pos_block(transactions, 2)
+
             # check wallet best block if it is synced
             best_block_height = await wallet.get_best_block_height()
-            assert_in(best_block_height, '1')
+            assert_in(best_block_height, '2')
 
             assert_in("Success", await wallet.select_account(1))
             decommission_address = await wallet.new_address()

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1731,6 +1731,19 @@ impl<B: storage::Backend> Wallet<B> {
         Ok(())
     }
 
+    /// Save an unconfirmed transaction for a specific account in case we need to rebroadcast it later
+    /// and mark it as Inactive for now
+    pub fn add_account_unconfirmed_tx(
+        &mut self,
+        account_index: U31,
+        transaction: SignedTransaction,
+        wallet_events: &impl WalletEvents,
+    ) -> WalletResult<()> {
+        self.for_account_rw(account_index, |acc, db_tx| {
+            acc.scan_new_inactive_transactions(&[transaction], db_tx, wallet_events)
+        })
+    }
+
     pub fn set_median_time(&mut self, median_time: BlockTimestamp) -> WalletResult<()> {
         self.latest_median_time = median_time;
         let mut db_tx = self.db.transaction_rw(None)?;

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -1190,7 +1190,9 @@ fn wallet_get_transaction(#[case] seed: Seed) {
     let err = wallet.get_transaction(DEFAULT_ACCOUNT_INDEX, tx_id).unwrap_err();
     assert_eq!(err, WalletError::NoTransactionFound(tx_id));
 
-    wallet.add_unconfirmed_tx(tx.clone(), &WalletEventsNoOp).unwrap();
+    wallet
+        .add_account_unconfirmed_tx(DEFAULT_ACCOUNT_INDEX, tx.clone(), &WalletEventsNoOp)
+        .unwrap();
     let found_tx = wallet.get_transaction(DEFAULT_ACCOUNT_INDEX, tx_id).unwrap();
 
     assert_eq!(*found_tx.state(), TxState::Inactive(1));
@@ -1348,7 +1350,13 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
     let fee = feerate.compute_fee(tx_size).unwrap();
 
     // register the successful transaction and check the balance
-    wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
+    wallet
+        .add_account_unconfirmed_tx(
+            DEFAULT_ACCOUNT_INDEX,
+            transaction.clone(),
+            &WalletEventsNoOp,
+        )
+        .unwrap();
     let coin_balance = get_coin_balance_with_inactive(&wallet);
     assert!(coin_balance <= ((block1_amount - amount_to_transfer).unwrap() - fee.into()).unwrap());
 }
@@ -1471,7 +1479,9 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
     }
 
     {
-        wallet.add_unconfirmed_tx(tx, &WalletEventsNoOp).unwrap();
+        wallet
+            .add_account_unconfirmed_tx(DEFAULT_ACCOUNT_INDEX, tx, &WalletEventsNoOp)
+            .unwrap();
         // Try to select the same UTXOs now they should be already consumed
 
         let err = wallet
@@ -1880,7 +1890,13 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
         )
         .unwrap();
 
-    wallet.add_unconfirmed_tx(delegation_tx1.clone(), &WalletEventsNoOp).unwrap();
+    wallet
+        .add_account_unconfirmed_tx(
+            DEFAULT_ACCOUNT_INDEX,
+            delegation_tx1.clone(),
+            &WalletEventsNoOp,
+        )
+        .unwrap();
     let delegation_tx1 = vec![delegation_tx1];
 
     // Check delegation balance after unconfirmed tx status
@@ -1905,7 +1921,13 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
         .unwrap();
-    wallet.add_unconfirmed_tx(delegation_tx2.clone(), &WalletEventsNoOp).unwrap();
+    wallet
+        .add_account_unconfirmed_tx(
+            DEFAULT_ACCOUNT_INDEX,
+            delegation_tx2.clone(),
+            &WalletEventsNoOp,
+        )
+        .unwrap();
 
     // Check delegation balance after unconfirmed tx status
     let mut delegations = wallet.get_delegations(DEFAULT_ACCOUNT_INDEX).unwrap().collect_vec();
@@ -1953,7 +1975,13 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
         .unwrap_or(Amount::ZERO);
     assert_eq!(coin_balance, Amount::ZERO);
 
-    wallet.add_unconfirmed_tx(delegation_tx2.clone(), &WalletEventsNoOp).unwrap();
+    wallet
+        .add_account_unconfirmed_tx(
+            DEFAULT_ACCOUNT_INDEX,
+            delegation_tx2.clone(),
+            &WalletEventsNoOp,
+        )
+        .unwrap();
     let delegation_tx3 = wallet
         .create_transaction_to_addresses_from_delegation(
             DEFAULT_ACCOUNT_INDEX,
@@ -1964,7 +1992,9 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
         .unwrap();
-    wallet.add_unconfirmed_tx(delegation_tx3, &WalletEventsNoOp).unwrap();
+    wallet
+        .add_account_unconfirmed_tx(DEFAULT_ACCOUNT_INDEX, delegation_tx3, &WalletEventsNoOp)
+        .unwrap();
 
     let mut delegations = wallet.get_delegations(DEFAULT_ACCOUNT_INDEX).unwrap().collect_vec();
     assert_eq!(delegations.len(), 1);
@@ -2056,7 +2086,11 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         );
 
         wallet
-            .add_unconfirmed_tx(token_issuance_transaction.clone(), &WalletEventsNoOp)
+            .add_account_unconfirmed_tx(
+                DEFAULT_ACCOUNT_INDEX,
+                token_issuance_transaction.clone(),
+                &WalletEventsNoOp,
+            )
             .unwrap();
 
         let unconfirmed_token_info =
@@ -2142,7 +2176,11 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         )
         .unwrap();
     wallet
-        .add_unconfirmed_tx(transfer_tokens_transaction.clone(), &WalletEventsNoOp)
+        .add_account_unconfirmed_tx(
+            DEFAULT_ACCOUNT_INDEX,
+            transfer_tokens_transaction.clone(),
+            &WalletEventsNoOp,
+        )
         .unwrap();
 
     let _ = create_block(
@@ -3704,7 +3742,13 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
             )
             .unwrap();
-        wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
+        wallet
+            .add_account_unconfirmed_tx(
+                DEFAULT_ACCOUNT_INDEX,
+                transaction.clone(),
+                &WalletEventsNoOp,
+            )
+            .unwrap();
 
         for utxo in transaction.inputs().iter().map(|inp| inp.utxo_outpoint().unwrap()) {
             // assert the utxos used in this transaction have not been used before

--- a/wallet/wallet-cli-lib/tests/basic.rs
+++ b/wallet/wallet-cli-lib/tests/basic.rs
@@ -122,6 +122,9 @@ async fn produce_blocks_decommission_genesis_pool(#[case] seed: Seed) {
     assert!(test
         .exec(&format!("address-send {} 50000", acc2_address))
         .starts_with("The transaction was submitted successfully with ID"));
+    // create a block
+    assert_eq!(test.exec("node-generate-blocks 1"), "Success");
+
     assert_eq!(test.exec("account-select 1"), "Success");
     assert!(test
         .exec(&format!(
@@ -171,7 +174,7 @@ async fn produce_blocks_decommission_genesis_pool(#[case] seed: Seed) {
     // stake with the first acc
     assert_eq!(test.exec("account-select 0"), "Success");
     assert!(test.exec("account-balance").starts_with("Coins amount: 99869999"));
-    assert!(test.exec("account-balance locked").starts_with("Coins amount: 44242"));
+    assert!(test.exec("account-balance locked").starts_with("Coins amount: 44444"));
     assert_eq!(test.exec("node-generate-blocks 2"), "Success");
 
     test.shutdown().await;

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -869,7 +869,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     ) -> Result<SignedTransaction, ControllerError<T>> {
         if self.config.broadcast_to_mempool {
             self.wallet
-                .add_unconfirmed_tx(tx.clone(), self.wallet_events)
+                .add_account_unconfirmed_tx(self.account_index, tx.clone(), self.wallet_events)
                 .map_err(ControllerError::WalletError)?;
 
             self.rpc_client

--- a/wallet/wallet-rpc-lib/tests/basic.rs
+++ b/wallet/wallet-rpc-lib/tests/basic.rs
@@ -172,10 +172,7 @@ async fn stake_and_send_coins_to_acct1(#[case] seed: Seed) {
 
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
     let evt1 = EventInfo::from_json(wallet_events.next().await.unwrap().unwrap());
-    let evt2 = EventInfo::from_json(wallet_events.next().await.unwrap().unwrap());
 
-    // The two events above refer to the same transaction. It is emitted twice, once for account 0
-    // which sends the coins, once for account 1 which receives the coins.
     assert!(matches!(
         evt1,
         EventInfo::TxUpdated {
@@ -184,7 +181,6 @@ async fn stake_and_send_coins_to_acct1(#[case] seed: Seed) {
             id: _,
         }
     ));
-    assert_eq!(evt1, evt2);
 
     let coins_after = balances.coins().to_amount(coin_decimals).unwrap();
     assert!(coins_after <= (coins_before / 2).unwrap());


### PR DESCRIPTION
- only add newly created transactions to the account that created it