### PR TITLE
fix nft issuance in API Server endpoints

### DIFF
--- a/api-server/stack-test-suite/tests/v2/nft.rs
+++ b/api-server/stack-test-suite/tests/v2/nft.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use api_web_server::api::json_helpers::to_json_string;
+use api_web_server::api::json_helpers::nft_issuance_data_to_json;
 use common::{
     chain::tokens::{make_token_id, NftIssuance, NftIssuanceV0, TokenId},
     primitives::H256,
@@ -126,20 +126,7 @@ async fn ok(#[case] seed: Seed) {
 
                 _ = tx.send([(
                     token_id,
-                    json!({
-                        "authority": nft.metadata.creator
-                            .map(|creator| Address::new(&chain_config, Destination::PublicKey(creator.public_key))
-                            .expect("no error in encoding")
-                            .as_str().to_owned()
-                        ),
-                        "name": nft.metadata.name,
-                        "description": nft.metadata.description,
-                        "ticker": to_json_string(&nft.metadata.ticker),
-                        "icon_uri": nft.metadata.icon_uri.as_ref().as_ref().map(|b| to_json_string(b)),
-                        "additional_metadata_uri": nft.metadata.additional_metadata_uri.as_ref().as_ref().map(|b| to_json_string(b)),
-                        "media_uri": nft.metadata.media_uri.as_ref().as_ref().map(|b| to_json_string(b)),
-                        "media_hash": to_json_string(&nft.metadata.media_hash),
-                    }),
+                    nft_issuance_data_to_json(&NftIssuance::V0(nft), &chain_config),
                 )]);
 
                 chainstate_block_ids

--- a/api-server/web-server/src/api/v2.rs
+++ b/api-server/web-server/src/api/v2.rs
@@ -38,7 +38,7 @@ use common::{
     address::Address,
     chain::{
         block::timestamp::BlockTimestamp,
-        tokens::{IsTokenFreezable, IsTokenFrozen, IsTokenUnfreezable, NftIssuance},
+        tokens::{IsTokenFreezable, IsTokenFrozen, IsTokenUnfreezable},
         Block, Destination, SignedTransaction, Transaction,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId, Id, Idable, H256},
@@ -52,7 +52,7 @@ use utils::ensure;
 
 use crate::ApiServerWebServerState;
 
-use super::json_helpers::to_json_string;
+use super::json_helpers::{nft_issuance_data_to_json, to_json_string};
 
 pub const API_VERSION: &str = "2.0.0";
 
@@ -1107,20 +1107,5 @@ pub async fn nft<T: ApiServerStorage>(
             ApiServerWebServerNotFoundError::NftNotFound,
         ))?;
 
-    match nft {
-        NftIssuance::V0(nft) => Ok(Json(json!({
-            "authority": nft.metadata.creator
-                .map(|creator| Address::new(&state.chain_config, Destination::PublicKey(creator.public_key))
-                .expect("no error in encoding")
-                .as_str().to_owned()
-            ),
-            "name": nft.metadata.name,
-            "description": nft.metadata.description,
-            "ticker": to_json_string(&nft.metadata.ticker),
-            "icon_uri": nft.metadata.icon_uri.as_ref().as_ref().map(|b| to_json_string(b)),
-            "additional_metadata_uri": nft.metadata.additional_metadata_uri.as_ref().as_ref().map(|b| to_json_string(b)),
-            "media_uri": nft.metadata.media_uri.as_ref().as_ref().map(|b| to_json_string(b)),
-            "media_hash": to_json_string(&nft.metadata.media_hash),
-        }))),
-    }
+    Ok(Json(nft_issuance_data_to_json(&nft, &state.chain_config)))
 }


### PR DESCRIPTION
- fix API Server response for nft issuance to not return byte vectors