### PR TITLE
Track storage errors and recover in more cases in chainstate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7027,6 +7027,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "storage-failing"
+version = "0.4.2"
+dependencies = [
+ "enumflags2",
+ "storage",
+ "storage-core",
+ "test-utils",
+ "thiserror",
+ "utils",
+]
+
+[[package]]
 name = "storage-inmemory"
 version = "0.4.2"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,8 @@ dependencies = [
  "pos-accounting",
  "rstest",
  "serialization",
+ "storage-failing",
+ "storage-inmemory",
  "test-utils",
  "tokens-accounting",
  "tx-verifier",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
   "storage",                            # storage abstraction layer and its implementation.
   "storage/backend-test-suite",         # Tests for validating storage backend implementations.
   "storage/core",                       # Core backend-agnostic storage abstraction.
+  "storage/failing",                    # Storage adapter to occasionally fail certain operations, for testing.
   "storage/inmemory",                   # In-memory storage backend implementation.
   "storage/lmdb",                       # LMDB-based persistent storage backend implementation.
   "storage/sqlite",                     # SQLite-based persistent storage backend implementation.
@@ -149,6 +150,7 @@ directories = "5.0"
 humantime = "2.1"
 dyn-clone = "1.0"
 enum-iterator = "2.0"
+enumflags2 = "0.7"
 expect-test = "1.3"
 fallible-iterator = "0.3"
 fix-hidden-lifetime-bug = "0.2"

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -119,9 +119,8 @@ impl<'a, S: TransactionRw, V> ChainstateRef<'a, S, V> {
         self.db_tx.commit()
     }
 
-    #[log_error]
-    pub fn abort_db_tx(self) -> chainstate_storage::Result<()> {
-        self.db_tx.abort()
+    pub fn check_storage_error(&self) -> chainstate_storage::Result<()> {
+        self.db_tx.check_error()
     }
 }
 

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -118,6 +118,11 @@ impl<'a, S: TransactionRw, V> ChainstateRef<'a, S, V> {
     pub fn commit_db_tx(self) -> chainstate_storage::Result<()> {
         self.db_tx.commit()
     }
+
+    #[log_error]
+    pub fn abort_db_tx(self) -> chainstate_storage::Result<()> {
+        self.db_tx.abort()
+    }
 }
 
 impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> ChainstateRef<'a, S, V> {

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -301,8 +301,7 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
             let result = match main_action_result {
                 Ok(result) => result,
                 err @ Err(_) => {
-                    let abort_result = chainstate_ref.abort_db_tx();
-                    match abort_result {
+                    match chainstate_ref.check_storage_error() {
                         // There is an error but not related to storage, no point retrying.
                         Ok(()) => (),
 

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -271,12 +271,11 @@ impl<S: BlockchainStorage, V: TransactionVerificationStrategy> Chainstate<S, V> 
     }
 
     /// Create a read-write transaction, call `main_action` on it and commit.
-    /// If committing fails, repeat the whole process again until it succeeds or
-    /// the maximum number of commit attempts is reached.
-    /// If the maximum number of attempts is reached, use `on_db_err` to create
-    /// a BlockError and return it.
-    /// On each iteration, before doing anything else, call `on_new_attempt`
-    /// (this can be used for logging).
+    ///
+    /// If a storage failure occurs during execution or committing fails, repeat the whole process
+    /// again until it succeeds or the maximum number of commit attempts is reached. If the maximum
+    /// number of attempts is reached, use `on_db_err` to create a BlockError and return it. On each
+    /// iteration, before doing anything else, call `on_new_attempt` (this can be used for logging).
     #[log_error]
     fn with_rw_tx<MainAction, OnNewAttempt, OnDbCommitErr, Res, Err>(
         &mut self,

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -106,7 +106,7 @@ impl<'tx, B: storage::Backend + 'tx> Transactional<'tx> for Store<B> {
         &'st self,
         size: Option<usize>,
     ) -> crate::Result<Self::TransactionRw> {
-        self.0.transaction_rw(size).map_err(crate::Error::from).map(StoreTxRw)
+        self.0.transaction_rw(size).map_err(crate::Error::from).map(StoreTxRw::new)
     }
 }
 

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -69,7 +69,7 @@ impl<B: storage::Backend> Store<B> {
     }
 
     #[log_error]
-    fn from_backend(backend: B) -> crate::Result<Self> {
+    pub fn from_backend(backend: B) -> crate::Result<Self> {
         let storage = Self(storage::Storage::new(backend).map_err(crate::Error::from)?);
         Ok(storage)
     }

--- a/chainstate/storage/src/internal/store_tx/mod.rs
+++ b/chainstate/storage/src/internal/store_tx/mod.rs
@@ -208,9 +208,11 @@ impl<'st, B: storage::Backend> crate::TransactionRw for StoreTxRw<'st, B> {
         self.db_tx.commit().map_err(Into::into)
     }
 
-    fn abort(self) -> crate::Result<()> {
-        self.check_error()?;
+    fn abort(self) {
         self.db_tx.abort();
-        Ok(())
+    }
+
+    fn check_error(&self) -> crate::Result<()> {
+        self.check_error()
     }
 }

--- a/chainstate/storage/src/internal/store_tx/mod.rs
+++ b/chainstate/storage/src/internal/store_tx/mod.rs
@@ -185,7 +185,7 @@ impl<'st, B: storage::Backend> StoreTxRw<'st, B> {
         self.write::<db::DBValue, _, _, _>(E::KEY, val.encode())
     }
 
-    // Encode a value and write it to the database
+    // Delete a value from the database
     fn del<DbMap, I, K>(&mut self, key: K) -> crate::Result<()>
     where
         DbMap: schema::DbMap,

--- a/chainstate/storage/src/internal/store_tx/read_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/read_impls.rs
@@ -410,7 +410,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
 
     #[log_error]
     fn get_block_reward(&self, block_index: &BlockIndex) -> crate::Result<Option<BlockReward>> {
-        let store = self.0.get::<db::DBBlock, _>();
+        let store = self.db_tx.get::<db::DBBlock, _>();
         let encoded_block = store.get(block_index.block_id());
         private::block_index_to_block_reward(block_index, encoded_block)
     }
@@ -453,7 +453,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
         &self,
         start_from: BlockHeight,
     ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>> {
-        let map = self.0.get::<db::DBBlockIndex, _>();
+        let map = self.db_tx.get::<db::DBBlockIndex, _>();
         let items = map.prefix_iter_decoded(&())?;
 
         let mut result = BTreeMap::<BlockHeight, Vec<Id<Block>>>::new();
@@ -500,7 +500,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     // the logic duplication between StoreTxRo and StoreTxRw.
     #[log_error]
     fn get_block_map_keys(&self) -> crate::Result<BTreeSet<Id<Block>>> {
-        let map = self.0.get::<db::DBBlock, _>();
+        let map = self.db_tx.get::<db::DBBlock, _>();
         let items = map.prefix_iter_keys(&())?;
         Ok(items.collect::<BTreeSet<_>>())
     }
@@ -508,7 +508,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     // TODO: same as above.
     #[log_error]
     fn get_block_index_map(&self) -> crate::Result<BTreeMap<Id<Block>, BlockIndex>> {
-        let map = self.0.get::<db::DBBlockIndex, _>();
+        let map = self.db_tx.get::<db::DBBlockIndex, _>();
         let items = map.prefix_iter_decoded(&())?;
         Ok(items.collect::<BTreeMap<_, _>>())
     }
@@ -516,7 +516,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     // TODO: same as above.
     #[log_error]
     fn get_block_by_height_map(&self) -> crate::Result<BTreeMap<BlockHeight, Id<GenBlock>>> {
-        let map = self.0.get::<db::DBBlockByHeight, _>();
+        let map = self.db_tx.get::<db::DBBlockByHeight, _>();
         let items = map.prefix_iter_decoded(&())?;
         Ok(items.collect::<BTreeMap<_, _>>())
     }
@@ -575,7 +575,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageRead<TipStorageTag>
         &self,
         pool_id: PoolId,
     ) -> crate::Result<Option<BTreeMap<DelegationId, Amount>>> {
-        let db_map = self.0.get::<db::DBAccountingPoolDelegationSharesTip, _>();
+        let db_map = self.db_tx.get::<db::DBAccountingPoolDelegationSharesTip, _>();
         let shares_iter = db_map.prefix_iter_decoded(&())?;
         private::filter_delegation_shares_for_poolid(pool_id, shares_iter)
     }
@@ -621,7 +621,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageRead<SealedStorageTag>
         &self,
         pool_id: PoolId,
     ) -> crate::Result<Option<BTreeMap<DelegationId, Amount>>> {
-        let db_map = self.0.get::<db::DBAccountingPoolDelegationSharesSealed, _>();
+        let db_map = self.db_tx.get::<db::DBAccountingPoolDelegationSharesSealed, _>();
         let shares_iter = db_map.prefix_iter_decoded(&())?;
         private::filter_delegation_shares_for_poolid(pool_id, shares_iter)
     }

--- a/chainstate/storage/src/internal/store_tx/read_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/read_impls.rs
@@ -410,7 +410,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
 
     #[log_error]
     fn get_block_reward(&self, block_index: &BlockIndex) -> crate::Result<Option<BlockReward>> {
-        let store = self.db_tx.get::<db::DBBlock, _>();
+        let store = self.get_map::<db::DBBlock, _>()?;
         let encoded_block = store.get(block_index.block_id());
         private::block_index_to_block_reward(block_index, encoded_block)
     }
@@ -453,7 +453,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
         &self,
         start_from: BlockHeight,
     ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>> {
-        let map = self.db_tx.get::<db::DBBlockIndex, _>();
+        let map = self.get_map::<db::DBBlockIndex, _>()?;
         let items = map.prefix_iter_decoded(&())?;
 
         let mut result = BTreeMap::<BlockHeight, Vec<Id<Block>>>::new();
@@ -500,7 +500,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     // the logic duplication between StoreTxRo and StoreTxRw.
     #[log_error]
     fn get_block_map_keys(&self) -> crate::Result<BTreeSet<Id<Block>>> {
-        let map = self.db_tx.get::<db::DBBlock, _>();
+        let map = self.get_map::<db::DBBlock, _>()?;
         let items = map.prefix_iter_keys(&())?;
         Ok(items.collect::<BTreeSet<_>>())
     }
@@ -508,7 +508,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     // TODO: same as above.
     #[log_error]
     fn get_block_index_map(&self) -> crate::Result<BTreeMap<Id<Block>, BlockIndex>> {
-        let map = self.db_tx.get::<db::DBBlockIndex, _>();
+        let map = self.get_map::<db::DBBlockIndex, _>()?;
         let items = map.prefix_iter_decoded(&())?;
         Ok(items.collect::<BTreeMap<_, _>>())
     }
@@ -516,7 +516,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     // TODO: same as above.
     #[log_error]
     fn get_block_by_height_map(&self) -> crate::Result<BTreeMap<BlockHeight, Id<GenBlock>>> {
-        let map = self.db_tx.get::<db::DBBlockByHeight, _>();
+        let map = self.get_map::<db::DBBlockByHeight, _>()?;
         let items = map.prefix_iter_decoded(&())?;
         Ok(items.collect::<BTreeMap<_, _>>())
     }
@@ -575,7 +575,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageRead<TipStorageTag>
         &self,
         pool_id: PoolId,
     ) -> crate::Result<Option<BTreeMap<DelegationId, Amount>>> {
-        let db_map = self.db_tx.get::<db::DBAccountingPoolDelegationSharesTip, _>();
+        let db_map = self.get_map::<db::DBAccountingPoolDelegationSharesTip, _>()?;
         let shares_iter = db_map.prefix_iter_decoded(&())?;
         private::filter_delegation_shares_for_poolid(pool_id, shares_iter)
     }
@@ -621,7 +621,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageRead<SealedStorageTag>
         &self,
         pool_id: PoolId,
     ) -> crate::Result<Option<BTreeMap<DelegationId, Amount>>> {
-        let db_map = self.db_tx.get::<db::DBAccountingPoolDelegationSharesSealed, _>();
+        let db_map = self.get_map::<db::DBAccountingPoolDelegationSharesSealed, _>()?;
         let shares_iter = db_map.prefix_iter_decoded(&())?;
         private::filter_delegation_shares_for_poolid(pool_id, shares_iter)
     }

--- a/chainstate/storage/src/internal/store_tx/write_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/write_impls.rs
@@ -312,10 +312,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<SealedStorageTag> for S
 
     #[log_error]
     fn del_pool_balance(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.db_tx
-            .get_mut::<db::DBAccountingPoolBalancesSealed, _>()
-            .del(pool_id)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingPoolBalancesSealed, _, _>(pool_id)
     }
 
     #[log_error]

--- a/chainstate/storage/src/internal/store_tx/write_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/write_impls.rs
@@ -62,7 +62,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_block(&mut self, id: Id<Block>) -> crate::Result<()> {
-        self.0.get_mut::<db::DBBlock, _>().del(id).map_err(Into::into)
+        self.del::<db::DBBlock, _, _>(id)
     }
 
     #[log_error]
@@ -72,7 +72,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_block_index(&mut self, block_id: Id<Block>) -> crate::Result<()> {
-        self.0.get_mut::<db::DBBlockIndex, _>().del(block_id).map_err(Into::into)
+        self.del::<db::DBBlockIndex, _, _>(block_id)
     }
 
     #[log_error]
@@ -91,7 +91,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_block_id_at_height(&mut self, height: &BlockHeight) -> crate::Result<()> {
-        self.0.get_mut::<db::DBBlockByHeight, _>().del(height).map_err(Into::into)
+        self.del::<db::DBBlockByHeight, _, _>(height)
     }
 
     #[log_error]
@@ -101,7 +101,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_undo_data(&mut self, id: Id<Block>) -> crate::Result<()> {
-        self.0.get_mut::<db::DBUtxosBlockUndo, _>().del(id).map_err(Into::into)
+        self.del::<db::DBUtxosBlockUndo, _, _>(id)
     }
 
     #[log_error]
@@ -115,7 +115,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_token_aux_data(&mut self, token_id: &TokenId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBTokensAuxData, _>().del(&token_id).map_err(Into::into)
+        self.del::<db::DBTokensAuxData, _, _>(token_id)
     }
 
     #[log_error]
@@ -129,10 +129,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_token_id(&mut self, issuance_tx_id: &Id<Transaction>) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBIssuanceTxVsTokenId, _>()
-            .del(&issuance_tx_id)
-            .map_err(Into::into)
+        self.del::<db::DBIssuanceTxVsTokenId, _, _>(issuance_tx_id)
     }
 
     #[log_error]
@@ -146,10 +143,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_tokens_accounting_undo_data(&mut self, id: Id<Block>) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBTokensAccountingBlockUndo, _>()
-            .del(id)
-            .map_err(Into::into)
+        self.del::<db::DBTokensAccountingBlockUndo, _, _>(id)
     }
 
     #[log_error]
