### PR TITLE
Call blockprod::find_timestamps_for_staking directly from wallet cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8437,6 +8437,7 @@ version = "0.4.2"
 dependencies = [
  "async-trait",
  "base64 0.22.0",
+ "blockprod",
  "chainstate",
  "chainstate-storage",
  "common",
@@ -8482,6 +8483,7 @@ version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
+ "blockprod",
  "chainstate",
  "clap",
  "common",

--- a/node-gui/src/backend/backend_impl.rs
+++ b/node-gui/src/backend/backend_impl.rs
@@ -1341,7 +1341,7 @@ async fn select_acc_and_execute_cmd<N>(
     c: &mut CommandHandler<WalletRpcHandlesClient<N>>,
     account_id: AccountId,
     command: ManageableWalletCommand,
-    chain_config: &ChainConfig,
+    chain_config: &Arc<ChainConfig>,
 ) -> Result<ConsoleCommand, BackendError>
 where
     N: NodeInterface + Clone + Send + Sync + 'static + Debug,

--- a/wallet/wallet-cli-commands/Cargo.toml
+++ b/wallet/wallet-cli-commands/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+blockprod = { path = "../../blockprod" }
 chainstate = { path = "../../chainstate" }
 common = { path = "../../common" }
 consensus = { path = "../../consensus" }

--- a/wallet/wallet-cli-commands/src/errors.rs
+++ b/wallet/wallet-cli-commands/src/errors.rs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crypto::key::hdkd::u31::U31;
+use blockprod::BlockProductionError;
+use crypto::{ephemeral_e2e, key::hdkd::u31::U31};
 use node_comm::node_traits::NodeInterface;
 use utils::qrcode::QrCodeError;
 use wallet_rpc_client::{handles_client::WalletRpcHandlesClientError, rpc_client::WalletRpcError};
@@ -47,4 +48,8 @@ pub enum WalletCliCommandError<N: NodeInterface> {
     DifferentWalletWasOpened,
     #[error("The wallet has been closed between commands")]
     ExistingWalletWasClosed,
+    #[error("Search for timestamps failed: {0}")]
+    SearchForTimestampsFailed(BlockProductionError),
+    #[error(transparent)]
+    E2eError(#[from] ephemeral_e2e::error::Error),
 }

--- a/wallet/wallet-rpc-client/Cargo.toml
+++ b/wallet/wallet-rpc-client/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+blockprod = { path = "../../blockprod" }
 chainstate = { path = "../../chainstate" }
 common = { path = "../../common" }
 crypto = { path = "../../crypto" }

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -13,18 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, fmt::Debug, num::NonZeroUsize, path::PathBuf, str::FromStr};
+use std::{fmt::Debug, num::NonZeroUsize, path::PathBuf, str::FromStr};
 
+use blockprod::TimestampSearchData;
 use chainstate::ChainInfo;
 use common::{
     address::{dehexify::dehexify_all_addresses, AddressError},
     chain::{
-        block::timestamp::BlockTimestamp, tokens::IsTokenUnfreezable, Block, GenBlock,
-        SignedTransaction, Transaction, TxOutput, UtxoOutPoint,
+        tokens::IsTokenUnfreezable, Block, GenBlock, SignedTransaction, Transaction, TxOutput,
+        UtxoOutPoint,
     },
     primitives::{BlockHeight, DecimalAmount, Id, Idable, H256},
 };
-use crypto::key::{hdkd::u31::U31, PrivateKey};
+use crypto::{
+    ephemeral_e2e::EndToEndPublicKey,
+    key::{hdkd::u31::U31, PrivateKey},
+};
 use node_comm::node_traits::NodeInterface;
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
 use rpc::types::RpcHexString;
@@ -1260,23 +1264,41 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static + Debug> WalletInterface
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 
-    async fn node_find_timestamps_for_staking(
+    async fn e2e_public_key(&self) -> Result<HexEncoded<EndToEndPublicKey>, Self::Error> {
+        Ok(HexEncoded::new(self.wallet_rpc.e2e_public_key()))
+    }
+
+    async fn get_timestamp_search_input_data(
         &self,
+        caller_public_key: HexEncoded<EndToEndPublicKey>,
         pool_id: String,
+    ) -> Result</*PoSTimestampSearchInputData*/ Vec<u8>, Self::Error> {
+        self.wallet_rpc
+            .get_timestamp_search_input_data(caller_public_key.take(), pool_id.into())
+            .await
+            .map_err(WalletRpcHandlesClientError::WalletRpcError)
+    }
+
+    async fn node_collect_timestamp_search_data(
+        &self,
+        caller_public_key: HexEncoded<EndToEndPublicKey>,
+        encrypted_input_data: /*PoSTimestampSearchInputData*/ Vec<u8>,
         min_height: BlockHeight,
         max_height: Option<BlockHeight>,
         seconds_to_check_for_height: u64,
         check_all_timestamps_between_blocks: bool,
-    ) -> Result<BTreeMap<BlockHeight, Vec<BlockTimestamp>>, Self::Error> {
+    ) -> Result<HexEncoded<TimestampSearchData>, Self::Error> {
         self.wallet_rpc
-            .find_timestamps_for_staking(
-                pool_id.into(),
+            .collect_timestamp_search_data(
+                caller_public_key.take(),
+                encrypted_input_data,
                 min_height,
                 max_height,
                 seconds_to_check_for_height,
                 check_all_timestamps_between_blocks,
             )
             .await
+            .map(HexEncoded::new)
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -1643,12 +1643,40 @@ Returns:
 nothing
 ```
 
-### Method `node_find_timestamps_for_staking`
+### Method `e2e_public_key`
+
+Parameters:
+```
+{}
+```
+
+Returns:
+```
+hex string
+```
+
+### Method `get_timestamp_search_input_data`
 
 Parameters:
 ```
 {
+    "caller_public_key": hex string,
     "pool_id": bech32 string,
+}
+```
+
+Returns:
+```
+[ number, .. ]
+```
+
+### Method `node_collect_timestamp_search_data`
+
+Parameters:
+```
+{
+    "caller_public_key": hex string,
+    "encrypted_input_data": [ number, .. ],
     "min_height": number,
     "max_height": EITHER OF
          1) number
@@ -1660,7 +1688,7 @@ Parameters:
 
 Returns:
 ```
-{ number: [ { "timestamp": number }, .. ], .. }
+hex string
 ```
 
 ### Method `node_get_block`

--- a/wallet/wallet-rpc-lib/Cargo.toml
+++ b/wallet/wallet-rpc-lib/Cargo.toml
@@ -6,8 +6,9 @@ version.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-
+blockprod = { path = "../../blockprod" }
 common = { path = "../../common" }
+consensus = { path = "../../consensus" }
 chainstate = { path = "../../chainstate" }
 crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -28,6 +28,7 @@ use common::{
     primitives::{per_thousand::PerThousand, Amount, BlockHeight, Id, Idable},
 };
 use crypto::{
+    ephemeral_e2e,
     key::{
         hdkd::{child_number::ChildNumber, u31::U31},
         PublicKey,
@@ -128,6 +129,9 @@ pub enum RpcError<N: NodeInterface> {
 
     #[error(transparent)]
     Address(#[from] AddressError),
+
+    #[error(transparent)]
+    E2eError(#[from] ephemeral_e2e::error::Error),
 }
 
 impl<N: NodeInterface> From<RpcError<N>> for rpc::Error {


### PR DESCRIPTION
This addresses the problem from #1747 where the timestamp search RPC call from wallet-cli to wallet-rpc-daemon would timeout if the search takes a long time.

To solve the problem, the call to `blockprod::find_timestamps_for_staking` was moved from the wallet controller to wallet-cli itself. Since the call needs `PoSTimestampSearchInputData`, I had to add the `get_timestamp_search_input_data` function to wallet RPC that returns the data. And since the data contains the private vrf key, I had to use e2e encryption for it.

In the end, I'm not sure it's worth the added complexity, because the timeout problem only exists if wallet-cli connects to wallet-rpc-daemon. 
Given that `FindTimestampsForStaking` is a "niche" (and hidden) command, probably no one will ever use it in this scenario. 