### PR TITLE
Remove unused forks

### DIFF
--- a/chainstate/constraints-value-accumulator/src/tests/constraints_tests.rs
+++ b/chainstate/constraints-value-accumulator/src/tests/constraints_tests.rs
@@ -16,9 +16,9 @@
 use common::{
     chain::{
         config::ChainType, output_value::OutputValue, stakelock::StakePoolData,
-        timelock::OutputTimeLock, AccountNonce, AccountSpending, ConsensusUpgrade, DelegationId,
-        Destination, NetUpgrades, OutPointSourceId, PoSChainConfigBuilder, PoolId, TxInput,
-        TxOutput, UtxoOutPoint,
+        timelock::OutputTimeLock, AccountNonce, AccountSpending, AccountType, ConsensusUpgrade,
+        DelegationId, Destination, NetUpgrades, OutPointSourceId, PoSChainConfigBuilder, PoolId,
+        TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{
         per_thousand::PerThousand, Amount, BlockCount, BlockHeight, CoinOrTokenId, Fee, Id, H256,
@@ -547,7 +547,7 @@ fn try_to_overspend_on_spending_delegation(#[case] seed: Seed) {
 
         assert_eq!(
             inputs_accumulator.unwrap_err(),
-            Error::AttemptToPrintMoney(CoinOrTokenId::Coin)
+            Error::NegativeAccountBalance(AccountType::Delegation(delegation_id))
         );
     }
 

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -771,9 +771,13 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     }
 
     #[log_error]
-    fn check_transactions(&self, block: &Block) -> Result<(), CheckBlockTransactionsError> {
+    fn check_transactions(
+        &self,
+        block: &Block,
+        block_height: BlockHeight,
+    ) -> Result<(), CheckBlockTransactionsError> {
         for tx in block.transactions() {
-            tx_verifier::check_transaction(self.chain_config, tx)?;
+            tx_verifier::check_transaction(self.chain_config, block_height, tx)?;
         }
 
         // Note: duplicate txs are detected through duplicate inputs
@@ -821,7 +825,15 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             );
         }
 
-        self.check_transactions(block)
+        let prev_block_height = self
+            .get_gen_block_index(&block.prev_block_id())?
+            .ok_or_else(|| PropertyQueryError::PrevBlockIndexNotFound {
+                block_id: block.get_id(),
+                prev_block_id: block.prev_block_id(),
+            })?
+            .block_height();
+
+        self.check_transactions(block, prev_block_height.next_height())
             .map_err(CheckBlockError::CheckTransactionFailed)?;
 
         Ok(())

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -771,13 +771,9 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     }
 
     #[log_error]
-    fn check_transactions(
-        &self,
-        block: &Block,
-        block_height: BlockHeight,
-    ) -> Result<(), CheckBlockTransactionsError> {
+    fn check_transactions(&self, block: &Block) -> Result<(), CheckBlockTransactionsError> {
         for tx in block.transactions() {
-            tx_verifier::check_transaction(self.chain_config, block_height, tx)?;
+            tx_verifier::check_transaction(self.chain_config, tx)?;
         }
 
         // Note: duplicate txs are detected through duplicate inputs
@@ -825,15 +821,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
             );
         }
 
-        let prev_block_height = self
-            .get_gen_block_index(&block.prev_block_id())?
-            .ok_or_else(|| PropertyQueryError::PrevBlockIndexNotFound {
-                block_id: block.get_id(),
-                prev_block_id: block.prev_block_id(),
-            })?
-            .block_height();
-
-        self.check_transactions(block, prev_block_height.next_height())
+        self.check_transactions(block)
             .map_err(CheckBlockError::CheckTransactionFailed)?;
 
         Ok(())

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -25,8 +25,7 @@ use common::{
         output_value::OutputValue,
         tokens::{make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0},
         ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, Transaction, TxInput,
-        TxOutput, UtxoOutPoint,
+        TokenIssuanceVersion, TokensFeeVersion, Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Id, Idable},
 };
@@ -119,7 +118,6 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -198,7 +196,6 @@ fn store_nft_v0(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -508,7 +505,6 @@ fn store_aux_data_from_issue_nft(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -24,9 +24,9 @@ use common::{
     chain::{
         output_value::OutputValue,
         tokens::{make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0},
-        ChainstateUpgrade, Destination, NetUpgrades, NftIdMismatchCheck, OutPointSourceId,
-        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
-        TokensTickerMaxLengthVersion, Transaction, TxInput, TxOutput, UtxoOutPoint,
+        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
+        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, Transaction, TxInput,
+        TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Id, Idable},
 };
@@ -120,7 +120,6 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),
@@ -200,7 +199,6 @@ fn store_nft_v0(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),
@@ -511,7 +509,6 @@ fn store_aux_data_from_issue_nft(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -24,10 +24,9 @@ use common::{
     chain::{
         output_value::OutputValue,
         tokens::{make_token_id, NftIssuance, TokenAuxiliaryData, TokenIssuanceV0},
-        AccountsBalancesCheckVersion, ChainstateUpgrade, Destination, NetUpgrades,
-        NftIdMismatchCheck, OutPointSourceId, RewardDistributionVersion, TokenIssuanceVersion,
-        TokensFeeVersion, TokensTickerMaxLengthVersion, Transaction, TxInput, TxOutput,
-        UtxoOutPoint,
+        ChainstateUpgrade, Destination, NetUpgrades, NftIdMismatchCheck, OutPointSourceId,
+        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+        TokensTickerMaxLengthVersion, Transaction, TxInput, TxOutput, UtxoOutPoint,
     },
     primitives::{Amount, Id, Idable},
 };
@@ -122,7 +121,6 @@ fn store_fungible_token_v0(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -203,7 +201,6 @@ fn store_nft_v0(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -515,7 +512,6 @@ fn store_aux_data_from_issue_nft(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -21,9 +21,7 @@ use chainstate::{
 };
 use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::chain::tokens::{Metadata, NftIssuanceV0, TokenIssuanceV0, TokenTransfer};
-use common::chain::{
-    NftIdMismatchCheck, RewardDistributionVersion, TokensTickerMaxLengthVersion, UtxoOutPoint,
-};
+use common::chain::{RewardDistributionVersion, TokensTickerMaxLengthVersion, UtxoOutPoint};
 use common::primitives::{id, BlockHeight, Id};
 use common::{
     chain::{
@@ -59,7 +57,6 @@ fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramewor
                             RewardDistributionVersion::V1,
                             TokensFeeVersion::V1,
                             TokensTickerMaxLengthVersion::V1,
-                            NftIdMismatchCheck::Yes,
                         ),
                     )])
                     .unwrap(),
@@ -964,7 +961,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),
@@ -1024,7 +1020,6 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     RewardDistributionVersion::V1,
                                     TokensFeeVersion::V1,
                                     TokensTickerMaxLengthVersion::V1,
-                                    NftIdMismatchCheck::Yes,
                                 ),
                             ),
                             (
@@ -1034,7 +1029,6 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     RewardDistributionVersion::V1,
                                     TokensFeeVersion::V1,
                                     TokensTickerMaxLengthVersion::V1,
-                                    NftIdMismatchCheck::Yes,
                                 ),
                             ),
                         ])

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -22,8 +22,7 @@ use chainstate::{
 use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::chain::tokens::{Metadata, NftIssuanceV0, TokenIssuanceV0, TokenTransfer};
 use common::chain::{
-    AccountsBalancesCheckVersion, NftIdMismatchCheck, RewardDistributionVersion,
-    TokensTickerMaxLengthVersion, UtxoOutPoint,
+    NftIdMismatchCheck, RewardDistributionVersion, TokensTickerMaxLengthVersion, UtxoOutPoint,
 };
 use common::primitives::{id, BlockHeight, Id};
 use common::{
@@ -61,7 +60,6 @@ fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramewor
                             TokensFeeVersion::V1,
                             TokensTickerMaxLengthVersion::V1,
                             NftIdMismatchCheck::Yes,
-                            AccountsBalancesCheckVersion::V1,
                         ),
                     )])
                     .unwrap(),
@@ -967,7 +965,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1028,7 +1025,6 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     TokensFeeVersion::V1,
                                     TokensTickerMaxLengthVersion::V1,
                                     NftIdMismatchCheck::Yes,
-                                    AccountsBalancesCheckVersion::V1,
                                 ),
                             ),
                             (
@@ -1039,7 +1035,6 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     TokensFeeVersion::V1,
                                     TokensTickerMaxLengthVersion::V1,
                                     NftIdMismatchCheck::Yes,
-                                    AccountsBalancesCheckVersion::V1,
                                 ),
                             ),
                         ])

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -21,7 +21,7 @@ use chainstate::{
 };
 use chainstate_test_framework::{get_output_value, TestFramework, TransactionBuilder};
 use common::chain::tokens::{Metadata, NftIssuanceV0, TokenIssuanceV0, TokenTransfer};
