### PR TITLE
add force option to wallet open to convert between hot and cold

### DIFF
--- a/node-daemon/docs/RPC.md
+++ b/node-daemon/docs/RPC.md
@@ -678,6 +678,21 @@ Returns:
 
 ## Module `p2p`
 
+### Method `p2p_enable_networking`
+
+Enable or disable networking
+
+
+Parameters:
+```
+{ "enable": bool }
+```
+
+Returns:
+```
+nothing
+```
+
 ### Method `p2p_connect`
 
 Attempt to connect to a remote node (just once).

--- a/node-gui/src/backend/backend_impl.rs
+++ b/node-gui/src/backend/backend_impl.rs
@@ -127,6 +127,7 @@ impl Backend {
             file_path.clone(),
             None,
             WalletType::Hot,
+            false,
         )
         .map_err(|e| BackendError::WalletError(e.to_string()))?;
 

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -173,9 +173,11 @@ class WalletCliController:
         mnemonic_str = "" if mnemonic is None else f'"{mnemonic}"'
         return await self._write_command(f"wallet-create \"{wallet_file}\" store-seed-phrase {mnemonic_str}\n")
 
-    async def open_wallet(self, name: str) -> str:
+    async def open_wallet(self, name: str, password: Optional[str] = None, force_change_wallet_type: bool = False) -> str:
+        password_str = password if password else ""
+        force_change_wallet_type_str = "--force-change-wallet-type" if force_change_wallet_type else ""
         wallet_file = os.path.join(self.node.datadir, name)
-        return await self._write_command(f"wallet-open \"{wallet_file}\"\n")
+        return await self._write_command(f"wallet-open \"{wallet_file}\" {password_str} {force_change_wallet_type_str}\n")
 
     async def recover_wallet(self, mnemonic: str, name: str = "recovered_wallet") -> str:
         wallet_file = os.path.join(self.node.datadir, name)

--- a/test/functional/test_framework/wallet_rpc_controller.py
+++ b/test/functional/test_framework/wallet_rpc_controller.py
@@ -137,11 +137,11 @@ class WalletRpcController:
         self._write_command("wallet_create", [wallet_file, True])
         return "Success"
 
-    async def open_wallet(self, name: str = "wallet") -> str:
+    async def open_wallet(self, name: str = "wallet", password: Optional[str] = None, force_change_wallet_type: bool = False) -> str:
         wallet_file = os.path.join(self.node.datadir, name)
-        output = self._write_command("wallet_open", [wallet_file, None])
+        output = self._write_command("wallet_open", [wallet_file, password, force_change_wallet_type])
         if 'result' in output:
-            return "Success"
+            return "Wallet loaded successfully"
         else:
             return output['error']['message']
 

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -233,6 +233,7 @@ fn verify_wallet_balance(
         None,
         |_| Ok(()),
         WalletType::Hot,
+        false,
     )
     .unwrap();
     let coin_balance = get_coin_balance(&wallet);
@@ -322,6 +323,7 @@ fn wallet_creation_in_memory() {
         None,
         |_| Ok(()),
         WalletType::Hot,
+        false,
     ) {
         Ok(_) => panic!("Wallet loading should fail"),
         Err(err) => assert_eq!(err, WalletError::WalletNotInitialized),
@@ -338,6 +340,7 @@ fn wallet_creation_in_memory() {
         None,
         |_| Ok(()),
         WalletType::Hot,
+        false,
     )
     .unwrap();
 }
@@ -424,6 +427,7 @@ fn wallet_migration_to_v2(#[case] seed: Seed) {
         password,
         |_| Ok(()),
         WalletType::Hot,
+        false,
     )
     .unwrap();
 
@@ -908,6 +912,7 @@ fn test_wallet_accounts(
         None,
         |_| Ok(()),
         WalletType::Hot,
+        false,
     )
     .unwrap();
     let accounts = wallet.account_indexes().cloned().collect::<Vec<_>>();

