### PR TITLE
Bump API server storage version

### DIFF
--- a/api-server/api-server-common/src/storage/impls/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const CURRENT_STORAGE_VERSION: u32 = 11;
+pub const CURRENT_STORAGE_VERSION: u32 = 12;
 
 pub mod in_memory;
 pub mod postgres;


### PR DESCRIPTION
After bumping the version to 0.4.3 in another branch and merging, the API server versions match, but that doesn't take into account other possible differences. It's safer to just bump it again.