### PR TITLE
Feature/api server token statistics

### DIFF
--- a/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
@@ -541,6 +541,17 @@ impl ApiServerInMemoryStorage {
             .or_else(|| self.nft_token_issuances.get(&token_id).map(|_| 0)))
     }
 
+    fn get_token_ids(&self, len: u32, offset: u32) -> Result<Vec<TokenId>, ApiServerStorageError> {
+        Ok(self
+            .fungible_token_issuances
+            .keys()
+            .chain(self.nft_token_issuances.keys())
+            .skip(offset as usize)
+            .take(len as usize)
+            .copied()
+            .collect())
+    }
+
     fn get_statistic(
         &self,
         statistic: CoinOrTokenStatistic,

--- a/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/mod.rs
@@ -554,6 +554,18 @@ impl ApiServerInMemoryStorage {
             .copied())
     }
 
+    fn get_all_statistic(
+        &self,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<BTreeMap<CoinOrTokenStatistic, Amount>, ApiServerStorageError> {
+        Ok(self
+            .statistics
+            .iter()
+            .filter_map(|(statistic, by_coin)| Some((statistic, by_coin.get(&coin_or_token_id)?)))
+            .map(|(statistic, data)| (*statistic, *data.values().last().expect("not empty")))
+            .collect())
+    }
+
     fn set_statistic(
         &mut self,
         statistic: CoinOrTokenStatistic,

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
@@ -228,6 +228,14 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRo<'t> {
         self.transaction.get_token_num_decimals(token_id)
     }
 
+    async fn get_token_ids(
+        &self,
+        len: u32,
+        offset: u32,
+    ) -> Result<Vec<TokenId>, ApiServerStorageError> {
+        self.transaction.get_token_ids(len, offset)
+    }
+
     async fn get_statistic(
         &self,
         statistic: CoinOrTokenStatistic,

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
@@ -235,4 +235,11 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRo<'t> {
     ) -> Result<Option<Amount>, ApiServerStorageError> {
         self.transaction.get_statistic(statistic, coin_or_token_id)
     }
+
+    async fn get_all_statistic(
+        &self,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<BTreeMap<CoinOrTokenStatistic, Amount>, ApiServerStorageError> {
+        self.transaction.get_all_statistic(coin_or_token_id)
+    }
 }

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/read.rs
@@ -27,7 +27,8 @@ use pos_accounting::PoolData;
 
 use crate::storage::storage_api::{
     block_aux_data::BlockAuxData, ApiServerStorageError, ApiServerStorageRead, BlockInfo,
-    Delegation, FungibleTokenData, PoolBlockStats, TransactionInfo, Utxo, UtxoWithExtraInfo,
+    CoinOrTokenStatistic, Delegation, FungibleTokenData, PoolBlockStats, TransactionInfo, Utxo,
+    UtxoWithExtraInfo,
 };
 
 use super::ApiServerInMemoryStorageTransactionalRo;
@@ -225,5 +226,13 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRo<'t> {
         token_id: TokenId,
     ) -> Result<Option<u8>, ApiServerStorageError> {
         self.transaction.get_token_num_decimals(token_id)
+    }
+
+    async fn get_statistic(
+        &self,
+        statistic: CoinOrTokenStatistic,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<Option<Amount>, ApiServerStorageError> {
+        self.transaction.get_statistic(statistic, coin_or_token_id)
     }
 }

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
@@ -451,6 +451,14 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRw<'t> {
         self.transaction.get_token_num_decimals(token_id)
     }
 
+    async fn get_token_ids(
+        &self,
+        len: u32,
+        offset: u32,
+    ) -> Result<Vec<TokenId>, ApiServerStorageError> {
+        self.transaction.get_token_ids(len, offset)
+    }
+
     async fn get_statistic(
         &self,
         statistic: CoinOrTokenStatistic,

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
@@ -27,8 +27,9 @@ use pos_accounting::PoolData;
 
 use crate::storage::storage_api::{
     block_aux_data::{BlockAuxData, BlockWithExtraData},
-    ApiServerStorageError, ApiServerStorageRead, ApiServerStorageWrite, BlockInfo, Delegation,
-    FungibleTokenData, LockedUtxo, PoolBlockStats, TransactionInfo, Utxo, UtxoWithExtraInfo,
+    ApiServerStorageError, ApiServerStorageRead, ApiServerStorageWrite, BlockInfo,
+    CoinOrTokenStatistic, Delegation, FungibleTokenData, LockedUtxo, PoolBlockStats,
+    TransactionInfo, Utxo, UtxoWithExtraInfo,
 };
 
 use super::ApiServerInMemoryStorageTransactionalRw;
@@ -235,6 +236,24 @@ impl<'t> ApiServerStorageWrite for ApiServerInMemoryStorageTransactionalRw<'t> {
     ) -> Result<(), ApiServerStorageError> {
         self.transaction.del_nft_issuance_above_height(block_height)
     }
+
+    async fn set_statistic(
+        &mut self,
+        statistic: CoinOrTokenStatistic,
+        coin_or_token_id: CoinOrTokenId,
+        block_height: BlockHeight,
+        amount: Amount,
+    ) -> Result<(), ApiServerStorageError> {
+        self.transaction
+            .set_statistic(statistic, coin_or_token_id, block_height, amount)
+    }
+
+    async fn del_statistics_above_height(
+        &mut self,
+        block_height: BlockHeight,
+    ) -> Result<(), ApiServerStorageError> {
+        self.transaction.del_statistics_above_height(block_height)
+    }
 }
 
 #[async_trait::async_trait]
@@ -430,5 +449,13 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRw<'t> {
         token_id: TokenId,
     ) -> Result<Option<u8>, ApiServerStorageError> {
         self.transaction.get_token_num_decimals(token_id)
+    }
+
+    async fn get_statistic(
+        &self,
+        statistic: CoinOrTokenStatistic,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<Option<Amount>, ApiServerStorageError> {
+        self.transaction.get_statistic(statistic, coin_or_token_id)
     }
 }

--- a/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/in_memory/transactional/write.rs
@@ -458,4 +458,11 @@ impl<'t> ApiServerStorageRead for ApiServerInMemoryStorageTransactionalRw<'t> {
     ) -> Result<Option<Amount>, ApiServerStorageError> {
         self.transaction.get_statistic(statistic, coin_or_token_id)
     }
+
+    async fn get_all_statistic(
+        &self,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<BTreeMap<CoinOrTokenStatistic, Amount>, ApiServerStorageError> {
+        self.transaction.get_all_statistic(coin_or_token_id)
+    }
 }

--- a/api-server/api-server-common/src/storage/impls/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const CURRENT_STORAGE_VERSION: u32 = 12;
+pub const CURRENT_STORAGE_VERSION: u32 = 13;
 
 pub mod in_memory;
 pub mod postgres;

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
@@ -26,7 +26,8 @@ use crate::storage::{
     impls::postgres::queries::QueryFromConnection,
     storage_api::{
         block_aux_data::BlockAuxData, ApiServerStorageError, ApiServerStorageRead, BlockInfo,
-        Delegation, FungibleTokenData, PoolBlockStats, TransactionInfo, Utxo, UtxoWithExtraInfo,
+        CoinOrTokenStatistic, Delegation, FungibleTokenData, PoolBlockStats, TransactionInfo, Utxo,
+        UtxoWithExtraInfo,
     },
 };
 use std::collections::BTreeMap;
@@ -317,6 +318,17 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
     ) -> Result<Option<u8>, ApiServerStorageError> {
         let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_token_num_decimals(token_id).await?;
+
+        Ok(res)
+    }
+
+    async fn get_statistic(
+        &self,
+        statistic: CoinOrTokenStatistic,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<Option<Amount>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_statistic(statistic, coin_or_token_id).await?;
 
         Ok(res)
     }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
@@ -332,4 +332,14 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
 
         Ok(res)
     }
+
+    async fn get_all_statistic(
+        &self,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<BTreeMap<CoinOrTokenStatistic, Amount>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_all_statistic(coin_or_token_id).await?;
+
+        Ok(res)
+    }
 }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/read.rs
@@ -322,6 +322,17 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRo<'a> {
         Ok(res)
     }
 
