### PR TITLE
Blockprod pow/pos separation

### DIFF
--- a/blockprod/src/detail/block_production_job_wrapper.rs
+++ b/blockprod/src/detail/block_production_job_wrapper.rs
@@ -1,0 +1,252 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{cmp, sync::Arc};
+
+use chainstate::{ChainstateHandle, GenBlockIndex};
+use common::{
+    chain::{
+        block::timestamp::BlockTimestamp, Block, ChainConfig, RequiredConsensus, SignedTransaction,
+        Transaction,
+    },
+    primitives::Id,
+    time_getter::TimeGetter,
+};
+use consensus::ConsensusCreationError;
+use mempool::{tx_accumulator::PackingStrategy, MempoolHandle};
+use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
+use utils::{atomics::RelaxedAtomicBool, once_destructor::OnceDestructor};
+
+use crate::BlockProductionError;
+
+use super::{job_manager::JobManagerInterface, CustomId};
+
+pub struct BlockProductionJobWrapper {
+    job_id: CustomId,
+    tip_block_index: GenBlockIndex,
+    /// The so-called "median time past" timestamp calculated from the current tip.
+    /// Note: when validating a block, the lock-time constraints of its transactions
+    /// are validated against the "median time past" of the block's parent, rather than
+    /// the timestamp of the block itself.
+    /// So when constructing a new block we must make sure that transactions with locks
+    /// after this point are not included, otherwise the block will be incorrect.
+    tip_median_time_past: BlockTimestamp,
+    stop_flag: Arc<RelaxedAtomicBool>,
+    starting_timestamp: BlockTimestamp,
+    max_timestamp: BlockTimestamp,
+    cancel_receiver: UnboundedReceiver<()>,
+    job_finished_receiver: Option<oneshot::Receiver<usize>>,
+}
+
+impl BlockProductionJobWrapper {
+    pub async fn new(
+        job_id: CustomId,
+        job_manager_handle: &dyn JobManagerInterface,
+        chainstate_handle: &ChainstateHandle,
+        chain_config: &ChainConfig,
+        time_getter: &TimeGetter,
+    ) -> Result<(Self, OnceDestructor<impl FnOnce()>), BlockProductionError> {
+        let (tip_block_index, tip_median_time_past) = chainstate_handle
+            .call(move |cs| {
+                let tip_block_index = cs.get_best_block_index().map_err(|err| {
+                    BlockProductionError::ChainstateError(
+                        consensus::ChainstateError::FailedToObtainBestBlockIndex(err.to_string()),
+                    )
+                })?;
+                let tip_block_id = tip_block_index.block_id();
+
+                let tip_median_time_past =
+                    cs.calculate_median_time_past(&tip_block_id).map_err(|err| {
+                        BlockProductionError::ChainstateError(
+                            consensus::ChainstateError::FailedToCalculateMedianTimePast(
+                                tip_block_id,
+                                err.to_string(),
+                            ),
+                        )
+                    })?;
+
+                Result::<_, BlockProductionError>::Ok((tip_block_index, tip_median_time_past))
+            })
+            .await??;
+
+        let stop_flag = Arc::new(RelaxedAtomicBool::new(false));
+
+        let (job_key, last_used_block_timestamp, cancel_receiver) =
+            job_manager_handle.add_job(job_id.clone(), tip_block_index.block_id()).await?;
+
+        let (job_stopper_function, job_finished_receiver) =
+            job_manager_handle.make_job_stopper_function();
+
+        // This destructor ensures that the job manager cleans up its housekeeping for the job.
+        // We create it as early as possible - after the job itself has been created but before any
+        // failing code is called.
+        let job_stopper_destructor = OnceDestructor::new(move || job_stopper_function(job_key));
+
+        let starting_timestamp = {
+            let prev_timestamp = cmp::max(
+                last_used_block_timestamp.unwrap_or(BlockTimestamp::from_int_seconds(0)),
+                tip_block_index.block_timestamp(),
+            );
+
+            prev_timestamp
+                .add_int_seconds(1)
+                .ok_or(ConsensusCreationError::TimestampOverflow(prev_timestamp, 1))?
+        };
+
+        let max_timestamp = {
+            let cur_timestamp = BlockTimestamp::from_time(time_getter.get_time());
+
+            cur_timestamp
+                .add_int_seconds(chain_config.max_future_block_time_offset().as_secs())
+                .ok_or(ConsensusCreationError::TimestampOverflow(
+                    cur_timestamp,
+                    chain_config.max_future_block_time_offset().as_secs(),
+                ))?
+        };
+
+        if starting_timestamp > max_timestamp {
+            return Err(BlockProductionError::TryAgainLater);
+        }
+
+        Ok((
+            Self {
+                job_id,
+                tip_block_index,
+                tip_median_time_past,
+                stop_flag,
+                starting_timestamp,
+                max_timestamp,
+                cancel_receiver,
+                job_finished_receiver: Some(job_finished_receiver),
+            },
+            job_stopper_destructor,
+        ))
+    }
+
+    pub fn job_custom_id(&self) -> &CustomId {
+        &self.job_id
+    }
+
+    pub fn tip_block_index(&self) -> &GenBlockIndex {
+        &self.tip_block_index
+    }
+
+    pub fn starting_timestamp(&self) -> BlockTimestamp {
+        self.starting_timestamp
+    }
+
+    pub fn max_timestamp(&self) -> BlockTimestamp {
+        self.max_timestamp
+    }
+
+    pub fn required_consensus_at_next_height(
+        &self,
+        chain_config: &ChainConfig,
+    ) -> RequiredConsensus {
+        let next_block_height = self.tip_block_index.block_height().next_height();
+        chain_config.consensus_upgrades().consensus_status(next_block_height)
+    }
+
+    pub async fn collect_transactions(
+        &self,
+        mempool_handle: &MempoolHandle,
+        chain_config: &ChainConfig,
+        transactions: Vec<SignedTransaction>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
+    ) -> Result<Vec<SignedTransaction>, BlockProductionError> {
+        super::collect_transactions(
+            mempool_handle,
+            chain_config,
+            self.tip_block_index.block_id(),
+            self.tip_median_time_past,
+            transactions,
+            transaction_ids,
+            packing_strategy,
+        )
+        .await
+    }
+
+    pub fn spawn_block_solver<Solver, SolverResult>(
+        &mut self,
+        mining_thread_pool: &slave_pool::ThreadPool,
+        block_solver: Solver,
+    ) -> SpawnedBlockSolverHandle<SolverResult>
+    where
+        Solver: FnOnce(
+                /*stop_flag:*/ Arc<RelaxedAtomicBool>,
+            ) -> Result<SolverResult, BlockProductionError>
+            + Send
+            + 'static,
+        SolverResult: Send + 'static,
+    {
+        // A synchronous channel that sends only when the mining/staking is done
+        let (ended_sender, ended_receiver) = std::sync::mpsc::channel::<()>();
+
+        // Return the result of mining
+        let (result_sender, result_receiver) = oneshot::channel();
+
+        mining_thread_pool.spawn({
+            let stop_flag = Arc::clone(&self.stop_flag);
+
+            move || {
+                let result = block_solver(stop_flag);
+
+                // These can fail if the function exited before the mining thread finished
+                let _ = result_sender.send(result);
+                let _ = ended_sender.send(());
+            }
+        });
+
+        SpawnedBlockSolverHandle {
+            result_receiver,
+            ended_receiver,
+        }
+    }
+
+    pub async fn wait_for_block_solver_result<SolverResult>(
+        &mut self,
+        mut handle: SpawnedBlockSolverHandle<SolverResult>,
+    ) -> Result<SolverResult, BlockProductionError> {
+        tokio::select! {
+            _ = self.cancel_receiver.recv() => {
+                self.stop_flag.store(true);
+
+                // This can fail if the mining thread has already finished
+                let _ended = handle.ended_receiver.recv();
+
+                Err(BlockProductionError::Cancelled)
+            }
+            solver_result = &mut handle.result_receiver => {
+                let solver_result = solver_result.map_err(|_| BlockProductionError::TaskExitedPrematurely)??;
+                Ok(solver_result)
+            }
+        }
+    }
+
+    pub fn finish(mut self, block: Block) -> (Block, oneshot::Receiver<usize>) {
+        (
+            block,
+            self.job_finished_receiver
+                .take()
+                .expect("'Job finished' receiver must not be None"),
+        )
+    }
+}
+
+pub struct SpawnedBlockSolverHandle<SolverResult> {
+    result_receiver: oneshot::Receiver<Result<SolverResult, BlockProductionError>>,
+    ended_receiver: std::sync::mpsc::Receiver<()>,
+}

