### PR TITLE
rpc: Introduce RpcString types and apply them to token metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5912,7 +5912,9 @@ version = "0.3.0"
 dependencies = [
  "hex",
  "rpc-description",
+ "rstest",
  "serde",
+ "serde_json",
  "thiserror",
  "utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5868,6 +5868,7 @@ dependencies = [
  "base64 0.22.0",
  "crypto",
  "expect-test",
+ "hex",
  "http",
  "hyper",
  "jsonrpsee",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5868,13 +5868,13 @@ dependencies = [
  "base64 0.22.0",
  "crypto",
  "expect-test",
- "hex",
  "http",
  "hyper",
  "jsonrpsee",
  "logging",
  "rpc-description",
  "rpc-description-macro",
+ "rpc-types",
  "rstest",
  "serde",
  "serde_json",
@@ -5903,6 +5903,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "rpc-types"
+version = "0.3.0"
+dependencies = [
+ "hex",
+ "rpc-description",
+ "serde",
+ "thiserror",
+ "utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "ref-cast",
  "regex",
  "rpc-description",
+ "rpc-types",
  "rstest",
  "script",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
   "rpc/description",                    # Data types describing an RPC interface.
   "rpc/description-macro",              # Macro to generate rpc interface description.
   "rpc/gen-rpc-docs",                   # A tool to generate RPC documentation.
+  "rpc/types",                          # Support types for use in RPC interfaces.
   "script",                             # Bitcoin script and its interfaces.
   "serialization",                      # Full featured serialization interfaces and implementations.
   "serialization/core",                 # Serialization core tools.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,6 +12,7 @@ crypto = { path = '../crypto'}
 logging = { path = "../logging/" }
 merkletree = { path = "../merkletree", features = ["scale-codec"] }
 rpc-description = { path = "../rpc/description" }
+rpc-types = { path = "../rpc/types" }
 script = { path = '../script'}
 serialization = { path = "../serialization" }
 typename = { path = "../utils/typename" }

--- a/node-daemon/docs/RPC.md
+++ b/node-daemon/docs/RPC.md
@@ -354,9 +354,19 @@ Returns:
 EITHER OF
      1) { "FungibleToken": {
             "token_id": hex string,
-            "token_ticker": [ number, .. ],
+            "token_ticker": {
+                "text": EITHER OF
+                     1) string
+                     2) null,
+                "hex": hex string,
+            },
             "number_of_decimals": number,
-            "metadata_uri": [ number, .. ],
+            "metadata_uri": {
+                "text": EITHER OF
+                     1) string
+                     2) null,
+                "hex": hex string,
+            },
             "circulating_supply": { "atoms": number string },
             "total_supply": EITHER OF
                  1) { "Fixed": { "atoms": number string } }
@@ -385,13 +395,49 @@ EITHER OF
                 "creator": EITHER OF
                      1) [ number, .. ]
                      2) null,
-                "name": [ number, .. ],
-                "description": [ number, .. ],
-                "ticker": [ number, .. ],
-                "icon_uri": [ number, .. ],
-                "additional_metadata_uri": [ number, .. ],
-                "media_uri": [ number, .. ],
-                "media_hash": [ number, .. ],
+                "name": {
+                    "text": EITHER OF
+                         1) string
+                         2) null,
+                    "hex": hex string,
+                },
+                "description": {
+                    "text": EITHER OF
+                         1) string
+                         2) null,
+                    "hex": hex string,
+                },
+                "ticker": {
+                    "text": EITHER OF
+                         1) string
+                         2) null,
+                    "hex": hex string,
+                },
+                "icon_uri": EITHER OF
+                     1) {
+                            "text": EITHER OF
+                                 1) string
+                                 2) null,
+                            "hex": hex string,
+                        }
+                     2) null,
+                "additional_metadata_uri": EITHER OF
+                     1) {
+                            "text": EITHER OF
+                                 1) string
+                                 2) null,
+                            "hex": hex string,
+                        }
+                     2) null,
+                "media_uri": EITHER OF
+                     1) {
+                            "text": EITHER OF
+                                 1) string
+                                 2) null,
+                            "hex": hex string,
+                        }
+                     2) null,
+                "media_hash": hex string,
             },
         } }
      3) null

--- a/node-daemon/docs/RPC.md
+++ b/node-daemon/docs/RPC.md
@@ -678,6 +678,21 @@ Returns:
 
 ## Module `p2p`
 
