### PR TITLE
rpc: Introduce `RpcAddress` and use it in wallet RPC

### DIFF
--- a/api-server/api-server-common/src/storage/impls/postgres/queries.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/queries.rs
@@ -841,7 +841,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                 WHERE delegation_id = $1
                 AND block_height = (SELECT MAX(block_height) FROM ml_delegations WHERE delegation_id = $1);
                 "#,
-                &[&delegation_id.get()],
+                &[&delegation_id.as_str()],
             )
             .await
             .map_err(|e| ApiServerStorageError::LowLevelStorageError(e.to_string()))?;
@@ -854,8 +854,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
         let pool_id: String = data.get(0);
         let pool_id = Address::<PoolId>::from_str(chain_config, &pool_id)
             .map_err(|_| ApiServerStorageError::AddressableError)?
-            .decode_object(chain_config)
-            .expect("already checked");
+            .decode_object();
         let balance: String = data.get(1);
         let spend_destination: Vec<u8> = data.get(2);
         let next_nonce: Vec<u8> = data.get(3);
@@ -911,13 +910,11 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                 let delegation_id: String = row.get(0);
                 let delegation_id = Address::<DelegationId>::from_str(chain_config, &delegation_id)
                     .map_err(|_| ApiServerStorageError::AddressableError)?
-                    .decode_object(chain_config)
-                    .expect("already checked");
+                    .decode_object();
                 let pool_id: String = row.get(1);
                 let pool_id = Address::<PoolId>::from_str(chain_config, &pool_id)
                     .map_err(|_| ApiServerStorageError::AddressableError)?
-                    .decode_object(chain_config)
-                    .expect("already checked");
+                    .decode_object();
                 let balance: String = row.get(2);
                 let spend_destination: Vec<u8> = row.get(3);
                 let next_nonce: Vec<u8> = row.get(4);
@@ -970,9 +967,9 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                     SET pool_id = $3, balance = $4, spend_destination = $5, next_nonce = $6;
                 "#,
                 &[
-                    &delegation_id.get(),
+                    &delegation_id.as_str(),
                     &height,
-                    &pool_id.get(),
+                    &pool_id.as_str(),
                     &amount_to_str(*delegation.balance()),
                     &delegation.spend_destination().encode(),
                     &delegation.next_nonce().encode(),
@@ -1037,7 +1034,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                     AND block_height != (SELECT COALESCE(MIN(block_height), 0) FROM ml_pool_data WHERE pool_id = $1)
                     AND staker_balance::NUMERIC != 0
                 "#,
-                &[&pool_id_str.get(), &from_height, &to_height],
+                &[&pool_id_str.as_str(), &from_height, &to_height],
             )
             .await
             .map_err(|e| ApiServerStorageError::LowLevelStorageError(e.to_string()))?;
@@ -1065,7 +1062,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                                                             WHERE pool_id = $1
                                                             GROUP BY delegation_id)
                 "#,
-                &[&pool_id_str.get()],
+                &[&pool_id_str.as_str()],
             )
             .await
             .map_err(|e| ApiServerStorageError::LowLevelStorageError(e.to_string()))?
@@ -1075,8 +1072,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                 let delegation_id =
                     Address::<DelegationId>::from_str(chain_config, &delegation_id_str)
                         .map_err(|_| ApiServerStorageError::AddressableError)?
-                        .decode_object(chain_config)
-                        .expect("already checked");
+                        .decode_object();
                 let balance: String = row.get(1);
                 let spend_destination: Vec<u8> = row.get(2);
                 let next_nonce: Vec<u8> = row.get(3);
@@ -1125,7 +1121,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                 ORDER BY block_height DESC
                 LIMIT 1;
             "#,
-                &[&pool_id.get()],
+                &[&pool_id.as_str()],
             )
             .await
             .map_err(|e| ApiServerStorageError::LowLevelStorageError(e.to_string()))?
@@ -1176,8 +1172,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                 let pool_id: String = row.get(0);
                 let pool_id = Address::<PoolId>::from_str(chain_config, &pool_id)
                     .map_err(|_| ApiServerStorageError::AddressableError)?
