### PR TITLE
Fixes related to block invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ dependencies = [
 name = "chainstate"
 version = "0.4.2"
 dependencies = [
+ "accounting",
  "async-trait",
  "chainstate-storage",
  "chainstate-types",
@@ -1239,6 +1240,7 @@ dependencies = [
  "constraints-value-accumulator",
  "criterion",
  "crypto",
+ "ctor",
  "expect-test",
  "hex",
  "itertools 0.12.1",

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+accounting = {path = '../accounting'}
 chainstate-storage = {path = './storage', features = ["mock"]}
 chainstate-types = {path = './types'}
 common = {path = '../common'}

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -55,7 +55,6 @@ impl BanScore for BlockError {
             // a peer sent a block they're not supposed to send.
             BlockError::PrevBlockNotFoundForNewBlock(_) => 100,
             BlockError::BlockAlreadyExists(_) => 0,
-            BlockError::BlockIndexAlreadyExists(_) => 0,
             BlockError::BlockAlreadyProcessed(_) => 0,
             BlockError::InvalidBlockAlreadyProcessed(_) => 100,
             BlockError::DbCommitError(_, _, _) => 0,
@@ -225,7 +224,7 @@ impl BanScore for CheckBlockError {
             CheckBlockError::TransactionVerifierError(err) => err.ban_score(),
             CheckBlockError::BlockNotFoundDuringInMemoryReorg(_) => 100,
             CheckBlockError::BlockTimeOrderInvalid(_, _) => 100,
-            CheckBlockError::BlockFromTheFuture => 100,
+            CheckBlockError::BlockFromTheFuture(_) => 100,
             CheckBlockError::BlockSizeError(err) => err.ban_score(),
             CheckBlockError::CheckTransactionFailed(err) => err.ban_score(),
             CheckBlockError::ConsensusVerificationFailed(err) => err.ban_score(),

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -55,6 +55,7 @@ impl BanScore for BlockError {
             // a peer sent a block they're not supposed to send.
             BlockError::PrevBlockNotFoundForNewBlock(_) => 100,
             BlockError::BlockAlreadyExists(_) => 0,
+            BlockError::BlockIndexAlreadyExists(_) => 0,
             BlockError::BlockAlreadyProcessed(_) => 0,
             BlockError::InvalidBlockAlreadyProcessed(_) => 100,
             BlockError::DbCommitError(_, _, _) => 0,

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -1084,7 +1084,9 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> Chainsta
             let mut block_status = block_index.status();
             ensure!(
                 block_status.is_ok(),
-                BlockError::InvariantErrorAttemptToConnectInvalidBlock(block_index.get_id().into())
+                BlockError::InvariantErrorAttemptToConnectInvalidBlock(
+                    (*block_index.block_id()).into()
+                )
             );
 
             let block: WithId<Block> = self

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -1224,6 +1224,14 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> Chainsta
         self.db_tx.set_block_index(block_index).map_err(BlockError::from)
     }
 
+    #[log_error]
+    pub fn set_new_block_index(&mut self, block_index: &BlockIndex) -> Result<(), BlockError> {
+        if self.db_tx.get_block_index(block_index.block_id())?.is_some() {
+            return Err(BlockError::BlockIndexAlreadyExists(*block_index.block_id()));
+        }
+        self.set_block_index(block_index)
+    }
+
     /// Update the status of the passed `block_index`.
     /// If a BlockIndex already exists for this block, it must be equal to `block_index`.
     #[log_error]

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -405,16 +405,16 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             GenBlockId::Genesis(_) => return Ok(Some(BlockHeight::zero())),
         };
 
-        let block_index = self.get_existing_block_index(&id)?;
-        let mainchain_block_id = self.get_block_id_by_height(&block_index.block_height())?;
+        if let Some(block_index) = self.get_block_index(&id)? {
+            let mainchain_block_id = self.get_block_id_by_height(&block_index.block_height())?;
 
-        // Note: this function may be called when the chain is still empty, so we don't unwrap
-        // mainchain_block_id and wrap gen_id instead.
-        if mainchain_block_id.as_ref() == Some(gen_id) {
-            Ok(Some(block_index.block_height()))
-        } else {
-            Ok(None)
+            // Note: this function may be called when the chain is still empty, so we don't unwrap
+            // mainchain_block_id and wrap gen_id instead.
+            if mainchain_block_id.as_ref() == Some(gen_id) {
+                return Ok(Some(block_index.block_height()));
+            }
         }
+        Ok(None)
     }
 
     // Get indexes for a new longest chain

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -1232,6 +1232,11 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> Chainsta
         self.set_block_index(block_index)
     }
 
+    #[log_error]
+    pub fn del_block_index(&mut self, block_id: &Id<Block>) -> Result<(), BlockError> {
+        self.db_tx.del_block_index(*block_id).map_err(BlockError::from)
+    }
+
     /// Update the status of the passed `block_index`.
     /// If a BlockIndex already exists for this block, it must be equal to `block_index`.
     #[log_error]

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -50,6 +50,8 @@ pub enum BlockError {
     PrevBlockNotFoundForNewBlock(Id<Block>),
     #[error("Block {0} already exists")]
     BlockAlreadyExists(Id<Block>),
+    #[error("Block {0} index already exists")]
+    BlockIndexAlreadyExists(Id<Block>),
     #[error("Block {0} has already been processed")]
     BlockAlreadyProcessed(Id<Block>),
     #[error("Block {0} has already been processed and marked as invalid")]

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -50,8 +50,6 @@ pub enum BlockError {
     PrevBlockNotFoundForNewBlock(Id<Block>),
     #[error("Block {0} already exists")]
     BlockAlreadyExists(Id<Block>),
-    #[error("Block {0} index already exists")]
-    BlockIndexAlreadyExists(Id<Block>),
     #[error("Block {0} has already been processed")]
     BlockAlreadyProcessed(Id<Block>),
     #[error("Block {0} has already been processed and marked as invalid")]
@@ -129,8 +127,8 @@ pub enum CheckBlockError {
     BlockNotFoundDuringInMemoryReorg(Id<GenBlock>),
     #[error("Block time ({0:?}) must be equal or higher than the median of its ancestors ({1:?})")]
     BlockTimeOrderInvalid(BlockTimestamp, BlockTimestamp),
-    #[error("Block time too far into the future")]
-    BlockFromTheFuture,
+    #[error("Block {0} time too far into the future")]
+    BlockFromTheFuture(Id<Block>),
     #[error("Block size is too large: {0}")]
     BlockSizeError(#[from] BlockSizeError),
     #[error("Check transaction failed: {0}")]

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -89,6 +89,7 @@ impl BlockProcessingErrorClassification for BlockError {
             | BlockError::InvariantErrorDisconnectedHeaders
             | BlockError::DbCommitError(_, _, _)
             | BlockError::BlockAlreadyExists(_)
+            | BlockError::BlockIndexAlreadyExists(_)
             | BlockError::BlockAlreadyProcessed(_)
             | BlockError::BlockDataMissingForValidBlockIndex(_)
             // These contain an error inside, but they are meant to denote storage/invariant

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -42,7 +42,7 @@ use super::{
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum BlockProcessingErrorClass {
-    /// General error - the operation failed  due to storage issues, invariant violations etc.
+    /// General error - the operation failed due to storage issues, invariant violations etc.
     General,
     /// This error type signifies that the block is definitely bad.
     BadBlock,

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -1,0 +1,776 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_types::{
+    pos_randomness::PoSRandomnessError, storage_result, GetAncestorError, PropertyQueryError,
+};
+use common::{
+    chain::{block::block_body::BlockMerkleTreeError, signature::DestinationSigError},
+    UintConversionError,
+};
+use consensus::{
+    BlockSignatureError, ConsensusPoSError, ConsensusPoWError, ConsensusVerificationError,
+    EffectivePoolBalanceError,
+};
+use tx_verifier::{
+    error::{ConnectTransactionError, SpendStakeError, TokensError},
+    timelock_check,
+    transaction_verifier::{
+        signature_destination_getter::SignatureDestinationGetterError, RewardDistributionError,
+    },
+    CheckTransactionError, TransactionVerifierStorageError,
+};
+use utxo::UtxosBlockUndoError;
+
+use crate::{BlockError, CheckBlockError, CheckBlockTransactionsError, OrphanCheckError};
+
+use super::{
+    block_invalidation::BestChainCandidatesError, chainstateref::EpochSealError, BlockSizeError,
+};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum BlockProcessingErrorClass {
+    /// General error - the operation failed  due to storage issues, invariant violations etc.
+    General,
+    /// This error type signifies that the block is definitely bad.
+    BadBlock,
+    /// This error type signifies that the block is bad at this moment, but might become ok later.
+    TemporarilyBadBlock,
+}
+
+impl BlockProcessingErrorClass {
+    pub fn block_should_be_invalidated(&self) -> bool {
+        match self {
+            BlockProcessingErrorClass::General | BlockProcessingErrorClass::TemporarilyBadBlock => {
+                false
+            }
+            BlockProcessingErrorClass::BadBlock => true,
+        }
+    }
+}
+
+// Note:
+// 1) For some errors it's not always clear whether they denote an invariant violation or a
+// problem with the block itself.
+// But misclassification of such an error is not a critical issue:
+// a) If an invariant violation happened, the local copy of the chainstate is likely to be broken
+// anyway, so marking a possibly ok block as bad won't do much additional harm.
+// b) Returning General for an objectively bad block (and therefore not marking it as invalid
+// in the block index) is not a huge problem either, because the block will be rejected anyway
+// on all future attempts to add it.
+// 2) Technically the same can be said about storage errors too - they'll "normally" happen if
+// the user's storage device is faulty; though we should try to handle such situations gracefully,
+// occasional failure to do so is not critical.
+// 3) The errors that should be treated carefully are those that can happen during normal
+// cause of operation and that don't represent a 100% invalid block (e.g. BlockFromTheFuture).
+
+pub trait BlockProcessingErrorClassification {
+    fn classify(&self) -> BlockProcessingErrorClass;
+}
+
+impl BlockProcessingErrorClassification for BlockError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            BlockError::InvariantErrorFailedToFindNewChainPath(_, _, _)
+            | BlockError::InvariantErrorInvalidTip(_)
+            | BlockError::InvariantErrorAttemptToConnectInvalidBlock(_)
+            | BlockError::InvariantErrorDisconnectedHeaders
+            | BlockError::DbCommitError(_, _, _)
+            | BlockError::BlockAlreadyExists(_)
+            | BlockError::BlockAlreadyProcessed(_)
+            | BlockError::BlockDataMissingForValidBlockIndex(_)
+            // These contain an error inside, but they are meant to denote storage/invariant
+            // problems in any case, so we don't delegate to inner error's `classify` here.
+            | BlockError::BestBlockIdQueryError(_)
+            | BlockError::BestBlockIndexQueryError(_)
+            | BlockError::BlockIndexQueryError(_, _)
+            | BlockError::IsBlockInMainChainQueryError(_, _)
+            | BlockError::MinHeightForReorgQueryError(_) => BlockProcessingErrorClass::General,
+
+            BlockError::PrevBlockNotFoundForNewBlock(_) => {
+                BlockProcessingErrorClass::TemporarilyBadBlock
+            }
+
+            // It's not clear what should be returned here - from the one side, the block is definitely
+            // bad, from the other side any "bad" status handling has already been done for the block
+            // during the previous attempt.
+            // Currently though, it doesn't matter whether we return "BadBlock" or "General" here.
+            BlockError::InvalidBlockAlreadyProcessed(_) => BlockProcessingErrorClass::BadBlock,
+
+            BlockError::BlockProofCalculationError(_) => BlockProcessingErrorClass::BadBlock,
+
+            BlockError::TransactionVerifierError(err) => err.classify(),
+            BlockError::PoSAccountingError(err) => err.classify(),
+            BlockError::EpochSealError(err) => err.classify(),
+
+            BlockError::BestChainCandidatesAccessorError(err) => err.classify(),
+            BlockError::TokensAccountingError(err) => err.classify(),
+            BlockError::StorageError(err) => err.classify(),
+            BlockError::OrphanCheckFailed(err) => err.classify(),
+            BlockError::CheckBlockFailed(err) => err.classify(),
+            BlockError::StateUpdateFailed(err) => err.classify(),
+            BlockError::PropertyQueryError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for BestChainCandidatesError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            BestChainCandidatesError::PropertyQueryError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for OrphanCheckError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            OrphanCheckError::LocalOrphan => BlockProcessingErrorClass::TemporarilyBadBlock,
+
+            OrphanCheckError::StorageError(err) => err.classify(),
+            OrphanCheckError::PropertyQueryError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for CheckBlockError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            CheckBlockError::MerkleRootMismatch
+            | CheckBlockError::ParentBlockMissing { .. }
+            | CheckBlockError::BlockNotFoundDuringInMemoryReorg(_)
+            | CheckBlockError::BlockTimeOrderInvalid(_, _)
+            | CheckBlockError::InvalidBlockRewardOutputType(_)
+            | CheckBlockError::CheckpointMismatch(_, _)
+            | CheckBlockError::ParentCheckpointMismatch(_, _, _)
+            | CheckBlockError::AttemptedToAddBlockBeforeReorgLimit(_, _, _)
+            | CheckBlockError::InvalidParent { .. } => BlockProcessingErrorClass::BadBlock,
+
+            CheckBlockError::BlockFromTheFuture(_) => {
+                BlockProcessingErrorClass::TemporarilyBadBlock
+            }
+
+            CheckBlockError::StorageError(err) => err.classify(),
+            CheckBlockError::PropertyQueryError(err) => err.classify(),
+            CheckBlockError::MerkleRootCalculationFailed(_, err) => err.classify(),
+            CheckBlockError::StateUpdateFailed(err) => err.classify(),
+            CheckBlockError::BlockSizeError(err) => err.classify(),
+            CheckBlockError::BlockRewardMaturityError(err) => err.classify(),
+            CheckBlockError::TransactionVerifierError(err) => err.classify(),
+            CheckBlockError::EpochSealError(err) => err.classify(),
+            CheckBlockError::CheckTransactionFailed(err) => err.classify(),
+            CheckBlockError::ConsensusVerificationFailed(err) => err.classify(),
+            CheckBlockError::GetAncestorError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for BlockMerkleTreeError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        // Nothing other than BadBlock here.
+        // TODO: should we descend into inner errors just in case?
+        BlockProcessingErrorClass::BadBlock
+    }
+}
+
+impl BlockProcessingErrorClassification for BlockSizeError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        // Nothing other than BadBlock here.
+        // TODO: should we descend into inner errors just in case?
+        BlockProcessingErrorClass::BadBlock
+    }
+}
+
+impl BlockProcessingErrorClassification for EpochSealError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            EpochSealError::PoolDataNotFound(_) => BlockProcessingErrorClass::General,
+
+            EpochSealError::StorageError(err) => err.classify(),
+            EpochSealError::PoSAccountingError(err) => err.classify(),
+            EpochSealError::SpendStakeError(err) => err.classify(),
+            EpochSealError::RandomnessError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for CheckBlockTransactionsError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            CheckBlockTransactionsError::DuplicateInputInBlock(_) => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            CheckBlockTransactionsError::CheckTransactionError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for ConsensusVerificationError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            ConsensusVerificationError::PrevBlockNotFound(_, _)
+            | ConsensusVerificationError::ConsensusTypeMismatch(_)
+            | ConsensusVerificationError::UnsupportedConsensusType => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            ConsensusVerificationError::PrevBlockLoadError(_, _, err) => err.classify(),
+            ConsensusVerificationError::PoWError(err) => err.classify(),
+            ConsensusVerificationError::PoSError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for ConnectTransactionError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            ConnectTransactionError::TxNumWrongInBlockOnDisconnect(_, _)
+            | ConnectTransactionError::InvariantBrokenAlreadyUnspent
+            | ConnectTransactionError::MissingBlockUndo(_)
+            | ConnectTransactionError::MissingBlockRewardUndo(_)
+            | ConnectTransactionError::MissingTxUndo(_)
+            | ConnectTransactionError::MissingMempoolTxsUndo
+            | ConnectTransactionError::StakerBalanceNotFound(_)
+            | ConnectTransactionError::PoolDataNotFound(_)
+            | ConnectTransactionError::UndoFetchFailure
+            | ConnectTransactionError::TxVerifierStorage
+            | ConnectTransactionError::FailedToIncrementAccountNonce => {
+                BlockProcessingErrorClass::General
+            }
+
+            ConnectTransactionError::TxNumWrongInBlockOnConnect(_, _)
+            | ConnectTransactionError::MissingOutputOrSpent(_)
+            | ConnectTransactionError::MissingTxInputs
+            | ConnectTransactionError::AttemptToPrintMoney(_, _)
+            | ConnectTransactionError::BlockRewardInputOutputMismatch(_, _)
+            | ConnectTransactionError::TxFeeTotalCalcFailed(_, _)
+            | ConnectTransactionError::BlockHeightArithmeticError
+            | ConnectTransactionError::BlockTimestampArithmeticError
+            | ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoaded(_)
+            | ConnectTransactionError::InvariantErrorHeaderCouldNotBeLoadedFromHeight(_, _)
+            | ConnectTransactionError::BlockIndexCouldNotBeLoaded(_)
+            | ConnectTransactionError::FailedToAddAllFeesOfBlock(_)
+            | ConnectTransactionError::RewardAdditionError(_)
+            | ConnectTransactionError::TimeLockViolation(_)
+            | ConnectTransactionError::BurnAmountSumError(_)
+            | ConnectTransactionError::AttemptToSpendBurnedAmount
+            | ConnectTransactionError::PoolBalanceNotFound(_)
+            | ConnectTransactionError::UnexpectedPoolId(_, _)
+            | ConnectTransactionError::NonceIsNotIncremental(_, _, _)
+            | ConnectTransactionError::MissingTransactionNonce(_)
+            | ConnectTransactionError::NotEnoughPledgeToCreateStakePool(_, _, _)
+            | ConnectTransactionError::AttemptToCreateStakePoolFromAccounts
+            | ConnectTransactionError::AttemptToCreateDelegationFromAccounts
+            | ConnectTransactionError::IOPolicyError(_, _)
+            | ConnectTransactionError::TotalFeeRequiredOverflow
+            | ConnectTransactionError::InsufficientCoinsFee(_, _)
+            | ConnectTransactionError::AttemptToSpendFrozenToken(_) => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            ConnectTransactionError::StorageError(err) => err.classify(),
+            ConnectTransactionError::SignatureVerificationFailed(err) => err.classify(),
+            ConnectTransactionError::UtxoError(err) => err.classify(),
+            ConnectTransactionError::TokensError(err) => err.classify(),
+            ConnectTransactionError::TransactionVerifierError(err) => err.classify(),
+            ConnectTransactionError::UtxoBlockUndoError(err) => err.classify(),
+            ConnectTransactionError::AccountingBlockUndoError(err) => err.classify(),
+            ConnectTransactionError::DestinationRetrievalError(err) => err.classify(),
+            ConnectTransactionError::OutputTimelockError(err) => err.classify(),
+            ConnectTransactionError::SpendStakeError(err) => err.classify(),
+            ConnectTransactionError::TokensAccountingError(err) => err.classify(),
+            ConnectTransactionError::TokensAccountingBlockUndoError(err) => err.classify(),
+            ConnectTransactionError::RewardDistributionError(err) => err.classify(),
+            ConnectTransactionError::CheckTransactionError(err) => err.classify(),
+            ConnectTransactionError::PoSAccountingError(err) => err.classify(),
+            ConnectTransactionError::ConstrainedValueAccumulatorError(err, _) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for storage_result::Error {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        BlockProcessingErrorClass::General
+    }
+}
+
+impl BlockProcessingErrorClassification for PropertyQueryError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            PropertyQueryError::BestBlockIndexNotFound
+            | PropertyQueryError::BlockNotFound(_)
+            | PropertyQueryError::BlockIndexNotFound(_)
+            | PropertyQueryError::PrevBlockIndexNotFound { .. }
+            | PropertyQueryError::BlockForHeightNotFound(_)
+            | PropertyQueryError::GenesisHeaderRequested
+            | PropertyQueryError::InvalidStartingBlockHeightForMainchainBlocks(_)
+            | PropertyQueryError::InvalidBlockHeightRange { .. } => {
+                BlockProcessingErrorClass::General
+            }
+            // Note: these errors are strange - sometimes they don't look like General, judging
+            // by the code that uses them. But other times some of them seem to just wrap storage
+            // errors.
+            // For now, since their p2p ban score is 0, let's consider them General.
+            PropertyQueryError::StakePoolDataNotFound(_)
+            | PropertyQueryError::StakerBalanceOverflow(_)
+            | PropertyQueryError::PoolBalanceNotFound(_) => BlockProcessingErrorClass::General,
+
+            PropertyQueryError::StorageError(err) => err.classify(),
+            PropertyQueryError::GetAncestorError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for DestinationSigError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        // Nothing other than BadBlock here.
+        // TODO: should we descend into inner errors just in case?
+        BlockProcessingErrorClass::BadBlock
+    }
+}
+
+impl BlockProcessingErrorClassification for utxo::Error {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        // Nothing other than BadBlock here.
+        // TODO: should we descend into inner errors just in case?
+        BlockProcessingErrorClass::BadBlock
+    }
+}
+
+impl BlockProcessingErrorClassification for TokensError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            TokensError::StorageError(_) => BlockProcessingErrorClass::General,
+
+            TokensError::IssueError(_, _)
+            | TokensError::MultipleTokenIssuanceInTransaction(_)
+            | TokensError::CoinOrTokenOverflow(_)
+            | TokensError::InsufficientTokenFees(_)
+            | TokensError::TransferZeroTokens(_, _)
+            | TokensError::TokenIdCantBeCalculated
+            | TokensError::TokensInBlockReward
+            | TokensError::InvariantBrokenUndoIssuanceOnNonexistentToken(_)
+            | TokensError::InvariantBrokenRegisterIssuanceWithDuplicateId(_)
+            | TokensError::DeprecatedTokenOperationVersion(_, _) => {
+                BlockProcessingErrorClass::BadBlock
+            }
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for TransactionVerifierStorageError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            TransactionVerifierStorageError::GenBlockIndexRetrievalFailed(_)
+            | TransactionVerifierStorageError::DuplicateBlockUndo(_) => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            TransactionVerifierStorageError::StatePersistenceError(err) => err.classify(),
+            TransactionVerifierStorageError::GetAncestorError(err) => err.classify(),
+            TransactionVerifierStorageError::TokensError(err) => err.classify(),
+            TransactionVerifierStorageError::UtxoError(err) => err.classify(),
+            TransactionVerifierStorageError::UtxoBlockUndoError(err) => err.classify(),
+            TransactionVerifierStorageError::PoSAccountingError(err) => err.classify(),
+            TransactionVerifierStorageError::AccountingBlockUndoError(err) => err.classify(),
+            TransactionVerifierStorageError::TokensAccountingError(err) => err.classify(),
+            TransactionVerifierStorageError::TokensAccountingBlockUndoError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for GetAncestorError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            GetAncestorError::PrevBlockIndexNotFound(_)
+            | GetAncestorError::StartingPointNotFound(_)
+            // Note: this one is more like an invariant violation, despite its ban score being 100.
+            | GetAncestorError::InvalidAncestorHeight { .. }
+            => BlockProcessingErrorClass::General,
+
+            GetAncestorError::StorageError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for UtxosBlockUndoError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            UtxosBlockUndoError::UndoAlreadyExists(_)
+            | UtxosBlockUndoError::UndoAlreadyExistsForReward
+            | UtxosBlockUndoError::TxUndoWithDependency(_) => BlockProcessingErrorClass::BadBlock,
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for pos_accounting::BlockUndoError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        use pos_accounting::BlockUndoError;
+
+        match self {
+            BlockUndoError::UndoAlreadyExists(_)
+            | BlockUndoError::MissingTxUndo(_)
+            | BlockUndoError::UndoAlreadyExistsForReward => BlockProcessingErrorClass::BadBlock,
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for SignatureDestinationGetterError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            SignatureDestinationGetterError::SpendingOutputInBlockReward
+            | SignatureDestinationGetterError::SpendingFromAccountInBlockReward
+            | SignatureDestinationGetterError::SigVerifyOfNotSpendableOutput
+            | SignatureDestinationGetterError::PoolDataNotFound(_)
+            | SignatureDestinationGetterError::DelegationDataNotFound(_)
+            | SignatureDestinationGetterError::TokenDataNotFound(_)
+            | SignatureDestinationGetterError::UtxoOutputNotFound(_) => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            SignatureDestinationGetterError::UtxoViewError(err) => err.classify(),
+            SignatureDestinationGetterError::SigVerifyPoSAccountingError(err) => err.classify(),
+            SignatureDestinationGetterError::SigVerifyTokensAccountingError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for timelock_check::OutputMaturityError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        use timelock_check::OutputMaturityError;
+
+        match self {
+            OutputMaturityError::InvalidOutputMaturitySettingType(_)
+            | OutputMaturityError::InvalidOutputMaturityDistance(_, _, _) => {
+                BlockProcessingErrorClass::BadBlock
+            }
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for SpendStakeError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            SpendStakeError::NoBlockRewardOutputs
+            | SpendStakeError::MultipleBlockRewardOutputs
+            | SpendStakeError::InvalidBlockRewardOutputType
+            | SpendStakeError::StakePoolDataMismatch
+            | SpendStakeError::StakePoolIdMismatch(_, _) => BlockProcessingErrorClass::BadBlock,
+
+            SpendStakeError::ConsensusPoSError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for ConsensusPoWError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            ConsensusPoWError::PreviousBitsDecodingFailed(_) => BlockProcessingErrorClass::General,
+
+            ConsensusPoWError::InvalidPoW(_)
+            | ConsensusPoWError::PrevBlockNotFound(_)
+            | ConsensusPoWError::NoPowDataInPreviousBlock
+            | ConsensusPoWError::DecodingBitsFailed(_)
+            | ConsensusPoWError::InvalidTargetBits(_, _)
+            | ConsensusPoWError::PoSInputDataProvided
+            | ConsensusPoWError::NoInputDataProvided => BlockProcessingErrorClass::BadBlock,
+
+            ConsensusPoWError::PrevBlockLoadError(_, err) => err.classify(),
+            ConsensusPoWError::AncestorAtHeightNotFound(_, _, err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for ConsensusPoSError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            ConsensusPoSError::NoEpochData
+            | ConsensusPoSError::PrevBlockIndexNotFound(_)
+            | ConsensusPoSError::PoolDataNotFound(_)
+            | ConsensusPoSError::FailedToFetchUtxo
+            | ConsensusPoSError::FailedToSignBlockHeader
+            | ConsensusPoSError::FailedReadingBlock(_)
+            | ConsensusPoSError::FutureTimestampInThePast
+            | ConsensusPoSError::FailedToSignKernel => BlockProcessingErrorClass::General,
+
+            ConsensusPoSError::StakeKernelHashTooHigh
+            | ConsensusPoSError::TimestampViolation(_, _)
+            | ConsensusPoSError::NoKernel
+            | ConsensusPoSError::MissingKernelUtxo
+            | ConsensusPoSError::KernelOutpointMustBeUtxo
+            | ConsensusPoSError::MultipleKernels
+            | ConsensusPoSError::BitsToTargetConversionFailed(_)
+            | ConsensusPoSError::PoolBalanceNotFound(_)
+            | ConsensusPoSError::InvalidTarget(_)
+            | ConsensusPoSError::DecodingBitsFailed(_)
+            | ConsensusPoSError::NotEnoughTimestampsToAverage
+            | ConsensusPoSError::InvalidTargetBlockTime
+            | ConsensusPoSError::TimestampOverflow
+            | ConsensusPoSError::InvariantBrokenNotMonotonicBlockTime
+            | ConsensusPoSError::EmptyTimespan
+            | ConsensusPoSError::NoInputDataProvided
+            | ConsensusPoSError::PoWInputDataProvided
+            | ConsensusPoSError::PoSBlockTimeStrictOrderInvalid(_)
+            | ConsensusPoSError::FiniteTotalSupplyIsRequired
+            | ConsensusPoSError::UnsupportedConsensusVersion
+            | ConsensusPoSError::FailedToCalculateCappedBalance => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            ConsensusPoSError::TargetConversionError(err) => match err {
+                UintConversionError::ConversionOverflow => BlockProcessingErrorClass::BadBlock,
+            },
+
+            ConsensusPoSError::StorageError(err) => err.classify(),
+            ConsensusPoSError::PropertyQueryError(err) => err.classify(),
+            ConsensusPoSError::ChainstateError(err) => err.classify(),
+            ConsensusPoSError::PoSAccountingError(err) => err.classify(),
+            ConsensusPoSError::RandomnessError(err) => err.classify(),
+            ConsensusPoSError::BlockSignatureError(err) => err.classify(),
+            ConsensusPoSError::EffectivePoolBalanceError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for consensus::ChainstateError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        use consensus::ChainstateError;
+
+        match self {
+            // These all represent a general chainstate failure.
+            // TODO: it's better to delegate to the inner error anyway.
+            ChainstateError::FailedToObtainEpochData(_, _err)
+            | ChainstateError::StakePoolDataReadError(_, _err)
+            | ChainstateError::PoolBalanceReadError(_, _err) => BlockProcessingErrorClass::General,
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for PoSRandomnessError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        // Nothing other than BadBlock here.
+        // TODO: should we descend into inner errors just in case?
+        BlockProcessingErrorClass::BadBlock
+    }
+}
+
+impl BlockProcessingErrorClassification for BlockSignatureError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        // Nothing other than BadBlock here.
+        // TODO: should we descend into inner errors just in case?
+        BlockProcessingErrorClass::BadBlock
+    }
+}
+
+impl BlockProcessingErrorClassification for EffectivePoolBalanceError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            EffectivePoolBalanceError::ArithmeticError
+            | EffectivePoolBalanceError::FinalSupplyZero
+            | EffectivePoolBalanceError::PoolBalanceGreaterThanSupply(_, _)
+            | EffectivePoolBalanceError::PoolPledgeGreaterThanBalance(_, _)
+            | EffectivePoolBalanceError::AdjustmentMustFitIntoAmount => {
+                BlockProcessingErrorClass::BadBlock
+            }
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for tokens_accounting::Error {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        use tokens_accounting::Error;
+
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            Error::ViewFail | Error::StorageWrite => BlockProcessingErrorClass::General,
+
+            Error::TokenAlreadyExists(_)
+            | Error::TokenDataNotFound(_)
+            | Error::TokenDataNotFoundOnReversal(_)
+            | Error::CirculatingSupplyNotFound(_)
+            | Error::MintExceedsSupplyLimit(_, _, _)
+            | Error::AmountOverflow
+            | Error::CannotMintFromLockedSupply(_)
+            | Error::CannotMintFrozenToken(_)
+            | Error::CannotUnmintFromLockedSupply(_)
+            | Error::CannotUnmintFrozenToken(_)
+            | Error::NotEnoughCirculatingSupplyToUnmint(_, _, _)
+            | Error::SupplyIsAlreadyLocked(_)
+            | Error::CannotLockNotLockableSupply(_)
+            | Error::CannotLockFrozenToken(_)
+            | Error::CannotUnlockNotLockedSupplyOnReversal(_)
+            | Error::CannotUndoMintForLockedSupplyOnReversal(_)
+            | Error::CannotUndoUnmintForLockedSupplyOnReversal(_)
+            | Error::TokenIsAlreadyFrozen(_)
+            | Error::CannotFreezeNotFreezableToken(_)
+            | Error::CannotUnfreezeNotUnfreezableToken(_)
+            | Error::CannotUnfreezeTokenThatIsNotFrozen(_)
+            | Error::CannotUndoFreezeTokenThatIsNotFrozen(_)
+            | Error::CannotUndoUnfreezeTokenThatIsFrozen(_)
+            | Error::CannotChangeAuthorityForFrozenToken(_)
+            | Error::CannotUndoChangeAuthorityForFrozenToken(_) => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            Error::StorageError(err) => err.classify(),
+            Error::AccountingError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for accounting::Error {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        // Nothing other than BadBlock here.
+        // TODO: should we descend into inner errors just in case?
+        BlockProcessingErrorClass::BadBlock
+    }
+}
+
+impl BlockProcessingErrorClassification for tokens_accounting::BlockUndoError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        // Nothing other than BadBlock here.
+        // TODO: should we descend into inner errors just in case?
+        BlockProcessingErrorClass::BadBlock
+    }
+}
+
+impl BlockProcessingErrorClassification for RewardDistributionError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            RewardDistributionError::PoolDataNotFound(_)
+            | RewardDistributionError::PoolBalanceNotFound(_) => BlockProcessingErrorClass::General,
+
+            RewardDistributionError::InvariantPoolBalanceIsZero(_)
+            | RewardDistributionError::InvariantStakerBalanceGreaterThanPoolBalance(_, _, _)
+            | RewardDistributionError::RewardAdditionError(_)
+            | RewardDistributionError::TotalDelegationBalanceZero(_)
+            | RewardDistributionError::StakerRewardCalculationFailed(_, _)
+            | RewardDistributionError::StakerRewardCannotExceedTotalReward(_, _, _, _)
+            | RewardDistributionError::DistributedDelegationsRewardExceedTotal(_, _, _, _)
+            | RewardDistributionError::DelegationRewardOverflow(_, _, _, _)
+            | RewardDistributionError::DelegationsRewardSumFailed(_, _)
+            | RewardDistributionError::StakerRewardOverflow(_, _, _, _) => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            RewardDistributionError::PoSAccountingError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for CheckTransactionError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            CheckTransactionError::DuplicateInputInTransaction(_)
+            | CheckTransactionError::InvalidWitnessCount(_)
+            | CheckTransactionError::EmptyInputsInTransaction(_)
+            | CheckTransactionError::NoSignatureDataSizeTooLarge(_, _, _)
+            | CheckTransactionError::NoSignatureDataNotAllowed(_)
+            | CheckTransactionError::DataDepositMaxSizeExceeded(_, _, _)
+            | CheckTransactionError::TxSizeTooLarge(_, _, _) => BlockProcessingErrorClass::BadBlock,
+
+            CheckTransactionError::PropertyQueryError(err) => err.classify(),
+            CheckTransactionError::TokensError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for pos_accounting::Error {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        use pos_accounting::Error;
+
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            Error::ViewFail => BlockProcessingErrorClass::General,
+
+            Error::InvariantErrorPoolBalanceAlreadyExists
+            | Error::InvariantErrorPoolDataAlreadyExists
+            | Error::AttemptedDecommissionNonexistingPoolBalance
+            | Error::AttemptedDecommissionNonexistingPoolData
+            | Error::DelegationCreationFailedPoolDoesNotExist
+            | Error::DelegationDeletionFailedIdDoesNotExist
+            | Error::DelegationDeletionFailedBalanceNonZero
+            | Error::DelegationDeletionFailedPoolsShareNonZero
+            | Error::DelegationDeletionFailedPoolStillExists
+            | Error::InvariantErrorDelegationCreationFailedIdAlreadyExists
+            | Error::DelegateToNonexistingId
+            | Error::DelegateToNonexistingPool
+            | Error::AdditionError
+            | Error::SubError
+            | Error::DelegationBalanceAdditionError
+            | Error::DelegationBalanceSubtractionError
+            | Error::PoolBalanceAdditionError
+            | Error::PoolBalanceSubtractionError
+            | Error::DelegationSharesAdditionError
+            | Error::DelegationSharesSubtractionError
+            | Error::InvariantErrorPoolCreationReversalFailedBalanceNotFound
+            | Error::InvariantErrorPoolCreationReversalFailedDataNotFound
+            | Error::InvariantErrorPoolCreationReversalFailedAmountChanged
+            | Error::InvariantErrorDecommissionUndoFailedPoolBalanceAlreadyExists
+            | Error::InvariantErrorDecommissionUndoFailedPoolDataAlreadyExists
+            | Error::InvariantErrorDelegationIdUndoFailedNotFound
+            | Error::InvariantErrorDelegationIdUndoFailedDataConflict
+            | Error::InvariantErrorDelegationBalanceAdditionUndoError
+            | Error::InvariantErrorPoolBalanceAdditionUndoError
+            | Error::InvariantErrorDelegationSharesAdditionUndoError
+            | Error::InvariantErrorDelegationShareNotFound
+            | Error::PledgeValueToSignedError
+            | Error::InvariantErrorDelegationUndoFailedDataNotFound(_)
+            | Error::DuplicatesInDeltaAndUndo
+            | Error::IncreaseStakerRewardsOfNonexistingPool
+            | Error::StakerBalanceOverflow
+            | Error::InvariantErrorIncreasePledgeUndoFailedPoolBalanceNotFound
+            | Error::InvariantErrorIncreaseStakerRewardUndoFailedPoolBalanceNotFound => {
+                BlockProcessingErrorClass::BadBlock
+            }
+
+            Error::StorageError(err) => err.classify(),
+            Error::AccountingError(err) => err.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for constraints_value_accumulator::Error {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        use constraints_value_accumulator::Error;
+
+        match self {
+            // Use "General" for consistency with the zero ban score.
+            Error::DelegationBalanceNotFound(_) | Error::AccountBalanceNotFound(_) => {
+                BlockProcessingErrorClass::General
+            }
+
+            Error::AmountOverflow
+            | Error::CoinOrTokenOverflow(_)
+            | Error::AttemptToPrintMoney(_)
+            | Error::AttemptToPrintMoneyOrViolateTimelockConstraints(_)
+            | Error::AttemptToViolateFeeRequirements
+            | Error::InputsAndInputsUtxosLengthMismatch(_, _)
+            | Error::MissingOutputOrSpent(_)
+            | Error::PledgeAmountNotFound(_)
+            | Error::SpendingNonSpendableOutput(_)
+            | Error::NegativeAccountBalance(_) => BlockProcessingErrorClass::BadBlock,
+
+            Error::PoSAccountingError(err) => err.classify(),
+        }
+    }
+}

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -40,6 +40,13 @@ use super::{
     block_invalidation::BestChainCandidatesError, chainstateref::EpochSealError, BlockSizeError,
 };
 
