### PR TITLE
fix tracking of multisig/script addresses in api server

### DIFF
--- a/api-server/api-server-common/src/storage/impls/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const CURRENT_STORAGE_VERSION: u32 = 9;
+pub const CURRENT_STORAGE_VERSION: u32 = 10;
 
 pub mod in_memory;
 pub mod postgres;

--- a/api-server/scanner-lib/src/sync/tests.rs
+++ b/api-server/scanner-lib/src/sync/tests.rs
@@ -1080,7 +1080,7 @@ async fn sync_and_compare(
 #[trace]
 #[case(test_utils::random::Seed::from_entropy())]
 #[tokio::test]
-async fn check_all_destinations_are_trucked(#[case] seed: Seed) {
+async fn check_all_destinations_are_tracked(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
 
     let mut tf = TestFramework::builder(&mut rng).build();


### PR DESCRIPTION
- track all destinations, previously only PublicKey/PublicKeyHash and AnyoneCanSpend were tracked.
- add a test that creates a Tx with all possible destinations both locked and unlocked utxos and check they are all present in the db
- bump db version to force rescan of the blocks