--- a/wallet/wallet-cli-lib/src/cli_event_loop.rs
+++ b/wallet/wallet-cli-lib/src/cli_event_loop.rs
@@ -60,9 +60,10 @@ pub async fn run<N: NodeInterface + Clone + Send + Sync + 'static + Debug>(
             node_rpc,
             wallet_rpc_config,
         } => {
-            let wallet_service = WalletService::start(chain_config.clone(), None, vec![], node_rpc)
-                .await
-                .map_err(|err| WalletCliError::InvalidConfig(err.to_string()))?;
+            let wallet_service =
+                WalletService::start(chain_config.clone(), None, false, vec![], node_rpc)
+                    .await
+                    .map_err(|err| WalletCliError::InvalidConfig(err.to_string()))?;
 
             let wallet_handle = wallet_service.handle();
             let node_rpc = wallet_service.node_rpc().clone();

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -182,8 +182,16 @@ where
             ColdWalletCommand::OpenWallet {
                 wallet_path,
                 encryption_password,
+                force_change_wallet_type,
             } => {
-                self.wallet().await?.open_wallet(wallet_path, encryption_password).await?;
+                self.wallet()
+                    .await?
+                    .open_wallet(
+                        wallet_path,
+                        encryption_password,
+                        Some(force_change_wallet_type),
+                    )
+                    .await?;
                 self.wallet.update_wallet::<N>().await;
 
                 Ok(ConsoleCommand::SetStatus {

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -65,6 +65,9 @@ pub enum ColdWalletCommand {
         wallet_path: PathBuf,
         /// The existing password, if the wallet is encrypted.
         encryption_password: Option<String>,
+        /// Force change the wallet type from hot to cold or from cold to hot
+        #[arg(long)]
+        force_change_wallet_type: bool,
     },
 
     #[clap(name = "wallet-close")]

--- a/wallet/wallet-cli-lib/src/config.rs
+++ b/wallet/wallet-cli-lib/src/config.rs
@@ -73,6 +73,10 @@ pub struct CliArgs {
     #[clap(long)]
     pub wallet_password: Option<String>,
 
+    /// Force change the wallet type from hot to cold or from cold to hot
+    #[clap(long, requires("wallet_file"))]
+    pub force_change_wallet_type: bool,
+
     /// DEPRECATED: use start_staking_for_account instead!
     /// Start staking for the DEFAULT account after starting the wallet
     #[clap(long, requires("wallet_file"))]

--- a/wallet/wallet-cli-lib/src/lib.rs
+++ b/wallet/wallet-cli-lib/src/lib.rs
@@ -283,6 +283,7 @@ fn setup_events_and_repl<N: NodeInterface + Send + Sync + 'static>(
                 command: WalletCommand::ColdCommands(commands::ColdWalletCommand::OpenWallet {
                     wallet_path,
                     encryption_password: args.wallet_password,
+                    force_change_wallet_type: args.force_change_wallet_type,
                 }),
                 res_tx,
             })

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -96,6 +96,7 @@ impl CliTestFramework {
                 run_options: wallet_cli_lib::config::CliArgs {
                     wallet_file: None,
                     wallet_password: None,
+                    force_change_wallet_type: false,
                     start_staking: false,
                     start_staking_for_account: vec![],
                     node_rpc_address: Some(rpc_address.into()),
@@ -123,6 +124,7 @@ impl CliTestFramework {
             run_options: wallet_cli_lib::config::CliArgs {
                 wallet_file: None,
                 wallet_password: None,
+                force_change_wallet_type: false,
                 start_staking: false,
                 start_staking_for_account: vec![],
                 node_rpc_address: Some(rpc_address.into()),

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -293,6 +293,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
         file_path: impl AsRef<Path>,
         password: Option<String>,
         wallet_type: WalletType,
+        force_change_wallet_type: bool,
     ) -> Result<DefaultWallet, ControllerError<T>> {
         utils::ensure!(
             file_path.as_ref().exists(),
@@ -311,6 +312,7 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
             password,
             |version| Self::make_backup_wallet_file(file_path.as_ref(), version),
             wallet_type,
+            force_change_wallet_type,
         )
         .map_err(ControllerError::WalletError)?;
 

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -135,9 +135,10 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
         &self,
         path: PathBuf,
         password: Option<String>,
+        force_migrate_wallet_type: Option<bool>,
     ) -> Result<(), Self::Error> {
         self.wallet_rpc
-            .open_wallet(path, password)
+            .open_wallet(path, password, force_migrate_wallet_type.unwrap_or(false))
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -91,11 +91,13 @@ impl WalletInterface for ClientWalletRpc {
         &self,
         path: PathBuf,
         password: Option<String>,
+        force_migrate_wallet_type: Option<bool>,
     ) -> Result<(), Self::Error> {
         ColdWalletRpcClient::open_wallet(
             &self.http_client,
             path.to_string_lossy().to_string(),
             password,
+            force_migrate_wallet_type,
         )
         .await
         .map_err(WalletRpcError::ResponseError)

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -65,8 +65,12 @@ pub trait WalletInterface {
         passphrase: Option<String>,
     ) -> Result<CreatedWallet, Self::Error>;
 
-    async fn open_wallet(&self, path: PathBuf, password: Option<String>)
-        -> Result<(), Self::Error>;
+    async fn open_wallet(
+        &self,
+        path: PathBuf,
+        password: Option<String>,
+        force_migrate_wallet_type: Option<bool>,
+    ) -> Result<(), Self::Error>;
 
     async fn close_wallet(&self) -> Result<(), Self::Error>;
 

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -927,6 +927,21 @@ Returns:
 nothing
 ```
 
+### Method `node_enable_networking`
+
+Enable or disable p2p networking in the node
+
+
+Parameters:
+```
+{ "enable": bool }
+```
+
+Returns:
+```
+nothing
+```
+
 ### Method `node_connect_to_peer`
 
 Connect to a remote peer in the node
@@ -1493,6 +1508,9 @@ Parameters:
     "path": string,
     "password": EITHER OF
          1) string
+         2) null,
+    "force_migrate_wallet_type": EITHER OF
+         1) bool
          2) null,
 }
 ```

--- a/wallet/wallet-rpc-lib/src/cmdline.rs
+++ b/wallet/wallet-rpc-lib/src/cmdline.rs
@@ -94,6 +94,10 @@ pub struct WalletRpcDaemonChainArgs {
     #[arg(long, value_name("PATH"))]
     wallet_file: Option<PathBuf>,
 
+    /// Force change the wallet type from hot to cold or from cold to hot
+    #[arg(long, requires("wallet_file"))]
+    force_change_wallet_type: bool,
+
     /// Start staking for the specified account after starting the wallet
     #[arg(long, value_name("ACC_NUMBER"), requires("wallet_file"))]
     start_staking_for_account: Vec<U31>,
@@ -153,6 +157,7 @@ impl WalletRpcDaemonChainArgs {
     ) -> Result<(WalletServiceConfig, WalletRpcConfig), ConfigError> {
         let Self {
             wallet_file,
+            force_change_wallet_type,
             rpc_bind_address,
             start_staking_for_account,
             node_rpc_address,
@@ -167,8 +172,12 @@ impl WalletRpcDaemonChainArgs {
         } = self;
 
         let ws_config = {
-            let service =
-                WalletServiceConfig::new(chain_type, wallet_file, start_staking_for_account);
+            let service = WalletServiceConfig::new(
+                chain_type,
+                wallet_file,
+                force_change_wallet_type,
+                start_staking_for_account,
+            );
 
             if cold_wallet {
                 service

--- a/wallet/wallet-rpc-lib/src/config.rs
+++ b/wallet/wallet-rpc-lib/src/config.rs
@@ -42,6 +42,9 @@ pub struct WalletServiceConfig {
     /// Wallet file to operate on
     pub wallet_file: Option<PathBuf>,
 
+    /// Force change the wallet type from hot to cold or from cold to hot
+    pub force_change_wallet_type: bool,
+
     /// Start staking for account after starting the wallet
     pub start_staking_for_account: Vec<U31>,
 
@@ -53,11 +56,13 @@ impl WalletServiceConfig {
     pub fn new(
         chain_type: ChainType,
         wallet_file: Option<PathBuf>,
+        force_change_wallet_type: bool,
         start_staking_for_account: Vec<U31>,
     ) -> Self {
         Self {
             chain_config: Arc::new(common::chain::config::Builder::new(chain_type).build()),
             wallet_file,
+            force_change_wallet_type,
             start_staking_for_account,
             node_rpc: NodeRpc::ColdWallet,
         }

--- a/wallet/wallet-rpc-lib/src/lib.rs
+++ b/wallet/wallet-rpc-lib/src/lib.rs
@@ -105,6 +105,7 @@ where
     let wallet_service = WalletService::start(
         wallet_config.chain_config,
         wallet_config.wallet_file,
+        wallet_config.force_change_wallet_type,
         wallet_config.start_staking_for_account,
         node_rpc,
     )

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -63,7 +63,12 @@ trait ColdWalletRpc {
 
     /// Open an exiting wallet by specifying the file location of the wallet file
     #[method(name = "wallet_open")]
-    async fn open_wallet(&self, path: String, password: Option<String>) -> rpc::RpcResult<()>;
+    async fn open_wallet(
+        &self,
+        path: String,
+        password: Option<String>,
+        force_migrate_wallet_type: Option<bool>,
+    ) -> rpc::RpcResult<()>;
 
     /// Close the currently open wallet file
     #[method(name = "wallet_close")]

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -127,11 +127,16 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         &self,
         wallet_path: PathBuf,
         password: Option<String>,
+        force_migrate_wallet_type: bool,
     ) -> WRpcResult<(), N> {
         Ok(self
             .wallet
             .manage_async(move |wallet_manager| {
-                Box::pin(async move { wallet_manager.open_wallet(wallet_path, password).await })
+                Box::pin(async move {
+                    wallet_manager
+                        .open_wallet(wallet_path, password, force_migrate_wallet_type)
+                        .await
+                })
             })
             .await??)
     }

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -104,8 +104,20 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> ColdWalletRpcServ
         )
     }
 
-    async fn open_wallet(&self, path: String, password: Option<String>) -> rpc::RpcResult<()> {
-        rpc::handle_result(self.open_wallet(path.into(), password).await)
+    async fn open_wallet(
+        &self,
+        path: String,
+        password: Option<String>,
+        force_migrate_wallet_type: Option<bool>,
+    ) -> rpc::RpcResult<()> {
+        rpc::handle_result(
+            self.open_wallet(
+                path.into(),
+                password,
+                force_migrate_wallet_type.unwrap_or(false),
+            )
+            .await,
+        )
     }
 
     async fn close_wallet(&self) -> rpc::RpcResult<()> {

--- a/wallet/wallet-rpc-lib/src/service/mod.rs
+++ b/wallet/wallet-rpc-lib/src/service/mod.rs
@@ -54,6 +54,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletService<N> {
     pub async fn start(
         chain_config: Arc<ChainConfig>,
         wallet_file: Option<PathBuf>,
+        force_change_wallet_type: bool,
         start_staking_for_account: Vec<U31>,
         node_rpc: N,
     ) -> Result<Self, InitError<N>> {
@@ -69,6 +70,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletService<N> {
                     wallet_file,
                     wallet_password,
                     node_rpc.is_cold_wallet_node(),
+                    force_change_wallet_type,
                 )?
             };
 

--- a/wallet/wallet-rpc-lib/src/service/worker.rs
+++ b/wallet/wallet-rpc-lib/src/service/worker.rs
@@ -172,6 +172,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletWorker<N> {
         &mut self,
         wallet_path: PathBuf,
         password: Option<String>,
+        force_migrate_wallet_type: bool,
     ) -> Result<(), ControllerError<N>> {
         utils::ensure!(
             self.controller.is_none(),
@@ -183,6 +184,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletWorker<N> {
             wallet_path,
             password,
             self.node_rpc.is_cold_wallet_node(),
+            force_migrate_wallet_type,
         )?;
 
         let controller = WalletController::new(

--- a/wallet/wallet-rpc-lib/tests/utils.rs
+++ b/wallet/wallet-rpc-lib/tests/utils.rs
@@ -103,7 +103,7 @@ impl TestFramework {
 
         // Start the wallet service
         let (wallet_service, rpc_server) = {
-            let ws_config = WalletServiceConfig::new(chain_type, Some(wallet_path), vec![])
+            let ws_config = WalletServiceConfig::new(chain_type, Some(wallet_path), false, vec![])
                 .with_regtest_options(chain_config_options)
                 .unwrap()
                 .with_custom_chain_config(chain_config.clone());


### PR DESCRIPTION
- add command line options to CLI and RPC wallet 
- add optional flag to the wallet-open command to force change between hot and cold or cold and hot wallet types