+/// When handling errors during block processing, we need to differentiate between errors that
+/// should lead to block invalidation and those that shouldn't. Ideally, this separation should
+/// be done inside the BlockError type itself. But currently BlockError is a fairly deep tree
+/// of error types and on most of its levels there are errors that represent block invalidity
+/// and there are ones that don't (e.g. the storage error can be found on almost any level).
+/// So instead we introduce and implement a trait that allows to classify a BlockError instance.
+/// This enum represents the classes that we're interested in.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum BlockProcessingErrorClass {
     /// General error - the operation failed due to storage issues, invariant violations etc.
@@ -76,6 +83,7 @@ impl BlockProcessingErrorClass {
 // 3) The errors that should be treated carefully are those that can happen during normal
 // cause of operation and that don't represent a 100% invalid block (e.g. BlockFromTheFuture).
 
+/// The trait that handles the classification.
 pub trait BlockProcessingErrorClassification {
     fn classify(&self) -> BlockProcessingErrorClass;
 }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -348,13 +348,6 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
                     block_id,
                 )
             }
-            ReorgError::BlockDataMissing(block_id) => {
-                BlockIntegrationError::ConnectBlockErrorDuringReorg(
-                    BlockError::BlockDataMissingForValidBlockIndex(block_id),
-                    block_status,
-                    block_id,
-                )
-            }
             ReorgError::OtherError(block_err) => {
                 BlockIntegrationError::OtherReorgError(block_err, block_status)
             }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -315,15 +315,10 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
     ) -> Result<bool, BlockIntegrationError> {
         let mut block_status = BlockStatus::new();
 
-        let result = chainstate_ref.check_block(block);
-
-        if result.as_ref().is_err_and(|err| err.classify().block_should_be_invalidated()) {
-            block_status.set_validation_failed();
-        }
-
-        result
+        chainstate_ref
+            .check_block(block)
             .map_err(BlockError::CheckBlockFailed)
-            .map_err(|err| BlockIntegrationError::OtherValidationError(err, block_status))?;
+            .map_err(|err| BlockIntegrationError::BlockCheckError(err, block_status))?;
 
         block_status.advance_validation_stage_to(BlockValidationStage::CheckBlockOk);
         let block_status = block_status;
@@ -332,7 +327,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
         chainstate_ref
             .set_new_block_index(&block_index)
             .and_then(|_| chainstate_ref.persist_block(block))
-            .map_err(|err| BlockIntegrationError::OtherValidationError(err, block_status))?;
+            .map_err(|err| BlockIntegrationError::BlockCheckError(err, block_status))?;
 
         // Note: we don't advance the stage to FullyChecked if activate_best_chain succeeds even
         // if we know that a reorg has occurred, because during a reorg multiple blocks get
@@ -361,7 +356,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
                 )
             }
             ReorgError::OtherError(block_err) => {
-                BlockIntegrationError::OtherValidationError(block_err, block_status)
+                BlockIntegrationError::OtherReorgError(block_err, block_status)
             }
         })
     }
