### PR TITLE
rpc: Split out input and output type hints

### DIFF
--- a/common/src/address/pubkeyhash.rs
+++ b/common/src/address/pubkeyhash.rs
@@ -66,5 +66,5 @@ impl TryFrom<Vec<u8>> for PublicKeyHash {
 }
 
 impl rpc_description::HasValueHint for PublicKeyHash {
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
+    const HINT_SER: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
 }

--- a/common/src/chain/tokens/rpc.rs
+++ b/common/src/chain/tokens/rpc.rs
@@ -22,7 +22,7 @@ use crate::{
     primitives::{Amount, Id},
 };
 use rpc_description::HasValueHint;
-use rpc_types::{RpcHexString, RpcStringOut};
+use rpc_types::{RpcHexString, RpcString};
 use serialization::{Decode, Encode};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
@@ -140,9 +140,9 @@ impl RPCIsTokenFrozen {
 pub struct RPCFungibleTokenInfo {
     // TODO: Add the controller public key to issuance data - https://github.com/mintlayer/mintlayer-core/issues/401
     pub token_id: TokenId,
-    pub token_ticker: RpcStringOut,
+    pub token_ticker: RpcString,
     pub number_of_decimals: u8,
-    pub metadata_uri: RpcStringOut,
+    pub metadata_uri: RpcString,
     pub circulating_supply: Amount,
     pub total_supply: RPCTokenTotalSupply,
     pub is_locked: bool,
@@ -214,12 +214,12 @@ impl From<&TokenCreator> for RPCTokenCreator {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
 pub struct RPCNonFungibleTokenMetadata {
     pub creator: Option<RPCTokenCreator>,
-    pub name: RpcStringOut,
-    pub description: RpcStringOut,
-    pub ticker: RpcStringOut,
-    pub icon_uri: Option<RpcStringOut>,
-    pub additional_metadata_uri: Option<RpcStringOut>,
-    pub media_uri: Option<RpcStringOut>,
+    pub name: RpcString,
+    pub description: RpcString,
+    pub ticker: RpcString,
+    pub icon_uri: Option<RpcString>,
+    pub additional_metadata_uri: Option<RpcString>,
+    pub media_uri: Option<RpcString>,
     pub media_hash: RpcHexString,
 }
 

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -300,5 +300,5 @@ impl TextSummary for TxOutput {
 }
 
 impl rpc_description::HasValueHint for TxOutput {
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::GENERIC_OBJECT;
+    const HINT_SER: rpc_description::ValueHint = rpc_description::ValueHint::GENERIC_OBJECT;
 }

--- a/common/src/primitives/amount/serde_support.rs
+++ b/common/src/primitives/amount/serde_support.rs
@@ -107,16 +107,16 @@ pub enum RpcAmountInSerde {
 }
 
 impl HasValueHint for RpcAmountInSerde {
-    const HINT: VH = VH::Choice(&[
-        &VH::Object(&[("atoms", &AtomsInner::HINT)]),
-        &VH::Object(&[("decimal", &DecimalInner::HINT)]),
+    const HINT_SER: VH = VH::Choice(&[
+        &VH::Object(&[("atoms", &AtomsInner::HINT_SER)]),
+        &VH::Object(&[("decimal", &DecimalInner::HINT_SER)]),
     ]);
 }
 
 rpc_description::impl_value_hint!({
     AtomsInner => VH::NUMBER_STRING;
     DecimalInner => VH::DECIMAL_STRING;
-    Amount => AmountSerde::HINT;
-    super::RpcAmountIn => RpcAmountInSerde::HINT;
-    super::RpcAmountOut => RpcAmountOutSerde::HINT;
+    Amount => AmountSerde::HINT_SER;
+    super::RpcAmountIn => RpcAmountInSerde::HINT_SER;
+    super::RpcAmountOut => RpcAmountOutSerde::HINT_SER;
 });

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -103,7 +103,7 @@ impl<'de> serde::Deserialize<'de> for H256 {
 }
 
 impl rpc_description::HasValueHint for H256 {
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
+    const HINT_SER: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
 }
 
 #[derive(PartialEq, Eq, Encode, Decode, RefCast)]
@@ -227,7 +227,7 @@ impl<T> AsRef<[u8]> for Id<T> {
 }
 
 impl<T> rpc_description::HasValueHint for Id<T> {
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
+    const HINT_SER: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
 }
 
 /// a trait for objects that deserve having a unique id with implementations to how to ID them

--- a/crypto/src/key/mod.rs
+++ b/crypto/src/key/mod.rs
@@ -73,7 +73,7 @@ impl<'d> serde::Deserialize<'d> for PublicKey {
 }
 
 impl rpc_description::HasValueHint for PublicKey {
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
+    const HINT_SER: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
 }
 
 impl PrivateKey {

--- a/mempool/src/config.rs
+++ b/mempool/src/config.rs
@@ -98,7 +98,9 @@ impl<'de> serde::Deserialize<'de> for MempoolMaxSize {
 }
 
 impl HasValueHint for MempoolMaxSize {
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::Prim(
+    const HINT_SER: rpc_description::ValueHint =
+        rpc_description::ValueHint::Prim("number in bytes");
+    const HINT_DE: rpc_description::ValueHint = rpc_description::ValueHint::Prim(
         "String with units, such as MB/KB/GB, or integer for bytes",
     );
 }

--- a/mempool/types/src/tx_options.rs
+++ b/mempool/types/src/tx_options.rs
@@ -93,7 +93,7 @@ pub struct TxOptionsOverrides {
 }
 
 impl rpc_description::HasValueHint for TxOptionsOverrides {
-    const HINT: VH = VH::Object(&[(
+    const HINT_SER: VH = VH::Object(&[(
         "trust_policy",
         &VH::Choice(&[&VH::StrLit("Trusted"), &VH::StrLit("Untrusted")]),
     )]);

--- a/rpc/description-macro/Cargo.toml
+++ b/rpc/description-macro/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
+
 quote.workspace = true
 proc-macro2.workspace = true
-syn.workspace = true
+syn = { workspace = true, features = ["full", "extra-traits"] }

--- a/rpc/description-macro/src/describe_impl.rs
+++ b/rpc/description-macro/src/describe_impl.rs
@@ -198,7 +198,7 @@ impl quote::ToTokens for MethodMeta<'_> {
                 let ret = return_type.unwrap_or(&unit);
                 quote! {
                     ::rpc::description::MethodKindData::Method {
-                        return_type: <#ret as ::rpc::description::HasValueHint>::HINT,
+                        return_type: <#ret as ::rpc::description::HasValueHint>::HINT_SER,
                     }
                 }
             }
@@ -207,7 +207,7 @@ impl quote::ToTokens for MethodMeta<'_> {
                 quote! {
                     ::rpc::description::MethodKindData::Subscription {
                         unsubscribe_name: #unsub,
-                        item_type: <#item_ty as ::rpc::description::HasValueHint>::HINT,
+                        item_type: <#item_ty as ::rpc::description::HasValueHint>::HINT_SER,
                     }
                 }
             }
@@ -215,7 +215,7 @@ impl quote::ToTokens for MethodMeta<'_> {
 
         let params = params
             .iter()
-            .map(|(n, t)| quote!((#n, &<#t as ::rpc::description::HasValueHint>::HINT)));
+            .map(|(n, t)| quote!((#n, &<#t as ::rpc::description::HasValueHint>::HINT_DE)));
 
         tokens.extend(quote! {
             ::rpc::description::Method {

--- a/rpc/description/src/value_hint.rs
+++ b/rpc/description/src/value_hint.rs
@@ -17,7 +17,8 @@ pub use rpc_description_macro::HasValueHint;
 
 /// Value hint associated with given type
 pub trait HasValueHint {
-    const HINT: ValueHint;
+    const HINT_SER: ValueHint;
+    const HINT_DE: ValueHint = Self::HINT_SER;
 }
 
 /// A compositional way of describing values of RPC arguments and return values
@@ -48,9 +49,10 @@ pub enum ValueHint {
 type VH = ValueHint;
 
 impl ValueHint {
-    pub const BOOL: VH = VH::Prim("bool");
+    pub const IRRELEVANT: VH = VH::Prim("IRRELEVANT");
     pub const NOTHING: VH = VH::Prim("nothing");
     pub const NULL: VH = VH::Prim("null");
+    pub const BOOL: VH = VH::Prim("bool");
     pub const NUMBER: VH = VH::Prim("number");
     pub const STRING: VH = VH::Prim("string");
     pub const NUMBER_STRING: VH = VH::Prim("number string");
@@ -61,52 +63,67 @@ impl ValueHint {
     pub const JSON: VH = VH::Prim("json");
 }
 
+impl HasValueHint for () {
+    const HINT_SER: VH = VH::NOTHING;
+    const HINT_DE: VH = VH::NULL;
+}
+
 impl HasValueHint for std::time::Duration {
-    const HINT: VH = VH::Tuple(&[&VH::Prim("secs number"), &VH::Prim("nanos number")]);
+    const HINT_SER: VH = VH::Tuple(&[&VH::Prim("secs number"), &VH::Prim("nanos number")]);
 }
 
 impl<T: HasValueHint + ?Sized> HasValueHint for &T {
-    const HINT: VH = T::HINT;
+    const HINT_SER: VH = T::HINT_SER;
+    const HINT_DE: VH = T::HINT_DE;
 }
 
 impl<T: HasValueHint + ?Sized> HasValueHint for Box<T> {
-    const HINT: VH = T::HINT;
+    const HINT_SER: VH = T::HINT_SER;
+    const HINT_DE: VH = T::HINT_DE;
 }
 
 impl<T: HasValueHint> HasValueHint for Option<T> {
-    const HINT: VH = VH::Choice(&[&T::HINT, &VH::NULL]);
+    const HINT_SER: VH = VH::Choice(&[&T::HINT_SER, &VH::NULL]);
+    const HINT_DE: VH = VH::Choice(&[&T::HINT_DE, &VH::NULL]);
 }
 
 impl<T: HasValueHint, E> HasValueHint for Result<T, E> {
     // We report just the "happy path" value hint here. It works as long as the result type is only
     // used in RPC return values (not arguments) and it is the outer-most type wrapper.
-    const HINT: VH = T::HINT;
+    const HINT_SER: VH = T::HINT_SER;
+    const HINT_DE: VH = T::HINT_DE;
 }
 
 impl<T: HasValueHint> HasValueHint for Vec<T> {
-    const HINT: VH = VH::Array(&T::HINT);
+    const HINT_SER: VH = VH::Array(&T::HINT_SER);
+    const HINT_DE: VH = VH::Array(&T::HINT_DE);
 }
 
 impl<K: HasValueHint, V: HasValueHint> HasValueHint for std::collections::BTreeMap<K, V> {
-    const HINT: VH = VH::Map(&K::HINT, &V::HINT);
+    const HINT_SER: VH = VH::Map(&K::HINT_SER, &V::HINT_SER);
+    const HINT_DE: VH = VH::Map(&K::HINT_DE, &V::HINT_DE);
 }
 
 impl<T0: HasValueHint> HasValueHint for (T0,) {
-    const HINT: VH = VH::Tuple(&[&T0::HINT]);
+    const HINT_SER: VH = VH::Tuple(&[&T0::HINT_SER]);
+    const HINT_DE: VH = VH::Tuple(&[&T0::HINT_DE]);
 }
 
 impl<T0: HasValueHint, T1: HasValueHint> HasValueHint for (T0, T1) {
-    const HINT: VH = VH::Tuple(&[&T0::HINT, &T1::HINT]);
+    const HINT_SER: VH = VH::Tuple(&[&T0::HINT_SER, &T1::HINT_SER]);
+    const HINT_DE: VH = VH::Tuple(&[&T0::HINT_DE, &T1::HINT_DE]);
 }
 
 impl<T0: HasValueHint, T1: HasValueHint, T2: HasValueHint> HasValueHint for (T0, T1, T2) {
-    const HINT: VH = VH::Tuple(&[&T0::HINT, &T1::HINT, &T2::HINT]);
+    const HINT_SER: VH = VH::Tuple(&[&T0::HINT_SER, &T1::HINT_SER, &T2::HINT_SER]);
+    const HINT_DE: VH = VH::Tuple(&[&T0::HINT_DE, &T1::HINT_DE, &T2::HINT_DE]);
 }
 
 impl<T0: HasValueHint, T1: HasValueHint, T2: HasValueHint, T3: HasValueHint> HasValueHint
     for (T0, T1, T2, T3)
 {
-    const HINT: VH = VH::Tuple(&[&T0::HINT, &T1::HINT, &T2::HINT, &T3::HINT]);
+    const HINT_SER: VH = VH::Tuple(&[&T0::HINT_SER, &T1::HINT_SER, &T2::HINT_SER, &T3::HINT_SER]);
+    const HINT_DE: VH = VH::Tuple(&[&T0::HINT_DE, &T1::HINT_DE, &T2::HINT_DE, &T3::HINT_DE]);
 }
 
 #[macro_export]
@@ -116,13 +133,13 @@ macro_rules! impl_value_hint {
     };
     ($ty:ty => $hint:expr) => {
         impl $crate::HasValueHint for $ty {
-            const HINT: $crate::ValueHint = $hint;
+            const HINT_SER: $crate::ValueHint = $hint;
+            const HINT_DE: $crate::ValueHint = $hint;
         }
     };
 }
 
 impl_value_hint!({
-    () => VH::NOTHING;
     bool => VH::BOOL;
     i8 => VH::NUMBER;
     u8 => VH::NUMBER;

--- a/rpc/tests/basic/desc.rs
+++ b/rpc/tests/basic/desc.rs
@@ -69,7 +69,7 @@ fn value_hint_tagged() {
         String(String),
     }
 
-    let actual = Tagged::HINT.to_string();
+    let actual = Tagged::HINT_SER.to_string();
     expect_file!["./HINT_TAGGED.txt"].assert_eq(&actual);
 }
 
@@ -83,7 +83,7 @@ fn value_hint_untagged() {
         String(String),
     }
 
-    let actual = Untagged::HINT.to_string();
+    let actual = Untagged::HINT_SER.to_string();
     expect_file!["./HINT_UNTAGGED.txt"].assert_eq(&actual);
 }
 

--- a/rpc/types/src/lib.rs
+++ b/rpc/types/src/lib.rs
@@ -15,7 +15,7 @@
 
 mod string;
 
-pub use string::{RpcHexString, RpcStringIn, RpcStringOut};
+pub use string::{RpcHexString, RpcString};
 
 #[cfg(test)]
 mod tests;

--- a/rpc/types/src/string.rs
+++ b/rpc/types/src/string.rs
@@ -49,7 +49,7 @@ impl From<RpcHexString> for Vec<u8> {
 }
 
 impl rpc_description::HasValueHint for RpcHexString {
-    const HINT: VH = VH::HEX_STRING;
+    const HINT_SER: VH = VH::HEX_STRING;
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -126,7 +126,7 @@ impl From<RpcHexString> for RpcStringIn {
 }
 
 impl HasValueHint for RpcStringIn {
-    const HINT: VH = VH::Choice(&[&VH::STRING, &VH::Object(&[("hex", &VH::HEX_STRING)])]);
+    const HINT_SER: VH = VH::Choice(&[&VH::STRING, &VH::Object(&[("hex", &VH::HEX_STRING)])]);
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -181,7 +181,7 @@ impl From<String> for RpcStringOut {
 }
 
 impl HasValueHint for RpcStringOut {
-    const HINT: VH = RpcStringOutSerde::HINT;
+    const HINT_SER: VH = RpcStringOutSerde::HINT_SER;
 }
 
 #[derive(serde::Serialize, serde::Deserialize, HasValueHint)]

--- a/serialization/src/hex_encoded.rs
+++ b/serialization/src/hex_encoded.rs
@@ -73,5 +73,5 @@ impl<T: serialization_core::Encode> Display for HexEncoded<T> {
 }
 
 impl<T> rpc_description::HasValueHint for HexEncoded<T> {
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
+    const HINT_SER: rpc_description::ValueHint = rpc_description::ValueHint::HEX_STRING;
 }

--- a/utils/networking/src/ip_or_socket_address.rs
+++ b/utils/networking/src/ip_or_socket_address.rs
@@ -72,7 +72,7 @@ impl IpOrSocketAddress {
 }
 
 impl rpc_description::HasValueHint for IpOrSocketAddress {
-    const HINT: rpc_description::ValueHint = rpc_description::ValueHint::STRING;
+    const HINT_SER: rpc_description::ValueHint = rpc_description::ValueHint::STRING;
 }
 
 #[cfg(test)]

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -39,7 +39,7 @@ use wallet::account::PoolData;
 
 pub use common::primitives::amount::{RpcAmountIn, RpcAmountOut};
 pub use mempool_types::tx_options::TxOptionsOverrides;
-pub use rpc::types::RpcStringIn;
+pub use rpc::types::RpcString;
 pub use serde_json::Value as JsonValue;
 pub use serialization::hex_encoded::HexEncoded;
 pub use wallet_controller::types::{
@@ -339,13 +339,13 @@ impl DelegationInfo {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
 pub struct NftMetadata {
     pub media_hash: String,
-    pub name: RpcStringIn,
-    pub description: RpcStringIn,
+    pub name: RpcString,
+    pub description: RpcString,
     pub ticker: String,
     pub creator: Option<HexEncoded<PublicKey>>,
-    pub icon_uri: Option<RpcStringIn>,
-    pub media_uri: Option<RpcStringIn>,
-    pub additional_metadata_uri: Option<RpcStringIn>,
+    pub icon_uri: Option<RpcString>,
+    pub media_uri: Option<RpcString>,
+    pub additional_metadata_uri: Option<RpcString>,
 }
 
 impl NftMetadata {
@@ -384,9 +384,9 @@ impl TokenTotalSupply {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
 pub struct TokenMetadata {
-    pub token_ticker: RpcStringIn,
+    pub token_ticker: RpcString,
     pub number_of_decimals: u8,
-    pub metadata_uri: RpcStringIn,
+    pub metadata_uri: RpcString,
     pub token_supply: TokenTotalSupply,
     pub is_freezable: bool,
 }

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -177,7 +177,7 @@ impl PublicKeyInfo {
 }
 
 impl rpc::description::HasValueHint for PublicKeyInfo {
-    const HINT: VH = VH::Object(&[
+    const HINT_SER: VH = VH::Object(&[
         ("public_key_hex", &VH::HEX_STRING),
         ("public_key_address", &VH::BECH32_STRING),
     ]);
@@ -189,7 +189,7 @@ pub struct LegacyVrfPublicKeyInfo {
 }
 
 impl rpc::description::HasValueHint for LegacyVrfPublicKeyInfo {
-    const HINT: VH = VH::Object(&[("vrf_public_key", &VH::STRING)]);
+    const HINT_SER: VH = VH::Object(&[("vrf_public_key", &VH::STRING)]);
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -210,10 +210,10 @@ impl VrfPublicKeyInfo {
 }
 
 impl rpc::description::HasValueHint for VrfPublicKeyInfo {
-    const HINT: VH = VH::Object(&[
+    const HINT_SER: VH = VH::Object(&[
         ("vrf_public_key", &VH::HEX_STRING),
-        ("child_number", &u32::HINT),
-        ("used", &bool::HINT),
+        ("child_number", &u32::HINT_SER),
+        ("used", &bool::HINT_SER),
     ]);
 }
 
@@ -224,8 +224,8 @@ pub struct UtxoInfo {
 }
 
 impl rpc::description::HasValueHint for UtxoInfo {
-    const HINT: VH =
-        VH::Object(&[("outpoint", &UtxoOutPoint::HINT), ("output", &VH::GENERIC_OBJECT)]);
+    const HINT_SER: VH =
+        VH::Object(&[("outpoint", &UtxoOutPoint::HINT_SER), ("output", &VH::GENERIC_OBJECT)]);
 }
 
 impl UtxoInfo {
@@ -302,8 +302,10 @@ pub struct NewDelegation {
 }
 
 impl rpc::description::HasValueHint for NewDelegation {
-    const HINT: VH =
-        VH::Object(&[("tx_id", &<Id<Transaction>>::HINT), ("delegation_id", &VH::BECH32_STRING)]);
+    const HINT_SER: VH = VH::Object(&[
+        ("tx_id", &<Id<Transaction>>::HINT_SER),
+        ("delegation_id", &VH::BECH32_STRING),
+    ]);
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -313,8 +315,10 @@ pub struct DelegationInfo {
 }
 
 impl rpc::description::HasValueHint for DelegationInfo {
-    const HINT: VH =
-        VH::Object(&[("delegation_id", &VH::BECH32_STRING), ("balance", &RpcAmountOut::HINT)]);
+    const HINT_SER: VH =
+        VH::Object(&[("delegation_id", &VH::BECH32_STRING), ("balance", &RpcAmountOut::HINT_SER)]);
+    const HINT_DE: VH =
+        VH::Object(&[("delegation_id", &VH::BECH32_STRING), ("balance", &RpcAmountOut::HINT_DE)]);
 }
 
 impl DelegationInfo {
@@ -415,7 +419,8 @@ pub struct RpcTokenId {
 }
 
 impl rpc::description::HasValueHint for RpcTokenId {
-    const HINT: VH = VH::Object(&[("token_id", &VH::BECH32_STRING), ("tx_id", &VH::HEX_STRING)]);
+    const HINT_SER: VH =
+        VH::Object(&[("token_id", &VH::BECH32_STRING), ("tx_id", &VH::HEX_STRING)]);
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]


### PR DESCRIPTION
* Specify input and output type hints separately
* Use that to unify `RpcStringIn` and `RpcStringOut` into one `RpcString`
* Some more `RpcString` serialization tests
* (Doing the same for `RpcAmount` is a bit trickier because it requires chain config for full decoding)