--- a/blockprod/src/detail/tests.rs
+++ b/blockprod/src/detail/tests.rs
@@ -491,7 +491,7 @@ mod produce_block {
                     .await;
 
                 match result {
-                    Err(BlockProductionError::FailedConsensusInitialization(
+                    Err(BlockProductionError::ConsensusCreationError(
                         ConsensusCreationError::TimestampOverflow(_, 1),
                     )) => {}
                     _ => panic!("Expected timestamp overflow"),
@@ -544,7 +544,7 @@ mod produce_block {
                     .await;
 
                 match result {
-                    Err(BlockProductionError::FailedConsensusInitialization(
+                    Err(BlockProductionError::ConsensusCreationError(
                         ConsensusCreationError::TimestampOverflow(_, _),
                     )) => {}
                     _ => panic!("Expected timestamp overflow"),
@@ -619,7 +619,7 @@ mod produce_block {
                     .await;
 
                 match result {
-                    Err(BlockProductionError::FailedConsensusInitialization(
+                    Err(BlockProductionError::ConsensusCreationError(
                         ConsensusCreationError::TimestampOverflow(_, _),
                     )) => {}
                     _ => panic!("Expected timestamp overflow"),
@@ -1589,7 +1589,7 @@ mod produce_block {
                                 .await;
 
                             match input_data_none_result {
-                                Err(BlockProductionError::FailedConsensusInitialization(
+                                Err(BlockProductionError::ConsensusCreationError(
                                     ConsensusCreationError::StakingError(
                                         ConsensusPoSError::NoInputDataProvided,
                                     ),
@@ -1609,7 +1609,7 @@ mod produce_block {
                                 .await;
 
                             match input_data_pow_result {
-                                Err(BlockProductionError::FailedConsensusInitialization(
+                                Err(BlockProductionError::ConsensusCreationError(
                                     ConsensusCreationError::StakingError(
                                         ConsensusPoSError::PoWInputDataProvided,
                                     ),
@@ -1661,7 +1661,7 @@ mod produce_block {
                                 .await;
 
                             match input_data_none_result {
-                                Err(BlockProductionError::FailedConsensusInitialization(
+                                Err(BlockProductionError::ConsensusCreationError(
                                     ConsensusCreationError::MiningError(
                                         ConsensusPoWError::NoInputDataProvided,
                                     ),
@@ -1681,7 +1681,7 @@ mod produce_block {
                                 .await;
 
                             match input_data_pos_result {
-                                Err(BlockProductionError::FailedConsensusInitialization(
+                                Err(BlockProductionError::ConsensusCreationError(
                                     ConsensusCreationError::MiningError(
                                         ConsensusPoWError::PoSInputDataProvided,
                                     ),

--- a/blockprod/src/lib.rs
+++ b/blockprod/src/lib.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 
 use chainstate::ChainstateHandle;
 use common::{
-    chain::{block::BlockCreationError, ChainConfig, GenBlock, Transaction},
-    primitives::{BlockHeight, Id},
+    chain::{block::BlockCreationError, ChainConfig, Transaction},
+    primitives::Id,
     time_getter::TimeGetter,
 };
 use config::BlockProdConfig;
@@ -40,8 +40,6 @@ use subsystem::error::CallError;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum BlockProductionError {
-    #[error("Failed to retrieve chainstate info")]
-    ChainstateInfoRetrievalError,
     #[error("Wait for chainstate to sync before producing blocks")]
     ChainstateWaitForSync,
     #[error("Subsystem call error")]
@@ -60,8 +58,6 @@ pub enum BlockProductionError {
     PeerCountBelowRequiredThreshold(usize, usize),
     #[error("Block not found in this round")]
     TryAgainLater,
-    #[error("Tip has changed. Stopping block production for previous tip {0} with height {1} to new tip {2} with height {3}")]
-    TipChanged(Id<GenBlock>, BlockHeight, Id<GenBlock>, BlockHeight),
     #[error("Job already exists")]
     JobAlreadyExists(JobKey),
     #[error("Job manager error: {0}")]
@@ -70,6 +66,12 @@ pub enum BlockProductionError {
     MempoolBlockConstruction(#[from] mempool::error::BlockConstructionError),
     #[error("Failed to decrypt generate-block input data: {0}")]
     E2eError(#[from] ephemeral_e2e::error::Error),
+    #[error("Task exited prematurely")]
+    TaskExitedPrematurely,
+    #[error("Recoverable mempool error")]
+    RecoverableMempoolError,
+    #[error("Chainstate error: `{0}`")]
+    ChainstateError(#[from] consensus::ChainstateError),
 }
 
 pub type BlockProductionSubsystem = Box<dyn BlockProductionInterface>;

--- a/blockprod/src/lib.rs
+++ b/blockprod/src/lib.rs
@@ -49,11 +49,11 @@ pub enum BlockProductionError {
     #[error("Block creation error: {0}")]
     FailedToConstructBlock(#[from] BlockCreationError),
     #[error("Initialization of consensus failed: {0}")]
-    FailedConsensusInitialization(#[from] ConsensusCreationError),
+    ConsensusCreationError(#[from] ConsensusCreationError),
     #[error("Block production cancelled")]
     Cancelled,
     #[error("Failed to retrieve peer count")]
-    PeerCountRetrievalError,
+    PeerCountRetrievalError(String),
     #[error("Connected peers {0} is below the required peer threshold {0}")]
     PeerCountBelowRequiredThreshold(usize, usize),
     #[error("Block not found in this round")]
@@ -72,6 +72,10 @@ pub enum BlockProductionError {
     RecoverableMempoolError,
     #[error("Chainstate error: `{0}`")]
     ChainstateError(#[from] consensus::ChainstateError),
+    #[error("PoS data provided when consensus is supposed to be ignored")]
+    PoSInputDataProvidedWhenIgnoringConsensus,
+    #[error("PoW data provided when consensus is supposed to be ignored")]
+    PoWInputDataProvidedWhenIgnoringConsensus,
 }
 
 pub type BlockProductionSubsystem = Box<dyn BlockProductionInterface>;

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -303,6 +303,7 @@ impl BanScore for ConsensusVerificationError {
 impl BanScore for ConsensusPoWError {
     fn ban_score(&self) -> u32 {
         match self {
+            ConsensusPoWError::ChainstateError(_) => 0,
             ConsensusPoWError::InvalidPoW(_) => 100,
             ConsensusPoWError::NoInputDataProvided => 100,
             ConsensusPoWError::PoSInputDataProvided => 100,

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -203,7 +203,7 @@ where
         epoch_index,
         block.header().timestamp(),
         &sealed_epoch_randomness,
-        pos_data,
+        pos_data.vrf_data(),
         &vrf_pub_key,
     )
     .map_err(EpochSealError::RandomnessError)

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -501,6 +501,7 @@ impl BlockProcessingErrorClassification for ConsensusPoWError {
             | ConsensusPoWError::PoSInputDataProvided
             | ConsensusPoWError::NoInputDataProvided => BlockProcessingErrorClass::BadBlock,
 
+            ConsensusPoWError::ChainstateError(err) => err.classify(),
             ConsensusPoWError::PrevBlockLoadError(_, err) => err.classify(),
             ConsensusPoWError::AncestorAtHeightNotFound(_, _, err) => err.classify(),
         }
@@ -568,6 +569,7 @@ impl BlockProcessingErrorClassification for consensus::ChainstateError {
             ChainstateError::FailedToObtainEpochData(_, _)
             | ChainstateError::FailedToCalculateMedianTimePast(_, _)
             | ChainstateError::FailedToObtainBestBlockIndex(_)
+            | ChainstateError::FailedToObtainAncestor(_, _, _)
             | ChainstateError::StakePoolDataReadError(_, _)
             | ChainstateError::PoolBalanceReadError(_, _) => BlockProcessingErrorClass::General,
         }

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -565,11 +565,11 @@ impl BlockProcessingErrorClassification for consensus::ChainstateError {
 
         match self {
             // These all represent a general chainstate failure.
-            // TODO: it's better to delegate to the inner error anyway.
-            ChainstateError::FailedToObtainEpochData(_, _err)
-            | ChainstateError::FailedToCalculateMedianTimePast(_, _err)
-            | ChainstateError::StakePoolDataReadError(_, _err)
-            | ChainstateError::PoolBalanceReadError(_, _err) => BlockProcessingErrorClass::General,
+            ChainstateError::FailedToObtainEpochData(_, _)
+            | ChainstateError::FailedToCalculateMedianTimePast(_, _)
+            | ChainstateError::FailedToObtainBestBlockIndex(_)
+            | ChainstateError::StakePoolDataReadError(_, _)
+            | ChainstateError::PoolBalanceReadError(_, _) => BlockProcessingErrorClass::General,
         }
     }
 }

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -1322,7 +1322,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         1,
         block_e.timestamp(),
         &initial_randomness,
-        block_e_pos_data,
+        block_e_pos_data.vrf_data(),
         &vrf_pk,
     )
     .unwrap();

--- a/chainstate/types/src/pos_randomness.rs
+++ b/chainstate/types/src/pos_randomness.rs
@@ -14,14 +14,10 @@
 // limitations under the License.
 
 use common::{
-    chain::{
-        block::{consensus_data::PoSData, timestamp::BlockTimestamp},
-        config::EpochIndex,
-        Block, ChainConfig,
-    },
+    chain::{block::timestamp::BlockTimestamp, config::EpochIndex, Block, ChainConfig},
     primitives::{Id, H256},
 };
-use crypto::vrf::VRFPublicKey;
+use crypto::vrf::{VRFPublicKey, VRFReturn};
 use serialization::{Decode, Encode};
 use thiserror::Error;
 
@@ -49,13 +45,13 @@ impl PoSRandomness {
         epoch_index: EpochIndex,
         block_timestamp: BlockTimestamp,
         seal_randomness: &PoSRandomness,
-        pos_data: &PoSData,
+        vrf_data: &VRFReturn,
         vrf_pub_key: &VRFPublicKey,
     ) -> Result<Self, PoSRandomnessError> {
         let hash: H256 = verify_vrf_and_get_vrf_output(
             epoch_index,
             &seal_randomness.value(),
-            pos_data.vrf_data(),
+            vrf_data,
             vrf_pub_key,
             block_timestamp,
         )?;

--- a/common/src/chain/block/mod.rs
+++ b/common/src/chain/block/mod.rs
@@ -52,8 +52,6 @@ use super::signed_transaction::SignedTransaction;
 pub enum BlockCreationError {
     #[error("Merkle tree calculation error: {0}")]
     MerkleTreeError(#[from] BlockMerkleTreeError),
-    #[error("Error finding current tip")]
-    CurrentTipRetrievalError,
     #[error("Merkle tree mismatch: Provided {0} vs calculated {1}")]
     MerkleTreeMismatch(H256, H256),
     #[error("Witness merkle tree mismatch: Provided {0} vs calculated {1}")]

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -72,12 +72,6 @@ pub enum ConsensusCreationError {
     StakingFailed,
     #[error("Overflowed when calculating a block timestamp: {0} + {1}")]
     TimestampOverflow(BlockTimestamp, u64),
-
-    // FIXME better place?
-    #[error("PoS data provided when consensus is supposed to be ignored")]
-    PoSInputDataProvidedWhenIgnoringConsensus,
-    #[error("PoW data provided when consensus is supposed to be ignored")]
-    PoWInputDataProvidedWhenIgnoringConsensus,
 }
 
 // TODO: include the original chainstate::ChainstateError in each error below.

--- a/consensus/src/pos/error.rs
+++ b/consensus/src/pos/error.rs
@@ -115,6 +115,8 @@ pub enum ChainstateError {
     FailedToObtainEpochData(BlockHeight, String),
     #[error("Failed to calculate median time past starting from block {0}: {1}")]
     FailedToCalculateMedianTimePast(Id<GenBlock>, String),
+    #[error("Failed to obtain best block index: {0}")]
+    FailedToObtainBestBlockIndex(String),
     #[error("Failed to read data of pool {0}: {1}")]
     StakePoolDataReadError(PoolId, String),
     #[error("Failed to read balance of pool {0}: {1}")]

--- a/consensus/src/pos/error.rs
+++ b/consensus/src/pos/error.rs
@@ -17,8 +17,8 @@ use thiserror::Error;
 
 use chainstate_types::pos_randomness::PoSRandomnessError;
 use common::{
-    chain::{block::timestamp::BlockTimestamp, Block, GenBlock, PoolId},
-    primitives::{BlockHeight, Compact, Id},
+    chain::{block::timestamp::BlockTimestamp, Block, PoolId},
+    primitives::{Compact, Id},
     UintConversionError,
 };
 
@@ -31,7 +31,7 @@ pub enum ConsensusPoSError {
     #[error("Property query error: `{0}`")]
     PropertyQueryError(#[from] chainstate_types::PropertyQueryError),
     #[error("Chainstate error: `{0}`")]
-    ChainstateError(#[from] ChainstateError),
+    ChainstateError(#[from] crate::ChainstateError),
 
     #[error("Stake kernel hash failed to meet the target requirement")]
     StakeKernelHashTooHigh,
@@ -106,19 +106,4 @@ pub enum ConsensusPoSError {
     EffectivePoolBalanceError(#[from] EffectivePoolBalanceError),
     #[error("Failed to calculate capped balance")]
     FailedToCalculateCappedBalance,
-}
-
-// TODO: include the original chainstate::ChainstateError in each error below.
-#[derive(Error, Debug, PartialEq, Eq, Clone)]
-pub enum ChainstateError {
-    #[error("Failed to obtain epoch for block height {0}: {1}")]
-    FailedToObtainEpochData(BlockHeight, String),
-    #[error("Failed to calculate median time past starting from block {0}: {1}")]
-    FailedToCalculateMedianTimePast(Id<GenBlock>, String),
-    #[error("Failed to obtain best block index: {0}")]
-    FailedToObtainBestBlockIndex(String),
-    #[error("Failed to read data of pool {0}: {1}")]
-    StakePoolDataReadError(PoolId, String),
-    #[error("Failed to read balance of pool {0}: {1}")]
-    PoolBalanceReadError(PoolId, String),
 }

--- a/consensus/src/pos/input_data.rs
+++ b/consensus/src/pos/input_data.rs
@@ -24,7 +24,6 @@ use chainstate_types::{
 use common::{
     chain::block::{
         consensus_data::PoSData, timestamp::BlockTimestamp, BlockReward, BlockRewardTransactable,
-        ConsensusData,
     },
     chain::{
         config::EpochIndex,
@@ -134,8 +133,6 @@ pub struct PoSFinalizeBlockInputData {
     epoch_index: EpochIndex,
     /// The sealed epoch randomness (i.e used in producing VRF data)
     sealed_epoch_randomness: PoSRandomness,
-    /// The maximum timestamp to try and staking with
-    max_block_timestamp: BlockTimestamp,
     /// The amount pledged to the pool
     pledge_amount: Amount,
     /// The current pool balance of the stake pool
@@ -148,7 +145,6 @@ impl PoSFinalizeBlockInputData {
         vrf_private_key: VRFPrivateKey,
         epoch_index: EpochIndex,
         sealed_epoch_randomness: PoSRandomness,
-        max_block_timestamp: BlockTimestamp,
         pledge_amount: Amount,
         pool_balance: Amount,
     ) -> Self {
@@ -157,7 +153,6 @@ impl PoSFinalizeBlockInputData {
             vrf_private_key,
             epoch_index,
             sealed_epoch_randomness,
-            max_block_timestamp,
             pledge_amount,
             pool_balance,
         }
@@ -165,10 +160,6 @@ impl PoSFinalizeBlockInputData {
 
     pub fn epoch_index(&self) -> EpochIndex {
         self.epoch_index
-    }
-
-    pub fn max_block_timestamp(&self) -> BlockTimestamp {
-        self.max_block_timestamp
     }
 
     pub fn pool_balance(&self) -> Amount {
@@ -206,7 +197,7 @@ pub fn generate_pos_consensus_data_and_reward<G>(
     block_timestamp: BlockTimestamp,
     block_height: BlockHeight,
     get_ancestor: G,
-) -> Result<(ConsensusData, BlockReward), ConsensusCreationError>
+) -> Result<(PoSData, BlockReward), ConsensusCreationError>
 where
     G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
 {
@@ -258,13 +249,13 @@ where
         get_ancestor,
     )?;
 
-    let consensus_data = ConsensusData::PoS(Box::new(PoSData::new(
+    let consensus_data = PoSData::new(
         pos_input_data.kernel_inputs().clone(),
         vec![input_witness],
         pos_input_data.pool_id(),
         vrf_data,
         target_required,
-    )));
+    );
 
     let block_reward = BlockReward::new(kernel_output);
 

--- a/consensus/src/pos/input_data.rs
+++ b/consensus/src/pos/input_data.rs
@@ -13,10 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    pos::{error::ConsensusPoSError, target::calculate_target_required_from_block_index},
-    ConsensusCreationError,
-};
+use crate::pos::{error::ConsensusPoSError, target::calculate_target_required_from_block_index};
 use chainstate_types::{
     pos_randomness::PoSRandomness, vrf_tools::construct_transcript, BlockIndex, GenBlockIndex,
 };
@@ -196,7 +193,7 @@ pub fn generate_pos_consensus_data_and_reward<G>(
     block_timestamp: BlockTimestamp,
     block_height: BlockHeight,
     get_ancestor: G,
-) -> Result<(PoSData, BlockReward), ConsensusCreationError>
+) -> Result<(PoSData, BlockReward), ConsensusPoSError>
 where
     G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {

--- a/consensus/src/pos/input_data.rs
+++ b/consensus/src/pos/input_data.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 use chainstate_types::{
     pos_randomness::PoSRandomness, vrf_tools::construct_transcript, BlockIndex, GenBlockIndex,
-    PropertyQueryError,
 };
 use common::{
     chain::block::{
@@ -199,7 +198,7 @@ pub fn generate_pos_consensus_data_and_reward<G>(
     get_ancestor: G,
 ) -> Result<(PoSData, BlockReward), ConsensusCreationError>
 where
-    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     let reward_destination = Destination::PublicKey(pos_input_data.stake_public_key());
 

--- a/consensus/src/pos/target.rs
+++ b/consensus/src/pos/target.rs
@@ -243,7 +243,10 @@ mod tests {
     use itertools::Itertools;
     use randomness::{CryptoRng, Rng};
     use rstest::rstest;
-    use test_utils::random::{make_seedable_rng, Seed};
+    use test_utils::{
+        assert_matches,
+        random::{make_seedable_rng, Seed},
+    };
 
     use super::*;
 
@@ -662,10 +665,12 @@ mod tests {
 
         let res = calculate_average_block_time(&pos_config, &random_block_index, get_ancestor)
             .unwrap_err();
-        assert_eq!(
+        assert_matches!(
             res,
-            ConsensusPoSError::PropertyQueryError(PropertyQueryError::GetAncestorError(
-                GetAncestorError::PrevBlockIndexNotFound(random_block.get_id().into())
+            ConsensusPoSError::ChainstateError(crate::ChainstateError::FailedToObtainAncestor(
+                _,
+                _,
+                _
             ))
         );
     }

--- a/consensus/src/pow/error.rs
+++ b/consensus/src/pow/error.rs
@@ -24,6 +24,8 @@ use common::{
 /// A proof of work consensus error.
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum ConsensusPoWError {
+    #[error("Chainstate error: `{0}`")]
+    ChainstateError(#[from] crate::ChainstateError),
     #[error("Invalid Proof of Work for block {0}")]
     InvalidPoW(Id<Block>),
     #[error("Error while loading previous block with id {0} with error {1}")]

--- a/consensus/src/pow/helpers.rs
+++ b/consensus/src/pow/helpers.rs
@@ -15,7 +15,7 @@
 
 use std::num::NonZeroU64;
 
-use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
+use chainstate_types::{BlockIndex, GenBlockIndex};
 use common::{
     chain::block::timestamp::BlockTimestamp,
     primitives::{BlockHeight, Compact},
@@ -38,7 +38,7 @@ pub fn get_starting_block_time<F>(
     get_ancestor: F,
 ) -> Result<BlockTimestamp, ConsensusPoWError>
 where
-    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     let retarget_height = {
         let height: u64 = block_index.block_height().into();
@@ -47,9 +47,7 @@ where
         BlockHeight::new(old_block_height)
     };
 
-    let retarget_block_index = get_ancestor(block_index, retarget_height).map_err(|err| {
-        ConsensusPoWError::AncestorAtHeightNotFound(*block_index.block_id(), retarget_height, err)
-    })?;
+    let retarget_block_index = get_ancestor(block_index, retarget_height)?;
 
     Ok(retarget_block_index.block_timestamp())
 }

--- a/consensus/src/pow/input_data.rs
+++ b/consensus/src/pow/input_data.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::pow::{calculate_work_required, error::ConsensusPoWError};
-use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
+use chainstate_types::{BlockIndex, GenBlockIndex};
 use common::{
     chain::{
         block::{consensus_data::PoWData, timestamp::BlockTimestamp, BlockReward},
@@ -52,7 +52,7 @@ pub fn generate_pow_consensus_data_and_reward<G>(
     block_height: BlockHeight,
 ) -> Result<(PoWData, BlockReward), ConsensusPoWError>
 where
-    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     let work_required = calculate_work_required(
         chain_config,

--- a/consensus/src/pow/input_data.rs
+++ b/consensus/src/pow/input_data.rs
@@ -17,7 +17,7 @@ use crate::pow::{calculate_work_required, error::ConsensusPoWError};
 use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
 use common::{
     chain::{
-        block::{consensus_data::PoWData, timestamp::BlockTimestamp, BlockReward, ConsensusData},
+        block::{consensus_data::PoWData, timestamp::BlockTimestamp, BlockReward},
         output_value::OutputValue,
         timelock::OutputTimeLock,
         ChainConfig, Destination, PoWStatus, TxOutput,
@@ -50,7 +50,7 @@ pub fn generate_pow_consensus_data_and_reward<G>(
     get_ancestor: G,
     pow_input_data: PoWGenerateBlockInputData,
     block_height: BlockHeight,
-) -> Result<(ConsensusData, BlockReward), ConsensusPoWError>
+) -> Result<(PoWData, BlockReward), ConsensusPoWError>
 where
     G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
 {
@@ -62,7 +62,7 @@ where
         get_ancestor,
     )?;
 
-    let consensus_data = ConsensusData::PoW(Box::new(PoWData::new(work_required, 0)));
+    let consensus_data = PoWData::new(work_required, 0);
 
     let time_lock = {
         let block_count = chain_config.get_proof_of_work_config().reward_maturity_distance();

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -971,6 +971,9 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                 continue;
             }
 
+            let staking_start_time = std::time::Instant::now();
+            log::debug!("Starting staking loop");
+
             for account_index in staking_started.iter() {
                 let generate_res = self
                     .generate_block(
@@ -996,6 +999,11 @@ impl<T: NodeInterface + Clone + Send + Sync + 'static, W: WalletEvents> Controll
                     continue 'outer;
                 }
             }
+
+            log::debug!(
+                "Ended staking loop, elapsed time = {:?}",
+                staking_start_time.elapsed()
+            );
 
             tokio::time::sleep(NORMAL_DELAY).await;
 


### PR DESCRIPTION
 `BlockProduction::produce_block_with_custom_id` now delegates to one of 3 separate functions, based on the passed input data and the required consensus - `produce_block_pos`/`produce_block_pow`/`produce_block_ignore_consensus`; each of the functions works with the specific type of consensus and doesn't have to `match` it anymore (in the current master we `match` the required consensus multiple times on different levels).

Some common code that is shared among the functions has been put to the `Helper` struct.

The produce_block_xxx functions are now implemented differently:
1) Only the "pow" one spawns a new job on the thread pool (because only in this case the task is heavy and needs cancellation if the tip has changed).
2) the "pos" one constructs the block only after it has found a free time slot (though currently I don't take any advantage of this).

Also, the internal loop that the original `produce_block_with_custom_id` used to have no longer exists because IMO it was redundant (iteration could only happen on a "recoverable" mempool error, i.e. the one that happens when the tip changes; in this case we may just exit and let the wallet call blockprod again).

This is still work-in-progress. There is still more cleanup to be done (e.g. I'd get rid of the `last_used_block_timestamps` in `JobsContainer` because it's PoS specific and IMO should be stored somewhere else). Also, we need to make use of the fact that in PoS the block can now be constructed after staking has suceeded.