+    async fn get_token_ids(
+        &self,
+        len: u32,
+        offset: u32,
+    ) -> Result<Vec<TokenId>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_token_ids(len, offset).await?;
+
+        Ok(res)
+    }
+
     async fn get_statistic(
         &self,
         statistic: CoinOrTokenStatistic,

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
@@ -616,4 +616,14 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
 
         Ok(res)
     }
+
+    async fn get_all_statistic(
+        &self,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<BTreeMap<CoinOrTokenStatistic, Amount>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_all_statistic(coin_or_token_id).await?;
+
+        Ok(res)
+    }
 }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
@@ -29,8 +29,9 @@ use crate::storage::{
     impls::postgres::queries::QueryFromConnection,
     storage_api::{
         block_aux_data::{BlockAuxData, BlockWithExtraData},
-        ApiServerStorageError, ApiServerStorageRead, ApiServerStorageWrite, BlockInfo, Delegation,
-        FungibleTokenData, LockedUtxo, PoolBlockStats, TransactionInfo, Utxo, UtxoWithExtraInfo,
+        ApiServerStorageError, ApiServerStorageRead, ApiServerStorageWrite, BlockInfo,
+        CoinOrTokenStatistic, Delegation, FungibleTokenData, LockedUtxo, PoolBlockStats,
+        TransactionInfo, Utxo, UtxoWithExtraInfo,
     },
 };
 
@@ -296,6 +297,29 @@ impl<'a> ApiServerStorageWrite for ApiServerPostgresTransactionalRw<'a> {
     ) -> Result<(), ApiServerStorageError> {
         let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         conn.del_nft_issuance_above_height(block_height).await?;
+
+        Ok(())
+    }
+
+    async fn set_statistic(
+        &mut self,
+        statistic: CoinOrTokenStatistic,
+        coin_or_token_id: CoinOrTokenId,
+        block_height: BlockHeight,
+        amount: Amount,
+    ) -> Result<(), ApiServerStorageError> {
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        conn.set_statistic(statistic, coin_or_token_id, block_height, amount).await?;
+
+        Ok(())
+    }
+
+    async fn del_statistics_above_height(
+        &mut self,
+        block_height: BlockHeight,
+    ) -> Result<(), ApiServerStorageError> {
+        let mut conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        conn.del_statistics_above_height(block_height).await?;
 
         Ok(())
     }
@@ -578,6 +602,17 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
     ) -> Result<Option<u8>, ApiServerStorageError> {
         let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
         let res = conn.get_token_num_decimals(token_id).await?;
+
+        Ok(res)
+    }
+
+    async fn get_statistic(
+        &self,
+        statistic: CoinOrTokenStatistic,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<Option<Amount>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_statistic(statistic, coin_or_token_id).await?;
 
         Ok(res)
     }

--- a/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
+++ b/api-server/api-server-common/src/storage/impls/postgres/transactional/write.rs
@@ -606,6 +606,17 @@ impl<'a> ApiServerStorageRead for ApiServerPostgresTransactionalRw<'a> {
         Ok(res)
     }
 
