### PR TITLE
chainstate: Fix the conditions under which transaction is retried

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "serialization",
  "static_assertions",
  "storage",
+ "storage-core",
  "subsystem",
  "test-utils",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "pos-accounting",
  "rstest",
  "serialization",
+ "storage-core",
  "test-utils",
  "tokens-accounting",
  "tx-verifier",

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -18,6 +18,7 @@ pos-accounting = {path = '../pos-accounting'}
 rpc = {path = '../rpc'}
 rpc-description = {path = '../rpc/description'}
 serialization = {path = "../serialization"}
+storage-core = {path = '../storage/core'}
 subsystem = {path = '../subsystem'}
 tx-verifier = {path = './tx-verifier'}
 tokens-accounting = {path = '../tokens-accounting'}

--- a/chainstate/src/detail/block_invalidation/mod.rs
+++ b/chainstate/src/detail/block_invalidation/mod.rs
@@ -386,6 +386,16 @@ enum ReorgDuringInvalidationError {
     OtherDbError(#[from] chainstate_storage::Error),
 }
 
+impl super::error::intermittency::CheckIntermittency for ReorgDuringInvalidationError {
+    fn check_intermittency(&self) -> super::intermittency::Intermittency {
+        match self {
+            Self::ReorgError(e) => e.check_intermittency(),
+            Self::OtherError(e) => e.check_intermittency(),
+            Self::OtherDbError(e) => e.check_intermittency(),
+        }
+    }
+}
+
 #[log_error]
 fn is_block_in_main_chain<S, V>(
     chainstate_ref: &ChainstateRef<S, V>,

--- a/chainstate/src/detail/error/classification.rs
+++ b/chainstate/src/detail/error/classification.rs
@@ -34,10 +34,11 @@ use tx_verifier::{
 };
 use utxo::UtxosBlockUndoError;
 
-use crate::{BlockError, CheckBlockError, CheckBlockTransactionsError, OrphanCheckError};
-
-use super::{
-    block_invalidation::BestChainCandidatesError, chainstateref::EpochSealError, BlockSizeError,
+use crate::{
+    detail::{
+        block_invalidation::BestChainCandidatesError, chainstateref::EpochSealError, BlockSizeError,
+    },
+    BlockError, CheckBlockError, CheckBlockTransactionsError, OrphanCheckError,
 };
 
 /// When handling errors during block processing, we need to differentiate between errors that

--- a/chainstate/src/detail/error/intermittency.rs
+++ b/chainstate/src/detail/error/intermittency.rs
@@ -1,0 +1,649 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_storage::Error as StorageError;
+use tx_verifier::transaction_verifier::signature_destination_getter;
+
+pub enum Intermittency {
+    /// Error is temporary, retrying the operation that produced it might make it go away.
+    Temporary(StorageError),
+
+    /// Error is final, no point retrying.
+    Final,
+}
+
+impl Intermittency {
+    /// We use this if there is insufficient information about the error. Make it temporary so we
+    /// retry to be on the safe side (it is OK to retry final errors, just inefficient).
+    const UNKNOWN: Self = Self::Temporary(StorageError::Storage(
+        storage_core::error::Recoverable::TemporarilyUnavailable,
+    ));
+}
+
+/// Separate out temporary and final errors in a result.
+///
+/// Usage:
+/// ```ignore
+/// match intermittency::classify(some_operation())? {
+///     Ok(result) => process_result(result),
+///     Err(_temporary_error) => retry(),
+/// }
+/// ```
+pub fn classify<T, E: CheckIntermittency>(res: Result<T, E>) -> Result<Result<T, StorageError>, E> {
+    match res {
+        Ok(r) => Ok(Ok(r)),
+        Err(e) => match e.check_intermittency() {
+            Intermittency::Temporary(e) => Ok(Err(e)),
+            Intermittency::Final => Err(e),
+        },
+    }
+}
+
+pub trait CheckIntermittency {
+    fn check_intermittency(&self) -> Intermittency;
+}
+
+impl CheckIntermittency for storage_core::error::Recoverable {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            e @ (Self::TransactionFailed | Self::TemporarilyUnavailable | Self::MemMapFull) => {
+                Intermittency::Temporary(chainstate_storage::Error::Storage(e.clone()))
+            }
+            Self::DbInit | Self::Io(_, _) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for chainstate_storage::Error {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::Storage(e) => e.check_intermittency(),
+        }
+    }
+}
+
+impl CheckIntermittency for crate::BlockError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+            Self::OrphanCheckFailed(e) => e.check_intermittency(),
+            Self::CheckBlockFailed(e) => e.check_intermittency(),
+            Self::StateUpdateFailed(e) => e.check_intermittency(),
+            Self::TransactionVerifierError(e) => e.check_intermittency(),
+            Self::PoSAccountingError(e) => e.check_intermittency(),
+            Self::EpochSealError(e) => e.check_intermittency(),
+            Self::BestChainCandidatesAccessorError(e) => e.check_intermittency(),
+            Self::TokensAccountingError(e) => e.check_intermittency(),
+            Self::DbCommitError(_, e, _) => e.check_intermittency(),
+            Self::BestBlockIdQueryError(e)
+            | Self::BestBlockIndexQueryError(e)
+            | Self::BlockIndexQueryError(_, e)
+            | Self::IsBlockInMainChainQueryError(_, e)
+            | Self::MinHeightForReorgQueryError(e)
+            | Self::PropertyQueryError(e)
+            | Self::InvariantErrorFailedToFindNewChainPath(_, _, e) => e.check_intermittency(),
+
+            Self::PrevBlockNotFoundForNewBlock(_)
+            | Self::BlockAlreadyExists(_)
+            | Self::BlockIndexAlreadyExists(_)
+            | Self::BlockAlreadyProcessed(_)
+            | Self::BlockProofCalculationError(_)
+            | Self::BlockDataMissingForValidBlockIndex(_)
+            | Self::InvariantErrorInvalidTip(_)
+            | Self::InvariantErrorAttemptToConnectInvalidBlock(_)
+            | Self::InvariantErrorDisconnectedHeaders
+            | Self::InvalidBlockAlreadyProcessed(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for crate::PropertyQueryError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+            Self::GetAncestorError(e) => e.check_intermittency(),
+
+            Self::BestBlockIndexNotFound
+            | Self::BlockNotFound(_)
+            | Self::BlockIndexNotFound(_)
+            | Self::PrevBlockIndexNotFound { .. }
+            | Self::BlockForHeightNotFound(_)
+            | Self::GenesisHeaderRequested
+            | Self::StakePoolDataNotFound(_)
+            | Self::StakerBalanceOverflow(_)
+            | Self::PoolBalanceNotFound(_)
+            | Self::InvalidStartingBlockHeightForMainchainBlocks(_)
+            | Self::InvalidBlockHeightRange { .. } => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for chainstate_types::GetAncestorError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+
+            Self::InvalidAncestorHeight { .. }
+            | Self::PrevBlockIndexNotFound(_)
+            | Self::StartingPointNotFound(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for crate::BlockInvalidatorError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::BlocksDisconnectionError {
+                disconnect_until: _,
+                error: e,
+            }
+            | Self::BlockStatusUpdateError(_, e)
+            | Self::GenericReorgError(e) => e.check_intermittency(),
+            Self::DelBlockIndexError(_, e) => e.check_intermittency(),
+            Self::BlockIndicesForBranchQueryError(e)
+            | Self::IsBlockInMainChainQueryError(_, e)
+            | Self::MinHeightForReorgQueryError(e)
+            | Self::BestBlockIndexQueryError(e)
+            | Self::BlockIndexQueryError(_, e)
+            | Self::BlockQueryError(_, e) => e.check_intermittency(),
+            Self::StorageError(e) | Self::DbCommitError(_, e, _) => e.check_intermittency(),
+            Self::BestChainCandidatesError(e) => e.check_intermittency(),
+
+            Self::BlockTooDeepToInvalidate(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for crate::detail::BlockIntegrationError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::BlockCommitError(_, _, e) => e.check_intermittency(),
+            Self::ConnectBlockErrorDuringReorg(e, _, _)
+            | Self::OtherReorgError(e, _)
+            | Self::BlockCheckError(e, _)
+            | Self::OtherNonValidationError(e) => e.check_intermittency(),
+        }
+    }
+}
+
+impl CheckIntermittency for crate::detail::block_invalidation::BestChainCandidatesError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::PropertyQueryError(e) => e.check_intermittency(),
+        }
+    }
+}
+
+impl CheckIntermittency for crate::OrphanCheckError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            crate::OrphanCheckError::StorageError(e) => e.check_intermittency(),
+            crate::OrphanCheckError::PropertyQueryError(e) => e.check_intermittency(),
+            crate::OrphanCheckError::LocalOrphan => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for crate::CheckBlockError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+            Self::PropertyQueryError(e) => e.check_intermittency(),
+            Self::StateUpdateFailed(e) => e.check_intermittency(),
+            Self::CheckTransactionFailed(e) => e.check_intermittency(),
+            Self::ConsensusVerificationFailed(e) => e.check_intermittency(),
+            Self::GetAncestorError(e) => e.check_intermittency(),
+            Self::TransactionVerifierError(e) => e.check_intermittency(),
+            Self::EpochSealError(e) => e.check_intermittency(),
+
+            Self::MerkleRootCalculationFailed(_, _)
+            | Self::MerkleRootMismatch
+            | Self::ParentBlockMissing { .. }
+            | Self::BlockNotFoundDuringInMemoryReorg(_)
+            | Self::BlockTimeOrderInvalid(_, _)
+            | Self::BlockFromTheFuture(_)
+            | Self::BlockSizeError(_)
+            | Self::InvalidBlockRewardOutputType(_)
+            | Self::BlockRewardMaturityError(_)
+            | Self::CheckpointMismatch(_, _)
+            | Self::ParentCheckpointMismatch(_, _, _)
+            | Self::AttemptedToAddBlockBeforeReorgLimit(_, _, _)
+            | Self::InvalidParent { .. } => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for tx_verifier::error::ConnectTransactionError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+            Self::TransactionVerifierError(e) => e.check_intermittency(),
+            Self::PoSAccountingError(e) => e.check_intermittency(),
+            Self::UtxoError(e) => e.check_intermittency(),
+            Self::TokensError(e) => e.check_intermittency(),
+            Self::UtxoBlockUndoError(e) => e.check_intermittency(),
+            Self::AccountingBlockUndoError(e) => e.check_intermittency(),
+            Self::DestinationRetrievalError(e) => e.check_intermittency(),
+            Self::TokensAccountingError(e) => e.check_intermittency(),
+            Self::TokensAccountingBlockUndoError(e) => e.check_intermittency(),
+            Self::RewardDistributionError(e) => e.check_intermittency(),
+            Self::CheckTransactionError(e) => e.check_intermittency(),
+
+            Self::TxNumWrongInBlockOnConnect(_, _)
+            | Self::TxNumWrongInBlockOnDisconnect(_, _)
+            | Self::InvariantBrokenAlreadyUnspent
+            | Self::MissingOutputOrSpent(_)
+            | Self::MissingTxInputs
+            | Self::MissingTxUndo(_)
+            | Self::MissingBlockUndo(_)
+            | Self::MissingBlockRewardUndo(_)
+            | Self::MissingMempoolTxsUndo
+            | Self::AttemptToPrintMoney(_, _)
+            | Self::BlockRewardInputOutputMismatch(_, _)
+            | Self::TxFeeTotalCalcFailed(_, _)
+            | Self::SignatureVerificationFailed(_)
+            | Self::BlockHeightArithmeticError
+            | Self::BlockTimestampArithmeticError
+            | Self::InvariantErrorHeaderCouldNotBeLoaded(_)
+            | Self::InvariantErrorHeaderCouldNotBeLoadedFromHeight(_, _)
+            | Self::BlockIndexCouldNotBeLoaded(_)
+            | Self::FailedToAddAllFeesOfBlock(_)
+            | Self::RewardAdditionError(_)
+            | Self::TimeLockViolation(_)
+            | Self::BurnAmountSumError(_)
+            | Self::AttemptToSpendBurnedAmount
+            | Self::SpendStakeError(_)
+            | Self::StakerBalanceNotFound(_)
+            | Self::PoolDataNotFound(_)
+            | Self::PoolBalanceNotFound(_)
+            | Self::UnexpectedPoolId(_, _)
+            | Self::UndoFetchFailure
+            | Self::TxVerifierStorage
+            | Self::OutputTimelockError(_)
+            | Self::NonceIsNotIncremental(_, _, _)
+            | Self::MissingTransactionNonce(_)
+            | Self::NotEnoughPledgeToCreateStakePool(_, _, _)
+            | Self::AttemptToCreateStakePoolFromAccounts
+            | Self::AttemptToCreateDelegationFromAccounts
+            | Self::FailedToIncrementAccountNonce
+            | Self::IOPolicyError(_, _)
+            | Self::ConstrainedValueAccumulatorError(_, _)
+            | Self::TotalFeeRequiredOverflow
+            | Self::InsufficientCoinsFee(_, _)
+            | Self::AttemptToSpendFrozenToken(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for tx_verifier::TransactionVerifierStorageError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StatePersistenceError(e) => e.check_intermittency(),
+            Self::TokensError(e) => e.check_intermittency(),
+            Self::UtxoError(e) => e.check_intermittency(),
+            Self::UtxoBlockUndoError(e) => e.check_intermittency(),
+            Self::PoSAccountingError(e) => e.check_intermittency(),
+            Self::AccountingBlockUndoError(e) => e.check_intermittency(),
+            Self::TokensAccountingError(e) => e.check_intermittency(),
+            Self::TokensAccountingBlockUndoError(e) => e.check_intermittency(),
+
+            Self::GenBlockIndexRetrievalFailed(_)
+            | Self::GetAncestorError(_)
+            | Self::DuplicateBlockUndo(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for crate::detail::chainstateref::ReorgError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::OtherError(e) => e.check_intermittency(),
+            Self::ConnectTipFailed(_, _) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for tokens_accounting::BlockUndoError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::UndoAlreadyExists(_) | Self::MissingTxUndo(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for tokens_accounting::Error {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+            Self::AccountingError(e) => e.check_intermittency(),
+            Self::StorageWrite => Intermittency::UNKNOWN,
+
+            Self::TokenAlreadyExists(_)
+            | Self::TokenDataNotFound(_)
+            | Self::TokenDataNotFoundOnReversal(_)
+            | Self::CirculatingSupplyNotFound(_)
+            | Self::MintExceedsSupplyLimit(_, _, _)
+            | Self::AmountOverflow
+            | Self::CannotMintFromLockedSupply(_)
+            | Self::CannotMintFrozenToken(_)
+            | Self::CannotUnmintFromLockedSupply(_)
+            | Self::CannotUnmintFrozenToken(_)
+            | Self::NotEnoughCirculatingSupplyToUnmint(_, _, _)
+            | Self::SupplyIsAlreadyLocked(_)
+            | Self::CannotLockNotLockableSupply(_)
+            | Self::CannotLockFrozenToken(_)
+            | Self::CannotUnlockNotLockedSupplyOnReversal(_)
+            | Self::CannotUndoMintForLockedSupplyOnReversal(_)
+            | Self::CannotUndoUnmintForLockedSupplyOnReversal(_)
+            | Self::TokenIsAlreadyFrozen(_)
+            | Self::CannotFreezeNotFreezableToken(_)
+            | Self::CannotUnfreezeNotUnfreezableToken(_)
+            | Self::CannotUnfreezeTokenThatIsNotFrozen(_)
+            | Self::CannotUndoFreezeTokenThatIsNotFrozen(_)
+            | Self::CannotUndoUnfreezeTokenThatIsFrozen(_)
+            | Self::CannotChangeAuthorityForFrozenToken(_)
+            | Self::CannotUndoChangeAuthorityForFrozenToken(_)
+            | Self::ViewFail => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for pos_accounting::Error {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+            Self::AccountingError(e) => e.check_intermittency(),
+
+            Self::InvariantErrorPoolBalanceAlreadyExists
+            | Self::InvariantErrorPoolDataAlreadyExists
+            | Self::AttemptedDecommissionNonexistingPoolBalance
+            | Self::AttemptedDecommissionNonexistingPoolData
+            | Self::DelegationCreationFailedPoolDoesNotExist
+            | Self::DelegationDeletionFailedIdDoesNotExist
+            | Self::DelegationDeletionFailedBalanceNonZero
+            | Self::DelegationDeletionFailedPoolsShareNonZero
+            | Self::DelegationDeletionFailedPoolStillExists
+            | Self::InvariantErrorDelegationCreationFailedIdAlreadyExists
+            | Self::DelegateToNonexistingId
+            | Self::DelegateToNonexistingPool
+            | Self::AdditionError
+            | Self::SubError
+            | Self::DelegationBalanceAdditionError
+            | Self::DelegationBalanceSubtractionError
+            | Self::PoolBalanceAdditionError
+            | Self::PoolBalanceSubtractionError
+            | Self::DelegationSharesAdditionError
+            | Self::DelegationSharesSubtractionError
+            | Self::InvariantErrorPoolCreationReversalFailedBalanceNotFound
+            | Self::InvariantErrorPoolCreationReversalFailedDataNotFound
+            | Self::InvariantErrorPoolCreationReversalFailedAmountChanged
+            | Self::InvariantErrorDecommissionUndoFailedPoolBalanceAlreadyExists
+            | Self::InvariantErrorDecommissionUndoFailedPoolDataAlreadyExists
+            | Self::InvariantErrorDelegationIdUndoFailedNotFound
+            | Self::InvariantErrorDelegationIdUndoFailedDataConflict
+            | Self::InvariantErrorDelegationBalanceAdditionUndoError
+            | Self::InvariantErrorPoolBalanceAdditionUndoError
+            | Self::InvariantErrorDelegationSharesAdditionUndoError
+            | Self::InvariantErrorDelegationShareNotFound
+            | Self::PledgeValueToSignedError
+            | Self::InvariantErrorDelegationUndoFailedDataNotFound(_)
+            | Self::DuplicatesInDeltaAndUndo
+            | Self::IncreaseStakerRewardsOfNonexistingPool
+            | Self::StakerBalanceOverflow
+            | Self::InvariantErrorIncreasePledgeUndoFailedPoolBalanceNotFound
+            | Self::InvariantErrorIncreaseStakerRewardUndoFailedPoolBalanceNotFound
+            | Self::ViewFail => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for accounting::Error {
+    fn check_intermittency(&self) -> Intermittency {
+        Intermittency::Final
+    }
+}
+
+impl CheckIntermittency for pos_accounting::BlockUndoError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::UndoAlreadyExists(_)
+            | Self::MissingTxUndo(_)
+            | Self::UndoAlreadyExistsForReward => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for tx_verifier::error::TokensError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+
+            Self::IssueError(_, _)
+            | Self::MultipleTokenIssuanceInTransaction(_)
+            | Self::CoinOrTokenOverflow(_)
+            | Self::InsufficientTokenFees(_)
+            | Self::TransferZeroTokens(_, _)
+            | Self::TokenIdCantBeCalculated
+            | Self::TokensInBlockReward
+            | Self::InvariantBrokenUndoIssuanceOnNonexistentToken(_)
+            | Self::InvariantBrokenRegisterIssuanceWithDuplicateId(_)
+            | Self::DeprecatedTokenOperationVersion(_, _) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for tx_verifier::CheckTransactionError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::PropertyQueryError(e) => e.check_intermittency(),
+            Self::TokensError(e) => e.check_intermittency(),
+
+            Self::DuplicateInputInTransaction(_)
+            | Self::InvalidWitnessCount(_)
+            | Self::EmptyInputsInTransaction(_)
+            | Self::NoSignatureDataSizeTooLarge(_, _, _)
+            | Self::NoSignatureDataNotAllowed(_)
+            | Self::DataDepositMaxSizeExceeded(_, _, _)
+            | Self::TxSizeTooLarge(_, _, _) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for tx_verifier::transaction_verifier::RewardDistributionError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::PoSAccountingError(e) => e.check_intermittency(),
+
+            Self::InvariantPoolBalanceIsZero(_)
+            | Self::InvariantStakerBalanceGreaterThanPoolBalance(_, _, _)
+            | Self::RewardAdditionError(_)
+            | Self::TotalDelegationBalanceZero(_)
+            | Self::PoolDataNotFound(_)
+            | Self::PoolBalanceNotFound(_)
+            | Self::StakerRewardCalculationFailed(_, _)
+            | Self::StakerRewardCannotExceedTotalReward(_, _, _, _)
+            | Self::DistributedDelegationsRewardExceedTotal(_, _, _, _)
+            | Self::DelegationRewardOverflow(_, _, _, _)
+            | Self::DelegationsRewardSumFailed(_, _)
+            | Self::StakerRewardOverflow(_, _, _, _) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for signature_destination_getter::SignatureDestinationGetterError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::UtxoViewError(e) => e.check_intermittency(),
+            Self::SigVerifyPoSAccountingError(e) => e.check_intermittency(),
+            Self::SigVerifyTokensAccountingError(e) => e.check_intermittency(),
+
+            Self::SpendingOutputInBlockReward
+            | Self::SpendingFromAccountInBlockReward
+            | Self::SigVerifyOfNotSpendableOutput
+            | Self::PoolDataNotFound(_)
+            | Self::DelegationDataNotFound(_)
+            | Self::TokenDataNotFound(_)
+            | Self::UtxoOutputNotFound(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for utxo::Error {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageWrite => Intermittency::UNKNOWN,
+
+            Self::OverwritingUtxo
+            | Self::FreshUtxoAlreadyExists
+            | Self::UtxoAlreadySpent(_)
+            | Self::NoUtxoFound
+            | Self::NoBlockchainHeightFound
+            | Self::MissingBlockRewardUndo(_)
+            | Self::InvalidBlockRewardOutputType(_)
+            | Self::TxInputAndUndoMismatch(_)
+            | Self::ViewRead => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for utxo::UtxosBlockUndoError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::UndoAlreadyExists(_)
+            | Self::UndoAlreadyExistsForReward
+            | Self::TxUndoWithDependency(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for crate::detail::chainstateref::EpochSealError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+            Self::PoSAccountingError(e) => e.check_intermittency(),
+            Self::SpendStakeError(e) => e.check_intermittency(),
+
+            Self::RandomnessError(_) | Self::PoolDataNotFound(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for tx_verifier::error::SpendStakeError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::ConsensusPoSError(e) => e.check_intermittency(),
+
+            Self::NoBlockRewardOutputs
+            | Self::MultipleBlockRewardOutputs
+            | Self::InvalidBlockRewardOutputType
+            | Self::StakePoolDataMismatch
+            | Self::StakePoolIdMismatch(_, _) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for crate::CheckBlockTransactionsError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::CheckTransactionError(e) => e.check_intermittency(),
+
+            Self::DuplicateInputInBlock(_) => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for consensus::ConsensusVerificationError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::PrevBlockLoadError(_, _, e) => e.check_intermittency(),
+            Self::PoWError(e) => e.check_intermittency(),
+            Self::PoSError(e) => e.check_intermittency(),
+
+            Self::PrevBlockNotFound(_, _)
+            | Self::ConsensusTypeMismatch(_)
+            | Self::UnsupportedConsensusType => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for consensus::ConsensusPoWError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::PrevBlockLoadError(_, e) | Self::AncestorAtHeightNotFound(_, _, e) => {
+                e.check_intermittency()
+            }
+
+            Self::InvalidPoW(_)
+            | Self::PrevBlockNotFound(_)
+            | Self::NoPowDataInPreviousBlock
+            | Self::DecodingBitsFailed(_)
+            | Self::PreviousBitsDecodingFailed(_)
+            | Self::InvalidTargetBits(_, _)
+            | Self::PoSInputDataProvided
+            | Self::NoInputDataProvided => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for consensus::ConsensusPoSError {
+    fn check_intermittency(&self) -> Intermittency {
+        match self {
+            Self::StorageError(e) => e.check_intermittency(),
+            Self::PropertyQueryError(e) => e.check_intermittency(),
+            Self::ChainstateError(e) => e.check_intermittency(),
+            Self::PoSAccountingError(e) => e.check_intermittency(),
+
+            Self::StakeKernelHashTooHigh
+            | Self::NoEpochData
+            | Self::TimestampViolation(_, _)
+            | Self::NoKernel
+            | Self::MissingKernelUtxo
+            | Self::KernelOutpointMustBeUtxo
+            | Self::MultipleKernels
+            | Self::BitsToTargetConversionFailed(_)
+            | Self::PrevBlockIndexNotFound(_)
+            | Self::PoolBalanceNotFound(_)
+            | Self::PoolDataNotFound(_)
+            | Self::RandomnessError(_)
+            | Self::InvalidTarget(_)
+            | Self::DecodingBitsFailed(_)
+            | Self::TargetConversionError(_)
+            | Self::NotEnoughTimestampsToAverage
+            | Self::InvalidTargetBlockTime
+            | Self::TimestampOverflow
+            | Self::InvariantBrokenNotMonotonicBlockTime
+            | Self::EmptyTimespan
+            | Self::NoInputDataProvided
+            | Self::PoWInputDataProvided
+            | Self::FailedReadingBlock(_)
+            | Self::FutureTimestampInThePast
+            | Self::FailedToFetchUtxo
+            | Self::BlockSignatureError(_)
+            | Self::FailedToSignBlockHeader
+            | Self::FailedToSignKernel
+            | Self::PoSBlockTimeStrictOrderInvalid(_)
+            | Self::FiniteTotalSupplyIsRequired
+            | Self::UnsupportedConsensusVersion
+            | Self::EffectivePoolBalanceError(_)
+            | Self::FailedToCalculateCappedBalance => Intermittency::Final,
+        }
+    }
+}
+
+impl CheckIntermittency for consensus::ChainstateError {
+    fn check_intermittency(&self) -> Intermittency {
+        Intermittency::UNKNOWN
+    }
+}

--- a/chainstate/src/detail/error/mod.rs
+++ b/chainstate/src/detail/error/mod.rs
@@ -36,6 +36,11 @@ use common::{
 };
 use consensus::ConsensusVerificationError;
 
+mod classification;
+pub mod intermittency;
+
+pub use classification::{BlockProcessingErrorClass, BlockProcessingErrorClassification};
+
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum BlockError {
     #[error("Block storage error: `{0}`")]

--- a/chainstate/test-framework/Cargo.toml
+++ b/chainstate/test-framework/Cargo.toml
@@ -15,8 +15,10 @@ common = { path = "../../common" }
 consensus = { path = "../../consensus" }
 constraints-value-accumulator = {path = '../constraints-value-accumulator'}
 crypto = { path = "../../crypto" }
+logging = { path = "../../logging" }
 pos-accounting = { path = "../../pos-accounting" }
 serialization = { path = "../../serialization" }
+storage-core = { path = "../../storage/core" }
 test-utils = { path = "../../test-utils" }
 tokens-accounting = {path = '../../tokens-accounting'}
 tx-verifier = { path = "../tx-verifier" }
@@ -29,6 +31,5 @@ variant_count.workspace = true
 
 [dev-dependencies]
 consensus = { path = "../../consensus" }
-logging = { path = "../../logging" }
 
 hex.workspace = true

--- a/chainstate/test-framework/src/failing_storage/mod.rs
+++ b/chainstate/test-framework/src/failing_storage/mod.rs
@@ -1,0 +1,195 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Mutex;
+
+use chainstate_storage::{BlockchainStorage, TransactionRw, Transactional};
+use chainstate_types::storage_result;
+use logging::log;
+use test_utils::random::{Rng, Seed, TestRng};
+use utils::atomics::AcqRelAtomicU32;
+
+mod read;
+mod write;
+
+#[derive(Debug, Clone)]
+pub struct FailureParams {
+    pub failure_probability: f32,
+    pub max_failures: u32,
+}
+
+impl FailureParams {
+    // Set the default probability of failure for affected operations to 5%. Also limit the max
+    // number of spurious failures to two, since that is the maximum amount the system is designed
+    // to handle by default, making max 3 attempts before giving up.
+    pub const FAILING: Self = Self::new_unchecked(0.05, 2);
+
+    // Reliable storage can be achieved by either setting the failure probability to zero or by
+    // limiting the max number of spurious errors to zero. Here, we do both just in case.
+    pub const RELIABLE: Self = Self::new_unchecked(0.00, 0);
+
+    const fn new_unchecked(failure_probability: f32, max_failures: u32) -> Self {
+        Self {
+            failure_probability,
+            max_failures,
+        }
+    }
+
+    pub fn new(failure_probability: f32, max_failures: u32) -> Self {
+        assert!(
+            (0.0..=1.0).contains(&failure_probability),
+            "{failure_probability} not a probability"
+        );
+        Self::new_unchecked(failure_probability, max_failures)
+    }
+}
+
+/// Chainstate storage that occasionally fails to resize storage map.
+#[derive(Debug)]
+pub struct FailingStorage<S> {
+    inner: S,
+    failures: AcqRelAtomicU32,
+    params: FailureParams,
+    rng: Mutex<TestRng>,
+}
+
+impl<S> FailingStorage<S> {
+    pub fn new_failing(inner: S, seed: Seed) -> Self {
+        Self::from_storage_with_params(inner, seed, FailureParams::FAILING)
+    }
+
+    pub fn new_reliable(inner: S) -> Self {
+        // Note: Random seed is irrelevant if no failures are generated
+        Self::from_storage_with_params(inner, Seed(0), FailureParams::RELIABLE)
+    }
+
+    pub fn from_storage_with_params(inner: S, seed: Seed, params: FailureParams) -> Self {
+        Self {
+            inner,
+            params,
+            failures: AcqRelAtomicU32::new(0).into(),
+            rng: Mutex::new(TestRng::new(seed)),
+        }
+    }
+
+    pub fn from_storage_reliable(storage: S) -> Self {
+        Self::from_storage_with_params(storage, Seed(0), FailureParams::RELIABLE)
+    }
+
+    pub fn set_failures(&mut self, params: FailureParams, seed: Seed) {
+        self.reseed(seed);
+        self.params = params;
+    }
+
+    pub fn reseed(&mut self, seed: Seed) {
+        *self.rng.get_mut().unwrap() = TestRng::new(seed);
+    }
+
+    pub fn reset_failure_counter(&mut self) {
+        self.failures.store(0);
+    }
+
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl FailingStorage<chainstate_storage::inmemory::Store> {
+    pub fn new_empty() -> chainstate_storage::Result<Self> {
+        chainstate_storage::inmemory::Store::new_empty().map(Self::new_reliable)
+    }
+}
+
+impl<S: Clone> Clone for FailingStorage<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            failures: AcqRelAtomicU32::new(self.failures.load()),
+            params: self.params.clone(),
+            rng: Mutex::new(self.rng.lock().unwrap().clone()),
+        }
+    }
+}
+
+impl<S> From<S> for FailingStorage<S> {
+    fn from(storage: S) -> Self {
+        Self::from_storage_reliable(storage)
+    }
+}
+
+impl<S: BlockchainStorage> BlockchainStorage for FailingStorage<S> {}
+
+impl<'t, S: Transactional<'t>> Transactional<'t> for FailingStorage<S> {
+    type TransactionRo = S::TransactionRo;
+
+    type TransactionRw = FailingStorageTxRw<'t, S::TransactionRw>;
+
+    fn transaction_ro<'s: 't>(&'s self) -> chainstate_storage::Result<Self::TransactionRo> {
+        // For now, we do not consider failing read operations
+        self.inner.transaction_ro()
+    }
+
+    fn transaction_rw<'s: 't>(
+        &'s self,
+        size: Option<usize>,
+    ) -> chainstate_storage::Result<Self::TransactionRw> {
+        Ok(FailingStorageTxRw {
+            inner: self.inner.transaction_rw(size)?,
+            params: &self.params,
+            failures: &self.failures,
+            rng: TestRng::random(&mut *self.rng.lock().unwrap()),
+        })
+    }
+}
+
+pub struct FailingStorageTxRw<'a, T> {
+    inner: T,
+    params: &'a FailureParams,
+    failures: &'a AcqRelAtomicU32,
+    rng: TestRng,
+}
+
+impl<T> FailingStorageTxRw<'_, T> {
+    fn spurious_failure<E: std::fmt::Debug>(&mut self, err: E) -> Result<(), E> {
+        if self.rng.gen_range(0.0_f32..1.0) < self.params.failure_probability {
+            let prior_fails = self.failures.fetch_add(1);
+            let curr_fails = prior_fails + 1;
+            let max_fails = self.params.max_failures;
+            if prior_fails < self.params.max_failures {
+                log::debug!("Spuriously emitting error ({curr_fails}/{max_fails}) {err:?}");
+                return Err(err);
+            } else {
+                let _ = self.failures.fetch_min(self.params.max_failures);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn spurious_map_full_failure(&mut self) -> storage_result::Result<()> {
+        let err = storage_core::Error::from(storage_core::error::Recoverable::MemMapFull);
+        self.spurious_failure(err.into())
+    }
+}
+
+impl<T: TransactionRw> TransactionRw for FailingStorageTxRw<'_, T> {
+    fn abort(self) {
+        self.inner.abort()
+    }
+
+    fn commit(self) -> chainstate_storage::Result<()> {
+        self.inner.commit()
+    }
+}

--- a/chainstate/test-framework/src/failing_storage/read.rs
+++ b/chainstate/test-framework/src/failing_storage/read.rs
@@ -1,0 +1,269 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use chainstate_storage::{BlockchainStorageRead, ChainstateStorageVersion};
+use chainstate_types::{storage_result, BlockIndex, EpochData, EpochStorageRead};
+use common::{
+    chain::{
+        block::signed_block_header::SignedBlockHeader,
+        config::{EpochIndex, MagicBytes},
+        tokens::TokenId,
+        Block, DelegationId, GenBlock, PoolId, Transaction, UtxoOutPoint,
+    },
+    primitives::{Amount, BlockHeight, Id},
+};
+use pos_accounting::PoSAccountingStorageRead;
+use tokens_accounting::{TokenData, TokensAccountingStorageRead};
+use utxo::UtxosStorageRead;
+
+use super::{FailingStorage, FailingStorageTxRw};
+
+impl<T: BlockchainStorageRead> BlockchainStorageRead for FailingStorageTxRw<'_, T> {
+    fn get_storage_version(&self) -> chainstate_storage::Result<Option<ChainstateStorageVersion>> {
+        self.inner.get_storage_version()
+    }
+
+    fn get_magic_bytes(&self) -> chainstate_storage::Result<Option<MagicBytes>> {
+        self.inner.get_magic_bytes()
+    }
+
+    fn get_chain_type(&self) -> chainstate_storage::Result<Option<String>> {
+        self.inner.get_chain_type()
+    }
+
+    fn get_best_block_id(&self) -> chainstate_storage::Result<Option<Id<GenBlock>>> {
+        self.inner.get_best_block_id()
+    }
+
+    fn get_block_index(
+        &self,
+        block_id: &Id<Block>,
+    ) -> chainstate_storage::Result<Option<BlockIndex>> {
+        self.inner.get_block_index(block_id)
+    }
+
+    fn get_block_reward(
+        &self,
+        block_index: &BlockIndex,
+    ) -> chainstate_storage::Result<Option<common::chain::block::BlockReward>> {
+        self.inner.get_block_reward(block_index)
+    }
+
+    fn get_block(&self, id: Id<Block>) -> chainstate_storage::Result<Option<Block>> {
+        self.inner.get_block(id)
+    }
+
+    fn get_block_header(
+        &self,
+        id: Id<Block>,
+    ) -> chainstate_storage::Result<Option<SignedBlockHeader>> {
+        self.inner.get_block_header(id)
+    }
+
+    fn get_min_height_with_allowed_reorg(&self) -> chainstate_storage::Result<Option<BlockHeight>> {
+        self.inner.get_min_height_with_allowed_reorg()
+    }
+
+    fn get_block_id_by_height(
+        &self,
+        height: &BlockHeight,
+    ) -> chainstate_storage::Result<Option<Id<GenBlock>>> {
+        self.inner.get_block_id_by_height(height)
+    }
+
+    fn get_undo_data(
+        &self,
+        id: Id<Block>,
+    ) -> chainstate_storage::Result<Option<utxo::UtxosBlockUndo>> {
+        self.inner.get_undo_data(id)
+    }
+
+    fn get_token_aux_data(
+        &self,
+        token_id: &TokenId,
+    ) -> chainstate_storage::Result<Option<common::chain::tokens::TokenAuxiliaryData>> {
+        self.inner.get_token_aux_data(token_id)
+    }
+
+    fn get_token_id(&self, tx_id: &Id<Transaction>) -> chainstate_storage::Result<Option<TokenId>> {
+        self.inner.get_token_id(tx_id)
+    }
+
+    fn get_block_tree_by_height(
+        &self,
+        start_from: BlockHeight,
+    ) -> chainstate_storage::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>> {
+        self.inner.get_block_tree_by_height(start_from)
+    }
+
+    fn get_tokens_accounting_undo(
+        &self,
+        id: Id<Block>,
+    ) -> chainstate_storage::Result<Option<tokens_accounting::BlockUndo>> {
+        self.inner.get_tokens_accounting_undo(id)
+    }
+
+    fn get_pos_accounting_undo(
+        &self,
+        id: Id<Block>,
+    ) -> chainstate_storage::Result<Option<pos_accounting::BlockUndo>> {
+        self.inner.get_pos_accounting_undo(id)
+    }
+
+    fn get_accounting_epoch_delta(
+        &self,
+        epoch_index: EpochIndex,
+    ) -> chainstate_storage::Result<Option<pos_accounting::PoSAccountingDeltaData>> {
+        self.inner.get_accounting_epoch_delta(epoch_index)
+    }
+
+    fn get_accounting_epoch_undo_delta(
+        &self,
+        epoch_index: EpochIndex,
+    ) -> chainstate_storage::Result<Option<pos_accounting::DeltaMergeUndo>> {
+        self.inner.get_accounting_epoch_undo_delta(epoch_index)
+    }
+
+    fn get_account_nonce_count(
+        &self,
+        account: common::chain::AccountType,
+    ) -> chainstate_storage::Result<Option<common::chain::AccountNonce>> {
+        self.inner.get_account_nonce_count(account)
+    }
+}
+
+impl<T: EpochStorageRead> EpochStorageRead for FailingStorageTxRw<'_, T> {
+    fn get_epoch_data(&self, epoch_index: EpochIndex) -> storage_result::Result<Option<EpochData>> {
+        self.inner.get_epoch_data(epoch_index)
+    }
+}
+
+impl<T: TokensAccountingStorageRead> TokensAccountingStorageRead for FailingStorageTxRw<'_, T> {
+    type Error = T::Error;
+
+    fn get_token_data(&self, id: &TokenId) -> Result<Option<TokenData>, Self::Error> {
+        self.inner.get_token_data(id)
+    }
+
+    fn get_circulating_supply(&self, id: &TokenId) -> Result<Option<Amount>, Self::Error> {
+        self.inner.get_circulating_supply(id)
+    }
+}
+
+impl<Tag, T> PoSAccountingStorageRead<Tag> for FailingStorageTxRw<'_, T>
+where
+    T: PoSAccountingStorageRead<Tag>,
+    Tag: pos_accounting::StorageTag,
+{
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, storage_result::Error> {
+        self.inner.get_pool_balance(pool_id)
+    }
+
+    fn get_pool_data(
+        &self,
+        pool_id: PoolId,
+    ) -> Result<Option<pos_accounting::PoolData>, storage_result::Error> {
+        self.inner.get_pool_data(pool_id)
+    }
+
+    fn get_delegation_balance(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, storage_result::Error> {
+        self.inner.get_delegation_balance(delegation_id)
+    }
+
+    fn get_delegation_data(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<pos_accounting::DelegationData>, storage_result::Error> {
+        self.inner.get_delegation_data(delegation_id)
+    }
+
+    fn get_pool_delegations_shares(
+        &self,
+        pool_id: PoolId,
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, storage_result::Error> {
+        self.inner.get_pool_delegations_shares(pool_id)
+    }
+
+    fn get_pool_delegation_share(
+        &self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, storage_result::Error> {
+        self.inner.get_pool_delegation_share(pool_id, delegation_id)
+    }
+}
+
+impl<T: UtxosStorageRead> UtxosStorageRead for FailingStorageTxRw<'_, T> {
+    type Error = T::Error;
+
+    fn get_utxo(&self, outpoint: &UtxoOutPoint) -> Result<Option<utxo::Utxo>, Self::Error> {
+        self.inner.get_utxo(outpoint)
+    }
+
+    fn get_best_block_for_utxos(&self) -> Result<Id<GenBlock>, Self::Error> {
+        self.inner.get_best_block_for_utxos()
+    }
+}
+
+impl<Tag, T> PoSAccountingStorageRead<Tag> for FailingStorage<T>
+where
+    T: PoSAccountingStorageRead<Tag>,
+    Tag: pos_accounting::StorageTag,
+{
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, storage_result::Error> {
+        self.inner.get_pool_balance(pool_id)
+    }
+
+    fn get_pool_data(
+        &self,
+        pool_id: PoolId,
+    ) -> Result<Option<pos_accounting::PoolData>, storage_result::Error> {
+        self.inner.get_pool_data(pool_id)
+    }
+
+    fn get_delegation_balance(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, storage_result::Error> {
+        self.inner.get_delegation_balance(delegation_id)
+    }
+
+    fn get_delegation_data(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<pos_accounting::DelegationData>, storage_result::Error> {
+        self.inner.get_delegation_data(delegation_id)
+    }
+
+    fn get_pool_delegations_shares(
+        &self,
+        pool_id: PoolId,
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, storage_result::Error> {
+        self.inner.get_pool_delegations_shares(pool_id)
+    }
+
+    fn get_pool_delegation_share(
+        &self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, storage_result::Error> {
+        self.inner.get_pool_delegation_share(pool_id, delegation_id)
+    }
+}

--- a/chainstate/test-framework/src/failing_storage/write.rs
+++ b/chainstate/test-framework/src/failing_storage/write.rs
@@ -1,0 +1,392 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_storage::{BlockchainStorageWrite, ChainstateStorageVersion};
+use chainstate_types::{storage_result, BlockIndex, EpochData, EpochStorageWrite};
+use common::{
+    chain::{
+        config::{EpochIndex, MagicBytes},
+        tokens::TokenId,
+        Block, DelegationId, GenBlock, PoolId, Transaction, UtxoOutPoint,
+    },
+    primitives::{Amount, BlockHeight, Id},
+};
+use pos_accounting::PoSAccountingStorageWrite;
+use tokens_accounting::{TokenData, TokensAccountingStorageWrite};
+use utxo::UtxosStorageWrite;
+
+use super::{FailingStorage, FailingStorageTxRw};
+
+impl<T: BlockchainStorageWrite> BlockchainStorageWrite for FailingStorageTxRw<'_, T> {
+    fn set_storage_version(
+        &mut self,
+        version: ChainstateStorageVersion,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_storage_version(version)
+    }
+
+    fn set_magic_bytes(&mut self, bytes: &MagicBytes) -> chainstate_storage::Result<()> {
+        self.inner.set_magic_bytes(bytes)
+    }
+
+    fn set_chain_type(&mut self, chain: &str) -> chainstate_storage::Result<()> {
+        self.inner.set_chain_type(chain)
+    }
+
+    fn set_best_block_id(&mut self, id: &Id<GenBlock>) -> chainstate_storage::Result<()> {
+        self.inner.set_best_block_id(id)
+    }
+
+    fn set_block_index(&mut self, block_index: &BlockIndex) -> chainstate_storage::Result<()> {
+        self.inner.set_block_index(block_index)
+    }
+
+    fn del_block_index(&mut self, block_id: Id<Block>) -> chainstate_storage::Result<()> {
+        self.inner.del_block_index(block_id)
+    }
+
+    fn add_block(&mut self, block: &Block) -> chainstate_storage::Result<()> {
+        self.spurious_map_full_failure()?;
+        self.inner.add_block(block)
+    }
+
+    fn del_block(&mut self, id: Id<Block>) -> chainstate_storage::Result<()> {
+        self.inner.del_block(id)
+    }
+
+    fn set_min_height_with_allowed_reorg(
+        &mut self,
+        height: BlockHeight,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_min_height_with_allowed_reorg(height)
+    }
+
+    fn set_block_id_at_height(
+        &mut self,
+        height: &BlockHeight,
+        block_id: &Id<GenBlock>,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_block_id_at_height(height, block_id)
+    }
+
+    fn del_block_id_at_height(&mut self, height: &BlockHeight) -> chainstate_storage::Result<()> {
+        self.inner.del_block_id_at_height(height)
+    }
+
+    fn set_undo_data(
+        &mut self,
+        id: Id<Block>,
+        undo: &utxo::UtxosBlockUndo,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_undo_data(id, undo)
+    }
+
+    fn del_undo_data(&mut self, id: Id<Block>) -> chainstate_storage::Result<()> {
+        self.inner.del_undo_data(id)
+    }
+
+    fn set_token_aux_data(
+        &mut self,
+        token_id: &TokenId,
+        data: &common::chain::tokens::TokenAuxiliaryData,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_token_aux_data(token_id, data)
+    }
+
+    fn del_token_aux_data(&mut self, token_id: &TokenId) -> chainstate_storage::Result<()> {
+        self.inner.del_token_aux_data(token_id)
+    }
+
+    fn set_token_id(
+        &mut self,
+        issuance_tx_id: &Id<Transaction>,
+        token_id: &TokenId,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_token_id(issuance_tx_id, token_id)
+    }
+
+    fn del_token_id(&mut self, issuance_tx_id: &Id<Transaction>) -> chainstate_storage::Result<()> {
+        self.inner.del_token_id(issuance_tx_id)
+    }
+
+    fn set_tokens_accounting_undo_data(
+        &mut self,
+        id: Id<Block>,
+        undo: &tokens_accounting::BlockUndo,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_tokens_accounting_undo_data(id, undo)
+    }
+
+    fn del_tokens_accounting_undo_data(&mut self, id: Id<Block>) -> chainstate_storage::Result<()> {
+        self.inner.del_tokens_accounting_undo_data(id)
+    }
+
+    fn set_pos_accounting_undo_data(
+        &mut self,
+        id: Id<Block>,
+        undo: &pos_accounting::BlockUndo,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_pos_accounting_undo_data(id, undo)
+    }
+
+    fn del_pos_accounting_undo_data(&mut self, id: Id<Block>) -> chainstate_storage::Result<()> {
+        self.inner.del_pos_accounting_undo_data(id)
+    }
+
+    fn set_accounting_epoch_delta(
+        &mut self,
+        epoch_index: EpochIndex,
+        delta: &pos_accounting::PoSAccountingDeltaData,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_accounting_epoch_delta(epoch_index, delta)
+    }
+
+    fn del_accounting_epoch_delta(
+        &mut self,
+        epoch_index: EpochIndex,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.del_accounting_epoch_delta(epoch_index)
+    }
+
+    fn set_accounting_epoch_undo_delta(
+        &mut self,
+        epoch_index: EpochIndex,
+        undo: &pos_accounting::DeltaMergeUndo,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_accounting_epoch_undo_delta(epoch_index, undo)
+    }
+
+    fn del_accounting_epoch_undo_delta(
+        &mut self,
+        epoch_index: EpochIndex,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.del_accounting_epoch_undo_delta(epoch_index)
+    }
+
+    fn set_account_nonce_count(
+        &mut self,
+        account: common::chain::AccountType,
+        nonce: common::chain::AccountNonce,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.set_account_nonce_count(account, nonce)
+    }
+
+    fn del_account_nonce_count(
+        &mut self,
+        account: common::chain::AccountType,
+    ) -> chainstate_storage::Result<()> {
+        self.inner.del_account_nonce_count(account)
+    }
+}
+
+impl<T: EpochStorageWrite> EpochStorageWrite for FailingStorageTxRw<'_, T> {
+    fn set_epoch_data(
+        &mut self,
+        epoch_index: EpochIndex,
+        epoch_data: &EpochData,
+    ) -> storage_result::Result<()> {
+        self.inner.set_epoch_data(epoch_index, epoch_data)
+    }
+
+    fn del_epoch_data(&mut self, epoch_index: EpochIndex) -> storage_result::Result<()> {
+        self.inner.del_epoch_data(epoch_index)
+    }
+}
+
+impl<T: TokensAccountingStorageWrite> TokensAccountingStorageWrite for FailingStorageTxRw<'_, T> {
+    fn set_token_data(&mut self, id: &TokenId, data: &TokenData) -> Result<(), Self::Error> {
+        self.inner.set_token_data(id, data)
+    }
+
+    fn del_token_data(&mut self, id: &TokenId) -> Result<(), Self::Error> {
+        self.inner.del_token_data(id)
+    }
+
+    fn set_circulating_supply(&mut self, id: &TokenId, supply: &Amount) -> Result<(), Self::Error> {
+        self.inner.set_circulating_supply(id, supply)
+    }
+
+    fn del_circulating_supply(&mut self, id: &TokenId) -> Result<(), Self::Error> {
+        self.inner.del_circulating_supply(id)
+    }
+}
+
+impl<Tag, T> PoSAccountingStorageWrite<Tag> for FailingStorageTxRw<'_, T>
+where
+    T: PoSAccountingStorageWrite<Tag>,
+    Tag: pos_accounting::StorageTag,
+{
+    fn set_pool_balance(
+        &mut self,
+        pool_id: PoolId,
+        amount: Amount,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_pool_balance(pool_id, amount)
+    }
+
+    fn del_pool_balance(&mut self, pool_id: PoolId) -> Result<(), storage_result::Error> {
+        self.inner.del_pool_balance(pool_id)
+    }
+
+    fn set_pool_data(
+        &mut self,
+        pool_id: PoolId,
+        pool_data: &pos_accounting::PoolData,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_pool_data(pool_id, pool_data)
+    }
+
+    fn del_pool_data(&mut self, pool_id: PoolId) -> Result<(), storage_result::Error> {
+        self.inner.del_pool_data(pool_id)
+    }
+
+    fn set_delegation_balance(
+        &mut self,
+        delegation_target: DelegationId,
+        amount: Amount,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_delegation_balance(delegation_target, amount)
+    }
+
+    fn del_delegation_balance(
+        &mut self,
+        delegation_target: DelegationId,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.del_delegation_balance(delegation_target)
+    }
+
+    fn set_delegation_data(
+        &mut self,
+        delegation_id: DelegationId,
+        delegation_data: &pos_accounting::DelegationData,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_delegation_data(delegation_id, delegation_data)
+    }
+
+    fn del_delegation_data(
+        &mut self,
+        delegation_id: DelegationId,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.del_delegation_data(delegation_id)
+    }
+
+    fn set_pool_delegation_share(
+        &mut self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+        amount: Amount,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_pool_delegation_share(pool_id, delegation_id, amount)
+    }
+
+    fn del_pool_delegation_share(
+        &mut self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.del_pool_delegation_share(pool_id, delegation_id)
+    }
+}
+
+impl<T: UtxosStorageWrite> UtxosStorageWrite for FailingStorageTxRw<'_, T> {
+    fn set_utxo(&mut self, outpoint: &UtxoOutPoint, entry: utxo::Utxo) -> Result<(), Self::Error> {
+        self.inner.set_utxo(outpoint, entry)
+    }
+
+    fn del_utxo(&mut self, outpoint: &UtxoOutPoint) -> Result<(), Self::Error> {
+        self.inner.del_utxo(outpoint)
+    }
+
+    fn set_best_block_for_utxos(&mut self, block_id: &Id<GenBlock>) -> Result<(), Self::Error> {
+        self.inner.set_best_block_for_utxos(block_id)
+    }
+}
+
+impl<Tag, T> PoSAccountingStorageWrite<Tag> for FailingStorage<T>
+where
+    T: PoSAccountingStorageWrite<Tag>,
+    Tag: pos_accounting::StorageTag,
+{
+    fn set_pool_balance(
+        &mut self,
+        pool_id: PoolId,
+        amount: Amount,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_pool_balance(pool_id, amount)
+    }
+
+    fn del_pool_balance(&mut self, pool_id: PoolId) -> Result<(), storage_result::Error> {
+        self.inner.del_pool_balance(pool_id)
+    }
+
+    fn set_pool_data(
+        &mut self,
+        pool_id: PoolId,
+        pool_data: &pos_accounting::PoolData,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_pool_data(pool_id, pool_data)
+    }
+
+    fn del_pool_data(&mut self, pool_id: PoolId) -> Result<(), storage_result::Error> {
+        self.inner.del_pool_data(pool_id)
+    }
+
+    fn set_delegation_balance(
+        &mut self,
+        delegation_target: DelegationId,
+        amount: Amount,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_delegation_balance(delegation_target, amount)
+    }
+
+    fn del_delegation_balance(
+        &mut self,
+        delegation_target: DelegationId,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.del_delegation_balance(delegation_target)
+    }
+
+    fn set_delegation_data(
+        &mut self,
+        delegation_id: DelegationId,
+        delegation_data: &pos_accounting::DelegationData,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_delegation_data(delegation_id, delegation_data)
+    }
+
+    fn del_delegation_data(
+        &mut self,
+        delegation_id: DelegationId,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.del_delegation_data(delegation_id)
+    }
+
+    fn set_pool_delegation_share(
+        &mut self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+        amount: Amount,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.set_pool_delegation_share(pool_id, delegation_id, amount)
+    }
+
+    fn del_pool_delegation_share(
+        &mut self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+    ) -> Result<(), storage_result::Error> {
+        self.inner.del_pool_delegation_share(pool_id, delegation_id)
+    }
+}

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -20,7 +20,7 @@ use crate::{
     tx_verification_strategy::{
         DisposableTransactionVerificationStrategy, RandomizedTransactionVerificationStrategy,
     },
-    TestFramework, TestStore,
+    StorageFailureParams, TestFramework, TestStore,
 };
 use chainstate::{BlockError, ChainstateConfig, DefaultTransactionVerificationStrategy};
 use common::{
@@ -113,8 +113,13 @@ impl TestFrameworkBuilder {
         }
     }
 
-    pub fn with_storage(mut self, s: TestStore) -> Self {
-        self.chainstate_storage = s;
+    pub fn with_storage(mut self, s: impl Into<TestStore>) -> Self {
+        self.chainstate_storage = s.into();
+        self
+    }
+
+    pub fn with_storage_failures(mut self, params: StorageFailureParams, seed: Seed) -> Self {
+        self.chainstate_storage.set_failures(params, seed);
         self
     }
 

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -20,13 +20,14 @@ mod framework;
 mod framework_builder;
 mod pos_block_builder;
 mod random_tx_maker;
+mod failing_storage;
 mod staking_pools;
 mod transaction_builder;
 mod tx_verification_strategy;
 mod utils;
 
 /// Storage backend used for testing (the in-memory backend)
-pub type TestStore = chainstate_storage::inmemory::Store;
+pub type TestStore = FailingStorage<chainstate_storage::inmemory::Store>;
 
 /// Chainstate instantiation for testing, using the in-memory storage backend
 pub type TestChainstate = Box<dyn chainstate::chainstate_interface::ChainstateInterface>;
@@ -40,5 +41,6 @@ pub use {
     block_builder::BlockBuilder,
     framework::TestFramework,
     framework_builder::{OrphanErrorHandler, TestFrameworkBuilder, TxVerificationStrategy},
+    failing_storage::{FailingStorage, FailureParams as StorageFailureParams},
     transaction_builder::TransactionBuilder,
 };

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -16,11 +16,11 @@
 #![allow(clippy::unwrap_used)]
 
 mod block_builder;
+mod failing_storage;
 mod framework;
 mod framework_builder;
 mod pos_block_builder;
 mod random_tx_maker;
-mod failing_storage;
 mod staking_pools;
 mod transaction_builder;
 mod tx_verification_strategy;
@@ -39,8 +39,8 @@ pub use {
         produce_kernel_signature,
     },
     block_builder::BlockBuilder,
+    failing_storage::{FailingStorage, FailureParams as StorageFailureParams},
     framework::TestFramework,
     framework_builder::{OrphanErrorHandler, TestFrameworkBuilder, TxVerificationStrategy},
-    failing_storage::{FailingStorage, FailureParams as StorageFailureParams},
     transaction_builder::TransactionBuilder,
 };

--- a/chainstate/test-suite/src/tests/block_invalidation.rs
+++ b/chainstate/test-suite/src/tests/block_invalidation.rs
@@ -21,7 +21,7 @@ use super::helpers::{block_creation_helpers::*, block_status_helpers::*};
 use chainstate::{
     BlockError, BlockInvalidatorError, BlockSource, ChainstateError, CheckBlockError,
 };
-use chainstate_test_framework::TestFramework;
+use chainstate_test_framework::{StorageFailureParams, TestFramework};
 use chainstate_types::{BlockStatus, BlockValidationStage};
 use common::{
     chain::{
@@ -44,11 +44,15 @@ use utils::atomics::SeqCstAtomicU64;
 // G----m0----m1----m2----m3
 #[rstest]
 #[trace]
-#[case(Seed::from_entropy())]
-fn test_stale_chain_invalidation(#[case] seed: Seed) {
+#[case(Seed::from_entropy(), StorageFailureParams::RELIABLE)]
+#[trace]
+#[case::failing(Seed::from_entropy(), StorageFailureParams::FAILING)]
+fn test_stale_chain_invalidation(#[case] seed: Seed, #[case] failure_params: StorageFailureParams) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let mut tf = TestFramework::builder(&mut rng).build();
+        let mut tf = TestFramework::builder(&mut rng)
+            .with_storage_failures(failure_params.clone(), Seed(rng.gen()))
+            .build();
         let genesis_id = tf.genesis().get_id();
 
         let m_tip_id = tf.create_chain(&genesis_id.into(), 4, &mut rng).unwrap();
@@ -92,11 +96,15 @@ fn test_stale_chain_invalidation(#[case] seed: Seed) {
 // G----m0----m1
 #[rstest]
 #[trace]
-#[case(Seed::from_entropy())]
-fn test_basic_tip_invalidation(#[case] seed: Seed) {
+#[case(Seed::from_entropy(), StorageFailureParams::RELIABLE)]
+#[trace]
+#[case(Seed::from_entropy(), StorageFailureParams::FAILING)]
+fn test_basic_tip_invalidation(#[case] seed: Seed, #[case] failure_params: StorageFailureParams) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let mut tf = TestFramework::builder(&mut rng).build();
+        let mut tf = TestFramework::builder(&mut rng)
+            .with_storage_failures(failure_params.clone(), Seed(rng.gen()))
+            .build();
         let genesis_id = tf.genesis().get_id();
 
         let (m0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
@@ -123,11 +131,18 @@ fn test_basic_tip_invalidation(#[case] seed: Seed) {
 // G----m0----m1
 #[rstest]
 #[trace]
-#[case(Seed::from_entropy())]
-fn test_basic_parent_invalidation(#[case] seed: Seed) {
+#[case(Seed::from_entropy(), StorageFailureParams::RELIABLE)]
+#[trace]
+#[case::failing(Seed::from_entropy(), StorageFailureParams::FAILING)]
+fn test_basic_parent_invalidation(
+    #[case] seed: Seed,
+    #[case] failure_params: StorageFailureParams,
+) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let mut tf = TestFramework::builder(&mut rng).build();
+        let mut tf = TestFramework::builder(&mut rng)
+            .with_storage_failures(failure_params.clone(), Seed(rng.gen()))
+            .build();
         let genesis_id = tf.genesis().get_id();
 
         let (m0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
@@ -592,11 +607,18 @@ fn complex_test_after_reload(#[case] seed: Seed) {
 // where a0 and m0 have the same chain trust. The reorg should not occur.
 #[rstest]
 #[trace]
-#[case(Seed::from_entropy())]
-fn test_tip_invalidation_with_no_better_candidates(#[case] seed: Seed) {
+#[case(Seed::from_entropy(), StorageFailureParams::RELIABLE)]
+#[trace]
+#[case::failing(Seed::from_entropy(), StorageFailureParams::FAILING)]
+fn test_tip_invalidation_with_no_better_candidates(
+    #[case] seed: Seed,
+    #[case] failure_params: StorageFailureParams,
+) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let mut tf = TestFramework::builder(&mut rng).build();
+        let mut tf = TestFramework::builder(&mut rng)
+            .with_storage_failures(failure_params.clone(), Seed(rng.gen()))
+            .build();
         let genesis_id = tf.genesis().get_id();
 
         let (m0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
@@ -859,11 +881,18 @@ fn test_invalidation_with_reorg_to_chain_with_tip_far_in_the_future(#[case] seed
 // its status to ok and add 2 more blocks on top of it.
 #[rstest]
 #[trace]
-#[case(Seed::from_entropy())]
-fn test_reset_bad_stale_tip_status_and_add_blocks(#[case] seed: Seed) {
+#[case(Seed::from_entropy(), StorageFailureParams::RELIABLE)]
+#[trace]
+#[case::failing(Seed::from_entropy(), StorageFailureParams::FAILING)]
+fn test_reset_bad_stale_tip_status_and_add_blocks(
+    #[case] seed: Seed,
+    #[case] failure_params: StorageFailureParams,
+) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
-        let mut tf = TestFramework::builder(&mut rng).build();
+        let mut tf = TestFramework::builder(&mut rng)
+            .with_storage_failures(failure_params.clone(), Seed(rng.gen()))
+            .build();
         let genesis_id = tf.genesis().get_id();
 
         let (m0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -19,8 +19,8 @@ use ::tx_verifier::transaction_verifier::storage::{
     TransactionVerifierStorageError, TransactionVerifierStorageRef,
 };
 use chainstate_storage::{BlockchainStorageRead, TipStorageTag, Transactional};
-use chainstate_types::{storage_result, GenBlockIndex};
 use chainstate_test_framework::TestStore;
+use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -18,8 +18,9 @@ use std::{collections::BTreeMap, sync::Arc};
 use ::tx_verifier::transaction_verifier::storage::{
     TransactionVerifierStorageError, TransactionVerifierStorageRef,
 };
-use chainstate_storage::{inmemory::Store, BlockchainStorageRead, TipStorageTag, Transactional};
+use chainstate_storage::{BlockchainStorageRead, TipStorageTag, Transactional};
 use chainstate_types::{storage_result, GenBlockIndex};
+use chainstate_test_framework::TestStore;
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
@@ -37,12 +38,12 @@ use tx_verifier::{
 use utxo::UtxosStorageRead;
 
 pub struct InMemoryStorageWrapper {
-    storage: Store,
+    storage: TestStore,
     chain_config: ChainConfig,
 }
 
 impl InMemoryStorageWrapper {
-    pub fn new(storage: Store, chain_config: ChainConfig) -> Self {
+    pub fn new(storage: TestStore, chain_config: ChainConfig) -> Self {
         Self {
             storage,
             chain_config,

--- a/storage/core/src/error.rs
+++ b/storage/core/src/error.rs
@@ -28,6 +28,10 @@ pub enum Recoverable {
     #[error("The database has temporarily exhausted some resource")]
     TemporarilyUnavailable,
 
+    /// Memory map is full and has to be resized.
+    #[error("Memory map is full")]
+    MemMapFull,
+
     /// Database file failed to initialize. For example, if the DB file format is wrong.
     #[error("The database file failed to initialize")]
     DbInit,

--- a/test-utils/src/random.rs
+++ b/test-utils/src/random.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 pub use crypto::random as inner_random;
-pub use crypto::random::{CryptoRng, Rng, SeedableRng, RngCore};
+pub use crypto::random::{CryptoRng, Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::{num::ParseIntError, str::FromStr};
 


### PR DESCRIPTION
This works by making sure that even when any of the intermediate transaction operations fail, the transaction is reattempted. Previously, the transaction was only reattempted when the final `commit` failed but the intermediate operations were allowed to exit early.

I don't like this approach, especially the 600+ lines of chasing up storage errors buried deep inside other errors. Working on an alternative fix that operates on chainstate storage level, will see how that goes.