@@ -406,9 +401,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
             },
         );
 
-        // Check the result and bail out on success or on a db error.
-        // On a validation error, retrieve its data for the next step.
-        let (err, status, first_invalid_block_id) = match integrate_block_result {
+        match integrate_block_result {
             Ok(reorg_occurred) => {
                 // If the above code has succeeded, then the block_index must be present in the DB.
                 // Note that we can't return the initially obtained block_index, because its
@@ -432,61 +425,97 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
             Err(BlockIntegrationError::ConnectBlockErrorDuringReorg(
                 err,
                 status,
-                first_invalid_block_id,
-            )) => (err, status, Some(first_invalid_block_id)),
-            Err(BlockIntegrationError::OtherValidationError(err, status)) => (err, status, None),
-        };
+                first_invalid_parent_id,
+            )) => {
+                let is_block_in_main_chain = {
+                    let chainstate_ref = self.make_db_tx_ro().map_err(BlockError::from)?;
+                    is_block_in_main_chain(&chainstate_ref, &first_invalid_parent_id.into())?
+                };
+                assert!(!is_block_in_main_chain);
 
-        // Update the block status; note that this is needed even if we're going to call
-        // invalidate_stale_block below, because it expects that all block indices
-        // already exist (also, it will update this block's status, setting the appropriate
-        // failure bit).
-        {
-            // Note: we already have an error to return, so we ignore the result of
-            // the following call.
-            let _result = self.with_rw_tx(
-                |chainstate_ref| chainstate_ref.update_block_status(block_index.clone(), status),
-                |attempt_number| {
-                    log::info!("Updating status for block {block_id}, attempt #{attempt_number}");
-                },
-                |attempts_count, db_err| {
-                    BlockError::DbCommitError(
-                        attempts_count,
-                        db_err,
-                        DbCommittingContext::BlockStatus(block_id),
-                    )
-                },
-            );
-        }
+                let error_class = err.classify();
+                if error_class.block_should_be_invalidated() {
+                    log::warn!(
+                        "Bad block {} found during reorg, invalidating",
+                        first_invalid_parent_id
+                    );
 
-        if let Some(first_invalid_block_id) = first_invalid_block_id {
-            let is_block_in_main_chain = {
-                let chainstate_ref = self.make_db_tx_ro().map_err(BlockError::from)?;
-                is_block_in_main_chain(&chainstate_ref, &first_invalid_block_id.into())?
-            };
-            assert!(!is_block_in_main_chain);
+                    // Since the failure occurred during reorg, the new block itself is ok.
+                    // Update its block status to persist its validation stage.
+                    // Also, invalidate_block needs the block index to exist in order to be able to
+                    // set the corresponding failure bit.
+                    debug_assert!(status.is_ok());
+                    // Ignore the result, because we already have an error to return.
+                    let _result = self.update_block_status(&block_index, status);
 
-            let error_class = err.classify();
-            let should_invalidate = error_class.block_should_be_invalidated();
-
-            if should_invalidate {
-                log::warn!(
-                    "Bad block {} found during reorg, invalidating",
-                    first_invalid_block_id
-                );
-
-                // Again, we ignore the result here.
-                let _result = BlockInvalidator::new(self)
-                    .invalidate_block(&first_invalid_block_id, block_invalidation::IsExplicit::No);
-            } else {
-                log::warn!(
-                    "Error occurred during reorg, but the block ({}) may not be invalid; skipping invalidation",
-                    first_invalid_block_id
-                );
+                    // Again, we ignore the result here.
+                    let _result = BlockInvalidator::new(self).invalidate_block(
+                        &first_invalid_parent_id,
+                        block_invalidation::IsExplicit::No,
+                    );
+                } else {
+                    log::warn!(
+                        "Error occurred during reorg, but the block ({}) may not be invalid; skipping invalidation",
+                        first_invalid_parent_id
+                    );
+                    // Don't save an "ok" status for a block that hasn't been persisted.
+                }
+                return Err(err);
             }
-        }
+            Err(BlockIntegrationError::OtherReorgError(err, _status)) => {
+                log::warn!("Error occurred during reorg, but no blocks can be blamed");
+                // Don't save an "ok" status for a block that hasn't been persisted.
+                return Err(err);
+            }
+            Err(BlockIntegrationError::BlockCheckError(err, status)) => {
+                // The failure occurred during the integration of the new block itself.
 
-        Err(err)
+                let error_class = err.classify();
+                if error_class.block_should_be_invalidated() {
+                    log::warn!(
+                        "Block {} integration failed, marking it as a bad block",
+                        block_id
+                    );
+
+                    let mut status = status;
+                    status.set_validation_failed();
+                    // Ignore the result, because we already have an error to return.
+                    let _result = self.update_block_status(&block_index, status);
+                } else {
+                    log::warn!(
+                        "Block {} integration failed, but it may not be a bad block",
+                        block_id
+                    );
+                    // Don't save an "ok" status for a block that hasn't been persisted.
+                }
+                return Err(err);
+            }
+        };
+    }
+
+    #[log_error]
+    fn update_block_status(
+        &mut self,
+        block_index: &BlockIndex,
+        status: BlockStatus,
+    ) -> Result<(), BlockError> {
+        self.with_rw_tx(
+            |chainstate_ref| chainstate_ref.update_block_status(block_index.clone(), status),
+            |attempt_number| {
+                log::info!(
+                    "Updating status for block {}, attempt #{}",
+                    block_index.block_id(),
+                    attempt_number
+                );
+            },
+            |attempts_count, db_err| {
+                BlockError::DbCommitError(
+                    attempts_count,
+                    db_err,
+                    DbCommittingContext::BlockStatus(*block_index.block_id()),
+                )
+            },
+        )
     }
 
     /// process orphan blocks that depend on the given block, recursively
