### PR TITLE
API server don't return spent utxos

### DIFF
--- a/api-server/api-server-common/src/storage/impls/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const CURRENT_STORAGE_VERSION: u32 = 10;
+pub const CURRENT_STORAGE_VERSION: u32 = 11;
 
 pub mod in_memory;
 pub mod postgres;

--- a/api-server/stack-test-suite/tests/v2/address_all_utxos.rs
+++ b/api-server/stack-test-suite/tests/v2/address_all_utxos.rs
@@ -118,9 +118,6 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
                     .build();
 
                 let previous_transaction_id = transaction.transaction().get_id();
-                let utxo =
-                    UtxoOutPoint::new(OutPointSourceId::Transaction(previous_transaction_id), 0);
-                alice_utxos.insert(utxo, previous_tx_out.clone());
 
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
@@ -369,13 +366,6 @@ async fn ok(#[case] seed: Seed) {
                     .build();
 
                 let mut previous_transaction_id = transaction.transaction().get_id();
-                alice_utxos.insert(
-                    UtxoOutPoint::new(
-                        OutPointSourceId::Transaction(transaction.transaction().get_id()),
-                        0,
-                    ),
-                    previous_tx_out.clone(),
-                );
 
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(

--- a/api-server/storage-test-suite/src/basic.rs
+++ b/api-server/storage-test-suite/src/basic.rs
@@ -601,16 +601,10 @@ where
                 .await
                 .unwrap();
 
-            // should return only once the first utxo and also the locked utxo
+            // should return only the locked utxo as the other one is spent
             let utxos = db_tx.get_address_all_utxos(bob_address.as_str()).await.unwrap();
-            assert_eq!(utxos.len(), 2);
-            assert_eq!(
-                utxos.iter().find(|utxo| utxo.0 == outpoint),
-                Some(&(
-                    outpoint.clone(),
-                    UtxoWithExtraInfo::new(output.clone(), None)
-                ))
-            );
+            assert_eq!(utxos.len(), 1);
+            assert_eq!(utxos.iter().find(|utxo| utxo.0 == outpoint), None,);
             assert_eq!(
                 utxos.iter().find(|utxo| utxo.0 == locked_outpoint),
                 Some(&(locked_outpoint, UtxoWithExtraInfo::new(locked_output, None)))


### PR DESCRIPTION
- filter out spent utxos from all-utxos endpoint
- add any missing token decimals when spending utxos