### PR TITLE
Return the pool id for address delegations

### DIFF
--- a/api-server/stack-test-suite/tests/v2/address_delegations.rs
+++ b/api-server/stack-test-suite/tests/v2/address_delegations.rs
@@ -171,6 +171,9 @@ async fn ok(#[case] seed: Seed) {
                                 "delegation_id": Address::new(&chain_config, &delegation_id).expect(
                                     "no error in encoding"
                                 ).get(),
+                                "pool_id": Address::new(&chain_config, &pool_id).expect(
+                                    "no error in encoding"
+                                ).get(),
                                 "next_nonce": AccountNonce::new(0),
                                 "spend_destination": alice_address.get(),
                                 "balance": amount_to_json(amount, chain_config.coin_decimals()),

--- a/api-server/web-server/src/api/v2.rs
+++ b/api-server/web-server/src/api/v2.rs
@@ -733,6 +733,9 @@ pub async fn address_delegations<T: ApiServerStorage>(
             "delegation_id": Address::new(&state.chain_config, &delegation_id).expect(
                 "no error in encoding"
             ).get(),
+            "pool_id": Address::new(&state.chain_config, delegation.pool_id()).expect(
+                "no error in encoding"
+            ).get(),
             "next_nonce": delegation.next_nonce(),
             "spend_destination": Address::new(&state.chain_config, delegation.spend_destination()).expect(
                 "no error in encoding"


### PR DESCRIPTION
- add the pool id to the response when fetching address delegations 