+    async fn get_token_ids(
+        &self,
+        len: u32,
+        offset: u32,
+    ) -> Result<Vec<TokenId>, ApiServerStorageError> {
+        let conn = QueryFromConnection::new(self.connection.as_ref().expect(CONN_ERR));
+        let res = conn.get_token_ids(len, offset).await?;
+
+        Ok(res)
+    }
+
     async fn get_statistic(
         &self,
         statistic: CoinOrTokenStatistic,

--- a/api-server/api-server-common/src/storage/storage_api/mod.rs
+++ b/api-server/api-server-common/src/storage/storage_api/mod.rs
@@ -70,7 +70,7 @@ pub enum ApiServerStorageError {
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum CoinOrTokenStatistic {
-    TotalSupply,
+    CirculatingSupply,
     Staked,
     Burned,
     Preminted,
@@ -81,7 +81,7 @@ impl FromStr for CoinOrTokenStatistic {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let statistic = match s {
-            "TotalSupply" => Self::TotalSupply,
+            "CirculatingSupply" => Self::CirculatingSupply,
             "Staked" => Self::Staked,
             "Burned" => Self::Burned,
             "Preminted" => Self::Preminted,
@@ -99,7 +99,7 @@ impl FromStr for CoinOrTokenStatistic {
 impl Display for CoinOrTokenStatistic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
-            Self::TotalSupply => "TotalSupply",
+            Self::CirculatingSupply => "CirculatingSupply",
             Self::Staked => "Staked",
             Self::Burned => "Burned",
             Self::Preminted => "Preminted",

--- a/api-server/api-server-common/src/storage/storage_api/mod.rs
+++ b/api-server/api-server-common/src/storage/storage_api/mod.rs
@@ -16,6 +16,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Display,
+    str::FromStr,
 };
 
 use common::{
@@ -73,6 +74,26 @@ pub enum CoinOrTokenStatistic {
     Staked,
     Burned,
     Preminted,
+}
+
+impl FromStr for CoinOrTokenStatistic {
+    type Err = ApiServerStorageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let statistic = match s {
+            "TotalSupply" => Self::TotalSupply,
+            "Staked" => Self::Staked,
+            "Burned" => Self::Burned,
+            "Preminted" => Self::Preminted,
+            _ => {
+                return Err(ApiServerStorageError::DeserializationError(format!(
+                    "invalid coin or token statistic type: {s}"
+                )))
+            }
+        };
+
+        Ok(statistic)
+    }
 }
 
 impl Display for CoinOrTokenStatistic {
@@ -503,6 +524,11 @@ pub trait ApiServerStorageRead: Sync {
         statistic: CoinOrTokenStatistic,
         coin_or_token_id: CoinOrTokenId,
     ) -> Result<Option<Amount>, ApiServerStorageError>;
+
+    async fn get_all_statistic(
+        &self,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<BTreeMap<CoinOrTokenStatistic, Amount>, ApiServerStorageError>;
 }
 
 #[async_trait::async_trait]

--- a/api-server/api-server-common/src/storage/storage_api/mod.rs
+++ b/api-server/api-server-common/src/storage/storage_api/mod.rs
@@ -519,6 +519,12 @@ pub trait ApiServerStorageRead: Sync {
         token_id: TokenId,
     ) -> Result<Option<u8>, ApiServerStorageError>;
 
+    async fn get_token_ids(
+        &self,
+        len: u32,
+        offset: u32,
+    ) -> Result<Vec<TokenId>, ApiServerStorageError>;
+
     async fn get_statistic(
         &self,
         statistic: CoinOrTokenStatistic,

--- a/api-server/api-server-common/src/storage/storage_api/mod.rs
+++ b/api-server/api-server-common/src/storage/storage_api/mod.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Display,
+};
 
 use common::{
     chain::{
@@ -62,6 +65,27 @@ pub enum ApiServerStorageError {
     AddressableError,
     #[error("Block timestamp to high {0}")]
     TimestampToHigh(BlockTimestamp),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum CoinOrTokenStatistic {
+    TotalSupply,
+    Staked,
+    Burned,
+    Preminted,
+}
+
+impl Display for CoinOrTokenStatistic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            Self::TotalSupply => "TotalSupply",
+            Self::Staked => "Staked",
+            Self::Burned => "Burned",
+            Self::Preminted => "Preminted",
+        };
+
+        f.write_str(str)
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Encode, Decode)]
@@ -473,6 +497,12 @@ pub trait ApiServerStorageRead: Sync {
         &self,
         token_id: TokenId,
     ) -> Result<Option<u8>, ApiServerStorageError>;
+
+    async fn get_statistic(
+        &self,
+        statistic: CoinOrTokenStatistic,
+        coin_or_token_id: CoinOrTokenId,
+    ) -> Result<Option<Amount>, ApiServerStorageError>;
 }
 
 #[async_trait::async_trait]
@@ -615,6 +645,19 @@ pub trait ApiServerStorageWrite: ApiServerStorageRead {
     ) -> Result<(), ApiServerStorageError>;
 
     async fn del_nft_issuance_above_height(
+        &mut self,
+        block_height: BlockHeight,
+    ) -> Result<(), ApiServerStorageError>;
+
+    async fn set_statistic(
+        &mut self,
+        statistic: CoinOrTokenStatistic,
+        coin_or_token_id: CoinOrTokenId,
+        block_height: BlockHeight,
+        amount: Amount,
+    ) -> Result<(), ApiServerStorageError>;
+
+    async fn del_statistics_above_height(
         &mut self,
         block_height: BlockHeight,
     ) -> Result<(), ApiServerStorageError>;

--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -17,8 +17,8 @@ use crate::sync::local_state::LocalBlockchainState;
 use api_server_common::storage::storage_api::{
     block_aux_data::{BlockAuxData, BlockWithExtraData},
     ApiServerStorage, ApiServerStorageError, ApiServerStorageRead, ApiServerStorageWrite,
-    ApiServerTransactionRw, Delegation, FungibleTokenData, LockedUtxo, TransactionInfo,
-    TxAdditionalInfo, Utxo, UtxoLock,
+    ApiServerTransactionRw, CoinOrTokenStatistic, Delegation, FungibleTokenData, LockedUtxo,
+    TransactionInfo, TxAdditionalInfo, Utxo, UtxoLock,
 };
 use chainstate::{
     calculate_median_time_past_from_blocktimestamps,
@@ -420,6 +420,30 @@ async fn update_tables_from_block_reward<T: ApiServerStorageWrite>(
                     &chain_config,
                 )
                 .await;
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::Preminted,
+                    &pool_data.pledge_amount(),
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::TotalSupply,
+                    &pool_data.pledge_amount(),
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::Staked,
+                    &pool_data.pledge_amount(),
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
             }
             TxOutput::Transfer(output_value, destination)
             | TxOutput::LockThenTransfer(output_value, destination, _) => {
@@ -436,12 +460,44 @@ async fn update_tables_from_block_reward<T: ApiServerStorageWrite>(
                             block_height,
                         )
                         .await;
+                        increase_statistic_amount(
+                            db_tx,
+                            CoinOrTokenStatistic::Preminted,
+                            amount,
+                            CoinOrTokenId::TokenId(*token_id),
+                            block_height,
+                        )
+                        .await;
+                        increase_statistic_amount(
+                            db_tx,
+                            CoinOrTokenStatistic::TotalSupply,
+                            amount,
+                            CoinOrTokenId::TokenId(*token_id),
+                            block_height,
+                        )
+                        .await;
                         Some(token_decimals(*token_id, &BTreeMap::new(), db_tx).await?.1)
                     }
                     OutputValue::Coin(amount) => {
                         increase_address_amount(
                             db_tx,
                             &address,
+                            amount,
+                            CoinOrTokenId::Coin,
+                            block_height,
+                        )
+                        .await;
+                        increase_statistic_amount(
+                            db_tx,
+                            CoinOrTokenStatistic::Preminted,
+                            amount,
+                            CoinOrTokenId::Coin,
+                            block_height,
+                        )
+                        .await;
+                        increase_statistic_amount(
+                            db_tx,
+                            CoinOrTokenStatistic::TotalSupply,
                             amount,
                             CoinOrTokenId::Coin,
                             block_height,
@@ -757,6 +813,22 @@ async fn update_tables_from_consensus_data<T: ApiServerStorageWrite>(
                 reward_distribution_version,
             )
             .expect("no error");
+            increase_statistic_amount(
+                db_tx,
+                CoinOrTokenStatistic::Staked,
+                &total_reward,
+                CoinOrTokenId::Coin,
+                block_height,
+            )
+            .await;
+            increase_statistic_amount(
+                db_tx,
+                CoinOrTokenStatistic::TotalSupply,
+                &total_reward,
+                CoinOrTokenId::Coin,
+                block_height,
+            )
+            .await;
 
             for (delegation_id, rewards) in adapter.rewards_per_delegation() {
                 let delegation = delegation_shares.get(delegation_id).expect("must exist").clone();
@@ -825,6 +897,31 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
 
                     let issuance = issuance.mint_tokens(*amount);
                     db_tx.set_fungible_token_issuance(*token_id, block_height, issuance).await?;
+                    increase_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::TotalSupply,
+                        amount,
+                        CoinOrTokenId::TokenId(*token_id),
+                        block_height,
+                    )
+                    .await;
+                    let amount = chain_config.token_supply_change_fee(block_height);
+                    increase_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::Burned,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
+                    decrease_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::TotalSupply,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
                 }
                 AccountCommand::UnmintTokens(token_id) => {
                     let total_burned =
@@ -835,6 +932,23 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
 
                     let issuance = issuance.unmint_tokens(total_burned);
                     db_tx.set_fungible_token_issuance(*token_id, block_height, issuance).await?;
+                    let amount = chain_config.token_supply_change_fee(block_height);
+                    increase_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::Burned,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
+                    decrease_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::TotalSupply,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
                 }
                 AccountCommand::FreezeToken(token_id, is_unfreezable) => {
                     let issuance =
@@ -842,6 +956,23 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
 
                     let issuance = issuance.freeze(*is_unfreezable);
                     db_tx.set_fungible_token_issuance(*token_id, block_height, issuance).await?;
+                    let amount = chain_config.token_freeze_fee(block_height);
+                    increase_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::Burned,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
+                    decrease_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::TotalSupply,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
                 }
                 AccountCommand::UnfreezeToken(token_id) => {
                     let issuance =
@@ -849,6 +980,23 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
 
                     let issuance = issuance.unfreeze();
                     db_tx.set_fungible_token_issuance(*token_id, block_height, issuance).await?;
+                    let amount = chain_config.token_freeze_fee(block_height);
+                    increase_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::Burned,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
+                    decrease_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::TotalSupply,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
                 }
                 AccountCommand::LockTokenSupply(token_id) => {
                     let issuance =
@@ -856,6 +1004,23 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
 
                     let issuance = issuance.lock();
                     db_tx.set_fungible_token_issuance(*token_id, block_height, issuance).await?;
+                    let amount = chain_config.token_supply_change_fee(block_height);
+                    increase_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::Burned,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
+                    decrease_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::TotalSupply,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
                 }
                 AccountCommand::ChangeTokenAuthority(token_id, destination) => {
                     let issuance =
@@ -863,6 +1028,23 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
 
                     let issuance = issuance.change_authority(destination.clone());
                     db_tx.set_fungible_token_issuance(*token_id, block_height, issuance).await?;
+                    let amount = chain_config.token_change_authority_fee(block_height);
+                    increase_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::Burned,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
+                    decrease_statistic_amount(
+                        db_tx,
+                        CoinOrTokenStatistic::TotalSupply,
+                        &amount,
+                        CoinOrTokenId::Coin,
+                        block_height,
+                    )
+                    .await;
                 }
             },
             TxInput::Account(outpoint) => {
@@ -883,6 +1065,14 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                             .set_delegation_at_height(*delegation_id, &new_delegation, block_height)
                             .await
                             .expect("Unable to update delegation");
+                        decrease_statistic_amount(
+                            db_tx,
+                            CoinOrTokenStatistic::Staked,
+                            amount,
+                            CoinOrTokenId::Coin,
+                            block_height,
+                        )
+                        .await;
                     }
                 }
             }
@@ -932,6 +1122,14 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                                 .entry(address.clone())
                                 .or_default()
                                 .insert(tx.get_id());
+                            decrease_statistic_amount(
+                                db_tx,
+                                CoinOrTokenStatistic::Staked,
+                                &pool_data.pledge_amount(),
+                                CoinOrTokenId::Coin,
+                                block_height,
+                            )
+                            .await;
                         }
                     }
                 }