-use common::chain::{RewardDistributionVersion, TokensTickerMaxLengthVersion, UtxoOutPoint};
+use common::chain::{RewardDistributionVersion, UtxoOutPoint};
 use common::primitives::{id, BlockHeight, Id};
 use common::{
     chain::{
@@ -56,7 +56,6 @@ fn make_test_framework_with_v0(rng: &mut (impl Rng + CryptoRng)) -> TestFramewor
                             TokenIssuanceVersion::V0,
                             RewardDistributionVersion::V1,
                             TokensFeeVersion::V1,
-                            TokensTickerMaxLengthVersion::V1,
                         ),
                     )])
                     .unwrap(),
@@ -960,7 +959,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1019,7 +1017,6 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     TokenIssuanceVersion::V0,
                                     RewardDistributionVersion::V1,
                                     TokensFeeVersion::V1,
-                                    TokensTickerMaxLengthVersion::V1,
                                 ),
                             ),
                             (
@@ -1028,7 +1025,6 @@ fn no_v0_transfer_after_v1(#[case] seed: Seed) {
                                     TokenIssuanceVersion::V1,
                                     RewardDistributionVersion::V1,
                                     TokensFeeVersion::V1,
-                                    TokensTickerMaxLengthVersion::V1,
                                 ),
                             ),
                         ])

--- a/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
@@ -257,8 +257,7 @@ fn token_issue_test(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let genesis_source_id: OutPointSourceId = tf.genesis().get_id().into();
 
-        let token_max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let token_max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let token_max_dec_count = tf.chainstate.get_chain_config().token_max_dec_count();
         let token_max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
 
@@ -3802,8 +3801,7 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let genesis_block_id = tf.best_block_id();
 
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         // Try not ascii alphanumeric ticker
         let c = test_utils::get_random_non_ascii_alphanumeric_byte(&mut rng);

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -18,7 +18,7 @@ use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
     output_value::OutputValue, signature::inputsig::InputWitness, tokens::make_token_id,
     ChainstateUpgrade, Destination, RewardDistributionVersion, TokenIssuanceVersion,
-    TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    TokensFeeVersion, TxInput, TxOutput,
 };
 use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