@@ -163,7 +157,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_pos_accounting_undo_data(&mut self, id: Id<Block>) -> crate::Result<()> {
-        self.0.get_mut::<db::DBAccountingBlockUndo, _>().del(id).map_err(Into::into)
+        self.del::<db::DBAccountingBlockUndo, _, _>(id)
     }
 
     #[log_error]
@@ -177,10 +171,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_accounting_epoch_delta(&mut self, epoch_index: EpochIndex) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingEpochDelta, _>()
-            .del(epoch_index)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingEpochDelta, _, _>(epoch_index)
     }
 
     #[log_error]
@@ -194,10 +185,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_accounting_epoch_undo_delta(&mut self, epoch_index: EpochIndex) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingEpochDeltaUndo, _>()
-            .del(epoch_index)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingEpochDeltaUndo, _, _>(epoch_index)
     }
 
     #[log_error]
@@ -211,7 +199,7 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_account_nonce_count(&mut self, account: AccountType) -> crate::Result<()> {
-        self.0.get_mut::<db::DBAccountNonceCount, _>().del(account).map_err(Into::into)
+        self.del::<db::DBAccountNonceCount, _, _>(account)
     }
 }
 
@@ -223,7 +211,7 @@ impl<'st, B: storage::Backend> EpochStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_epoch_data(&mut self, epoch_index: u64) -> crate::Result<()> {
-        self.0.get_mut::<db::DBEpochData, _>().del(epoch_index).map_err(Into::into)
+        self.del::<db::DBEpochData, _, _>(epoch_index)
     }
 }
 