@@ -949,9 +1147,9 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                     .await;
 
                     match utxo.into_output() {
-                        TxOutput::CreateDelegationId(_, _)
+                        TxOutput::Burn(_)
+                        | TxOutput::CreateDelegationId(_, _)
                         | TxOutput::DelegateStaking(_, _)
-                        | TxOutput::Burn(_)
                         | TxOutput::DataDeposit(_)
                         | TxOutput::IssueFungibleToken(_) => {}
                         | TxOutput::CreateStakePool(pool_id, _)
@@ -966,6 +1164,14 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                                 .set_pool_data_at_height(pool_id, &pool_data, block_height)
                                 .await
                                 .expect("unable to update pool data");
+                            decrease_statistic_amount(
+                                db_tx,
+                                CoinOrTokenStatistic::Staked,
+                                &pool_data.pledge_amount(),
+                                CoinOrTokenId::Coin,
+                                block_height,
+                            )
+                            .await;
                         }
                         TxOutput::IssueNft(token_id, _, destination) => {
                             let address = Address::<Destination>::new(&chain_config, destination)
@@ -1058,7 +1264,53 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
     for (idx, output) in outputs.iter().enumerate() {
         let outpoint = UtxoOutPoint::new(OutPointSourceId::Transaction(transaction_id), idx as u32);
         match output {
-            TxOutput::Burn(_) | TxOutput::DataDeposit(_) => {}
+            TxOutput::Burn(value) => {
+                let (coin_or_token_id, amount) = match value {
+                    OutputValue::Coin(amount) => (CoinOrTokenId::Coin, amount),
+                    OutputValue::TokenV0(_) => {
+                        continue;
+                    }
+                    OutputValue::TokenV1(token_id, amount) => {
+                        (CoinOrTokenId::TokenId(*token_id), amount)
+                    }
+                };
+
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::Burned,
+                    amount,
+                    coin_or_token_id,
+                    block_height,
+                )
+                .await;
+                decrease_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::TotalSupply,
+                    amount,
+                    coin_or_token_id,
+                    block_height,
+                )
+                .await;
+            }
+            TxOutput::DataDeposit(_) => {
+                let amount = chain_config.data_deposit_fee();
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::Burned,
+                    &amount,
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
+                decrease_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::TotalSupply,
+                    &amount,
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
+            }
             TxOutput::IssueFungibleToken(issuance) => {
                 let token_id = make_token_id(inputs).expect("should not fail");
                 let issuance = match issuance.as_ref() {
@@ -1074,6 +1326,23 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                     },
                 };
                 db_tx.set_fungible_token_issuance(token_id, block_height, issuance).await?;
+                let amount = chain_config.fungible_token_issuance_fee();
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::Burned,
+                    &amount,
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
+                decrease_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::TotalSupply,
+                    &amount,
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
             }
             TxOutput::IssueNft(token_id, issuance, destination) => {
                 let address = Address::<Destination>::new(&chain_config, destination.clone())
@@ -1085,6 +1354,31 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                     &address,
                     &Amount::from_atoms(1),
                     CoinOrTokenId::TokenId(*token_id),
+                    block_height,
+                )
+                .await;
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::TotalSupply,
+                    &Amount::from_atoms(1),
+                    CoinOrTokenId::TokenId(*token_id),
+                    block_height,
+                )
+                .await;
+                let amount = chain_config.nft_issuance_fee(block_height);
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::Burned,
+                    &amount,
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
+                decrease_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::TotalSupply,
+                    &amount,
+                    CoinOrTokenId::Coin,
                     block_height,
                 )
                 .await;
