### PR TITLE
p2p: fix the failure of the test `banned_address_not_in_addr_response`

### DIFF
--- a/dns-server/src/crawler_p2p/crawler_manager/mod.rs
+++ b/dns-server/src/crawler_p2p/crawler_manager/mod.rs
@@ -224,7 +224,7 @@ where
                     peer_id,
                     address.to_string()
                 );
-                if let Some(address) = SocketAddress::from_peer_address(&address, false) {
+                if let Some(address) = address.as_discoverable_socket_address(false) {
                     self.send_crawler_event(CrawlerEvent::AddressAnnouncement {
                         address,
                         sender: peer_id,
@@ -257,7 +257,7 @@ where
 
                 let addresses = addresses
                     .iter()
-                    .filter_map(|addr| SocketAddress::from_peer_address(addr, false))
+                    .filter_map(|addr| addr.as_discoverable_socket_address(false))
                     .collect::<Vec<_>>();
 
                 self.send_crawler_event(CrawlerEvent::AddressListResponse {

--- a/p2p/src/peer_manager/dns_seed.rs
+++ b/p2p/src/peer_manager/dns_seed.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common::chain::ChainConfig;
 use logging::log;
-use p2p_types::socket_address::SocketAddress;
+use p2p_types::{peer_address::PeerAddress, socket_address::SocketAddress};
 use randomness::{make_pseudo_rng, seq::IteratorRandom};
 
 use crate::config::P2pConfig;
@@ -67,9 +67,8 @@ impl DnsSeed for DefaultDnsSeed {
             match result {
                 Ok(list) => {
                     list.filter_map(|addr| {
-                        SocketAddress::from_peer_address(
-                            // Convert SocketAddr to PeerAddress
-                            &addr.into(),
+                        let addr: PeerAddress = addr.into();
+                        addr.as_discoverable_socket_address(
                             *self.p2p_config.allow_discover_private_ips,
                         )
                     })

--- a/p2p/src/peer_manager/peerdb/address_tables/table.rs
+++ b/p2p/src/peer_manager/peerdb/address_tables/table.rs
@@ -270,7 +270,12 @@ pub mod test_utils {
     pub fn make_random_address(rng: &mut impl Rng) -> SocketAddress {
         let addr_v4 = SocketAddrV4::new(
             Ipv4Addr::new(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
-            rng.gen(),
+            // Note: addresses with zero port are never considered discoverable
+            // (PeerAddress::.as_discoverable_socket_address always returns None for them),
+            // so some test may malfunction if such an address is generated.
+            // On the other hand, in general, it doesn't make much sense to produce random socket
+            // addresses with zero port, so we disable it on this level.
+            rng.gen_range(1..=u16::MAX),
         );
         SocketAddress::new(SocketAddr::V4(addr_v4))
     }

--- a/p2p/src/peer_manager/tests/addr_list_response_caching.rs
+++ b/p2p/src/peer_manager/tests/addr_list_response_caching.rs
@@ -25,7 +25,7 @@ use common::{
 use networking::test_helpers::TestAddressMaker;
 use networking::{transport::TcpTransportSocket, types::ConnectionDirection};
 use p2p_test_utils::expect_recv;
-use p2p_types::{peer_address::PeerAddress, socket_address::SocketAddress};
+use p2p_types::peer_address::PeerAddress;
 use randomness::Rng;
 use test_utils::{
     assert_matches_return_val,
@@ -99,7 +99,8 @@ async fn basic_test(#[case] seed: Seed) {
     // Remove the addresses from the db
     for address in &addresses_for_peer1 {
         peer_mgr.peerdb.remove_address(
-            &SocketAddress::from_peer_address(address, *p2p_config.allow_discover_private_ips)
+            &address
+                .as_discoverable_socket_address(*p2p_config.allow_discover_private_ips)
                 .unwrap(),
         );
     }

--- a/p2p/src/peer_manager/tests/addresses.rs
+++ b/p2p/src/peer_manager/tests/addresses.rs
@@ -72,10 +72,10 @@ use crate::{
     PeerManagerEvent,
 };
 
-fn get_new_public_address(rng: &mut impl Rng) -> PeerAddress {
+fn get_new_discoverable_address(rng: &mut impl Rng) -> PeerAddress {
     loop {
         let address = TestAddressMaker::new_random_address(&mut *rng).as_peer_address();
-        if SocketAddress::from_peer_address(&address, false).is_some() {
+        if address.as_discoverable_socket_address(false).is_some() {
             return address;
         }
     }
@@ -123,7 +123,7 @@ where
     assert_eq!(pm.peers.len(), 1);
 
     // Check that nodes are allowed to send own address immediately after connecting
-    let address = get_new_public_address(&mut rng);
+    let address = get_new_discoverable_address(&mut rng);
     pm.handle_announce_addr_request(peer_id, address);
     let accepted_count = pm.peerdb.known_addresses().count();
     assert_eq!(accepted_count, 1);
@@ -460,7 +460,7 @@ async fn resend_own_addresses(#[case] seed: Seed) {
                 PeerManagerMessage::AnnounceAddrRequest(AnnounceAddrRequest { address }),
             ) = message.categorize()
             {
-                let announced_addr = SocketAddress::from_peer_address(&address, false).unwrap();
+                let announced_addr = address.as_discoverable_socket_address(false).unwrap();
                 listening_addresses.remove(&announced_addr);
             }
         }

--- a/p2p/types/src/socket_address.rs
+++ b/p2p/types/src/socket_address.rs
@@ -15,13 +15,13 @@
 
 use std::{
     fmt::Display,
-    net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{AddrParseError, IpAddr, SocketAddr},
     str::FromStr,
 };
 
 use serde::{Deserialize, Serialize};
 
-use crate::{bannable_address::BannableAddress, peer_address::PeerAddress, IsGlobalIp};
+use crate::{bannable_address::BannableAddress, peer_address::PeerAddress};
 
 #[derive(
     Debug,
@@ -57,24 +57,6 @@ impl SocketAddress {
 
     pub fn as_peer_address(&self) -> PeerAddress {
         self.0.into()
-    }
-
-    pub fn from_peer_address(address: &PeerAddress, allow_private_ips: bool) -> Option<Self> {
-        match &address {
-            PeerAddress::Ip4(socket)
-                if (Ipv4Addr::from(socket.ip).is_global_unicast_ip() || allow_private_ips)
-                    && socket.port != 0 =>
-            {
-                Some(SocketAddress::new(address.into()))
-            }
-            PeerAddress::Ip6(socket)
-                if (Ipv6Addr::from(socket.ip).is_global_unicast_ip() || allow_private_ips)
-                    && socket.port != 0 =>
-            {
-                Some(SocketAddress::new(address.into()))
-            }
-            _ => None,
-        }
     }
 }
 


### PR DESCRIPTION
The failure was because an address with zero port was generated for `normal_addr`, which made it non-discoverable, so the fix is that one line in `make_random_address`. But I also decided to replace `SocketAddress::from_peer_address` with `PeerAddress::as_discoverable_socket_address`, because this name and location make more sense.