@@ -733,8 +762,10 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
 enum BlockIntegrationError {
     #[error("Reorg error during block integration: {0}; resulting block status is {1}; first bad block id is {2}")]
     ConnectBlockErrorDuringReorg(BlockError, BlockStatus, Id<Block>),
-    #[error("Generic error during block integration: {0}; resulting block status is {1}")]
-    OtherValidationError(BlockError, BlockStatus),
+    #[error("Reorg error during block integration: {0}; resulting block status is {1}")]
+    OtherReorgError(BlockError, BlockStatus),
+    #[error("Error checking block during block integration: {0}; resulting block status is {1}")]
+    BlockCheckError(BlockError, BlockStatus),
     #[error("Failed to commit block data for block {0} after {1} attempts: {2}")]
     BlockCommitError(Id<Block>, usize, chainstate_storage::Error),
     #[error("Generic error: {0}")]

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -330,7 +330,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
 
         let block_index = block_index.with_status(block_status);
         chainstate_ref
-            .set_block_index(&block_index)
+            .set_new_block_index(&block_index)
             .and_then(|_| chainstate_ref.persist_block(block))
             .map_err(|err| BlockIntegrationError::OtherValidationError(err, block_status))?;
 
@@ -384,17 +384,14 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
             let existing_block_index = get_block_index(&chainstate_ref, &block_id)?;
 
             if let Some(block_index) = existing_block_index {
-                if block_index.status().is_fully_valid() {
-                    return Err(BlockError::BlockAlreadyProcessed(block_id));
-                } else if !block_index.status().is_ok() {
-                    return Err(BlockError::InvalidBlockAlreadyProcessed(block_id));
-                }
-
-                // The block is ok, but not fully valid.
-                block_index
-            } else {
-                chainstate_ref.create_block_index_for_new_block(&block, BlockStatus::new())?
+                return if block_index.status().is_ok() {
+                    Err(BlockError::BlockAlreadyProcessed(block_id))
+                } else {
+                    Err(BlockError::InvalidBlockAlreadyProcessed(block_id))
+                };
             }
+
+            chainstate_ref.create_block_index_for_new_block(&block, BlockStatus::new())?
         };
 
         // Perform block checks; `integrate_block_result` is `Result<bool>`, where the bool

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -435,8 +435,8 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
 
                     // Since the failure occurred during reorg, the new block itself is ok.
                     // Update its block status to persist its validation stage.
