### PR TITLE
Unify all related stuff of checking running as root to be able to put it by just adding a clap arg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7956,6 +7956,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "utils"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "clap",
  "criterion",
  "crypto",

--- a/node-lib/src/options.rs
+++ b/node-lib/src/options.rs
@@ -24,7 +24,9 @@ use std::{
 
 use clap::{Args, Parser, Subcommand};
 use common::chain::config::{regtest_options::ChainConfigOptions, ChainType};
-use utils::{clap_utils, default_data_dir::default_data_dir_common};
+use utils::{
+    clap_utils, default_data_dir::default_data_dir_common, root_user::ForceRunAsRootOptions,
+};
 use utils_networking::IpOrSocketAddress;
 
 use crate::config_files::{NodeTypeConfigFile, StorageBackendConfigFile};
@@ -222,11 +224,8 @@ pub struct RunOptions {
     #[clap(long, value_name = "VAL")]
     pub min_tx_relay_fee_rate: Option<u64>,
 
-    /// Allow the program to be run as root, which is NOT RECOMMENDED and DANGEROUS.
-    /// There is no need to run the mintlayer-software as root. The correct
-    /// security practice is to only provide root access to programs that need it.
-    #[clap(long)]
-    pub force_allow_run_as_root: bool,
+    #[clap(flatten)]
+    pub force_allow_run_as_root_outer: ForceRunAsRootOptions,
 }
 
 impl Options {

--- a/node-lib/tests/cli.rs
+++ b/node-lib/tests/cli.rs
@@ -156,7 +156,7 @@ fn read_config_override_values() {
         rpc_cookie_file: Some(rpc_cookie_file.to_owned()),
         clean_data: Some(false),
         min_tx_relay_fee_rate: Some(min_tx_relay_fee_rate),
-        force_allow_run_as_root: false,
+        force_allow_run_as_root_outer: Default::default(),
     };
     let config = NodeConfigFile::read(&chain_config, &config_path, &options).unwrap();
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,7 +11,8 @@ logging = {path = '../logging'}
 log_error = { path = "log_error" }
 serialization = { path = "../serialization" }
 
-clap = { workspace = true, features = ["env", "string"] }
+anyhow.workspace = true
+clap = { workspace = true, features = ["env", "string", "derive"] }
 directories.workspace = true
 fix-hidden-lifetime-bug.workspace = true
 heck.workspace = true

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -34,6 +34,7 @@ pub mod maybe_encrypted;
 pub mod newtype;
 pub mod once_destructor;
 pub mod qrcode;
+pub mod root_user;
 pub mod rust_backtrace;
 pub mod set_flag;
 pub mod shallow_clone;

--- a/utils/src/root_user.rs
+++ b/utils/src/root_user.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The node command line options.
+
+use clap::Args;
+use logging::log;
+
+fn is_unix() -> bool {
+    cfg!(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+    ))
+}
+
+const FORCE_ALLOW_ROOT_FLAG: &str = "--force-allow-run-as-root";
+
+#[derive(Args, Clone, Debug, Default)]
+pub struct ForceRunAsRootOptions {
+    /// Allow the program to be run as root, which is NOT RECOMMENDED and DANGEROUS.
+    /// There is no need to run the mintlayer-software as root. The correct
+    /// security practice is to only provide root access to programs that need it.
+    #[clap(long, default_value_t = false)]
+    pub force_allow_run_as_root: bool,
+}
+
+impl ForceRunAsRootOptions {
+    pub fn ensure_not_running_as_root_user(&self) -> anyhow::Result<()> {
+        if is_unix() && !self.force_allow_run_as_root {
+            use std::os::unix::fs::MetadataExt;
+            let uid = std::fs::metadata("/proc/self").map(|m| m.uid());
+            match uid {
+                Ok(id) => {
+                    if id == 0 {
+                        return Err(anyhow::anyhow!("ERROR: It is a mistake to run the node as root (user with uid=0), as it gives the node power that it does not need and violates good security practices. Either run the program as non-root, or do the VERY NOT RECOMMENDED THING TO DO, and add the flag `{FORCE_ALLOW_ROOT_FLAG}`"));
+                    }
+                }
+                Err(e) => log::error!("Failed to get user id to prevent running as root: {e}"),
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
So, everyone can use this now. Just add it to your run options and call that function.