### PR TITLE
GUI: fix addresses display order

### DIFF
--- a/node-gui/src/backend/error.rs
+++ b/node-gui/src/backend/error.rs
@@ -27,6 +27,8 @@ pub enum BackendError {
     UnknownAccountIndex(WalletId, AccountId),
     #[error("Invalid address: {0}")]
     AddressError(String),
+    #[error("Invalid address index: {0}")]
+    InvalidAddressIndex(String),
     #[error("Invalid amount: {0}")]
     InvalidAmount(String),
     #[error("Invalid pledge amount: {0}")]

--- a/node-gui/src/main_window/main_widget/tabs/wallet/addresses.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/addresses.rs
@@ -34,7 +34,7 @@ pub fn view_addresses(
         .addresses
         .iter()
         .map(|(index, address)| {
-            GridRow::new().push(field(index.clone())).push(field(address.clone())).push(
+            GridRow::new().push(field(index.to_string())).push(field(address.clone())).push(
                 button(
                     Text::new(iced_aw::BootstrapIcon::ClipboardCheck.to_string())
                         .font(iced_aw::BOOTSTRAP_FONT),

--- a/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/stake.rs
@@ -95,8 +95,7 @@ pub fn view_stake(
                     .push(field("Pool Address".to_owned()))
                     .push(field("Margin ratio".to_owned()))
                     .push(field("Cost per block".to_owned()))
-                    .push(field("Pool balance".to_owned()))
-                    .push(field("Decommission".to_owned())),
+                    .push(field("Pool balance".to_owned())),
             );
             for (pool_id, pool_data) in account.staking_balance.iter() {
                 let pool_id_address = Address::new(chain_config, *pool_id)


### PR DESCRIPTION
- Address indexes were Strings and therefore sorted lexicographically. I reworked that to integers.
- Removed duplicate `get_account_info2` function.
- Removed unused Decommission column from Staking view.  