+### Method `p2p_enable_networking`
+
+Enable or disable networking
+
+
+Parameters:
+```
+{ "enable": bool }
+```
+
+Returns:
+```
+nothing
+```
+
 ### Method `p2p_connect`
 
 Attempt to connect to a remote node (just once).

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -13,6 +13,7 @@ crypto = { path = "../crypto/" }
 logging = { path = "../logging" }
 rpc-description = { path = "description" }
 rpc-description-macro = { path = "description-macro" }
+rpc-types = { path = "types" }
 subsystem = { path = "../subsystem" }
 utils = { path = "../utils/" }
 utils-networking = { path = "../utils/networking" }
@@ -20,7 +21,6 @@ utils-networking = { path = "../utils/networking" }
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
-hex.workspace = true
 http.workspace = true
 hyper.workspace = true
 jsonrpsee = { workspace = true, features = ["server", "server-core", "http-client", "ws-client", "macros"] }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -20,6 +20,7 @@ utils-networking = { path = "../utils/networking" }
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+hex.workspace = true
 http.workspace = true
 hyper.workspace = true
 jsonrpsee = { workspace = true, features = ["server", "server-core", "http-client", "ws-client", "macros"] }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -17,6 +17,7 @@ mod error;
 mod rpc_auth;
 pub mod rpc_creds;
 pub mod subscription;
+pub mod types;
 
 /// Data structures describing an RPC interface
 pub use rpc_description as description;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -17,12 +17,14 @@ mod error;
 mod rpc_auth;
 pub mod rpc_creds;
 pub mod subscription;
-pub mod types;
 
 /// Data structures describing an RPC interface
 pub use rpc_description as description;
 /// A macro to generate RPC interface description for given trait. Has to come before `#[rpc(...)]`
 pub use rpc_description_macro::describe;
+
+/// Support types for RPC interfaces
+pub use rpc_types as types;
 
 use std::{net::SocketAddr, path::PathBuf};
 