-                    // Also, invalidate_block needs the block index to exist in order to be able to
-                    // set the corresponding failure bit.
+                    // (Also, invalidate_block needs the block index to exist in order to be able to
+                    // set the corresponding failure bit.)
                     debug_assert!(status.is_ok());
                     // Ignore the result, because we already have an error to return.
                     let _result = self.update_block_status(&block_index, status);
@@ -456,7 +456,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
                 return Err(err);
             }
             Err(BlockIntegrationError::OtherReorgError(err, _status)) => {
-                log::warn!("Error occurred during reorg, but no blocks can be blamed");
+                log::warn!("An error occurred during reorg, but none of the blocks can be blamed");
                 // Don't save an "ok" status for a block that hasn't been persisted.
                 return Err(err);
             }

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -90,7 +90,7 @@ where
     #[tracing::instrument(skip_all, fields(block_id = %block_id))]
     fn reset_block_failure_flags(&mut self, block_id: &Id<Block>) -> Result<(), ChainstateError> {
         BlockInvalidator::new(&mut self.chainstate)
-            .reset_block_failure_flags(block_id, true)
+            .reset_block_failure_flags(block_id)
             .map_err(ChainstateError::BlockInvalidatorError)
     }
 

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -90,7 +90,7 @@ where
     #[tracing::instrument(skip_all, fields(block_id = %block_id))]
     fn reset_block_failure_flags(&mut self, block_id: &Id<Block>) -> Result<(), ChainstateError> {
         BlockInvalidator::new(&mut self.chainstate)
-            .reset_block_failure_flags(block_id)
+            .reset_block_failure_flags(block_id, true)
             .map_err(ChainstateError::BlockInvalidatorError)
     }
 

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -35,11 +35,11 @@ pub use crate::{
     config::{ChainstateConfig, MaxTipAge},
     detail::{
         ban_score, block_invalidation::BlockInvalidatorError, calculate_median_time_past,
-        calculate_median_time_past_from_blocktimestamps, BlockError, BlockSource, ChainInfo,
-        CheckBlockError, CheckBlockTransactionsError, ConnectTransactionError, IOPolicyError,
-        InitializationError, Locator, OrphanCheckError, SpendStakeError,
-        StorageCompatibilityCheckError, TokenIssuanceError, TokensError,
-        TransactionVerifierStorageError, MEDIAN_TIME_SPAN,
+        calculate_median_time_past_from_blocktimestamps, BlockError, BlockProcessingErrorClass,
+        BlockProcessingErrorClassification, BlockSource, ChainInfo, CheckBlockError,
+        CheckBlockTransactionsError, ConnectTransactionError, IOPolicyError, InitializationError,
+        Locator, OrphanCheckError, SpendStakeError, StorageCompatibilityCheckError,
+        TokenIssuanceError, TokensError, TransactionVerifierStorageError, MEDIAN_TIME_SPAN,
     },
 };
 pub use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};

--- a/chainstate/storage/src/internal/store_tx/write_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/write_impls.rs
@@ -71,6 +71,11 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
     }
 
     #[log_error]
+    fn del_block_index(&mut self, block_id: Id<Block>) -> crate::Result<()> {
+        self.0.get_mut::<db::DBBlockIndex, _>().del(block_id).map_err(Into::into)
+    }
+
+    #[log_error]
     fn set_min_height_with_allowed_reorg(&mut self, height: BlockHeight) -> crate::Result<()> {
         self.write_value::<well_known::MinHeightForReorg>(&height)
     }

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -83,6 +83,10 @@ pub trait BlockchainStorageRead:
     /// Get block by its hash
     fn get_block(&self, id: Id<Block>) -> crate::Result<Option<Block>>;
 
+    // TODO: sometimes get_block is used just to check for block existence in the db; it's better
+    // to add a separate function for this, which wouldn't have the overhead of copying and decoding
+    // of the block's data.
+
     fn get_block_header(&self, id: Id<Block>) -> crate::Result<Option<SignedBlockHeader>>;
 
     /// Get the height below which reorgs should not be allowed.
@@ -156,6 +160,9 @@ pub trait BlockchainStorageWrite:
 
     /// Set the block index
     fn set_block_index(&mut self, block_index: &BlockIndex) -> Result<()>;
