### PR TITLE
Some minor blockprod-related improvements and cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ qrcodegen = "1.8"
 quote = "1.0"
 rand = "0.8"
 rand_chacha = "0.3"
+rayon = "1.10"
 reedline = "0.31"
 ref-cast = "1.0"
 regex = "1.10"
@@ -261,6 +262,11 @@ panic = "abort" # prevent panic catching (mostly for the tokio runtime)
 [profile.release]
 panic = "abort" # prevent panic catching (mostly for the tokio runtime)
 overflow-checks = true
+
+# "Release" profile with debug info enabled.
+[profile.release-with-debug-info]
+inherits = "release"
+debug = true
 
 # "Release" profile with debug info and debug assertions enabled.
 [profile.release-with-debug]

--- a/blockprod/src/detail/utils.rs
+++ b/blockprod/src/detail/utils.rs
@@ -1,0 +1,185 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use chainstate::{
+    chainstate_interface::ChainstateInterface, BlockIndex, GenBlockIndex, NonZeroPoolBalances,
+};
+use chainstate_types::{pos_randomness::PoSRandomness, EpochData};
+use common::{
+    chain::{
+        block::timestamp::{BlockTimestamp, BlockTimestampInternalType},
+        ChainConfig, PoolId,
+    },
+    primitives::{Amount, BlockHeight},
+};
+
+use crate::BlockProductionError;
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum PoSAccountingError {
+    #[error("Staker balance retrieval error: {0}")]
+    StakerBalanceRetrievalError(String),
+}
+
+pub fn get_pool_staker_balance(
+    chainstate: &dyn ChainstateInterface,
+    pool_id: &PoolId,
+) -> Result<Amount, BlockProductionError> {
+    let balance = chainstate
+        .get_stake_pool_data(*pool_id)
+        .map_err(|err| {
+            BlockProductionError::ChainstateError(
+                consensus::ChainstateError::StakePoolDataReadError(*pool_id, err.to_string()),
+            )
+        })?
+        .ok_or(BlockProductionError::PoolDataNotFound(*pool_id))?
+        .staker_balance()
+        .map_err(|err| PoSAccountingError::StakerBalanceRetrievalError(err.to_string()))?;
+
+    Ok(balance)
+}
+
+pub fn get_pool_total_balance(
+    chainstate: &dyn ChainstateInterface,
+    pool_id: &PoolId,
+) -> Result<Amount, BlockProductionError> {
+    let pool_balance = chainstate
+        .get_stake_pool_balance(*pool_id)
+        .map_err(|err| {
+            BlockProductionError::ChainstateError(consensus::ChainstateError::PoolBalanceReadError(
+                *pool_id,
+                err.to_string(),
+            ))
+        })?
+        .ok_or(BlockProductionError::PoolBalanceNotFound(*pool_id))?;
+
+    Ok(pool_balance)
+}
+
+pub fn get_pool_balances_at_heights(
+    chainstate: &dyn ChainstateInterface,
+    min_height: BlockHeight,
+    max_height: BlockHeight,
+    pool_id: &PoolId,
+) -> Result<BTreeMap<BlockHeight, NonZeroPoolBalances>, BlockProductionError> {
+    let balances = chainstate
+        .get_stake_pool_balances_at_heights(&[*pool_id], min_height, max_height)
+        .map_err(|err| {
+            BlockProductionError::ChainstateError(consensus::ChainstateError::PoolBalanceReadError(
+                *pool_id,
+                err.to_string(),
+            ))
+        })?;
+
+    let balances = balances
+        .iter()
+        .filter_map(|(height, balances)| {
+            balances.get(pool_id).map(|balance| (*height, balance.clone()))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    Ok(balances)
+}
+
+pub fn get_pool_balances_at_height(
+    chainstate: &dyn ChainstateInterface,
+    height: BlockHeight,
+    pool_id: &PoolId,
+) -> Result<NonZeroPoolBalances, BlockProductionError> {
+    let mut height_map = get_pool_balances_at_heights(chainstate, height, height, pool_id)?;
+
+    let balances = height_map
+        .remove(&height)
+        .ok_or(BlockProductionError::PoolBalanceNotFound(*pool_id))?;
+
+    Ok(balances)
+}
+
+pub fn get_epoch_data(
+    chainstate: &dyn ChainstateInterface,
+    epoch_index: u64,
+) -> Result<Option<EpochData>, BlockProductionError> {
+    chainstate.get_epoch_data(epoch_index).map_err(|err| {
+        BlockProductionError::ChainstateError(consensus::ChainstateError::FailedToObtainEpochData {
+            epoch_index,
+            error: err.to_string(),
+        })
+    })
+}
+
+pub fn get_sealed_epoch_randomness(
+    chain_config: &ChainConfig,
+    chainstate: &dyn ChainstateInterface,
+    block_height: BlockHeight,
+) -> Result<PoSRandomness, BlockProductionError> {
+    let sealed_epoch_index = chain_config.sealed_epoch_index(&block_height);
+    get_sealed_epoch_randomness_from_sealed_epoch_index(
+        chain_config,
+        chainstate,
+        sealed_epoch_index,
+    )
+}
+
+pub fn get_sealed_epoch_randomness_from_sealed_epoch_index(
+    chain_config: &ChainConfig,
+    chainstate: &dyn ChainstateInterface,
+    sealed_epoch_index: Option<u64>,
+) -> Result<PoSRandomness, BlockProductionError> {
+    let sealed_epoch_randomness = sealed_epoch_index
+        .map(|index| get_epoch_data(chainstate, index))
+        .transpose()?
+        .flatten()
+        .map_or(PoSRandomness::at_genesis(chain_config), |epoch_data| {
+            *epoch_data.randomness()
+        });
+    Ok(sealed_epoch_randomness)
+}
+
+pub fn make_ancestor_getter(
+    cs: &dyn ChainstateInterface,
+) -> impl Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, consensus::ChainstateError> + '_ {
+    |block_index: &BlockIndex, ancestor_height: BlockHeight| {
+        cs.get_ancestor(&block_index.clone().into_gen_block_index(), ancestor_height)
+            .map_err(|err| {
+                consensus::ChainstateError::FailedToObtainAncestor(
+                    *block_index.block_id(),
+                    ancestor_height,
+                    err.to_string(),
+                )
+            })
+    }
+}
+
+pub fn get_best_block_index(
+    chainstate: &dyn ChainstateInterface,
+) -> Result<GenBlockIndex, BlockProductionError> {
+    chainstate.get_best_block_index().map_err(|err| {
+        BlockProductionError::ChainstateError(
+            consensus::ChainstateError::FailedToObtainBestBlockIndex(err.to_string()),
+        )
+    })
+}
+
+pub fn timestamp_add_secs(
+    timestamp: BlockTimestamp,
+    secs: BlockTimestampInternalType,
+) -> Result<BlockTimestamp, BlockProductionError> {
+    let timestamp = timestamp
+        .add_int_seconds(secs)
+        .ok_or(BlockProductionError::TimestampOverflow(timestamp, secs))?;
+    Ok(timestamp)
+}

--- a/blockprod/src/lib.rs
+++ b/blockprod/src/lib.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 pub mod config;
-pub mod detail;
+mod detail;
 pub mod interface;
 pub mod rpc;
 
@@ -22,7 +22,10 @@ use std::sync::Arc;
 
 use chainstate::ChainstateHandle;
 use common::{
-    chain::{block::BlockCreationError, ChainConfig, GenBlock, Transaction},
+    chain::{
+        block::{timestamp::BlockTimestamp, BlockCreationError},
+        ChainConfig, GenBlock, PoolId, Transaction,
+    },
     primitives::{BlockHeight, Id},
     time_getter::TimeGetter,
 };
@@ -70,6 +73,16 @@ pub enum BlockProductionError {
     MempoolBlockConstruction(#[from] mempool::error::BlockConstructionError),
     #[error("Failed to decrypt generate-block input data: {0}")]
     E2eError(#[from] ephemeral_e2e::error::Error),
+    #[error("Overflowed when calculating a block timestamp: {0} + {1}")]
+    TimestampOverflow(BlockTimestamp, u64),
+    #[error("Chainstate error: `{0}`")]
+    ChainstateError(#[from] consensus::ChainstateError),
+    #[error("Pool data for pool {0} not found")]
+    PoolDataNotFound(PoolId),
+    #[error("Balance for pool {0} not found")]
+    PoolBalanceNotFound(PoolId),
+    #[error("PoS accounting error: {0}")]
+    PoSAccountingError(#[from] detail::utils::PoSAccountingError),
 }
 
 pub type BlockProductionSubsystem = Box<dyn BlockProductionInterface>;

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -325,12 +325,12 @@ impl BanScore for ConsensusVerificationError {
 impl BanScore for ConsensusPoWError {
     fn ban_score(&self) -> u32 {
         match self {
+            ConsensusPoWError::ChainstateError(_) => 0,
             ConsensusPoWError::InvalidPoW(_) => 100,
             ConsensusPoWError::NoInputDataProvided => 100,
             ConsensusPoWError::PoSInputDataProvided => 100,
             ConsensusPoWError::PrevBlockLoadError(_, _) => 0,
             ConsensusPoWError::PrevBlockNotFound(_) => 100,
-            ConsensusPoWError::AncestorAtHeightNotFound(_, _, _) => 0,
             ConsensusPoWError::NoPowDataInPreviousBlock => 100,
             ConsensusPoWError::DecodingBitsFailed(_) => 100,
             ConsensusPoWError::PreviousBitsDecodingFailed(_) => 0,

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -203,7 +203,7 @@ where
         epoch_index,
         block.header().timestamp(),
         &sealed_epoch_randomness,
-        pos_data,
+        pos_data.vrf_data(),
         &vrf_pub_key,
     )
     .map_err(EpochSealError::RandomnessError)

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -525,8 +525,8 @@ impl BlockProcessingErrorClassification for ConsensusPoWError {
             | ConsensusPoWError::PoSInputDataProvided
             | ConsensusPoWError::NoInputDataProvided => BlockProcessingErrorClass::BadBlock,
 
+            ConsensusPoWError::ChainstateError(err) => err.classify(),
             ConsensusPoWError::PrevBlockLoadError(_, err) => err.classify(),
-            ConsensusPoWError::AncestorAtHeightNotFound(_, _, err) => err.classify(),
         }
     }
 }
@@ -590,8 +590,13 @@ impl BlockProcessingErrorClassification for consensus::ChainstateError {
         match self {
             // These all represent a general chainstate failure.
             // TODO: it's better to delegate to the inner error anyway.
-            ChainstateError::FailedToObtainEpochData(_, _err)
+            ChainstateError::FailedToObtainEpochData {
+                epoch_index: _,
+                error: _err,
+            }
             | ChainstateError::FailedToCalculateMedianTimePast(_, _err)
+            | ChainstateError::FailedToObtainBestBlockIndex(_err)
+            | ChainstateError::FailedToObtainAncestor(_, _, _err)
             | ChainstateError::StakePoolDataReadError(_, _err)
             | ChainstateError::PoolBalanceReadError(_, _err) => BlockProcessingErrorClass::General,
         }

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -34,6 +34,7 @@ use common::{
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Compact, Id, Idable, H256},
     Uint256,
 };
+use consensus::find_timestamp_for_staking;
 use crypto::{
     key::{PrivateKey, PublicKey},
     vrf::{VRFPrivateKey, VRFPublicKey},
@@ -41,7 +42,6 @@ use crypto::{
 use itertools::Itertools;
 use pos_accounting::{PoSAccountingDB, PoSAccountingView};
 use randomness::{CryptoRng, Rng};
-use test_utils::random::{make_seedable_rng, Seed};
 
 pub fn empty_witness(rng: &mut impl Rng) -> InputWitness {
     use randomness::SliceRandom;
@@ -252,7 +252,6 @@ pub fn produce_kernel_signature(
     .unwrap()
 }
 
-// TODO: consider replacing this function with consensus::pos::stake
 #[allow(clippy::too_many_arguments)]
 pub fn pos_mine(
     rng: &mut (impl Rng + CryptoRng),
@@ -273,18 +272,21 @@ pub fn pos_mine(
     let pool_balance = pos_db.get_pool_balance(pool_id).unwrap().unwrap();
     let pledge_amount = pos_db.get_pool_data(pool_id).unwrap().unwrap().staker_balance().unwrap();
 
-    let seed = rng.gen::<Seed>();
-    let mut timestamp = initial_timestamp;
-    for _ in 0..1000 {
-        let rng = make_seedable_rng(seed);
-        let transcript = chainstate_types::vrf_tools::construct_transcript(
-            epoch_index,
-            &sealed_epoch_randomness.value(),
-            timestamp,
-        )
-        .with_rng(rng);
-        let vrf_data = vrf_sk.produce_vrf_data(transcript);
-
+    find_timestamp_for_staking(
+        final_supply,
+        pos_config,
+        target,
+        initial_timestamp,
+        initial_timestamp.add_int_seconds(1000).unwrap(),
+        &sealed_epoch_randomness,
+        epoch_index,
+        pledge_amount,
+        pool_balance,
+        vrf_sk,
+        rng,
+    )
+    .unwrap()
+    .map(|(timestamp, vrf_data)| {
         let pos_data = PoSData::new(
             vec![kernel_outpoint.clone().into()],
             vec![kernel_witness.clone()],
@@ -293,26 +295,8 @@ pub fn pos_mine(
             target,
         );
 
-        let vrf_pk = VRFPublicKey::from_private_key(vrf_sk);
-        if consensus::check_pos_hash(
-            pos_config.consensus_version(),
-            epoch_index,
-            &sealed_epoch_randomness,
-            &pos_data,
-            &vrf_pk,
-            timestamp,
-            pledge_amount,
-            pool_balance,
-            final_supply.to_amount_atoms(),
-        )
-        .is_ok()
-        {
-            return Some((pos_data, timestamp));
-        }
-
-        timestamp = timestamp.add_int_seconds(1).unwrap();
-    }
-    None
+        (pos_data, timestamp)
+    })
 }
 
 #[allow(unused)]

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -1342,7 +1342,7 @@ fn check_pool_balance_after_reorg(#[case] seed: Seed) {
         1,
         block_e.timestamp(),
         &initial_randomness,
-        block_e_pos_data,
+        block_e_pos_data.vrf_data(),
         &vrf_pk,
     )
     .unwrap();

--- a/chainstate/types/src/pos_randomness.rs
+++ b/chainstate/types/src/pos_randomness.rs
@@ -14,14 +14,10 @@
 // limitations under the License.
 
 use common::{
-    chain::{
-        block::{consensus_data::PoSData, timestamp::BlockTimestamp},
-        config::EpochIndex,
-        Block, ChainConfig,
-    },
+    chain::{block::timestamp::BlockTimestamp, config::EpochIndex, Block, ChainConfig},
     primitives::{Id, H256},
 };
-use crypto::vrf::VRFPublicKey;
+use crypto::vrf::{VRFPublicKey, VRFReturn};
 use serialization::{Decode, Encode};
 use thiserror::Error;
 
@@ -35,7 +31,7 @@ pub enum PoSRandomnessError {
     VRFDataVerificationFailed(#[from] ProofOfStakeVRFError),
 }
 
-#[derive(Debug, Encode, Decode, Clone, Copy)]
+#[derive(Debug, Encode, Decode, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PoSRandomness {
     value: H256,
 }
@@ -49,13 +45,13 @@ impl PoSRandomness {
         epoch_index: EpochIndex,
         block_timestamp: BlockTimestamp,
         seal_randomness: &PoSRandomness,
-        pos_data: &PoSData,
+        vrf_data: &VRFReturn,
         vrf_pub_key: &VRFPublicKey,
     ) -> Result<Self, PoSRandomnessError> {
         let hash: H256 = verify_vrf_and_get_vrf_output(
             epoch_index,
             &seal_randomness.value(),
-            pos_data.vrf_data(),
+            vrf_data,
             vrf_pub_key,
             block_timestamp,
         )?;

--- a/common/src/chain/block/timestamp.rs
+++ b/common/src/chain/block/timestamp.rs
@@ -78,6 +78,13 @@ impl BlockTimestamp {
     pub fn add_int_seconds(&self, seconds: BlockTimestampInternalType) -> Option<BlockTimestamp> {
         self.timestamp.checked_add(seconds).map(|ts| Self { timestamp: ts })
     }
+
+    pub fn iter_up_to_including(
+        &self,
+        other: BlockTimestamp,
+    ) -> impl Iterator<Item = BlockTimestamp> {
+        (self.timestamp..=other.timestamp).map(BlockTimestamp::from_int_seconds)
+    }
 }
 
 #[cfg(test)]
@@ -89,5 +96,18 @@ mod tests {
         let timestamp = BlockTimestamp::from_int_seconds(u64::MAX);
         let timestamp_next = timestamp.add_int_seconds(1);
         assert!(timestamp_next.is_none());
+    }
+
+    #[test]
+    fn iteration() {
+        let timestamps = BlockTimestamp::from_int_seconds(1)
+            .iter_up_to_including(BlockTimestamp::from_int_seconds(3))
+            .collect::<Vec<_>>();
+        let expected_timestamps = vec![
+            BlockTimestamp::from_int_seconds(1),
+            BlockTimestamp::from_int_seconds(2),
+            BlockTimestamp::from_int_seconds(3),
+        ];
+        assert_eq!(timestamps, expected_timestamps);
     }
 }

--- a/common/src/primitives/height.rs
+++ b/common/src/primitives/height.rs
@@ -163,6 +163,10 @@ impl BlockHeight {
     pub const fn into_int(self) -> HeightIntType {
         self.0
     }
+
+    pub fn iter_up_to_including(&self, other: BlockHeight) -> impl Iterator<Item = BlockHeight> {
+        (self.0..=other.0).map(BlockHeight::new)
+    }
 }
 
 /////////////////////////////
@@ -334,5 +338,14 @@ mod tests {
         check(BlockHeight::new(u32::MAX as u64 + 1));
         check(BlockHeight::new(u64::MAX - 1));
         check(BlockHeight::new(u64::MAX));
+    }
+
+    #[test]
+    fn iteration() {
+        let heights = BlockHeight::new(1)
+            .iter_up_to_including(BlockHeight::new(3))
+            .collect::<Vec<_>>();
+        let expected_heights = vec![BlockHeight::new(1), BlockHeight::new(2), BlockHeight::new(3)];
+        assert_eq!(heights, expected_heights);
     }
 }

--- a/consensus/src/pos/error.rs
+++ b/consensus/src/pos/error.rs
@@ -17,10 +17,12 @@ use thiserror::Error;
 
 use chainstate_types::pos_randomness::PoSRandomnessError;
 use common::{
-    chain::{block::timestamp::BlockTimestamp, Block, GenBlock, PoolId},
-    primitives::{BlockHeight, Compact, Id},
+    chain::{block::timestamp::BlockTimestamp, Block, PoolId},
+    primitives::{Compact, Id},
     UintConversionError,
 };
+
+use crate::ChainstateError;
 
 use super::{block_sig::BlockSignatureError, EffectivePoolBalanceError};
 
@@ -106,17 +108,4 @@ pub enum ConsensusPoSError {
     EffectivePoolBalanceError(#[from] EffectivePoolBalanceError),
     #[error("Failed to calculate capped balance")]
     FailedToCalculateCappedBalance,
-}
-
-// TODO: include the original chainstate::ChainstateError in each error below.
-#[derive(Error, Debug, PartialEq, Eq, Clone)]
-pub enum ChainstateError {
-    #[error("Failed to obtain epoch for block height {0}: {1}")]
-    FailedToObtainEpochData(BlockHeight, String),
-    #[error("Failed to calculate median time past starting from block {0}: {1}")]
-    FailedToCalculateMedianTimePast(Id<GenBlock>, String),
-    #[error("Failed to read data of pool {0}: {1}")]
-    StakePoolDataReadError(PoolId, String),
-    #[error("Failed to read balance of pool {0}: {1}")]
-    PoolBalanceReadError(PoolId, String),
 }

--- a/consensus/src/pos/input_data.rs
+++ b/consensus/src/pos/input_data.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 use chainstate_types::{
     pos_randomness::PoSRandomness, vrf_tools::construct_transcript, BlockIndex, GenBlockIndex,
-    PropertyQueryError,
 };
 use common::{
     chain::block::{
@@ -135,8 +134,6 @@ pub struct PoSFinalizeBlockInputData {
     epoch_index: EpochIndex,
     /// The sealed epoch randomness (i.e used in producing VRF data)
     sealed_epoch_randomness: PoSRandomness,
-    /// The maximum timestamp to try and staking with
-    max_block_timestamp: BlockTimestamp,
     /// The amount pledged to the pool
     pledge_amount: Amount,
     /// The current pool balance of the stake pool
@@ -149,7 +146,6 @@ impl PoSFinalizeBlockInputData {
         vrf_private_key: VRFPrivateKey,
         epoch_index: EpochIndex,
         sealed_epoch_randomness: PoSRandomness,
-        max_block_timestamp: BlockTimestamp,
         pledge_amount: Amount,
         pool_balance: Amount,
     ) -> Self {
@@ -158,7 +154,6 @@ impl PoSFinalizeBlockInputData {
             vrf_private_key,
             epoch_index,
             sealed_epoch_randomness,
-            max_block_timestamp,
             pledge_amount,
             pool_balance,
         }
@@ -166,10 +161,6 @@ impl PoSFinalizeBlockInputData {
 
     pub fn epoch_index(&self) -> EpochIndex {
         self.epoch_index
-    }
-
-    pub fn max_block_timestamp(&self) -> BlockTimestamp {
-        self.max_block_timestamp
     }
 
     pub fn pool_balance(&self) -> Amount {
@@ -210,7 +201,7 @@ pub fn generate_pos_consensus_data_and_reward<G, R: Rng + CryptoRng>(
     rng: R,
 ) -> Result<(ConsensusData, BlockReward), ConsensusCreationError>
 where
-    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     let reward_destination = Destination::PublicKey(pos_input_data.stake_public_key());
 

--- a/consensus/src/pos/target.rs
+++ b/consensus/src/pos/target.rs
@@ -15,7 +15,7 @@
 
 use std::num::NonZeroU64;
 
-use chainstate_types::{BlockIndex, BlockIndexHandle, GenBlockIndex, PropertyQueryError};
+use chainstate_types::{BlockIndex, BlockIndexHandle, GenBlockIndex};
 use common::{
     chain::{
         block::ConsensusData, ChainConfig, GenBlock, GenBlockId, PoSChainConfig, PoSStatus,
@@ -26,7 +26,7 @@ use common::{
 };
 use utils::ensure;
 
-use crate::pos::error::ConsensusPoSError;
+use crate::{get_ancestor_from_block_index_handle, pos::error::ConsensusPoSError};
 
 fn calculate_average_block_time<F>(
     pos_config: &PoSChainConfig,
@@ -34,7 +34,7 @@ fn calculate_average_block_time<F>(
     get_ancestor: F,
 ) -> Result<u64, ConsensusPoSError>
 where
-    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     // Average is calculated based on 2 timestamps and then is divided by number of blocks in between.
     // Choose a block from the history that would be the start of a timespan.
@@ -114,7 +114,7 @@ pub fn calculate_target_required_from_block_index<F>(
     get_ancestor: F,
 ) -> Result<Compact, ConsensusPoSError>
 where
-    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     let pos_config = match pos_status {
         PoSStatus::Threshold {
@@ -162,7 +162,7 @@ pub fn calculate_target_required(
         .ok_or(ConsensusPoSError::PrevBlockIndexNotFound(prev_block_id))?;
 
     let get_ancestor = |block_index: &BlockIndex, ancestor_height: BlockHeight| {
-        block_index_handle.get_ancestor(block_index, ancestor_height)
+        get_ancestor_from_block_index_handle(block_index_handle, block_index, ancestor_height)
     };
 
     calculate_target_required_internal(chain_config, pos_config, &prev_block_index, get_ancestor)
@@ -175,7 +175,7 @@ fn calculate_target_required_internal<F>(
     get_ancestor: F,
 ) -> Result<Compact, ConsensusPoSError>
 where
-    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     // check if prev block is a net upgrade threshold
     match chain_config
@@ -513,7 +513,7 @@ mod tests {
         );
 
         let get_ancestor = |block_index: &BlockIndex, ancestor_height: BlockHeight| {
-            block_index_handle.get_ancestor(block_index, ancestor_height)
+            get_ancestor_from_block_index_handle(&block_index_handle, block_index, ancestor_height)
         };
 
         let average_block_time = calculate_average_block_time(
@@ -579,7 +579,7 @@ mod tests {
             TestBlockIndexHandle::new_with_blocks(&mut rng, &chain_config, &[10, 30]);
 
         let get_ancestor = |block_index: &BlockIndex, ancestor_height: BlockHeight| {
-            block_index_handle.get_ancestor(block_index, ancestor_height)
+            get_ancestor_from_block_index_handle(&block_index_handle, block_index, ancestor_height)
         };
 
         // calculating average between 2 blocks with timestamps 10 and 30 should give 20
@@ -621,7 +621,7 @@ mod tests {
             TestBlockIndexHandle::new_with_blocks(&mut rng, &chain_config, &[10, 20, 40]);
 
         let get_ancestor = |block_index: &BlockIndex, ancestor_height: BlockHeight| {
-            block_index_handle.get_ancestor(block_index, ancestor_height)
+            get_ancestor_from_block_index_handle(&block_index_handle, block_index, ancestor_height)
         };
 
         let average_block_time = calculate_average_block_time(
@@ -637,6 +637,8 @@ mod tests {
     #[trace]
     #[case(Seed::from_entropy())]
     fn calculate_average_block_time_no_ancestor(#[case] seed: Seed) {
+        use test_utils::assert_matches;
+
         let mut rng = make_seedable_rng(seed);
         let pos_config = PoSChainConfigBuilder::new_for_unit_test().build();
         let net_upgrades = NetUpgrades::regtest_with_pos();
@@ -657,15 +659,17 @@ mod tests {
         );
 
         let get_ancestor = |block_index: &BlockIndex, ancestor_height: BlockHeight| {
-            block_index_handle.get_ancestor(block_index, ancestor_height)
+            get_ancestor_from_block_index_handle(&block_index_handle, block_index, ancestor_height)
         };
 
         let res = calculate_average_block_time(&pos_config, &random_block_index, get_ancestor)
             .unwrap_err();
-        assert_eq!(
+        assert_matches!(
             res,
-            ConsensusPoSError::PropertyQueryError(PropertyQueryError::GetAncestorError(
-                GetAncestorError::PrevBlockIndexNotFound(random_block.get_id().into())
+            ConsensusPoSError::ChainstateError(crate::ChainstateError::FailedToObtainAncestor(
+                _,
+                _,
+                _
             ))
         );
     }
@@ -815,7 +819,7 @@ mod tests {
             TestBlockIndexHandle::new_with_blocks(&mut rng, &chain_config, &[30, 20, 10]);
 
         let get_ancestor = |block_index: &BlockIndex, ancestor_height: BlockHeight| {
-            block_index_handle.get_ancestor(block_index, ancestor_height)
+            get_ancestor_from_block_index_handle(&block_index_handle, block_index, ancestor_height)
         };
 
         for i in 1..4 {

--- a/consensus/src/pow/error.rs
+++ b/consensus/src/pow/error.rs
@@ -18,20 +18,20 @@ use thiserror::Error;
 use chainstate_types::PropertyQueryError;
 use common::{
     chain::block::Block,
-    primitives::{BlockHeight, Compact, Id},
+    primitives::{Compact, Id},
 };
 
 /// A proof of work consensus error.
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
 pub enum ConsensusPoWError {
+    #[error("Chainstate error: `{0}`")]
+    ChainstateError(#[from] crate::ChainstateError),
     #[error("Invalid Proof of Work for block {0}")]
     InvalidPoW(Id<Block>),
     #[error("Error while loading previous block with id {0} with error {1}")]
     PrevBlockLoadError(Id<Block>, PropertyQueryError),
     #[error("Previous block {0} not found in database")]
     PrevBlockNotFound(Id<Block>),
-    #[error("Error while loading ancestor of block {0} at height {1} with error {2}")]
-    AncestorAtHeightNotFound(Id<Block>, BlockHeight, PropertyQueryError),
     #[error("No PoW data for block for block")]
     NoPowDataInPreviousBlock,
     #[error("Decoding bits of block failed: `{0:?}`")]

--- a/consensus/src/pow/helpers.rs
+++ b/consensus/src/pow/helpers.rs
@@ -15,7 +15,7 @@
 
 use std::num::NonZeroU64;
 
-use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
+use chainstate_types::{BlockIndex, GenBlockIndex};
 use common::{
     chain::block::timestamp::BlockTimestamp,
     primitives::{BlockHeight, Compact},
@@ -38,7 +38,7 @@ pub fn get_starting_block_time<F>(
     get_ancestor: F,
 ) -> Result<BlockTimestamp, ConsensusPoWError>
 where
-    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    F: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     let retarget_height = {
         let height: u64 = block_index.block_height().into();
@@ -47,9 +47,7 @@ where
         BlockHeight::new(old_block_height)
     };
 
-    let retarget_block_index = get_ancestor(block_index, retarget_height).map_err(|err| {
-        ConsensusPoWError::AncestorAtHeightNotFound(*block_index.block_id(), retarget_height, err)
-    })?;
+    let retarget_block_index = get_ancestor(block_index, retarget_height)?;
 
     Ok(retarget_block_index.block_timestamp())
 }

--- a/consensus/src/pow/input_data.rs
+++ b/consensus/src/pow/input_data.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::pow::{calculate_work_required, error::ConsensusPoWError};
-use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};
+use chainstate_types::{BlockIndex, GenBlockIndex};
 use common::{
     chain::{
         block::{consensus_data::PoWData, timestamp::BlockTimestamp, BlockReward, ConsensusData},
@@ -52,7 +52,7 @@ pub fn generate_pow_consensus_data_and_reward<G>(
     block_height: BlockHeight,
 ) -> Result<(ConsensusData, BlockReward), ConsensusPoWError>
 where
-    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, PropertyQueryError>,
+    G: Fn(&BlockIndex, BlockHeight) -> Result<GenBlockIndex, crate::ChainstateError>,
 {
     let work_required = calculate_work_required(
         chain_config,


### PR DESCRIPTION
I ended up not needed some of these changes, however they still seem useful. Also, my later PR depends on them.

The logic hasn't changed here, just some code was moved, functions split etc.

Some "noisy" code (that calls chainstate and then just maps error types) was moved from `blockprod/src/detail/mod.rs` to a separate `utils.rs`, to make the former cleaner.

Also, I partially got rid of the `block_timestamp_seconds` atomic (at least, it's no longer propagated from `blockprod` to `consensus`).