### PR TITLE
rpc: Support internally tagged enums in the `HasValueHint` macro

### DIFF
--- a/common/src/primitives/amount/serde_support.rs
+++ b/common/src/primitives/amount/serde_support.rs
@@ -108,8 +108,8 @@ pub enum RpcAmountInSerde {
 
 impl HasValueHint for RpcAmountInSerde {
     const HINT_SER: VH = VH::Choice(&[
-        &VH::Object(&[("atoms", &AtomsInner::HINT_SER)]),
-        &VH::Object(&[("decimal", &DecimalInner::HINT_SER)]),
+        &VH::object(&[("atoms", &AtomsInner::HINT_SER)]),
+        &VH::object(&[("decimal", &DecimalInner::HINT_SER)]),
     ]);
 }
 

--- a/mempool/types/src/tx_options.rs
+++ b/mempool/types/src/tx_options.rs
@@ -93,7 +93,7 @@ pub struct TxOptionsOverrides {
 }
 
 impl rpc_description::HasValueHint for TxOptionsOverrides {
-    const HINT_SER: VH = VH::Object(&[(
+    const HINT_SER: VH = VH::object(&[(
         "trust_policy",
         &VH::Choice(&[&VH::StrLit("Trusted"), &VH::StrLit("Untrusted")]),
     )]);

--- a/rpc/description-macro/src/describe_impl.rs
+++ b/rpc/description-macro/src/describe_impl.rs
@@ -221,7 +221,7 @@ impl quote::ToTokens for MethodMeta<'_> {
             ::rpc::description::Method {
                 name: #name,
                 description: #docs,
-                params: ::rpc::description::ValueHint::Object(&[#(#params),*]),
+                params: ::rpc::description::ValueHint::object(&[#(#params),*]),
                 kind_data: #kind_data,
             }
         })

--- a/rpc/description/src/display.rs
+++ b/rpc/description/src/display.rs
@@ -167,7 +167,7 @@ impl ValueHint {
                 }
             },
 
-            ValueHint::Object(hints) => match *hints {
+            ValueHint::Object(hints) => match hints.to_slice().as_ref() {
                 [] => f.write_str("{}")?,
                 [(name, hint)] => {
                     write!(f, "{{ {name:?}: ")?;

--- a/rpc/description/src/lib.rs
+++ b/rpc/description/src/lib.rs
@@ -16,7 +16,7 @@
 mod display;
 mod value_hint;
 
-pub use value_hint::{HasValueHint, ValueHint};
+pub use value_hint::{Fields, HasValueHint, ValueHint};
 
 /// Type that has RPC interface description associated with it
 pub trait Described {

--- a/rpc/tests/basic/HINT_EXTERNALLY_TAGGED.txt
+++ b/rpc/tests/basic/HINT_EXTERNALLY_TAGGED.txt
@@ -1,0 +1,15 @@
+EITHER OF
+     1) { "kind": "Hello" }
+     2) { "kind": "World" }
+     3) {
+            "kind": "String",
+            "value": string,
+        }
+     4) {
+            "kind": "BigObject",
+            "field": string,
+            "maybe_number": EITHER OF
+                 1) number
+                 2) null,
+            "flag": bool,
+        }

--- a/rpc/types/src/string.rs
+++ b/rpc/types/src/string.rs
@@ -151,8 +151,8 @@ impl From<RpcHexString> for RpcString {
 
 impl HasValueHint for RpcString {
     const HINT_SER: VH =
-        VH::Object(&[("text", &<Option<String>>::HINT_SER), ("hex", &VH::HEX_STRING)]);
-    const HINT_DE: VH = VH::Choice(&[&VH::STRING, &VH::Object(&[("hex", &VH::HEX_STRING)])]);
+        VH::object(&[("text", &<Option<String>>::HINT_SER), ("hex", &VH::HEX_STRING)]);
+    const HINT_DE: VH = VH::Choice(&[&VH::STRING, &VH::object(&[("hex", &VH::HEX_STRING)])]);
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -209,7 +209,7 @@ pub struct UtxoInfo {
 
 impl rpc::description::HasValueHint for UtxoInfo {
     const HINT_SER: VH =
-        VH::Object(&[("outpoint", &UtxoOutPoint::HINT_SER), ("output", &VH::GENERIC_OBJECT)]);
+        VH::object(&[("outpoint", &UtxoOutPoint::HINT_SER), ("output", &VH::GENERIC_OBJECT)]);
 }
 
 impl UtxoInfo {


### PR DESCRIPTION
Just implemented the macro support for internally tagged enum representation from serde. Not applied anywhere yet.