+
+    /// Remove block index from the database
+    fn del_block_index(&mut self, block_id: Id<Block>) -> Result<()>;
 
     /// Add a new block into the database
     fn add_block(&mut self, block: &Block) -> Result<()>;

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -157,6 +157,7 @@ mockall::mock! {
         fn set_chain_type(&mut self, chain: &str) -> crate::Result<()>;
         fn set_best_block_id(&mut self, id: &Id<GenBlock>) -> crate::Result<()>;
         fn set_block_index(&mut self, block_index: &BlockIndex) -> crate::Result<()>;
+        fn del_block_index(&mut self, block_id: Id<Block>) -> crate::Result<()>;
         fn add_block(&mut self, block: &Block) -> crate::Result<()>;
         fn del_block(&mut self, id: Id<Block>) -> crate::Result<()>;
 
@@ -533,6 +534,7 @@ mockall::mock! {
         fn set_chain_type(&mut self, chain: &str) -> crate::Result<()>;
         fn set_best_block_id(&mut self, id: &Id<GenBlock>) -> crate::Result<()>;
         fn set_block_index(&mut self, block_index: &BlockIndex) -> crate::Result<()>;
+        fn del_block_index(&mut self, block_id: Id<Block>) -> crate::Result<()>;
         fn add_block(&mut self, block: &Block) -> crate::Result<()>;
         fn del_block(&mut self, id: Id<Block>) -> crate::Result<()>;
 

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -315,6 +315,10 @@ impl TestFramework {
         self.chainstate.get_gen_block_index(id).unwrap().unwrap()
     }
 
+    pub fn block_index_exists(&self, id: &Id<GenBlock>) -> bool {
+        self.chainstate.get_gen_block_index(id).unwrap().is_some()
+    }
+
     pub fn index_at(&self, at: usize) -> &BlockIndex {
         assert!(at > 0, "No block index for genesis");
         &self.block_indexes[at - 1]

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -355,6 +355,15 @@ impl TestFramework {
         tx_rw.set_block_index(&block_idx).unwrap();
         tx_rw.commit().unwrap();
     }
+
+    // Delete the block and its index
+    pub fn purge_block(&mut self, block_id: &Id<Block>) {
+        let mut tx_rw = self.storage.transaction_rw(None).unwrap();
+
+        tx_rw.del_block(*block_id).unwrap();
+        tx_rw.del_block_index(*block_id).unwrap();
+        tx_rw.commit().unwrap();
+    }
 }
 
 #[rstest]

--- a/chainstate/test-suite/Cargo.toml
+++ b/chainstate/test-suite/Cargo.toml
@@ -26,6 +26,7 @@ tx-verifier = { path = '../tx-verifier' }
 utils = { path = '../../utils' }
 utxo = { path = '../../utxo' }
 
+ctor.workspace = true
 hex.workspace = true
 itertools.workspace = true
 

--- a/chainstate/test-suite/src/tests/block_invalidation.rs
+++ b/chainstate/test-suite/src/tests/block_invalidation.rs
@@ -538,7 +538,7 @@ fn complex_test_impl(mut tf: TestFramework, block_ids: &TestChainBlockIds) {
         assert_eq!(tf.best_block_id(), m[6]);
 
         // "b", "c" and "d" are different - fully validated blocks have retained their FullyChecked
-        // status; and block indices of blocks that were initially invalid have been removed.
+        // status and block indices of blocks that were initially invalid have been removed.
         assert_in_stale_chain(&tf, b);
         assert_fully_valid_blocks(&tf, &b[..1]);
         assert_no_block_indices(&tf, &b[1..]);
@@ -728,7 +728,7 @@ fn test_invalidation_with_reorg_to_chain_with_bad_tip2(#[case] seed: Seed) {
 // Reset failure flags of a1 in:
 // /----a0---!a1
 // G----m0----m1
-// Here a1 is invalid and has the highest chain trust; a0 and m0 has the same chain trust.
+// Here a1 is invalid and has the highest chain trust; a0 and m0 have the same chain trust.
 // What happens:
 // 1) a reorg attempt is made, where the list of candidates is not empty - a1 is the candidate;
 // 2) a1 is invalid, so it is removed from the candidates list; its parent is supposed to be tried

--- a/chainstate/test-suite/src/tests/block_invalidation.rs
+++ b/chainstate/test-suite/src/tests/block_invalidation.rs
@@ -13,18 +13,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{sync::Arc, time::Duration};
+
 use rstest::rstest;
 
 use super::helpers::{block_creation_helpers::*, block_status_helpers::*};
-use chainstate::{BlockInvalidatorError, ChainstateError};
+use chainstate::{
+    BlockError, BlockInvalidatorError, BlockProcessingErrorClass,
+    BlockProcessingErrorClassification, BlockSource, ChainstateError, CheckBlockError,
+};
 use chainstate_test_framework::TestFramework;
-use chainstate_types::BlockValidationStage;
+use chainstate_types::{BlockStatus, BlockValidationStage};
 use common::{
-    chain::{self, Block},
+    chain::{
+        self,
+        block::{consensus_data::PoWData, timestamp::BlockTimestamp, Block, ConsensusData},
+    },
     primitives::{BlockDistance, Id, Idable},
+    Uint256,
 };
 use crypto::random::{CryptoRng, Rng};
-use test_utils::random::{make_seedable_rng, Seed};
+use logging::log;
+use test_utils::{
+    assert_matches,
+    mock_time_getter::mocked_time_getter_seconds,
+    random::{make_seedable_rng, Seed},
+};
+use utils::atomics::SeqCstAtomicU64;
 
 // Invalidate a0 in:
 // /----a0----a1----a2
@@ -621,8 +636,8 @@ fn test_tip_invalidation_with_no_better_candidates(#[case] seed: Seed) {
 // Invalidate m0 in:
 // /----a0---!a1
 // G----m0----m1
-// where a1 is completely invalid (i.e. it didn't pass even the check_block stage), but its
-// status has been manually reset to "ok".
+// where a1 is invalid (it didn't pass even the check_block stage), but its status
+// has been manually reset to "ok".
 // This checks two facts:
 // 1) It's ok to try to reorg to blocks like that (i.e. it'll fail gracefully);
 // 2) If a reorg to the tip of a branch fails, its parents from the same branch are still
@@ -658,7 +673,137 @@ fn test_invalidation_with_reorg_to_chain_with_bad_tip(#[case] seed: Seed) {
 
         // a0 is now the best block, a1 is back to its "bad" status.
         assert_eq!(tf.best_block_id(), a0_id);
-        assert_bad_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
+        // Note: reorg to a1 will fail due to the missing block data, which doesn't lead
+        // to block invalidation; so, a1 is still "ok".
+        assert_ok_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
+        assert_fully_valid_blocks(&tf, &[a0_id]);
+        assert_invalidated_blocks_at_stage(&tf, &[m0_id], BlockValidationStage::FullyChecked);
+        assert_blocks_with_bad_parent_at_stage(&tf, &[m1_id], BlockValidationStage::FullyChecked);
+    });
+}
+
+// Reset failure flags of a1 in:
+// /----a0---!a1
+// G----m0----m1
+// Here a1 is invalid and has the highest chain trust; a0 and m0 has the same chain trust.
+// What happens:
+// 1) a reorg attempt is made, where the list of candidates is not empty - a1 is the candidate;
+// 2) a1 is invalid, so it is removed from the candidates list; its parent is supposed to be tried
+// instead.
+// 3) but a0 has lower chain trust than m1, so actually it should not be added to the candidates list.
+// Expected result: the test completes without panicking.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn test_invalidation_with_reorg_attempt_to_chain_with_lower_chain_trust(#[case] seed: Seed) {
+    utils::concurrency::model(move || {
+        let mut rng = make_seedable_rng(seed);
+        let mut tf = TestFramework::builder(&mut rng).build();
+        let genesis_id = tf.genesis().get_id();
+
+        let (m0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
+        assert!(result.is_ok());
+        let (m1_id, result) = process_block(&mut tf, &m0_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        let (a0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        // Creating a1 with some bogus PoWData data serves 2 purposes:
+        // 1) It will be invalid, because the chain is configured with ConsensusData::None.
+        // 2) It will have some large chain trust, which will definitely be bigger than
+        // chain trusts of blocks that adhere to ConsensusData::None.
+        let a1 = tf
+            .make_block_builder()
+            .add_test_transaction_with_parent(a0_id.into(), &mut rng)
+            .with_parent(a0_id.into())
+            .with_reward(make_block_reward())
+            .with_consensus_data(ConsensusData::PoW(Box::new(PoWData::new(
+                Uint256::from_u64(123).into(),
+                0,
+            ))))
+            .build();
+        let a1_id = a1.get_id();
+        let result = tf.process_block(a1, BlockSource::Local);
+
+        assert_matches!(
+            result,
+            Err(ChainstateError::ProcessBlockError(
+                BlockError::CheckBlockFailed(CheckBlockError::ConsensusVerificationFailed(_))
+            ))
+        );
+
+        // Some sanity checks
+        let m0_ct = tf.block_index(&m0_id.into()).chain_trust();
+        let m1_ct = tf.block_index(&m1_id.into()).chain_trust();
+        let a0_ct = tf.block_index(&a0_id.into()).chain_trust();
+        let a1_ct = tf.block_index(&a1_id.into()).chain_trust();
+        assert_eq!(m0_ct, a0_ct);
+        assert!(m1_ct > m0_ct);
+        assert!(a1_ct > a0_ct);
+        assert!(a1_ct > m1_ct);
+
+        tf.chainstate.reset_block_failure_flags(&a1_id).unwrap();
+
+        assert_eq!(tf.best_block_id(), m1_id);
+        assert_fully_valid_blocks(&tf, &[m0_id, m1_id]);
+        assert_ok_blocks_at_stage(&tf, &[a0_id], BlockValidationStage::CheckBlockOk);
+        assert_ok_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
+    });
+}
+
+// Same as in test_invalidation_with_reorg_to_chain_with_bad_tip, invalidate m0 in:
+// /----a0---*a1
+// G----m0----m1
+// where a1 is classified as TemporarilyBadBlock (we use some hacks to achieve this situation).
+// The mainchain should be reorged to a0, but a1 should not be marked as invalid.
+// Note: the purpose of the test is to ensure that blocks are not invalidated on an error
+// that isn't classified as BadBlock. We use a TemporarilyBadBlock kind of error only because
+// it's easier to simulate compared to the General kind (e.g. some kind of storage error).
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn test_invalidation_with_reorg_to_chain_with_tip_far_in_the_future(#[case] seed: Seed) {
+    utils::concurrency::model(move || {
+        let mut rng = make_seedable_rng(seed);
+        let chain_config = chain::config::create_unit_test_config();
+        let genesis = Arc::clone(chain_config.genesis_block());
+        let start_time_secs = genesis.timestamp().as_int_seconds();
+        let real_time_secs = Arc::new(SeqCstAtomicU64::new(start_time_secs));
+        let mut tf = TestFramework::builder(&mut rng)
+            .with_chain_config(chain_config)
+            .with_time_getter(mocked_time_getter_seconds(Arc::clone(&real_time_secs)))
+            .build();
+
+        let (m0_id, result) = process_block(&mut tf, &genesis.get_id().into(), &mut rng);
+        assert!(result.is_ok());
+        let (m1_id, result) = process_block(&mut tf, &m0_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        let (a0_id, result) = process_block(&mut tf, &genesis.get_id().into(), &mut rng);
+        assert!(result.is_ok());
+
+        let bad_block_time_secs = start_time_secs + 60 * 60 * 24;
+        real_time_secs.store(bad_block_time_secs);
+
+        let (a1_id, result) = process_block(&mut tf, &a0_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        real_time_secs.store(start_time_secs);
+
+        // We want the "bad" block to be Unchecked, so that check_block is called again on it during reorg.
+        tf.set_block_status(&a1_id, BlockStatus::new());
+
+        assert_eq!(tf.best_block_id(), m1_id);
+        assert_fully_valid_blocks(&tf, &[m0_id, m1_id]);
+        assert_ok_blocks_at_stage(&tf, &[a0_id], BlockValidationStage::CheckBlockOk);
+        assert_ok_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
+
+        tf.chainstate.invalidate_block(&m0_id).unwrap();
+
+        // a0 is now the best block, a1 is still ok and unchecked.
+        assert_eq!(tf.best_block_id(), a0_id);
+        assert_ok_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
         assert_fully_valid_blocks(&tf, &[a0_id]);
         assert_invalidated_blocks_at_stage(&tf, &[m0_id], BlockValidationStage::FullyChecked);
         assert_blocks_with_bad_parent_at_stage(&tf, &[m1_id], BlockValidationStage::FullyChecked);
@@ -688,8 +833,16 @@ fn test_add_block_to_chain_with_bad_tip(#[case] seed: Seed) {
 
         let (a0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
         assert!(result.is_ok());
+
         let (a1_id, result) = process_block_with_empty_tx(&mut tf, &a0_id.into());
-        assert!(result.is_err());
+        assert_matches!(
+            result,
+            Err(ChainstateError::ProcessBlockError(
+                BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(_))
+            ))
+        );
+
+        assert_bad_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
 
         // Reset the fail flags of a1 to get to the desired state of the chain.
         tf.chainstate.reset_block_failure_flags(&a1_id).unwrap();
@@ -709,18 +862,160 @@ fn test_add_block_to_chain_with_bad_tip(#[case] seed: Seed) {
         assert_ok_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
 
         let (a3_id, result) = process_block(&mut tf, &a2_id.into(), &mut rng);
-        assert!(result.is_err());
+        assert_eq!(
+            result,
+            Err(ChainstateError::ProcessBlockError(
+                BlockError::BlockDataMissingForValidBlockIndex(a1_id)
+            ))
+        );
 
         // A reorg has been triggered, which has failed.
-        // "m" is still the best chain; a1 has been marked as invalid, a2 and a3 have been marked
-        // as having an invalid parent.
+        // "m" is still the best chain.
+        // But note that since the reorg has failed with the BlockDataMissingForValidBlockIndex
+        // error, the block a0 hasn't been marked as invalid this time, because it couldn't
+        // be checked. And its children retained their original statuses.
         assert_eq!(tf.best_block_id(), m2_id);
         assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
-        assert_ok_blocks_at_stage(&tf, &[a0_id], BlockValidationStage::CheckBlockOk);
-        assert_bad_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
-        assert_blocks_with_bad_parent_at_stage(
+        assert_ok_blocks_at_stage(
             &tf,
-            &[a2_id, a3_id],
+            &[a0_id, a2_id, a3_id],
+            BlockValidationStage::CheckBlockOk,
+        );
+        assert_ok_blocks_at_stage(&tf, &[a1_id], BlockValidationStage::Unchecked);
+    });
+}
+
+// Check that a block is not invalidated if it is rejected with the "TemporarilyBadBlock" kind
+// of error:
+// 1) Add a block with a timestamp too far in the future on top of mainchain.
+// 2) The block should be rejected, but its status shouldn't be set to invalid.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn temporarily_bad_block_not_invalidated_during_integration(#[case] seed: Seed) {
+    utils::concurrency::model(move || {
+        let mut rng = make_seedable_rng(seed);
+        let mut tf = TestFramework::builder(&mut rng).build();
+        let genesis_id = tf.genesis().get_id();
+
+        let (m0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
+        assert!(result.is_ok());
+        let (m1_id, result) = process_block(&mut tf, &m0_id.into(), &mut rng);
+        assert!(result.is_ok());
+        let (m2_id, result) = process_block(&mut tf, &m1_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        let bad_block_time = (tf.current_time() + Duration::from_secs(60 * 60 * 24)).unwrap();
+        let bad_block = tf
+            .make_block_builder()
+            .with_parent(m2_id.into())
+            .with_timestamp(BlockTimestamp::from_time(bad_block_time))
+            .build();
+        let bad_block_id = bad_block.get_id();
+        let result = tf.process_block(bad_block, BlockSource::Local);
+
+        let expected_error =
+            BlockError::CheckBlockFailed(CheckBlockError::BlockFromTheFuture(bad_block_id));
+        assert_eq!(
+            expected_error.classify(),
+            BlockProcessingErrorClass::TemporarilyBadBlock
+        );
+        assert_eq!(
+            result,
+            Err(ChainstateError::ProcessBlockError(expected_error))
+        );
+
+        assert_eq!(tf.best_block_id(), m2_id);
+        assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
+        assert_ok_blocks_at_stage(&tf, &[bad_block_id], BlockValidationStage::Unchecked);
+    });
+}
+
+// Check that a block is not invalidated if it is rejected with the "TemporarilyBadBlock" kind
+// of error, when it happens during a reorg:
+// 1) Advance time into the future and add a sidechain block at that time;
+// 2) Reset the time; reset the "future" blocks status, so that check_block will be called again
+// on it during a reorg.
+// 3) Add some valid blocks on top of the future block, triggering a reorg.
+// 4) The "future" block should be rejected and reorg fail, but the block's status shouldn't be
+// set to invalid.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn temporarily_bad_block_not_invalidated_after_reorg(#[case] seed: Seed) {
+    utils::concurrency::model(move || {
+        let mut rng = make_seedable_rng(seed);
+        let chain_config = chain::config::create_unit_test_config();
+        let genesis = Arc::clone(chain_config.genesis_block());
+        let start_time_secs = genesis.timestamp().as_int_seconds();
+        let real_time_secs = Arc::new(SeqCstAtomicU64::new(start_time_secs));
+        let mut tf = TestFramework::builder(&mut rng)
+            .with_chain_config(chain_config)
+            .with_time_getter(mocked_time_getter_seconds(Arc::clone(&real_time_secs)))
+            .build();
+
+        // Later we'll be adding a child block with the timestamp of the genesis over a parent
+        // with a bigger timestamp. Here we add enough blocks with the genesis timestamp,
+        // so that it will be the median parents' timestamp when that child is added;
+        // this way we avoid BlockTimeOrderInvalid error being generated.
+        let starting_block_id = tf.create_chain(&genesis.get_id().into(), 10, &mut rng).unwrap();
+
+        let (m0_id, result) = process_block(&mut tf, &starting_block_id, &mut rng);
+        assert!(result.is_ok());
+        let (m1_id, result) = process_block(&mut tf, &m0_id.into(), &mut rng);
+        assert!(result.is_ok());
+        let (m2_id, result) = process_block(&mut tf, &m1_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        let bad_block_time_secs = start_time_secs + 60 * 60 * 24;
+        real_time_secs.store(bad_block_time_secs);
+        let bad_block = tf
+            .make_block_builder()
+            .with_parent(starting_block_id)
+            .with_reward(make_block_reward())
+            .build();
+        let bad_block_id = bad_block.get_id();
+        let result = tf.process_block(bad_block, BlockSource::Local);
+        assert!(result.is_ok());
+
+        let (c0_id, result) = process_block(&mut tf, &bad_block_id.into(), &mut rng);
+        log::error!("result = {result:?}");
+        assert!(result.is_ok());
+        let (c1_id, result) = process_block(&mut tf, &c0_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        assert_eq!(tf.best_block_id(), m2_id);
+        assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
+        assert_ok_blocks_at_stage(
+            &tf,
+            &[bad_block_id, c0_id, c1_id],
+            BlockValidationStage::CheckBlockOk,
+        );
+
+        real_time_secs.store(start_time_secs);
+
+        // We want the bad block to be Unchecked, so that check_block is called again on it during reorg.
+        tf.set_block_status(&bad_block_id, BlockStatus::new());
+
+        let (c2_id, result) = process_block(&mut tf, &c1_id.into(), &mut rng);
+
+        let expected_error =
+            BlockError::CheckBlockFailed(CheckBlockError::BlockFromTheFuture(bad_block_id));
+        assert_eq!(
+            expected_error.classify(),
+            BlockProcessingErrorClass::TemporarilyBadBlock
+        );
+        assert_eq!(
+            result,
+            Err(ChainstateError::ProcessBlockError(expected_error))
+        );
+
+        assert_eq!(tf.best_block_id(), m2_id);
+        assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
+        assert_ok_blocks_at_stage(&tf, &[bad_block_id], BlockValidationStage::Unchecked);
+        assert_ok_blocks_at_stage(
+            &tf,
+            &[c0_id, c1_id, c2_id],
             BlockValidationStage::CheckBlockOk,
         );
     });

--- a/chainstate/test-suite/src/tests/events_tests.rs
+++ b/chainstate/test-suite/src/tests/events_tests.rs
@@ -189,6 +189,7 @@ fn custom_orphan_error_hook(#[case] seed: Seed) {
             .with_parent(first_block.get_id().into())
             .with_timestamp(BlockTimestamp::from_int_seconds(timestamp))
             .build();
+        let second_block_id = second_block.get_id();
 
         // The second block isn't processed because its parent isn't known.
         assert_eq!(
@@ -209,7 +210,7 @@ fn custom_orphan_error_hook(#[case] seed: Seed) {
         assert_eq!(errors_guard.len(), 1);
         assert_eq!(
             errors_guard[0],
-            BlockError::CheckBlockFailed(CheckBlockError::BlockFromTheFuture)
+            BlockError::CheckBlockFailed(CheckBlockError::BlockFromTheFuture(second_block_id))
         );
     });
 }

--- a/chainstate/test-suite/src/tests/helpers/block_creation_helpers.rs
+++ b/chainstate/test-suite/src/tests/helpers/block_creation_helpers.rs
@@ -39,7 +39,7 @@ pub fn build_block(
         .build()
 }
 
-fn make_block_reward() -> Vec<TxOutput> {
+pub fn make_block_reward() -> Vec<TxOutput> {
     vec![TxOutput::LockThenTransfer(
         coins(1_000_000),
         anyonecanspend_address(),

--- a/chainstate/test-suite/src/tests/helpers/block_status_helpers.rs
+++ b/chainstate/test-suite/src/tests/helpers/block_status_helpers.rs
@@ -103,6 +103,15 @@ pub fn assert_fully_valid_blocks(tf: &TestFramework, block_ids: &[Id<Block>]) {
     }
 }
 
+pub fn assert_no_block_indices(tf: &TestFramework, block_ids: &[Id<Block>]) {
+    for block_id in block_ids {
+        assert!(
+            !tf.block_index_exists(block_id.into()),
+            "Block {block_id} index must not exist"
+        );
+    }
+}
+
 pub fn assert_ok_blocks_at_stage(
     tf: &TestFramework,
     block_ids: &[Id<Block>],

--- a/chainstate/test-suite/src/tests/mod.rs
+++ b/chainstate/test-suite/src/tests/mod.rs
@@ -64,3 +64,8 @@ mod tx_verifier_disconnect;
 mod helpers;
 
 type EventList = Arc<Mutex<Vec<(Id<Block>, BlockHeight)>>>;
+
+#[ctor::ctor]
+fn init() {
+    logging::init_logging();
+}

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -1181,13 +1181,12 @@ fn make_invalid_pow_block(
 #[trace]
 #[case(Seed::from_entropy())]
 fn reprocess_previously_temporarily_invalid_block(#[case] seed: Seed) {
-    use chainstate_types::BlockValidationStage;
     use common::chain;
     use test_utils::assert_matches;
 
     use crate::tests::helpers::{
         block_creation_helpers::process_block,
-        block_status_helpers::{assert_fully_valid_blocks, assert_ok_blocks_at_stage},
+        block_status_helpers::{assert_fully_valid_blocks, assert_no_block_indices},
     };
 
     utils::concurrency::model(move || {
@@ -1226,7 +1225,7 @@ fn reprocess_previously_temporarily_invalid_block(#[case] seed: Seed) {
 
         assert_eq!(tf.best_block_id(), m2_id);
         assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
-        assert_ok_blocks_at_stage(&tf, &[future_block_id], BlockValidationStage::Unchecked);
+        assert_no_block_indices(&tf, &[future_block_id]);
 
         real_time_secs.store(future_block_time_secs);
 

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -15,29 +15,30 @@
 
 use std::sync::Arc;
 
-use super::helpers::new_pub_key_destination;
-
-use chainstate::chainstate_interface::ChainstateInterface;
 use chainstate::{
-    make_chainstate, BlockError, BlockSource, ChainstateConfig, ChainstateError, CheckBlockError,
-    CheckBlockTransactionsError, ConnectTransactionError, DefaultTransactionVerificationStrategy,
-    OrphanCheckError,
+    chainstate_interface::ChainstateInterface, make_chainstate, BlockError,
+    BlockProcessingErrorClass, BlockProcessingErrorClassification, BlockSource, ChainstateConfig,
+    ChainstateError, CheckBlockError, CheckBlockTransactionsError, ConnectTransactionError,
+    DefaultTransactionVerificationStrategy, OrphanCheckError,
 };
 use chainstate_test_framework::{
     anyonecanspend_address, empty_witness, get_output_value, TestFramework, TestStore,
     TransactionBuilder,
 };
-use chainstate_types::{GenBlockIndex, GetAncestorError, PropertyQueryError};
-use common::chain::{
-    signed_transaction::SignedTransaction, stakelock::StakePoolData, Transaction, UtxoOutPoint,
+use chainstate_types::{
+    BlockStatus, BlockValidationStage, GenBlockIndex, GetAncestorError, PropertyQueryError,
 };
 use common::{
     chain::{
+        self,
         block::{consensus_data::PoWData, timestamp::BlockTimestamp, ConsensusData},
         config::{create_unit_test_config, Builder as ConfigBuilder},
         output_value::OutputValue,
+        signed_transaction::SignedTransaction,
+        stakelock::StakePoolData,
         timelock::OutputTimeLock,
-        Block, ConsensusUpgrade, Destination, GenBlock, NetUpgrades, PoolId, TxInput, TxOutput,
+        Block, ConsensusUpgrade, Destination, GenBlock, NetUpgrades, PoolId, Transaction, TxInput,
+        TxOutput, UtxoOutPoint,
     },
     primitives::{
         per_thousand::PerThousand, Amount, BlockCount, BlockHeight, Compact, Id, Idable, H256,
@@ -50,12 +51,25 @@ use crypto::{
     random::Rng,
     vrf::{VRFKeyKind, VRFPrivateKey},
 };
+use logging::log;
 use rstest::rstest;
-use test_utils::mock_time_getter::mocked_time_getter_seconds;
-use test_utils::random::{make_seedable_rng, Seed};
+use test_utils::{
+    assert_matches,
+    mock_time_getter::mocked_time_getter_seconds,
+    random::{make_seedable_rng, Seed},
+};
 use tx_verifier::timelock_check::OutputMaturityError;
 use utils::atomics::SeqCstAtomicU64;
 use utxo::UtxoSource;
+
+use crate::tests::helpers::{
+    block_creation_helpers::{build_block, process_block},
+    block_status_helpers::{
+        assert_fully_valid_blocks, assert_no_block_indices, assert_ok_blocks_at_stage,
+    },
+};
+
+use super::helpers::new_pub_key_destination;
 
 #[rstest]
 #[trace]
@@ -1174,21 +1188,16 @@ fn make_invalid_pow_block(
     Ok(false)
 }
 
-// Process a block with timestamp far in the future, make sure it fails with the
-// BlockFromTheFuture error.
-// Advance time, process the block again. Now it should succeed.
+// Check that a block is not invalidated if it is rejected with the "TemporarilyBadBlock" kind
+// of error. Also check that the block can be added successfully later, when it's no longer
+// considered invalid.
+// 1) Add a block with a timestamp too far in the future on top of mainchain.
+// The block should be rejected, but its status shouldn't be set to invalid.
+// 2) Advance the time into the future, add the same block again. Now it should be accepted.
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn reprocess_previously_temporarily_invalid_block(#[case] seed: Seed) {
-    use common::chain;
-    use test_utils::assert_matches;
-
-    use crate::tests::helpers::{
-        block_creation_helpers::process_block,
-        block_status_helpers::{assert_fully_valid_blocks, assert_no_block_indices},
-    };
-
+fn temporarily_bad_block_not_invalidated_during_integration(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let chain_config = chain::config::create_unit_test_config();
@@ -1219,20 +1228,126 @@ fn reprocess_previously_temporarily_invalid_block(#[case] seed: Seed) {
         let expected_error =
             BlockError::CheckBlockFailed(CheckBlockError::BlockFromTheFuture(future_block_id));
         assert_eq!(
+            expected_error.classify(),
+            BlockProcessingErrorClass::TemporarilyBadBlock
+        );
+        assert_eq!(
             result,
             Err(ChainstateError::ProcessBlockError(expected_error))
         );
 
         assert_eq!(tf.best_block_id(), m2_id);
         assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
+        // An "ok" block index is not saved for a block that wasn't persisted.
         assert_no_block_indices(&tf, &[future_block_id]);
 
         real_time_secs.store(future_block_time_secs);
 
-        let result = tf.process_block(future_block.clone(), BlockSource::Local);
+        let result = tf.process_block(future_block, BlockSource::Local);
         assert_matches!(result, Ok(_));
 
         assert_eq!(tf.best_block_id(), future_block_id);
         assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id, future_block_id]);
+    });
+}
+
+// Check that a block is not invalidated if it is rejected with the "TemporarilyBadBlock" kind
+// of error, when it happens during a reorg. Also check that the block can be successfully
+// reorged to later, when it's no longer considered invalid.
+// 1) Advance time into the future and add a sidechain block at that time;
+// 2) Reset the time; reset the "future" blocks status, so that check_block will be called again
+// on it during a reorg.
+// 3) Add some valid blocks on top of the future block, triggering a reorg.
+// 4) The "future" block should be rejected and reorg fail, but the block's status shouldn't be
+// set to invalid.
+// 5) Advance the time into the future; add the top-most block from the previous step again.
+// Now the reorg should succeed.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn temporarily_bad_block_not_invalidated_after_reorg(#[case] seed: Seed) {
+    utils::concurrency::model(move || {
+        let mut rng = make_seedable_rng(seed);
+        let chain_config = chain::config::create_unit_test_config();
+        let genesis = Arc::clone(chain_config.genesis_block());
+        let start_time_secs = genesis.timestamp().as_int_seconds();
+        let real_time_secs = Arc::new(SeqCstAtomicU64::new(start_time_secs));
+        let mut tf = TestFramework::builder(&mut rng)
+            .with_chain_config(chain_config)
+            .with_time_getter(mocked_time_getter_seconds(Arc::clone(&real_time_secs)))
+            .build();
+
+        // Later we'll be adding a child block with the timestamp of the genesis over a parent
+        // with a bigger timestamp. Here we add enough blocks with the genesis timestamp,
+        // so that it will be the median parents' timestamp when that child is added;
+        // this way we avoid BlockTimeOrderInvalid error being generated.
+        let starting_block_id = tf.create_chain(&genesis.get_id().into(), 10, &mut rng).unwrap();
+
+        let (m0_id, result) = process_block(&mut tf, &starting_block_id, &mut rng);
+        assert!(result.is_ok());
+        let (m1_id, result) = process_block(&mut tf, &m0_id.into(), &mut rng);
+        assert!(result.is_ok());
+        let (m2_id, result) = process_block(&mut tf, &m1_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        let future_block_time_secs = start_time_secs + 60 * 60 * 24;
+        real_time_secs.store(future_block_time_secs);
+        let future_block = build_block(&mut tf, &starting_block_id, &mut rng);
+
+        let future_block_id = future_block.get_id();
+        let result = tf.process_block(future_block, BlockSource::Local);
+        assert!(result.is_ok());
+
+        let (c0_id, result) = process_block(&mut tf, &future_block_id.into(), &mut rng);
+        log::error!("result = {result:?}");
+        assert!(result.is_ok());
+        let (c1_id, result) = process_block(&mut tf, &c0_id.into(), &mut rng);
+        assert!(result.is_ok());
+
+        assert_eq!(tf.best_block_id(), m2_id);
+        assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
+        assert_ok_blocks_at_stage(
+            &tf,
+            &[future_block_id, c0_id, c1_id],
+            BlockValidationStage::CheckBlockOk,
+        );
+
+        real_time_secs.store(start_time_secs);
+
+        // We want the bad block to be Unchecked, so that check_block is called again on it during reorg.
+        tf.set_block_status(&future_block_id, BlockStatus::new());
+
+        let c2 = build_block(&mut tf, &c1_id.into(), &mut rng);
+        let c2_id = c2.get_id();
+        let result = tf.process_block(c2.clone(), BlockSource::Local);
+
+        let expected_error =
+            BlockError::CheckBlockFailed(CheckBlockError::BlockFromTheFuture(future_block_id));
+        assert_eq!(
+            expected_error.classify(),
+            BlockProcessingErrorClass::TemporarilyBadBlock
+        );
+        assert_eq!(
+            result,
+            Err(ChainstateError::ProcessBlockError(expected_error))
+        );
+
+        assert_eq!(tf.best_block_id(), m2_id);
+        assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
+        assert_ok_blocks_at_stage(&tf, &[future_block_id], BlockValidationStage::Unchecked);
+        assert_ok_blocks_at_stage(&tf, &[c0_id, c1_id], BlockValidationStage::CheckBlockOk);
+        // An "ok" block index is not saved for a block that wasn't persisted.
+        assert_no_block_indices(&tf, &[c2_id]);
+
+        real_time_secs.store(future_block_time_secs);
+
+        let result = tf.process_block(c2.clone(), BlockSource::Local);
+        assert!(result.is_ok());
+
+        assert_eq!(tf.best_block_id(), c2_id);
+        assert_fully_valid_blocks(
+            &tf,
+            &[m0_id, m1_id, m2_id, c0_id, c1_id, c2_id, future_block_id],
+        );
     });
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::{
         stake,
         target::calculate_target_required,
         target::calculate_target_required_from_block_index,
-        StakeResult,
+        EffectivePoolBalanceError, StakeResult,
     },
     pow::{
         calculate_work_required, check_proof_of_work, input_data::PoWGenerateBlockInputData, mine,

--- a/node-lib/src/runner.rs
+++ b/node-lib/src/runner.rs
@@ -147,7 +147,8 @@ async fn initialize(
                 | P2pError::InvalidStorageState(_)
                 | P2pError::MempoolError(_)
                 | P2pError::MessageCodecError(_)
-                | P2pError::ConnectionValidationFailed(_) => Err(err),
+                | P2pError::ConnectionValidationFailed(_)
+                | P2pError::SyncError(_) => Err(err),
             },
         }
     }?;

--- a/p2p/src/disconnection_reason.rs
+++ b/p2p/src/disconnection_reason.rs
@@ -89,7 +89,8 @@ impl DisconnectionReason {
             | P2pError::InvalidStorageState(_)
             | P2pError::PeerDbStorageVersionMismatch { .. }
             | P2pError::MempoolError(_)
-            | P2pError::MessageCodecError(_) => None,
+            | P2pError::MessageCodecError(_)
+            | P2pError::SyncError(_) => None,
             P2pError::ConnectionValidationFailed(err) => match err {
                 ConnectionValidationError::UnsupportedProtocol {
                     peer_protocol_version: _,

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -263,7 +263,7 @@ impl TestNode {
                         break (peer, score);
                     }
                     PeerManagerEvent::PeerBlockSyncStatusUpdate { .. } => {}
-                    e => panic!("Expected PeerManagerEvent::Disconnect, received: {e:?}"),
+                    e => panic!("Expected peer score adjustment, received: {e:?}"),
                 }
             }
         };


### PR DESCRIPTION
1) Block error "classification" is introduced, which separates errors into 3 categories - "BadBlock", "TemporarilyBadBlock" and "General". This is used to decide whether the block should be marked as invalid in the block index when the corresponding error occurs.
2) ~`attempt_to_process_block` now can handle blocks that were origianlly rejected, but whose status was manually reset to "ok" (i.e. the function now allows to add a block whose index already exists in the db, if it's not "failed" or "fully valid").~ I've reverted this change. Instead, now "ok" block indices are not saved by `attempt_to_process_block` if the block itself is not going to be persisted. Also, resetting failure flags now removes block indices if the corresponding blocks are not in the db. 
3) An assertion failure in `BlockInvalidator::find_and_activate_best_chain` was fixed.