### PR TITLE
mempool: Adjust max size of a transaction accepted into mempool

### DIFF
--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -544,6 +544,7 @@ impl Builder {
     builder_method!(empty_consensus_reward_maturity_block_count: BlockCount);
     builder_method!(epoch_length: NonZeroU64);
     builder_method!(sealed_epoch_distance_from_tip: usize);
+    builder_method!(data_deposit_max_size: usize);
 
     pub fn checkpoints(mut self, checkpoints: BTreeMap<BlockHeight, Id<GenBlock>>) -> Self {
         self.checkpoints = Some(checkpoints);

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -499,10 +499,16 @@ impl ChainConfig {
 
     /// The maximum size of any transaction submitted to the node for the mempool
     pub fn max_tx_size_for_mempool(&self) -> usize {
-        std::cmp::min(
+        // Reserve some space in the block for the data it needs to store beyond the transaction
+        // data itself, namely the transaction count due to how sequences of elements are encoded.
+        const BLOCK_DATA_OVERHEAD: usize = 1000;
+
+        let max_block_size = std::cmp::min(
             self.max_block_size_from_std_scripts(),
             self.max_block_size_from_smart_contracts(),
-        )
+        );
+
+        max_block_size.saturating_sub(BLOCK_DATA_OVERHEAD)
     }
 
     /// The initial randomness used for the first few epochs until sealed blocks kick in


### PR DESCRIPTION
If the max transaction size coincides with the max block size, a block with given size cannot be constructed since it has to contain some more metadata such as the number of transactions. This changes the max size of a transaction accepted into the mempool such that a block containing given transaction can actually be constructed.