@@ -235,7 +223,7 @@ impl<'st, B: storage::Backend> UtxosStorageWrite for StoreTxRw<'st, B> {
 
     #[log_error]
     fn del_utxo(&mut self, outpoint: &UtxoOutPoint) -> crate::Result<()> {
-        self.0.get_mut::<db::DBUtxo, _>().del(outpoint).map_err(Into::into)
+        self.del::<db::DBUtxo, _, _>(outpoint)
     }
 
     #[log_error]
@@ -252,10 +240,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<TipStorageTag> for Stor
 
     #[log_error]
     fn del_pool_balance(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolBalancesTip, _>()
-            .del(pool_id)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingPoolBalancesTip, _, _>(pool_id)
     }
 
     #[log_error]
@@ -265,10 +250,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<TipStorageTag> for Stor
 
     #[log_error]
     fn del_pool_data(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolDataTip, _>()
-            .del(pool_id)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingPoolDataTip, _, _>(pool_id)
     }
 
     #[log_error]
@@ -282,10 +264,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<TipStorageTag> for Stor
 
     #[log_error]
     fn del_delegation_balance(&mut self, delegation_target: DelegationId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingDelegationBalancesTip, _>()
-            .del(delegation_target)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingDelegationBalancesTip, _, _>(delegation_target)
     }
 
     #[log_error]
@@ -299,10 +278,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<TipStorageTag> for Stor
 
     #[log_error]
     fn del_delegation_data(&mut self, delegation_id: DelegationId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingDelegationDataTip, _>()
-            .del(delegation_id)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingDelegationDataTip, _, _>(delegation_id)
     }
 
     #[log_error]
@@ -324,10 +300,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<TipStorageTag> for Stor
         pool_id: PoolId,
         delegation_id: DelegationId,
     ) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolDelegationSharesTip, _>()
-            .del((pool_id, delegation_id))
-            .map_err(Into::into)
+        self.del::<db::DBAccountingPoolDelegationSharesTip, _, _>((pool_id, delegation_id))
     }
 }
 
@@ -339,7 +312,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<SealedStorageTag> for S
 
     #[log_error]
     fn del_pool_balance(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.0
+        self.db_tx
             .get_mut::<db::DBAccountingPoolBalancesSealed, _>()
             .del(pool_id)
             .map_err(Into::into)
@@ -352,10 +325,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<SealedStorageTag> for S
 
     #[log_error]
     fn del_pool_data(&mut self, pool_id: PoolId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolDataSealed, _>()
-            .del(pool_id)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingPoolDataSealed, _, _>(pool_id)
     }
 
     #[log_error]
@@ -369,10 +339,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<SealedStorageTag> for S
 
     #[log_error]
     fn del_delegation_balance(&mut self, delegation_target: DelegationId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingDelegationBalancesSealed, _>()
-            .del(delegation_target)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingDelegationBalancesSealed, _, _>(delegation_target)
     }
 
     #[log_error]
@@ -386,10 +353,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<SealedStorageTag> for S
 
     #[log_error]
     fn del_delegation_data(&mut self, delegation_id: DelegationId) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingDelegationDataSealed, _>()
-            .del(delegation_id)
-            .map_err(Into::into)
+        self.del::<db::DBAccountingDelegationDataSealed, _, _>(delegation_id)
     }
 
     #[log_error]
@@ -411,10 +375,7 @@ impl<'st, B: storage::Backend> PoSAccountingStorageWrite<SealedStorageTag> for S
         pool_id: PoolId,
         delegation_id: DelegationId,
     ) -> crate::Result<()> {
-        self.0
-            .get_mut::<db::DBAccountingPoolDelegationSharesSealed, _>()
-            .del((pool_id, delegation_id))
-            .map_err(Into::into)
+        self.del::<db::DBAccountingPoolDelegationSharesSealed, _, _>((pool_id, delegation_id))
     }
 }
 
@@ -430,7 +391,7 @@ impl<'st, B: storage::Backend> TokensAccountingStorageWrite for StoreTxRw<'st, B
 
     #[log_error]
     fn del_token_data(&mut self, id: &TokenId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBTokensData, _>().del(id).map_err(Into::into)
+        self.del::<db::DBTokensData, _, _>(id)
     }
 
     #[log_error]