@@ -215,7 +215,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -17,9 +17,8 @@ use chainstate::{BlockError, ChainstateError, ConnectTransactionError, TokensErr
 use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
     output_value::OutputValue, signature::inputsig::InputWitness, tokens::make_token_id,
-    AccountsBalancesCheckVersion, ChainstateUpgrade, Destination, NftIdMismatchCheck,
-    RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
-    TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    ChainstateUpgrade, Destination, NftIdMismatchCheck, RewardDistributionVersion,
+    TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
@@ -218,7 +217,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -17,8 +17,8 @@ use chainstate::{BlockError, ChainstateError, ConnectTransactionError, TokensErr
 use chainstate_test_framework::{TestFramework, TransactionBuilder};
 use common::chain::{
     output_value::OutputValue, signature::inputsig::InputWitness, tokens::make_token_id,
-    ChainstateUpgrade, Destination, NftIdMismatchCheck, RewardDistributionVersion,
-    TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    ChainstateUpgrade, Destination, RewardDistributionVersion, TokenIssuanceVersion,
+    TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::chain::{OutPointSourceId, UtxoOutPoint};
 use common::primitives::{Amount, BlockHeight, CoinOrTokenId, Idable};
@@ -216,7 +216,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -22,8 +22,8 @@ use common::chain::{
     output_value::OutputValue,
     signature::inputsig::InputWitness,
     tokens::{is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0},
-    AccountsBalancesCheckVersion, Block, ChainstateUpgrade, Destination, NftIdMismatchCheck,
-    OutPointSourceId, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+    Block, ChainstateUpgrade, Destination, NftIdMismatchCheck, OutPointSourceId,
+    RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
     TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
@@ -1672,7 +1672,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1733,7 +1732,6 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -22,9 +22,8 @@ use common::chain::{
     output_value::OutputValue,
     signature::inputsig::InputWitness,
     tokens::{is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0},
-    Block, ChainstateUpgrade, Destination, NftIdMismatchCheck, OutPointSourceId,
-    RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
-    TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    Block, ChainstateUpgrade, Destination, OutPointSourceId, RewardDistributionVersion,
+    TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
 use crypto::random::{CryptoRng, Rng};
@@ -1671,7 +1670,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),
@@ -1731,7 +1729,6 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -23,7 +23,7 @@ use common::chain::{
     signature::inputsig::InputWitness,
     tokens::{is_rfc3986_valid_symbol, make_token_id, Metadata, NftIssuance, NftIssuanceV0},
     Block, ChainstateUpgrade, Destination, OutPointSourceId, RewardDistributionVersion,
-    TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+    TokenIssuanceVersion, TokensFeeVersion, TxInput, TxOutput,
 };
 use common::primitives::{BlockHeight, Idable};
 use crypto::random::{CryptoRng, Rng};
@@ -49,8 +49,7 @@ fn nft_name_too_long(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -121,8 +120,7 @@ fn nft_empty_name(#[case] seed: Seed) {
         let token_id = make_token_id(&[TxInput::from_utxo(outpoint_source_id.clone(), 0)]).unwrap();
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -190,8 +188,7 @@ fn nft_invalid_name(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         // try all possible chars for name and ensure everything fails except for alphanumeric chars
         for c in u8::MIN..u8::MAX {
@@ -270,8 +267,7 @@ fn nft_ticker_too_long(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         let result = tf
             .make_block_builder()
@@ -412,8 +408,7 @@ fn nft_invalid_ticker(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         // try all possible chars for ticker and ensure everything fails except for alphanumeric chars
         for c in u8::MIN..u8::MAX {
@@ -492,8 +487,7 @@ fn nft_description_too_long(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         let result = tf
             .make_block_builder()
@@ -565,8 +559,7 @@ fn nft_empty_description(#[case] seed: Seed) {
         let token_id = make_token_id(&[TxInput::from_utxo(outpoint_source_id.clone(), 0)]).unwrap();
 
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         let result = tf
             .make_block_builder()
@@ -635,8 +628,7 @@ fn nft_invalid_description(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         // try all possible chars for description and ensure everything fails except for alphanumeric chars
         for c in u8::MIN..u8::MAX {
@@ -716,8 +708,7 @@ fn nft_icon_uri_too_long(#[case] seed: Seed) {
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -795,8 +786,7 @@ fn nft_icon_uri_empty(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         let token_min_issuance_fee =
             tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
@@ -866,8 +856,7 @@ fn nft_icon_uri_invalid(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
 
         // try all possible chars for icon_uri and ensure everything fails except for alphanumeric chars
@@ -954,8 +943,7 @@ fn nft_metadata_uri_too_long(#[case] seed: Seed) {
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -1036,8 +1024,7 @@ fn nft_metadata_uri_empty(#[case] seed: Seed) {
         // Metadata URI is empty
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let metadata = Metadata {
             creator: Some(random_creator(&mut rng)),
             name: random_ascii_alphanumeric_string(&mut rng, 1..max_name_len).into_bytes(),
@@ -1103,8 +1090,7 @@ fn nft_metadata_uri_invalid(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
 
         // try all possible chars for additional_metadata_uri and ensure everything fails except for alphanumeric chars
@@ -1191,8 +1177,7 @@ fn nft_media_uri_too_long(#[case] seed: Seed) {
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let result = tf
             .make_block_builder()
             .add_transaction(
@@ -1274,8 +1259,7 @@ fn nft_media_uri_empty(#[case] seed: Seed) {
         // Media URI is empty
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let metadata = Metadata {
             creator: Some(random_creator(&mut rng)),
             name: random_ascii_alphanumeric_string(&mut rng, 1..max_name_len).into_bytes(),
@@ -1342,8 +1326,7 @@ fn nft_media_uri_invalid(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let max_uri_len = tf.chainstate.get_chain_config().token_max_uri_len();
 
         // try all possible chars for media_uri and ensure everything fails except for alphanumeric chars
@@ -1424,7 +1407,7 @@ fn new_block_with_media_hash(
 ) -> Block {
     let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
     let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-    let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+    let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
     let name = random_ascii_alphanumeric_string(rng, 1..max_name_len).into_bytes();
     let description = random_ascii_alphanumeric_string(rng, 1..max_desc_len).into_bytes();
     let ticker = random_ascii_alphanumeric_string(rng, 1..max_ticker_len).into_bytes();
@@ -1592,8 +1575,7 @@ fn nft_valid_case(#[case] seed: Seed) {
 
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
         let valid_rfc3986_uri =
             b"https://something.com/?a:b.c_d-e~f!g/h?I#J[K]L@M$N&O/P'Q(R)S*T+U,V;W=Xyz".to_vec();
         let token_min_issuance_fee =
@@ -1669,7 +1651,6 @@ fn no_v0_issuance_after_v1(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1728,7 +1709,6 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),
@@ -1743,8 +1723,7 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
             tf.chainstate.get_chain_config().nft_issuance_fee(BlockHeight::zero());
         let max_desc_len = tf.chainstate.get_chain_config().token_max_description_len();
         let max_name_len = tf.chainstate.get_chain_config().token_max_name_len();
-        let max_ticker_len =
-            tf.chainstate.get_chain_config().token_max_ticker_len(BlockHeight::zero());
+        let max_ticker_len = tf.chainstate.get_chain_config().token_max_ticker_len();
 
         // Try not ascii alphanumeric name
         let c = test_utils::get_random_non_ascii_alphanumeric_byte(&mut rng);

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -21,9 +21,8 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         tokens::{make_token_id, NftIssuance, TokenId},
-        ChainstateUpgrade, Destination, NetUpgrades, NftIdMismatchCheck, OutPointSourceId,
-        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
-        TokensTickerMaxLengthVersion, TxInput, TxOutput,
+        ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
+        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId},
 };
@@ -371,7 +370,6 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -22,7 +22,7 @@ use common::{
         signature::inputsig::InputWitness,
         tokens::{make_token_id, NftIssuance, TokenId},
         ChainstateUpgrade, Destination, NetUpgrades, OutPointSourceId, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+        TokenIssuanceVersion, TokensFeeVersion, TxInput, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId},
 };
@@ -369,7 +369,6 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V1,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -21,9 +21,9 @@ use common::{
         output_value::OutputValue,
         signature::inputsig::InputWitness,
         tokens::{make_token_id, NftIssuance, TokenId},
-        AccountsBalancesCheckVersion, ChainstateUpgrade, Destination, NetUpgrades,
-        NftIdMismatchCheck, OutPointSourceId, RewardDistributionVersion, TokenIssuanceVersion,
-        TokensFeeVersion, TokensTickerMaxLengthVersion, TxInput, TxOutput,
+        ChainstateUpgrade, Destination, NetUpgrades, NftIdMismatchCheck, OutPointSourceId,
+        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+        TokensTickerMaxLengthVersion, TxInput, TxOutput,
     },
     primitives::{Amount, BlockHeight, CoinOrTokenId},
 };
@@ -372,7 +372,6 @@ fn ensure_nft_cannot_be_printed_from_tokens_op(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -21,10 +21,7 @@ use super::*;
 
 use chainstate_test_framework::{empty_witness, TestFramework, TestStore, TransactionBuilder};
 use common::chain::config::create_unit_test_config;
-use common::chain::{
-    AccountCommand, AccountNonce, AccountSpending, RewardDistributionVersion,
-    TokensTickerMaxLengthVersion,
-};
+use common::chain::{AccountCommand, AccountNonce, AccountSpending, RewardDistributionVersion};
 use common::{
     chain::{
         config::ChainType,
@@ -579,7 +576,6 @@ fn issue_fungible_token_v0(#[case] seed: Seed) {
                                 TokenIssuanceVersion::V0,
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
-                                TokensTickerMaxLengthVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -22,8 +22,8 @@ use super::*;
 use chainstate_test_framework::{empty_witness, TestFramework, TestStore, TransactionBuilder};
 use common::chain::config::create_unit_test_config;
 use common::chain::{
-    AccountCommand, AccountNonce, AccountSpending, AccountsBalancesCheckVersion,
-    NftIdMismatchCheck, RewardDistributionVersion, TokensTickerMaxLengthVersion,
+    AccountCommand, AccountNonce, AccountSpending, NftIdMismatchCheck, RewardDistributionVersion,
+    TokensTickerMaxLengthVersion,
 };
 use common::{
     chain::{
@@ -581,7 +581,6 @@ fn issue_fungible_token_v0(#[case] seed: Seed) {
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
                                 NftIdMismatchCheck::Yes,
-                                AccountsBalancesCheckVersion::V1,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/test-suite/src/tests/tx_fee.rs
+++ b/chainstate/test-suite/src/tests/tx_fee.rs
@@ -22,7 +22,7 @@ use super::*;
 use chainstate_test_framework::{empty_witness, TestFramework, TestStore, TransactionBuilder};
 use common::chain::config::create_unit_test_config;
 use common::chain::{
-    AccountCommand, AccountNonce, AccountSpending, NftIdMismatchCheck, RewardDistributionVersion,
+    AccountCommand, AccountNonce, AccountSpending, RewardDistributionVersion,
     TokensTickerMaxLengthVersion,
 };
 use common::{
@@ -580,7 +580,6 @@ fn issue_fungible_token_v0(#[case] seed: Seed) {
                                 RewardDistributionVersion::V1,
                                 TokensFeeVersion::V1,
                                 TokensTickerMaxLengthVersion::V1,
-                                NftIdMismatchCheck::Yes,
                             ),
                         )])
                         .unwrap(),

--- a/chainstate/tx-verifier/src/transaction_verifier/check_transaction.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/check_transaction.rs
@@ -22,7 +22,7 @@ use common::{
         tokens::{get_tokens_issuance_count, NftIssuance},
         ChainConfig, SignedTransaction, Transaction, TransactionSize, TxOutput,
     },
-    primitives::{BlockHeight, Id, Idable},
+    primitives::{Id, Idable},
 };
 use thiserror::Error;
 use utils::ensure;
@@ -56,13 +56,12 @@ pub enum CheckTransactionError {
 
 pub fn check_transaction(
     chain_config: &ChainConfig,
-    block_height: BlockHeight,
     tx: &SignedTransaction,
 ) -> Result<(), CheckTransactionError> {
     check_size(chain_config, tx)?;
     check_duplicate_inputs(tx)?;
     check_witness_count(tx)?;
-    check_tokens_tx(chain_config, block_height, tx)?;
+    check_tokens_tx(chain_config, tx)?;
     check_no_signature_size(chain_config, tx)?;
     check_data_deposit_outputs(chain_config, tx)?;
     Ok(())
@@ -128,7 +127,6 @@ fn check_witness_count(tx: &SignedTransaction) -> Result<(), CheckTransactionErr
 
 fn check_tokens_tx(
     chain_config: &ChainConfig,
-    block_height: BlockHeight,
     tx: &SignedTransaction,
 ) -> Result<(), CheckTransactionError> {
     // We can't issue multiple tokens in a single tx
@@ -144,12 +142,10 @@ fn check_tokens_tx(
     tx.outputs()
         .iter()
         .try_for_each(|output| match output {
-            TxOutput::IssueFungibleToken(issuance) => {
-                check_tokens_issuance(chain_config, block_height, issuance)
-                    .map_err(|e| TokensError::IssueError(e, tx.transaction().get_id()))
-            }
+            TxOutput::IssueFungibleToken(issuance) => check_tokens_issuance(chain_config, issuance)
+                .map_err(|e| TokensError::IssueError(e, tx.transaction().get_id())),
             TxOutput::IssueNft(_, issuance, _) => match issuance.as_ref() {
-                NftIssuance::V0(data) => check_nft_issuance_data(chain_config, block_height, data)
+                NftIssuance::V0(data) => check_nft_issuance_data(chain_config, data)
                     .map_err(|e| TokensError::IssueError(e, tx.transaction().get_id())),
             },
             TxOutput::Transfer(_, _)

--- a/chainstate/tx-verifier/src/transaction_verifier/check_transaction.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/check_transaction.rs
@@ -22,7 +22,7 @@ use common::{
         tokens::{get_tokens_issuance_count, NftIssuance},
         ChainConfig, SignedTransaction, Transaction, TransactionSize, TxOutput,
     },
-    primitives::{Id, Idable},
+    primitives::{BlockHeight, Id, Idable},
 };
 use thiserror::Error;
 use utils::ensure;
@@ -56,12 +56,13 @@ pub enum CheckTransactionError {
 
 pub fn check_transaction(
     chain_config: &ChainConfig,
+    block_height: BlockHeight,
     tx: &SignedTransaction,
 ) -> Result<(), CheckTransactionError> {
     check_size(chain_config, tx)?;
     check_duplicate_inputs(tx)?;
     check_witness_count(tx)?;
-    check_tokens_tx(chain_config, tx)?;
+    check_tokens_tx(chain_config, block_height, tx)?;
     check_no_signature_size(chain_config, tx)?;
     check_data_deposit_outputs(chain_config, tx)?;
     Ok(())
@@ -127,6 +128,7 @@ fn check_witness_count(tx: &SignedTransaction) -> Result<(), CheckTransactionErr
 
 fn check_tokens_tx(
     chain_config: &ChainConfig,
+    _block_height: BlockHeight,
     tx: &SignedTransaction,
 ) -> Result<(), CheckTransactionError> {
     // We can't issue multiple tokens in a single tx

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -749,11 +749,7 @@ where
         tx: &SignedTransaction,
         median_time_past: &BlockTimestamp,
     ) -> Result<AccumulatedFee, ConnectTransactionError> {
-        check_transaction::check_transaction(
-            self.chain_config.as_ref(),
-            tx_source.expected_block_height(),
-            tx,
-        )?;
+        check_transaction::check_transaction(self.chain_config.as_ref(), tx)?;
 
         let block_id = tx_source.chain_block_index().map(|c| *c.block_id());
 

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -749,7 +749,11 @@ where
         tx: &SignedTransaction,
         median_time_past: &BlockTimestamp,
     ) -> Result<AccumulatedFee, ConnectTransactionError> {
-        check_transaction::check_transaction(self.chain_config.as_ref(), tx)?;
+        check_transaction::check_transaction(
+            self.chain_config.as_ref(),
+            tx_source.expected_block_height(),
+            tx,
+        )?;
 
         let block_id = tx_source.chain_block_index().map(|c| *c.block_id());
 

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -758,17 +758,11 @@ where
         let block_id = tx_source.chain_block_index().map(|c| *c.block_id());
 
         // Register tokens if tx has issuance data
-        self.token_issuance_cache.register(
-            self.chain_config.as_ref(),
-            tx_source.expected_block_height(),
-            block_id,
-            tx.transaction(),
-            |id| {
-                self.storage
-                    .get_token_aux_data(id)
-                    .map_err(|_| ConnectTransactionError::TxVerifierStorage)
-            },
-        )?;
+        self.token_issuance_cache.register(block_id, tx.transaction(), |id| {
+            self.storage
+                .get_token_aux_data(id)
+                .map_err(|_| ConnectTransactionError::TxVerifierStorage)
+        })?;
 
         // check for attempted money printing and invalid inputs/outputs combinations
         let fee = input_output_policy::check_tx_inputs_outputs_policy(

--- a/chainstate/tx-verifier/src/transaction_verifier/tokens_check/check_utils.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tokens_check/check_utils.rs
@@ -15,10 +15,7 @@
 
 use crate::error::TokenIssuanceError;
 
-use common::{
-    chain::{tokens::is_rfc3986_valid_symbol, ChainConfig},
-    primitives::BlockHeight,
-};
+use common::chain::{tokens::is_rfc3986_valid_symbol, ChainConfig};
 use utils::ensure;
 
 fn check_is_text_ascii_alphanumeric(str: &[u8]) -> bool {
@@ -49,12 +46,11 @@ pub fn check_media_hash(chain_config: &ChainConfig, hash: &[u8]) -> Result<(), T
 
 pub fn check_token_ticker(
     chain_config: &ChainConfig,
-    block_height: BlockHeight,
     ticker: &[u8],
 ) -> Result<(), TokenIssuanceError> {
     // Check length
     ensure!(
-        ticker.len() <= chain_config.token_max_ticker_len(block_height) && !ticker.is_empty(),
+        ticker.len() <= chain_config.token_max_ticker_len() && !ticker.is_empty(),
         TokenIssuanceError::IssueErrorInvalidTickerLength
     );
 

--- a/chainstate/tx-verifier/src/transaction_verifier/tokens_check/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tokens_check/mod.rs
@@ -17,12 +17,9 @@ use self::check_utils::check_media_hash;
 
 use crate::error::TokenIssuanceError;
 
-use common::{
-    chain::{
-        tokens::{NftIssuanceV0, TokenIssuance},
-        ChainConfig,
-    },
-    primitives::BlockHeight,
+use common::chain::{
+    tokens::{NftIssuanceV0, TokenIssuance},
+    ChainConfig,
 };
 use serialization::{DecodeAll, Encode};
 use utils::ensure;
@@ -31,10 +28,9 @@ mod check_utils;
 
 pub fn check_nft_issuance_data(
     chain_config: &ChainConfig,
-    block_height: BlockHeight,
     issuance: &NftIssuanceV0,
 ) -> Result<(), TokenIssuanceError> {
-    check_utils::check_token_ticker(chain_config, block_height, &issuance.metadata.ticker)?;
+    check_utils::check_token_ticker(chain_config, &issuance.metadata.ticker)?;
     check_utils::check_nft_name(chain_config, &issuance.metadata.name)?;
     check_utils::check_nft_description(chain_config, &issuance.metadata.description)?;
 
@@ -83,17 +79,12 @@ pub fn check_nft_issuance_data(
 
 pub fn check_tokens_issuance(
     chain_config: &ChainConfig,
-    block_height: BlockHeight,
     issuance: &TokenIssuance,
 ) -> Result<(), TokenIssuanceError> {
     match issuance {
         TokenIssuance::V1(issuance_data) => {
             // Check token ticker
-            check_utils::check_token_ticker(
-                chain_config,
-                block_height,
-                &issuance_data.token_ticker,
-            )?;
+            check_utils::check_token_ticker(chain_config, &issuance_data.token_ticker)?;
 
             // Check decimals
             ensure!(

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -29,9 +29,8 @@ use crate::{
         pos_initial_difficulty,
         pow::PoWChainConfigBuilder,
         ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
-        NftIdMismatchCheck, PoSChainConfig, PoSConsensusVersion, PoWChainConfig,
-        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
-        TokensTickerMaxLengthVersion,
+        PoSChainConfig, PoSConsensusVersion, PoWChainConfig, RewardDistributionVersion,
+        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion,
     },
     primitives::{
         id::WithId, per_thousand::PerThousand, semver::SemVer, Amount, BlockCount, BlockDistance,
@@ -164,7 +163,6 @@ impl ChainType {
                         RewardDistributionVersion::V1,
                         TokensFeeVersion::V1,
                         TokensTickerMaxLengthVersion::V1,
-                        NftIdMismatchCheck::Yes,
                     ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
@@ -177,7 +175,6 @@ impl ChainType {
                         RewardDistributionVersion::V1,
                         TokensFeeVersion::V1,
                         TokensTickerMaxLengthVersion::V1,
-                        NftIdMismatchCheck::Yes,
                     ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
@@ -191,7 +188,6 @@ impl ChainType {
                             RewardDistributionVersion::V0,
                             TokensFeeVersion::V0,
                             TokensTickerMaxLengthVersion::V0,
-                            NftIdMismatchCheck::No,
                         ),
                     ),
                     (
@@ -201,7 +197,6 @@ impl ChainType {
                             RewardDistributionVersion::V0,
                             TokensFeeVersion::V0,
                             TokensTickerMaxLengthVersion::V0,
-                            NftIdMismatchCheck::No,
                         ),
                     ),
                     (
@@ -211,7 +206,6 @@ impl ChainType {
                             RewardDistributionVersion::V1,
                             TokensFeeVersion::V1,
                             TokensTickerMaxLengthVersion::V1,
-                            NftIdMismatchCheck::Yes,
                         ),
                     ),
                 ];

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -30,7 +30,7 @@ use crate::{
         pow::PoWChainConfigBuilder,
         ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
         PoSChainConfig, PoSConsensusVersion, PoWChainConfig, RewardDistributionVersion,
-        TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion,
+        TokenIssuanceVersion, TokensFeeVersion,
     },
     primitives::{
         id::WithId, per_thousand::PerThousand, semver::SemVer, Amount, BlockCount, BlockDistance,
@@ -47,8 +47,8 @@ use super::{
 
 // The fork, at which we upgrade consensus to dis-incentivize large pools + enable tokens v1
 const TESTNET_TOKEN_FORK_HEIGHT: BlockHeight = BlockHeight::new(78440);
-// The fork, at which we upgrade chainstate to distribute reward to staker proportionally to its balance,
-// changed various tokens fees and also increased max ticker length for tokens
+// The fork, at which we upgrade chainstate to distribute reward to staker proportionally to their balance
+// and change various tokens fees
 const TESTNET_STAKER_REWARD_AND_TOKENS_FEE_FORK_HEIGHT: BlockHeight = BlockHeight::new(138244);
 
 impl ChainType {
@@ -162,7 +162,6 @@ impl ChainType {
                         TokenIssuanceVersion::V1,
                         RewardDistributionVersion::V1,
                         TokensFeeVersion::V1,
-                        TokensTickerMaxLengthVersion::V1,
                     ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
@@ -174,7 +173,6 @@ impl ChainType {
                         TokenIssuanceVersion::V1,
                         RewardDistributionVersion::V1,
                         TokensFeeVersion::V1,
-                        TokensTickerMaxLengthVersion::V1,
                     ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
@@ -187,7 +185,6 @@ impl ChainType {
                             TokenIssuanceVersion::V0,
                             RewardDistributionVersion::V0,
                             TokensFeeVersion::V0,
-                            TokensTickerMaxLengthVersion::V0,
                         ),
                     ),
                     (
@@ -196,7 +193,6 @@ impl ChainType {
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V0,
                             TokensFeeVersion::V0,
-                            TokensTickerMaxLengthVersion::V0,
                         ),
                     ),
                     (
@@ -205,7 +201,6 @@ impl ChainType {
                             TokenIssuanceVersion::V1,
                             RewardDistributionVersion::V1,
                             TokensFeeVersion::V1,
-                            TokensTickerMaxLengthVersion::V1,
                         ),
                     ),
                 ];

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -28,9 +28,9 @@ use crate::{
         },
         pos_initial_difficulty,
         pow::PoWChainConfigBuilder,
-        AccountsBalancesCheckVersion, ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination,
-        GenBlock, Genesis, NetUpgrades, NftIdMismatchCheck, PoSChainConfig, PoSConsensusVersion,
-        PoWChainConfig, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+        ChainstateUpgrade, CoinUnit, ConsensusUpgrade, Destination, GenBlock, Genesis, NetUpgrades,
+        NftIdMismatchCheck, PoSChainConfig, PoSConsensusVersion, PoWChainConfig,
+        RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
         TokensTickerMaxLengthVersion,
     },
     primitives::{
@@ -51,9 +51,6 @@ const TESTNET_TOKEN_FORK_HEIGHT: BlockHeight = BlockHeight::new(78440);
 // The fork, at which we upgrade chainstate to distribute reward to staker proportionally to its balance,
 // changed various tokens fees and also increased max ticker length for tokens
 const TESTNET_STAKER_REWARD_AND_TOKENS_FEE_FORK_HEIGHT: BlockHeight = BlockHeight::new(138244);
-const TESTNET_CONSTRAINTS_ACCUMULATOR_FORK_HEIGHT: BlockHeight = BlockHeight::new(185891);
-
-const MAINNET_CONSTRAINTS_ACCUMULATOR_FORK_HEIGHT: BlockHeight = BlockHeight::new(58344);
 
 impl ChainType {
     fn default_genesis_init(&self) -> GenesisBlockInit {
@@ -160,30 +157,16 @@ impl ChainType {
     fn default_chainstate_upgrades(&self) -> NetUpgrades<ChainstateUpgrade> {
         match self {
             ChainType::Mainnet => {
-                let upgrades = vec![
-                    (
-                        BlockHeight::new(0),
-                        ChainstateUpgrade::new(
-                            TokenIssuanceVersion::V1,
-                            RewardDistributionVersion::V1,
-                            TokensFeeVersion::V1,
-                            TokensTickerMaxLengthVersion::V1,
-                            NftIdMismatchCheck::Yes,
-                            AccountsBalancesCheckVersion::V0,
-                        ),
+                let upgrades = vec![(
+                    BlockHeight::new(0),
+                    ChainstateUpgrade::new(
+                        TokenIssuanceVersion::V1,
+                        RewardDistributionVersion::V1,
+                        TokensFeeVersion::V1,
+                        TokensTickerMaxLengthVersion::V1,
+                        NftIdMismatchCheck::Yes,
                     ),
-                    (
-                        MAINNET_CONSTRAINTS_ACCUMULATOR_FORK_HEIGHT,
-                        ChainstateUpgrade::new(
-                            TokenIssuanceVersion::V1,
-                            RewardDistributionVersion::V1,
-                            TokensFeeVersion::V1,
-                            TokensTickerMaxLengthVersion::V1,
-                            NftIdMismatchCheck::Yes,
-                            AccountsBalancesCheckVersion::V1,
-                        ),
-                    ),
-                ];
+                )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
             }
             ChainType::Regtest | ChainType::Signet => {
@@ -195,7 +178,6 @@ impl ChainType {
                         TokensFeeVersion::V1,
                         TokensTickerMaxLengthVersion::V1,
                         NftIdMismatchCheck::Yes,
-                        AccountsBalancesCheckVersion::V1,
                     ),
                 )];
                 NetUpgrades::initialize(upgrades).expect("net upgrades")
@@ -210,7 +192,6 @@ impl ChainType {
                             TokensFeeVersion::V0,
                             TokensTickerMaxLengthVersion::V0,
                             NftIdMismatchCheck::No,
-                            AccountsBalancesCheckVersion::V0,
                         ),
                     ),
                     (
@@ -221,7 +202,6 @@ impl ChainType {
                             TokensFeeVersion::V0,
                             TokensTickerMaxLengthVersion::V0,
                             NftIdMismatchCheck::No,
-                            AccountsBalancesCheckVersion::V0,
                         ),
                     ),
                     (
@@ -232,18 +212,6 @@ impl ChainType {
                             TokensFeeVersion::V1,
                             TokensTickerMaxLengthVersion::V1,
                             NftIdMismatchCheck::Yes,
-                            AccountsBalancesCheckVersion::V0,
-                        ),
-                    ),
-                    (
-                        TESTNET_CONSTRAINTS_ACCUMULATOR_FORK_HEIGHT,
-                        ChainstateUpgrade::new(
-                            TokenIssuanceVersion::V1,
-                            RewardDistributionVersion::V1,
-                            TokensFeeVersion::V1,
-                            TokensTickerMaxLengthVersion::V1,
-                            NftIdMismatchCheck::Yes,
-                            AccountsBalancesCheckVersion::V1,
                         ),
                     ),
                 ];

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -50,7 +50,6 @@ use crypto::key::hdkd::{child_number::ChildNumber, u31::U31};
 use self::checkpoints::Checkpoints;
 use self::emission_schedule::DEFAULT_INITIAL_MINT;
 use super::output_value::OutputValue;
-use super::TokensTickerMaxLengthVersion;
 use super::{stakelock::StakePoolData, RequiredConsensus};
 use super::{ChainstateUpgrade, ConsensusUpgrade};
 use super::{RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion};
@@ -616,16 +615,8 @@ impl ChainConfig {
 
     /// The maximum length of a ticker of a token
     #[must_use]
-    pub fn token_max_ticker_len(&self, height: BlockHeight) -> usize {
-        let ticker_version = self
-            .chainstate_upgrades
-            .version_at_height(height)
-            .1
-            .tokens_ticker_length_version();
-        match ticker_version {
-            TokensTickerMaxLengthVersion::V0 => TOKEN_MAX_TICKER_LEN_V0,
-            TokensTickerMaxLengthVersion::V1 => TOKEN_MAX_TICKER_LEN_V1,
-        }
+    pub fn token_max_ticker_len(&self) -> usize {
+        TOKEN_MAX_TICKER_LEN
     }
 
     /// The maximum length of a description of a token
@@ -727,8 +718,7 @@ const DATA_DEPOSIT_MAX_SIZE: usize = 128;
 const DATA_DEPOSIT_FEE: Amount = CoinUnit::from_coins(100).to_amount_atoms();
 
 const TOKEN_MAX_DEC_COUNT: u8 = 18;
-const TOKEN_MAX_TICKER_LEN_V0: usize = 5;
-const TOKEN_MAX_TICKER_LEN_V1: usize = 12;
+const TOKEN_MAX_TICKER_LEN: usize = 12;
 const TOKEN_MIN_HASH_LEN: usize = 4;
 const TOKEN_MAX_HASH_LEN: usize = 32;
 const TOKEN_MAX_NAME_LEN: usize = 10;
@@ -874,7 +864,6 @@ pub fn create_unit_test_config_builder() -> Builder {
                     TokenIssuanceVersion::V1,
                     RewardDistributionVersion::V1,
                     TokensFeeVersion::V1,
-                    TokensTickerMaxLengthVersion::V1,
                 ),
             )])
             .expect("cannot fail"),

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -50,7 +50,6 @@ use crypto::key::hdkd::{child_number::ChildNumber, u31::U31};
 use self::checkpoints::Checkpoints;
 use self::emission_schedule::DEFAULT_INITIAL_MINT;
 use super::output_value::OutputValue;
-use super::AccountsBalancesCheckVersion;
 use super::NftIdMismatchCheck;
 use super::TokensTickerMaxLengthVersion;
 use super::{stakelock::StakePoolData, RequiredConsensus};
@@ -878,7 +877,6 @@ pub fn create_unit_test_config_builder() -> Builder {
                     TokensFeeVersion::V1,
                     TokensTickerMaxLengthVersion::V1,
                     NftIdMismatchCheck::Yes,
-                    AccountsBalancesCheckVersion::V1,
                 ),
             )])
             .expect("cannot fail"),

--- a/common/src/chain/config/mod.rs
+++ b/common/src/chain/config/mod.rs
@@ -50,7 +50,6 @@ use crypto::key::hdkd::{child_number::ChildNumber, u31::U31};
 use self::checkpoints::Checkpoints;
 use self::emission_schedule::DEFAULT_INITIAL_MINT;
 use super::output_value::OutputValue;
-use super::NftIdMismatchCheck;
 use super::TokensTickerMaxLengthVersion;
 use super::{stakelock::StakePoolData, RequiredConsensus};
 use super::{ChainstateUpgrade, ConsensusUpgrade};
@@ -876,7 +875,6 @@ pub fn create_unit_test_config_builder() -> Builder {
                     RewardDistributionVersion::V1,
                     TokensFeeVersion::V1,
                     TokensTickerMaxLengthVersion::V1,
-                    NftIdMismatchCheck::Yes,
                 ),
             )])
             .expect("cannot fail"),

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -47,19 +47,12 @@ pub enum TokensTickerMaxLengthVersion {
     V1,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
-pub enum NftIdMismatchCheck {
-    Yes,
-    No,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ChainstateUpgrade {
     token_issuance_version: TokenIssuanceVersion,
     reward_distribution_version: RewardDistributionVersion,
     tokens_fee_version: TokensFeeVersion,
     tokens_ticker_length_version: TokensTickerMaxLengthVersion,
-    nft_id_mismatch_check: NftIdMismatchCheck,
 }
 
 impl ChainstateUpgrade {
@@ -68,14 +61,12 @@ impl ChainstateUpgrade {
         reward_distribution_version: RewardDistributionVersion,
         tokens_fee_version: TokensFeeVersion,
         tokens_ticker_length_version: TokensTickerMaxLengthVersion,
-        nft_id_mismatch_check: NftIdMismatchCheck,
     ) -> Self {
         Self {
             token_issuance_version,
             reward_distribution_version,
             tokens_fee_version,
             tokens_ticker_length_version,
-            nft_id_mismatch_check,
         }
     }
 
@@ -93,10 +84,6 @@ impl ChainstateUpgrade {
 
     pub fn tokens_ticker_length_version(&self) -> TokensTickerMaxLengthVersion {
         self.tokens_ticker_length_version
-    }
-
-    pub fn nft_id_mismatch_check(&self) -> NftIdMismatchCheck {
-        self.nft_id_mismatch_check
     }
 }
 

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -53,12 +53,6 @@ pub enum NftIdMismatchCheck {
     No,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
-pub enum AccountsBalancesCheckVersion {
-    V0,
-    V1,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ChainstateUpgrade {
     token_issuance_version: TokenIssuanceVersion,
@@ -66,7 +60,6 @@ pub struct ChainstateUpgrade {
     tokens_fee_version: TokensFeeVersion,
     tokens_ticker_length_version: TokensTickerMaxLengthVersion,
     nft_id_mismatch_check: NftIdMismatchCheck,
-    accounts_balances_version: AccountsBalancesCheckVersion,
 }
 
 impl ChainstateUpgrade {
@@ -76,7 +69,6 @@ impl ChainstateUpgrade {
         tokens_fee_version: TokensFeeVersion,
         tokens_ticker_length_version: TokensTickerMaxLengthVersion,
         nft_id_mismatch_check: NftIdMismatchCheck,
-        accounts_balances_version: AccountsBalancesCheckVersion,
     ) -> Self {
         Self {
             token_issuance_version,
@@ -84,7 +76,6 @@ impl ChainstateUpgrade {
             tokens_fee_version,
             tokens_ticker_length_version,
             nft_id_mismatch_check,
-            accounts_balances_version,
         }
     }
 
@@ -106,10 +97,6 @@ impl ChainstateUpgrade {
 
     pub fn nft_id_mismatch_check(&self) -> NftIdMismatchCheck {
         self.nft_id_mismatch_check
-    }
-
-    pub fn accounts_balances_version(&self) -> AccountsBalancesCheckVersion {
-        self.accounts_balances_version
     }
 }
 

--- a/common/src/chain/upgrades/chainstate_upgrade.rs
+++ b/common/src/chain/upgrades/chainstate_upgrade.rs
@@ -39,20 +39,11 @@ pub enum TokensFeeVersion {
     V1,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
-pub enum TokensTickerMaxLengthVersion {
-    /// Initial tokens ticker max length values
-    V0,
-    /// Updated tokens ticker max length values
-    V1,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ChainstateUpgrade {
     token_issuance_version: TokenIssuanceVersion,
     reward_distribution_version: RewardDistributionVersion,
     tokens_fee_version: TokensFeeVersion,
-    tokens_ticker_length_version: TokensTickerMaxLengthVersion,
 }
 
 impl ChainstateUpgrade {
@@ -60,13 +51,11 @@ impl ChainstateUpgrade {
         token_issuance_version: TokenIssuanceVersion,
         reward_distribution_version: RewardDistributionVersion,
         tokens_fee_version: TokensFeeVersion,
-        tokens_ticker_length_version: TokensTickerMaxLengthVersion,
     ) -> Self {
         Self {
             token_issuance_version,
             reward_distribution_version,
             tokens_fee_version,
-            tokens_ticker_length_version,
         }
     }
 
@@ -80,10 +69,6 @@ impl ChainstateUpgrade {
 
     pub fn tokens_fee_version(&self) -> TokensFeeVersion {
         self.tokens_fee_version
-    }
-
-    pub fn tokens_ticker_length_version(&self) -> TokensTickerMaxLengthVersion {
-        self.tokens_ticker_length_version
     }
 }
 

--- a/common/src/chain/upgrades/mod.rs
+++ b/common/src/chain/upgrades/mod.rs
@@ -18,8 +18,8 @@ mod consensus_upgrade;
 mod netupgrade;
 
 pub use chainstate_upgrade::{
-    AccountsBalancesCheckVersion, ChainstateUpgrade, NftIdMismatchCheck, RewardDistributionVersion,
-    TokenIssuanceVersion, TokensFeeVersion, TokensTickerMaxLengthVersion,
+    ChainstateUpgrade, NftIdMismatchCheck, RewardDistributionVersion, TokenIssuanceVersion,
+    TokensFeeVersion, TokensTickerMaxLengthVersion,
 };
 pub use consensus_upgrade::{ConsensusUpgrade, PoSStatus, PoWStatus, RequiredConsensus};
 pub use netupgrade::{Activate, NetUpgrades};

--- a/common/src/chain/upgrades/mod.rs
+++ b/common/src/chain/upgrades/mod.rs
@@ -19,7 +19,6 @@ mod netupgrade;
 
 pub use chainstate_upgrade::{
     ChainstateUpgrade, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
-    TokensTickerMaxLengthVersion,
 };
 pub use consensus_upgrade::{ConsensusUpgrade, PoSStatus, PoWStatus, RequiredConsensus};
 pub use netupgrade::{Activate, NetUpgrades};

--- a/common/src/chain/upgrades/mod.rs
+++ b/common/src/chain/upgrades/mod.rs
@@ -18,8 +18,8 @@ mod consensus_upgrade;
 mod netupgrade;
 
 pub use chainstate_upgrade::{
-    ChainstateUpgrade, NftIdMismatchCheck, RewardDistributionVersion, TokenIssuanceVersion,
-    TokensFeeVersion, TokensTickerMaxLengthVersion,
+    ChainstateUpgrade, RewardDistributionVersion, TokenIssuanceVersion, TokensFeeVersion,
+    TokensTickerMaxLengthVersion,
 };
 pub use consensus_upgrade::{ConsensusUpgrade, PoSStatus, PoWStatus, RequiredConsensus};
 pub use netupgrade::{Activate, NetUpgrades};

--- a/test-utils/src/nft_utils.rs
+++ b/test-utils/src/nft_utils.rs
@@ -23,7 +23,7 @@ use common::{
         },
         Destination,
     },
-    primitives::{Amount, BlockHeight},
+    primitives::Amount,
 };
 use crypto::key::{KeyKind, PrivateKey};
 use crypto::random::{CryptoRng, Rng};
@@ -35,7 +35,7 @@ pub fn random_creator(rng: &mut (impl Rng + CryptoRng)) -> TokenCreator {
 }
 
 pub fn random_token_issuance(chain_config: &ChainConfig, rng: &mut impl Rng) -> TokenIssuanceV0 {
-    let max_ticker_len = chain_config.token_max_ticker_len(BlockHeight::zero());
+    let max_ticker_len = chain_config.token_max_ticker_len();
     let max_dec_count = chain_config.token_max_dec_count();
     let max_uri_len = chain_config.token_max_uri_len();
 
@@ -52,7 +52,7 @@ pub fn random_token_issuance_v1(
     authority: Destination,
     rng: &mut impl Rng,
 ) -> TokenIssuanceV1 {
-    let max_ticker_len = chain_config.token_max_ticker_len(BlockHeight::zero());
+    let max_ticker_len = chain_config.token_max_ticker_len();
     let max_dec_count = chain_config.token_max_dec_count();
     let max_uri_len = chain_config.token_max_uri_len();
 
@@ -72,7 +72,7 @@ pub fn random_nft_issuance(
 ) -> NftIssuanceV0 {
     let max_desc_len = chain_config.token_max_description_len();
     let max_name_len = chain_config.token_max_name_len();
-    let max_ticker_len = chain_config.token_max_ticker_len(BlockHeight::zero());
+    let max_ticker_len = chain_config.token_max_ticker_len();
 
     NftIssuanceV0 {
         metadata: Metadata {

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1018,11 +1018,7 @@ impl Account {
         let nft_issuance = NftIssuanceV0 {
             metadata: nft_issue_arguments.metadata,
         };
-        tx_verifier::check_nft_issuance_data(
-            &self.chain_config,
-            self.account_info.best_block_height().next_height(),
-            &nft_issuance,
-        )?;
+        tx_verifier::check_nft_issuance_data(&self.chain_config, &nft_issuance)?;
 
         // the first UTXO is needed in advance to issue a new nft, so just make a dummy one
         // and then replace it with when we can calculate the pool_id

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -71,9 +71,8 @@ pub fn make_address_output_token(
 pub fn make_issue_token_outputs(
     token_issuance: TokenIssuance,
     chain_config: &ChainConfig,
-    block_height: BlockHeight,
 ) -> WalletResult<Vec<TxOutput>> {
-    tx_verifier::check_tokens_issuance(chain_config, block_height, &token_issuance)?;
+    tx_verifier::check_tokens_issuance(chain_config, &token_issuance)?;
     let issuance_output = TxOutput::IssueFungibleToken(Box::new(token_issuance));
 
     Ok(vec![issuance_output])

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -947,10 +947,9 @@ impl<B: storage::Backend> Wallet<B> {
         account_index: U31,
         f: impl FnOnce(&mut Account, &mut StoreTxRwUnlocked<B>) -> WalletResult<SignedTransaction>,
     ) -> WalletResult<SignedTransaction> {
-        let (_, block_height) = self.get_best_block_for_account(account_index)?;
         self.for_account_rw_unlocked(account_index, |account, db_tx, chain_config| {
             let tx = f(account, db_tx)?;
-            check_transaction(chain_config, block_height.next_height(), &tx)?;
+            check_transaction(chain_config, &tx)?;
             Ok(tx)
         })
     }
@@ -1484,11 +1483,7 @@ impl<B: storage::Backend> Wallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<(TokenId, SignedTransaction)> {
-        let outputs = make_issue_token_outputs(
-            token_issuance,
-            self.chain_config.as_ref(),
-            self.get_best_block_for_account(account_index)?.1.next_height(),
-        )?;
+        let outputs = make_issue_token_outputs(token_issuance, self.chain_config.as_ref())?;
 
         let tx = self.create_transaction_to_addresses(
             account_index,

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -947,9 +947,10 @@ impl<B: storage::Backend> Wallet<B> {
         account_index: U31,
         f: impl FnOnce(&mut Account, &mut StoreTxRwUnlocked<B>) -> WalletResult<SignedTransaction>,
     ) -> WalletResult<SignedTransaction> {
+        let (_, block_height) = self.get_best_block_for_account(account_index)?;
         self.for_account_rw_unlocked(account_index, |account, db_tx, chain_config| {
             let tx = f(account, db_tx)?;
-            check_transaction(chain_config, &tx)?;
+            check_transaction(chain_config, block_height.next_height(), &tx)?;
             Ok(tx)
         })
     }

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -419,8 +419,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         options: TxOptionsOverrides,
     ) -> WRpcResult<NewTransaction, N> {
         let tx = tx.take();
-        let block_height = self.best_block().await?.height;
-        check_transaction(&self.chain_config, block_height, &tx).map_err(|err| {
+        check_transaction(&self.chain_config, &tx).map_err(|err| {
             RpcError::Controller(ControllerError::WalletError(
                 WalletError::InvalidTransaction(err),
             ))

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -419,7 +419,8 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         options: TxOptionsOverrides,
     ) -> WRpcResult<NewTransaction, N> {
         let tx = tx.take();
-        check_transaction(&self.chain_config, &tx).map_err(|err| {
+        let block_height = self.best_block().await?.height;
+        check_transaction(&self.chain_config, block_height, &tx).map_err(|err| {
             RpcError::Controller(ControllerError::WalletError(
                 WalletError::InvalidTransaction(err),
             ))

--- a/wasm-wrappers/js-bindings/wasm_test.js
+++ b/wasm-wrappers/js-bindings/wasm_test.js
@@ -253,7 +253,8 @@ export async function run_test() {
 
     assert_eq_arrays(inputs, expected_inputs);
 
-    const token_id = "tmltk15tgfrs49rv88v8utcllqh0nvpaqtgvn26vdxhuner5m6ewg9c3msn9fxns";
+    const token_id =
+      "tmltk15tgfrs49rv88v8utcllqh0nvpaqtgvn26vdxhuner5m6ewg9c3msn9fxns";
     try {
       encode_output_coin_burn(Amount.from_atoms("invalid amount"));
       throw new Error("Invalid value for amount worked somehow!");
@@ -264,7 +265,11 @@ export async function run_test() {
       console.log("Tested invalid amount successfully");
     }
     try {
-      encode_output_token_burn(Amount.from_atoms("invalid amount"), token_id, Network.Testnet);
+      encode_output_token_burn(
+        Amount.from_atoms("invalid amount"),
+        token_id,
+        Network.Testnet
+      );
       throw new Error("Invalid value for amount worked somehow!");
     } catch (e) {
       if (!e.includes("Invalid amount")) {
@@ -274,7 +279,11 @@ export async function run_test() {
     }
     try {
       const invalid_token_id = "asd";
-      encode_output_token_burn(Amount.from_atoms("100"), invalid_token_id, Network.Testnet);
+      encode_output_token_burn(
+        Amount.from_atoms("100"),
+        invalid_token_id,
+        Network.Testnet
+      );
       throw new Error("Invalid token id worked somehow!");
     } catch (e) {
       if (!e.includes("Invalid addressable encoding")) {
@@ -283,13 +292,15 @@ export async function run_test() {
       console.log("Tested invalid token id successfully for token burn");
     }
 
-    const token_burn = encode_output_token_burn(Amount.from_atoms("100"), token_id, Network.Testnet);
+    const token_burn = encode_output_token_burn(
+      Amount.from_atoms("100"),
+      token_id,
+      Network.Testnet
+    );
     const expected_token_burn = [
-      2, 2, 162, 208, 145, 194, 165, 27,
-      14, 118, 31, 139, 199, 254, 11, 190,
-      108, 15, 64, 180, 50, 106, 211, 26,
-      107, 242, 121, 29, 55, 172, 185, 5,
-      196, 119, 145, 1
+      2, 2, 162, 208, 145, 194, 165, 27, 14, 118, 31, 139, 199, 254, 11, 190,
+      108, 15, 64, 180, 50, 106, 211, 26, 107, 242, 121, 29, 55, 172, 185, 5,
+      196, 119, 145, 1,
     ];
     assert_eq_arrays(token_burn, expected_token_burn);
 
@@ -363,12 +374,10 @@ export async function run_test() {
       Network.Testnet
     );
     const expected_token_lock_transfer_out = [
-      1, 2, 162, 208, 145, 194, 165, 27, 14, 118, 31,
-      139, 199, 254, 11, 190, 108, 15, 64, 180, 50, 106,
-      211, 26, 107, 242, 121, 29, 55, 172, 185, 5, 196,
-      119, 145, 1, 1, 91, 58, 110, 176, 100, 207, 6,
-      194, 41, 193, 30, 91, 4, 195, 202, 103, 207, 80,
-      217, 178, 0, 145, 1
+      1, 2, 162, 208, 145, 194, 165, 27, 14, 118, 31, 139, 199, 254, 11, 190,
+      108, 15, 64, 180, 50, 106, 211, 26, 107, 242, 121, 29, 55, 172, 185, 5,
+      196, 119, 145, 1, 1, 91, 58, 110, 176, 100, 207, 6, 194, 41, 193, 30, 91,
+      4, 195, 202, 103, 207, 80, 217, 178, 0, 145, 1,
     ];
     assert_eq_arrays(token_lock_transfer_out, expected_token_lock_transfer_out);
 
@@ -385,7 +394,9 @@ export async function run_test() {
       if (!e.includes("Invalid addressable encoding")) {
         throw e;
       }
-      console.log("Tested invalid address in encode output token transfer successfully");
+      console.log(
+        "Tested invalid address in encode output token transfer successfully"
+      );
     }
 
     try {
@@ -402,7 +413,9 @@ export async function run_test() {
       if (!e.includes("Invalid addressable encoding")) {
         throw e;
       }
-      console.log("Tested invalid token id successfully in output token transfer");
+      console.log(
+        "Tested invalid token id successfully in output token transfer"
+      );
     }
 
     const token_transfer_out = encode_output_token_transfer(
@@ -412,12 +425,10 @@ export async function run_test() {
       Network.Testnet
     );
     const expected_token_transfer_out = [
-      0, 2, 162, 208, 145, 194, 165, 27, 14, 118, 31,
-      139, 199, 254, 11, 190, 108, 15, 64, 180, 50, 106,
-      211, 26, 107, 242, 121, 29, 55, 172, 185, 5, 196,
-      119, 145, 1, 1, 91, 58, 110, 176, 100, 207, 6,
-      194, 41, 193, 30, 91, 4, 195, 202, 103, 207, 80,
-      217, 178
+      0, 2, 162, 208, 145, 194, 165, 27, 14, 118, 31, 139, 199, 254, 11, 190,
+      108, 15, 64, 180, 50, 106, 211, 26, 107, 242, 121, 29, 55, 172, 185, 5,
+      196, 119, 145, 1, 1, 91, 58, 110, 176, 100, 207, 6, 194, 41, 193, 30, 91,
+      4, 195, 202, 103, 207, 80, 217, 178,
     ];
 
     assert_eq_arrays(token_transfer_out, expected_token_transfer_out);
@@ -465,7 +476,20 @@ export async function run_test() {
 
     try {
       const invalid_token_id = "asd";
-      encode_output_issue_nft(invalid_token_id, address, "nft", "XXX", "desc", "123", undefined, undefined, undefined, undefined, Network.Testnet);
+      encode_output_issue_nft(
+        invalid_token_id,
+        address,
+        "nft",
+        "XXX",
+        "desc",
+        "123",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        BigInt(1),
+        Network.Testnet
+      );
       throw new Error("Invalid token id worked somehow!");
     } catch (e) {
       console.log(`err: ${e}`);
@@ -478,7 +502,20 @@ export async function run_test() {
     try {
       console.log("Testing invalid creator successfully..");
       const creator_public_key_hash = address;
-      encode_output_issue_nft(token_id, address, "nft", "XXX", "desc", "123", creator_public_key_hash, undefined, undefined, undefined, Network.Testnet);
+      encode_output_issue_nft(
+        token_id,
+        address,
+        "nft",
+        "XXX",
+        "desc",
+        "123",
+        creator_public_key_hash,
+        undefined,
+        undefined,
+        undefined,
+        BigInt(1),
+        Network.Testnet
+      );
       throw new Error("Invalid creator worked somehow!");
     } catch (e) {
       if (!e.includes("NFT Creator needs to be a public key address")) {
@@ -490,7 +527,20 @@ export async function run_test() {
     try {
       console.log("Testing invalid nft ticker successfully..");
       const empty_ticker = "";
-      encode_output_issue_nft(token_id, address, "nft", empty_ticker, "desc", "123", undefined, undefined, undefined, undefined, Network.Testnet);
+      encode_output_issue_nft(
+        token_id,
+        address,
+        "nft",
+        empty_ticker,
+        "desc",
+        "123",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        BigInt(1),
+        Network.Testnet
+      );
       throw new Error("Invalid ticker worked somehow!");
     } catch (e) {
       if (!e.includes("Invalid ticker length")) {
@@ -502,7 +552,20 @@ export async function run_test() {
     try {
       console.log("Testing invalid nft name successfully..");
       const empty_name = "";
-      encode_output_issue_nft(token_id, address, empty_name, "xxx", "desc", "123", undefined, undefined, undefined, undefined, Network.Testnet);
+      encode_output_issue_nft(
+        token_id,
+        address,
+        empty_name,
+        "xxx",
+        "desc",
+        "123",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        BigInt(1),
+        Network.Testnet
+      );
       throw new Error("Invalid name worked somehow!");
     } catch (e) {
       if (!e.includes("Invalid name length")) {
@@ -514,7 +577,20 @@ export async function run_test() {
     try {
       console.log("Testing invalid nft description successfully..");
       const empty_description = "";
-      encode_output_issue_nft(token_id, address, "name", "XXX", empty_description, "123", undefined, undefined, undefined, undefined, Network.Testnet);
+      encode_output_issue_nft(
+        token_id,
+        address,
+        "name",
+        "XXX",
+        empty_description,
+        "123",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        BigInt(1),
+        Network.Testnet
+      );
       throw new Error("Invalid description worked somehow!");
     } catch (e) {
       if (!e.includes("Invalid description length")) {

--- a/wasm-wrappers/js-bindings/wasm_test.js
+++ b/wasm-wrappers/js-bindings/wasm_test.js
@@ -465,7 +465,7 @@ export async function run_test() {
 
     try {
       const invalid_token_id = "asd";
-      encode_output_issue_nft(invalid_token_id, address, "nft", "XXX", "desc", "123", undefined, undefined, undefined, undefined, BigInt(1), Network.Testnet);
+      encode_output_issue_nft(invalid_token_id, address, "nft", "XXX", "desc", "123", undefined, undefined, undefined, undefined, Network.Testnet);
       throw new Error("Invalid token id worked somehow!");
     } catch (e) {
       console.log(`err: ${e}`);
@@ -478,7 +478,7 @@ export async function run_test() {
     try {
       console.log("Testing invalid creator successfully..");
       const creator_public_key_hash = address;
-      encode_output_issue_nft(token_id, address, "nft", "XXX", "desc", "123", creator_public_key_hash, undefined, undefined, undefined, BigInt(1), Network.Testnet);
+      encode_output_issue_nft(token_id, address, "nft", "XXX", "desc", "123", creator_public_key_hash, undefined, undefined, undefined, Network.Testnet);
       throw new Error("Invalid creator worked somehow!");
     } catch (e) {
       if (!e.includes("NFT Creator needs to be a public key address")) {
@@ -490,7 +490,7 @@ export async function run_test() {
     try {
       console.log("Testing invalid nft ticker successfully..");
       const empty_ticker = "";
-      encode_output_issue_nft(token_id, address, "nft", empty_ticker, "desc", "123", undefined, undefined, undefined, undefined, BigInt(1), Network.Testnet);
+      encode_output_issue_nft(token_id, address, "nft", empty_ticker, "desc", "123", undefined, undefined, undefined, undefined, Network.Testnet);
       throw new Error("Invalid ticker worked somehow!");
     } catch (e) {
       if (!e.includes("Invalid ticker length")) {
@@ -502,7 +502,7 @@ export async function run_test() {
     try {
       console.log("Testing invalid nft name successfully..");
       const empty_name = "";
-      encode_output_issue_nft(token_id, address, empty_name, "xxx", "desc", "123", undefined, undefined, undefined, undefined, BigInt(1), Network.Testnet);
+      encode_output_issue_nft(token_id, address, empty_name, "xxx", "desc", "123", undefined, undefined, undefined, undefined, Network.Testnet);
       throw new Error("Invalid name worked somehow!");
     } catch (e) {
       if (!e.includes("Invalid name length")) {
@@ -514,7 +514,7 @@ export async function run_test() {
     try {
       console.log("Testing invalid nft description successfully..");
       const empty_description = "";
-      encode_output_issue_nft(token_id, address, "name", "XXX", empty_description, "123", undefined, undefined, undefined, undefined, BigInt(1), Network.Testnet);
+      encode_output_issue_nft(token_id, address, "name", "XXX", empty_description, "123", undefined, undefined, undefined, undefined, Network.Testnet);
       throw new Error("Invalid description worked somehow!");
     } catch (e) {
       if (!e.includes("Invalid description length")) {

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -635,7 +635,6 @@ pub fn encode_output_issue_fungible_token(
     total_supply: TotalSupply,
     supply_amount: Option<Amount>,
     is_token_freezable: FreezableToken,
-    current_block_height: u64,
     network: Network,
 ) -> Result<Vec<u8>, Error> {
     let chain_config = Builder::new(network.into()).build();
@@ -654,11 +653,7 @@ pub fn encode_output_issue_fungible_token(
         is_freezable,
     });
 
-    tx_verifier::check_tokens_issuance(
-        &chain_config,
-        BlockHeight::new(current_block_height),
-        &token_issuance,
-    )?;
+    tx_verifier::check_tokens_issuance(&chain_config, &token_issuance)?;
 
     let output = TxOutput::IssueFungibleToken(Box::new(token_issuance));
     Ok(output.encode())
@@ -679,7 +674,6 @@ pub fn encode_output_issue_nft(
     media_uri: Option<Vec<u8>>,
     icon_uri: Option<Vec<u8>>,
     additional_metadata_uri: Option<Vec<u8>>,
-    current_block_height: u64,
     network: Network,
 ) -> Result<Vec<u8>, Error> {
     let chain_config = Builder::new(network.into()).build();
@@ -716,11 +710,7 @@ pub fn encode_output_issue_nft(
         },
     };
 
-    tx_verifier::check_nft_issuance_data(
-        &chain_config,
-        BlockHeight::new(current_block_height),
-        &nft_issuance,
-    )?;
+    tx_verifier::check_nft_issuance_data(&chain_config, &nft_issuance)?;
 
     let output = TxOutput::IssueNft(token_id, Box::new(NftIssuance::V0(nft_issuance)), authority);
     Ok(output.encode())

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -635,6 +635,7 @@ pub fn encode_output_issue_fungible_token(
     total_supply: TotalSupply,
     supply_amount: Option<Amount>,
     is_token_freezable: FreezableToken,
+    _current_block_height: u64,
     network: Network,
 ) -> Result<Vec<u8>, Error> {
     let chain_config = Builder::new(network.into()).build();
@@ -674,6 +675,7 @@ pub fn encode_output_issue_nft(
     media_uri: Option<Vec<u8>>,
     icon_uri: Option<Vec<u8>>,
     additional_metadata_uri: Option<Vec<u8>>,
+    _current_block_height: u64,
     network: Network,
 ) -> Result<Vec<u8>, Error> {
     let chain_config = Builder::new(network.into()).build();


### PR DESCRIPTION
For mainnet:
- `AccountsBalancesCheckVersion`: where the rules for verification of spending from delegation account changed

For testnet:
- `AccountsBalancesCheckVersion`
- `NftIdMismatchCheck`: check was added to verify that token id in the output matches the calculated one
- `TokensTickerMaxLengthVersion`: max token ticker length was changed from 5 to 12