@@ -1129,6 +1423,14 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                     .set_pool_data_at_height(*pool_id, &new_pool_data, block_height)
                     .await
                     .expect("Unable to update pool balance");
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::Staked,
+                    &stake_pool_data.pledge(),
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
                 set_utxo(
                     outpoint,
                     output,
@@ -1166,6 +1468,14 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                     .set_delegation_at_height(*delegation_id, &new_delegation, block_height)
                     .await
                     .expect("Unable to update delegation");
+                increase_statistic_amount(
+                    db_tx,
+                    CoinOrTokenStatistic::Staked,
+                    amount,
+                    CoinOrTokenId::Coin,
+                    block_height,
+                )
+                .await;
 
                 let address = Address::<Destination>::new(
                     &chain_config,
@@ -1314,6 +1624,48 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
     }
 
     Ok(())
+}
+
+async fn increase_statistic_amount<T: ApiServerStorageWrite>(
+    db_tx: &mut T,
+    statistic: CoinOrTokenStatistic,
+    amount: &Amount,
+    coin_or_token_id: CoinOrTokenId,
+    block_height: BlockHeight,
+) {
+    let current_balance = db_tx
+        .get_statistic(statistic, coin_or_token_id)
+        .await
+        .expect("Unable to get statistic")
+        .unwrap_or(Amount::ZERO);
+
+    let new_amount = current_balance.add(*amount).expect("Balance should not overflow");
+
+    db_tx
+        .set_statistic(statistic, coin_or_token_id, block_height, new_amount)
+        .await
+        .expect("Unable to update statistic")
+}
+
+async fn decrease_statistic_amount<T: ApiServerStorageWrite>(
+    db_tx: &mut T,
+    statistic: CoinOrTokenStatistic,
+    amount: &Amount,
+    coin_or_token_id: CoinOrTokenId,
+    block_height: BlockHeight,
+) {
+    let current_balance = db_tx
+        .get_statistic(statistic, coin_or_token_id)
+        .await
+        .expect("Unable to get statistic")
+        .unwrap_or(Amount::ZERO);
+
+    let new_amount = current_balance.sub(*amount).expect("Balance should not underflow");
+
+    db_tx
+        .set_statistic(statistic, coin_or_token_id, block_height, new_amount)
+        .await
+        .expect("Unable to update statistic")
 }
 
 async fn increase_address_amount<T: ApiServerStorageWrite>(

--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -342,6 +342,11 @@ async fn disconnect_tables_above_height<T: ApiServerStorageWrite>(
         .await
         .expect("Unable to disconnect block");
 
+    db_tx
+        .del_statistics_above_height(block_height)
+        .await
+        .expect("Unable to disconnect block");
+
     Ok(())
 }
 
@@ -430,7 +435,7 @@ async fn update_tables_from_block_reward<T: ApiServerStorageWrite>(
                 .await;
                 increase_statistic_amount(
                     db_tx,
-                    CoinOrTokenStatistic::TotalSupply,
+                    CoinOrTokenStatistic::CirculatingSupply,
                     &pool_data.pledge_amount(),
                     CoinOrTokenId::Coin,
                     block_height,
@@ -470,7 +475,7 @@ async fn update_tables_from_block_reward<T: ApiServerStorageWrite>(
                         .await;
                         increase_statistic_amount(
                             db_tx,
-                            CoinOrTokenStatistic::TotalSupply,
+                            CoinOrTokenStatistic::CirculatingSupply,
                             amount,
                             CoinOrTokenId::TokenId(*token_id),
                             block_height,
@@ -497,7 +502,7 @@ async fn update_tables_from_block_reward<T: ApiServerStorageWrite>(
                         .await;
                         increase_statistic_amount(
                             db_tx,
-                            CoinOrTokenStatistic::TotalSupply,
+                            CoinOrTokenStatistic::CirculatingSupply,
                             amount,
                             CoinOrTokenId::Coin,
                             block_height,
@@ -823,8 +828,8 @@ async fn update_tables_from_consensus_data<T: ApiServerStorageWrite>(
             .await;
             increase_statistic_amount(
                 db_tx,
-                CoinOrTokenStatistic::TotalSupply,
-                &total_reward,
+                CoinOrTokenStatistic::CirculatingSupply,
+                &block_subsidy,
                 CoinOrTokenId::Coin,
                 block_height,
             )
@@ -899,7 +904,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                     db_tx.set_fungible_token_issuance(*token_id, block_height, issuance).await?;
                     increase_statistic_amount(
                         db_tx,
-                        CoinOrTokenStatistic::TotalSupply,
+                        CoinOrTokenStatistic::CirculatingSupply,
                         amount,
                         CoinOrTokenId::TokenId(*token_id),
                         block_height,
@@ -916,7 +921,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                     .await;
                     decrease_statistic_amount(
                         db_tx,
-                        CoinOrTokenStatistic::TotalSupply,
+                        CoinOrTokenStatistic::CirculatingSupply,
                         &amount,
                         CoinOrTokenId::Coin,
                         block_height,
@@ -943,7 +948,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                     .await;
                     decrease_statistic_amount(
                         db_tx,
-                        CoinOrTokenStatistic::TotalSupply,
+                        CoinOrTokenStatistic::CirculatingSupply,
                         &amount,
                         CoinOrTokenId::Coin,
                         block_height,
@@ -967,7 +972,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                     .await;
                     decrease_statistic_amount(
                         db_tx,
-                        CoinOrTokenStatistic::TotalSupply,
+                        CoinOrTokenStatistic::CirculatingSupply,
                         &amount,
                         CoinOrTokenId::Coin,
                         block_height,
@@ -991,7 +996,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                     .await;
                     decrease_statistic_amount(
                         db_tx,
-                        CoinOrTokenStatistic::TotalSupply,
+                        CoinOrTokenStatistic::CirculatingSupply,
                         &amount,
                         CoinOrTokenId::Coin,
                         block_height,
@@ -1015,7 +1020,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                     .await;
                     decrease_statistic_amount(
                         db_tx,
-                        CoinOrTokenStatistic::TotalSupply,
+                        CoinOrTokenStatistic::CirculatingSupply,
                         &amount,
                         CoinOrTokenId::Coin,
                         block_height,
@@ -1039,7 +1044,7 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                     .await;
                     decrease_statistic_amount(
                         db_tx,
-                        CoinOrTokenStatistic::TotalSupply,
+                        CoinOrTokenStatistic::CirculatingSupply,
                         &amount,
                         CoinOrTokenId::Coin,
                         block_height,
@@ -1285,7 +1290,7 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                 .await;
                 decrease_statistic_amount(
                     db_tx,
-                    CoinOrTokenStatistic::TotalSupply,
+                    CoinOrTokenStatistic::CirculatingSupply,
                     amount,
                     coin_or_token_id,
                     block_height,
@@ -1304,7 +1309,7 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                 .await;
                 decrease_statistic_amount(
                     db_tx,
-                    CoinOrTokenStatistic::TotalSupply,
+                    CoinOrTokenStatistic::CirculatingSupply,
                     &amount,
                     CoinOrTokenId::Coin,
                     block_height,
@@ -1337,7 +1342,7 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                 .await;
                 decrease_statistic_amount(
                     db_tx,
-                    CoinOrTokenStatistic::TotalSupply,
+                    CoinOrTokenStatistic::CirculatingSupply,
                     &amount,
                     CoinOrTokenId::Coin,
                     block_height,
@@ -1359,7 +1364,7 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                 .await;
                 increase_statistic_amount(
                     db_tx,
-                    CoinOrTokenStatistic::TotalSupply,
+                    CoinOrTokenStatistic::CirculatingSupply,
                     &Amount::from_atoms(1),
                     CoinOrTokenId::TokenId(*token_id),
                     block_height,
@@ -1376,7 +1381,7 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                 .await;
                 decrease_statistic_amount(
                     db_tx,
-                    CoinOrTokenStatistic::TotalSupply,
+                    CoinOrTokenStatistic::CirculatingSupply,
                     &amount,
                     CoinOrTokenId::Coin,
                     block_height,

--- a/api-server/stack-test-suite/tests/v2/address_delegations.rs
+++ b/api-server/stack-test-suite/tests/v2/address_delegations.rs
@@ -150,11 +150,9 @@ async fn ok(#[case] seed: Seed) {
                 );
 
                 let mut blocks = vec![];
-                tf.process_block(block.clone(), BlockSource::Local).unwrap();
                 blocks.push(block.clone());
                 for delegation in &delegations {
                     for block in &delegation.3 {
-                        tf.process_block(block.clone(), BlockSource::Local).unwrap();
                         blocks.push(block.clone());
                     }
                 }

--- a/api-server/stack-test-suite/tests/v2/helpers.rs
+++ b/api-server/stack-test-suite/tests/v2/helpers.rs
@@ -73,6 +73,7 @@ pub fn prepare_stake_pool(
     );
 
     let block = tf.make_block_builder().add_transaction(stake_pool_transaction).build(rng);
+    tf.process_block(block.clone(), chainstate::BlockSource::Local).unwrap();
 
     (transfer_outpoint, stake_pool_data, pool_id, block)
 }
@@ -103,6 +104,7 @@ pub fn prepare_delegation(
     );
 
     let block = tf.make_block_builder().add_transaction(create_delegation_tx).build(rng);
+    tf.process_block(block.clone(), chainstate::BlockSource::Local).unwrap();
 
     (delegation_id, destination, transfer_outpoint, block)
 }
@@ -131,6 +133,7 @@ pub fn stake_delegation(
     );
 
     let block = tf.make_block_builder().add_transaction(stake_tx).build(rng);
+    tf.process_block(block.clone(), chainstate::BlockSource::Local).unwrap();
 
     (amount_to_delegate, transfer_outpoint, block)
 }

--- a/api-server/stack-test-suite/tests/v2/mod.rs
+++ b/api-server/stack-test-suite/tests/v2/mod.rs
@@ -29,6 +29,7 @@ mod nft;
 mod pool;
 mod pool_block_stats;
 mod pools;
+mod statistics;
 mod token;
 mod transaction;
 mod transaction_merkle_path;

--- a/api-server/stack-test-suite/tests/v2/mod.rs
+++ b/api-server/stack-test-suite/tests/v2/mod.rs
@@ -31,6 +31,7 @@ mod pool_block_stats;
 mod pools;
 mod statistics;
 mod token;
+mod token_ids;
 mod transaction;
 mod transaction_merkle_path;
 mod transaction_submit;

--- a/api-server/stack-test-suite/tests/v2/pool.rs
+++ b/api-server/stack-test-suite/tests/v2/pool.rs
@@ -143,11 +143,9 @@ async fn ok(#[case] seed: Seed) {
 
                 let mut blocks = vec![];
                 for pool in &pools {
-                    tf.process_block(pool.3.clone(), BlockSource::Local).unwrap();
                     blocks.push(pool.3.clone());
                     for delegation in &pool.2 {
                         for block in &delegation.3 {
-                            tf.process_block(block.clone(), BlockSource::Local).unwrap();
                             blocks.push(block.clone());
                         }
                     }

--- a/api-server/stack-test-suite/tests/v2/pools.rs
+++ b/api-server/stack-test-suite/tests/v2/pools.rs
@@ -172,11 +172,9 @@ async fn ok(#[case] seed: Seed) {
 
                 let mut blocks = vec![];
                 for pool in &pools {
-                    tf.process_block(pool.3.clone(), BlockSource::Local).unwrap();
                     blocks.push(pool.3.clone());
                     for delegation in &pool.2 {
                         for block in &delegation.3 {
-                            tf.process_block(block.clone(), BlockSource::Local).unwrap();
                             blocks.push(block.clone());
                         }
                     }

--- a/api-server/stack-test-suite/tests/v2/statistics.rs
+++ b/api-server/stack-test-suite/tests/v2/statistics.rs
@@ -1,0 +1,431 @@
+// Copyright (c) 2023 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api_web_server::api::json_helpers::amount_to_json;
+use common::{
+    chain::{
+        config::emission_schedule::DEFAULT_INITIAL_MINT,
+        tokens::{
+            make_token_id, IsTokenFreezable, TokenId, TokenIssuance, TokenIssuanceV1,
+            TokenTotalSupply,
+        },
+        AccountCommand, AccountNonce, AccountOutPoint, AccountSpending, UtxoOutPoint,
+    },
+    primitives::H256,
+};
+
+use crate::DummyRPC;
+
+use super::{
+    helpers::{prepare_delegation, prepare_stake_pool, stake_delegation},
+    *,
+};
+
+#[tokio::test]
+async fn invalid_token_id() {
+    let (task, response) = spawn_webserver("/api/v2/statistics/token/invalid-token-id").await;
+
+    assert_eq!(response.status(), 400);
+
+    let body = response.text().await.unwrap();
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(body["error"].as_str().unwrap(), "Invalid token Id");
+
+    task.abort();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test]
+async fn token_not_found(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = create_unit_test_config();
+
+    let token_id = TokenId::new(H256::random_using(&mut rng));
+    let token_id = Address::<TokenId>::new(&chain_config, token_id).unwrap();
+
+    let (task, response) =
+        spawn_webserver(&format!("/api/v2/statistics/token/{}", token_id.as_str())).await;
+
+    assert_eq!(response.status(), 404);
+
+    let body = response.text().await.unwrap();
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(body["error"].as_str().unwrap(), "Token not found");
+
+    task.abort();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test]
+async fn ok_tokens(#[case] seed: Seed) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let web_server_state = {
+            let mut rng = make_seedable_rng(seed);
+            let chain_config = create_unit_test_config();
+
+            let chainstate_blocks = {
+                let mut tf = TestFramework::builder(&mut rng)
+                    .with_chain_config(chain_config.clone())
+                    .build();
+
+                // generate addresses
+
+                let (alice_sk, alice_pk) =
+                    PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+
+                let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
+
+                let token_decimals = rng.gen_range(1..18);
+                let token_issuance = TokenIssuanceV1 {
+                    token_ticker: "XXXX".as_bytes().to_vec(),
+                    number_of_decimals: token_decimals,
+                    metadata_uri: "http://uri".as_bytes().to_vec(),
+                    total_supply: TokenTotalSupply::Unlimited,
+                    authority: alice_destination.clone(),
+                    is_freezable: IsTokenFreezable::No,
+                };
+
+                let issue_token_transaction = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(
+                            OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+                            0,
+                        ),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(TxOutput::Transfer(
+                        OutputValue::Coin(
+                            (Amount::from_atoms(100)
+                                + chain_config.token_supply_change_fee(BlockHeight::zero()))
+                            .unwrap(),
+                        ),
+                        Destination::AnyoneCanSpend,
+                    ))
+                    .add_output(TxOutput::IssueFungibleToken(Box::new(TokenIssuance::V1(
+                        token_issuance.clone(),
+                    ))))
+                    .build();
+
+                let token_id = make_token_id(issue_token_transaction.inputs()).unwrap();
+                let to_mint = Amount::from_atoms(1000);
+                let mint_transaction = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(
+                            OutPointSourceId::Transaction(
+                                issue_token_transaction.transaction().get_id(),
+                            ),
+                            0,
+                        ),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_input(
+                        TxInput::from_command(
+                            AccountNonce::new(0),
+                            AccountCommand::MintTokens(token_id, to_mint),
+                        ),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(TxOutput::Transfer(
+                        OutputValue::Coin(Amount::from_atoms(10)),
+                        Destination::AnyoneCanSpend,
+                    ))
+                    .add_output(TxOutput::Transfer(
+                        OutputValue::TokenV1(token_id, to_mint),
+                        Destination::AnyoneCanSpend,
+                    ))
+                    .build();
+
+                let token_witness = InputWitness::Standard(
+                    StandardInputSignature::produce_uniparty_signature_for_input(
+                        &alice_sk,
+                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        alice_destination.clone(),
+                        &mint_transaction,
+                        &[Some(&issue_token_transaction.outputs()[0]), None],
+                        1,
+                        &mut rng,
+                    )
+                    .unwrap(),
+                );
+
+                let signed_mint_tx = SignedTransaction::new(
+                    mint_transaction.transaction().clone(),
+                    vec![InputWitness::NoSignature(None), token_witness.clone()],
+                )
+                .unwrap();
+
+                let to_burn = Amount::from_atoms(100);
+                let unmint_transaction = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(
+                            OutPointSourceId::Transaction(mint_transaction.transaction().get_id()),
+                            0,
+                        ),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_input(
+                        TxInput::from_utxo(
+                            OutPointSourceId::Transaction(mint_transaction.transaction().get_id()),
+                            1,
+                        ),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(TxOutput::Burn(OutputValue::TokenV1(token_id, to_burn)))
+                    .build();
+
+                let chainstate_block_ids = [*tf
+                    .make_block_builder()
+                    .add_transaction(issue_token_transaction.clone())
+                    .add_transaction(signed_mint_tx.clone())
+                    .add_transaction(unmint_transaction.clone())
+                    .build_and_process(&mut rng)
+                    .unwrap()
+                    .unwrap()
+                    .block_id()];
+
+                _ = tx.send([(
+                    token_id,
+                    json!({
+                    "total_amount": amount_to_json((to_mint - to_burn).unwrap(), token_decimals),
+                    "preminted": amount_to_json(Amount::ZERO, token_decimals),
+                    "staked": amount_to_json(Amount::ZERO, token_decimals),
+                    "burned": amount_to_json(to_burn, token_decimals),
+                                }),
+                )]);
+
+                chainstate_block_ids
+                    .iter()
+                    .map(|id| tf.block(tf.to_chain_block_id(id.into())))
+                    .collect::<Vec<_>>()
+            };
+
+            let storage = {
+                let mut storage = TransactionalApiServerInMemoryStorage::new(&chain_config);
+
+                let mut db_tx = storage.transaction_rw().await.unwrap();
+                db_tx.reinitialize_storage(&chain_config).await.unwrap();
+                db_tx.commit().await.unwrap();
+
+                storage
+            };
+
+            let chain_config = Arc::new(chain_config);
+
+            let mut local_node = BlockchainState::new(Arc::clone(&chain_config), storage);
+            local_node.scan_genesis(chain_config.genesis_block()).await.unwrap();
+            local_node.scan_blocks(BlockHeight::new(0), chainstate_blocks).await.unwrap();
+
+            ApiServerWebServerState {
+                db: Arc::new(local_node.storage().clone_storage().await),
+                chain_config: Arc::clone(&chain_config),
+                rpc: Arc::new(DummyRPC {}),
+                cached_values: Arc::new(CachedValues {
+                    feerate_points: RwLock::new((get_time(), vec![])),
+                }),
+                time_getter: Default::default(),
+            }
+        };
+
+        web_server(listener, web_server_state, false).await
+    });
+
+    let chain_config = create_unit_test_config();
+    for (token_id, expected_values) in rx.await.unwrap() {
+        let token_id = Address::new(&chain_config, token_id).unwrap();
+        let url = format!("/api/v2/statistics/token/{token_id}");
+
+        // Given that the listener port is open, this will block until a
+        // response is made (by the web server, which takes the listener
+        // over)
+        let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            200,
+            "Failed getting token for {token_id}"
+        );
+
+        let body = response.text().await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(body, expected_values);
+    }
+
+    task.abort();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test]
+async fn ok_coins(#[case] seed: Seed) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let web_server_state = {
+            let mut rng = make_seedable_rng(seed);
+            let chain_config = create_unit_test_config();
+
+            let chainstate_blocks = {
+                let mut tf = TestFramework::builder(&mut rng)
+                    .with_chain_config(chain_config.clone())
+                    .build();
+
+                let stake_pool_outpoint = UtxoOutPoint::new(
+                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+                    0,
+                );
+
+                let mut available_amount = ((chain_config.min_stake_pool_pledge() * 10).unwrap()
+                    + Amount::from_atoms(10000))
+                .unwrap();
+
+                let (transfer_outpoint, stake_pool_data, pool_id, _) = prepare_stake_pool(
+                    stake_pool_outpoint,
+                    &mut rng,
+                    &mut available_amount,
+                    &mut tf,
+                );
+
+                let (delegation_id, _, transfer_outpoint, _) = prepare_delegation(
+                    transfer_outpoint,
+                    &mut rng,
+                    pool_id,
+                    available_amount,
+                    Some(Destination::AnyoneCanSpend),
+                    &mut tf,
+                );
+
+                let (delegated_amount, transfer_outpoint, _) = stake_delegation(
+                    &mut rng,
+                    available_amount,
+                    transfer_outpoint,
+                    delegation_id,
+                    &mut tf,
+                );
+                available_amount = (available_amount - delegated_amount).unwrap();
+
+                let amount_to_unstake =
+                    Amount::from_atoms(rng.gen_range(1..delegated_amount.into_atoms()));
+                let amount_to_burn =
+                    Amount::from_atoms(rng.gen_range(1..available_amount.into_atoms()));
+
+                let undelegate_and_burn = TransactionBuilder::new()
+                    .add_input(transfer_outpoint.into(), InputWitness::NoSignature(None))
+                    .add_input(
+                        TxInput::Account(AccountOutPoint::new(
+                            AccountNonce::new(0),
+                            AccountSpending::DelegationBalance(delegation_id, amount_to_unstake),
+                        )),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(TxOutput::Burn(OutputValue::Coin(amount_to_burn)))
+                    .build();
+
+                tf.block_id(1);
+                tf.block_id(2);
+                tf.block_id(3);
+                let block4 = tf
+                    .make_block_builder()
+                    .add_transaction(undelegate_and_burn.clone())
+                    .build(&mut rng);
+                tf.process_block(block4.clone(), BlockSource::Local).unwrap();
+
+                let total_amount = (DEFAULT_INITIAL_MINT - amount_to_burn).unwrap();
+                let staked = ((stake_pool_data.pledge() + delegated_amount).unwrap()
+                    - amount_to_unstake)
+                    .unwrap();
+
+                let decimals = chain_config.coin_decimals();
+                _ = tx.send([json!({
+                "total_amount": amount_to_json(total_amount, decimals),
+                "preminted": amount_to_json(DEFAULT_INITIAL_MINT, decimals),
+                "staked": amount_to_json(staked, decimals),
+                "burned": amount_to_json(amount_to_burn, decimals),
+                            })]);
+
+                // chainstate_block_ids
+                tf.block_indexes
+                    .iter()
+                    .map(|idx| tf.block(tf.to_chain_block_id(idx.block_id().into())))
+                    .collect::<Vec<_>>()
+            };
+
+            let storage = {
+                let mut storage = TransactionalApiServerInMemoryStorage::new(&chain_config);
+
+                let mut db_tx = storage.transaction_rw().await.unwrap();
+                db_tx.reinitialize_storage(&chain_config).await.unwrap();
+                db_tx.commit().await.unwrap();
+
+                storage
+            };
+
+            let chain_config = Arc::new(chain_config);
+
+            let mut local_node = BlockchainState::new(Arc::clone(&chain_config), storage);
+            local_node.scan_genesis(chain_config.genesis_block()).await.unwrap();
+            local_node.scan_blocks(BlockHeight::new(0), chainstate_blocks).await.unwrap();
+
+            ApiServerWebServerState {
+                db: Arc::new(local_node.storage().clone_storage().await),
+                chain_config: Arc::clone(&chain_config),
+                rpc: Arc::new(DummyRPC {}),
+                cached_values: Arc::new(CachedValues {
+                    feerate_points: RwLock::new((get_time(), vec![])),
+                }),
+                time_getter: Default::default(),
+            }
+        };
+
+        web_server(listener, web_server_state, false).await
+    });
+
+    for expected_values in rx.await.unwrap() {
+        let url = "/api/v2/statistics/coin";
+
+        // Given that the listener port is open, this will block until a
+        // response is made (by the web server, which takes the listener
+        // over)
+        let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200, "Failed getting coin statistics");
+
+        let body = response.text().await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(body, expected_values);
+    }
+
+    task.abort();
+}

--- a/api-server/stack-test-suite/tests/v2/statistics.rs
+++ b/api-server/stack-test-suite/tests/v2/statistics.rs
@@ -209,7 +209,7 @@ async fn ok_tokens(#[case] seed: Seed) {
                 _ = tx.send([(
                     token_id,
                     json!({
-                    "total_amount": amount_to_json((to_mint - to_burn).unwrap(), token_decimals),
+                    "circulating_supply": amount_to_json((to_mint - to_burn).unwrap(), token_decimals),
                     "preminted": amount_to_json(Amount::ZERO, token_decimals),
                     "staked": amount_to_json(Amount::ZERO, token_decimals),
                     "burned": amount_to_json(to_burn, token_decimals),
@@ -366,7 +366,7 @@ async fn ok_coins(#[case] seed: Seed) {
 
                 let decimals = chain_config.coin_decimals();
                 _ = tx.send([json!({
-                "total_amount": amount_to_json(total_amount, decimals),
+                "circulating_supply": amount_to_json(total_amount, decimals),
                 "preminted": amount_to_json(DEFAULT_INITIAL_MINT, decimals),
                 "staked": amount_to_json(staked, decimals),
                 "burned": amount_to_json(amount_to_burn, decimals),

--- a/api-server/stack-test-suite/tests/v2/token_ids.rs
+++ b/api-server/stack-test-suite/tests/v2/token_ids.rs
@@ -1,0 +1,249 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::chain::tokens::{
+    make_token_id, IsTokenFreezable, NftIssuance, TokenIssuance, TokenIssuanceV1, TokenTotalSupply,
+};
+
+use crate::DummyRPC;
+
+use super::*;
+
+#[tokio::test]
+async fn invalid_offset() {
+    let (task, response) = spawn_webserver("/api/v2/token?offset=asd").await;
+
+    assert_eq!(response.status(), 400);
+
+    let body = response.text().await.unwrap();
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(body["error"].as_str().unwrap(), "Invalid offset");
+
+    task.abort();
+}
+
+#[tokio::test]
+async fn invalid_num_items() {
+    let (task, response) = spawn_webserver("/api/v2/token?items=asd").await;
+
+    assert_eq!(response.status(), 400);
+
+    let body = response.text().await.unwrap();
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(body["error"].as_str().unwrap(), "Invalid number of items");
+
+    task.abort();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test]
+async fn invalid_num_items_max(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let more_than_max = rng.gen_range(101..1000);
+    let (task, response) = spawn_webserver(&format!("/api/v2/token?items={more_than_max}")).await;
+
+    assert_eq!(response.status(), 400);
+
+    let body = response.text().await.unwrap();
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(body["error"].as_str().unwrap(), "Invalid number of items");
+
+    task.abort();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test]
+async fn ok(#[case] seed: Seed) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let web_server_state = {
+            let mut rng = make_seedable_rng(seed);
+            let chain_config = create_unit_test_config();
+
+            let chainstate_blocks = {
+                let mut tf = TestFramework::builder(&mut rng)
+                    .with_chain_config(chain_config.clone())
+                    .build();
+
+                // generate addresses
+
+                let (_, alice_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+
+                let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
+
+                let token_issuance = TokenIssuanceV1 {
+                    token_ticker: "XXXX".as_bytes().to_vec(),
+                    number_of_decimals: rng.gen_range(1..18),
+                    metadata_uri: "http://uri".as_bytes().to_vec(),
+                    total_supply: TokenTotalSupply::Unlimited,
+                    authority: alice_destination.clone(),
+                    is_freezable: IsTokenFreezable::No,
+                };
+
+                let mut remaining = ((chain_config.fungible_token_issuance_fee() * 10).unwrap()
+                    + (chain_config.nft_issuance_fee(BlockHeight::new(1)) * 10).unwrap())
+                .unwrap();
+
+                let mut token_ids = vec![];
+                let mut input = TxInput::from_utxo(
+                    OutPointSourceId::BlockReward(tf.genesis().get_id().into()),
+                    0,
+                );
+                for _ in 0..10 {
+                    let transaction = TransactionBuilder::new()
+                        .add_input(input, InputWitness::NoSignature(None))
+                        .add_output(TxOutput::Transfer(
+                            OutputValue::Coin(remaining),
+                            Destination::AnyoneCanSpend,
+                        ))
+                        .add_output(TxOutput::IssueFungibleToken(Box::new(TokenIssuance::V1(
+                            token_issuance.clone(),
+                        ))))
+                        .build();
+
+                    let token_id = make_token_id(transaction.inputs()).unwrap();
+                    token_ids.push(token_id);
+                    input = TxInput::from_utxo(
+                        OutPointSourceId::Transaction(transaction.transaction().get_id()),
+                        0,
+                    );
+                    remaining = (remaining - chain_config.fungible_token_issuance_fee()).unwrap();
+
+                    tf.make_block_builder()
+                        .add_transaction(transaction.clone())
+                        .build_and_process(&mut rng)
+                        .unwrap()
+                        .unwrap();
+                }
+
+                let mut nft_ids = vec![];
+                for _ in 0..10 {
+                    let nft = test_utils::nft_utils::random_nft_issuance(&chain_config, &mut rng);
+                    let token_id = make_token_id(&[input.clone()]).unwrap();
+
+                    // issue NFT
+                    let transaction = TransactionBuilder::new()
+                        .add_input(input, InputWitness::NoSignature(None))
+                        .add_output(TxOutput::Transfer(
+                            OutputValue::Coin(remaining),
+                            Destination::AnyoneCanSpend,
+                        ))
+                        .add_output(TxOutput::IssueNft(
+                            token_id,
+                            Box::new(NftIssuance::V0(nft.clone())),
+                            alice_destination.clone(),
+                        ))
+                        .build();
+
+                    let token_id = make_token_id(transaction.inputs()).unwrap();
+                    nft_ids.push(token_id);
+                    input = TxInput::from_utxo(
+                        OutPointSourceId::Transaction(transaction.transaction().get_id()),
+                        0,
+                    );
+                    remaining =
+                        (remaining - chain_config.nft_issuance_fee(BlockHeight::new(1))).unwrap();
+
+                    tf.make_block_builder()
+                        .add_transaction(transaction.clone())
+                        .build_and_process(&mut rng)
+                        .unwrap()
+                        .unwrap();
+                }
+
+                _ = tx.send([(token_ids, nft_ids)]);
+
+                tf.block_indexes
+                    .iter()
+                    .map(|idx| tf.block(tf.to_chain_block_id(idx.block_id().into())))
+                    .collect::<Vec<_>>()
+            };
+
+            let storage = {
+                let mut storage = TransactionalApiServerInMemoryStorage::new(&chain_config);
+
+                let mut db_tx = storage.transaction_rw().await.unwrap();
+                db_tx.reinitialize_storage(&chain_config).await.unwrap();
+                db_tx.commit().await.unwrap();
+
+                storage
+            };
+
+            let chain_config = Arc::new(chain_config);
+
+            let mut local_node = BlockchainState::new(Arc::clone(&chain_config), storage);
+            local_node.scan_genesis(chain_config.genesis_block()).await.unwrap();
+            local_node.scan_blocks(BlockHeight::new(0), chainstate_blocks).await.unwrap();
+
+            ApiServerWebServerState {
+                db: Arc::new(local_node.storage().clone_storage().await),
+                chain_config: Arc::clone(&chain_config),
+                rpc: Arc::new(DummyRPC {}),
+                cached_values: Arc::new(CachedValues {
+                    feerate_points: RwLock::new((get_time(), vec![])),
+                }),
+                time_getter: Default::default(),
+            }
+        };
+
+        web_server(listener, web_server_state, false).await
+    });
+
+    let chain_config = create_unit_test_config();
+    for (token_ids, nft_ids) in rx.await.unwrap() {
+        let url = format!(
+            "/api/v2/token?offset=0&items={}",
+            token_ids.len() + nft_ids.len()
+        );
+
+        // Given that the listener port is open, this will block until a
+        // response is made (by the web server, which takes the listener
+        // over)
+        let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200, "Failed getting token ids");
+
+        let body = response.text().await.unwrap();
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let arr_body = body.as_array().unwrap();
+
+        for token_id in token_ids {
+            assert!(arr_body.contains(&serde_json::Value::String(
+                Address::new(&chain_config, token_id).unwrap().into_string()
+            )));
+        }
+
+        for token_id in nft_ids {
+            assert!(arr_body.contains(&serde_json::Value::String(
+                Address::new(&chain_config, token_id).unwrap().into_string()
+            )));
+        }
+    }
+
+    task.abort();
+}

--- a/api-server/storage-test-suite/src/basic.rs
+++ b/api-server/storage-test-suite/src/basic.rs
@@ -1183,7 +1183,7 @@ where
         let random_token_id = TokenId::new(H256::random_using(&mut rng));
         let random_coin_or_token_id = CoinOrTokenId::TokenId(random_token_id);
         let random_statistic = match rng.gen_range(0..4) {
-            0 => CoinOrTokenStatistic::TotalSupply,
+            0 => CoinOrTokenStatistic::CirculatingSupply,
             1 => CoinOrTokenStatistic::Staked,
             2 => CoinOrTokenStatistic::Burned,
             _ => CoinOrTokenStatistic::Preminted,

--- a/api-server/web-server/src/api/v2.rs
+++ b/api-server/web-server/src/api/v2.rs
@@ -111,7 +111,10 @@ pub fn routes<
         .route("/statistics/coin", get(coin_statistics))
         .route("/statistics/token/:id", get(token_statistics));
 
-    router.route("/token/:id", get(token)).route("/nft/:id", get(nft))
+    router
+        .route("/token", get(token_ids))
+        .route("/token/:id", get(token))
+        .route("/nft/:id", get(nft))
 }
 
 async fn forbidden_request() -> Result<(), ApiServerWebServerError> {
@@ -1179,4 +1182,59 @@ pub async fn token_statistics<T: ApiServerStorage>(
         "burned": amount_to_json(statistics.remove(&CoinOrTokenStatistic::Burned).unwrap_or(Amount::ZERO), token_decimals),
         "staked": amount_to_json(statistics.remove(&CoinOrTokenStatistic::Staked).unwrap_or(Amount::ZERO), token_decimals),
     })))
+}
+
+pub async fn token_ids<T: ApiServerStorage>(
+    Query(params): Query<BTreeMap<String, String>>,
+    State(state): State<ApiServerWebServerState<Arc<T>, Arc<impl TxSubmitClient>>>,
+) -> Result<impl IntoResponse, ApiServerWebServerError> {
+    const OFFSET: &str = "offset";
+    const ITEMS: &str = "items";
+    const DEFAULT_NUM_ITEMS: u32 = 10;
+    const MAX_NUM_ITEMS: u32 = 100;
+
+    let offset = params
+        .get(OFFSET)
+        .map(|offset| u32::from_str(offset))
+        .transpose()
+        .map_err(|_| {
+            ApiServerWebServerError::ClientError(ApiServerWebServerClientError::InvalidOffset)
+        })?
+        .unwrap_or_default();
+
+    let items = params
+        .get(ITEMS)
+        .map(|items| u32::from_str(items))
+        .transpose()
+        .map_err(|_| {
+            ApiServerWebServerError::ClientError(ApiServerWebServerClientError::InvalidNumItems)
+        })?
+        .unwrap_or(DEFAULT_NUM_ITEMS);
+    ensure!(
+        items <= MAX_NUM_ITEMS,
+        ApiServerWebServerError::ClientError(ApiServerWebServerClientError::InvalidNumItems)
+    );
+    let token_ids: Vec<_> = state
+        .db
+        .transaction_ro()
+        .await
+        .map_err(|e| {
+            logging::log::error!("internal error: {e}");
+            ApiServerWebServerError::ServerError(ApiServerWebServerServerError::InternalServerError)
+        })?
+        .get_token_ids(items, offset)
+        .await
+        .map_err(|e| {
+            logging::log::error!("internal error: {e}");
+            ApiServerWebServerError::ServerError(ApiServerWebServerServerError::InternalServerError)
+        })?
+        .into_iter()
+        .map(|token_id| {
+            serde_json::Value::String(
+                Address::new(&state.chain_config, token_id).expect("addressable").into_string(),
+            )
+        })
+        .collect();
+
+    Ok(Json(serde_json::Value::Array(token_ids)))
 }

--- a/api-server/web-server/src/api/v2.rs
+++ b/api-server/web-server/src/api/v2.rs
@@ -1134,7 +1134,7 @@ pub async fn coin_statistics<T: ApiServerStorage>(
             ApiServerWebServerError::ServerError(ApiServerWebServerServerError::InternalServerError)
         })?;
     Ok(Json(json!({
-        "total_amount": amount_to_json(statistics.remove(&CoinOrTokenStatistic::TotalSupply).unwrap_or(Amount::ZERO), state.chain_config.coin_decimals()),
+        "circulating_supply": amount_to_json(statistics.remove(&CoinOrTokenStatistic::CirculatingSupply).unwrap_or(Amount::ZERO), state.chain_config.coin_decimals()),
         "preminted": amount_to_json(statistics.remove(&CoinOrTokenStatistic::Preminted).unwrap_or(Amount::ZERO), state.chain_config.coin_decimals()),
         "burned": amount_to_json(statistics.remove(&CoinOrTokenStatistic::Burned).unwrap_or(Amount::ZERO), state.chain_config.coin_decimals()),
         "staked": amount_to_json(statistics.remove(&CoinOrTokenStatistic::Staked).unwrap_or(Amount::ZERO), state.chain_config.coin_decimals()),
@@ -1174,7 +1174,7 @@ pub async fn token_statistics<T: ApiServerStorage>(
         })?;
 
     Ok(Json(json!({
-        "total_amount": amount_to_json(statistics.remove(&CoinOrTokenStatistic::TotalSupply).unwrap_or(Amount::ZERO), token_decimals),
+        "circulating_supply": amount_to_json(statistics.remove(&CoinOrTokenStatistic::CirculatingSupply).unwrap_or(Amount::ZERO), token_decimals),
         "preminted": amount_to_json(statistics.remove(&CoinOrTokenStatistic::Preminted).unwrap_or(Amount::ZERO), token_decimals),
         "burned": amount_to_json(statistics.remove(&CoinOrTokenStatistic::Burned).unwrap_or(Amount::ZERO), token_decimals),
         "staked": amount_to_json(statistics.remove(&CoinOrTokenStatistic::Staked).unwrap_or(Amount::ZERO), token_decimals),


### PR DESCRIPTION
add endpoints for statistics for coins and tokens, returning
- ciruculating_amount the total available circulating amount
- preminted the total amount of coins that were preminted in the genesis block
- burned the total amount of coins/tokens that got burned or spent on issuance fees
- staked the total amount of coins currently being staked in pools or delegations

Added new endpoint GET token that returns a list of token ids with length and offset query parameters