--- a/rpc/src/types.rs
+++ b/rpc/src/types.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2022-2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::description::{HasValueHint, ValueHint as VH};
+
+/// Binary data encoded as a hex string in Serde/RPC.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "HexStringSerde", into = "HexStringSerde")]
+pub struct HexString(Vec<u8>);
+
+impl HexString {
+    pub fn from_bytes(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for HexString {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for HexString {
+    fn from(value: Vec<u8>) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
+impl From<HexString> for Vec<u8> {
+    fn from(value: HexString) -> Self {
+        value.into_bytes()
+    }
+}
+
+impl rpc_description::HasValueHint for HexString {
+    const HINT: VH = VH::HEX_STRING;
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct HexStringSerde(String);
+
+impl From<HexString> for HexStringSerde {
+    fn from(value: HexString) -> Self {
+        Self(hex::encode(value.0))
+    }
+}
+
+impl TryFrom<HexStringSerde> for HexString {
+    type Error = hex::FromHexError;
+
+    fn try_from(value: HexStringSerde) -> Result<Self, Self::Error> {
+        Ok(HexString::from_bytes(hex::decode(value.0)?))
+    }
+}
+
+/// A binary string type suitable for use in RPC input parameters. Accepts a string or a hex
+/// string.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(into = "RpcStringInSerde", from = "RpcStringInSerde")]
+pub struct RpcStringIn(Vec<u8>);
+
+impl RpcStringIn {
+    pub fn from_bytes(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+
+    pub fn from_string(data: String) -> Self {
+        Self(data.into_bytes())
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    pub fn try_into_string(self) -> Result<String, (Self, std::str::Utf8Error)> {
+        String::from_utf8(self.0).map_err(|e| {
+            let err = e.utf8_error();
+            let this = Self::from_bytes(e.into_bytes());
+            (this, err)
+        })
+    }
+
+    pub fn try_as_str(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(self.as_ref())
+    }
+}
+
+impl AsRef<[u8]> for RpcStringIn {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for RpcStringIn {
+    fn from(value: Vec<u8>) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
+impl From<String> for RpcStringIn {
+    fn from(value: String) -> Self {
+        Self::from_string(value)
+    }
+}
+
+impl From<HexString> for RpcStringIn {
+    fn from(value: HexString) -> Self {
+        Self::from_bytes(value.into_bytes())
+    }
+}
+
+impl HasValueHint for RpcStringIn {
+    const HINT: VH = VH::Choice(&[&VH::STRING, &VH::Object(&[("hex", &VH::HEX_STRING)])]);
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum RpcStringInSerde {
+    Text(String),
+    Hex(HexString),
+    #[serde(untagged)]
+    Bare(String),
+}
+
+impl From<RpcStringIn> for RpcStringInSerde {
+    fn from(value: RpcStringIn) -> Self {
+        Self::Hex(HexString::from_bytes(value.0))
+    }
+}
+
+impl From<RpcStringInSerde> for RpcStringIn {
+    fn from(value: RpcStringInSerde) -> Self {
+        match value {
+            RpcStringInSerde::Text(s) | RpcStringInSerde::Bare(s) => s.into(),
+            RpcStringInSerde::Hex(hex) => hex.into(),
+        }
+    }
+}
+
+/// A binary string type suitable for use in RPC return values.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(into = "RpcStringOutSerde", try_from = "RpcStringOutSerde")]
+pub struct RpcStringOut(Vec<u8>);
+
+impl RpcStringOut {
+    pub fn from_bytes(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+
+    pub fn from_string(data: String) -> Self {
+        Self(data.into_bytes())
+    }
+}
+
+impl From<Vec<u8>> for RpcStringOut {
+    fn from(value: Vec<u8>) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
+impl From<String> for RpcStringOut {
+    fn from(value: String) -> Self {
+        Self::from_string(value)
+    }
+}
+
+impl HasValueHint for RpcStringOut {
+    const HINT: VH = RpcStringOutSerde::HINT;
+}
+
+#[derive(serde::Serialize, serde::Deserialize, HasValueHint)]
+struct RpcStringOutSerde {
+    text: Option<String>,
+    hex: String,
+}
+
+impl From<RpcStringOut> for RpcStringOutSerde {
+    fn from(value: RpcStringOut) -> Self {
+        let hex = hex::encode(&value.0);
+        let text = String::from_utf8(value.0).ok();
+        Self { text, hex }
+    }
+}
+
+#[derive(PartialEq, Debug, thiserror::Error)]
+enum RpcStringOutConversionError {
+    #[error("Text and hex keys hold different data")]
+    TextHexMismatch,
+}
+
+impl TryFrom<RpcStringOutSerde> for RpcStringOut {
+    type Error = RpcStringOutConversionError;
+    fn try_from(value: RpcStringOutSerde) -> Result<Self, Self::Error> {
+        let bytes = value.hex.into_bytes();
+        utils::ensure!(
+            value.text.map_or(true, |text| text.as_bytes() == &bytes),
+            RpcStringOutConversionError::TextHexMismatch,
+        );
+        Ok(Self(bytes))
+    }
+}

--- a/rpc/types/Cargo.toml
+++ b/rpc/types/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rpc-types"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+rpc-description = { path = "../description" }
+utils = { path = "../../utils" }
+
+hex.workspace = true
+serde.workspace = true
+thiserror.workspace = true

--- a/rpc/types/Cargo.toml
+++ b/rpc/types/Cargo.toml
@@ -13,3 +13,8 @@ utils = { path = "../../utils" }
 hex.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+
+rstest.workspace = true
+serde_json.workspace = true

--- a/rpc/types/src/lib.rs
+++ b/rpc/types/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::description::{HasValueHint, ValueHint as VH};
+use rpc_description::{HasValueHint, ValueHint as VH};
 
 /// Binary data encoded as a hex string in Serde/RPC.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/rpc/types/src/string.rs
+++ b/rpc/types/src/string.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rpc_description::{HasValueHint, ValueHint as VH};
+
+/// Binary data encoded as a hex string in Serde/RPC.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "HexStringSerde", into = "HexStringSerde")]
+pub struct RpcHexString(Vec<u8>);
+
+impl RpcHexString {
+    pub fn from_bytes(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for RpcHexString {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for RpcHexString {
+    fn from(value: Vec<u8>) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
+impl From<RpcHexString> for Vec<u8> {
+    fn from(value: RpcHexString) -> Self {
+        value.into_bytes()
+    }
+}
+
+impl rpc_description::HasValueHint for RpcHexString {
+    const HINT: VH = VH::HEX_STRING;
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct HexStringSerde(String);
+
+impl From<RpcHexString> for HexStringSerde {
+    fn from(value: RpcHexString) -> Self {
+        Self(hex::encode(value.0))
+    }
+}
+
+impl TryFrom<HexStringSerde> for RpcHexString {
+    type Error = hex::FromHexError;
+
+    fn try_from(value: HexStringSerde) -> Result<Self, Self::Error> {
+        Ok(RpcHexString::from_bytes(hex::decode(value.0)?))
+    }
+}
+
+/// A binary string type suitable for use in RPC input parameters. Accepts a string or a hex
+/// string.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(into = "RpcStringInSerde", from = "RpcStringInSerde")]
+pub struct RpcStringIn(Vec<u8>);
+
+impl RpcStringIn {
+    pub fn from_bytes(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+
+    pub fn from_string(data: String) -> Self {
+        Self(data.into_bytes())
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    pub fn try_into_string(self) -> Result<String, (Self, std::str::Utf8Error)> {
+        String::from_utf8(self.0).map_err(|e| {
+            let err = e.utf8_error();
+            let this = Self::from_bytes(e.into_bytes());
+            (this, err)
+        })
+    }
+
+    pub fn try_as_str(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(self.as_ref())
+    }
+}
+
+impl AsRef<[u8]> for RpcStringIn {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for RpcStringIn {
+    fn from(value: Vec<u8>) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
+impl From<String> for RpcStringIn {
+    fn from(value: String) -> Self {
+        Self::from_string(value)
+    }
+}
+
+impl From<RpcHexString> for RpcStringIn {
+    fn from(value: RpcHexString) -> Self {
+        Self::from_bytes(value.into_bytes())
+    }
+}
+
+impl HasValueHint for RpcStringIn {
+    const HINT: VH = VH::Choice(&[&VH::STRING, &VH::Object(&[("hex", &VH::HEX_STRING)])]);
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum RpcStringInSerde {
+    Text(String),
+    Hex(RpcHexString),
+    #[serde(untagged)]
+    Bare(String),
+}
+
+impl From<RpcStringIn> for RpcStringInSerde {
+    fn from(value: RpcStringIn) -> Self {
+        Self::Hex(RpcHexString::from_bytes(value.0))
+    }
+}
+
+impl From<RpcStringInSerde> for RpcStringIn {
+    fn from(value: RpcStringInSerde) -> Self {
+        match value {
+            RpcStringInSerde::Text(s) | RpcStringInSerde::Bare(s) => s.into(),
+            RpcStringInSerde::Hex(hex) => hex.into(),
+        }
+    }
+}
+
+/// A binary string type suitable for use in RPC return values.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(into = "RpcStringOutSerde", try_from = "RpcStringOutSerde")]
+pub struct RpcStringOut(Vec<u8>);
+
+impl RpcStringOut {
+    pub fn from_bytes(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+
+    pub fn from_string(data: String) -> Self {
+        Self(data.into_bytes())
+    }
+}
+
+impl From<Vec<u8>> for RpcStringOut {
+    fn from(value: Vec<u8>) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
+impl From<String> for RpcStringOut {
+    fn from(value: String) -> Self {
+        Self::from_string(value)
+    }
+}
+
+impl HasValueHint for RpcStringOut {
+    const HINT: VH = RpcStringOutSerde::HINT;
+}
+
+#[derive(serde::Serialize, serde::Deserialize, HasValueHint)]
+struct RpcStringOutSerde {
+    text: Option<String>,
+    hex: RpcHexString,
+}
+
+impl From<RpcStringOut> for RpcStringOutSerde {
+    fn from(value: RpcStringOut) -> Self {
+        let hex = value.0.clone().into();
+        let text = String::from_utf8(value.0).ok();
+        Self { text, hex }
+    }
+}
+
+#[derive(PartialEq, Debug, thiserror::Error)]
+enum RpcStringOutConversionError {
+    #[error("Text and hex keys hold different data")]
+    TextHexMismatch,
+}
+
+impl TryFrom<RpcStringOutSerde> for RpcStringOut {
+    type Error = RpcStringOutConversionError;
+    fn try_from(value: RpcStringOutSerde) -> Result<Self, Self::Error> {
+        let bytes = value.hex.into_bytes();
+        utils::ensure!(
+            value.text.map_or(true, |text| text.as_bytes() == &bytes),
+            RpcStringOutConversionError::TextHexMismatch,
+        );
+        Ok(Self(bytes))
+    }
+}

--- a/rpc/types/src/tests.rs
+++ b/rpc/types/src/tests.rs
@@ -13,9 +13,3 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod string;
-
-pub use string::{RpcHexString, RpcStringIn, RpcStringOut};
-
-#[cfg(test)]
-mod tests;

--- a/rpc/types/src/tests.rs
+++ b/rpc/types/src/tests.rs
@@ -13,3 +13,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde_json::json;
+
+use super::*;
+
+#[rstest::rstest]
+#[case(&[0xab], "ab")]
+#[case(&[0xab, 0xcd], "abcd")]
+#[case(&[0x20, 0x80], "2080")]
+#[case(&[0x22, 0x90], "2290")]
+fn invalid_utf8(#[case] bytes: &[u8], #[case] hex: &str) {
+    let rpc_out = RpcStringOut::from_bytes(bytes.to_vec());
+
+    let json = serde_json::to_value(rpc_out).unwrap();
+    let expected_json = json!({ "hex": hex, "text": null });
+    assert_eq!(json, expected_json);
+
+    let rpc_in_hex = json!({ "hex": hex });
+    let rpc_in: RpcStringIn = serde_json::from_value(rpc_in_hex.clone()).unwrap();
+    assert_eq!(rpc_in.as_ref(), bytes);
+    assert_eq!(serde_json::to_value(&rpc_in).unwrap(), rpc_in_hex);
+}
+
+#[rstest::rstest]
+#[case("", "")]
+#[case(" ", "20")]
+#[case("\t", "09")]
+#[case("Hello!", "48656c6c6f21")]
+fn valid_utf8(#[case] in_str: &str, #[case] hex: &str) {
+    let rpc_out = RpcStringOut::from_string(in_str.to_string());
+    let rpc_out_from_bytes = RpcStringOut::from_bytes(in_str.as_bytes().to_vec());
+    assert_eq!(rpc_out, rpc_out_from_bytes);
+
+    let json = serde_json::to_value(rpc_out).unwrap();
+    let expected_json = json!({ "hex": hex, "text": in_str });
+    assert_eq!(json, expected_json);
+
+    let rpc_in_hex = json!({ "hex": hex });
+    let rpc_in_hex_obj: RpcStringIn = serde_json::from_value(rpc_in_hex.clone()).unwrap();
+    assert_eq!(rpc_in_hex_obj.as_ref(), in_str.as_bytes());
+    assert_eq!(serde_json::to_value(&rpc_in_hex_obj).unwrap(), rpc_in_hex);
+
+    let rpc_in_str = json!({ "text": in_str });
+    let rpc_in_str_obj: RpcStringIn = serde_json::from_value(rpc_in_str).unwrap();
+    assert_eq!(rpc_in_str_obj, rpc_in_hex_obj);
+
+    let rpc_in_str_bare = serde_json::Value::from(in_str);
+    let rpc_in_str_bare_obj: RpcStringIn = serde_json::from_value(rpc_in_str_bare).unwrap();
+    assert_eq!(rpc_in_str_bare_obj, rpc_in_hex_obj);
+}

--- a/serialization/src/extras/non_empty_vec.rs
+++ b/serialization/src/extras/non_empty_vec.rs
@@ -24,6 +24,12 @@ use serialization_core::{Decode, Encode};
 #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DataOrNoVec<T>(Option<Vec<T>>);
 
+impl<T> DataOrNoVec<T> {
+    pub fn as_opt_slice(&self) -> Option<&[T]> {
+        self.0.as_ref().map(AsRef::as_ref)
+    }
+}
+
 impl<T> AsRef<Option<Vec<T>>> for DataOrNoVec<T> {
     fn as_ref(&self) -> &Option<Vec<T>> {
         &self.0

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -713,9 +713,9 @@ where
                         selected_account,
                         destination_address,
                         TokenMetadata {
-                            token_ticker,
+                            token_ticker: token_ticker.into(),
                             number_of_decimals,
-                            metadata_uri,
+                            metadata_uri: metadata_uri.into(),
                             token_supply,
                             is_freezable: is_freezable.to_bool(),
                         },
@@ -743,12 +743,12 @@ where
             } => {
                 let metadata = NftMetadata {
                     creator,
-                    name,
-                    description,
+                    name: name.into(),
+                    description: description.into(),
                     ticker,
-                    icon_uri,
-                    additional_metadata_uri,
-                    media_uri,
+                    icon_uri: icon_uri.map(Into::into),
+                    additional_metadata_uri: additional_metadata_uri.map(Into::into),
+                    media_uri: media_uri.map(Into::into),
                     media_hash,
                 };
 

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -658,21 +658,28 @@ Parameters:
     "destination_address": string,
     "metadata": {
         "media_hash": string,
-        "name": string,
-        "description": string,
+        "name": EITHER OF
+             1) string
+             2) { "hex": hex string },
+        "description": EITHER OF
+             1) string
+             2) { "hex": hex string },
         "ticker": string,
         "creator": EITHER OF
              1) hex string
              2) null,
         "icon_uri": EITHER OF
              1) string
-             2) null,
+             2) { "hex": hex string }
+             3) null,
         "media_uri": EITHER OF
              1) string
-             2) null,
+             2) { "hex": hex string }
+             3) null,
         "additional_metadata_uri": EITHER OF
              1) string
-             2) null,
+             2) { "hex": hex string }
+             3) null,
     },
     "options": { "in_top_x_mb": number },
 }
@@ -699,9 +706,13 @@ Parameters:
     "account": number,
     "destination_address": string,
     "metadata": {
-        "token_ticker": string,
+        "token_ticker": EITHER OF
+             1) string
+             2) { "hex": hex string },
         "number_of_decimals": number,
-        "metadata_uri": string,
+        "metadata_uri": EITHER OF
+             1) string
+             2) { "hex": hex string },
         "token_supply": EITHER OF
              1) { "Fixed": EITHER OF
                      1) { "atoms": number string }

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -1790,7 +1790,7 @@ Parameters:
 
 Returns:
 ```
-{ "vrf_public_key": hex string }
+{ "vrf_public_key": string }
 ```
 
 ### Method `staking_show_vrf_public_keys`

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -927,6 +927,21 @@ Returns:
 nothing
 ```
 
+### Method `node_enable_networking`
+
+Enable or disable p2p networking in the node
+
+
+Parameters:
+```
+{ "enable": bool }
+```
+
+Returns:
+```
+nothing
+```
+
 ### Method `node_connect_to_peer`
 
 Connect to a remote peer in the node
@@ -1035,7 +1050,7 @@ Returns:
 ], .. ]
 ```
 
-### Method `node-peer-count`
+### Method `node_peer_count`
 
 Get the number of connected peer in the node
 

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -591,7 +591,7 @@ trait WalletRpc {
     ) -> rpc::RpcResult<Vec<(BannableAddress, common::primitives::time::Time)>>;
 
     /// Get the number of connected peer in the node
-    #[method(name = "node-peer-count")]
+    #[method(name = "node_peer_count")]
     async fn peer_count(&self) -> rpc::RpcResult<usize>;
 
     /// Get connected peers in the node

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -189,7 +189,7 @@ pub struct LegacyVrfPublicKeyInfo {
 }
 
 impl rpc::description::HasValueHint for LegacyVrfPublicKeyInfo {
-    const HINT: VH = VH::Object(&[("vrf_public_key", &VH::HEX_STRING)]);
+    const HINT: VH = VH::Object(&[("vrf_public_key", &VH::STRING)]);
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -39,6 +39,7 @@ use wallet::account::PoolData;
 
 pub use common::primitives::amount::{RpcAmountIn, RpcAmountOut};
 pub use mempool_types::tx_options::TxOptionsOverrides;
+pub use rpc::types::RpcStringIn;
 pub use serde_json::Value as JsonValue;
 pub use serialization::hex_encoded::HexEncoded;
 pub use wallet_controller::types::{
@@ -334,13 +335,13 @@ impl DelegationInfo {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
 pub struct NftMetadata {
     pub media_hash: String,
-    pub name: String,
-    pub description: String,
+    pub name: RpcStringIn,
+    pub description: RpcStringIn,
     pub ticker: String,
     pub creator: Option<HexEncoded<PublicKey>>,
-    pub icon_uri: Option<String>,
-    pub media_uri: Option<String>,
-    pub additional_metadata_uri: Option<String>,
+    pub icon_uri: Option<RpcStringIn>,
+    pub media_uri: Option<RpcStringIn>,
+    pub additional_metadata_uri: Option<RpcStringIn>,
 }
 
 impl NftMetadata {
@@ -379,9 +380,9 @@ impl TokenTotalSupply {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
 pub struct TokenMetadata {
-    pub token_ticker: String,
+    pub token_ticker: RpcStringIn,
     pub number_of_decimals: u8,
-    pub metadata_uri: String,
+    pub metadata_uri: RpcStringIn,
     pub token_supply: TokenTotalSupply,
     pub is_freezable: bool,
 }


### PR DESCRIPTION
* These types represent strings that are supposed to be human-readable most of the time. However, because arbitrary data are allowed, sometimes we have to use the hex representation
* `RpcStringIn` is used for parameters and tolerates either a string or a hex string as an input.
* `RpcStringOut` is used for return values and writes both textual string (if possible, `null` otherwise) and hex string
* Use that for token metadata