### PR TITLE
Fix PerThousand serde implementation and add String implementation

### DIFF
--- a/common/src/primitives/per_thousand.rs
+++ b/common/src/primitives/per_thousand.rs
@@ -23,6 +23,7 @@ use super::Amount;
 
 const DENOMINATOR: u16 = 1000;
 
+// DO NOT derive traits that construct Self, like Deserialize and Decode. This struct uses a non-trivial constructor.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Encode, Debug)]
 pub struct PerThousand(u16);
 


### PR DESCRIPTION
PerThousand json deserialization wasn't implemented correctly. It should not be allowed to construct PerThousand with a value > 1000 in the internal integer. This fixes that.

I also added string implementations and made the default serialization use a percentage. Better for readability.