@@ -440,6 +401,6 @@ impl<'st, B: storage::Backend> TokensAccountingStorageWrite for StoreTxRw<'st, B
 
     #[log_error]
     fn del_circulating_supply(&mut self, id: &TokenId) -> crate::Result<()> {
-        self.0.get_mut::<db::DBTokensCirculatingSupply, _>().del(id).map_err(Into::into)
+        self.del::<db::DBTokensCirculatingSupply, _, _>(id)
     }
 }

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -266,10 +266,13 @@ pub trait TransactionRo: BlockchainStorageRead {
 /// Operations on read-write transactions
 pub trait TransactionRw: BlockchainStorageWrite {
     /// Abort the transaction
-    fn abort(self) -> crate::Result<()>;
+    fn abort(self);
 
     /// Commit the transaction
     fn commit(self) -> crate::Result<()>;
+
+    /// Check if an error has occurred during the transaction execution so far
+    fn check_error(&self) -> crate::Result<()>;
 }
 
 /// Support for transactions over blockchain storage

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -266,7 +266,7 @@ pub trait TransactionRo: BlockchainStorageRead {
 /// Operations on read-write transactions
 pub trait TransactionRw: BlockchainStorageWrite {
     /// Abort the transaction
-    fn abort(self);
+    fn abort(self) -> crate::Result<()>;
 
     /// Commit the transaction
     fn commit(self) -> crate::Result<()>;

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -691,7 +691,8 @@ mockall::mock! {
     }
 
     impl crate::TransactionRw for StoreTxRw {
-        fn abort(self) -> crate::Result<()>;
+        fn abort(self);
         fn commit(self) -> crate::Result<()>;
+        fn check_error(&self) -> crate::Result<()>;
     }
 }

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -691,7 +691,7 @@ mockall::mock! {
     }
 
     impl crate::TransactionRw for StoreTxRw {
-        fn abort(self);
+        fn abort(self) -> crate::Result<()>;
         fn commit(self) -> crate::Result<()>;
     }
 }

--- a/chainstate/storage/src/mock/tests.rs
+++ b/chainstate/storage/src/mock/tests.rs
@@ -219,7 +219,7 @@ fn attach_to_top_no_best_block() {
     store.expect_transaction_rw().returning(move |_| {
         let mut tx = MockStoreTxRw::new();
         tx.expect_get_best_block_id().return_const(Ok(None));
-        tx.expect_abort().return_const(());
+        tx.expect_abort().return_const(Ok(()));
         Ok(tx)
     });
 
@@ -235,7 +235,7 @@ fn attach_to_top_bad_parent() {
     store.expect_transaction_rw().returning(move |_| {
         let mut tx = MockStoreTxRw::new();
         tx.expect_get_best_block_id().return_const(Ok(Some(top_id)));
-        tx.expect_abort().return_const(());
+        tx.expect_abort().return_const(Ok(()));
         Ok(tx)
     });
 

--- a/chainstate/storage/src/mock/tests.rs
+++ b/chainstate/storage/src/mock/tests.rs
@@ -219,7 +219,7 @@ fn attach_to_top_no_best_block() {
     store.expect_transaction_rw().returning(move |_| {
         let mut tx = MockStoreTxRw::new();
         tx.expect_get_best_block_id().return_const(Ok(None));
-        tx.expect_abort().return_const(Ok(()));
+        tx.expect_abort().return_const(());
         Ok(tx)
     });
 
@@ -235,7 +235,7 @@ fn attach_to_top_bad_parent() {
     store.expect_transaction_rw().returning(move |_| {
         let mut tx = MockStoreTxRw::new();
         tx.expect_get_best_block_id().return_const(Ok(Some(top_id)));
-        tx.expect_abort().return_const(Ok(()));
+        tx.expect_abort().return_const(());
         Ok(tx)
     });
 

--- a/chainstate/test-framework/Cargo.toml
+++ b/chainstate/test-framework/Cargo.toml
@@ -17,6 +17,8 @@ constraints-value-accumulator = {path = '../constraints-value-accumulator'}
 crypto = { path = "../../crypto" }
 pos-accounting = { path = "../../pos-accounting" }
 serialization = { path = "../../serialization" }
+storage-failing = { path = "../../storage/failing" }
+storage-inmemory = { path = "../../storage/inmemory" }
 test-utils = { path = "../../test-utils" }
 tokens-accounting = {path = '../../tokens-accounting'}
 tx-verifier = { path = "../tx-verifier" }

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -22,12 +22,13 @@ mod key_manager;
 mod pos_block_builder;
 mod random_tx_maker;
 mod staking_pools;
+pub mod storage;
 mod transaction_builder;
 mod tx_verification_strategy;
 mod utils;
 
-/// Storage backend used for testing (the in-memory backend)
-pub type TestStore = chainstate_storage::inmemory::Store;
+/// Storage backend used for testing (the in-memory backend with simulated failures)
+pub use storage::TestStore;
 
 /// Chainstate instantiation for testing, using the in-memory storage backend
 pub type TestChainstate = Box<dyn chainstate::chainstate_interface::ChainstateInterface>;

--- a/chainstate/test-framework/src/storage.rs
+++ b/chainstate/test-framework/src/storage.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use storage_failing::{Failing, FailureConfig};
+use storage_inmemory::InMemory;
+use test_utils::random::Seed;
+
+pub use storage_failing::StorageError;
+
+pub type TestStore = chainstate_storage::Store<Failing<InMemory>>;
+pub type ConfigBuilder = storage_failing::Builder<chainstate_storage::schema::Schema>;
+
+/// A builder for chainstate testing storage
+#[derive(Clone)]
+pub struct Builder {
+    inner: InMemory,
+    config: ConfigBuilder,
+}
+
+impl Builder {
+    /// Build reliable storage
+    pub fn reliable() -> Self {
+        let inner = InMemory::default();
+        let config = ConfigBuilder::new(FailureConfig::reliable());
+        Self { inner, config }
+    }
+
+    /// New failing [TestStore] builder.
+    pub fn new(config_fn: impl FnOnce(ConfigBuilder) -> ConfigBuilder) -> Self {
+        let inner = InMemory::default();
+        let config = config_fn(FailureConfig::builder());
+        Self { inner, config }
+    }
+
+    /// Build the storage.
+    pub fn build(self, seed: Seed) -> TestStore {
+        let Self { inner, config } = self;
+        let backend = Failing::new(inner, config.build(), seed);
+        TestStore::from_backend(backend).expect("backend creation to succeed")
+    }
+
+    /// Use the specified in-memory backend as the underlying storage.
+    pub fn with_inner(mut self, inner: InMemory) -> Self {
+        self.inner = inner;
+        self
+    }
+
+    /// Apply given function to the failure config builder.
+    pub fn failure_config(self, config_fn: impl FnOnce(ConfigBuilder) -> ConfigBuilder) -> Self {
+        let Self { inner, config } = self;
+        Self {
+            inner,
+            config: config_fn(config),
+        }
+    }
+}
+
+impl std::fmt::Debug for Builder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { inner: _, config } = self;
+        config.fmt(f)
+    }
+}

--- a/chainstate/test-suite/src/tests/block_invalidation.rs
+++ b/chainstate/test-suite/src/tests/block_invalidation.rs
@@ -68,10 +68,9 @@ mod storage_configs {
 // /----a0----a1----a2
 // G----m0----m1----m2----m3
 #[rstest]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::reliable())]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::failing())]
+#[trace]
 fn test_stale_chain_invalidation(#[case] seed: Seed, #[case] sb: StorageBuilder) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
@@ -120,10 +119,9 @@ fn test_stale_chain_invalidation(#[case] seed: Seed, #[case] sb: StorageBuilder)
 // Invalidate m1 in:
 // G----m0----m1
 #[rstest]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::reliable())]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::failing())]
+#[trace]
 fn test_basic_tip_invalidation(#[case] seed: Seed, #[case] sb: StorageBuilder) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
@@ -155,10 +153,9 @@ fn test_basic_tip_invalidation(#[case] seed: Seed, #[case] sb: StorageBuilder) {
 // Invalidate m0 in:
 // G----m0----m1
 #[rstest]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::reliable())]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::failing())]
+#[trace]
 fn test_basic_parent_invalidation(#[case] seed: Seed, #[case] sb: StorageBuilder) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
@@ -628,10 +625,9 @@ fn complex_test_after_reload(#[case] seed: Seed) {
 // G----m0----m1
 // where a0 and m0 have the same chain trust. The reorg should not occur.
 #[rstest]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::reliable())]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::failing())]
+#[trace]
 fn test_tip_invalidation_with_no_better_candidates(#[case] seed: Seed, #[case] sb: StorageBuilder) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
@@ -899,10 +895,9 @@ fn test_invalidation_with_reorg_to_chain_with_tip_far_in_the_future(#[case] seed
 // where a1 has been determined to be invalid but still remains in the db, reset
 // its status to ok and add 2 more blocks on top of it.
 #[rstest]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::reliable())]
-#[trace]
 #[case(Seed::from_entropy(), storage_configs::failing_add_only())]
+#[trace]
 fn test_reset_bad_stale_tip_status_and_add_blocks(#[case] seed: Seed, #[case] sb: StorageBuilder) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);

--- a/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
@@ -20,9 +20,9 @@ use super::helpers::new_pub_key_destination;
 
 use accounting::{DataDelta, DeltaAmountCollection, DeltaDataCollection};
 use chainstate::BlockSource;
-use chainstate_storage::{inmemory::Store, BlockchainStorageRead, Transactional};
+use chainstate_storage::{BlockchainStorageRead, Transactional};
 use chainstate_test_framework::{
-    anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
+    anyonecanspend_address, empty_witness, TestFramework, TestStore, TransactionBuilder,
 };
 use common::{
     chain::{
@@ -129,7 +129,7 @@ fn make_tx_with_stake_pool(
 #[case(Seed::from_entropy())]
 fn store_pool_data_and_balance(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).with_storage(storage.clone()).build();
         let amount_to_stake = tf.chainstate.get_chain_config().min_stake_pool_pledge();
@@ -188,7 +188,7 @@ fn store_pool_data_and_balance(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn accounting_storage_two_blocks_one_epoch_no_seal(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let chain_config = ConfigBuilder::test_chain()
             .epoch_length(NonZeroU64::new(3).unwrap())
@@ -317,7 +317,7 @@ fn accounting_storage_two_blocks_one_epoch_no_seal(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn accounting_storage_two_epochs_no_seal(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let chain_config =
             ConfigBuilder::test_chain().epoch_length(NonZeroU64::new(1).unwrap()).build();
@@ -445,7 +445,7 @@ fn accounting_storage_two_epochs_no_seal(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn accounting_storage_seal_one_epoch(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let chain_config = ConfigBuilder::test_chain()
             .epoch_length(NonZeroU64::new(1).unwrap())
@@ -603,7 +603,7 @@ fn accounting_storage_seal_one_epoch(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn accounting_storage_seal_every_block(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let chain_config = ConfigBuilder::test_chain()
             .epoch_length(NonZeroU64::new(1).unwrap())
@@ -700,7 +700,7 @@ fn accounting_storage_seal_every_block(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn accounting_storage_no_accounting_data(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let chain_config = ConfigBuilder::test_chain()
             .epoch_length(NonZeroU64::new(1).unwrap())

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -16,9 +16,9 @@
 use std::collections::BTreeMap;
 
 use super::*;
-use chainstate_storage::{inmemory::Store, BlockchainStorageRead, Transactional};
+use chainstate_storage::{BlockchainStorageRead, Transactional};
 use chainstate_test_framework::{
-    anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
+    anyonecanspend_address, empty_witness, TestFramework, TestStore, TransactionBuilder,
 };
 use common::{
     chain::{
@@ -38,7 +38,7 @@ use utxo::{Utxo, UtxosStorageRead, UtxosTxUndo};
 #[case(Seed::from_entropy())]
 fn store_coin(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).with_storage(storage.clone()).build();
 
@@ -105,7 +105,7 @@ fn store_coin(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn store_fungible_token_v0(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng)
             .with_storage(storage.clone())
@@ -183,7 +183,7 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn store_nft_v0(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng)
             .with_storage(storage.clone())
@@ -258,7 +258,7 @@ fn store_nft_v0(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn reorg_store_coin(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).with_storage(storage.clone()).build();
         let genesis_id = tf.genesis().get_id();
@@ -372,7 +372,7 @@ fn reorg_store_coin(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn reorg_store_coin_disposable(#[case] seed: Seed) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng)
             .with_storage(storage.clone())

--- a/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
+++ b/chainstate/test-suite/src/tests/helpers/in_memory_storage_wrapper.rs
@@ -18,7 +18,8 @@ use std::collections::BTreeMap;
 use ::tx_verifier::transaction_verifier::storage::{
     TransactionVerifierStorageError, TransactionVerifierStorageRef,
 };
-use chainstate_storage::{inmemory::Store, BlockchainStorageRead, TipStorageTag, Transactional};
+use chainstate_storage::{BlockchainStorageRead, TipStorageTag, Transactional};
+use chainstate_test_framework::TestStore;
 use chainstate_types::{storage_result, GenBlockIndex};
 use common::{
     chain::{
@@ -37,12 +38,12 @@ use tx_verifier::{
 use utxo::UtxosStorageRead;
 
 pub struct InMemoryStorageWrapper {
-    storage: Store,
+    storage: TestStore,
     chain_config: ChainConfig,
 }
 
 impl InMemoryStorageWrapper {
-    pub fn new(storage: Store, chain_config: ChainConfig) -> Self {
+    pub fn new(storage: TestStore, chain_config: ChainConfig) -> Self {
         Self {
             storage,
             chain_config,

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -21,9 +21,9 @@ use super::helpers::{
 
 use accounting::{DataDelta, DeltaAmountCollection, DeltaDataCollection};
 use chainstate::BlockSource;
-use chainstate_storage::{inmemory::Store, BlockchainStorageWrite, TransactionRw, Transactional};
+use chainstate_storage::{BlockchainStorageWrite, TransactionRw, Transactional};
 use chainstate_test_framework::{
-    anyonecanspend_address, empty_witness, TestFramework, TransactionBuilder,
+    anyonecanspend_address, empty_witness, TestFramework, TestStore, TransactionBuilder,
 };
 use common::{
     chain::{
@@ -65,7 +65,7 @@ fn stake_pool_reorg(
     #[case] sealed_epoch_distance_from_tip: usize,
 ) {
     utils::concurrency::model(move || {
-        let storage = Store::new_empty().unwrap();
+        let storage = TestStore::new_empty().unwrap();
         let mut rng = make_seedable_rng(seed);
         let chain_config = ConfigBuilder::test_chain()
             .epoch_length(epoch_length)
@@ -178,7 +178,7 @@ fn stake_pool_reorg(
         //
         // Construct fresh `genesis -> b -> c` chain as a reference
         let expected_storage = {
-            let storage = Store::new_empty().unwrap();
+            let storage = TestStore::new_empty().unwrap();
             let block_a_epoch = chain_config.epoch_index_from_height(&block_a_index.block_height());
             let mut tf = TestFramework::builder(&mut rng)
                 .with_storage(storage.clone())

--- a/chainstate/types/src/storage_result.rs
+++ b/chainstate/types/src/storage_result.rs
@@ -20,6 +20,18 @@ pub enum Error {
     Storage(storage::error::Recoverable),
 }
 
+impl Error {
+    pub fn is_intermittent(&self) -> bool {
+        use storage::error::Recoverable as E;
+        match self {
+            Error::Storage(err) => match err {
+                E::TransactionFailed | E::TemporarilyUnavailable | E::MemMapFull => true,
+                E::DbInit | E::Io(_, _) => false,
+            }
+        }
+    }
+}
+
 impl From<storage::Error> for Error {
     fn from(e: storage::Error) -> Self {
         Error::Storage(e.recoverable())

--- a/chainstate/types/src/storage_result.rs
+++ b/chainstate/types/src/storage_result.rs
@@ -27,7 +27,7 @@ impl Error {
             Error::Storage(err) => match err {
                 E::TransactionFailed | E::TemporarilyUnavailable | E::MemMapFull => true,
                 E::DbInit | E::Io(_, _) => false,
-            }
+            },
         }
     }
 }

--- a/common/src/chain/config/checkpoints.rs
+++ b/common/src/chain/config/checkpoints.rs
@@ -64,8 +64,7 @@ impl Checkpoints {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use test_utils::random::inner_random::Rng;
-    use test_utils::random::{make_seedable_rng, Seed};
+    use test_utils::random::{make_seedable_rng, Rng, Seed};
 
     use crate::primitives::H256;
 

--- a/common/src/chain/transaction/signed_transaction.rs
+++ b/common/src/chain/transaction/signed_transaction.rs
@@ -114,8 +114,7 @@ impl Decode for SignedTransaction {
 mod tests {
     use crate::primitives::Amount;
     use rstest::rstest;
-    use test_utils::random::inner_random::Rng;
-    use test_utils::random::{make_seedable_rng, Seed};
+    use test_utils::random::{make_seedable_rng, Rng, Seed};
 
     use super::*;
 

--- a/storage/core/src/error.rs
+++ b/storage/core/src/error.rs
@@ -32,6 +32,10 @@ pub enum Recoverable {
     #[error("The database file failed to initialize")]
     DbInit,
 
+    /// The memory map is full, needs a resize.
+    #[error("Memory map full")]
+    MemMapFull,
+
     /// Recoverable I/O error
     #[error("I/O error: {1}")]
     Io(std::io::ErrorKind, String),

--- a/storage/failing/Cargo.toml
+++ b/storage/failing/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "storage-failing"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+storage = { path = ".." }
+storage-core = { path = "../core" }
+test-utils = { path = "../../test-utils" }
+utils = { path = "../../utils" }
+
+enumflags2.workspace = true
+thiserror.workspace = true

--- a/storage/failing/src/backend.rs
+++ b/storage/failing/src/backend.rs
@@ -1,0 +1,196 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    borrow::Cow,
+    sync::{Arc, Mutex},
+};
+
+use storage_core::{backend, Data, DbMapId};
+use test_utils::random::{Rng, Seed, TestRng};
+use utils::{atomics::AcqRelAtomicU32, shallow_clone::ShallowClone};
+
+use crate::{ErrorGeneration, FailureConfig};
+
+pub struct Failing<B> {
+    inner: B,
+    config: FailureConfig,
+    seed: Seed,
+}
+
+impl<B> Failing<B> {
+    /// New failing storage backend adaptor.
+    pub fn new(inner: B, config: FailureConfig, seed: Seed) -> Self {
+        Self {
+            inner,
+            config,
+            seed,
+        }
+    }
+
+    /// New reliable storage backend adaptor.
+    pub fn reliable(inner: B) -> Self {
+        Self::new(inner, FailureConfig::reliable(), Seed(0))
+    }
+}
+
+impl<B: Default> Default for Failing<B> {
+    fn default() -> Self {
+        Self::reliable(B::default())
+    }
+}
+
+impl<B: backend::Backend> backend::Backend for Failing<B> {
+    type Impl = FailingImpl<B::Impl>;
+
+    fn open(self, desc: storage_core::DbDesc) -> storage_core::Result<Self::Impl> {
+        let Self {
+            inner,
+            config,
+            seed,
+        } = self;
+
+        Ok(FailingImpl::new(inner.open(desc)?, config, seed))
+    }
+}
+
+pub struct FailingImpl<T> {
+    inner: T,
+    config: Arc<FailureConfig>,
+    rng: Mutex<TestRng>,
+    total_failures: Arc<AcqRelAtomicU32>,
+}
+
+impl<T> FailingImpl<T> {
+    fn new(inner: T, config: FailureConfig, seed: Seed) -> Self {
+        Self {
+            inner,
+            config: Arc::new(config),
+            rng: TestRng::new(seed).into(),
+            total_failures: AcqRelAtomicU32::new(0).into(),
+        }
+    }
+
+    fn make_rng(&self) -> TestRng {
+        TestRng::new(Seed(self.rng.lock().expect("lock poisoned").gen()))
+    }
+
+    fn make_rw_tx_state(&self) -> RwTxState<'_> {
+        RwTxState {
+            config: &self.config,
+            rng: self.make_rng(),
+            total_failures: &self.total_failures,
+            transaction_failures: 0,
+        }
+    }
+}
+
+impl<T: Clone> Clone for FailingImpl<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            config: self.config.clone(),
+            rng: self.make_rng().into(),
+            total_failures: self.total_failures.clone(),
+        }
+    }
+}
+
+impl<T: ShallowClone> ShallowClone for FailingImpl<T> {
+    fn shallow_clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl<T: backend::BackendImpl> backend::BackendImpl for FailingImpl<T> {
+    type TxRo<'a> = T::TxRo<'a>;
+
+    type TxRw<'a> = TxRw<'a, T::TxRw<'a>>;
+
+    fn transaction_ro(&self) -> storage_core::Result<Self::TxRo<'_>> {
+        self.inner.transaction_ro()
+    }
+
+    fn transaction_rw(&self, size: Option<usize>) -> storage_core::Result<Self::TxRw<'_>> {
+        let mut state = self.make_rw_tx_state();
+        state.emit_error(self.config.error_generation_for_start_rw_tx())?;
+        let inner = self.inner.transaction_rw(size)?;
+        Ok(TxRw { inner, state })
+    }
+}
+
+struct RwTxState<'a> {
+    config: &'a FailureConfig,
+    rng: TestRng,
+    total_failures: &'a AcqRelAtomicU32,
+    transaction_failures: u32,
+}
+
+impl RwTxState<'_> {
+    fn emit_error(&mut self, eg: &ErrorGeneration) -> storage_core::Result<()> {
+        if self.transaction_failures < self.config.max_failures_per_transaction() {
+            if let Some(err) = eg.generate(&mut self.rng) {
+                if self.total_failures.fetch_add(1) < self.config.max_failures_total() {
+                    self.transaction_failures += 1;
+                    return Err(err.into());
+                } else {
+                    // Correct the previous fetch_add if we reached the max.
+                    self.total_failures.fetch_sub(1);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct TxRw<'a, T> {
+    inner: T,
+    state: RwTxState<'a>,
+}
+
+impl<T: backend::TxRw> backend::TxRw for TxRw<'_, T> {
+    fn commit(mut self) -> storage_core::Result<()> {
+        self.state.emit_error(self.state.config.error_generation_for_commit())?;
+        self.inner.commit()
+    }
+}
+
+impl<T: backend::ReadOps> backend::ReadOps for TxRw<'_, T> {
+    type PrefixIter<'i> = T::PrefixIter<'i> where Self: 'i;
+
+    fn get(&self, map_id: DbMapId, key: &[u8]) -> storage_core::Result<Option<Cow<[u8]>>> {
+        self.inner.get(map_id, key)
+    }
+
+    fn prefix_iter(
+        &self,
+        map_id: DbMapId,
+        prefix: Data,
+    ) -> storage_core::Result<Self::PrefixIter<'_>> {
+        self.inner.prefix_iter(map_id, prefix)
+    }
+}
+
+impl<T: backend::WriteOps> backend::WriteOps for TxRw<'_, T> {
+    fn put(&mut self, map_id: DbMapId, key: Data, val: Data) -> storage_core::Result<()> {
+        self.state.emit_error(self.state.config.error_generation_for_write(map_id))?;
+        self.inner.put(map_id, key, val)
+    }
+
+    fn del(&mut self, map_id: DbMapId, key: &[u8]) -> storage_core::Result<()> {
+        self.state.emit_error(self.state.config.error_generation_for_del(map_id))?;
+        self.inner.del(map_id, key)
+    }
+}

--- a/storage/failing/src/config/builder.rs
+++ b/storage/failing/src/config/builder.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use storage::schema;
+use storage_core::DbMapId;
+
+use crate::config::{ErrorGeneration, ErrorSet, FailureConfig};
+
+/// Builder for failure configuration.
+///
+/// While this is parametrized by the schema to automate the lookup of db indices, catch out of
+/// bounds errors and check database map existence, it does not guarantee the schema is the same as
+/// what is used during the storage initialization. Create an abstraction for creating the database
+/// on top of this if that guarantee is desired.
+pub struct Builder<Sch> {
+    config: FailureConfig,
+    _phantom: std::marker::PhantomData<Sch>,
+}
+
+impl<Sch> Builder<Sch> {
+    pub fn new(config: FailureConfig) -> Self {
+        let _phantom = std::marker::PhantomData;
+        Self { config, _phantom }
+    }
+
+    /// Build the configuration
+    pub fn build(self) -> FailureConfig {
+        self.config
+    }
+
+    /// Configure max number of spurious failures in a single transaction.
+    ///
+    /// Used to avoid exceeding max number of attempts certain operation is configured to perform.
+    pub fn max_failures_per_transaction(mut self, max: u32) -> Self {
+        self.config.max_failures_per_transaction = max;
+        self
+    }
+
+    /// Max number of spurious failures during the whole storage lifetime.
+    pub fn max_failures_total(mut self, max: u32) -> Self {
+        self.config.max_failures_total = max;
+        self
+    }
+
+    /// Default spurious failure rate for write operations.
+    pub fn background_write_errors(mut self, probability: f32, errs: impl Into<ErrorSet>) -> Self {
+        self.config.default_error_generation_write = ErrorGeneration::new(probability, errs);
+        self
+    }
+
+    /// Default spurious failure rate for delete operations.
+    pub fn background_del_errors(mut self, probability: f32, errs: impl Into<ErrorSet>) -> Self {
+        self.config.default_error_generation_del = ErrorGeneration::new(probability, errs);
+        self
+    }
+
+    /// Spurious failure rate on transaction commit.
+    pub fn commit_errors(mut self, probability: f32, errs: impl Into<ErrorSet>) -> Self {
+        self.config.error_generation_commit = ErrorGeneration::new(probability, errs);
+        self
+    }
+
+    /// Spurious failure rate when starting a new read-write transaction.
+    pub fn start_rw_tx_errors(mut self, probability: f32, errs: impl Into<ErrorSet>) -> Self {
+        self.config.error_generation_start_rw_tx = ErrorGeneration::new(probability, errs);
+        self
+    }
+
+    /// Spurious failure rate when writing to given DB map.
+    pub fn write_errors<DbMap, I>(mut self, probability: f32, errs: impl Into<ErrorSet>) -> Self
+    where
+        DbMap: schema::DbMap,
+        Sch: schema::HasDbMap<DbMap, I>,
+    {
+        Self::update_op_map(&mut self.config.error_generation_write, probability, errs);
+        self
+    }
+
+    /// Spurious failure rate when deleting from given DB map.
+    pub fn del_errors<DbMap, I>(mut self, probability: f32, errs: impl Into<ErrorSet>) -> Self
+    where
+        DbMap: schema::DbMap,
+        Sch: schema::HasDbMap<DbMap, I>,
+    {
+        Self::update_op_map(&mut self.config.error_generation_del, probability, errs);
+        self
+    }
+
+    fn update_op_map<DbMap, I>(
+        op_map: &mut BTreeMap<DbMapId, ErrorGeneration>,
+        probability: f32,
+        errs: impl Into<ErrorSet>,
+    ) where
+        DbMap: schema::DbMap,
+        Sch: schema::HasDbMap<DbMap, I>,
+    {
+        let map_id = <Sch as schema::HasDbMap<DbMap, I>>::INDEX;
+        let eg = ErrorGeneration::new(probability, errs);
+        let _old = op_map.insert(map_id, eg);
+    }
+}
+
+impl<Sch> Clone for Builder<Sch> {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            _phantom: self._phantom,
+        }
+    }
+}
+
+impl<Sch> std::fmt::Debug for Builder<Sch> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { config, _phantom } = self;
+        config.fmt(f)
+    }
+}

--- a/storage/failing/src/config/mod.rs
+++ b/storage/failing/src/config/mod.rs
@@ -169,7 +169,7 @@ impl FailureConfig {
     }
 
     pub fn builder<Sch>() -> builder::Builder<Sch> {
-        builder::Builder::new(Self::inactive(1_u32 << 31, 5))
+        builder::Builder::new(Self::inactive(5, 5))
     }
 
     pub fn error_generation_for_write(&self, map_id: DbMapId) -> &ErrorGeneration {

--- a/storage/failing/src/config/mod.rs
+++ b/storage/failing/src/config/mod.rs
@@ -1,0 +1,200 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use storage_core::{error::Recoverable as StorageError, DbMapId};
+use test_utils::random::{IteratorRandom, Rng};
+use utils::ensure;
+
+pub mod builder;
+
+#[enumflags2::bitflags]
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum ErrorToEmit {
+    TransactionFailed,
+    TemporarilyUnavailable,
+    MemMapFull,
+}
+
+impl ErrorToEmit {
+    fn from_err(err: StorageError) -> Self {
+        err.try_into().expect("Unsupported")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, thiserror::Error)]
+enum UnsupportedError {
+    #[error("The emission of the error {0:?} is not supported by the failing storage layer")]
+    Unsupported(StorageError),
+}
+
+impl TryFrom<StorageError> for ErrorToEmit {
+    type Error = UnsupportedError;
+
+    fn try_from(value: StorageError) -> Result<Self, Self::Error> {
+        match value {
+            StorageError::TransactionFailed => Ok(Self::TransactionFailed),
+            StorageError::TemporarilyUnavailable => Ok(Self::TemporarilyUnavailable),
+            StorageError::MemMapFull => Ok(Self::MemMapFull),
+            e @ (StorageError::DbInit | StorageError::Io(_, _)) => {
+                Err(UnsupportedError::Unsupported(e))
+            }
+        }
+    }
+}
+
+impl From<ErrorToEmit> for StorageError {
+    fn from(value: ErrorToEmit) -> Self {
+        match value {
+            ErrorToEmit::TransactionFailed => StorageError::TransactionFailed,
+            ErrorToEmit::TemporarilyUnavailable => StorageError::TemporarilyUnavailable,
+            ErrorToEmit::MemMapFull => StorageError::MemMapFull,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ErrorSet(enumflags2::BitFlags<ErrorToEmit>);
+
+impl ErrorSet {
+    pub const ALL: Self = Self(enumflags2::BitFlags::<ErrorToEmit>::ALL);
+
+    /// Always generate this particular error
+    pub fn single(err: StorageError) -> Self {
+        Self(ErrorToEmit::from_err(err).into())
+    }
+
+    pub fn generate(&self, rng: &mut impl Rng) -> Option<StorageError> {
+        self.0.iter().choose(rng).map(StorageError::from)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl FromIterator<StorageError> for ErrorSet {
+    fn from_iter<T: IntoIterator<Item = StorageError>>(iter: T) -> Self {
+        Self(iter.into_iter().map(ErrorToEmit::from_err).collect())
+    }
+}
+
+impl From<StorageError> for ErrorSet {
+    fn from(err: StorageError) -> Self {
+        Self::single(err)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ErrorGeneration {
+    probability: f32,
+    errors: ErrorSet,
+}
+
+impl ErrorGeneration {
+    pub const INACTIVE: Self = Self::new_internal(0.0, ErrorSet::ALL);
+
+    pub fn new(probability: f32, errors: impl Into<ErrorSet>) -> Self {
+        let errors = errors.into();
+        assert!(
+            (0.0..=1.0_f32).contains(&probability),
+            "Invalid probability {probability}, must be between 0.0 and 1.0",
+        );
+        assert!(
+            probability == 0.0 || !errors.is_empty(),
+            "Non-zero failure probability but error set is empty",
+        );
+
+        Self::new_internal(probability, errors)
+    }
+
+    const fn new_internal(probability: f32, errors: ErrorSet) -> Self {
+        Self {
+            probability,
+            errors,
+        }
+    }
+
+    pub fn generate(&self, rng: &mut impl Rng) -> Option<StorageError> {
+        ensure!(rng.gen_bool(self.probability.into()));
+        self.errors.generate(rng)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FailureConfig {
+    max_failures_total: u32,
+    max_failures_per_transaction: u32,
+    default_error_generation_write: ErrorGeneration,
+    default_error_generation_del: ErrorGeneration,
+    error_generation_commit: ErrorGeneration,
+    error_generation_start_rw_tx: ErrorGeneration,
+    error_generation_write: BTreeMap<DbMapId, ErrorGeneration>,
+    error_generation_del: BTreeMap<DbMapId, ErrorGeneration>,
+}
+
+impl FailureConfig {
+    /// Inactive failure generation with given limits. Operation failure probabilities have to be
+    /// configured in order to actually start generating errors.
+    fn inactive(max_failures_total: u32, max_failures_per_transaction: u32) -> Self {
+        Self {
+            max_failures_total,
+            max_failures_per_transaction,
+            default_error_generation_write: ErrorGeneration::INACTIVE,
+            default_error_generation_del: ErrorGeneration::INACTIVE,
+            error_generation_commit: ErrorGeneration::INACTIVE,
+            error_generation_start_rw_tx: ErrorGeneration::INACTIVE,
+            error_generation_write: BTreeMap::new(),
+            error_generation_del: BTreeMap::new(),
+        }
+    }
+
+    /// Reliable storage
+    pub fn reliable() -> Self {
+        Self::inactive(0, 0)
+    }
+
+    pub fn builder<Sch>() -> builder::Builder<Sch> {
+        builder::Builder::new(Self::inactive(1_u32 << 31, 5))
+    }
+
+    pub fn error_generation_for_write(&self, map_id: DbMapId) -> &ErrorGeneration {
+        let default = &self.default_error_generation_write;
+        self.error_generation_write.get(&map_id).unwrap_or(default)
+    }
+
+    pub fn error_generation_for_del(&self, map_id: DbMapId) -> &ErrorGeneration {
+        let default = &self.default_error_generation_del;
+        self.error_generation_del.get(&map_id).unwrap_or(default)
+    }
+
+    pub fn error_generation_for_commit(&self) -> &ErrorGeneration {
+        &self.error_generation_commit
+    }
+
+    pub fn error_generation_for_start_rw_tx(&self) -> &ErrorGeneration {
+        &self.error_generation_start_rw_tx
+    }
+
+    pub fn max_failures_per_transaction(&self) -> u32 {
+        self.max_failures_per_transaction
+    }
+
+    pub fn max_failures_total(&self) -> u32 {
+        self.max_failures_total
+    }
+}

--- a/storage/failing/src/lib.rs
+++ b/storage/failing/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Spuriously failing storage backend adapter, for testing.
+
+mod backend;
+mod config;
+
+pub use backend::Failing;
+pub use config::{builder::Builder, ErrorGeneration, ErrorSet, FailureConfig};
+pub use storage_core::error::Recoverable as StorageError;

--- a/storage/lmdb/src/error.rs
+++ b/storage/lmdb/src/error.rs
@@ -37,13 +37,15 @@ fn process<T>(err: Error, default: storage_core::Result<T>) -> storage_core::Res
             Err(Recoverable::TemporarilyUnavailable.into())
         }
 
+        // Memory map is full
+        Error::MapFull => Err(Recoverable::MemMapFull.into()),
+
         // These signify an implementation flaw
         err @ (Error::BadDbi
         | Error::Panic
         | Error::CursorFull
         | Error::PageFull
         | Error::BadRslot
-        | Error::MapFull
         | Error::MapResized) => Err(Fatal::InternalError(err.to_string()).into()),
 
         // These signify the database flags are not in sync with the schema

--- a/test-utils/src/random.rs
+++ b/test-utils/src/random.rs
@@ -13,8 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use crypto::random as inner_random;
-pub use crypto::random::{CryptoRng, Rng, SeedableRng};
+pub use crypto::random::{self, seq::IteratorRandom, CryptoRng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::{num::ParseIntError, str::FromStr};
 

--- a/test-utils/src/random.rs
+++ b/test-utils/src/random.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use crypto::random::{self, seq::IteratorRandom, CryptoRng, Rng, SeedableRng};
+pub use crypto::random::{self, seq::IteratorRandom, CryptoRng, Rng, RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::{num::ParseIntError, str::FromStr};
 
@@ -33,6 +33,10 @@ impl Seed {
 
     pub fn from_u64(v: u64) -> Self {
         Seed(v)
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        self.0
     }
 
     pub fn print_with_decoration(&self, test_name: &str) {
@@ -55,9 +59,46 @@ impl From<u64> for Seed {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct TestRng(rand_chacha::ChaChaRng);
+
+impl TestRng {
+    pub fn new(seed: Seed) -> Self {
+        Self(ChaChaRng::seed_from_u64(seed.as_u64()))
+    }
+
+    pub fn random(rng: &mut (impl Rng + CryptoRng)) -> Self {
+        Self::new(Seed(rng.gen()))
+    }
+
+    pub fn from_entropy() -> Self {
+        Self::new(Seed::from_entropy())
+    }
+}
+
+impl RngCore for TestRng {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_chacha::rand_core::Error> {
+        self.0.try_fill_bytes(dest)
+    }
+}
+
+impl CryptoRng for TestRng {}
+
 #[must_use]
 pub fn make_seedable_rng(seed: Seed) -> impl Rng + CryptoRng {
-    ChaChaRng::seed_from_u64(seed.0)
+    TestRng::new(seed)
 }
 
 // This is similar to SliceRandom::shuffle, but it makes sure that the resulting order


### PR DESCRIPTION
An alternative, in my opinion nicer, to #1711 and #1712.

Includes:
* Change to the storage layer to record and track errors during its operation. Once an error is encountered during transaction execution, all subsequent operations (including the final `commit` or `abort`) return that error. This allows us to detect whether a storage error occurred during transaction execution by checking the final abort/commit, even if it was masked, thrown away, or buried deep inside a nested web of error types. Also seems to be fairly sound behaviour.
* Change to make chainstate `with_rw_tx` retry even if that transaction fails somewhere in the middle, not just on commit. Uses the mechanism described above.
* Add a configurable storage backend wrapper capable of randomly injecting storage failures into its operation.
* Apply the failing storage to the block invalidation tests.
* A couple of minor changes to various testing tools, mostly to do with random generators.