### PR TITLE
Add support for adding separate addresses to an account

### DIFF
--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -224,8 +224,8 @@ class WalletCliController:
     async def rename_account(self, name: Optional[str] = '') -> str:
         return await self._write_command(f"account-rename {name}\n")
 
-    async def add_separate_address(self, address: str, label: Optional[str] = '') -> str:
-        return await self._write_command(f"account-add-separate-address {address} {label}\n")
+    async def add_standalone_address(self, address: str, label: Optional[str] = '') -> str:
+        return await self._write_command(f"account-add-standalone-address {address} {label}\n")
 
     async def select_account(self, account_index: int) -> str:
         return await self._write_command(f"account-select {account_index}\n")

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -224,6 +224,9 @@ class WalletCliController:
     async def rename_account(self, name: Optional[str] = '') -> str:
         return await self._write_command(f"account-rename {name}\n")
 
+    async def add_separate_address(self, address: str, label: Optional[str] = '') -> str:
+        return await self._write_command(f"account-add-separate-address {address} {label}\n")
+
     async def select_account(self, account_index: int) -> str:
         return await self._write_command(f"account-select {account_index}\n")
 
@@ -279,7 +282,7 @@ class WalletCliController:
     async def sweep_delegation(self, destination_address: str, delegation_id: str) -> str:
         return await self._write_command(f"staking-sweep-delegation {destination_address} {delegation_id}\n")
 