-                    .decode_object(chain_config)
-                    .expect("already checked");
+                    .decode_object();
                 let pool_data: Vec<u8> = row.get(1);
                 let pool_data = PoolData::decode_all(&mut pool_data.as_slice()).map_err(|e| {
                     ApiServerStorageError::DeserializationError(format!(
@@ -1221,8 +1216,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                 let pool_id: String = row.get(0);
                 let pool_id = Address::<PoolId>::from_str(chain_config, &pool_id)
                     .map_err(|_| ApiServerStorageError::AddressableError)?
-                    .decode_object(chain_config)
-                    .expect("already checked");
+                    .decode_object();
                 let pool_data: Vec<u8> = row.get(1);
                 let pool_data = PoolData::decode_all(&mut pool_data.as_slice()).map_err(|e| {
                     ApiServerStorageError::DeserializationError(format!(
@@ -1254,7 +1248,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                     INSERT INTO ml_pool_data (pool_id, block_height, staker_balance, data)
                     VALUES ($1, $2, $3, $4)
                 "#,
-                &[&pool_id.get(), &height, &amount_str, &pool_data.encode()],
+                &[&pool_id.as_str(), &height, &amount_str, &pool_data.encode()],
             )
             .await
             .map_err(|e| ApiServerStorageError::LowLevelStorageError(e.to_string()))?;

--- a/api-server/api-server-common/src/storage/impls/postgres/queries.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/queries.rs
@@ -831,7 +831,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
         delegation_id: DelegationId,
         chain_config: &ChainConfig,
     ) -> Result<Option<Delegation>, ApiServerStorageError> {
-        let delegation_id = Address::new(chain_config, &delegation_id)
+        let delegation_id = Address::new(chain_config, delegation_id)
             .map_err(|_| ApiServerStorageError::AddressableError)?;
         let row = self
             .tx
@@ -852,9 +852,9 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
         };
 
         let pool_id: String = data.get(0);
-        let pool_id = Address::<PoolId>::from_str(chain_config, &pool_id)
+        let pool_id = Address::<PoolId>::from_string(chain_config, pool_id)
             .map_err(|_| ApiServerStorageError::AddressableError)?
-            .decode_object();
+            .into_object();
         let balance: String = data.get(1);
         let spend_destination: Vec<u8> = data.get(2);
         let next_nonce: Vec<u8> = data.get(3);
@@ -910,11 +910,11 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                 let delegation_id: String = row.get(0);
                 let delegation_id = Address::<DelegationId>::from_str(chain_config, &delegation_id)
                     .map_err(|_| ApiServerStorageError::AddressableError)?
-                    .decode_object();
+                    .into_object();
                 let pool_id: String = row.get(1);
-                let pool_id = Address::<PoolId>::from_str(chain_config, &pool_id)
+                let pool_id = Address::<PoolId>::from_string(chain_config, pool_id)
                     .map_err(|_| ApiServerStorageError::AddressableError)?
-                    .decode_object();
+                    .into_object();
                 let balance: String = row.get(2);
                 let spend_destination: Vec<u8> = row.get(3);
                 let next_nonce: Vec<u8> = row.get(4);
@@ -953,9 +953,9 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
         chain_config: &ChainConfig,
     ) -> Result<(), ApiServerStorageError> {
         let height = Self::block_height_to_postgres_friendly(block_height);
-        let pool_id = Address::new(chain_config, delegation.pool_id())
+        let pool_id = Address::new(chain_config, *delegation.pool_id())
             .map_err(|_| ApiServerStorageError::AddressableError)?;
-        let delegation_id = Address::new(chain_config, &delegation_id)
+        let delegation_id = Address::new(chain_config, delegation_id)
             .map_err(|_| ApiServerStorageError::AddressableError)?;
 
         self.tx
@@ -1023,7 +1023,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
     ) -> Result<Option<PoolBlockStats>, ApiServerStorageError> {
         let from_height = Self::block_height_to_postgres_friendly(block_range.0);
         let to_height = Self::block_height_to_postgres_friendly(block_range.1);
-        let pool_id_str = Address::new(chain_config, &pool_id)
+        let pool_id_str = Address::new(chain_config, pool_id)
             .map_err(|_| ApiServerStorageError::AddressableError)?;
         let row = self
             .tx
@@ -1050,7 +1050,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
         pool_id: PoolId,
         chain_config: &ChainConfig,
     ) -> Result<BTreeMap<DelegationId, Delegation>, ApiServerStorageError> {
-        let pool_id_str = Address::new(chain_config, &pool_id)
+        let pool_id_str = Address::new(chain_config, pool_id)
             .map_err(|_| ApiServerStorageError::AddressableError)?;
         self.tx
             .query(
@@ -1072,7 +1072,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
                 let delegation_id =
                     Address::<DelegationId>::from_str(chain_config, &delegation_id_str)
                         .map_err(|_| ApiServerStorageError::AddressableError)?
-                        .decode_object();
+                        .into_object();
                 let balance: String = row.get(1);
                 let spend_destination: Vec<u8> = row.get(2);
                 let next_nonce: Vec<u8> = row.get(3);
@@ -1110,7 +1110,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
         pool_id: PoolId,
         chain_config: &ChainConfig,
     ) -> Result<Option<PoolData>, ApiServerStorageError> {
-        let pool_id = Address::new(chain_config, &pool_id)
+        let pool_id = Address::new(chain_config, pool_id)
             .map_err(|_| ApiServerStorageError::AddressableError)?;
         self.tx
             .query_opt(
@@ -1170,9 +1170,9 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
             .into_iter()
             .map(|row| -> Result<(PoolId, PoolData), ApiServerStorageError> {
                 let pool_id: String = row.get(0);
-                let pool_id = Address::<PoolId>::from_str(chain_config, &pool_id)
+                let pool_id = Address::<PoolId>::from_string(chain_config, pool_id)
                     .map_err(|_| ApiServerStorageError::AddressableError)?
-                    .decode_object();
+                    .into_object();
                 let pool_data: Vec<u8> = row.get(1);
                 let pool_data = PoolData::decode_all(&mut pool_data.as_slice()).map_err(|e| {
                     ApiServerStorageError::DeserializationError(format!(
@@ -1214,9 +1214,9 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
             .into_iter()
             .map(|row| -> Result<(PoolId, PoolData), ApiServerStorageError> {
                 let pool_id: String = row.get(0);
-                let pool_id = Address::<PoolId>::from_str(chain_config, &pool_id)
+                let pool_id = Address::<PoolId>::from_string(chain_config, pool_id)
                     .map_err(|_| ApiServerStorageError::AddressableError)?
-                    .decode_object();
+                    .into_object();
                 let pool_data: Vec<u8> = row.get(1);
                 let pool_data = PoolData::decode_all(&mut pool_data.as_slice()).map_err(|e| {
                     ApiServerStorageError::DeserializationError(format!(
@@ -1239,7 +1239,7 @@ impl<'a, 'b> QueryFromConnection<'a, 'b> {
     ) -> Result<(), ApiServerStorageError> {
         let height = Self::block_height_to_postgres_friendly(block_height);
         let amount_str = amount_to_str(pool_data.staker_balance().expect("no overflow"));
-        let pool_id = Address::new(chain_config, &pool_id)
+        let pool_id = Address::new(chain_config, pool_id)
             .map_err(|_| ApiServerStorageError::AddressableError)?;
 
         self.tx

--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -266,7 +266,7 @@ async fn update_locked_amounts_for_current_block<T: ApiServerStorageWrite>(
             let address = Address::<Destination>::new(chain_config, destination)
                 .expect("Unable to encode destination");
             let utxo = Utxo::new_with_info(locked_utxo, false);
-            db_tx.set_utxo_at_height(outpoint, utxo, address.get(), block_height).await?;
+            db_tx.set_utxo_at_height(outpoint, utxo, address.as_str(), block_height).await?;
         }
     }
 
@@ -1042,7 +1042,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
     for address_transaction in address_transactions {
         db_tx
             .set_address_transactions_at_height(
-                address_transaction.0.get(),
+                address_transaction.0.as_str(),
                 address_transaction.1.into_iter().collect(),
                 block_height,
             )
@@ -1208,7 +1208,7 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                     );
                     let utxo = Utxo::new(output.clone(), token_decimals, false);
                     db_tx
-                        .set_utxo_at_height(outpoint, utxo, address.get(), block_height)
+                        .set_utxo_at_height(outpoint, utxo, address.as_str(), block_height)
                         .await
                         .expect("Unable to set utxo");
                 }
@@ -1296,14 +1296,14 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                 if already_unlocked {
                     let utxo = Utxo::new(output.clone(), token_decimals, false);
                     db_tx
-                        .set_utxo_at_height(outpoint, utxo, address.get(), block_height)
+                        .set_utxo_at_height(outpoint, utxo, address.as_str(), block_height)
                         .await
                         .expect("Unable to set utxo");
                 } else {
                     let lock = UtxoLock::from_output_lock(*lock, median_time, block_height);
                     let utxo = LockedUtxo::new(output.clone(), token_decimals, lock);
                     db_tx
-                        .set_locked_utxo_at_height(outpoint, utxo, address.get(), block_height)
+                        .set_locked_utxo_at_height(outpoint, utxo, address.as_str(), block_height)
                         .await
                         .expect("Unable to set locked utxo");
                 }
@@ -1314,7 +1314,7 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
     for address_transaction in address_transactions {
         db_tx
             .set_address_transactions_at_height(
-                address_transaction.0.get(),
+                address_transaction.0.as_str(),
                 address_transaction.1,
                 block_height,
             )
@@ -1337,7 +1337,7 @@ async fn increase_address_amount<T: ApiServerStorageWrite>(
     block_height: BlockHeight,
 ) {
     let current_balance = db_tx
-        .get_address_balance(address.get(), coin_or_token_id)
+        .get_address_balance(address.as_str(), coin_or_token_id)
         .await
         .expect("Unable to get balance")
         .unwrap_or(Amount::ZERO);
@@ -1345,7 +1345,7 @@ async fn increase_address_amount<T: ApiServerStorageWrite>(
     let new_amount = current_balance.add(*amount).expect("Balance should not overflow");
 
     db_tx
-        .set_address_balance_at_height(address.get(), new_amount, coin_or_token_id, block_height)
+        .set_address_balance_at_height(address.as_str(), new_amount, coin_or_token_id, block_height)
         .await
         .expect("Unable to update balance")
 }
@@ -1358,7 +1358,7 @@ async fn increase_locked_address_amount<T: ApiServerStorageWrite>(
     block_height: BlockHeight,
 ) {
     let current_balance = db_tx
-        .get_address_locked_balance(address.get(), coin_or_token_id)
+        .get_address_locked_balance(address.as_str(), coin_or_token_id)
         .await
         .expect("Unable to get balance")
         .unwrap_or(Amount::ZERO);
@@ -1367,7 +1367,7 @@ async fn increase_locked_address_amount<T: ApiServerStorageWrite>(
 
     db_tx
         .set_address_locked_balance_at_height(
-            address.get(),
+            address.as_str(),
             new_amount,
             coin_or_token_id,
             block_height,
@@ -1384,7 +1384,7 @@ async fn decrease_address_amount<T: ApiServerStorageWrite>(
     block_height: BlockHeight,
 ) {
     let current_balance = db_tx
-        .get_address_balance(address.get(), coin_or_token_id)
+        .get_address_balance(address.as_str(), coin_or_token_id)
         .await
         .expect("Unable to get balance")
         .unwrap_or(Amount::ZERO);
@@ -1392,7 +1392,7 @@ async fn decrease_address_amount<T: ApiServerStorageWrite>(
     let new_amount = current_balance.sub(*amount).expect("Balance should not overflow");
 
     db_tx
-        .set_address_balance_at_height(address.get(), new_amount, coin_or_token_id, block_height)
+        .set_address_balance_at_height(address.as_str(), new_amount, coin_or_token_id, block_height)
         .await
         .expect("Unable to update balance")
 }
@@ -1405,7 +1405,7 @@ async fn decrease_address_locked_amount<T: ApiServerStorageWrite>(
     block_height: BlockHeight,
 ) {
     let current_balance = db_tx
-        .get_address_locked_balance(address.get(), coin_or_token_id)
+        .get_address_locked_balance(address.as_str(), coin_or_token_id)
         .await
         .expect("Unable to get balance")
         .unwrap_or(Amount::ZERO);
@@ -1414,7 +1414,7 @@ async fn decrease_address_locked_amount<T: ApiServerStorageWrite>(
 
     db_tx
         .set_address_locked_balance_at_height(
-            address.get(),
+            address.as_str(),
             new_amount,
             coin_or_token_id,
             block_height,
@@ -1438,7 +1438,7 @@ async fn set_utxo<T: ApiServerStorageWrite>(
         let address = Address::<Destination>::new(chain_config, destination)
             .expect("Unable to encode destination");
         db_tx
-            .set_utxo_at_height(outpoint, utxo, address.get(), block_height)
+            .set_utxo_at_height(outpoint, utxo, address.as_str(), block_height)
             .await
             .expect("Unable to set utxo");
     }

--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -216,7 +216,7 @@ async fn update_locked_amounts_for_current_block<T: ApiServerStorageWrite>(
     for (outpoint, locked_utxo) in locked_utxos {
         match &locked_utxo.output {
             TxOutput::LockThenTransfer(outvalue, destination, _) => {
-                let address = Address::<Destination>::new(chain_config, destination)
+                let address = Address::<Destination>::new(chain_config, destination.clone())
                     .expect("Unable to encode destination");
 
                 match outvalue {
@@ -263,7 +263,7 @@ async fn update_locked_amounts_for_current_block<T: ApiServerStorageWrite>(
         }
 
         if let Some(destination) = get_tx_output_destination(&locked_utxo.output) {
-            let address = Address::<Destination>::new(chain_config, destination)
+            let address = Address::<Destination>::new(chain_config, destination.clone())
                 .expect("Unable to encode destination");
             let utxo = Utxo::new_with_info(locked_utxo, false);
             db_tx.set_utxo_at_height(outpoint, utxo, address.as_str(), block_height).await?;
@@ -423,7 +423,7 @@ async fn update_tables_from_block_reward<T: ApiServerStorageWrite>(
             TxOutput::Transfer(output_value, destination)
             | TxOutput::LockThenTransfer(output_value, destination, _) => match destination {
                 Destination::PublicKey(_) | Destination::PublicKeyHash(_) => {
-                    let address = Address::<Destination>::new(&chain_config, destination)
+                    let address = Address::<Destination>::new(&chain_config, destination.clone())
                         .expect("Unable to encode destination");
                     match output_value {
                         OutputValue::TokenV0(_) => {}
@@ -937,7 +937,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
 
                             let address = Address::<Destination>::new(
                                 &chain_config,
-                                pool_data.decommission_destination(),
+                                pool_data.decommission_destination().clone(),
                             )
                             .expect("Unable to encode destination");
 
@@ -975,7 +975,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                             | Destination::ScriptHash(_) => {}
                             Destination::PublicKey(_) | Destination::PublicKeyHash(_) => {
                                 let address =
-                                    Address::<Destination>::new(&chain_config, &destination)
+                                    Address::<Destination>::new(&chain_config, destination)
                                         .expect("Unable to encode destination");
 
                                 address_transactions
@@ -1000,7 +1000,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                             | Destination::ScriptHash(_) => {}
                             Destination::PublicKey(_) | Destination::PublicKeyHash(_) => {
                                 let address =
-                                    Address::<Destination>::new(&chain_config, &destination)
+                                    Address::<Destination>::new(&chain_config, destination)
                                         .expect("Unable to encode destination");
 
                                 address_transactions
@@ -1138,13 +1138,15 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                     &chain_config,
                 )
                 .await;
-                let address =
-                    Address::<Destination>::new(&chain_config, stake_pool_data.decommission_key())
-                        .expect("Unable to encode address");
+                let address = Address::<Destination>::new(
+                    &chain_config,
+                    stake_pool_data.decommission_key().clone(),
+                )
+                .expect("Unable to encode address");
                 address_transactions.entry(address.clone()).or_default().insert(transaction_id);
 
                 let staker_address =
-                    Address::<Destination>::new(&chain_config, stake_pool_data.staker())
+                    Address::<Destination>::new(&chain_config, stake_pool_data.staker().clone())
                         .expect("Unable to encode address");
                 address_transactions.entry(staker_address).or_default().insert(transaction_id);
             }
@@ -1164,14 +1166,16 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                     .await
                     .expect("Unable to update delegation");
 
-                let address =
-                    Address::<Destination>::new(&chain_config, new_delegation.spend_destination())
-                        .expect("Unable to encode address");
+                let address = Address::<Destination>::new(
+                    &chain_config,
+                    new_delegation.spend_destination().clone(),
+                )
+                .expect("Unable to encode address");
                 address_transactions.entry(address.clone()).or_default().insert(transaction_id);
             }
             TxOutput::Transfer(output_value, destination) => match destination {
                 Destination::PublicKey(_) | Destination::PublicKeyHash(_) => {
-                    let address = Address::<Destination>::new(&chain_config, destination)
+                    let address = Address::<Destination>::new(&chain_config, destination.clone())
                         .expect("Unable to encode destination");
 
                     address_transactions.entry(address.clone()).or_default().insert(transaction_id);
@@ -1228,7 +1232,7 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                 Destination::ClassicMultisig(_) | Destination::ScriptHash(_) => {}
             },
             TxOutput::LockThenTransfer(output_value, destination, lock) => {
-                let address = Address::<Destination>::new(&chain_config, destination)
+                let address = Address::<Destination>::new(&chain_config, destination.clone())
                     .expect("Unable to encode destination");
 
                 address_transactions.entry(address.clone()).or_default().insert(transaction_id);
@@ -1435,7 +1439,7 @@ async fn set_utxo<T: ApiServerStorageWrite>(
     let outpoint = UtxoOutPoint::new(outpoint_source_id, idx as u32);
     let utxo = Utxo::new(output.clone(), None, spent);
     if let Some(destination) = get_tx_output_destination(output) {
-        let address = Address::<Destination>::new(chain_config, destination)
+        let address = Address::<Destination>::new(chain_config, destination.clone())
             .expect("Unable to encode destination");
         db_tx
             .set_utxo_at_height(outpoint, utxo, address.as_str(), block_height)

--- a/api-server/scanner-lib/src/sync/tests.rs
+++ b/api-server/scanner-lib/src/sync/tests.rs
@@ -712,7 +712,7 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
 
     // Check all the outputs are locked and the locked balance is updated
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
-    let address = Address::new(&chain_config, &destination).unwrap();
+    let address = Address::new(&chain_config, destination.clone()).unwrap();
     let locked_amount = db_tx
         .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
@@ -738,7 +738,7 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
 
     // Check all the height outputs are unlocked, but the time based ones are still not
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
-    let address = Address::new(&chain_config, &destination).unwrap();
+    let address = Address::new(&chain_config, destination.clone()).unwrap();
     let locked_amount = db_tx
         .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
@@ -814,7 +814,7 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
 
     // Check the time based ones are now unlocked as well
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
-    let address = Address::new(&chain_config, &destination).unwrap();
+    let address = Address::new(&chain_config, destination.clone()).unwrap();
     let locked_amount = db_tx
         .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
@@ -891,7 +891,7 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
 
     // check there are no more available utxos, and both balance and locked balance are 0
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
-    let address = Address::new(&chain_config, &destination).unwrap();
+    let address = Address::new(&chain_config, destination.clone()).unwrap();
     let locked_amount = db_tx
         .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
@@ -912,7 +912,7 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
 
     // we are back to 2 available utxos and balance is updated
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
-    let address = Address::new(&chain_config, &destination).unwrap();
+    let address = Address::new(&chain_config, destination.clone()).unwrap();
     let locked_amount = db_tx
         .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
@@ -938,7 +938,7 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
 
     // Check all the height outputs are unlocked, but the time based ones now back to locked
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
-    let address = Address::new(&chain_config, &destination).unwrap();
+    let address = Address::new(&chain_config, destination.clone()).unwrap();
     let locked_amount = db_tx
         .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
@@ -968,7 +968,7 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
 
     // Check all the outputs are locked and the locked balance is updated
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
-    let address = Address::new(&chain_config, &destination).unwrap();
+    let address = Address::new(&chain_config, destination).unwrap();
     let locked_amount = db_tx
         .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
@@ -1029,9 +1029,11 @@ async fn sync_and_compare(
 
     assert_eq!(node_data.staker_balance(), scanner_data.staker_balance());
 
-    let address =
-        Address::<Destination>::new(tf.chain_config(), scanner_data.decommission_destination())
-            .expect("Unable to encode destination");
+    let address = Address::<Destination>::new(
+        tf.chain_config(),
+        scanner_data.decommission_destination().clone(),
+    )
+    .expect("Unable to encode destination");
 
     let balance = tx
         .get_address_balance(address.as_str(), CoinOrTokenId::Coin)
@@ -1056,9 +1058,11 @@ async fn sync_and_compare(
         let scanner_delegation = scanner_delegations.get(&id).unwrap();
         assert_eq!(&share, scanner_delegation.balance());
 
-        let address =
-            Address::<Destination>::new(tf.chain_config(), scanner_delegation.spend_destination())
-                .expect("Unable to encode destination");
+        let address = Address::<Destination>::new(
+            tf.chain_config(),
+            scanner_delegation.spend_destination().clone(),
+        )
+        .expect("Unable to encode destination");
 
         let balance = tx
             .get_address_balance(address.as_str(), CoinOrTokenId::Coin)

--- a/api-server/scanner-lib/src/sync/tests.rs
+++ b/api-server/scanner-lib/src/sync/tests.rs
@@ -714,16 +714,16 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
     let address = Address::new(&chain_config, &destination).unwrap();
     let locked_amount = db_tx
-        .get_address_locked_balance(address.get(), CoinOrTokenId::Coin)
+        .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
         .unwrap();
 
     assert_eq!(locked_amount, Some(Amount::from_atoms(1 + 2 + 3 + 4)));
 
-    let balance = db_tx.get_address_balance(address.get(), CoinOrTokenId::Coin).await.unwrap();
+    let balance = db_tx.get_address_balance(address.as_str(), CoinOrTokenId::Coin).await.unwrap();
     assert_eq!(balance, Some(Amount::from_atoms(already_unlocked_coins)));
     // check there are only 2 available utxos
-    let utxos = db_tx.get_address_available_utxos(address.get()).await.unwrap();
+    let utxos = db_tx.get_address_available_utxos(address.as_str()).await.unwrap();
     assert_eq!(utxos.len(), already_unlocked_utxos);
     drop(db_tx);
 
@@ -740,19 +740,19 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
     let address = Address::new(&chain_config, &destination).unwrap();
     let locked_amount = db_tx
-        .get_address_locked_balance(address.get(), CoinOrTokenId::Coin)
+        .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
         .unwrap();
 
     assert_eq!(locked_amount, Some(Amount::from_atoms(3 + 4)));
 
-    let balance = db_tx.get_address_balance(address.get(), CoinOrTokenId::Coin).await.unwrap();
+    let balance = db_tx.get_address_balance(address.as_str(), CoinOrTokenId::Coin).await.unwrap();
     assert_eq!(
         balance,
         Some(Amount::from_atoms(1 + 2 + already_unlocked_coins))
     );
     // check all of the UTXOs are available
-    let utxos = db_tx.get_address_available_utxos(address.get()).await.unwrap();
+    let utxos = db_tx.get_address_available_utxos(address.as_str()).await.unwrap();
     assert_eq!(utxos.len(), 2 + already_unlocked_utxos);
     drop(db_tx);
 
@@ -816,20 +816,20 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
     let address = Address::new(&chain_config, &destination).unwrap();
     let locked_amount = db_tx
-        .get_address_locked_balance(address.get(), CoinOrTokenId::Coin)
+        .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
         .unwrap();
 
     assert_eq!(locked_amount, Some(Amount::ZERO));
 
-    let balance = db_tx.get_address_balance(address.get(), CoinOrTokenId::Coin).await.unwrap();
+    let balance = db_tx.get_address_balance(address.as_str(), CoinOrTokenId::Coin).await.unwrap();
 
     assert_eq!(
         balance,
         Some(Amount::from_atoms(3 + 4 + already_unlocked_coins))
     );
     // check all of the UTXOs are available
-    let utxos = db_tx.get_address_available_utxos(address.get()).await.unwrap();
+    let utxos = db_tx.get_address_available_utxos(address.as_str()).await.unwrap();
     assert_eq!(utxos.len(), 2 + already_unlocked_utxos);
     drop(db_tx);
 
@@ -893,17 +893,17 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
     let address = Address::new(&chain_config, &destination).unwrap();
     let locked_amount = db_tx
-        .get_address_locked_balance(address.get(), CoinOrTokenId::Coin)
+        .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
         .unwrap();
 
     assert_eq!(locked_amount, Some(Amount::ZERO));
 
-    let balance = db_tx.get_address_balance(address.get(), CoinOrTokenId::Coin).await.unwrap();
+    let balance = db_tx.get_address_balance(address.as_str(), CoinOrTokenId::Coin).await.unwrap();
 
     assert_eq!(balance, Some(Amount::from_atoms(already_unlocked_coins)));
     // check there are no utxos as all are spent
-    let utxos = db_tx.get_address_available_utxos(address.get()).await.unwrap();
+    let utxos = db_tx.get_address_available_utxos(address.as_str()).await.unwrap();
     assert_eq!(utxos.len(), already_unlocked_utxos);
     drop(db_tx);
 
@@ -914,19 +914,19 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
     let address = Address::new(&chain_config, &destination).unwrap();
     let locked_amount = db_tx
-        .get_address_locked_balance(address.get(), CoinOrTokenId::Coin)
+        .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
         .unwrap();
 
     assert_eq!(locked_amount, Some(Amount::ZERO));
 
-    let balance = db_tx.get_address_balance(address.get(), CoinOrTokenId::Coin).await.unwrap();
+    let balance = db_tx.get_address_balance(address.as_str(), CoinOrTokenId::Coin).await.unwrap();
     assert_eq!(
         balance,
         Some(Amount::from_atoms(3 + 4 + already_unlocked_coins))
     );
     // check all of the UTXOs are available
-    let utxos = db_tx.get_address_available_utxos(address.get()).await.unwrap();
+    let utxos = db_tx.get_address_available_utxos(address.as_str()).await.unwrap();
     assert_eq!(utxos.len(), 2 + already_unlocked_utxos);
     drop(db_tx);
 
@@ -940,20 +940,20 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
     let address = Address::new(&chain_config, &destination).unwrap();
     let locked_amount = db_tx
-        .get_address_locked_balance(address.get(), CoinOrTokenId::Coin)
+        .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
         .unwrap();
 
     assert_eq!(locked_amount, Some(Amount::from_atoms(3 + 4)));
 
-    let balance = db_tx.get_address_balance(address.get(), CoinOrTokenId::Coin).await.unwrap();
+    let balance = db_tx.get_address_balance(address.as_str(), CoinOrTokenId::Coin).await.unwrap();
 
     assert_eq!(
         balance,
         Some(Amount::from_atoms(1 + 2 + already_unlocked_coins))
     );
     // check all of the UTXOs are available
-    let utxos = db_tx.get_address_available_utxos(address.get()).await.unwrap();
+    let utxos = db_tx.get_address_available_utxos(address.as_str()).await.unwrap();
     assert_eq!(utxos.len(), 2 + already_unlocked_utxos);
     drop(db_tx);
 
@@ -970,15 +970,15 @@ async fn reorg_locked_balance(#[case] seed: Seed) {
     let db_tx = local_state.storage().transaction_ro().await.unwrap();
     let address = Address::new(&chain_config, &destination).unwrap();
     let locked_amount = db_tx
-        .get_address_locked_balance(address.get(), CoinOrTokenId::Coin)
+        .get_address_locked_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
         .unwrap();
 
     assert_eq!(locked_amount, Some(Amount::from_atoms(1 + 2 + 3 + 4)));
-    let balance = db_tx.get_address_balance(address.get(), CoinOrTokenId::Coin).await.unwrap();
+    let balance = db_tx.get_address_balance(address.as_str(), CoinOrTokenId::Coin).await.unwrap();
     assert_eq!(balance, Some(Amount::from_atoms(already_unlocked_coins)));
     // check there are no available UTXOs as all are locked
-    let utxos = db_tx.get_address_available_utxos(address.get()).await.unwrap();
+    let utxos = db_tx.get_address_available_utxos(address.as_str()).await.unwrap();
     assert_eq!(utxos.len(), already_unlocked_utxos);
     drop(db_tx);
 }
@@ -1034,7 +1034,7 @@ async fn sync_and_compare(
             .expect("Unable to encode destination");
 
     let balance = tx
-        .get_address_balance(address.get(), CoinOrTokenId::Coin)
+        .get_address_balance(address.as_str(), CoinOrTokenId::Coin)
         .await
         .unwrap()
         .unwrap_or(Amount::ZERO);
@@ -1061,7 +1061,7 @@ async fn sync_and_compare(
                 .expect("Unable to encode destination");
 
         let balance = tx
-            .get_address_balance(address.get(), CoinOrTokenId::Coin)
+            .get_address_balance(address.as_str(), CoinOrTokenId::Coin)
             .await
             .unwrap()
             .unwrap_or(Amount::ZERO);

--- a/api-server/stack-test-suite/tests/v2/address.rs
+++ b/api-server/stack-test-suite/tests/v2/address.rs
@@ -48,7 +48,7 @@ async fn address_not_found(#[case] seed: Seed) {
     let destination = Destination::PublicKeyHash(PublicKeyHash::from(&public_key));
     let address = Address::<Destination>::new(&chain_config, &destination).unwrap();
 
-    let (task, response) = spawn_webserver(&format!("/api/v2/address/{}", address.get())).await;
+    let (task, response) = spawn_webserver(&format!("/api/v2/address/{}", address.as_str())).await;
 
     assert_eq!(response.status(), 404);
 
@@ -220,7 +220,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
 
                 _ = tx.send([
                     (
-                        alice_address.get().to_string(),
+                        alice_address.as_str().to_string(),
                         json!({
                         "coin_balance": amount_to_json(alice_balance, chain_config.coin_decimals()),
                         "locked_coin_balance": amount_to_json(Amount::ZERO, chain_config.coin_decimals()),
@@ -463,7 +463,7 @@ async fn test_unlocking_for_locked_utxos(#[case] seed: Seed) {
 
                 _ = tx.send([
                     (
-                        alice_address.get().to_string(),
+                        alice_address.as_str().to_string(),
                         json!({
                         "coin_balance": amount_to_json(alice_balance, chain_config.coin_decimals()),
                         "locked_coin_balance": amount_to_json(Amount::ZERO, chain_config.coin_decimals()),
@@ -686,7 +686,7 @@ async fn ok(#[case] seed: Seed) {
 
                 _ = tx.send([
                     (
-                        alice_address.get().to_string(),
+                        alice_address.as_str().to_string(),
                         json!({
                         "coin_balance": amount_to_json(alice_balance, chain_config.coin_decimals()),
                         "locked_coin_balance": amount_to_json(Amount::ZERO, chain_config.coin_decimals()),

--- a/api-server/stack-test-suite/tests/v2/address.rs
+++ b/api-server/stack-test-suite/tests/v2/address.rs
@@ -46,7 +46,7 @@ async fn address_not_found(#[case] seed: Seed) {
 
     let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
     let destination = Destination::PublicKeyHash(PublicKeyHash::from(&public_key));
-    let address = Address::<Destination>::new(&chain_config, &destination).unwrap();
+    let address = Address::<Destination>::new(&chain_config, destination).unwrap();
 
     let (task, response) = spawn_webserver(&format!("/api/v2/address/{}", address.as_str())).await;
 
@@ -87,7 +87,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
                 let alice_address =
-                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, alice_destination.clone()).unwrap();
                 let mut alice_balance = Amount::from_atoms(1_000_000);
                 let mut alice_transaction_history: Vec<Id<Transaction>> = vec![];
 
@@ -96,7 +96,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
 
                 let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
                 let bob_address =
-                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
                 let mut bob_balance = Amount::ZERO;
                 let mut bob_locked_balance = Amount::ZERO;
                 let mut bob_transaction_history: Vec<Id<Transaction>> = vec![];
@@ -325,7 +325,7 @@ async fn test_unlocking_for_locked_utxos(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
                 let alice_address =
-                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, alice_destination.clone()).unwrap();
                 let mut alice_balance = Amount::from_atoms(1_000_000);
                 let mut alice_transaction_history: Vec<Id<Transaction>> = vec![];
 
@@ -334,7 +334,7 @@ async fn test_unlocking_for_locked_utxos(#[case] seed: Seed) {
 
                 let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
                 let bob_address =
-                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
                 let mut bob_balance = Amount::ZERO;
                 let mut bob_locked_balance = Amount::ZERO;
                 let mut bob_transaction_history: Vec<Id<Transaction>> = vec![];
@@ -568,7 +568,7 @@ async fn ok(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
                 let alice_address =
-                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, alice_destination.clone()).unwrap();
                 let mut alice_balance = Amount::from_atoms(1_000_000);
                 let mut alice_transaction_history: Vec<Id<Transaction>> = vec![];
 
@@ -577,7 +577,7 @@ async fn ok(#[case] seed: Seed) {
 
                 let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
                 let bob_address =
-                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
                 let mut bob_balance = Amount::ZERO;
                 let mut bob_transaction_history: Vec<Id<Transaction>> = vec![];
 

--- a/api-server/stack-test-suite/tests/v2/address_all_utxos.rs
+++ b/api-server/stack-test-suite/tests/v2/address_all_utxos.rs
@@ -49,7 +49,7 @@ async fn address_not_found(#[case] seed: Seed) {
     let address = Address::<Destination>::new(&chain_config, &destination).unwrap();
 
     let (task, response) =
-        spawn_webserver(&format!("/api/v2/address/{}/all-utxos", address.get())).await;
+        spawn_webserver(&format!("/api/v2/address/{}/all-utxos", address.as_str())).await;
 
     assert_eq!(response.status(), 200);
 
@@ -226,7 +226,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
 
                 _ = tx.send([
                     (
-                        alice_address.get().to_string(),
+                        alice_address.as_str().to_string(),
                         alice_utxos
                             .into_iter()
                             .map(|utxo| {
@@ -486,7 +486,7 @@ async fn ok(#[case] seed: Seed) {
 
                 _ = tx.send([
                     (
-                        alice_address.get().to_string(),
+                        alice_address.as_str().to_string(),
                         alice_utxos
                             .into_iter()
                             .map(|utxo| {

--- a/api-server/stack-test-suite/tests/v2/address_all_utxos.rs
+++ b/api-server/stack-test-suite/tests/v2/address_all_utxos.rs
@@ -46,7 +46,7 @@ async fn address_not_found(#[case] seed: Seed) {
 
     let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
     let destination = Destination::PublicKeyHash(PublicKeyHash::from(&public_key));
-    let address = Address::<Destination>::new(&chain_config, &destination).unwrap();
+    let address = Address::<Destination>::new(&chain_config, destination).unwrap();
 
     let (task, response) =
         spawn_webserver(&format!("/api/v2/address/{}/all-utxos", address.as_str())).await;
@@ -89,7 +89,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
                 let alice_address =
-                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, alice_destination.clone()).unwrap();
                 let mut alice_balance = Amount::from_atoms(1_000_000);
                 let mut alice_utxos = BTreeMap::new();
 
@@ -98,7 +98,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
 
                 let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
                 let bob_address =
-                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
                 let mut bob_utxos = BTreeMap::new();
 
                 // setup initial transaction
@@ -340,7 +340,7 @@ async fn ok(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
                 let alice_address =
-                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, alice_destination.clone()).unwrap();
                 let mut alice_balance = Amount::from_atoms(1_000_000);
                 let mut alice_utxos = BTreeMap::new();
 
@@ -349,7 +349,7 @@ async fn ok(#[case] seed: Seed) {
 
                 let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
                 let bob_address =
-                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
                 let mut bob_utxos = BTreeMap::new();
 
                 // setup initial transaction

--- a/api-server/stack-test-suite/tests/v2/address_delegations.rs
+++ b/api-server/stack-test-suite/tests/v2/address_delegations.rs
@@ -52,7 +52,7 @@ async fn address_not_found(#[case] seed: Seed) {
 
     let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
     let destination = Destination::PublicKeyHash(PublicKeyHash::from(&public_key));
-    let address = Address::<Destination>::new(&chain_config, &destination).unwrap();
+    let address = Address::<Destination>::new(&chain_config, destination).unwrap();
 
     let (task, response) =
         spawn_webserver(&format!("/api/v2/address/{}/delegations", address.as_str())).await;
@@ -95,14 +95,14 @@ async fn ok(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
                 let alice_address =
-                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, alice_destination.clone()).unwrap();
 
                 let (_bob_sk, bob_pk) =
                     PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
 
                 let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
                 let bob_address =
-                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, bob_destination).unwrap();
 
                 let stake_pool_outpoint = UtxoOutPoint::new(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
@@ -168,10 +168,10 @@ async fn ok(#[case] seed: Seed) {
                             .into_iter()
                             .map(|(delegation_id, amount, _, _)| {
                                 json!({
-                                "delegation_id": Address::new(&chain_config, &delegation_id).expect(
+                                "delegation_id": Address::new(&chain_config, delegation_id).expect(
                                     "no error in encoding"
                                 ).as_str(),
-                                "pool_id": Address::new(&chain_config, &pool_id).expect(
+                                "pool_id": Address::new(&chain_config, pool_id).expect(
                                     "no error in encoding"
                                 ).as_str(),
                                 "next_nonce": AccountNonce::new(0),

--- a/api-server/stack-test-suite/tests/v2/address_delegations.rs
+++ b/api-server/stack-test-suite/tests/v2/address_delegations.rs
@@ -55,7 +55,7 @@ async fn address_not_found(#[case] seed: Seed) {
     let address = Address::<Destination>::new(&chain_config, &destination).unwrap();
 
     let (task, response) =
-        spawn_webserver(&format!("/api/v2/address/{}/delegations", address.get())).await;
+        spawn_webserver(&format!("/api/v2/address/{}/delegations", address.as_str())).await;
 
     assert_eq!(response.status(), 200);
 
@@ -163,19 +163,19 @@ async fn ok(#[case] seed: Seed) {
 
                 _ = tx.send([
                     (
-                        alice_address.get().to_string(),
+                        alice_address.as_str().to_string(),
                         delegations
                             .into_iter()
                             .map(|(delegation_id, amount, _, _)| {
                                 json!({
                                 "delegation_id": Address::new(&chain_config, &delegation_id).expect(
                                     "no error in encoding"
-                                ).get(),
+                                ).as_str(),
                                 "pool_id": Address::new(&chain_config, &pool_id).expect(
                                     "no error in encoding"
-                                ).get(),
+                                ).as_str(),
                                 "next_nonce": AccountNonce::new(0),
-                                "spend_destination": alice_address.get(),
+                                "spend_destination": alice_address.as_str(),
                                 "balance": amount_to_json(amount, chain_config.coin_decimals()),
                             })})
                             .collect::<Vec<_>>()

--- a/api-server/stack-test-suite/tests/v2/address_spendable_utxos.rs
+++ b/api-server/stack-test-suite/tests/v2/address_spendable_utxos.rs
@@ -50,7 +50,7 @@ async fn address_not_found(#[case] seed: Seed) {
 
     let (task, response) = spawn_webserver(&format!(
         "/api/v2/address/{}/spendable-utxos",
-        address.get()
+        address.as_str()
     ))
     .await;
 
@@ -225,7 +225,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
 
                 _ = tx.send([
                     (
-                        alice_address.get().to_string(),
+                        alice_address.as_str().to_string(),
                         alice_utxos
                             .into_iter()
                             .map(|utxo| {
@@ -468,7 +468,7 @@ async fn ok(#[case] seed: Seed) {
 
                 _ = tx.send([
                     (
-                        alice_address.get().to_string(),
+                        alice_address.as_str().to_string(),
                         alice_utxos
                             .into_iter()
                             .map(|utxo| {

--- a/api-server/stack-test-suite/tests/v2/address_spendable_utxos.rs
+++ b/api-server/stack-test-suite/tests/v2/address_spendable_utxos.rs
@@ -46,7 +46,7 @@ async fn address_not_found(#[case] seed: Seed) {
 
     let (_, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
     let destination = Destination::PublicKeyHash(PublicKeyHash::from(&public_key));
-    let address = Address::<Destination>::new(&chain_config, &destination).unwrap();
+    let address = Address::<Destination>::new(&chain_config, destination).unwrap();
 
     let (task, response) = spawn_webserver(&format!(
         "/api/v2/address/{}/spendable-utxos",
@@ -92,7 +92,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
                 let alice_address =
-                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, alice_destination.clone()).unwrap();
                 let mut alice_balance = Amount::from_atoms(1_000_000);
                 let mut alice_utxos = BTreeMap::new();
 
@@ -101,7 +101,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
 
                 let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
                 let bob_address =
-                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
                 let mut bob_utxos = BTreeMap::new();
 
                 // setup initial transaction
@@ -338,7 +338,7 @@ async fn ok(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
                 let alice_address =
-                    Address::<Destination>::new(&chain_config, &alice_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, alice_destination.clone()).unwrap();
                 let mut alice_balance = Amount::from_atoms(1_000_000);
                 let mut alice_utxos = BTreeMap::new();
 
@@ -347,7 +347,7 @@ async fn ok(#[case] seed: Seed) {
 
                 let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
                 let bob_address =
-                    Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+                    Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
                 let mut bob_balance = Amount::ZERO;
                 let mut bob_utxos = BTreeMap::new();
 

--- a/api-server/stack-test-suite/tests/v2/nft.rs
+++ b/api-server/stack-test-suite/tests/v2/nft.rs
@@ -47,7 +47,7 @@ async fn nft_not_found(#[case] seed: Seed) {
     let chain_config = create_unit_test_config();
 
     let token_id = TokenId::new(H256::random_using(&mut rng));
-    let token_id = Address::<TokenId>::new(&chain_config, &token_id).unwrap();
+    let token_id = Address::<TokenId>::new(&chain_config, token_id).unwrap();
 
     let (task, response) = spawn_webserver(&format!("/api/v2/nft/{}", token_id.as_str())).await;
 
@@ -128,7 +128,7 @@ async fn ok(#[case] seed: Seed) {
                     token_id,
                     json!({
                         "authority": nft.metadata.creator
-                            .map(|creator| Address::new(&chain_config, &Destination::PublicKey(creator.public_key))
+                            .map(|creator| Address::new(&chain_config, Destination::PublicKey(creator.public_key))
                             .expect("no error in encoding")
                             .as_str().to_owned()
                         ),
@@ -180,7 +180,7 @@ async fn ok(#[case] seed: Seed) {
 
     let chain_config = create_unit_test_config();
     for (token_id, expected_values) in rx.await.unwrap() {
-        let token_id = Address::new(&chain_config, &token_id).unwrap();
+        let token_id = Address::new(&chain_config, token_id).unwrap();
         let url = format!("/api/v2/nft/{token_id}");
 
         // Given that the listener port is open, this will block until a

--- a/api-server/stack-test-suite/tests/v2/nft.rs
+++ b/api-server/stack-test-suite/tests/v2/nft.rs
@@ -49,7 +49,7 @@ async fn nft_not_found(#[case] seed: Seed) {
     let token_id = TokenId::new(H256::random_using(&mut rng));
     let token_id = Address::<TokenId>::new(&chain_config, &token_id).unwrap();
 
-    let (task, response) = spawn_webserver(&format!("/api/v2/nft/{}", token_id.get())).await;
+    let (task, response) = spawn_webserver(&format!("/api/v2/nft/{}", token_id.as_str())).await;
 
     assert_eq!(response.status(), 404);
 
@@ -130,7 +130,7 @@ async fn ok(#[case] seed: Seed) {
                         "authority": nft.metadata.creator
                             .map(|creator| Address::new(&chain_config, &Destination::PublicKey(creator.public_key))
                             .expect("no error in encoding")
-                            .get().to_owned()
+                            .as_str().to_owned()
                         ),
                         "name": nft.metadata.name,
                         "description": nft.metadata.description,

--- a/api-server/stack-test-suite/tests/v2/pool.rs
+++ b/api-server/stack-test-suite/tests/v2/pool.rs
@@ -42,7 +42,7 @@ async fn invalid_pool_id() {
 async fn pool_id_not_fund() {
     let pool_id = PoolId::new(H256::zero());
     let chain_config = create_unit_test_config();
-    let pool_id = Address::new(&chain_config, &pool_id).unwrap();
+    let pool_id = Address::new(&chain_config, pool_id).unwrap();
     let (task, response) = spawn_webserver(&format! {"/api/v2/pool/{pool_id}"}).await;
 
     assert_eq!(response.status(), 404);
@@ -190,7 +190,7 @@ async fn ok(#[case] seed: Seed) {
     let chain_config = create_unit_test_config();
     let pools = rx.await.unwrap();
     for (pool_id, pool_data, delegations, _) in pools {
-        let pool_id = Address::new(&chain_config, &pool_id).unwrap();
+        let pool_id = Address::new(&chain_config, pool_id).unwrap();
         let url = format!("/api/v2/pool/{pool_id}");
 
         // Given that the listener port is open, this will block until a
@@ -206,7 +206,8 @@ async fn ok(#[case] seed: Seed) {
         let body: serde_json::Value = serde_json::from_str(&body).unwrap();
         let body = body.as_object().unwrap();
 
-        let decommission_key = Address::new(&chain_config, pool_data.decommission_key()).unwrap();
+        let decommission_key =
+            Address::new(&chain_config, pool_data.decommission_key().clone()).unwrap();
         assert_eq!(
             body.get("decommission_destination").unwrap(),
             decommission_key.as_str(),
@@ -232,7 +233,7 @@ async fn ok(#[case] seed: Seed) {
             ))
         );
 
-        let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key()).unwrap();
+        let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key().clone()).unwrap();
         assert_eq!(
             body.get("vrf_public_key").unwrap(),
             &serde_json::json!(vrf_key.as_str())
@@ -251,7 +252,7 @@ async fn ok(#[case] seed: Seed) {
 
         assert_eq!(delegations.len(), body.len());
         for delegation in &delegations {
-            let delegation_id = Address::new(&chain_config, &delegation.0).unwrap();
+            let delegation_id = Address::new(&chain_config, delegation.0).unwrap();
             let resp = body
                 .iter()
                 .find(|d| {
@@ -269,12 +270,12 @@ async fn ok(#[case] seed: Seed) {
                 &serde_json::json!(amount_to_json(delegation.1, chain_config.coin_decimals()))
             );
 
-            let destination = Address::new(&chain_config, &delegation.2).unwrap();
+            let destination = Address::new(&chain_config, delegation.2.clone()).unwrap();
             assert_eq!(resp.get("spend_destination").unwrap(), destination.as_str());
         }
 
         for (delegation_id, balance, destination, _) in delegations {
-            let delegation_id = Address::new(&chain_config, &delegation_id).unwrap();
+            let delegation_id = Address::new(&chain_config, delegation_id).unwrap();
             let url = format!("/api/v2/delegation/{delegation_id}");
             let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
                 .await
@@ -294,7 +295,7 @@ async fn ok(#[case] seed: Seed) {
                 body.get("balance").unwrap(),
                 &serde_json::json!(amount_to_json(balance, chain_config.coin_decimals()))
             );
-            let destination = Address::new(&chain_config, &destination).unwrap();
+            let destination = Address::new(&chain_config, destination).unwrap();
             assert_eq!(body.get("spend_destination").unwrap(), destination.as_str());
         }
     }

--- a/api-server/stack-test-suite/tests/v2/pool.rs
+++ b/api-server/stack-test-suite/tests/v2/pool.rs
@@ -209,7 +209,7 @@ async fn ok(#[case] seed: Seed) {
         let decommission_key = Address::new(&chain_config, pool_data.decommission_key()).unwrap();
         assert_eq!(
             body.get("decommission_destination").unwrap(),
-            decommission_key.get(),
+            decommission_key.as_str(),
         );
         assert_eq!(
             body.get("staker_balance").unwrap(),
@@ -235,7 +235,7 @@ async fn ok(#[case] seed: Seed) {
         let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key()).unwrap();
         assert_eq!(
             body.get("vrf_public_key").unwrap(),
-            &serde_json::json!(vrf_key.get())
+            &serde_json::json!(vrf_key.as_str())
         );
 
         let url = format!("/api/v2/pool/{pool_id}/delegations");
@@ -255,13 +255,13 @@ async fn ok(#[case] seed: Seed) {
             let resp = body
                 .iter()
                 .find(|d| {
-                    d.get("delegation_id").unwrap() == &serde_json::json!(delegation_id.get())
+                    d.get("delegation_id").unwrap() == &serde_json::json!(delegation_id.as_str())
                 })
                 .unwrap();
 
             assert_eq!(
                 resp.get("delegation_id").unwrap(),
-                &serde_json::json!(delegation_id.get())
+                &serde_json::json!(delegation_id.as_str())
             );
 
             assert_eq!(
@@ -270,7 +270,7 @@ async fn ok(#[case] seed: Seed) {
             );
 
             let destination = Address::new(&chain_config, &delegation.2).unwrap();
-            assert_eq!(resp.get("spend_destination").unwrap(), destination.get());
+            assert_eq!(resp.get("spend_destination").unwrap(), destination.as_str());
         }
 
         for (delegation_id, balance, destination, _) in delegations {
@@ -288,14 +288,14 @@ async fn ok(#[case] seed: Seed) {
 
             assert_eq!(
                 body.get("pool_id").unwrap(),
-                &serde_json::json!(pool_id.get())
+                &serde_json::json!(pool_id.as_str())
             );
             assert_eq!(
                 body.get("balance").unwrap(),
                 &serde_json::json!(amount_to_json(balance, chain_config.coin_decimals()))
             );
             let destination = Address::new(&chain_config, &destination).unwrap();
-            assert_eq!(body.get("spend_destination").unwrap(), destination.get());
+            assert_eq!(body.get("spend_destination").unwrap(), destination.as_str());
         }
     }
 

--- a/api-server/stack-test-suite/tests/v2/pool_block_stats.rs
+++ b/api-server/stack-test-suite/tests/v2/pool_block_stats.rs
@@ -40,7 +40,7 @@ async fn invalid_pool_id() {
 async fn from_to_not_specified() {
     let pool_id = PoolId::new(H256::zero());
     let chain_config = create_unit_test_config();
-    let pool_id = Address::new(&chain_config, &pool_id).unwrap();
+    let pool_id = Address::new(&chain_config, pool_id).unwrap();
     let (task, response) = spawn_webserver(&format! {"/api/v2/pool/{pool_id}/block-stats"}).await;
 
     assert_eq!(response.status(), 400);
@@ -58,7 +58,7 @@ async fn from_to_not_specified() {
 async fn pool_id_not_fund() {
     let pool_id = PoolId::new(H256::zero());
     let chain_config = create_unit_test_config();
-    let pool_id = Address::new(&chain_config, &pool_id).unwrap();
+    let pool_id = Address::new(&chain_config, pool_id).unwrap();
     let (task, response) =
         spawn_webserver(&format! {"/api/v2/pool/{pool_id}/block-stats?from=0&to=0"}).await;
 
@@ -175,7 +175,7 @@ async fn ok(#[case] seed: Seed) {
 
     let chain_config = create_regtest();
     let (pool_id, num_blocks, (from, to)) = rx.await.unwrap();
-    let pool_id = Address::new(&chain_config, &pool_id).unwrap();
+    let pool_id = Address::new(&chain_config, pool_id).unwrap();
     let url = format!("/api/v2/pool/{pool_id}/block-stats?from={from}&to={to}");
 
     // Given that the listener port is open, this will block until a

--- a/api-server/stack-test-suite/tests/v2/pools.rs
+++ b/api-server/stack-test-suite/tests/v2/pools.rs
@@ -240,13 +240,13 @@ async fn ok(#[case] seed: Seed) {
 
         for ((pool_id, pool_data, _, _), json) in pools.iter().zip(body) {
             let pool_id = Address::new(&chain_config, pool_id).unwrap();
-            assert_eq!(json.get("pool_id").unwrap(), pool_id.get(),);
+            assert_eq!(json.get("pool_id").unwrap(), pool_id.as_str(),);
 
             let decommission_key =
                 Address::new(&chain_config, pool_data.decommission_key()).unwrap();
             assert_eq!(
                 json.get("decommission_destination").unwrap(),
-                decommission_key.get(),
+                decommission_key.as_str(),
             );
             assert_eq!(
                 json.get("staker_balance").unwrap(),
@@ -272,7 +272,7 @@ async fn ok(#[case] seed: Seed) {
             let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key()).unwrap();
             assert_eq!(
                 json.get("vrf_public_key").unwrap(),
-                &serde_json::json!(vrf_key.get())
+                &serde_json::json!(vrf_key.as_str())
             );
         }
     }
@@ -298,13 +298,13 @@ async fn ok(#[case] seed: Seed) {
 
         for ((pool_id, pool_data, _, _), json) in pools.iter().zip(body) {
             let pool_id = Address::new(&chain_config, pool_id).unwrap();
-            assert_eq!(json.get("pool_id").unwrap(), pool_id.get(),);
+            assert_eq!(json.get("pool_id").unwrap(), pool_id.as_str(),);
 
             let decommission_key =
                 Address::new(&chain_config, pool_data.decommission_key()).unwrap();
             assert_eq!(
                 json.get("decommission_destination").unwrap(),
-                decommission_key.get(),
+                decommission_key.as_str(),
             );
             assert_eq!(
                 json.get("staker_balance").unwrap(),
@@ -330,7 +330,7 @@ async fn ok(#[case] seed: Seed) {
             let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key()).unwrap();
             assert_eq!(
                 json.get("vrf_public_key").unwrap(),
-                &serde_json::json!(vrf_key.get())
+                &serde_json::json!(vrf_key.as_str())
             );
         }
     }

--- a/api-server/stack-test-suite/tests/v2/pools.rs
+++ b/api-server/stack-test-suite/tests/v2/pools.rs
@@ -239,11 +239,11 @@ async fn ok(#[case] seed: Seed) {
         assert_eq!(body.len(), items);
 
         for ((pool_id, pool_data, _, _), json) in pools.iter().zip(body) {
-            let pool_id = Address::new(&chain_config, pool_id).unwrap();
+            let pool_id = Address::new(&chain_config, *pool_id).unwrap();
             assert_eq!(json.get("pool_id").unwrap(), pool_id.as_str(),);
 
             let decommission_key =
-                Address::new(&chain_config, pool_data.decommission_key()).unwrap();
+                Address::new(&chain_config, pool_data.decommission_key().clone()).unwrap();
             assert_eq!(
                 json.get("decommission_destination").unwrap(),
                 decommission_key.as_str(),
@@ -269,7 +269,7 @@ async fn ok(#[case] seed: Seed) {
                 ))
             );
 
-            let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key()).unwrap();
+            let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key().clone()).unwrap();
             assert_eq!(
                 json.get("vrf_public_key").unwrap(),
                 &serde_json::json!(vrf_key.as_str())
@@ -297,11 +297,11 @@ async fn ok(#[case] seed: Seed) {
         assert_eq!(body.len(), items);
 
         for ((pool_id, pool_data, _, _), json) in pools.iter().zip(body) {
-            let pool_id = Address::new(&chain_config, pool_id).unwrap();
+            let pool_id = Address::new(&chain_config, *pool_id).unwrap();
             assert_eq!(json.get("pool_id").unwrap(), pool_id.as_str(),);
 
             let decommission_key =
-                Address::new(&chain_config, pool_data.decommission_key()).unwrap();
+                Address::new(&chain_config, pool_data.decommission_key().clone()).unwrap();
             assert_eq!(
                 json.get("decommission_destination").unwrap(),
                 decommission_key.as_str(),
@@ -327,7 +327,7 @@ async fn ok(#[case] seed: Seed) {
                 ))
             );
 
-            let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key()).unwrap();
+            let vrf_key = Address::new(&chain_config, pool_data.vrf_public_key().clone()).unwrap();
             assert_eq!(
                 json.get("vrf_public_key").unwrap(),
                 &serde_json::json!(vrf_key.as_str())

--- a/api-server/stack-test-suite/tests/v2/token.rs
+++ b/api-server/stack-test-suite/tests/v2/token.rs
@@ -50,7 +50,7 @@ async fn token_not_found(#[case] seed: Seed) {
     let chain_config = create_unit_test_config();
 
     let token_id = TokenId::new(H256::random_using(&mut rng));
-    let token_id = Address::<TokenId>::new(&chain_config, &token_id).unwrap();
+    let token_id = Address::<TokenId>::new(&chain_config, token_id).unwrap();
 
     let (task, response) = spawn_webserver(&format!("/api/v2/token/{}", token_id.as_str())).await;
 
@@ -136,7 +136,7 @@ async fn ok(#[case] seed: Seed) {
                 _ = tx.send([(
                     token_id,
                     json!({
-                        "authority": Address::new(&chain_config, &token_data.authority).expect(
+                        "authority": Address::new(&chain_config, token_data.authority.clone()).expect(
                             "no error in encoding"
                         ).as_str(),
                         "is_locked": token_data.is_locked,
@@ -189,7 +189,7 @@ async fn ok(#[case] seed: Seed) {
 
     let chain_config = create_unit_test_config();
     for (token_id, expected_values) in rx.await.unwrap() {
-        let token_id = Address::new(&chain_config, &token_id).unwrap();
+        let token_id = Address::new(&chain_config, token_id).unwrap();
         let url = format!("/api/v2/token/{token_id}");
 
         // Given that the listener port is open, this will block until a

--- a/api-server/stack-test-suite/tests/v2/token.rs
+++ b/api-server/stack-test-suite/tests/v2/token.rs
@@ -52,7 +52,7 @@ async fn token_not_found(#[case] seed: Seed) {
     let token_id = TokenId::new(H256::random_using(&mut rng));
     let token_id = Address::<TokenId>::new(&chain_config, &token_id).unwrap();
 
-    let (task, response) = spawn_webserver(&format!("/api/v2/token/{}", token_id.get())).await;
+    let (task, response) = spawn_webserver(&format!("/api/v2/token/{}", token_id.as_str())).await;
 
     assert_eq!(response.status(), 404);
 
@@ -138,7 +138,7 @@ async fn ok(#[case] seed: Seed) {
                     json!({
                         "authority": Address::new(&chain_config, &token_data.authority).expect(
                             "no error in encoding"
-                        ).get(),
+                        ).as_str(),
                         "is_locked": token_data.is_locked,
                         "circulating_supply": amount_to_json(token_data.circulating_supply, token_data.number_of_decimals),
                         "token_ticker": to_json_string(&token_data.token_ticker),

--- a/api-server/storage-test-suite/src/basic.rs
+++ b/api-server/storage-test-suite/src/basic.rs
@@ -399,7 +399,7 @@ where
         let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
         let bob_address = Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
 
-        let tx = db_tx.get_address_available_utxos(bob_address.get()).await.unwrap();
+        let tx = db_tx.get_address_available_utxos(bob_address.as_str()).await.unwrap();
         assert!(tx.is_empty());
 
         drop(db_tx);
@@ -430,7 +430,7 @@ where
                 .set_locked_utxo_at_height(
                     outpoint.clone(),
                     locked_utxo,
-                    bob_address.get(),
+                    bob_address.as_str(),
                     block_height,
                 )
                 .await
@@ -473,7 +473,7 @@ where
                 .set_locked_utxo_at_height(
                     outpoint.clone(),
                     locked_utxo,
-                    bob_address.get(),
+                    bob_address.as_str(),
                     block_height,
                 )
                 .await
@@ -530,7 +530,7 @@ where
                 .set_locked_utxo_at_height(
                     outpoint.clone(),
                     locked_utxo,
-                    bob_address.get(),
+                    bob_address.as_str(),
                     block_height,
                 )
                 .await
@@ -542,7 +542,7 @@ where
                 .set_utxo_at_height(
                     outpoint.clone(),
                     utxo,
-                    bob_address.get(),
+                    bob_address.as_str(),
                     block_height.next_height(),
                 )
                 .await
@@ -554,7 +554,7 @@ where
                 .set_utxo_at_height(
                     outpoint.clone(),
                     spent_utxo,
-                    bob_address.get(),
+                    bob_address.as_str(),
                     block_height.next_height().next_height(),
                 )
                 .await
@@ -581,14 +581,14 @@ where
                 .set_locked_utxo_at_height(
                     locked_outpoint.clone(),
                     locked_utxo,
-                    bob_address.get(),
+                    bob_address.as_str(),
                     block_height,
                 )
                 .await
                 .unwrap();
 
             // should return only once the first utxo and also the locked utxo
-            let utxos = db_tx.get_address_all_utxos(bob_address.get()).await.unwrap();
+            let utxos = db_tx.get_address_all_utxos(bob_address.as_str()).await.unwrap();
             assert_eq!(utxos.len(), 2);
             assert_eq!(
                 utxos.iter().find(|utxo| utxo.0 == outpoint),
@@ -606,11 +606,11 @@ where
         // set one and get it
         {
             db_tx
-                .set_utxo_at_height(outpoint.clone(), utxo, bob_address.get(), block_height)
+                .set_utxo_at_height(outpoint.clone(), utxo, bob_address.as_str(), block_height)
                 .await
                 .unwrap();
 
-            let bob_utxos = db_tx.get_address_available_utxos(bob_address.get()).await.unwrap();
+            let bob_utxos = db_tx.get_address_available_utxos(bob_address.as_str()).await.unwrap();
             assert_eq!(
                 bob_utxos,
                 vec![(
@@ -639,13 +639,13 @@ where
                 .set_utxo_at_height(
                     outpoint2.clone(),
                     utxo.clone(),
-                    bob_address.get(),
+                    bob_address.as_str(),
                     block_height,
                 )
                 .await
                 .unwrap();
 
-            let bob_utxos = db_tx.get_address_available_utxos(bob_address.get()).await.unwrap();
+            let bob_utxos = db_tx.get_address_available_utxos(bob_address.as_str()).await.unwrap();
             let mut expected_utxos = BTreeMap::from_iter([
                 (outpoint, UtxoWithExtraInfo::new(output, None)),
                 (
@@ -664,11 +664,11 @@ where
             let utxo = Utxo::new(output2.clone(), None, true);
             expected_utxos.remove(&outpoint2);
             db_tx
-                .set_utxo_at_height(outpoint2, utxo, bob_address.get(), block_height)
+                .set_utxo_at_height(outpoint2, utxo, bob_address.as_str(), block_height)
                 .await
                 .unwrap();
 
-            let bob_utxos = db_tx.get_address_available_utxos(bob_address.get()).await.unwrap();
+            let bob_utxos = db_tx.get_address_available_utxos(bob_address.as_str()).await.unwrap();
             assert_eq!(bob_utxos.len(), 1);
 
             for (outpoint, output) in bob_utxos {

--- a/api-server/storage-test-suite/src/basic.rs
+++ b/api-server/storage-test-suite/src/basic.rs
@@ -397,7 +397,8 @@ where
         let (_bob_sk, bob_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
 
         let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
-        let bob_address = Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+        let bob_address =
+            Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
 
         let tx = db_tx.get_address_available_utxos(bob_address.as_str()).await.unwrap();
         assert!(tx.is_empty());
@@ -507,7 +508,8 @@ where
             let (_bob_sk, bob_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
 
             let bob_destination = Destination::PublicKeyHash(PublicKeyHash::from(&bob_pk));
-            let bob_address = Address::<Destination>::new(&chain_config, &bob_destination).unwrap();
+            let bob_address =
+                Address::<Destination>::new(&chain_config, bob_destination.clone()).unwrap();
 
             let random_tx_id: Id<Transaction> =
                 Id::<Transaction>::new(H256::random_using(&mut rng));

--- a/api-server/web-server/src/api/json_helpers.rs
+++ b/api-server/web-server/src/api/json_helpers.rs
@@ -80,7 +80,7 @@ pub fn outputvalue_to_json(
         OutputValue::TokenV1(token_id, amount) => {
             json!({
                 "type": "TokenV1",
-                "token_id": Address::new(chain_config, token_id).expect("no error").get(),
+                "token_id": Address::new(chain_config, token_id).expect("no error").as_str(),
                 "amount": amount_to_json(*amount, token_decimals.get(token_id)),
             })
         }
@@ -97,14 +97,14 @@ pub fn txoutput_to_json(
             json!({
                 "type": "Transfer",
                 "value": outputvalue_to_json(value, chain_config, token_decimals),
-                "destination": Address::new(chain_config, dest).expect("no error").get(),
+                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
             })
         }
         TxOutput::LockThenTransfer(value, dest, lock) => {
             json!({
                 "type": "LockThenTransfer",
                 "value": outputvalue_to_json(value, chain_config, token_decimals),
-                "destination": Address::new(chain_config, dest).expect("no error").get(),
+                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
                 "lock": lock,
             })
         }
@@ -117,12 +117,12 @@ pub fn txoutput_to_json(
         TxOutput::CreateStakePool(pool_id, data) => {
             json!({
                 "type": "CreateStakePool",
-                "pool_id": Address::new(chain_config, pool_id).expect("no error").get(),
+                "pool_id": Address::new(chain_config, pool_id).expect("no error").as_str(),
                 "data": {
                     "amount": amount_to_json(data.pledge(), chain_config.coin_decimals()),
-                    "staker": Address::new(chain_config, data.staker()).expect("no error").get(),
-                    "vrf_public_key": Address::new(chain_config, data.vrf_public_key()).expect("no error").get(),
-                    "decommission_key": Address::new(chain_config, data.decommission_key()).expect("no error").get(),
+                    "staker": Address::new(chain_config, data.staker()).expect("no error").as_str(),
+                    "vrf_public_key": Address::new(chain_config, data.vrf_public_key()).expect("no error").as_str(),
+                    "decommission_key": Address::new(chain_config, data.decommission_key()).expect("no error").as_str(),
                     "margin_ratio_per_thousand": data.margin_ratio_per_thousand(),
                     "cost_per_block": amount_to_json(data.cost_per_block(), chain_config.coin_decimals())
                 },
@@ -131,22 +131,22 @@ pub fn txoutput_to_json(
         TxOutput::DelegateStaking(amount, delegation_id) => {
             json!({
                 "type": "DelegateStaking",
-                "delegation_id": Address::new(chain_config, delegation_id).expect("no error").get(),
+                "delegation_id": Address::new(chain_config, delegation_id).expect("no error").as_str(),
                 "amount": amount_to_json(*amount, chain_config.coin_decimals()),
             })
         }
         TxOutput::CreateDelegationId(dest, pool_id) => {
             json!({
                 "type": "CreateDelegationId",
-                "pool_id": Address::new(chain_config, pool_id).expect("no error").get(),
-                "destination": Address::new(chain_config, dest).expect("no error").get(),
+                "pool_id": Address::new(chain_config, pool_id).expect("no error").as_str(),
+                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
             })
         }
         TxOutput::IssueNft(token_id, data, dest) => {
             json!({
                 "type": "IssueNft",
-                "token_id": Address::new(chain_config, token_id).expect("no error").get(),
-                "destination": Address::new(chain_config, dest).expect("no error").get(),
+                "token_id": Address::new(chain_config, token_id).expect("no error").as_str(),
+                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
                 "data": data,
             })
         }
@@ -158,7 +158,7 @@ pub fn txoutput_to_json(
                     "number_of_decimals": data.number_of_decimals,
                     "metadata_uri": data.metadata_uri,
                     "total_supply": data.total_supply,
-                    "authority": Address::new(chain_config, &data.authority).expect("no error").get(),
+                    "authority": Address::new(chain_config, &data.authority).expect("no error").as_str(),
                     "is_freezable": data.is_freezable,
                 })
             }
@@ -172,8 +172,8 @@ pub fn txoutput_to_json(
         TxOutput::ProduceBlockFromStake(dest, pool_id) => {
             json!({
                 "type": "ProduceBlockFromStake",
-                "pool_id": Address::new(chain_config, pool_id).expect("no error").get(),
-                "destination": Address::new(chain_config, dest).expect("no error").get(),
+                "pool_id": Address::new(chain_config, pool_id).expect("no error").as_str(),
+                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
             })
         }
     }

--- a/api-server/web-server/src/api/json_helpers.rs
+++ b/api-server/web-server/src/api/json_helpers.rs
@@ -80,7 +80,7 @@ pub fn outputvalue_to_json(
         OutputValue::TokenV1(token_id, amount) => {
             json!({
                 "type": "TokenV1",
-                "token_id": Address::new(chain_config, token_id).expect("no error").as_str(),
+                "token_id": Address::new(chain_config, *token_id).expect("no error").as_str(),
                 "amount": amount_to_json(*amount, token_decimals.get(token_id)),
             })
         }
@@ -97,14 +97,14 @@ pub fn txoutput_to_json(
             json!({
                 "type": "Transfer",
                 "value": outputvalue_to_json(value, chain_config, token_decimals),
-                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
+                "destination": Address::new(chain_config, dest.clone()).expect("no error").as_str(),
             })
         }
         TxOutput::LockThenTransfer(value, dest, lock) => {
             json!({
                 "type": "LockThenTransfer",
                 "value": outputvalue_to_json(value, chain_config, token_decimals),
-                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
+                "destination": Address::new(chain_config, dest.clone()).expect("no error").as_str(),
                 "lock": lock,
             })
         }
@@ -117,12 +117,12 @@ pub fn txoutput_to_json(
         TxOutput::CreateStakePool(pool_id, data) => {
             json!({
                 "type": "CreateStakePool",
-                "pool_id": Address::new(chain_config, pool_id).expect("no error").as_str(),
+                "pool_id": Address::new(chain_config, *pool_id).expect("no error").as_str(),
                 "data": {
                     "amount": amount_to_json(data.pledge(), chain_config.coin_decimals()),
-                    "staker": Address::new(chain_config, data.staker()).expect("no error").as_str(),
-                    "vrf_public_key": Address::new(chain_config, data.vrf_public_key()).expect("no error").as_str(),
-                    "decommission_key": Address::new(chain_config, data.decommission_key()).expect("no error").as_str(),
+                    "staker": Address::new(chain_config, data.staker().clone()).expect("no error").as_str(),
+                    "vrf_public_key": Address::new(chain_config, data.vrf_public_key().clone()).expect("no error").as_str(),
+                    "decommission_key": Address::new(chain_config, data.decommission_key().clone()).expect("no error").as_str(),
                     "margin_ratio_per_thousand": data.margin_ratio_per_thousand(),
                     "cost_per_block": amount_to_json(data.cost_per_block(), chain_config.coin_decimals())
                 },
@@ -131,22 +131,22 @@ pub fn txoutput_to_json(
         TxOutput::DelegateStaking(amount, delegation_id) => {
             json!({
                 "type": "DelegateStaking",
-                "delegation_id": Address::new(chain_config, delegation_id).expect("no error").as_str(),
+                "delegation_id": Address::new(chain_config, *delegation_id).expect("no error").as_str(),
                 "amount": amount_to_json(*amount, chain_config.coin_decimals()),
             })
         }
         TxOutput::CreateDelegationId(dest, pool_id) => {
             json!({
                 "type": "CreateDelegationId",
-                "pool_id": Address::new(chain_config, pool_id).expect("no error").as_str(),
-                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
+                "pool_id": Address::new(chain_config, *pool_id).expect("no error").as_str(),
+                "destination": Address::new(chain_config, dest.clone()).expect("no error").as_str(),
             })
         }
         TxOutput::IssueNft(token_id, data, dest) => {
             json!({
                 "type": "IssueNft",
-                "token_id": Address::new(chain_config, token_id).expect("no error").as_str(),
-                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
+                "token_id": Address::new(chain_config, *token_id).expect("no error").as_str(),
+                "destination": Address::new(chain_config, dest.clone()).expect("no error").as_str(),
                 "data": data,
             })
         }
@@ -158,7 +158,7 @@ pub fn txoutput_to_json(
                     "number_of_decimals": data.number_of_decimals,
                     "metadata_uri": data.metadata_uri,
                     "total_supply": data.total_supply,
-                    "authority": Address::new(chain_config, &data.authority).expect("no error").as_str(),
+                    "authority": Address::new(chain_config, data.authority.clone()).expect("no error").as_str(),
                     "is_freezable": data.is_freezable,
                 })
             }
@@ -172,8 +172,8 @@ pub fn txoutput_to_json(
         TxOutput::ProduceBlockFromStake(dest, pool_id) => {
             json!({
                 "type": "ProduceBlockFromStake",
-                "pool_id": Address::new(chain_config, pool_id).expect("no error").as_str(),
-                "destination": Address::new(chain_config, dest).expect("no error").as_str(),
+                "pool_id": Address::new(chain_config, *pool_id).expect("no error").as_str(),
+                "destination": Address::new(chain_config, dest.clone()).expect("no error").as_str(),
             })
         }
     }
@@ -223,7 +223,7 @@ pub fn tx_input_to_json(inp: &TxInput, chain_config: &ChainConfig) -> serde_json
                 json!({
                     "input_type": "Account",
                     "account_type": "DelegationBalance",
-                    "delegation_id": Address::new(chain_config, delegation_id).expect("addressable").to_string(),
+                    "delegation_id": Address::new(chain_config, *delegation_id).expect("addressable").to_string(),
                     "amount": amount_to_json(*amount, chain_config.coin_decimals()),
                     "nonce": acc.nonce(),
                 })
@@ -234,7 +234,7 @@ pub fn tx_input_to_json(inp: &TxInput, chain_config: &ChainConfig) -> serde_json
                 json!({
                     "input_type": "AccountCommand",
                     "command": "MintTokens",
-                    "token_id": Address::new(chain_config, token_id).expect("addressable").to_string(),
+                    "token_id": Address::new(chain_config, *token_id).expect("addressable").to_string(),
                     "amount": amount_to_json(*amount, chain_config.coin_decimals()),
                     "nonce": nonce,
                 })
@@ -243,7 +243,7 @@ pub fn tx_input_to_json(inp: &TxInput, chain_config: &ChainConfig) -> serde_json
                 json!({
                     "input_type": "AccountCommand",
                     "command": "UnmintTokens",
-                    "token_id": Address::new(chain_config, token_id).expect("addressable").to_string(),
+                    "token_id": Address::new(chain_config, *token_id).expect("addressable").to_string(),
                     "nonce": nonce,
                 })
             }
@@ -255,7 +255,7 @@ pub fn tx_input_to_json(inp: &TxInput, chain_config: &ChainConfig) -> serde_json
                 json!({
                     "input_type": "AccountCommand",
                     "command": "FreezeTokens",
-                    "token_id": Address::new(chain_config, token_id).expect("addressable").to_string(),
+                    "token_id": Address::new(chain_config, *token_id).expect("addressable").to_string(),
                     "is_token_unfreezable": is_unfreezable,
                     "nonce": nonce,
                 })
@@ -264,7 +264,7 @@ pub fn tx_input_to_json(inp: &TxInput, chain_config: &ChainConfig) -> serde_json
                 json!({
                     "input_type": "AccountCommand",
                     "command": "UnfreezeTokens",
-                    "token_id": Address::new(chain_config, token_id).expect("addressable").to_string(),
+                    "token_id": Address::new(chain_config, *token_id).expect("addressable").to_string(),
                     "nonce": nonce,
                 })
             }
@@ -272,7 +272,7 @@ pub fn tx_input_to_json(inp: &TxInput, chain_config: &ChainConfig) -> serde_json
                 json!({
                     "input_type": "AccountCommand",
                     "command": "LockTokenSupply",
-                    "token_id": Address::new(chain_config, token_id).expect("addressable").to_string(),
+                    "token_id": Address::new(chain_config, *token_id).expect("addressable").to_string(),
                     "nonce": nonce,
                 })
             }
@@ -280,8 +280,8 @@ pub fn tx_input_to_json(inp: &TxInput, chain_config: &ChainConfig) -> serde_json
                 json!({
                     "input_type": "AccountCommand",
                     "command": "ChangeTokenAuthority",
-                    "token_id": Address::new(chain_config, token_id).expect("addressable").to_string(),
-                    "new_authority": Address::new(chain_config, authority).expect("addressable").to_string(),
+                    "token_id": Address::new(chain_config, *token_id).expect("addressable").to_string(),
+                    "new_authority": Address::new(chain_config, authority.clone()).expect("addressable").to_string(),
                     "nonce": nonce,
                 })
             }

--- a/chainstate/src/rpc/mod.rs
+++ b/chainstate/src/rpc/mod.rs
@@ -299,9 +299,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
             self.call(move |this| {
                 let chain_config = this.get_chain_config();
                 let id_result = Address::<PoolId>::from_str(chain_config, &pool_address);
-                let address_result =
-                    id_result.map(|address| address.decode_object(chain_config))?;
-                address_result.map(|address| this.get_stake_pool_balance(address))
+                id_result.map(|address| this.get_stake_pool_balance(address.decode_object()))
             })
             .await,
         )
@@ -313,7 +311,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
                 let chain_config = this.get_chain_config();
                 let result: Result<Option<Amount>, _> =
                     dynamize_err(Address::<PoolId>::from_str(chain_config, &pool_address))
-                        .and_then(|address| dynamize_err(address.decode_object(chain_config)))
+                        .map(|address| address.decode_object())
                         .and_then(|pool_id| dynamize_err(this.get_stake_pool_data(pool_id)))
                         .and_then(|pool_data| {
                             dynamize_err(pool_data.map(|d| d.staker_balance()).transpose())
@@ -336,13 +334,13 @@ impl ChainstateRpcServer for super::ChainstateHandle {
 
                 let pool_id_result =
                     dynamize_err(Address::<PoolId>::from_str(chain_config, &pool_address))
-                        .and_then(|address| dynamize_err(address.decode_object(chain_config)));
+                        .map(|address| address.decode_object());
 
                 let delegation_id_result = dynamize_err(Address::<DelegationId>::from_str(
                     chain_config,
                     &delegation_address,
                 ))
-                .and_then(|address| dynamize_err(address.decode_object(chain_config)));
+                .map(|address| address.decode_object());
 
                 let ids = pool_id_result.and_then(|x| delegation_id_result.map(|y| (x, y)));
 
@@ -360,7 +358,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
                 let chain_config = this.get_chain_config();
                 let token_info_result: Result<Option<RPCTokenInfo>, _> =
                     dynamize_err(Address::<TokenId>::from_str(chain_config, &token_id))
-                        .and_then(|address| dynamize_err(address.decode_object(chain_config)))
+                        .map(|address| address.decode_object())
                         .and_then(|token_id| dynamize_err(this.get_token_info_for_rpc(token_id)));
 
                 token_info_result

--- a/chainstate/src/rpc/mod.rs
+++ b/chainstate/src/rpc/mod.rs
@@ -299,7 +299,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
             self.call(move |this| {
                 let chain_config = this.get_chain_config();
                 let id_result = Address::<PoolId>::from_str(chain_config, &pool_address);
-                id_result.map(|address| this.get_stake_pool_balance(address.decode_object()))
+                id_result.map(|address| this.get_stake_pool_balance(address.into_object()))
             })
             .await,
         )
@@ -311,7 +311,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
                 let chain_config = this.get_chain_config();
                 let result: Result<Option<Amount>, _> =
                     dynamize_err(Address::<PoolId>::from_str(chain_config, &pool_address))
-                        .map(|address| address.decode_object())
+                        .map(|address| address.into_object())
                         .and_then(|pool_id| dynamize_err(this.get_stake_pool_data(pool_id)))
                         .and_then(|pool_data| {
                             dynamize_err(pool_data.map(|d| d.staker_balance()).transpose())
@@ -334,13 +334,13 @@ impl ChainstateRpcServer for super::ChainstateHandle {
 
                 let pool_id_result =
                     dynamize_err(Address::<PoolId>::from_str(chain_config, &pool_address))
-                        .map(|address| address.decode_object());
+                        .map(|address| address.into_object());
 
                 let delegation_id_result = dynamize_err(Address::<DelegationId>::from_str(
                     chain_config,
                     &delegation_address,
                 ))
-                .map(|address| address.decode_object());
+                .map(|address| address.into_object());
 
                 let ids = pool_id_result.and_then(|x| delegation_id_result.map(|y| (x, y)));
 
@@ -358,7 +358,7 @@ impl ChainstateRpcServer for super::ChainstateHandle {
                 let chain_config = this.get_chain_config();
                 let token_info_result: Result<Option<RPCTokenInfo>, _> =
                     dynamize_err(Address::<TokenId>::from_str(chain_config, &token_id))
-                        .map(|address| address.decode_object())
+                        .map(|address| address.into_object())
                         .and_then(|token_id| dynamize_err(this.get_token_info_for_rpc(token_id)));
 
                 token_info_result

--- a/common/src/address/hexified.rs
+++ b/common/src/address/hexified.rs
@@ -188,7 +188,7 @@ impl<'a, A: Addressable + DecodeAll> regex::Replacer for AddressableReplacer<'a,
                 return;
             }
         };
-        let address = match Address::new(self.chain_config, &obj) {
+        let address = match Address::new(self.chain_config, obj) {
             Ok(address) => address,
             Err(_) => {
                 logging::log::error!(
@@ -269,7 +269,7 @@ mod tests {
         let res = HexifiedAddress::<Destination>::replace_with_address(&chain_config, &s);
         assert_eq!(
             res,
-            format!("{}", Address::new(&chain_config, &address).unwrap())
+            Address::new(&chain_config, address).unwrap().into_string(),
         );
     }
 
@@ -336,7 +336,7 @@ mod tests {
 
         let expected = strings
             .iter()
-            .zip(keys.iter())
+            .zip(keys.into_iter())
             .map(|(s, k)| {
                 let address_str = Address::new(&chain_config, k).unwrap();
                 s.clone() + &address_str.to_string()
@@ -477,7 +477,7 @@ mod tests {
 
         {
             // Do the replacement, which will make the hexified address become a real address
-            let expected_address = Address::new(&chain_config, &obj).unwrap();
+            let expected_address = Address::new(&chain_config, obj.clone()).unwrap();
             let obj_json_replaced =
                 HexifiedAddress::<Destination>::replace_with_address(&chain_config, &obj_json);
             assert_eq!(obj_json_replaced, format!("\"{expected_address}\""));

--- a/common/src/address/hexified.rs
+++ b/common/src/address/hexified.rs
@@ -15,7 +15,7 @@
 
 use crate::chain::ChainConfig;
 
-use super::{traits::Addressable, Address};
+use super::{encoding, traits::Addressable, Address};
 use regex::Regex;
 use serde::{de::Error, Deserialize};
 use serialization::DecodeAll;
@@ -118,8 +118,19 @@ impl<'a, A: Addressable + DecodeAll + 'a> HexifiedAddress<'a, A> {
         } else if s.starts_with("0x") {
             Self::serde_hex_deserialize::<D>(&s)
         } else {
-            Address::<A>::from_str_no_hrp_verify(&s).map_err(D::Error::custom)
+            Self::decode_no_hrp_verify(&s)
         }
+    }
+
+    /// Decode an address without verifying the hrp
+    /// This is used only for the case of json deserialization, which is done as a compromise as
+    /// the alternative would be to not serialize at all. This is because chain config cannot be
+    /// passed to the json serializer/deserializer.
+    fn decode_no_hrp_verify<E: Error>(address: &str) -> Result<A, E> {
+        let data = encoding::decode(address).map_err(E::custom)?;
+        let raw_data = data.data();
+        let result = A::decode_from_bytes_from_address(raw_data).map_err(E::custom)?;
+        Ok(result)
     }
 }
 
@@ -199,8 +210,10 @@ mod tests {
     use crypto::{
         key::{KeyKind, PrivateKey},
         random,
+        vrf::VRFPublicKey,
     };
     use rstest::rstest;
+    use serde::de::value::Error as SerdeErr;
     use serialization::{Decode, DecodeAll, Encode};
     use test_utils::random::{make_seedable_rng, Rng, Seed};
 
@@ -218,6 +231,27 @@ mod tests {
             .take(length)
             .map(char::from)
             .collect()
+    }
+
+    #[test]
+    fn example_mainnet_address() {
+        let address = "mtc1q9aaqkulkth7qp7mqtyv0rpgdwdytdewdu6ykrsj";
+        let dest =
+            HexifiedAddress::<Destination>::decode_no_hrp_verify::<SerdeErr>(address).unwrap();
+        let hex = hex::encode(dest.encode());
+        assert_eq!(hex, "017bd05b9fb2efe007db02c8c78c286b9a45b72e6f");
+    }
+
+    #[test]
+    fn example_mainnet_vrf() {
+        let address = "mvrfpk1qqyxcl4tc6y9amf2vmv6sgu8x5jwqlxawx73vhgemkduag9c8ku57m03mze";
+        let dest =
+            HexifiedAddress::<VRFPublicKey>::decode_no_hrp_verify::<SerdeErr>(address).unwrap();
+        let hex = hex::encode(dest.encode());
+        assert_eq!(
+            hex,
+            "00086c7eabc6885eed2a66d9a823873524e07cdd71bd165d19dd9bcea0b83db94f"
+        );
     }
 
     #[rstest]

--- a/common/src/address/mod.rs
+++ b/common/src/address/mod.rs
@@ -16,6 +16,7 @@
 pub mod dehexify;
 pub mod hexified;
 pub mod pubkeyhash;
+pub mod rpc;
 pub mod traits;
 
 use crate::chain::ChainConfig;
@@ -24,6 +25,7 @@ use std::fmt::Display;
 use utils::qrcode::{qrcode_from_str, QrCode, QrCodeError};
 
 use self::traits::Addressable;
+pub use rpc::RpcAddress;
 
 #[derive(thiserror::Error, Debug, Eq, PartialEq, Clone, PartialOrd, Ord)]
 pub enum AddressError {
@@ -126,6 +128,12 @@ impl<T: Addressable> Address<T> {
             )
         };
         Ok(result)
+    }
+}
+
+impl<T> Address<T> {
+    pub fn into_string(self) -> String {
+        self.address
     }
 }
 

--- a/common/src/address/mod.rs
+++ b/common/src/address/mod.rs
@@ -85,17 +85,6 @@ impl<T: Addressable> Address<T> {
         Ok(result)
     }
 
-    /// Decode an address without verifying the hrp
-    /// This is used only for the case of json deserialization, which is done as a compromise as the alternative
-    /// would be to not serialize at all. This is because chain config cannot be passed to the json serializer/deserializer.
-    fn from_str_no_hrp_verify(address: impl AsRef<str>) -> Result<T, AddressError> {
-        let data = encoding::decode(address)?;
-        let raw_data = data.data();
-        let result = T::decode_from_bytes_from_address(raw_data)
-            .map_err(|e| AddressError::DecodingError(e.to_string()))?;
-        Ok(result)
-    }
-
     pub fn from_str(cfg: &ChainConfig, address: &str) -> Result<Self, AddressError> {
         let address = Self {
             address: address.to_owned(),
@@ -154,7 +143,6 @@ mod tests {
     };
     use pubkeyhash::PublicKeyHash;
     use rstest::rstest;
-    use serialization::Encode;
     use test_utils::random::Seed;
 
     #[rstest]
@@ -172,25 +160,6 @@ mod tests {
             .decode_object(&cfg)
             .expect("Failed to extract public key hash from address");
         assert_eq!(public_key_hash_restored_dest, public_key_hash_dest);
-    }
-
-    #[test]
-    fn example_mainnet_address() {
-        let address = "mtc1q9aaqkulkth7qp7mqtyv0rpgdwdytdewdu6ykrsj";
-        let dest = Address::<Destination>::from_str_no_hrp_verify(address).unwrap();
-        let hex = hex::encode(dest.encode());
-        assert_eq!(hex, "017bd05b9fb2efe007db02c8c78c286b9a45b72e6f");
-    }
-
-    #[test]
-    fn example_mainnet_vrf() {
-        let address = "mvrfpk1qqyxcl4tc6y9amf2vmv6sgu8x5jwqlxawx73vhgemkduag9c8ku57m03mze";
-        let dest = Address::<VRFPublicKey>::from_str_no_hrp_verify(address).unwrap();
-        let hex = hex::encode(dest.encode());
-        assert_eq!(
-            hex,
-            "00086c7eabc6885eed2a66d9a823873524e07cdd71bd165d19dd9bcea0b83db94f"
-        );
     }
 
     #[test]

--- a/common/src/address/rpc.rs
+++ b/common/src/address/rpc.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{Address, AddressError, Addressable, ChainConfig};
+
+/// Address string for use in RPC. Not guaranteed to hold a valid address.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct RpcAddress<T> {
+    address: String,
+    #[serde(skip)]
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> RpcAddress<T> {
+    /// Construct from a raw string.
+    pub fn from_string(address: String) -> Self {
+        let _phantom = Default::default();
+        Self { address, _phantom }
+    }
+
+    /// Construct from an [Address].
+    pub fn from_address(address: Address<T>) -> Self {
+        Self::from_string(address.into_string())
+    }
+
+    /// Get the address string, no validation is performed
+    pub fn as_str(&self) -> &str {
+        &self.address
+    }
+
+    /// Get the address string
+    pub fn into_string(self) -> String {
+        self.address
+    }
+}
+
+impl<T: Addressable> RpcAddress<T> {
+    /// Construct from an addressable object
+    pub fn new(cfg: &ChainConfig, object: &T) -> Result<Self, AddressError> {
+        Ok(Self::from_address(Address::new(cfg, object)?))
+    }
+
+    /// Convert to an address, according to given chain config.
+    pub fn to_address(&self, cfg: &ChainConfig) -> Result<Address<T>, AddressError> {
+        Address::from_str(cfg, &self.address)
+    }
+
+    /// Convert to an object, according to given chain config.
+    pub fn decode_object(&self, cfg: &ChainConfig) -> Result<T, AddressError> {
+        self.to_address(cfg)?.decode_object(cfg)
+    }
+}
+
+impl<T> From<Address<T>> for RpcAddress<T> {
+    fn from(value: Address<T>) -> Self {
+        Self::from_address(value)
+    }
+}
+
+impl<T> From<String> for RpcAddress<T> {
+    fn from(value: String) -> Self {
+        Self::from_string(value)
+    }
+}
+
+impl<T> std::fmt::Display for RpcAddress<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.address.fmt(f)
+    }
+}
+
+impl<T> rpc_description::HasValueHint for RpcAddress<T> {
+    const HINT_SER: rpc_description::ValueHint = rpc_description::ValueHint::BECH32_STRING;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::{from_value, json, to_value};
+
+    #[rstest::rstest]
+    #[case("")]
+    #[case("hello")]
+    #[case("rmt1qyyra5j3qduhyd43wa50lpn2ddpg9ql0u50ceu68")]
+    fn serde_bare_string(#[case] addr_str: &str) {
+        let addr = RpcAddress::<()>::from_string(addr_str.into());
+        let json = json!(addr_str);
+        assert_eq!(to_value(&addr).unwrap(), json);
+        assert_eq!(from_value::<RpcAddress<()>>(json).unwrap(), addr);
+    }
+}

--- a/common/src/address/rpc.rs
+++ b/common/src/address/rpc.rs
@@ -16,7 +16,7 @@
 use super::{Address, AddressError, Addressable, ChainConfig};
 
 /// Address string for use in RPC. Not guaranteed to hold a valid address.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct RpcAddress<T> {
     address: String,
@@ -54,13 +54,13 @@ impl<T: Addressable> RpcAddress<T> {
     }
 
     /// Convert to an address, according to given chain config.
-    pub fn to_address(&self, cfg: &ChainConfig) -> Result<Address<T>, AddressError> {
-        Address::from_str(cfg, &self.address)
+    pub fn into_address(self, cfg: &ChainConfig) -> Result<Address<T>, AddressError> {
+        Address::from_string(cfg, self.address)
     }
 
     /// Convert to an object, according to given chain config.
     pub fn decode_object(&self, cfg: &ChainConfig) -> Result<T, AddressError> {
-        self.to_address(cfg)?.decode_object(cfg)
+        Ok(self.clone().into_address(cfg)?.decode_object())
     }
 }
 
@@ -79,6 +79,12 @@ impl<T> From<String> for RpcAddress<T> {
 impl<T> std::fmt::Display for RpcAddress<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.address.fmt(f)
+    }
+}
+
+impl<T> Clone for RpcAddress<T> {
+    fn clone(&self) -> Self {
+        Self::from_string(self.address.clone())
     }
 }
 

--- a/common/src/address/rpc.rs
+++ b/common/src/address/rpc.rs
@@ -49,7 +49,7 @@ impl<T> RpcAddress<T> {
 
 impl<T: Addressable> RpcAddress<T> {
     /// Construct from an addressable object
-    pub fn new(cfg: &ChainConfig, object: &T) -> Result<Self, AddressError> {
+    pub fn new(cfg: &ChainConfig, object: T) -> Result<Self, AddressError> {
         Ok(Self::from_address(Address::new(cfg, object)?))
     }
 
@@ -60,7 +60,7 @@ impl<T: Addressable> RpcAddress<T> {
 
     /// Convert to an object, according to given chain config.
     pub fn decode_object(&self, cfg: &ChainConfig) -> Result<T, AddressError> {
-        Ok(self.clone().into_address(cfg)?.decode_object())
+        Ok(self.clone().into_address(cfg)?.into_object())
     }
 }
 

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -151,7 +151,7 @@ impl TextSummary for TxOutput {
                 OutputValue::TokenV1(id, amount) => {
                     format!(
                         "TokenV1({}, {amount:?})",
-                        Address::new(chain_config, id)
+                        Address::new(chain_config, *id)
                             .expect("Cannot fail due to TokenId being fixed size")
                     )
                 }
@@ -167,18 +167,20 @@ impl TextSummary for TxOutput {
                 format!("OutputTimeLock::ForSeconds({secs} seconds)")
             }
         };
-        let fmt_dest =
-            |d: &Destination| format!("{}", Address::new(chain_config, d).expect("addressable"));
-        let fmt_vrf =
-            |k: &VRFPublicKey| format!("{}", Address::new(chain_config, k).expect("addressable"));
+        let fmt_dest = |d: &Destination| {
+            Address::new(chain_config, d.clone()).expect("addressable").into_string()
+        };
+        let fmt_vrf = |k: &VRFPublicKey| {
+            Address::new(chain_config, k.clone()).expect("addressable").into_string()
+        };
         let fmt_poolid = |id: &PoolId| {
-            Address::new(chain_config, id).expect("Cannot fail because fixed size addressable")
+            Address::new(chain_config, *id).expect("Cannot fail because fixed size addressable")
         };
         let fmt_tknid = |id: &TokenId| {
-            Address::new(chain_config, id).expect("Cannot fail because fixed size addressable")
+            Address::new(chain_config, *id).expect("Cannot fail because fixed size addressable")
         };
         let fmt_delid = |id: &DelegationId| {
-            Address::new(chain_config, id).expect("Cannot fail because fixed size addressable")
+            Address::new(chain_config, *id).expect("Cannot fail because fixed size addressable")
         };
         let fmt_stakepooldata = |p: &StakePoolData| {
             let pledge = fmt_ml(&p.pledge());

--- a/common/src/chain/transaction/printout.rs
+++ b/common/src/chain/transaction/printout.rs
@@ -105,39 +105,34 @@ mod tests {
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(&cfg)
-                    .unwrap(),
+                    .decode_object(),
             ),
             TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(&cfg)
-                    .unwrap(),
+                    .decode_object(),
                 OutputTimeLock::ForBlockCount(10),
             ),
             TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(&cfg)
-                    .unwrap(),
+                    .decode_object(),
                 OutputTimeLock::ForSeconds(2000),
             ),
             TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(&cfg)
-                    .unwrap(),
+                    .decode_object(),
                 OutputTimeLock::UntilHeight(1000.into()),
             ),
             TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(&cfg)
-                    .unwrap(),
+                    .decode_object(),
                 OutputTimeLock::UntilTime(BlockTimestamp::from_time(
                     TimeGetter::default().get_time(),
                 )),

--- a/common/src/chain/transaction/printout.rs
+++ b/common/src/chain/transaction/printout.rs
@@ -105,34 +105,34 @@ mod tests {
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(),
+                    .into_object(),
             ),
             TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(),
+                    .into_object(),
                 OutputTimeLock::ForBlockCount(10),
             ),
             TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(),
+                    .into_object(),
                 OutputTimeLock::ForSeconds(2000),
             ),
             TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(),
+                    .into_object(),
                 OutputTimeLock::UntilHeight(1000.into()),
             ),
             TxOutput::LockThenTransfer(
                 OutputValue::Coin(Amount::from_fixedpoint_str("123.15", 11).unwrap()),
                 Address::from_str(&cfg, "mtc1q9d860uag5swe78ac9c2lct9mkctfyftqvwj3ypa")
                     .unwrap()
-                    .decode_object(),
+                    .into_object(),
                 OutputTimeLock::UntilTime(BlockTimestamp::from_time(
                     TimeGetter::default().get_time(),
                 )),

--- a/common/src/chain/transaction/signature/inputsig/arbitrary_message/mod.rs
+++ b/common/src/chain/transaction/signature/inputsig/arbitrary_message/mod.rs
@@ -76,6 +76,14 @@ impl ArbitraryMessageSignature {
         hex::encode(self.raw_signature)
     }
 
+    pub fn as_raw(&self) -> &[u8] {
+        &self.raw_signature
+    }
+
+    pub fn into_raw(self) -> Vec<u8> {
+        self.raw_signature
+    }
+
     pub fn verify_signature(
         &self,
         chain_config: &ChainConfig,

--- a/consensus/src/pos/mod.rs
+++ b/consensus/src/pos/mod.rs
@@ -224,7 +224,7 @@ pub fn stake(
         "Search for a valid block ({}..{}), pool_id: {}",
         block_timestamp,
         finalize_pos_data.max_block_timestamp(),
-        Address::new(chain_config, pos_data.stake_pool_id())
+        Address::new(chain_config, *pos_data.stake_pool_id())
             .expect("Pool id to address cannot fail")
     );
 

--- a/node-gui/src/backend/backend_impl.rs
+++ b/node-gui/src/backend/backend_impl.rs
@@ -459,7 +459,7 @@ impl Backend {
 
         let decommission_key = parse_address(&self.chain_config, &decommission_address)
             .map_err(|err| BackendError::AddressError(err.to_string()))?
-            .decode_object();
+            .into_object();
 
         let tx = self
             .synced_wallet_controller(wallet_id, account_id.account_index())
@@ -484,7 +484,7 @@ impl Backend {
 
         let pool_id = Address::from_str(&self.chain_config, &pool_id)
             .map_err(|e| BackendError::AddressError(e.to_string()))?
-            .decode_object();
+            .into_object();
 
         let delegation_key = parse_address(&self.chain_config, &delegation_address)
             .map_err(|err| BackendError::AddressError(err.to_string()))?;
@@ -543,7 +543,7 @@ impl Backend {
 
         let delegation_id = Address::from_str(&self.chain_config, &delegation_id)
             .map_err(|e| BackendError::AddressError(e.to_string()))?
-            .decode_object();
+            .into_object();
 
         let tx = self
             .synced_wallet_controller(wallet_id, account_id.account_index())

--- a/node-gui/src/backend/backend_impl.rs
+++ b/node-gui/src/backend/backend_impl.rs
@@ -459,8 +459,7 @@ impl Backend {
 
         let decommission_key = parse_address(&self.chain_config, &decommission_address)
             .map_err(|err| BackendError::AddressError(err.to_string()))?
-            .decode_object(&self.chain_config)
-            .map_err(|e| BackendError::AddressError(e.to_string()))?;
+            .decode_object();
 
         let tx = self
             .synced_wallet_controller(wallet_id, account_id.account_index())
@@ -484,8 +483,8 @@ impl Backend {
         } = request;
 
         let pool_id = Address::from_str(&self.chain_config, &pool_id)
-            .and_then(|addr| addr.decode_object(&self.chain_config))
-            .map_err(|e| BackendError::AddressError(e.to_string()))?;
+            .map_err(|e| BackendError::AddressError(e.to_string()))?
+            .decode_object();
 
         let delegation_key = parse_address(&self.chain_config, &delegation_address)
             .map_err(|err| BackendError::AddressError(err.to_string()))?;
@@ -543,8 +542,8 @@ impl Backend {
             .ok_or(BackendError::InvalidAmount(amount))?;
 
         let delegation_id = Address::from_str(&self.chain_config, &delegation_id)
-            .and_then(|addr| addr.decode_object(&self.chain_config))
-            .map_err(|e| BackendError::AddressError(e.to_string()))?;
+            .map_err(|e| BackendError::AddressError(e.to_string()))?
+            .decode_object();
 
         let tx = self
             .synced_wallet_controller(wallet_id, account_id.account_index())

--- a/node-gui/src/main_window/main_widget/tabs/wallet/addresses.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/addresses.rs
@@ -34,13 +34,13 @@ pub fn view_addresses(
     for (index, address) in account.addresses.iter() {
         addresses = addresses
             .push(field(index.to_string()))
-            .push(field(address.get().to_owned()))
+            .push(field(address.as_str().to_owned()))
             .push(
                 button(
                     Text::new(iced_aw::Icon::ClipboardCheck.to_string()).font(iced_aw::ICON_FONT),
                 )
                 .style(iced::theme::Button::Text)
-                .on_press(WalletMessage::CopyToClipboard(address.get().to_owned())),
+                .on_press(WalletMessage::CopyToClipboard(address.as_str().to_owned())),
             );
     }
     column![

--- a/node-gui/src/main_window/main_widget/tabs/wallet/delegation.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/delegation.rs
@@ -81,9 +81,9 @@ pub fn view_delegation(
                 .iter()
                 .map(|(del_id, (pool_id, b))| (*del_id, *pool_id, *b))
             {
-                let delegation_address = Address::new(chain_config, &delegation_id)
+                let delegation_address = Address::new(chain_config, delegation_id)
                     .expect("Encoding pool id to address can't fail (GUI)");
-                let pool_address = Address::new(chain_config, &pool_id)
+                let pool_address = Address::new(chain_config, pool_id)
                     .expect("Encoding pool id to address can't fail (GUI)");
                 let delegate_staking_amount =
                     delegate_staking_amounts.get(&delegation_id).cloned().unwrap_or(String::new());

--- a/node-gui/src/main_window/main_widget/tabs/wallet/delegation.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/delegation.rs
@@ -90,11 +90,7 @@ pub fn view_delegation(
                 delegation_balance_grid = delegation_balance_grid
                     .push(
                         tooltip(
-                            field(
-                                delegation_address
-                                    .to_short_string(chain_config)
-                                    .expect("cannot fail"),
-                            ),
+                            field(delegation_address.to_short_string()),
                             delegation_address.to_string(),
                             Position::Bottom,
                         )
@@ -114,7 +110,7 @@ pub fn view_delegation(
                     )
                     .push(
                         tooltip(
-                            field(pool_address.to_short_string(chain_config).expect("cannot fail")),
+                            field(pool_address.to_short_string()),
                             pool_address.to_string(),
                             Position::Bottom,
                         )

--- a/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
@@ -91,9 +91,7 @@ pub fn view_stake(
                 staking_balance_grid = staking_balance_grid
                     .push(
                         tooltip(
-                            field(
-                                pool_id_address.to_short_string(chain_config).expect("cannot fail"),
-                            ),
+                            field(pool_id_address.to_short_string()),
                             pool_id_address.to_string(),
                             Position::Bottom,
                         )

--- a/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
@@ -86,7 +86,7 @@ pub fn view_stake(
                 .push(field("Cost per block".to_owned()))
                 .push(field("Pool balance".to_owned()));
             for (pool_id, (pool_data, balance)) in account.staking_balance.iter() {
-                let pool_id_address = Address::new(chain_config, pool_id)
+                let pool_id_address = Address::new(chain_config, *pool_id)
                     .expect("Encoding pool id to address can't fail (GUI)");
                 staking_balance_grid = staking_balance_grid
                     .push(

--- a/rpc/types/src/string.rs
+++ b/rpc/types/src/string.rs
@@ -28,11 +28,23 @@ impl RpcHexString {
     pub fn into_bytes(self) -> Vec<u8> {
         self.0
     }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for RpcHexString {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        hex::decode(s).map(Self)
+    }
 }
 
 impl AsRef<[u8]> for RpcHexString {
     fn as_ref(&self) -> &[u8] {
-        &self.0
+        self.as_bytes()
     }
 }
 
@@ -45,6 +57,18 @@ impl From<Vec<u8>> for RpcHexString {
 impl From<RpcHexString> for Vec<u8> {
     fn from(value: RpcHexString) -> Self {
         value.into_bytes()
+    }
+}
+
+impl std::fmt::Display for RpcHexString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        hex::encode(self.as_bytes()).fmt(f)
+    }
+}
+
+impl std::fmt::LowerHex for RpcHexString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as std::fmt::Display>::fmt(self, f)
     }
 }
 
@@ -65,7 +89,7 @@ impl TryFrom<HexStringSerde> for RpcHexString {
     type Error = hex::FromHexError;
 
     fn try_from(value: HexStringSerde) -> Result<Self, Self::Error> {
-        Ok(RpcHexString::from_bytes(hex::decode(value.0)?))
+        value.0.parse()
     }
 }
 

--- a/test-rpc-functions/src/rpc.rs
+++ b/test-rpc-functions/src/rpc.rs
@@ -343,8 +343,7 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         let destination = self
             .call(move |this| {
                 this.get_chain_config().map(|chain| {
-                    Address::<Destination>::from_str(&chain, &address)
-                        .and_then(|addr| addr.decode_object(&chain))
+                    Address::<Destination>::from_str(&chain, &address).map(|a| a.decode_object())
                 })
             })
             .await

--- a/test-rpc-functions/src/rpc.rs
+++ b/test-rpc-functions/src/rpc.rs
@@ -343,7 +343,7 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         let destination = self
             .call(move |this| {
                 this.get_chain_config().map(|chain| {
-                    Address::<Destination>::from_str(&chain, &address).map(|a| a.decode_object())
+                    Address::<Destination>::from_str(&chain, &address).map(|a| a.into_object())
                 })
             })
             .await

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -738,7 +738,7 @@ impl Account {
         let output_destination = if let Some(dest) = output_address {
             dest
         } else {
-            self.get_new_address(db_tx, KeyPurpose::ReceiveFunds)?.1.decode_object()
+            self.get_new_address(db_tx, KeyPurpose::ReceiveFunds)?.1.into_object()
         };
 
         let pool_data = self.output_cache.pool_data(pool_id)?;
@@ -1208,7 +1208,7 @@ impl Account {
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
-        let new_authority = address.decode_object();
+        let new_authority = address.into_object();
 
         let nonce = token_info.get_next_nonce()?;
         let tx_input = TxInput::AccountCommand(
@@ -1511,7 +1511,8 @@ impl Account {
             self.key_chain.issue_vrf_key(db_tx).map(|(child_number, vrf_key)| {
                 (
                     child_number,
-                    Address::new(&self.chain_config, vrf_key.public_key()).expect("addressable"),
+                    Address::new(&self.chain_config, vrf_key.public_key().clone())
+                        .expect("addressable"),
                 )
             })?,
         )
@@ -2192,7 +2193,7 @@ fn coin_and_token_output_change_fees(
     destination: Option<&Address<Destination>>,
 ) -> WalletResult<(Amount, Amount)> {
     let destination = if let Some(addr) = destination {
-        addr.decode_object()
+        addr.as_object().clone()
     } else {
         let pub_key_hash = PublicKeyHash::from_low_u64_ne(0);
         Destination::PublicKeyHash(pub_key_hash)

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -359,7 +359,6 @@ impl Account {
                 let (coin_change_fee, token_change_fee) = coin_and_token_output_change_fees(
                     current_fee_rate,
                     change_addresses.get(currency),
-                    &self.chain_config,
                 )?;
 
                 let cost_of_change = match currency {
@@ -413,7 +412,6 @@ impl Account {
         let (coin_change_fee, token_change_fee) = coin_and_token_output_change_fees(
             current_fee_rate,
             change_addresses.get(&pay_fee_with_currency),
-            &self.chain_config,
         )?;
         let cost_of_change = match pay_fee_with_currency {
             currency_grouper::Currency::Coin => coin_change_fee,
@@ -481,17 +479,12 @@ impl Account {
                 };
 
                 let change_output = match currency {
-                    currency_grouper::Currency::Coin => make_address_output(
-                        self.chain_config.as_ref(),
-                        change_address,
-                        change_amount,
-                    )?,
-                    currency_grouper::Currency::Token(token_id) => make_address_output_token(
-                        self.chain_config.as_ref(),
-                        change_address,
-                        change_amount,
-                        *token_id,
-                    )?,
+                    currency_grouper::Currency::Coin => {
+                        make_address_output(change_address, change_amount)
+                    }
+                    currency_grouper::Currency::Token(token_id) => {
+                        make_address_output_token(change_address, change_amount, *token_id)
+                    }
                 };
                 request = request.with_outputs([change_output]);
             }
@@ -639,7 +632,7 @@ impl Account {
             address.clone(),
             delegation_share,
             current_block_height,
-        )?;
+        );
         let delegation_data = self.find_delegation(&delegation_id)?;
         let nonce = delegation_data
             .last_nonce
@@ -672,7 +665,7 @@ impl Account {
             address,
             amount,
             current_block_height,
-        )?;
+        );
 
         let tx = Transaction::new(0, vec![tx_input], vec![output])?;
 
@@ -745,10 +738,7 @@ impl Account {
         let output_destination = if let Some(dest) = output_address {
             dest
         } else {
-            self.get_new_address(db_tx, KeyPurpose::ReceiveFunds)?
-                .1
-                .decode_object(&self.chain_config)
-                .expect("already checked")
+            self.get_new_address(db_tx, KeyPurpose::ReceiveFunds)?.1.decode_object()
         };
 
         let pool_data = self.output_cache.pool_data(pool_id)?;
@@ -844,7 +834,7 @@ impl Account {
             address,
             amount,
             current_block_height,
-        )?;
+        );
         let delegation_data = self.find_delegation(&delegation_id)?;
         let nonce = delegation_data
             .last_nonce
@@ -1090,8 +1080,7 @@ impl Account {
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
         let token_id = *token_info.token_id();
-        let outputs =
-            make_mint_token_outputs(token_id, amount, address, self.chain_config.as_ref())?;
+        let outputs = make_mint_token_outputs(token_id, amount, address);
 
         token_info.check_can_mint(amount)?;
 
@@ -1219,7 +1208,7 @@ impl Account {
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
     ) -> WalletResult<SignedTransaction> {
-        let new_authority = address.decode_object(&self.chain_config)?;
+        let new_authority = address.decode_object();
 
         let nonce = token_info.get_next_nonce()?;
         let tx_input = TxInput::AccountCommand(
@@ -2201,10 +2190,9 @@ fn group_preselected_inputs(
 fn coin_and_token_output_change_fees(
     feerate: mempool::FeeRate,
     destination: Option<&Address<Destination>>,
-    chain_config: &ChainConfig,
 ) -> WalletResult<(Amount, Amount)> {
     let destination = if let Some(addr) = destination {
-        addr.decode_object(chain_config)?
+        addr.decode_object()
     } else {
         let pub_key_hash = PublicKeyHash::from_low_u64_ne(0);
         Destination::PublicKeyHash(pub_key_hash)

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -155,7 +155,7 @@ fn sign_transaction(#[case] seed: Seed) {
 
             TxOutput::Transfer(
                 OutputValue::Coin(*a),
-                account.get_new_address(&mut db_tx, purpose).unwrap().1.decode_object(),
+                account.get_new_address(&mut db_tx, purpose).unwrap().1.into_object(),
             )
         })
         .collect();
@@ -196,7 +196,7 @@ fn sign_transaction(#[case] seed: Seed) {
         TxOutput::Burn(OutputValue::Coin(burn_amount)),
         TxOutput::Transfer(
             OutputValue::Coin(Amount::from_atoms(100)),
-            account.get_new_address(&mut db_tx, Change).unwrap().1.decode_object(),
+            account.get_new_address(&mut db_tx, Change).unwrap().1.into_object(),
         ),
     ];
 

--- a/wallet/src/account/tests.rs
+++ b/wallet/src/account/tests.rs
@@ -67,7 +67,7 @@ fn account_addresses() {
     let mut db_tx = db.transaction_rw(None).unwrap();
     for (purpose, address_str) in test_vec {
         let address = account.get_new_address(&mut db_tx, purpose).unwrap().1;
-        assert_eq!(address.get(), address_str);
+        assert_eq!(address.as_str(), address_str);
     }
 }
 
@@ -155,12 +155,7 @@ fn sign_transaction(#[case] seed: Seed) {
 
             TxOutput::Transfer(
                 OutputValue::Coin(*a),
-                account
-                    .get_new_address(&mut db_tx, purpose)
-                    .unwrap()
-                    .1
-                    .decode_object(config.as_ref())
-                    .unwrap(),
+                account.get_new_address(&mut db_tx, purpose).unwrap().1.decode_object(),
             )
         })
         .collect();
@@ -201,12 +196,7 @@ fn sign_transaction(#[case] seed: Seed) {
         TxOutput::Burn(OutputValue::Coin(burn_amount)),
         TxOutput::Transfer(
             OutputValue::Coin(Amount::from_atoms(100)),
-            account
-                .get_new_address(&mut db_tx, Change)
-                .unwrap()
-                .1
-                .decode_object(config.as_ref())
-                .unwrap(),
+            account.get_new_address(&mut db_tx, Change).unwrap().1.decode_object(),
         ),
     ];
 

--- a/wallet/src/key_chain/leaf_key_chain/mod.rs
+++ b/wallet/src/key_chain/leaf_key_chain/mod.rs
@@ -206,7 +206,7 @@ impl LeafKeySoftChain {
         if self.last_used() == self.last_issued() {
             logging::log::debug!(
                 "new address: {}, index: {}, purpose {:?}",
-                address.get(),
+                address.as_str(),
                 new_issued_index,
                 self.purpose
             );
@@ -234,7 +234,7 @@ impl LeafKeySoftChain {
 
         logging::log::debug!(
             "new address: {}, index: {}, purpose {:?}",
-            address.get(),
+            address.as_str(),
             new_issued_index,
             self.purpose
         );

--- a/wallet/src/key_chain/leaf_key_chain/mod.rs
+++ b/wallet/src/key_chain/leaf_key_chain/mod.rs
@@ -326,7 +326,7 @@ impl LeafKeySoftChain {
         // Calculate the address
         let address = Address::new(
             &self.chain_config,
-            &Destination::PublicKeyHash(public_key_hash),
+            Destination::PublicKeyHash(public_key_hash),
         )?;
         // Calculate account derivation path id
         let account_path_id = AccountDerivationPathId::new(

--- a/wallet/src/key_chain/tests.rs
+++ b/wallet/src/key_chain/tests.rs
@@ -193,7 +193,7 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
         Err(KeyChainError::LookAheadExceeded)
     );
 
-    if let Destination::PublicKeyHash(pkh) = last_address.decode_object() {
+    if let Destination::PublicKeyHash(pkh) = last_address.into_object() {
         key_chain.mark_public_key_hash_as_used(&mut db_tx, &pkh).unwrap();
     } else {
         panic!("Address is not a public key hash destination");

--- a/wallet/src/key_chain/tests.rs
+++ b/wallet/src/key_chain/tests.rs
@@ -193,9 +193,7 @@ fn key_lookahead(#[case] purpose: KeyPurpose) {
         Err(KeyChainError::LookAheadExceeded)
     );
 
-    if let Destination::PublicKeyHash(pkh) =
-        last_address.decode_object(chain_config.as_ref()).unwrap()
-    {
+    if let Destination::PublicKeyHash(pkh) = last_address.decode_object() {
         key_chain.mark_public_key_hash_as_used(&mut db_tx, &pkh).unwrap();
     } else {
         panic!("Address is not a public key hash destination");

--- a/wallet/src/key_chain/vrf_key_chain/mod.rs
+++ b/wallet/src/key_chain/vrf_key_chain/mod.rs
@@ -155,7 +155,7 @@ impl VrfKeySoftChain {
 
         logging::log::debug!(
             "new vrf address: {}, index: {}",
-            Address::new(&self.chain_config, &key.clone().into_public_key()).expect("addressable"),
+            Address::new(&self.chain_config, key.clone().into_public_key()).expect("addressable"),
             new_issued_index,
         );
 
@@ -333,7 +333,8 @@ impl VrfKeySoftChain {
     }
 
     pub fn get_legacy_vrf_public_key(&self) -> Address<VRFPublicKey> {
-        Address::new(&self.chain_config, self.legacy_pubkey.public_key()).expect("addressable")
+        Address::new(&self.chain_config, self.legacy_pubkey.public_key().clone())
+            .expect("addressable")
     }
 
     pub fn get_all_issued_keys(&self) -> BTreeMap<ChildNumber, (Address<VRFPublicKey>, bool)> {
@@ -352,7 +353,8 @@ impl VrfKeySoftChain {
                 (
                     index,
                     (
-                        Address::new(&self.chain_config, key.public_key()).expect("addressable"),
+                        Address::new(&self.chain_config, key.public_key().clone())
+                            .expect("addressable"),
                         self.usage_state.last_used().is_some_and(|used| used >= index.get_index()),
                     ),
                 )

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -54,7 +54,7 @@ pub struct SendRequest {
 }
 
 pub fn make_address_output(address: Address<Destination>, amount: Amount) -> TxOutput {
-    TxOutput::Transfer(OutputValue::Coin(amount), address.decode_object())
+    TxOutput::Transfer(OutputValue::Coin(amount), address.into_object())
 }
 
 pub fn make_address_output_token(
@@ -64,7 +64,7 @@ pub fn make_address_output_token(
 ) -> TxOutput {
     TxOutput::Transfer(
         OutputValue::TokenV1(token_id, amount),
-        address.decode_object(),
+        address.into_object(),
     )
 }
 
@@ -84,7 +84,7 @@ pub fn make_mint_token_outputs(
     amount: Amount,
     address: Address<Destination>,
 ) -> Vec<TxOutput> {
-    let destination = address.decode_object();
+    let destination = address.into_object();
     let mint_output = TxOutput::Transfer(OutputValue::TokenV1(token_id, amount), destination);
 
     vec![mint_output]
@@ -96,7 +96,7 @@ pub fn make_unmint_token_outputs(token_id: TokenId, amount: Amount) -> Vec<TxOut
 }
 
 pub fn make_create_delegation_output(address: Address<Destination>, pool_id: PoolId) -> TxOutput {
-    TxOutput::CreateDelegationId(address.decode_object(), pool_id)
+    TxOutput::CreateDelegationId(address.into_object(), pool_id)
 }
 
 pub fn make_address_output_from_delegation(
@@ -110,7 +110,7 @@ pub fn make_address_output_from_delegation(
 
     TxOutput::LockThenTransfer(
         OutputValue::Coin(amount),
-        address.decode_object(),
+        address.into_object(),
         ForBlockCount(num_blocks_to_lock.to_int()),
     )
 }

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -53,28 +53,19 @@ pub struct SendRequest {
     fees: BTreeMap<Currency, Amount>,
 }
 
-pub fn make_address_output(
-    chain_config: &ChainConfig,
-    address: Address<Destination>,
-    amount: Amount,
-) -> WalletResult<TxOutput> {
-    let destination = address.decode_object(chain_config)?;
-
-    Ok(TxOutput::Transfer(OutputValue::Coin(amount), destination))
+pub fn make_address_output(address: Address<Destination>, amount: Amount) -> TxOutput {
+    TxOutput::Transfer(OutputValue::Coin(amount), address.decode_object())
 }
 
 pub fn make_address_output_token(
-    chain_config: &ChainConfig,
     address: Address<Destination>,
     amount: Amount,
     token_id: TokenId,
-) -> WalletResult<TxOutput> {
-    let destination = address.decode_object(chain_config)?;
-
-    Ok(TxOutput::Transfer(
+) -> TxOutput {
+    TxOutput::Transfer(
         OutputValue::TokenV1(token_id, amount),
-        destination,
-    ))
+        address.decode_object(),
+    )
 }
 
 pub fn make_issue_token_outputs(
@@ -92,12 +83,11 @@ pub fn make_mint_token_outputs(
     token_id: TokenId,
     amount: Amount,
     address: Address<Destination>,
-    chain_config: &ChainConfig,
-) -> WalletResult<Vec<TxOutput>> {
-    let destination = address.decode_object(chain_config)?;
+) -> Vec<TxOutput> {
+    let destination = address.decode_object();
     let mint_output = TxOutput::Transfer(OutputValue::TokenV1(token_id, amount), destination);
 
-    Ok(vec![mint_output])
+    vec![mint_output]
 }
 
 pub fn make_unmint_token_outputs(token_id: TokenId, amount: Amount) -> Vec<TxOutput> {
@@ -105,14 +95,8 @@ pub fn make_unmint_token_outputs(token_id: TokenId, amount: Amount) -> Vec<TxOut
     vec![burn_tokens]
 }
 
-pub fn make_create_delegation_output(
-    chain_config: &ChainConfig,
-    address: Address<Destination>,
-    pool_id: PoolId,
-) -> WalletResult<TxOutput> {
-    let destination = address.decode_object(chain_config)?;
-
-    Ok(TxOutput::CreateDelegationId(destination, pool_id))
+pub fn make_create_delegation_output(address: Address<Destination>, pool_id: PoolId) -> TxOutput {
+    TxOutput::CreateDelegationId(address.decode_object(), pool_id)
 }
 
 pub fn make_address_output_from_delegation(
@@ -120,16 +104,15 @@ pub fn make_address_output_from_delegation(
     address: Address<Destination>,
     amount: Amount,
     current_block_height: BlockHeight,
-) -> WalletResult<TxOutput> {
-    let destination = address.decode_object(chain_config)?;
+) -> TxOutput {
     let num_blocks_to_lock =
         chain_config.staking_pool_spend_maturity_block_count(current_block_height);
 
-    Ok(TxOutput::LockThenTransfer(
+    TxOutput::LockThenTransfer(
         OutputValue::Coin(amount),
-        destination,
+        address.decode_object(),
         ForBlockCount(num_blocks_to_lock.to_int()),
-    ))
+    )
 }
 
 pub fn make_decommission_stake_pool_output(

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1511,7 +1511,7 @@ impl<B: storage::Backend> Wallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<(TokenId, SignedTransaction)> {
-        let destination = address.decode_object();
+        let destination = address.into_object();
         let latest_median_time = self.latest_median_time;
 
         let signed_transaction =

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1511,7 +1511,7 @@ impl<B: storage::Backend> Wallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<(TokenId, SignedTransaction)> {
-        let destination = address.decode_object(self.chain_config.as_ref())?;
+        let destination = address.decode_object();
         let latest_median_time = self.latest_median_time;
 
         let signed_transaction =

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -280,12 +280,7 @@ fn create_block(
         chain_config.genesis_block_id(),
         chain_config.genesis_block().timestamp(),
         ConsensusData::None,
-        BlockReward::new(vec![make_address_output(
-            chain_config.as_ref(),
-            address.clone(),
-            reward,
-        )
-        .unwrap()]),
+        BlockReward::new(vec![make_address_output(address.clone(), reward)]),
     )
     .unwrap();
 
@@ -361,10 +356,7 @@ fn wallet_migration_to_v2(#[case] seed: Seed) {
     let genesis = Genesis::new(
         String::new(),
         BlockTimestamp::from_int_seconds(1639975460),
-        vec![TxOutput::Transfer(
-            OutputValue::Coin(genesis_amount),
-            address.decode_object(&create_regtest()).unwrap(),
-        )],
+        vec![TxOutput::Transfer(OutputValue::Coin(genesis_amount), address.decode_object())],
     );
     let chain_type = ChainType::Regtest;
     let chain_config = Arc::new(Builder::new(chain_type).genesis_custom(genesis).build());
@@ -570,10 +562,7 @@ fn wallet_seed_phrase_check_address() {
 
     let address = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap();
     let pk = wallet
-        .find_public_key(
-            DEFAULT_ACCOUNT_INDEX,
-            address.1.decode_object(&chain_config).unwrap(),
-        )
+        .find_public_key(DEFAULT_ACCOUNT_INDEX, address.1.decode_object())
         .unwrap();
 
     // m/44'/19788'/0'/0/0 for MNEMONIC
@@ -596,10 +585,7 @@ fn wallet_seed_phrase_check_address() {
     let address = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap();
     assert_eq!(address.0, ChildNumber::from_index_with_hardened_bit(0));
     let pk = wallet
-        .find_public_key(
-            DEFAULT_ACCOUNT_INDEX,
-            address.1.decode_object(&chain_config).unwrap(),
-        )
+        .find_public_key(DEFAULT_ACCOUNT_INDEX, address.1.decode_object())
         .unwrap();
 
     // m/44'/19788'/0'/0/0 for MNEMONIC with passphrase: phrase123
@@ -609,10 +595,7 @@ fn wallet_seed_phrase_check_address() {
     let address = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap();
     assert_eq!(address.0, ChildNumber::from_index_with_hardened_bit(1));
     let pk = wallet
-        .find_public_key(
-            DEFAULT_ACCOUNT_INDEX,
-            address.1.decode_object(&chain_config).unwrap(),
-        )
+        .find_public_key(DEFAULT_ACCOUNT_INDEX, address.1.decode_object())
         .unwrap();
     // m/44'/19788'/0'/0/1 for MNEMONIC with passphrase: phrase123
     let expected_pk2 = "0284857ecbeb0c19f078f4224313d9f43a86fcc875ffa6e00feca621bdc200d14a";
@@ -632,17 +615,15 @@ fn wallet_balance_genesis() {
         KeyPurpose::ReceiveFunds,
         0.try_into().unwrap(),
     );
-    let genesis_output = TxOutput::Transfer(
-        OutputValue::Coin(genesis_amount),
-        address.decode_object(chain_config.as_ref()).unwrap(),
-    );
+    let genesis_output =
+        TxOutput::Transfer(OutputValue::Coin(genesis_amount), address.decode_object());
 
     test_balance_from_genesis(chain_type, vec![genesis_output.clone()], genesis_amount);
 
     let genesis_amount_2 = Amount::from_atoms(54321);
     let genesis_output_2 = TxOutput::LockThenTransfer(
         OutputValue::Coin(genesis_amount_2),
-        address.decode_object(chain_config.as_ref()).unwrap(),
+        address.decode_object(),
         OutputTimeLock::UntilHeight(BlockHeight::zero()),
     );
 
@@ -665,8 +646,7 @@ fn wallet_balance_genesis() {
             );
 
             let genesis_amount = Amount::from_atoms(23456);
-            let genesis_output =
-                make_address_output(chain_config.as_ref(), address, genesis_amount).unwrap();
+            let genesis_output = make_address_output(address, genesis_amount);
 
             if address_index.into_u32() == LOOKAHEAD_SIZE {
                 test_balance_from_genesis(chain_type, vec![genesis_output], Amount::ZERO);
@@ -692,10 +672,8 @@ fn locked_wallet_balance_works(#[case] seed: Seed) {
         KeyPurpose::ReceiveFunds,
         0.try_into().unwrap(),
     );
-    let genesis_output = TxOutput::Transfer(
-        OutputValue::Coin(genesis_amount),
-        address.decode_object(chain_config.as_ref()).unwrap(),
-    );
+    let genesis_output =
+        TxOutput::Transfer(OutputValue::Coin(genesis_amount), address.decode_object());
     let genesis = Genesis::new(
         String::new(),
         BlockTimestamp::from_int_seconds(1639975460),
@@ -752,12 +730,7 @@ fn wallet_balance_block_reward() {
         block1.get_id().into(),
         chain_config.genesis_block().timestamp(),
         ConsensusData::None,
-        BlockReward::new(vec![make_address_output(
-            chain_config.as_ref(),
-            address,
-            block2_amount,
-        )
-        .unwrap()]),
+        BlockReward::new(vec![make_address_output(address, block2_amount)]),
     )
     .unwrap();
     let block2_id = block2.header().block_id();
@@ -787,12 +760,7 @@ fn wallet_balance_block_reward() {
         block1.get_id().into(),
         chain_config.genesis_block().timestamp(),
         ConsensusData::None,
-        BlockReward::new(vec![make_address_output(
-            chain_config.as_ref(),
-            address,
-            block2_amount_new,
-        )
-        .unwrap()]),
+        BlockReward::new(vec![make_address_output(address, block2_amount_new)]),
     )
     .unwrap();
     let block2_new_id = block2_new.header().block_id();
@@ -827,7 +795,7 @@ fn wallet_balance_block_transactions() {
     let transaction1 = Transaction::new(
         0,
         Vec::new(),
-        vec![make_address_output(chain_config.as_ref(), address, tx_amount1).unwrap()],
+        vec![make_address_output(address, tx_amount1)],
     )
     .unwrap();
     let signed_transaction1 = SignedTransaction::new(transaction1, Vec::new()).unwrap();
@@ -870,7 +838,7 @@ fn wallet_balance_parent_child_transactions() {
     let transaction1 = Transaction::new(
         0,
         Vec::new(),
-        vec![make_address_output(chain_config.as_ref(), address1, tx_amount1).unwrap()],
+        vec![make_address_output(address1, tx_amount1)],
     )
     .unwrap();
     let transaction_id1 = transaction1.get_id();
@@ -879,7 +847,7 @@ fn wallet_balance_parent_child_transactions() {
     let transaction2 = Transaction::new(
         0,
         vec![TxInput::from_utxo(OutPointSourceId::Transaction(transaction_id1), 0)],
-        vec![make_address_output(chain_config.as_ref(), address2, tx_amount2).unwrap()],
+        vec![make_address_output(address2, tx_amount2)],
     )
     .unwrap();
     let signed_transaction2 =
@@ -948,7 +916,7 @@ fn wallet_accounts_creation() {
             DEFAULT_ACCOUNT_INDEX,
             [TxOutput::Transfer(
                 OutputValue::Coin(Amount::from_atoms(1)),
-                acc1_pk.decode_object(&chain_config).unwrap(),
+                acc1_pk.decode_object(),
             )],
             SelectedInputs::Utxos(vec![]),
             BTreeMap::new(),
@@ -1035,7 +1003,7 @@ fn wallet_recover_new_account(#[case] seed: Seed) {
             let transaction1 = Transaction::new(
                 0,
                 Vec::new(),
-                vec![make_address_output(chain_config.as_ref(), address, tx_amount1).unwrap()],
+                vec![make_address_output(address, tx_amount1)],
             )
             .unwrap();
             let signed_transaction1 = SignedTransaction::new(transaction1, Vec::new()).unwrap();
@@ -1231,7 +1199,7 @@ fn wallet_list_mainchain_transactions(#[case] seed: Seed) {
     // Generate a new block which sends reward to the wallet
     let block1_amount = Amount::from_atoms(rng.gen_range(100000..1000000));
     let (addr, _) = create_block(&chain_config, &mut wallet, vec![], block1_amount, 0);
-    let dest = addr.decode_object(&chain_config).unwrap();
+    let dest = addr.decode_object();
 
     let coin_balance = get_coin_balance(&wallet);
     assert_eq!(coin_balance, block1_amount);
@@ -1400,7 +1368,7 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
                 KeyPurpose::ReceiveFunds,
                 idx.try_into().unwrap(),
             );
-            make_address_output(chain_config.as_ref(), address, utxo_amount).unwrap()
+            make_address_output(address, utxo_amount)
         })
         .collect_vec();
     let block1 = Block::new(
@@ -1542,7 +1510,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
                 amount: pool_amount,
                 margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
                 cost_per_block: Amount::ZERO,
-                decommission_key: decommission_key.decode_object(&chain_config).unwrap(),
+                decommission_key: decommission_key.decode_object(),
             },
         )
         .unwrap();
@@ -1562,10 +1530,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
     assert_eq!(pool_ids.len(), 1);
 
     let (pool_id, pool_data) = pool_ids.first().unwrap();
-    assert_eq!(
-        pool_data.decommission_key,
-        decommission_key.decode_object(&chain_config).unwrap()
-    );
+    assert_eq!(pool_data.decommission_key, decommission_key.decode_object());
     assert_eq!(
         &pool_data.utxo_outpoint,
         &UtxoOutPoint::new(OutPointSourceId::Transaction(stake_pool_transaction_id), 0)
@@ -1608,7 +1573,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
             common::primitives::Compact(0),
         ))),
         BlockReward::new(vec![TxOutput::ProduceBlockFromStake(
-            addr.decode_object(&chain_config).unwrap(),
+            addr.decode_object(),
             *pool_id,
         )]),
     )
@@ -1751,12 +1716,7 @@ fn send_to_unknown_delegation(#[case] seed: Seed) {
     let (delegation_id, delegation_tx) = wallet
         .create_delegation(
             DEFAULT_ACCOUNT_INDEX,
-            vec![make_create_delegation_output(
-                chain_config.as_ref(),
-                address.clone(),
-                unknown_pool_id,
-            )
-            .unwrap()],
+            vec![make_create_delegation_output(address.clone(), unknown_pool_id)],
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
@@ -1838,8 +1798,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
     let (delegation_id, delegation_tx) = wallet
         .create_delegation(
             DEFAULT_ACCOUNT_INDEX,
-            vec![make_create_delegation_output(chain_config.as_ref(), address.clone(), pool_id)
-                .unwrap()],
+            vec![make_create_delegation_output(address.clone(), pool_id)],
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
@@ -1860,10 +1819,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
     assert!(deleg_data.not_staked_yet);
     assert_eq!(deleg_data.last_nonce, None);
     assert_eq!(deleg_data.pool_id, pool_id);
-    assert_eq!(
-        deleg_data.destination,
-        address.decode_object(chain_config.as_ref()).unwrap()
-    );
+    assert_eq!(deleg_data.destination, address.decode_object());
 
     let delegation_stake_tx = wallet
         .create_transaction_to_addresses(
@@ -2066,7 +2022,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             number_of_decimals: rng.gen_range(1..18),
             metadata_uri: "http://uri".as_bytes().to_vec(),
             total_supply: common::chain::tokens::TokenTotalSupply::Unlimited,
-            authority: address2.decode_object(&chain_config).unwrap(),
+            authority: address2.decode_object(),
             is_freezable: common::chain::tokens::IsTokenFreezable::No,
         };
         let (issued_token_id, token_issuance_transaction) = wallet
@@ -2287,7 +2243,7 @@ fn check_tokens_v0_are_ignored(#[case] seed: Seed) {
                         amount_to_issue: Amount::from_atoms(rng.gen_range(1..10000)),
                     },
                 )))),
-                address2.decode_object(&chain_config).unwrap(),
+                address2.decode_object(),
             )],
             SelectedInputs::Utxos(vec![]),
             BTreeMap::new(),
@@ -2339,7 +2295,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
         number_of_decimals: rng.gen_range(1..18),
         metadata_uri: "http://uri".as_bytes().to_vec(),
         total_supply: common::chain::tokens::TokenTotalSupply::Fixed(fixed_max_amount),
-        authority: address2.decode_object(&chain_config).unwrap(),
+        authority: address2.decode_object(),
         is_freezable: common::chain::tokens::IsTokenFreezable::Yes,
     };
 
@@ -2622,7 +2578,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
         number_of_decimals: rng.gen_range(1..18),
         metadata_uri: "http://uri".as_bytes().to_vec(),
         total_supply: common::chain::tokens::TokenTotalSupply::Fixed(fixed_max_amount),
-        authority: address2.decode_object(&chain_config).unwrap(),
+        authority: address2.decode_object(),
         is_freezable: common::chain::tokens::IsTokenFreezable::No,
     };
     let (issued_token_id, token_issuance_transaction) = wallet
@@ -2660,7 +2616,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
 
     assert_eq!(
         unconfirmed_token_info.authority().unwrap(),
-        &address2.decode_object(&chain_config).unwrap()
+        &address2.decode_object()
     );
 
     assert_eq!(
@@ -2868,7 +2824,7 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
         number_of_decimals: rng.gen_range(1..18),
         metadata_uri: "http://uri".as_bytes().to_vec(),
         total_supply: common::chain::tokens::TokenTotalSupply::Unlimited,
-        authority: address2.decode_object(&chain_config).unwrap(),
+        authority: address2.decode_object(),
         is_freezable: common::chain::tokens::IsTokenFreezable::No,
     };
     let (issued_token_id, token_issuance_transaction) = wallet
@@ -2907,7 +2863,7 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
 
     assert_eq!(
         unconfirmed_token_info.authority().unwrap(),
-        &address2.decode_object(&chain_config).unwrap()
+        &address2.decode_object()
     );
 
     assert_eq!(
@@ -3056,7 +3012,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
         number_of_decimals: rng.gen_range(1..18),
         metadata_uri: "http://uri".as_bytes().to_vec(),
         total_supply: common::chain::tokens::TokenTotalSupply::Lockable,
-        authority: address2.decode_object(&chain_config).unwrap(),
+        authority: address2.decode_object(),
         is_freezable: common::chain::tokens::IsTokenFreezable::No,
     };
     let (issued_token_id, token_issuance_transaction) = wallet
@@ -3095,7 +3051,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
 
     assert_eq!(
         unconfirmed_token_info.authority().unwrap(),
-        &address2.decode_object(&chain_config).unwrap()
+        &address2.decode_object()
     );
 
     assert_eq!(
@@ -3299,12 +3255,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
         chain_config.genesis_block_id(),
         timestamp,
         ConsensusData::None,
-        BlockReward::new(vec![make_address_output(
-            chain_config.as_ref(),
-            address.clone(),
-            block1_amount,
-        )
-        .unwrap()]),
+        BlockReward::new(vec![make_address_output(address.clone(), block1_amount)]),
     )
     .unwrap();
 
@@ -3321,7 +3272,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
 
     let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
 
-    let destination = address2.decode_object(chain_config.as_ref()).unwrap();
+    let destination = address2.decode_object();
     let amount_fraction = (block1_amount.into_atoms() - NETWORK_FEE) / 10;
 
     let block_count_lock = rng.gen_range(1..10);
@@ -3355,12 +3306,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
         block1_id.into(),
         timestamp,
         ConsensusData::None,
-        BlockReward::new(vec![make_address_output(
-            chain_config.as_ref(),
-            address,
-            block1_amount,
-        )
-        .unwrap()]),
+        BlockReward::new(vec![make_address_output(address, block1_amount)]),
     )
     .unwrap();
 
@@ -3540,7 +3486,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             KeyPurpose::ReceiveFunds,
             (idx + 1).try_into().unwrap(),
         );
-        let change_output = make_address_output(chain_config.as_ref(), address, change).unwrap();
+        let change_output = make_address_output(address, change);
 
         let new_output = TxOutput::Transfer(
             OutputValue::Coin(amount_to_transfer),
@@ -3724,7 +3670,7 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
             KeyPurpose::ReceiveFunds,
             (idx + 1).try_into().unwrap(),
         );
-        let change_output = make_address_output(chain_config.as_ref(), address, change).unwrap();
+        let change_output = make_address_output(address, change);
 
         let new_output = TxOutput::Transfer(
             OutputValue::Coin(amount_to_transfer),
@@ -3928,7 +3874,7 @@ fn decommission_pool_wrong_account(#[case] seed: Seed) {
                 amount: pool_amount,
                 margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
                 cost_per_block: Amount::ZERO,
-                decommission_key: decommission_key.decode_object(&chain_config).unwrap(),
+                decommission_key: decommission_key.decode_object(),
             },
         )
         .unwrap();
@@ -4021,7 +3967,7 @@ fn decommission_pool_request_wrong_account(#[case] seed: Seed) {
                 amount: pool_amount,
                 margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
                 cost_per_block: Amount::ZERO,
-                decommission_key: decommission_key.decode_object(&chain_config).unwrap(),
+                decommission_key: decommission_key.decode_object(),
             },
         )
         .unwrap();
@@ -4107,7 +4053,7 @@ fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
                 amount: pool_amount,
                 margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
                 cost_per_block: Amount::ZERO,
-                decommission_key: decommission_key.decode_object(&chain_config).unwrap(),
+                decommission_key: decommission_key.decode_object(),
             },
         )
         .unwrap();
@@ -4212,7 +4158,7 @@ fn sign_decommission_pool_request_cold_wallet(#[case] seed: Seed) {
                 amount: pool_amount,
                 margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
                 cost_per_block: Amount::ZERO,
-                decommission_key: decommission_key.decode_object(&chain_config).unwrap(),
+                decommission_key: decommission_key.decode_object(),
             },
         )
         .unwrap();
@@ -4300,7 +4246,7 @@ fn filter_pools(#[case] seed: Seed) {
                 amount: pool_amount,
                 margin_ratio_per_thousand: PerThousand::new_from_rng(&mut rng),
                 cost_per_block: Amount::ZERO,
-                decommission_key: decommission_key.decode_object(&chain_config).unwrap(),
+                decommission_key: decommission_key.decode_object(),
             },
         )
         .unwrap();
@@ -4366,12 +4312,7 @@ fn sign_send_request_cold_wallet(#[case] seed: Seed) {
 
     // Generate a new block which sends reward to the cold wallet address
     let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
-    let reward_output = make_address_output(
-        chain_config.as_ref(),
-        cold_wallet_address.clone(),
-        block1_amount,
-    )
-    .unwrap();
+    let reward_output = make_address_output(cold_wallet_address.clone(), block1_amount);
     let block1 = Block::new(
         vec![],
         chain_config.genesis_block_id(),
@@ -4394,7 +4335,7 @@ fn sign_send_request_cold_wallet(#[case] seed: Seed) {
             DEFAULT_ACCOUNT_INDEX,
             [TxOutput::Transfer(
                 OutputValue::Coin(to_send),
-                hot_wallet_address.decode_object(&chain_config).unwrap(),
+                hot_wallet_address.decode_object(),
             )],
             SelectedInputs::Inputs(vec![(
                 UtxoOutPoint::new(OutPointSourceId::BlockReward(block1.get_id().into()), 0),
@@ -4459,7 +4400,7 @@ fn sign_send_request_cold_wallet(#[case] seed: Seed) {
     let (_, output, _) = utxos.pop().unwrap();
 
     matches!(output, TxOutput::Transfer(OutputValue::Coin(value), dest)
-            if value == balance && dest == cold_wallet_address.decode_object(&chain_config).unwrap());
+            if value == balance && dest == cold_wallet_address.decode_object());
 }
 
 #[rstest]
@@ -4477,8 +4418,7 @@ fn test_not_exhaustion_of_keys(#[case] seed: Seed) {
 
     // Generate a new block which sends reward to the cold wallet address
     let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
-    let reward_output =
-        make_address_output(chain_config.as_ref(), address.clone(), block1_amount).unwrap();
+    let reward_output = make_address_output(address.clone(), block1_amount);
     let block1 = Block::new(
         vec![],
         chain_config.genesis_block_id(),
@@ -4500,7 +4440,7 @@ fn test_not_exhaustion_of_keys(#[case] seed: Seed) {
                 DEFAULT_ACCOUNT_INDEX,
                 [TxOutput::Transfer(
                     OutputValue::Coin(Amount::from_atoms(1)),
-                    address.decode_object(&chain_config).unwrap(),
+                    address.decode_object(),
                 )],
                 SelectedInputs::Inputs(vec![]),
                 [].into(),

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -468,7 +468,7 @@ macro_rules! impl_write_ops {
                 id: &AccountDerivationPathId,
                 address: &Address<Destination>,
             ) -> crate::Result<()> {
-                self.write::<db::DBAddresses, _, _, _>(id, address.get().to_owned())
+                self.write::<db::DBAddresses, _, _, _>(id, address.to_string())
             }
 
             fn del_address(&mut self, id: &AccountDerivationPathId) -> crate::Result<()> {

--- a/wallet/types/src/wallet_tx.rs
+++ b/wallet/types/src/wallet_tx.rs
@@ -191,8 +191,16 @@ impl TxData {
         &self.tx
     }
 
+    pub fn into_signed_transaction(self) -> SignedTransaction {
+        self.tx
+    }
+
     pub fn get_transaction(&self) -> &Transaction {
         self.tx.transaction()
+    }
+
+    pub fn into_transaction(self) -> Transaction {
+        self.tx.take_transaction()
     }
 
     pub fn get_transaction_with_id(&self) -> WithId<&Transaction> {

--- a/wallet/wallet-address-generator-lib/src/lib.rs
+++ b/wallet/wallet-address-generator-lib/src/lib.rs
@@ -151,7 +151,7 @@ fn generate_addresses(
 
             Ok(Address::new(
                 &chain_config,
-                &Destination::PublicKeyHash(public_key_hash),
+                Destination::PublicKeyHash(public_key_hash),
             )?)
         })
         .collect::<WalletResult<Vec<_>>>()

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -338,14 +338,18 @@ where
                 let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
                 let public_key =
                     wallet.reveal_public_key(selected_account, public_key_hash).await?;
-                Ok(ConsoleCommand::Print(public_key.public_key_address))
+                Ok(ConsoleCommand::Print(
+                    public_key.public_key_address.to_string(),
+                ))
             }
 
             ColdWalletCommand::RevealPublicKeyHex { public_key_hash } => {
                 let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
                 let public_key =
                     wallet.reveal_public_key(selected_account, public_key_hash).await?;
-                Ok(ConsoleCommand::Print(public_key.public_key_hex))
+                Ok(ConsoleCommand::Print(
+                    public_key.public_key_hex.hex_encode(),
+                ))
             }
 
             ColdWalletCommand::ShowReceiveAddresses => {
@@ -1266,7 +1270,7 @@ where
                     .into_iter()
                     .map(|info| {
                         format_delegation_info(
-                            info.delegation_id,
+                            info.delegation_id.to_string(),
                             info.balance.decimal().to_string(),
                         )
                     })

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -887,7 +887,7 @@ where
                 let mut output = format!("Coins amount: {coins}\n");
 
                 for (token_id, amount) in tokens {
-                    let token_id = Address::new(chain_config, &token_id)
+                    let token_id = Address::new(chain_config, token_id)
                         .expect("Encoding token id should never fail");
                     let amount = amount.decimal();
                     writeln!(&mut output, "Token: {token_id} amount: {amount}")
@@ -1385,7 +1385,7 @@ fn format_fees(output: &mut String, fees: Balances, chain_config: &ChainConfig) 
 
     for (token_id, amount) in tokens {
         let token_id =
-            Address::new(chain_config, &token_id).expect("Encoding token id should never fail");
+            Address::new(chain_config, token_id).expect("Encoding token id should never fail");
         let amount = amount.decimal();
         writeln!(output, "Token: {token_id} amount: {amount}")
             .expect("Writing to a memory buffer should not fail");

--- a/wallet/wallet-cli-lib/src/commands/helper_types.rs
+++ b/wallet/wallet-cli-lib/src/commands/helper_types.rs
@@ -235,7 +235,7 @@ pub fn parse_output<N: NodeInterface>(
         .map_err(|err| {
             WalletCliError::<N>::InvalidInput(format!("invalid address {} {err}", parts[1]))
         })?
-        .decode_object();
+        .into_object();
 
     let amount = DecimalAmount::from_str(parts[2])
         .map_err(|err| {

--- a/wallet/wallet-cli-lib/src/commands/helper_types.rs
+++ b/wallet/wallet-cli-lib/src/commands/helper_types.rs
@@ -232,10 +232,10 @@ pub fn parse_output<N: NodeInterface>(
     }
 
     let dest = Address::from_str(chain_config, parts[1])
-        .and_then(|addr| addr.decode_object(chain_config))
         .map_err(|err| {
             WalletCliError::<N>::InvalidInput(format!("invalid address {} {err}", parts[1]))
-        })?;
+        })?
+        .decode_object();
 
     let amount = DecimalAmount::from_str(parts[2])
         .map_err(|err| {

--- a/wallet/wallet-cli-lib/tests/basic.rs
+++ b/wallet/wallet-cli-lib/tests/basic.rs
@@ -149,7 +149,7 @@ async fn produce_blocks_decommission_genesis_pool(#[case] seed: Seed) {
     let pool_id: PoolId = H256::zero().into();
     let output = test.exec(&format!(
         "staking-decommission-pool-request {} {address}",
-        Address::new(&test.chain_config, &pool_id).unwrap(),
+        Address::new(&test.chain_config, pool_id).unwrap(),
     ));
     let req = output.lines().nth(2).unwrap();
 

--- a/wallet/wallet-controller/src/read.rs
+++ b/wallet/wallet-controller/src/read.rs
@@ -249,7 +249,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
             .and_then(|balance| {
                 balance.ok_or(ControllerError::SyncError(format!(
                     "Pool id {} from wallet not found in node",
-                    Address::new(self.chain_config, &pool_id)?
+                    Address::new(self.chain_config, pool_id)?
                 )))
             })
             .log_err()?;
@@ -261,7 +261,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
             .and_then(|balance| {
                 balance.ok_or(ControllerError::SyncError(format!(
                     "Pool id {} from wallet not found in node",
-                    Address::new(self.chain_config, &pool_id)?
+                    Address::new(self.chain_config, pool_id)?
                 )))
             })
             .map(|pledge| (pool_id, pool_data, balance, pledge))
@@ -302,7 +302,7 @@ impl<'a, T: NodeInterface> ReadOnlyController<'a, T> {
                     .into_iter()
                     .map(|(height, id, pool_id)| {
                         let pool_id =
-                            Address::new(self.chain_config, &pool_id).expect("addressable");
+                            Address::new(self.chain_config, pool_id).expect("addressable");
 
                         CreatedBlockInfo {
                             height,

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -221,7 +221,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
                         number_of_decimals,
                         metadata_uri,
                         total_supply: token_total_supply,
-                        authority: address.decode_object(),
+                        authority: address.into_object(),
                         is_freezable,
                     }),
                     current_fee_rate,
@@ -565,7 +565,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
                         Box::new(utxo_output.clone()),
                     ))
                 })?;
-            Address::new(self.chain_config, &utxo_dest).expect("addressable")
+            Address::new(self.chain_config, utxo_dest).expect("addressable")
         };
 
         let selected_inputs = SelectedInputs::Inputs(vec![(selected_utxo, utxo_output)]);

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -209,8 +209,6 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         token_total_supply: TokenTotalSupply,
         is_freezable: IsTokenFreezable,
     ) -> Result<(SignedTransaction, TokenId), ControllerError<T>> {
-        let destination = address.decode_object(self.chain_config.as_ref())?;
-
         self.create_and_send_tx_with_id(
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
@@ -223,7 +221,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
                         number_of_decimals,
                         metadata_uri,
                         total_supply: token_total_supply,
-                        authority: destination,
+                        authority: address.decode_object(),
                         is_freezable,
                     }),
                     current_fee_rate,
@@ -442,8 +440,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     ) -> Result<SignedTransaction, ControllerError<T>> {
         self.check_tokens_in_selected_utxo(&selected_utxos).await?;
 
-        let output = make_address_output(self.chain_config, address, amount)
-            .map_err(ControllerError::WalletError)?;
+        let output = make_address_output(address, amount);
         self.create_and_send_tx(
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
@@ -556,8 +553,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         selected_utxo: UtxoOutPoint,
         change_address: Option<Address<Destination>>,
     ) -> Result<(PartiallySignedTransaction, Balances), ControllerError<T>> {
-        let output = make_address_output(self.chain_config, address, amount)
-            .map_err(ControllerError::WalletError)?;
+        let output = make_address_output(address, amount);
 
         let utxo_output = self.fetch_utxo(&selected_utxo).await?;
         let change_address = if let Some(change_address) = change_address {
@@ -602,8 +598,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         address: Address<Destination>,
         pool_id: PoolId,
     ) -> Result<(SignedTransaction, DelegationId), ControllerError<T>> {
-        let output = make_create_delegation_output(self.chain_config, address, pool_id)
-            .map_err(ControllerError::WalletError)?;
+        let output = make_create_delegation_output(address, pool_id);
         self.create_and_send_tx_with_id(
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
@@ -695,9 +690,7 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
         address: Address<Destination>,
         amount: Amount,
     ) -> Result<SignedTransaction, ControllerError<T>> {
-        let output =
-            make_address_output_token(self.chain_config, address, amount, token_info.token_id())
-                .map_err(ControllerError::WalletError)?;
+        let output = make_address_output_token(address, amount, token_info.token_id());
         self.create_and_send_token_tx(
             &token_info,
             move |current_fee_rate: FeeRate,

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -128,15 +128,15 @@ impl NodeInterface for NodeRpcClient {
     }
 
     async fn get_stake_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {
-        let pool_address = Address::new(&self.chain_config, &pool_id)?;
-        ChainstateRpcClient::stake_pool_balance(&self.http_client, pool_address.to_string())
+        let pool_address = Address::new(&self.chain_config, pool_id)?;
+        ChainstateRpcClient::stake_pool_balance(&self.http_client, pool_address.into_string())
             .await
             .map_err(NodeRpcError::ResponseError)
     }
 
     async fn get_staker_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {
-        let pool_address = Address::new(&self.chain_config, &pool_id)?;
-        ChainstateRpcClient::staker_balance(&self.http_client, pool_address.to_string())
+        let pool_address = Address::new(&self.chain_config, pool_id)?;
+        ChainstateRpcClient::staker_balance(&self.http_client, pool_address.into_string())
             .await
             .map_err(NodeRpcError::ResponseError)
     }
@@ -146,15 +146,15 @@ impl NodeInterface for NodeRpcClient {
         pool_id: PoolId,
         delegation_id: DelegationId,
     ) -> Result<Option<Amount>, Self::Error> {
-        let pool_address = Address::new(&self.chain_config, &pool_id)?.to_string();
-        let delegation_address = Address::new(&self.chain_config, &delegation_id)?.to_string();
+        let pool_address = Address::new(&self.chain_config, pool_id)?.into_string();
+        let delegation_address = Address::new(&self.chain_config, delegation_id)?.into_string();
         ChainstateRpcClient::delegation_share(&self.http_client, pool_address, delegation_address)
             .await
             .map_err(NodeRpcError::ResponseError)
     }
 
     async fn get_token_info(&self, token_id: TokenId) -> Result<Option<RPCTokenInfo>, Self::Error> {
-        let token_id = Address::new(&self.chain_config, &token_id)?.to_string();
+        let token_id = Address::new(&self.chain_config, token_id)?.into_string();
         ChainstateRpcClient::token_info(&self.http_client, token_id)
             .await
             .map_err(NodeRpcError::ResponseError)

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -219,9 +219,13 @@ impl WalletInterface for ClientWalletRpc {
         account_index: U31,
         address: String,
     ) -> Result<PublicKeyInfo, Self::Error> {
-        ColdWalletRpcClient::reveal_public_key(&self.http_client, account_index.into(), address)
-            .await
-            .map_err(WalletRpcError::ResponseError)
+        ColdWalletRpcClient::reveal_public_key(
+            &self.http_client,
+            account_index.into(),
+            address.into(),
+        )
+        .await
+        .map_err(WalletRpcError::ResponseError)
     }
 
     async fn get_balance(
@@ -272,7 +276,7 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::send_coins(
             &self.http_client,
             account_index.into(),
-            address,
+            address.into(),
             amount.into(),
             selected_utxos,
             options,
@@ -294,8 +298,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::sweep_addresses(
             &self.http_client,
             account_index.into(),
-            destination_address,
-            from_addresses,
+            destination_address.into(),
+            from_addresses.into_iter().map(Into::into).collect(),
             options,
         )
         .await
@@ -315,8 +319,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::sweep_delegation(
             &self.http_client,
             account_index.into(),
-            destination_address,
-            delegation_id,
+            destination_address.into(),
+            delegation_id.into(),
             options,
         )
         .await
@@ -338,10 +342,10 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::transaction_from_cold_input(
             &self.http_client,
             account_index.into(),
-            address,
+            address.into(),
             amount.into(),
             selected_utxo,
-            change_address,
+            change_address.map(Into::into),
             options,
         )
         .await
@@ -352,7 +356,7 @@ impl WalletInterface for ClientWalletRpc {
         &self,
         transaction: String,
     ) -> Result<InspectTransaction, Self::Error> {
-        WalletRpcClient::transaction_inspect(&self.http_client, transaction)
+        WalletRpcClient::transaction_inspect(&self.http_client, transaction.parse()?)
             .await
             .map_err(WalletRpcError::ResponseError)
     }
@@ -375,7 +379,7 @@ impl WalletInterface for ClientWalletRpc {
             amount.into(),
             cost_per_block.into(),
             margin_ratio_per_thousand,
-            decommission_address,
+            decommission_address.into(),
             options,
         )
         .await
@@ -395,8 +399,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::decommission_stake_pool(
             &self.http_client,
             account_index.into(),
-            pool_id,
-            output_address,
+            pool_id.into(),
+            output_address.map(Into::into),
             options,
         )
         .await
@@ -416,8 +420,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::decommission_stake_pool_request(
             &self.http_client,
             account_index.into(),
-            pool_id,
-            output_address,
+            pool_id.into(),
+            output_address.map(Into::into),
             options,
         )
         .await
@@ -437,8 +441,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::create_delegation(
             &self.http_client,
             account_index.into(),
-            address,
-            pool_id,
+            address.into(),
+            pool_id.into(),
             options,
         )
         .await
@@ -459,7 +463,7 @@ impl WalletInterface for ClientWalletRpc {
             &self.http_client,
             account_index.into(),
             amount.into(),
-            delegation_id,
+            delegation_id.into(),
             options,
         )
         .await
@@ -480,9 +484,9 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::withdraw_from_delegation(
             &self.http_client,
             account_index.into(),
-            address,
+            address.into(),
             amount.into(),
-            delegation_id,
+            delegation_id.into(),
             options,
         )
         .await
@@ -523,7 +527,7 @@ impl WalletInterface for ClientWalletRpc {
     }
 
     async fn stake_pool_balance(&self, pool_id: String) -> Result<StakePoolBalance, Self::Error> {
-        WalletRpcClient::stake_pool_balance(&self.http_client, pool_id)
+        WalletRpcClient::stake_pool_balance(&self.http_client, pool_id.into())
             .await
             .map_err(WalletRpcError::ResponseError)
     }
@@ -586,7 +590,7 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::issue_new_nft(
             &self.http_client,
             account_index.into(),
-            destination_address,
+            destination_address.into(),
             metadata,
             options,
         )
@@ -607,7 +611,7 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::issue_new_token(
             &self.http_client,
             account_index.into(),
-            destination_address,
+            destination_address.into(),
             metadata,
             options,
         )
@@ -628,8 +632,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::change_token_authority(
             &self.http_client,
             account_index.into(),
-            token_id,
-            address,
+            token_id.into(),
+            address.into(),
             options,
         )
         .await
@@ -650,8 +654,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::mint_tokens(
             &self.http_client,
             account_index.into(),
-            token_id,
-            address,
+            token_id.into(),
+            address.into(),
             amount.into(),
             options,
         )
@@ -672,7 +676,7 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::unmint_tokens(
             &self.http_client,
             account_index.into(),
-            token_id,
+            token_id.into(),
             amount.into(),
             options,
         )
@@ -692,7 +696,7 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::lock_token_supply(
             &self.http_client,
             account_index.into(),
-            token_id,
+            token_id.into(),
             options,
         )
         .await
@@ -712,7 +716,7 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::freeze_token(
             &self.http_client,
             account_index.into(),
-            token_id,
+            token_id.into(),
             is_unfreezable,
             options,
         )
@@ -729,9 +733,14 @@ impl WalletInterface for ClientWalletRpc {
         let options = TransactionOptions {
             in_top_x_mb: config.in_top_x_mb,
         };
-        WalletRpcClient::unfreeze_token(&self.http_client, account_index.into(), token_id, options)
-            .await
-            .map_err(WalletRpcError::ResponseError)
+        WalletRpcClient::unfreeze_token(
+            &self.http_client,
+            account_index.into(),
+            token_id.into(),
+            options,
+        )
+        .await
+        .map_err(WalletRpcError::ResponseError)
     }
 
     async fn send_tokens(
@@ -748,8 +757,8 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::send_tokens(
             &self.http_client,
             account_index.into(),
-            token_id,
-            address,
+            token_id.into(),
+            address.into(),
             amount.into(),
             options,
         )
@@ -766,9 +775,14 @@ impl WalletInterface for ClientWalletRpc {
         let options = TransactionOptions {
             in_top_x_mb: config.in_top_x_mb,
         };
-        WalletRpcClient::deposit_data(&self.http_client, account_index.into(), data, options)
-            .await
-            .map_err(WalletRpcError::ResponseError)
+        WalletRpcClient::deposit_data(
+            &self.http_client,
+            account_index.into(),
+            data.parse()?,
+            options,
+        )
+        .await
+        .map_err(WalletRpcError::ResponseError)
     }
 
     async fn node_version(&self) -> Result<NodeVersion, Self::Error> {
@@ -907,7 +921,7 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::list_transactions_by_address(
             &self.http_client,
             account_index.into(),
-            address,
+            address.map(Into::into),
             limit,
         )
         .await
@@ -919,13 +933,9 @@ impl WalletInterface for ClientWalletRpc {
         account_index: U31,
         transaction_id: Id<Transaction>,
     ) -> Result<serde_json::Value, Self::Error> {
-        WalletRpcClient::get_transaction(
-            &self.http_client,
-            account_index.into(),
-            HexEncoded::new(transaction_id),
-        )
-        .await
-        .map_err(WalletRpcError::ResponseError)
+        WalletRpcClient::get_transaction(&self.http_client, account_index.into(), transaction_id)
+            .await
+            .map_err(WalletRpcError::ResponseError)
     }
 
     async fn get_raw_transaction(
@@ -936,10 +946,11 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::get_raw_transaction(
             &self.http_client,
             account_index.into(),
-            HexEncoded::new(transaction_id),
+            transaction_id,
         )
         .await
         .map_err(WalletRpcError::ResponseError)
+        .map(|obj| obj.to_string())
     }
 
     async fn get_raw_signed_transaction(
@@ -950,10 +961,11 @@ impl WalletInterface for ClientWalletRpc {
         WalletRpcClient::get_raw_signed_transaction(
             &self.http_client,
             account_index.into(),
-            HexEncoded::new(transaction_id),
+            transaction_id,
         )
         .await
         .map_err(WalletRpcError::ResponseError)
+        .map(|obj| obj.to_string())
     }
 
     async fn sign_raw_transaction(
@@ -968,7 +980,7 @@ impl WalletInterface for ClientWalletRpc {
         ColdWalletRpcClient::sign_raw_transaction(
             &self.http_client,
             account_index.into(),
-            raw_tx,
+            raw_tx.parse()?,
             options,
         )
         .await
@@ -998,10 +1010,11 @@ impl WalletInterface for ClientWalletRpc {
             &self.http_client,
             account_index.into(),
             challenge,
-            address,
+            address.into(),
         )
         .await
         .map_err(WalletRpcError::ResponseError)
+        .map(|h| h.to_string())
     }
 
     async fn sign_challenge_hex(
@@ -1013,11 +1026,12 @@ impl WalletInterface for ClientWalletRpc {
         ColdWalletRpcClient::sign_challenge_hex(
             &self.http_client,
             account_index.into(),
-            challenge,
-            address,
+            challenge.parse()?,
+            address.into(),
         )
         .await
         .map_err(WalletRpcError::ResponseError)
+        .map(|h| h.to_string())
     }
 
     async fn verify_challenge(
@@ -1026,9 +1040,14 @@ impl WalletInterface for ClientWalletRpc {
         signed_challenge: String,
         address: String,
     ) -> Result<(), Self::Error> {
-        ColdWalletRpcClient::verify_challenge(&self.http_client, message, signed_challenge, address)
-            .await
-            .map_err(WalletRpcError::ResponseError)
+        ColdWalletRpcClient::verify_challenge(
+            &self.http_client,
+            message,
+            signed_challenge.parse()?,
+            address.into(),
+        )
+        .await
+        .map_err(WalletRpcError::ResponseError)
     }
 
     async fn verify_challenge_hex(
@@ -1039,9 +1058,9 @@ impl WalletInterface for ClientWalletRpc {
     ) -> Result<(), Self::Error> {
         ColdWalletRpcClient::verify_challenge_hex(
             &self.http_client,
-            message,
-            signed_challenge,
-            address,
+            message.parse()?,
+            signed_challenge.parse()?,
+            address.into(),
         )
         .await
         .map_err(WalletRpcError::ResponseError)
@@ -1100,9 +1119,10 @@ impl WalletInterface for ClientWalletRpc {
     }
 
     async fn node_block(&self, block_id: String) -> Result<Option<String>, Self::Error> {
-        WalletRpcClient::node_block(&self.http_client, block_id)
+        WalletRpcClient::node_block(&self.http_client, block_id.parse::<HexEncoded<_>>()?.take())
             .await
             .map_err(WalletRpcError::ResponseError)
+            .map(|r| r.map(|b| b.to_string()))
     }
 
     async fn node_get_block_ids_as_checkpoints(

--- a/wallet/wallet-rpc-client/src/rpc_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/mod.rs
@@ -34,6 +34,12 @@ pub enum WalletRpcError {
     ResponseError(ClientError),
 }
 
+impl From<hex::FromHexError> for WalletRpcError {
+    fn from(value: hex::FromHexError) -> Self {
+        Self::DecodingError(value.into())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ClientWalletRpc {
     http_client: RpcHttpClient,

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -178,7 +178,7 @@ Parameters:
 ```
 {
     "account": number,
-    "address": string,
+    "address": bech32 string,
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
@@ -208,8 +208,8 @@ Parameters:
 ```
 {
     "account": number,
-    "destination_address": string,
-    "from_addresses": [ string, .. ],
+    "destination_address": bech32 string,
+    "from_addresses": [ bech32 string, .. ],
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -229,8 +229,8 @@ Parameters:
 ```
 {
     "account": number,
-    "destination_address": string,
-    "delegation_id": string,
+    "destination_address": bech32 string,
+    "delegation_id": bech32 string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -256,7 +256,7 @@ Parameters:
 ```
 {
     "account": number,
-    "address": string,
+    "address": bech32 string,
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
@@ -267,7 +267,7 @@ Parameters:
         "index": number,
     },
     "change_address": EITHER OF
-         1) string
+         1) bech32 string
          2) null,
     "options": { "in_top_x_mb": number },
 }
@@ -297,7 +297,7 @@ Print the summary of the transaction
 
 Parameters:
 ```
-{ "transaction": string }
+{ "transaction": hex string }
 ```
 
 Returns:
@@ -352,7 +352,7 @@ Parameters:
          1) { "atoms": number string }
          2) { "decimal": decimal string },
     "margin_ratio_per_thousand": string,
-    "decommission_address": string,
+    "decommission_address": bech32 string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -372,9 +372,9 @@ Parameters:
 ```
 {
     "account": number,
-    "pool_id": string,
+    "pool_id": bech32 string,
     "output_address": EITHER OF
-         1) string
+         1) bech32 string
          2) null,
     "options": { "in_top_x_mb": number },
 }
@@ -397,9 +397,9 @@ Parameters:
 ```
 {
     "account": number,
-    "pool_id": string,
+    "pool_id": bech32 string,
     "output_address": EITHER OF
-         1) string
+         1) bech32 string
          2) null,
     "options": { "in_top_x_mb": number },
 }
@@ -422,8 +422,8 @@ Parameters:
 ```
 {
     "account": number,
-    "address": string,
-    "pool_id": string,
+    "address": bech32 string,
+    "pool_id": bech32 string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -448,7 +448,7 @@ Parameters:
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
-    "delegation_id": string,
+    "delegation_id": bech32 string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -468,11 +468,11 @@ Parameters:
 ```
 {
     "account": number,
-    "address": string,
+    "address": bech32 string,
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
-    "delegation_id": string,
+    "delegation_id": bech32 string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -542,7 +542,7 @@ Parameters:
 Returns:
 ```
 [ {
-    "pool_id": string,
+    "pool_id": bech32 string,
     "pledge": {
         "atoms": number string,
         "decimal": decimal string,
@@ -553,9 +553,9 @@ Returns:
     },
     "height": number,
     "block_timestamp": { "timestamp": number },
-    "vrf_public_key": string,
-    "decommission_key": string,
-    "staker": string,
+    "vrf_public_key": bech32 string,
+    "decommission_key": bech32 string,
+    "staker": bech32 string,
 }, .. ]
 ```
 
@@ -572,7 +572,7 @@ Parameters:
 Returns:
 ```
 [ {
-    "pool_id": string,
+    "pool_id": bech32 string,
     "pledge": {
         "atoms": number string,
         "decimal": decimal string,
@@ -583,9 +583,9 @@ Returns:
     },
     "height": number,
     "block_timestamp": { "timestamp": number },
-    "vrf_public_key": string,
-    "decommission_key": string,
-    "staker": string,
+    "vrf_public_key": bech32 string,
+    "decommission_key": bech32 string,
+    "staker": bech32 string,
 }, .. ]
 ```
 
@@ -596,7 +596,7 @@ Print the balance of available staking pools
 
 Parameters:
 ```
-{ "pool_id": string }
+{ "pool_id": bech32 string }
 ```
 
 Returns:
@@ -655,7 +655,7 @@ Parameters:
 ```
 {
     "account": number,
-    "destination_address": string,
+    "destination_address": bech32 string,
     "metadata": {
         "media_hash": string,
         "name": EITHER OF
@@ -704,7 +704,7 @@ Parameters:
 ```
 {
     "account": number,
-    "destination_address": string,
+    "destination_address": bech32 string,
     "metadata": {
         "token_ticker": EITHER OF
              1) string
@@ -742,8 +742,8 @@ Parameters:
 ```
 {
     "account": number,
-    "token_id": string,
-    "address": string,
+    "token_id": bech32 string,
+    "address": bech32 string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -762,8 +762,8 @@ Parameters:
 ```
 {
     "account": number,
-    "token_id": string,
-    "address": string,
+    "token_id": bech32 string,
+    "address": bech32 string,
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
@@ -787,7 +787,7 @@ Parameters:
 ```
 {
     "account": number,
-    "token_id": string,
+    "token_id": bech32 string,
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
@@ -810,7 +810,7 @@ Parameters:
 ```
 {
     "account_index": number,
-    "token_id": string,
+    "token_id": bech32 string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -832,7 +832,7 @@ Parameters:
 ```
 {
     "account": number,
-    "token_id": string,
+    "token_id": bech32 string,
     "is_unfreezable": bool,
     "options": { "in_top_x_mb": number },
 }
@@ -855,7 +855,7 @@ Parameters:
 ```
 {
     "account": number,
-    "token_id": string,
+    "token_id": bech32 string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -874,8 +874,8 @@ Parameters:
 ```
 {
     "account": number,
-    "token_id": string,
-    "address": string,
+    "token_id": bech32 string,
+    "address": bech32 string,
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
@@ -898,7 +898,7 @@ Parameters:
 ```
 {
     "account": number,
-    "data": string,
+    "data": hex string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -1239,7 +1239,7 @@ Parameters:
 {
     "account": number,
     "address": EITHER OF
-         1) string
+         1) bech32 string
          2) null,
     "limit": number,
 }
@@ -1287,7 +1287,7 @@ Parameters:
 
 Returns:
 ```
-string
+hex string
 ```
 
 ### Method `transaction_get_signed_raw`
@@ -1305,7 +1305,7 @@ Parameters:
 
 Returns:
 ```
-string
+hex string
 ```
 
 ### Method `transaction_compose`
@@ -1435,13 +1435,13 @@ Get a block by its hash, represented with hex encoded bytes
 
 Parameters:
 ```
-{ "block_id": string }
+{ "block_id": hex string }
 ```
 
 Returns:
 ```
 EITHER OF
-     1) string
+     1) hex string
      2) null
 ```
 
@@ -1733,7 +1733,7 @@ Parameters:
 Returns:
 ```
 [ {
-    "address": string,
+    "address": bech32 string,
     "index": string,
     "used": bool,
 }, .. ]
@@ -1768,7 +1768,7 @@ Parameters:
 ```
 {
     "account": number,
-    "address": string,
+    "address": bech32 string,
 }
 ```
 
@@ -1797,7 +1797,7 @@ Parameters:
 Returns:
 ```
 {
-    "vrf_public_key": hex string,
+    "vrf_public_key": bech32 string,
     "child_number": number,
     "used": bool,
 }
@@ -1835,7 +1835,7 @@ Parameters:
 Returns:
 ```
 [ {
-    "vrf_public_key": hex string,
+    "vrf_public_key": bech32 string,
     "child_number": number,
     "used": bool,
 }, .. ]
@@ -1853,7 +1853,7 @@ Parameters:
 ```
 {
     "account": number,
-    "raw_tx": string,
+    "raw_tx": hex string,
     "options": { "in_top_x_mb": number },
 }
 ```
@@ -1876,13 +1876,13 @@ Parameters:
 {
     "account": number,
     "challenge": string,
-    "address": string,
+    "address": bech32 string,
 }
 ```
 
 Returns:
 ```
-string
+hex string
 ```
 
 ### Method `challenge_sign_hex`
@@ -1894,14 +1894,14 @@ Parameters:
 ```
 {
     "account": number,
-    "challenge": string,
-    "address": string,
+    "challenge": hex string,
+    "address": bech32 string,
 }
 ```
 
 Returns:
 ```
-string
+hex string
 ```
 
 ### Method `challenge_verify_plain`
@@ -1913,8 +1913,8 @@ Parameters:
 ```
 {
     "message": string,
-    "signed_challenge": string,
-    "address": string,
+    "signed_challenge": hex string,
+    "address": bech32 string,
 }
 ```
 
@@ -1931,9 +1931,9 @@ Verifies a signed challenge against an address destination
 Parameters:
 ```
 {
-    "message": string,
-    "signed_challenge": string,
-    "address": string,
+    "message": hex string,
+    "signed_challenge": hex string,
+    "address": bech32 string,
 }
 ```
 

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -836,7 +836,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
             .await?
             .map(|(tx, delegation_id)| NewDelegation {
                 tx_id: tx.transaction().get_id(),
-                delegation_id: RpcAddress::new(&self.chain_config, &delegation_id)
+                delegation_id: RpcAddress::new(&self.chain_config, delegation_id)
                     .expect("addressable delegation id"),
             })
     }
@@ -1033,7 +1033,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
             .await?
             .map(|(tx, token_id)| RpcTokenId {
                 tx_id: tx.transaction().get_id(),
-                token_id: RpcAddress::new(&self.chain_config, &token_id)
+                token_id: RpcAddress::new(&self.chain_config, token_id)
                     .expect("Encoding token id should never fail"),
             })
     }
@@ -1059,7 +1059,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
             .await?
             .map(|(tx, token_id)| RpcTokenId {
                 tx_id: tx.transaction().get_id(),
-                token_id: RpcAddress::new(&self.chain_config, &token_id)
+                token_id: RpcAddress::new(&self.chain_config, token_id)
                     .expect("Encoding token id should never fail"),
             })
     }

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -569,7 +569,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidPoolId)?;
         let destination_address = destination_address
-            .to_address(self.chain_config())
+            .into_address(self.chain_config())
             .map_err(|_| RpcError::InvalidAddress)?;
 
         self.wallet
@@ -598,7 +598,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         let decimals = self.chain_config.coin_decimals();
         let amount = amount.to_amount(decimals).ok_or(RpcError::InvalidCoinAmount)?;
         let address =
-            address.to_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
+            address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
 
         self.wallet
             .call_async(move |controller| {
@@ -627,9 +627,9 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         let decimals = self.chain_config.coin_decimals();
         let amount = amount.to_amount(decimals).ok_or(RpcError::InvalidCoinAmount)?;
         let address =
-            address.to_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
+            address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
         let change_address = change_address
-            .map(|change| change.to_address(&self.chain_config))
+            .map(|change| change.into_address(&self.chain_config))
             .transpose()
             .map_err(|_| RpcError::InvalidAddress)?;
 
@@ -689,7 +689,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
         let address =
-            address.to_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
+            address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
 
         self.wallet
             .call_async(move |controller| {
@@ -817,7 +817,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         config: ControllerConfig,
     ) -> WRpcResult<NewDelegation, N> {
         let address =
-            address.to_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
+            address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
 
         let pool_id =
             pool_id.decode_object(&self.chain_config).map_err(|_| RpcError::InvalidPoolId)?;
@@ -881,7 +881,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         let decimals = self.chain_config.coin_decimals();
         let amount = amount.to_amount(decimals).ok_or(RpcError::InvalidCoinAmount)?;
         let address =
-            address.to_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
+            address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
         let delegation_id = delegation_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidDelegationId)?;
@@ -1011,7 +1011,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         );
 
         let destination_address = destination_address
-            .to_address(&self.chain_config)
+            .into_address(&self.chain_config)
             .map_err(|_| RpcError::InvalidAddress)?;
 
         self.wallet
@@ -1046,7 +1046,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         config: ControllerConfig,
     ) -> WRpcResult<RpcTokenId, N> {
         let address =
-            address.to_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
+            address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
         self.wallet
             .call_async(move |w| {
                 Box::pin(async move {
@@ -1076,7 +1076,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
         let address =
-            address.to_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
+            address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
 
         self.wallet
             .call_async(move |w| {
@@ -1216,7 +1216,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
         let address =
-            address.to_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
+            address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
         self.wallet
             .call_async(move |w| {
                 Box::pin(async move {

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -170,7 +170,7 @@ pub struct PublicKeyInfo {
 impl PublicKeyInfo {
     pub fn new(pub_key: PublicKey, chain_config: &ChainConfig) -> Self {
         let public_key_address =
-            RpcAddress::new(chain_config, &Destination::PublicKey(pub_key.clone()))
+            RpcAddress::new(chain_config, Destination::PublicKey(pub_key.clone()))
                 .expect("addressable");
         Self {
             public_key_hex: pub_key,
@@ -261,16 +261,16 @@ impl PoolInfo {
         let pledge = RpcAmountOut::from_amount_no_padding(pledge, decimals);
 
         Self {
-            pool_id: RpcAddress::new(chain_config, &pool_id).expect("addressable"),
+            pool_id: RpcAddress::new(chain_config, pool_id).expect("addressable"),
             balance,
             pledge,
             height: pool_data.creation_block.height,
             block_timestamp: pool_data.creation_block.timestamp,
-            vrf_public_key: RpcAddress::new(chain_config, &pool_data.vrf_public_key)
+            vrf_public_key: RpcAddress::new(chain_config, pool_data.vrf_public_key)
                 .expect("addressable"),
-            decommission_key: RpcAddress::new(chain_config, &pool_data.decommission_key)
+            decommission_key: RpcAddress::new(chain_config, pool_data.decommission_key)
                 .expect("addressable"),
-            staker: RpcAddress::new(chain_config, &pool_data.stake_destination)
+            staker: RpcAddress::new(chain_config, pool_data.stake_destination)
                 .expect("addressable"),
         }
     }
@@ -294,7 +294,7 @@ impl DelegationInfo {
         let balance = RpcAmountOut::from_amount_no_padding(balance, decimals);
 
         Self {
-            delegation_id: RpcAddress::new(chain_config, &delegation_id).expect("addressable"),
+            delegation_id: RpcAddress::new(chain_config, delegation_id).expect("addressable"),
             balance,
         }
     }

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -279,7 +279,7 @@ pub fn pubkey_to_pubkeyhash_address(
     let public_key_hash = PublicKeyHash::from(&public_key);
 
     Ok(
-        Address::new(&chain_config, &Destination::PublicKeyHash(public_key_hash))
+        Address::new(&chain_config, Destination::PublicKeyHash(public_key_hash))
             .expect("Should not fail to create address")
             .to_string(),
     )
@@ -330,7 +330,7 @@ fn parse_addressable<T: Addressable>(
 ) -> Result<T, Error> {
     let addressable = Address::from_str(chain_config, address)
         .map_err(|_| Error::InvalidAddressable)?
-        .decode_object();
+        .into_object();
     Ok(addressable)
 }
 

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -281,8 +281,7 @@ pub fn pubkey_to_pubkeyhash_address(
     Ok(
         Address::new(&chain_config, &Destination::PublicKeyHash(public_key_hash))
             .expect("Should not fail to create address")
-            .get()
-            .to_owned(),
+            .to_string(),
     )
 }
 
@@ -331,8 +330,7 @@ fn parse_addressable<T: Addressable>(
 ) -> Result<T, Error> {
     let addressable = Address::from_str(chain_config, address)
         .map_err(|_| Error::InvalidAddressable)?
-        .decode_object(chain_config)
-        .expect("already checked");
+        .decode_object();
     Ok(addressable)
 }
 


### PR DESCRIPTION
* New `RpcAddress<T>` type with conversions to/from `Address<T>`
* Use in wallet RPC for a more type safe interface
* Makes the docs more precise regarding the string format
* Removes a bunch of remaining manual `ValueHints`
* Also replace some uses of plain `String` with `RpcHexString`, `HexEncoded<T>`, `Id<T>` as appropriate
* The changes are backwards compatible

`WalletRpcClient` would benefit from similar changes. Unfortunately I do not have the willpower to do it so there is a bunch of conversions to/from strings there.