-    async def send_to_address(self, address: str, amount: int, selected_utxos: List[UtxoOutpoint] = []) -> str:
+    async def send_to_address(self, address: str, amount: Union[int, float, str], selected_utxos: List[UtxoOutpoint] = []) -> str:
         return await self._write_command(f"address-send {address} {amount} {' '.join(map(str, selected_utxos))}\n")
 
     async def compose_transaction(self, outputs: List[TxOutput], selected_utxos: List[UtxoOutpoint], only_transaction: bool = False) -> str:

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -158,7 +158,7 @@ BASE_SCRIPTS = [
     'wallet_generate_addresses.py',
     'wallet_set_lookahead_size.py',
     'wallet_connect_to_rpc.py',
-    'wallet_watch_address.py'
+    'wallet_watch_address.py',
     'mempool_basic_reorg.py',
     'mempool_eviction.py',
     'mempool_ibd.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -158,6 +158,7 @@ BASE_SCRIPTS = [
     'wallet_generate_addresses.py',
     'wallet_set_lookahead_size.py',
     'wallet_connect_to_rpc.py',
+    'wallet_watch_address.py'
     'mempool_basic_reorg.py',
     'mempool_eviction.py',
     'mempool_ibd.py',

--- a/test/functional/wallet_watch_address.py
+++ b/test/functional/wallet_watch_address.py
@@ -14,16 +14,16 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""Wallet watch separate address test
+"""Wallet watch standalone address test
 
 Check that:
 * We can create a new wallet,
 * get an address
 * send coins to the wallet's address
 * create a new wallet
-* add the an address from wallet 1 to wallet 2 to be watched
+* add an address from wallet 1 to wallet 2 to be watched
 * send coins to wallet 1's address
-* check that walelt 2 is keeping truck of transactions using that address in inputs or outputs
+* check that wallet 2 is keeping truck of transactions using that address in inputs or outputs
 """
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -136,7 +136,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             await wallet.create_wallet('wallet2')
             assert_in("Success", await wallet.sync())
 
-            assert_in("Success, the new address has been added to the account", await wallet.add_separate_address(address_from_wallet1))
+            assert_in("Success, the new address has been added to the account", await wallet.add_standalone_address(address_from_wallet1))
 
             await wallet.close_wallet()
             await wallet.open_wallet('wallet1')

--- a/test/functional/wallet_watch_address.py
+++ b/test/functional/wallet_watch_address.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+#  Copyright (c) 2023 RBB S.r.l
+#  Copyright (c) 2017-2021 The Bitcoin Core developers
+#  opensource@mintlayer.org
+#  SPDX-License-Identifier: MIT
+#  Licensed under the MIT License;
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Wallet watch separate address test
+
+Check that:
+* We can create a new wallet,
+* get an address
+* send coins to the wallet's address
+* create a new wallet
+* add the an address from wallet 1 to wallet 2 to be watched
+* send coins to wallet 1's address
+* check that walelt 2 is keeping truck of transactions using that address in inputs or outputs
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.mintlayer import (make_tx, reward_input, ATOMS_PER_COIN)
+from test_framework.util import assert_in, assert_equal, assert_not_in
+from test_framework.mintlayer import block_input_data_obj
+from test_framework.wallet_cli_controller import WalletCliController
+
+import asyncio
+import sys
+import random
+
+
+class WalletSubmitTransaction(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        relay_fee_rate = random.randint(1, 100_000_000)
+        self.extra_args = [[
+            "--blockprod-min-peers-to-produce-blocks=0",
+            f"--min-tx-relay-fee-rate={relay_fee_rate}",
+        ]]
+
+    def setup_network(self):
+        self.setup_nodes()
+        self.sync_all(self.nodes[0:1])
+
+    def generate_block(self):
+        node = self.nodes[0]
+
+        block_input_data = { "PoW": { "reward_destination": "AnyoneCanSpend" } }
+        block_input_data = block_input_data_obj.encode(block_input_data).to_hex()[2:]
+
+        # create a new block, taking transactions from mempool
+        block = node.blockprod_generate_block(block_input_data, [], [], "FillSpaceFromMempool")
+        node.chainstate_submit_block(block)
+        block_id = node.chainstate_best_block_id()
+
+        # Wait for mempool to sync
+        self.wait_until(lambda: node.mempool_local_best_block_id() == block_id, timeout = 5)
+
+        return block_id
+
+    def run_test(self):
+        if 'win32' in sys.platform:
+            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+        asyncio.run(self.async_test())
+
+    async def async_test(self):
+        node = self.nodes[0]
+        async with WalletCliController(node, self.config, self.log) as wallet:
+            # new wallet
+            await wallet.create_wallet('wallet1')
+
+            # check it is on genesis
+            best_block_height = await wallet.get_best_block_height()
+            self.log.info(f"best block height = {best_block_height}")
+            assert_equal(best_block_height, '0')
+
+            # new address
+            pub_key_bytes = await wallet.new_public_key()
+            assert_equal(len(pub_key_bytes), 33)
+
+            # Get chain tip
+            tip_id = node.chainstate_best_block_id()
+            self.log.debug(f'Tip: {tip_id}')
+
+            # Submit a valid transaction
+            coins_to_send = random.randint(2, 100)
+            output = {
+                    'Transfer': [ { 'Coin': coins_to_send * ATOMS_PER_COIN }, { 'PublicKey': {'key': {'Secp256k1Schnorr' : {'pubkey_data': pub_key_bytes}}} } ],
+            }
+            encoded_tx, receive_coins_tx_id = make_tx([reward_input(tip_id)], [output], 0)
+
+            self.log.debug(f"Encoded transaction {receive_coins_tx_id}: {encoded_tx}")
+
+            assert_in("No transaction found", await wallet.get_transaction(receive_coins_tx_id))
+
+            store_tx_in_wallet = random.choice([True, False])
+            assert_in("The transaction was submitted successfully", await wallet.submit_transaction(encoded_tx, not store_tx_in_wallet))
+
+            if store_tx_in_wallet:
+                assert_in(f"Coins amount: {coins_to_send}", await wallet.get_balance(utxo_states=['inactive']))
+            else:
+                assert_in(f"Coins amount: 0", await wallet.get_balance(utxo_states=['inactive']))
+
+            assert node.mempool_contains_tx(receive_coins_tx_id)
+
+            block_id = self.generate_block() # Block 1
+            assert not node.mempool_contains_tx(receive_coins_tx_id)
+
+            # sync the wallet
+            assert_in("Success", await wallet.sync())
+
+            # check wallet best block if it is synced
+            best_block_height = await wallet.get_best_block_height()
+            assert_equal(best_block_height, '1')
+
+            best_block_id = await wallet.get_best_block()
+            assert_equal(best_block_id, block_id)
+
+            # create a new account and get an address from it
+            await wallet.create_new_account()
+            await wallet.select_account(1)
+            address_from_wallet1 = await wallet.new_address()
+
+
+            await wallet.close_wallet()
+            await wallet.create_wallet('wallet2')
+            assert_in("Success", await wallet.sync())
+
+            assert_in("Success, the new address has been added to the account", await wallet.add_separate_address(address_from_wallet1))
+
+            await wallet.close_wallet()
+            await wallet.open_wallet('wallet1')
+
+            # send coins to that address
+            output = await wallet.send_to_address(address_from_wallet1, 1)
+            assert_in("The transaction was submitted successfully", output)
+            receive_coins_tx_id = output.splitlines()[1]
+
+            # check in wallet2
+            await wallet.close_wallet()
+            await wallet.open_wallet('wallet2')
+
+            # tx is still in mempool
+            assert node.mempool_contains_tx(receive_coins_tx_id)
+
+            assert_in("No transaction found", await wallet.get_raw_signed_transaction(receive_coins_tx_id))
+
+            block_id = self.generate_block()
+            assert not node.mempool_contains_tx(receive_coins_tx_id)
+            assert_in("Success", await wallet.sync())
+
+            # after syncing the tx should be found
+            assert_not_in("No transaction found", await wallet.get_raw_signed_transaction(receive_coins_tx_id))
+
+
+            # go back to wallet 1
+            await wallet.close_wallet()
+            await wallet.open_wallet('wallet1')
+
+            # send coins from that address to another one
+            await wallet.select_account(1)
+            other_address = await wallet.new_address()
+            output = await wallet.send_to_address(other_address, 0.1)
+            assert_in("The transaction was submitted successfully", output)
+            send_coins_tx_id = output.splitlines()[1]
+
+
+            # go back to wallet 2
+            await wallet.close_wallet()
+            await wallet.open_wallet('wallet2')
+
+            # tx is still in mempool
+            assert node.mempool_contains_tx(send_coins_tx_id)
+
+            assert_in("No transaction found", await wallet.get_raw_signed_transaction(send_coins_tx_id))
+
+            block_id = self.generate_block()
+            assert not node.mempool_contains_tx(send_coins_tx_id)
+            assert_in("Success", await wallet.sync())
+
+            # after syncing the tx should be found
+            assert_not_in("No transaction found", await wallet.get_raw_signed_transaction(send_coins_tx_id))
+
+
+if __name__ == '__main__':
+    WalletSubmitTransaction().main()
+

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -61,7 +61,7 @@ use common::chain::{
 use common::primitives::{Amount, BlockHeight, Id};
 use consensus::PoSGenerateBlockInputData;
 use crypto::key::hdkd::u31::U31;
-use crypto::key::PublicKey;
+use crypto::key::{PrivateKey, PublicKey};
 use crypto::vrf::VRFPublicKey;
 use itertools::{izip, Itertools};
 use serialization::{Decode, Encode};
@@ -1512,6 +1512,16 @@ impl Account {
         label: Option<String>,
     ) -> WalletResult<()> {
         Ok(self.key_chain.add_separate_address(db_tx, address, label)?)
+    }
+
+    /// Add a separate private key not derived from this account's key chain to be watched
+    pub fn add_separate_private_key(
+        &mut self,
+        db_tx: &mut impl WalletStorageWriteLocked,
+        private_key: PrivateKey,
+        label: Option<String>,
+    ) -> WalletResult<()> {
+        Ok(self.key_chain.add_separate_private_key(db_tx, private_key, label)?)
     }
 
     /// Get a new address that hasn't been used before

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -929,20 +929,20 @@ impl Account {
     pub fn get_delegations(&self) -> impl Iterator<Item = (&DelegationId, &DelegationData)> {
         self.output_cache
             .delegation_ids()
-            .filter(|(_, data)| self.is_mine_or_watched_destination(&data.destination))
+            .filter(|(_, data)| self.is_destination_mine(&data.destination))
     }
 
     pub fn find_delegation(&self, delegation_id: &DelegationId) -> WalletResult<&DelegationData> {
         self.output_cache
             .delegation_data(delegation_id)
-            .filter(|data| self.is_mine_or_watched_destination(&data.destination))
+            .filter(|data| self.is_destination_mine(&data.destination))
             .ok_or(WalletError::DelegationNotFound(*delegation_id))
     }
 
     pub fn find_token(&self, token_id: &TokenId) -> WalletResult<&TokenIssuanceData> {
         self.output_cache
             .token_data(token_id)
-            .filter(|data| self.is_mine_or_watched_destination(&data.authority))
+            .filter(|data| self.is_destination_mine(&data.authority))
             .ok_or(WalletError::UnknownTokenId(*token_id))
     }
 
@@ -952,7 +952,7 @@ impl Account {
     ) -> WalletResult<UnconfirmedTokenInfo> {
         self.output_cache
             .get_token_unconfirmed_info(token_info, |destination: &Destination| {
-                self.is_mine_or_watched_destination(destination)
+                self.is_destination_mine(destination)
             })
     }
 
@@ -1504,6 +1504,16 @@ impl Account {
         Ok(())
     }
 
+    /// Add a separate address not derived from this account's key chain to be watched
+    pub fn add_separate_address(
+        &mut self,
+        db_tx: &mut impl WalletStorageWriteLocked,
+        address: PublicKeyHash,
+        label: Option<String>,
+    ) -> WalletResult<()> {
+        Ok(self.key_chain.add_separate_address(db_tx, address, label)?)
+    }
+
     /// Get a new address that hasn't been used before
     pub fn get_new_address(
         &mut self,
@@ -1579,18 +1589,37 @@ impl Account {
         }
     }
 
+    /// Return true if this transaction output can be spent by this account
+    fn is_mine(&self, txo: &TxOutput) -> bool {
+        self.collect_output_destinations(txo)
+            .iter()
+            .any(|d| self.is_destination_mine(d))
+    }
+
     /// Return true if this transaction output can be spent by this account or if it is being
     /// watched.
     fn is_mine_or_watched(&self, txo: &TxOutput) -> bool {
         self.collect_output_destinations(txo)
             .iter()
-            .any(|d| self.is_mine_or_watched_destination(d))
+            .any(|d| self.is_destination_mine_or_watched(d))
+    }
+
+    /// Return true if this destination can be spent by this account
+    fn is_destination_mine(&self, destination: &Destination) -> bool {
+        match destination {
+            Destination::PublicKeyHash(pkh) => self.key_chain.is_public_key_hash_mine(pkh),
+            Destination::PublicKey(pk) => self.key_chain.is_public_key_mine(pk),
+            Destination::AnyoneCanSpend => false,
+            Destination::ScriptHash(_) | Destination::ClassicMultisig(_) => false,
+        }
     }
 
     /// Return true if this destination can be spent by this account or if it is being watched.
-    fn is_mine_or_watched_destination(&self, destination: &Destination) -> bool {
+    fn is_destination_mine_or_watched(&self, destination: &Destination) -> bool {
         match destination {
-            Destination::PublicKeyHash(pkh) => self.key_chain.is_public_key_hash_mine(pkh),
+            Destination::PublicKeyHash(pkh) => {
+                self.key_chain.is_public_key_hash_mine_or_watched(pkh)
+            }
             Destination::PublicKey(pk) => self.key_chain.is_public_key_mine(pk),
             Destination::AnyoneCanSpend => false,
             Destination::ScriptHash(_) | Destination::ClassicMultisig(_) => false,
@@ -1621,7 +1650,7 @@ impl Account {
             match destination {
                 Destination::PublicKeyHash(pkh) => {
                     let found = self.key_chain.mark_public_key_hash_as_used(db_tx, &pkh)?;
-                    if found {
+                    if found || self.key_chain.is_public_key_hash_watched(&pkh) {
                         return Ok(true);
                     }
                 }
@@ -1702,10 +1731,7 @@ impl Account {
             current_block_info,
             utxo_states,
             with_locked,
-            |txo| {
-                self.is_mine_or_watched(txo)
-                    && get_utxo_type(txo).is_some_and(|v| utxo_types.contains(v))
-            },
+            |txo| self.is_mine(txo) && get_utxo_type(txo).is_some_and(|v| utxo_types.contains(v)),
         )
     }
 
@@ -1784,7 +1810,7 @@ impl Account {
                 | AccountCommand::UnfreezeToken(token_id) => self.find_token(token_id).is_ok(),
                 AccountCommand::ChangeTokenAuthority(token_id, address) => {
                     self.find_token(token_id).is_ok()
-                        || self.is_mine_or_watched_destination(address)
+                        || self.is_destination_mine_or_watched(address)
                 }
             },
         });
@@ -2066,7 +2092,7 @@ impl Account {
 
     pub fn get_created_blocks(&self) -> Vec<(BlockHeight, Id<GenBlock>, PoolId)> {
         self.output_cache
-            .get_created_blocks(|destination| self.is_mine_or_watched_destination(destination))
+            .get_created_blocks(|destination| self.is_destination_mine(destination))
     }
 
     pub fn top_up_addresses(

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1504,24 +1504,24 @@ impl Account {
         Ok(())
     }
 
-    /// Add a separate address not derived from this account's key chain to be watched
-    pub fn add_separate_address(
+    /// Add a standalone address not derived from this account's key chain to be watched
+    pub fn add_standalone_address(
         &mut self,
         db_tx: &mut impl WalletStorageWriteLocked,
         address: PublicKeyHash,
         label: Option<String>,
     ) -> WalletResult<()> {
-        Ok(self.key_chain.add_separate_address(db_tx, address, label)?)
+        Ok(self.key_chain.add_standalone_address(db_tx, address, label)?)
     }
 
-    /// Add a separate private key not derived from this account's key chain to be watched
-    pub fn add_separate_private_key(
+    /// Add a standalone private key not derived from this account's key chain to be watched
+    pub fn add_standalone_private_key(
         &mut self,
         db_tx: &mut impl WalletStorageWriteLocked,
         private_key: PrivateKey,
         label: Option<String>,
     ) -> WalletResult<()> {
-        Ok(self.key_chain.add_separate_private_key(db_tx, private_key, label)?)
+        Ok(self.key_chain.add_standalone_private_key(db_tx, private_key, label)?)
     }
 
     /// Get a new address that hasn't been used before

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -54,7 +54,7 @@ use consensus::PoSGenerateBlockInputData;
 use crypto::key::hdkd::child_number::ChildNumber;
 use crypto::key::hdkd::derivable::Derivable;
 use crypto::key::hdkd::u31::U31;
-use crypto::key::PublicKey;
+use crypto::key::{PrivateKey, PublicKey};
 use crypto::vrf::VRFPublicKey;
 use mempool::FeeRate;
 use pos_accounting::make_delegation_id;
@@ -1090,6 +1090,17 @@ impl<B: storage::Backend> Wallet<B> {
     ) -> WalletResult<()> {
         self.for_account_rw(account_index, |account, db_tx| {
             account.add_separate_address(db_tx, public_key_hash, label)
+        })
+    }
+
+    pub fn add_separate_private_key(
+        &mut self,
+        account_index: U31,
+        private_key: PrivateKey,
+        label: Option<String>,
+    ) -> WalletResult<()> {
+        self.for_account_rw(account_index, |account, db_tx| {
+            account.add_separate_private_key(db_tx, private_key, label)
         })
     }
 

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -33,6 +33,7 @@ use crate::send_request::{
 use crate::wallet_events::{WalletEvents, WalletEventsNoOp};
 use crate::{Account, SendRequest};
 pub use bip39::{Language, Mnemonic};
+use common::address::pubkeyhash::PublicKeyHash;
 use common::address::{Address, AddressError};
 use common::chain::block::timestamp::BlockTimestamp;
 use common::chain::signature::inputsig::arbitrary_message::{
@@ -1079,6 +1080,17 @@ impl<B: storage::Backend> Wallet<B> {
     ) -> WalletResult<Vec<(BlockHeight, Id<GenBlock>, PoolId)>> {
         let block_ids = self.get_account(account_index)?.get_created_blocks();
         Ok(block_ids)
+    }
+
+    pub fn add_separate_address(
+        &mut self,
+        account_index: U31,
+        public_key_hash: PublicKeyHash,
+        label: Option<String>,
+    ) -> WalletResult<()> {
+        self.for_account_rw(account_index, |account, db_tx| {
+            account.add_separate_address(db_tx, public_key_hash, label)
+        })
     }
 
     pub fn get_new_address(

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1082,25 +1082,25 @@ impl<B: storage::Backend> Wallet<B> {
         Ok(block_ids)
     }
 
-    pub fn add_separate_address(
+    pub fn add_standalone_address(
         &mut self,
         account_index: U31,
         public_key_hash: PublicKeyHash,
         label: Option<String>,
     ) -> WalletResult<()> {
         self.for_account_rw(account_index, |account, db_tx| {
-            account.add_separate_address(db_tx, public_key_hash, label)
+            account.add_standalone_address(db_tx, public_key_hash, label)
         })
     }
 
-    pub fn add_separate_private_key(
+    pub fn add_standalone_private_key(
         &mut self,
         account_index: U31,
         private_key: PrivateKey,
         label: Option<String>,
     ) -> WalletResult<()> {
         self.for_account_rw(account_index, |account, db_tx| {
-            account.add_separate_private_key(db_tx, private_key, label)
+            account.add_standalone_private_key(db_tx, private_key, label)
         })
     }
 

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -4510,3 +4510,60 @@ fn test_not_exhaustion_of_keys(#[case] seed: Seed) {
             .unwrap();
     }
 }
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn test_add_separate_private_key(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = Arc::new(create_regtest());
+
+    let mut wallet = create_wallet(chain_config.clone());
+
+    let coin_balance = get_coin_balance(&wallet);
+    assert_eq!(coin_balance, Amount::ZERO);
+    // generate a random private key unrelated to the wallet and add it
+    let (private_key, pub_key) =
+        crypto::key::PrivateKey::new_from_rng(&mut rng, crypto::key::KeyKind::Secp256k1Schnorr);
+
+    wallet
+        .add_separate_private_key(DEFAULT_ACCOUNT_INDEX, private_key, None)
+        .unwrap();
+
+    // get the destination address from the new private key and send some coins to it
+    let address = Address::new(
+        &chain_config,
+        &Destination::PublicKeyHash((&pub_key).into()),
+    )
+    .unwrap();
+
+    // Generate a new block which sends reward to the new address
+    let block1_amount = Amount::from_atoms(rng.gen_range(NETWORK_FEE + 100..NETWORK_FEE + 10000));
+    let output =
+        make_address_output(chain_config.as_ref(), address.clone(), block1_amount).unwrap();
+
+    let tx =
+        SignedTransaction::new(Transaction::new(0, vec![], vec![output]).unwrap(), vec![]).unwrap();
+
+    let block1 = Block::new(
+        vec![tx.clone()],
+        chain_config.genesis_block_id(),
+        chain_config.genesis_block().timestamp(),
+        ConsensusData::None,
+        BlockReward::new(vec![]),
+    )
+    .unwrap();
+
+    scan_wallet(&mut wallet, BlockHeight::new(0), vec![block1.clone()]);
+
+    // Check amount is still zero
+    let coin_balance = get_coin_balance(&wallet);
+    assert_eq!(coin_balance, Amount::ZERO);
+
+    // but the transaction has been added to the wallet
+    let tx_data = wallet
+        .get_transaction(DEFAULT_ACCOUNT_INDEX, tx.transaction().get_id())
+        .unwrap();
+
+    assert_eq!(tx_data.get_transaction(), tx.transaction());
+}

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -4514,7 +4514,7 @@ fn test_not_exhaustion_of_keys(#[case] seed: Seed) {
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn test_add_separate_private_key(#[case] seed: Seed) {
+fn test_add_standalone_private_key(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
     let chain_config = Arc::new(create_regtest());
 
@@ -4527,7 +4527,7 @@ fn test_add_separate_private_key(#[case] seed: Seed) {
         crypto::key::PrivateKey::new_from_rng(&mut rng, crypto::key::KeyKind::Secp256k1Schnorr);
 
     wallet
-        .add_separate_private_key(DEFAULT_ACCOUNT_INDEX, private_key, None)
+        .add_standalone_private_key(DEFAULT_ACCOUNT_INDEX, private_key, None)
         .unwrap();
 
     // get the destination address from the new private key and send some coins to it

--- a/wallet/storage/src/internal/store_tx.rs
+++ b/wallet/storage/src/internal/store_tx.rs
@@ -33,7 +33,7 @@ use utils::{
 };
 use wallet_types::{
     account_id::AccountAddress,
-    account_info::{AccountSeparateKey, AccountVrfKeys},
+    account_info::{AccountStandaloneKey, AccountVrfKeys},
     chain_info::ChainInfo,
     keys::{RootKeyConstant, RootKeys},
     seed_phrase::{SeedPhraseConstant, SerializableSeedPhrase},
@@ -239,16 +239,16 @@ macro_rules! impl_read_ops {
                 self.read::<db::DBVRFPublicKeys, _, _>(account_id)
             }
 
-            fn get_account_separate_keys(
+            fn get_account_standalone_keys(
                 &self,
                 account_id: &AccountId,
-            ) -> crate::Result<BTreeMap<PublicKeyHash, AccountSeparateKey>> {
+            ) -> crate::Result<BTreeMap<PublicKeyHash, AccountStandaloneKey>> {
                 self.storage
-                    .get::<db::DBSeparateKeys, _>()
+                    .get::<db::DBStandaloneKeys, _>()
                     .prefix_iter_decoded(account_id)
                     .map_err(crate::Error::from)
                     .map(|iter| {
-                        iter.map(|(key, value): (AccountAddress, AccountSeparateKey)| {
+                        iter.map(|(key, value): (AccountAddress, AccountStandaloneKey)| {
                             (key.into_item_id(), value)
                         })
                         .collect()
@@ -472,12 +472,12 @@ macro_rules! impl_write_ops {
                 self.storage.get_mut::<db::DBUserTx, _>().del(id).map_err(Into::into)
             }
 
-            fn set_separate_key(
+            fn set_standalone_key(
                 &mut self,
                 id: &AccountAddress,
-                key: &AccountSeparateKey,
+                key: &AccountStandaloneKey,
             ) -> crate::Result<()> {
-                self.write::<db::DBSeparateKeys, _, _, _>(id, key)
+                self.write::<db::DBStandaloneKeys, _, _, _>(id, key)
             }
 
             fn set_account(&mut self, id: &AccountId, tx: &AccountInfo) -> crate::Result<()> {

--- a/wallet/storage/src/lib.rs
+++ b/wallet/storage/src/lib.rs
@@ -29,7 +29,7 @@ use std::collections::BTreeMap;
 
 use wallet_types::{
     account_id::AccountAddress,
-    account_info::{AccountSeparateKey, AccountVrfKeys},
+    account_info::{AccountStandaloneKey, AccountVrfKeys},
     chain_info::ChainInfo,
     keys::RootKeys,
     seed_phrase::SerializableSeedPhrase,
@@ -79,10 +79,10 @@ pub trait WalletStorageReadLocked {
     fn get_account_unconfirmed_tx_counter(&self, account_id: &AccountId) -> Result<Option<u64>>;
     fn get_account_vrf_public_keys(&self, account_id: &AccountId)
         -> Result<Option<AccountVrfKeys>>;
-    fn get_account_separate_keys(
+    fn get_account_standalone_keys(
         &self,
         account_id: &AccountId,
-    ) -> Result<BTreeMap<PublicKeyHash, AccountSeparateKey>>;
+    ) -> Result<BTreeMap<PublicKeyHash, AccountStandaloneKey>>;
     fn get_accounts_info(&self) -> crate::Result<BTreeMap<AccountId, AccountInfo>>;
     fn get_address(&self, id: &AccountDerivationPathId) -> Result<Option<String>>;
     fn get_addresses(
@@ -141,7 +141,8 @@ pub trait WalletStorageWriteLocked: WalletStorageReadLocked {
         tx: &SignedTransaction,
     ) -> Result<()>;
     fn del_user_transaction(&mut self, id: &AccountWalletCreatedTxId) -> crate::Result<()>;
-    fn set_separate_key(&mut self, id: &AccountAddress, key: &AccountSeparateKey) -> Result<()>;
+    fn set_standalone_key(&mut self, id: &AccountAddress, key: &AccountStandaloneKey)
+        -> Result<()>;
     fn set_account(&mut self, id: &AccountId, content: &AccountInfo) -> Result<()>;
     fn del_account(&mut self, id: &AccountId) -> Result<()>;
     fn set_address(

--- a/wallet/storage/src/schema.rs
+++ b/wallet/storage/src/schema.rs
@@ -20,7 +20,7 @@ use crypto::key::extended::ExtendedPublicKey;
 use utils::maybe_encrypted::MaybeEncrypted;
 use wallet_types::{
     account_id::AccountAddress,
-    account_info::{AccountSeparateKey, AccountVrfKeys},
+    account_info::{AccountStandaloneKey, AccountVrfKeys},
     keys::{RootKeyConstant, RootKeys},
     seed_phrase::{SeedPhraseConstant, SerializableSeedPhrase},
     AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletCreatedTxId,
@@ -54,7 +54,7 @@ storage::decl_schema! {
         pub DBUnconfirmedTxCounters: Map<AccountId, u64>,
         /// Store for each account's legacy VRF public key
         pub DBVRFPublicKeys: Map<AccountId, AccountVrfKeys>,
-        /// Store for separate keys added to accounts
-        pub DBSeparateKeys: Map<AccountAddress, AccountSeparateKey>,
+        /// Store for standalone keys added to accounts
+        pub DBStandaloneKeys: Map<AccountAddress, AccountStandaloneKey>,
     }
 }

--- a/wallet/storage/src/schema.rs
+++ b/wallet/storage/src/schema.rs
@@ -19,7 +19,8 @@ use common::chain::SignedTransaction;
 use crypto::key::extended::ExtendedPublicKey;
 use utils::maybe_encrypted::MaybeEncrypted;
 use wallet_types::{
-    account_info::AccountVrfKeys,
+    account_id::AccountAddress,
+    account_info::{AccountSeparateKey, AccountVrfKeys},
     keys::{RootKeyConstant, RootKeys},
     seed_phrase::{SeedPhraseConstant, SerializableSeedPhrase},
     AccountDerivationPathId, AccountId, AccountInfo, AccountKeyPurposeId, AccountWalletCreatedTxId,
@@ -53,5 +54,7 @@ storage::decl_schema! {
         pub DBUnconfirmedTxCounters: Map<AccountId, u64>,
         /// Store for each account's legacy VRF public key
         pub DBVRFPublicKeys: Map<AccountId, AccountVrfKeys>,
+        /// Store for separate keys added to accounts
+        pub DBSeparateKeys: Map<AccountAddress, AccountSeparateKey>,
     }
 }

--- a/wallet/types/src/account_id.rs
+++ b/wallet/types/src/account_id.rs
@@ -81,3 +81,4 @@ pub type AccountWalletCreatedTxId = AccountPrefixedId<Id<Transaction>>;
 pub type AccountWalletTxId = AccountPrefixedId<OutPointSourceId>;
 pub type AccountDerivationPathId = AccountPrefixedId<DerivationPath>;
 pub type AccountKeyPurposeId = AccountPrefixedId<KeyPurpose>;
+pub type AccountAddress = AccountPrefixedId<PublicKeyHash>;

--- a/wallet/types/src/account_info.rs
+++ b/wallet/types/src/account_info.rs
@@ -108,7 +108,7 @@ pub struct AccountVrfKeys {
 }
 
 #[derive(Debug, Clone, Encode, Decode)]
-pub enum AccountSeparateKey {
+pub enum AccountStandaloneKey {
     #[codec(index = 0)]
     V0 {
         label: Option<String>,

--- a/wallet/types/src/account_info.rs
+++ b/wallet/types/src/account_info.rs
@@ -18,7 +18,7 @@ use common::{
     primitives::{BlockHeight, Id},
 };
 use crypto::{
-    key::{extended::ExtendedPublicKey, hdkd::u31::U31},
+    key::{extended::ExtendedPublicKey, hdkd::u31::U31, PrivateKey, PublicKey},
     vrf::ExtendedVRFPublicKey,
 };
 use serialization::{Decode, Encode};
@@ -105,4 +105,14 @@ impl AccountInfo {
 pub struct AccountVrfKeys {
     pub account_vrf_key: ExtendedVRFPublicKey,
     pub legacy_vrf_key: ExtendedVRFPublicKey,
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+pub enum AccountSeparateKey {
+    #[codec(index = 0)]
+    V0 {
+        label: Option<String>,
+        public_key: Option<PublicKey>,
+        private_key: Option<PrivateKey>,
+    },
 }

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -604,9 +604,9 @@ where
                 })
             }
 
-            WalletCommand::AddSeparateKey { address, label } => {
+            WalletCommand::AddStandaloneKey { address, label } => {
                 let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
-                wallet.add_separate_address(selected_account, address, label).await?;
+                wallet.add_standalone_address(selected_account, address, label).await?;
 
                 Ok(ConsoleCommand::SetStatus {
                     status: self.repl_status().await?,
@@ -614,9 +614,12 @@ where
                 })
             }
 
-            WalletCommand::AddSeparatePrivateKey { private_key, label } => {
+            WalletCommand::AddStandalonePrivateKey {
+                hex_private_key: private_key,
+                label,
+            } => {
                 let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
-                wallet.add_separate_private_key(selected_account, private_key, label).await?;
+                wallet.add_standalone_private_key(selected_account, private_key, label).await?;
 
                 Ok(ConsoleCommand::SetStatus {
                     status: self.repl_status().await?,

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -614,6 +614,17 @@ where
                 })
             }
 
+            WalletCommand::AddSeparatePrivateKey { private_key, label } => {
+                let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
+                wallet.add_separate_private_key(selected_account, private_key, label).await?;
+
+                Ok(ConsoleCommand::SetStatus {
+                    status: self.repl_status().await?,
+                    print_message: "Success, the new private key has been added to the account"
+                        .into(),
+                })
+            }
+
             WalletCommand::SelectAccount { account_index } => {
                 self.set_selected_account(account_index).await?;
 

--- a/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/command_handler/mod.rs
@@ -604,6 +604,16 @@ where
                 })
             }
 
+            WalletCommand::AddSeparateKey { address, label } => {
+                let (wallet, selected_account) = wallet_and_selected_acc(&mut self.wallet).await?;
+                wallet.add_separate_address(selected_account, address, label).await?;
+
+                Ok(ConsoleCommand::SetStatus {
+                    status: self.repl_status().await?,
+                    print_message: "Success, the new address has been added to the account".into(),
+                })
+            }
+
             WalletCommand::SelectAccount { account_index } => {
                 self.set_selected_account(account_index).await?;
 

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -251,19 +251,19 @@ pub enum WalletCommand {
         utxo_states: Vec<CliUtxoState>,
     },
 
-    #[clap(name = "account-add-separate-address")]
-    AddSeparateKey {
-        /// The new separate address to be added to the selected account
+    #[clap(name = "account-add-standalone-address")]
+    AddStandaloneKey {
+        /// The new standalone address to be added to the selected account
         address: String,
 
         /// Optionally specify a label to the new address
         label: Option<String>,
     },
 
-    #[clap(name = "account-add-separate-private-key")]
-    AddSeparatePrivateKey {
-        /// The new separate private key to be added to the selected account
-        private_key: HexEncoded<PrivateKey>,
+    #[clap(name = "account-add-standalone-private-key-as-hex")]
+    AddStandalonePrivateKey {
+        /// The new hex encoded standalone private key to be added to the selected account
+        hex_private_key: HexEncoded<PrivateKey>,
 
         /// Optionally specify a label to the new address
         label: Option<String>,

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -251,6 +251,15 @@ pub enum WalletCommand {
         utxo_states: Vec<CliUtxoState>,
     },
 
+    #[clap(name = "account-add-separate-address")]
+    AddSeparateKey {
+        /// The new separate address to be added to the selected account
+        address: String,
+
+        /// Optionally specify a label to the new address
+        label: Option<String>,
+    },
+
     #[clap(name = "token-nft-issue-new")]
     IssueNewNft {
         /// The receiver of the token

--- a/wallet/wallet-cli-lib/src/commands/mod.rs
+++ b/wallet/wallet-cli-lib/src/commands/mod.rs
@@ -26,7 +26,7 @@ use common::{
     chain::{Block, SignedTransaction, Transaction},
     primitives::{BlockHeight, DecimalAmount, Id},
 };
-use crypto::key::{hdkd::u31::U31, PublicKey};
+use crypto::key::{hdkd::u31::U31, PrivateKey, PublicKey};
 use p2p_types::{bannable_address::BannableAddress, PeerId};
 use serialization::hex_encoded::HexEncoded;
 use utils_networking::IpOrSocketAddress;
@@ -255,6 +255,15 @@ pub enum WalletCommand {
     AddSeparateKey {
         /// The new separate address to be added to the selected account
         address: String,
+
+        /// Optionally specify a label to the new address
+        label: Option<String>,
+    },
+
+    #[clap(name = "account-add-separate-private-key")]
+    AddSeparatePrivateKey {
+        /// The new separate private key to be added to the selected account
+        private_key: HexEncoded<PrivateKey>,
 
         /// Optionally specify a label to the new address
         label: Option<String>,

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -175,23 +175,23 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
             .map_err(ControllerError::WalletError)
     }
 
-    pub fn add_separate_address(
+    pub fn add_standalone_address(
         &mut self,
         address: PublicKeyHash,
         label: Option<String>,
     ) -> Result<(), ControllerError<T>> {
         self.wallet
-            .add_separate_address(self.account_index, address, label)
+            .add_standalone_address(self.account_index, address, label)
             .map_err(ControllerError::WalletError)
     }
 
-    pub fn add_separate_private_key(
+    pub fn add_standalone_private_key(
         &mut self,
         private_key: PrivateKey,
         label: Option<String>,
     ) -> Result<(), ControllerError<T>> {
         self.wallet
-            .add_separate_private_key(self.account_index, private_key, label)
+            .add_standalone_private_key(self.account_index, private_key, label)
             .map_err(ControllerError::WalletError)
     }
 

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -16,7 +16,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use common::{
-    address::Address,
+    address::{pubkeyhash::PublicKeyHash, Address},
     chain::{
         signature::inputsig::arbitrary_message::ArbitraryMessageSignature,
         tokens::{
@@ -172,6 +172,16 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     ) -> Result<(), ControllerError<T>> {
         self.wallet
             .abandon_transaction(self.account_index, tx_id)
+            .map_err(ControllerError::WalletError)
+    }
+
+    pub fn add_separate_address(
+        &mut self,
+        address: PublicKeyHash,
+        label: Option<String>,
+    ) -> Result<(), ControllerError<T>> {
+        self.wallet
+            .add_separate_address(self.account_index, address, label)
             .map_err(ControllerError::WalletError)
     }
 

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -31,7 +31,7 @@ use common::{
 use crypto::{
     key::{
         hdkd::{child_number::ChildNumber, u31::U31},
-        PublicKey,
+        PrivateKey, PublicKey,
     },
     vrf::VRFPublicKey,
 };
@@ -182,6 +182,16 @@ impl<'a, T: NodeInterface, W: WalletEvents> SyncedController<'a, T, W> {
     ) -> Result<(), ControllerError<T>> {
         self.wallet
             .add_separate_address(self.account_index, address, label)
+            .map_err(ControllerError::WalletError)
+    }
+
+    pub fn add_separate_private_key(
+        &mut self,
+        private_key: PrivateKey,
+        label: Option<String>,
+    ) -> Result<(), ControllerError<T>> {
+        self.wallet
+            .add_separate_private_key(self.account_index, private_key, label)
             .map_err(ControllerError::WalletError)
     }
 

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -249,6 +249,18 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 
+    async fn add_separate_address(
+        &self,
+        account_index: U31,
+        address: String,
+        label: Option<String>,
+    ) -> Result<(), Self::Error> {
+        self.wallet_rpc
+            .add_separate_address(account_index, address, label)
+            .await
+            .map_err(WalletRpcHandlesClientError::WalletRpcError)
+    }
+
     async fn get_issued_addresses(
         &self,
         account_index: U31,

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -249,26 +249,26 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 
-    async fn add_separate_address(
+    async fn add_standalone_address(
         &self,
         account_index: U31,
         address: String,
         label: Option<String>,
     ) -> Result<(), Self::Error> {
         self.wallet_rpc
-            .add_separate_address(account_index, address, label)
+            .add_standalone_address(account_index, address, label)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 
-    async fn add_separate_private_key(
+    async fn add_standalone_private_key(
         &self,
         account_index: U31,
         private_key: HexEncoded<PrivateKey>,
         label: Option<String>,
     ) -> Result<(), Self::Error> {
         self.wallet_rpc
-            .add_separate_private_key(account_index, private_key.take(), label)
+            .add_standalone_private_key(account_index, private_key.take(), label)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -24,7 +24,7 @@ use common::{
     },
     primitives::{BlockHeight, DecimalAmount, Id, Idable, H256},
 };
-use crypto::key::hdkd::u31::U31;
+use crypto::key::{hdkd::u31::U31, PrivateKey};
 use node_comm::node_traits::NodeInterface;
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
 use serialization::{hex::HexEncode, hex_encoded::HexEncoded, json_encoded::JsonEncoded};
@@ -257,6 +257,18 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
     ) -> Result<(), Self::Error> {
         self.wallet_rpc
             .add_separate_address(account_index, address, label)
+            .await
+            .map_err(WalletRpcHandlesClientError::WalletRpcError)
+    }
+
+    async fn add_separate_private_key(
+        &self,
+        account_index: U31,
+        private_key: HexEncoded<PrivateKey>,
+        label: Option<String>,
+    ) -> Result<(), Self::Error> {
+        self.wallet_rpc
+            .add_separate_private_key(account_index, private_key.take(), label)
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -199,13 +199,13 @@ impl WalletInterface for ClientWalletRpc {
             .map_err(WalletRpcError::ResponseError)
     }
 
-    async fn add_separate_address(
+    async fn add_standalone_address(
         &self,
         account_index: U31,
         address: String,
         label: Option<String>,
     ) -> Result<(), Self::Error> {
-        WalletRpcClient::add_separate_address(
+        WalletRpcClient::add_standalone_address(
             &self.http_client,
             account_index.into(),
             address,
@@ -215,13 +215,13 @@ impl WalletInterface for ClientWalletRpc {
         .map_err(WalletRpcError::ResponseError)
     }
 
-    async fn add_separate_private_key(
+    async fn add_standalone_private_key(
         &self,
         account_index: U31,
         private_key: HexEncoded<PrivateKey>,
         label: Option<String>,
     ) -> Result<(), Self::Error> {
-        WalletRpcClient::add_separate_private_key(
+        WalletRpcClient::add_standalone_private_key(
             &self.http_client,
             account_index.into(),
             private_key,

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -24,7 +24,7 @@ use common::{
     chain::{Block, GenBlock, SignedTransaction, Transaction, TxOutput, UtxoOutPoint},
     primitives::{BlockHeight, DecimalAmount, Id},
 };
-use crypto::key::hdkd::u31::U31;
+use crypto::key::{hdkd::u31::U31, PrivateKey};
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
 use serialization::hex_encoded::HexEncoded;
 use serialization::DecodeAll;
@@ -209,6 +209,22 @@ impl WalletInterface for ClientWalletRpc {
             &self.http_client,
             account_index.into(),
             address,
+            label,
+        )
+        .await
+        .map_err(WalletRpcError::ResponseError)
+    }
+
+    async fn add_separate_private_key(
+        &self,
+        account_index: U31,
+        private_key: HexEncoded<PrivateKey>,
+        label: Option<String>,
+    ) -> Result<(), Self::Error> {
+        WalletRpcClient::add_separate_private_key(
+            &self.http_client,
+            account_index.into(),
+            private_key,
             label,
         )
         .await

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -199,6 +199,22 @@ impl WalletInterface for ClientWalletRpc {
             .map_err(WalletRpcError::ResponseError)
     }
 
+    async fn add_separate_address(
+        &self,
+        account_index: U31,
+        address: String,
+        label: Option<String>,
+    ) -> Result<(), Self::Error> {
+        WalletRpcClient::add_separate_address(
+            &self.http_client,
+            account_index.into(),
+            address,
+            label,
+        )
+        .await
+        .map_err(WalletRpcError::ResponseError)
+    }
+
     async fn get_issued_addresses(
         &self,
         account_index: U31,

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -108,6 +108,13 @@ pub trait WalletInterface {
         name: Option<String>,
     ) -> Result<NewAccountInfo, Self::Error>;
 
+    async fn add_separate_address(
+        &self,
+        account_index: U31,
+        address: String,
+        label: Option<String>,
+    ) -> Result<(), Self::Error>;
+
     async fn get_issued_addresses(
         &self,
         options: U31,

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -108,14 +108,14 @@ pub trait WalletInterface {
         name: Option<String>,
     ) -> Result<NewAccountInfo, Self::Error>;
 
-    async fn add_separate_address(
+    async fn add_standalone_address(
         &self,
         account_index: U31,
         address: String,
         label: Option<String>,
     ) -> Result<(), Self::Error>;
 
-    async fn add_separate_private_key(
+    async fn add_standalone_private_key(
         &self,
         account_index: U31,
         private_key: HexEncoded<PrivateKey>,

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -20,7 +20,7 @@ use common::{
     chain::{Block, GenBlock, SignedTransaction, Transaction, TxOutput, UtxoOutPoint},
     primitives::{BlockHeight, DecimalAmount, Id},
 };
-use crypto::key::hdkd::u31::U31;
+use crypto::key::{hdkd::u31::U31, PrivateKey};
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
 use serialization::hex_encoded::HexEncoded;
 use utils_networking::IpOrSocketAddress;
@@ -112,6 +112,13 @@ pub trait WalletInterface {
         &self,
         account_index: U31,
         address: String,
+        label: Option<String>,
+    ) -> Result<(), Self::Error>;
+
+    async fn add_separate_private_key(
+        &self,
+        account_index: U31,
+        private_key: HexEncoded<PrivateKey>,
         label: Option<String>,
     ) -> Result<(), Self::Error>;
 

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -101,6 +101,48 @@ Returns:
 }
 ```
 
+### Method `account_add_separate_address`
+
+Add a new separate address not derived from the selected account's key chain to be watched
+
+
+Parameters:
+```
+{
+    "account": number,
+    "address": string,
+    "label": EITHER OF
+         1) string
+         2) null,
+}
+```
+
+Returns:
+```
+nothing
+```
+
+### Method `account_add_separate_private_key`
+
+Add a new separate private key not derived from the selected account's key chain to be watched
+
+
+Parameters:
+```
+{
+    "account": number,
+    "private_key": hex string,
+    "label": EITHER OF
+         1) string
+         2) null,
+}
+```
+
+Returns:
+```
+nothing
+```
+
 ### Method `account_balance`
 
 Get the total balance in the selected account in this wallet. See available options to include more categories, like locked coins.

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -101,9 +101,9 @@ Returns:
 }
 ```
 
-### Method `account_add_separate_address`
+### Method `account_add_standalone_address`
 
-Add a new separate address not derived from the selected account's key chain to be watched
+Add a new standalone address not derived from the selected account's key chain to be watched
 
 
 Parameters:
@@ -122,9 +122,9 @@ Returns:
 nothing
 ```
 
-### Method `account_add_separate_private_key`
+### Method `account_add_standalone_private_key`
 
-Add a new separate private key not derived from the selected account's key chain to be watched
+Add a new standalone private key not derived from the selected account's key chain to be watched
 
 
 Parameters:

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -245,18 +245,18 @@ trait WalletRpc {
         name: Option<String>,
     ) -> rpc::RpcResult<NewAccountInfo>;
 
-    /// Add a new separate address not derived from the selected account's key chain to be watched
-    #[method(name = "account_add_separate_address")]
-    async fn add_separate_address(
+    /// Add a new standalone address not derived from the selected account's key chain to be watched
+    #[method(name = "account_add_standalone_address")]
+    async fn add_standalone_address(
         &self,
         account: AccountArg,
         address: String,
         label: Option<String>,
     ) -> rpc::RpcResult<()>;
 
-    /// Add a new separate private key not derived from the selected account's key chain to be watched
-    #[method(name = "account_add_separate_private_key")]
-    async fn add_separate_private_key(
+    /// Add a new standalone private key not derived from the selected account's key chain to be watched
+    #[method(name = "account_add_standalone_private_key")]
+    async fn add_standalone_private_key(
         &self,
         account: AccountArg,
         private_key: HexEncoded<PrivateKey>,

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -244,6 +244,15 @@ trait WalletRpc {
         name: Option<String>,
     ) -> rpc::RpcResult<NewAccountInfo>;
 
+    /// Add a new separate address not derived from the selected account's key chain to be watched
+    #[method(name = "account_add_separate_address")]
+    async fn add_separate_address(
+        &self,
+        account: AccountArg,
+        address: String,
+        label: Option<String>,
+    ) -> rpc::RpcResult<()>;
+
     /// Get the total balance in the selected account in this wallet. See available options to include more categories, like locked coins.
     #[method(name = "account_balance")]
     async fn get_balance(

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -18,6 +18,7 @@ use common::{
     chain::{Block, GenBlock, SignedTransaction, Transaction, TxOutput, UtxoOutPoint},
     primitives::{BlockHeight, Id},
 };
+use crypto::key::PrivateKey;
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress};
 use wallet::account::{PartiallySignedTransaction, TxInfo};
 use wallet_controller::{
@@ -250,6 +251,15 @@ trait WalletRpc {
         &self,
         account: AccountArg,
         address: String,
+        label: Option<String>,
+    ) -> rpc::RpcResult<()>;
+
+    /// Add a new separate private key not derived from the selected account's key chain to be watched
+    #[method(name = "account_add_separate_private_key")]
+    async fn add_separate_private_key(
+        &self,
+        account: AccountArg,
+        private_key: HexEncoded<PrivateKey>,
         label: Option<String>,
     ) -> rpc::RpcResult<()>;
 

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -18,7 +18,7 @@ mod server_impl;
 pub mod types;
 
 use chainstate::{tx_verifier::check_transaction, ChainInfo, TokenIssuanceError};
-use crypto::key::hdkd::u31::U31;
+use crypto::key::{hdkd::u31::U31, PrivateKey};
 use mempool::tx_accumulator::PackingStrategy;
 use mempool_types::tx_options::TxOptionsOverrides;
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
@@ -251,6 +251,28 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
                     w.synced_controller(account_index, config)
                         .await?
                         .add_separate_address(pkh, label)
+                })
+            })
+            .await??;
+        Ok(())
+    }
+
+    pub async fn add_separate_private_key(
+        &self,
+        account_index: U31,
+        private_key: PrivateKey,
+        label: Option<String>,
+    ) -> WRpcResult<(), N> {
+        let config = ControllerConfig {
+            in_top_x_mb: 5,
+            broadcast_to_mempool: true,
+        }; // irrelevant for issuing addresses
+        self.wallet
+            .call_async(move |w| {
+                Box::pin(async move {
+                    w.synced_controller(account_index, config)
+                        .await?
+                        .add_separate_private_key(private_key, label)
                 })
             })
             .await??;

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -224,7 +224,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         Ok(NewAccountInfo::new(num, name))
     }
 
-    pub async fn add_separate_address(
+    pub async fn add_standalone_address(
         &self,
         account_index: U31,
         address: String,
@@ -250,14 +250,14 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
                 Box::pin(async move {
                     w.synced_controller(account_index, config)
                         .await?
-                        .add_separate_address(pkh, label)
+                        .add_standalone_address(pkh, label)
                 })
             })
             .await??;
         Ok(())
     }
 
-    pub async fn add_separate_private_key(
+    pub async fn add_standalone_private_key(
         &self,
         account_index: U31,
         private_key: PrivateKey,
@@ -272,7 +272,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
                 Box::pin(async move {
                     w.synced_controller(account_index, config)
                         .await?
-                        .add_separate_private_key(private_key, label)
+                        .add_standalone_private_key(private_key, label)
                 })
             })
             .await??;

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -305,25 +305,25 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         rpc::handle_result(self.update_account_name(account_arg.index::<N>()?, name).await)
     }
 
-    async fn add_separate_address(
+    async fn add_standalone_address(
         &self,
         account_arg: AccountArg,
         address: String,
         label: Option<String>,
     ) -> rpc::RpcResult<()> {
         rpc::handle_result(
-            self.add_separate_address(account_arg.index::<N>()?, address, label).await,
+            self.add_standalone_address(account_arg.index::<N>()?, address, label).await,
         )
     }
 
-    async fn add_separate_private_key(
+    async fn add_standalone_private_key(
         &self,
         account_arg: AccountArg,
         private_key: HexEncoded<PrivateKey>,
         label: Option<String>,
     ) -> rpc::RpcResult<()> {
         rpc::handle_result(
-            self.add_separate_private_key(account_arg.index::<N>()?, private_key.take(), label)
+            self.add_standalone_private_key(account_arg.index::<N>()?, private_key.take(), label)
                 .await,
         )
     }

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -304,6 +304,17 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
         rpc::handle_result(self.update_account_name(account_arg.index::<N>()?, name).await)
     }
 
+    async fn add_separate_address(
+        &self,
+        account_arg: AccountArg,
+        address: String,
+        label: Option<String>,
+    ) -> rpc::RpcResult<()> {
+        rpc::handle_result(
+            self.add_separate_address(account_arg.index::<N>()?, address, label).await,
+        )
+    }
+
     async fn get_balance(
         &self,
         account_arg: AccountArg,

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -23,6 +23,7 @@ use common::{
     },
     primitives::{time::Time, BlockHeight, Id, Idable, H256},
 };
+use crypto::key::PrivateKey;
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
 use serialization::{hex::HexEncode, json_encoded::JsonEncoded};
 use std::{fmt::Debug, str::FromStr, time::Duration};
@@ -312,6 +313,18 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletRpcServer f
     ) -> rpc::RpcResult<()> {
         rpc::handle_result(
             self.add_separate_address(account_arg.index::<N>()?, address, label).await,
+        )
+    }
+
+    async fn add_separate_private_key(
+        &self,
+        account_arg: AccountArg,
+        private_key: HexEncoded<PrivateKey>,
+        label: Option<String>,
+    ) -> rpc::RpcResult<()> {
+        rpc::handle_result(
+            self.add_separate_private_key(account_arg.index::<N>()?, private_key.take(), label)
+                .await,
         )
     }
 


### PR DESCRIPTION
- new command for adding a separate public key has address to an account to be watched by the wallet
- new transactions using those addresses as inputs or outputs will be kept by the wallet