### PR TITLE
Store leaf blocks in chainstate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "derive_more",
  "enum-iterator",
  "generic-array",
+ "indextree",
  "logging",
  "num-derive",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "crypto",
  "derive_more",
  "hex",
+ "indextree",
  "itertools 0.13.0",
  "jsonrpsee",
  "logging",
@@ -3454,6 +3455,12 @@ dependencies = [
  "hashbrown 0.14.5",
  "serde",
 ]
+
+[[package]]
+name = "indextree"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6f7e29c1619ec492f411b021ac9f30649d5f522ca6f287f2467ee48c8dfe10"
 
 [[package]]
 name = "indoc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ hex-literal = "0.4"
 hmac = "0.12"
 iced = "0.12"
 iced_aw = "0.9"
+indextree = "4.6"
 indoc = "2.0"
 itertools = "0.13"
 jsonrpsee = { version = "0.22", default-features = false }

--- a/chainstate/Cargo.toml
+++ b/chainstate/Cargo.toml
@@ -30,6 +30,7 @@ utxo = { path = "../utxo" }
 async-trait.workspace = true
 derive_more.workspace = true
 hex.workspace = true
+indextree.workspace = true
 itertools.workspace = true
 jsonrpsee = { workspace = true, features = ["macros"] }
 mockall.workspace = true

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -84,6 +84,7 @@ impl BanScore for BlockError {
             BlockError::UnexpectedHeightRange(_, _) => 0,
 
             BlockError::TokensAccountingError(err) => err.ban_score(),
+            BlockError::InMemoryBlockTreeError(_) => 0,
         }
     }
 }

--- a/chainstate/src/detail/block_invalidation/best_chain_candidates.rs
+++ b/chainstate/src/detail/block_invalidation/best_chain_candidates.rs
@@ -230,7 +230,7 @@ where
         &self,
         start_from: BlockHeight,
     ) -> Result<impl DoubleEndedIterator<Item = Id<Block>>, PropertyQueryError> {
-        self.get_higher_block_ids_sorted_by_height(start_from)
+        self.get_higher_block_ids_sorted_by_height(start_from, true)
     }
 
     #[log_error]

--- a/chainstate/src/detail/block_invalidation/best_chain_candidates.rs
+++ b/chainstate/src/detail/block_invalidation/best_chain_candidates.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeSet;
 
 use thiserror::Error;
 
-use crate::{detail::chainstateref::ChainstateRef, TransactionVerificationStrategy};
+use crate::{detail::chainstateref::ChainstateRef, BlockValidity, TransactionVerificationStrategy};
 use chainstate_storage::BlockchainStorageRead;
 use chainstate_types::{BlockIndex, BlockStatus, GenBlockIndex, PropertyQueryError};
 use common::{
@@ -231,7 +231,7 @@ where
         &self,
         start_from: BlockHeight,
     ) -> Result<impl DoubleEndedIterator<Item = Id<Block>>, PropertyQueryError> {
-        self.get_higher_block_ids_sorted_by_height(start_from, true)
+        self.get_higher_block_ids_sorted_by_height(start_from, BlockValidity::Any)
     }
 
     #[log_error]

--- a/chainstate/src/detail/block_invalidation/best_chain_candidates.rs
+++ b/chainstate/src/detail/block_invalidation/best_chain_candidates.rs
@@ -85,8 +85,6 @@ impl BestChainCandidates {
     ) -> Result<BestChainCandidates, BestChainCandidatesError> {
         let min_height_with_allowed_reorg = chs.min_height_with_allowed_reorg()?;
 
-        // Note: currently, this call has linear complexity with respect to the total number of
-        // blocks, see the TODO near the function itself.
         let block_ids_by_height = chs
             .get_higher_block_ids_sorted_by_height(min_height_with_allowed_reorg)
             .log_err()?;

--- a/chainstate/src/detail/block_invalidation/best_chain_candidates.rs
+++ b/chainstate/src/detail/block_invalidation/best_chain_candidates.rs
@@ -85,6 +85,7 @@ impl BestChainCandidates {
     ) -> Result<BestChainCandidates, BestChainCandidatesError> {
         let min_height_with_allowed_reorg = chs.min_height_with_allowed_reorg()?;
 
+        // TODO: use get_block_tree_top_starting_from_height directly here.
         let block_ids_by_height_iter = chs
             .get_higher_block_ids_sorted_by_height(min_height_with_allowed_reorg)
             .log_err()?;
@@ -128,11 +129,11 @@ impl BestChainCandidates {
     // from the set and add the block's parent block to the set if its chain trust is not less than
     // the specified minimum.
     #[log_error]
-    pub fn remove_tree_add_parent<Chs: ChainstateAccessor>(
+    pub fn remove_tree_add_parent<'a, Chs: ChainstateAccessor>(
         &mut self,
-        chs: &Chs,
-        root_block_info: &Chs::BlockInfo,
-        descendant_block_infos: &[Chs::BlockInfo],
+        chs: &'a Chs,
+        root_block_info: &'a Chs::BlockInfo,
+        descendant_block_infos: impl Iterator<Item = &'a Chs::BlockInfo>,
         min_chain_trust: Uint256,
     ) -> Result<(), BestChainCandidatesError> {
         self.remove(root_block_info);

--- a/chainstate/src/detail/block_invalidation/best_chain_candidates_tests.rs
+++ b/chainstate/src/detail/block_invalidation/best_chain_candidates_tests.rs
@@ -355,8 +355,8 @@ mod test_framework {
         fn get_higher_block_ids_sorted_by_height(
             &self,
             start_from: BlockHeight,
-        ) -> Result<Vec<Id<Block>>, PropertyQueryError> {
-            let mut ids_heights: Vec<_> = self
+        ) -> Result<impl DoubleEndedIterator<Item = Id<Block>>, PropertyQueryError> {
+            let mut ids_heights = self
                 .nodes
                 .iter()
                 .filter_map(|(id, data)| {
@@ -366,9 +366,9 @@ mod test_framework {
                         None
                     }
                 })
-                .collect();
+                .collect::<Vec<_>>();
             ids_heights.sort_by(|(_, height1), (_, height2)| height1.cmp(height2));
-            Ok(ids_heights.iter().map(|(id, _)| *id).collect())
+            Ok(ids_heights.into_iter().map(|(id, _)| id))
         }
 
         fn get_block_info(

--- a/chainstate/src/detail/block_invalidation/mod.rs
+++ b/chainstate/src/detail/block_invalidation/mod.rs
@@ -97,7 +97,7 @@ impl<'a, S: BlockchainStorage, V: TransactionVerificationStrategy> BlockInvalida
     ) -> Result<(), BlockInvalidatorError> {
         self.chainstate.with_rw_tx(
             |chainstate_ref| {
-                for (i, block_index) in tree.iter_all().enumerate() {
+                for (i, block_index) in tree.iter_all_block_indices().enumerate() {
                     let mut status = block_index.status();
                     if i == 0 {
                         match is_explicit_invalidation {
@@ -272,7 +272,7 @@ impl<'a, S: BlockchainStorage, V: TransactionVerificationStrategy> BlockInvalida
                                 .make_db_tx_ro()
                                 .map_err(BlockInvalidatorError::from)?,
                             block_index_tree.root_block_index(),
-                            block_index_tree.iter_children(),
+                            block_index_tree.iter_child_block_indices(),
                             min_chain_trust,
                         )?;
                     }

--- a/chainstate/src/detail/block_invalidation/mod.rs
+++ b/chainstate/src/detail/block_invalidation/mod.rs
@@ -299,11 +299,13 @@ impl<'a, S: BlockchainStorage, V: TransactionVerificationStrategy> BlockInvalida
                     }
                 }
 
-                chainstate_ref
-                    .del_block_indices_of_non_persisted_blocks(
-                        non_persisted_block_indices.into_iter(),
-                    )
-                    .map_err(BlockInvalidatorError::DelBlockIndicesError)?;
+                if !non_persisted_block_indices.is_empty() {
+                    chainstate_ref
+                        .del_block_indices_of_non_persisted_blocks(
+                            non_persisted_block_indices.into_iter(),
+                        )
+                        .map_err(BlockInvalidatorError::DelBlockIndicesError)?;
+                }
 
                 Ok(())
             },

--- a/chainstate/src/detail/block_invalidation/mod.rs
+++ b/chainstate/src/detail/block_invalidation/mod.rs
@@ -66,7 +66,7 @@ impl<'a, S: BlockchainStorage, V: TransactionVerificationStrategy> BlockInvalida
             root_block_id.into()
         )?);
         let block_indices = chainstate_ref
-            .collect_block_indices_in_branch(root_block_id)
+            .collect_block_indices_in_branch_sorted_by_height(root_block_id)
             .map_err(BlockInvalidatorError::BlockIndicesForBranchQueryError)?;
         Ok(block_indices)
     }
@@ -279,7 +279,7 @@ impl<'a, S: BlockchainStorage, V: TransactionVerificationStrategy> BlockInvalida
                 self.chainstate.make_db_tx_ro().map_err(BlockInvalidatorError::from)?;
 
             chainstate_ref
-                .collect_block_indices_in_branch(block_id)
+                .collect_block_indices_in_branch_sorted_by_height(block_id)
                 .map_err(BlockInvalidatorError::BlockIndicesForBranchQueryError)?
         };
 
@@ -301,9 +301,9 @@ impl<'a, S: BlockchainStorage, V: TransactionVerificationStrategy> BlockInvalida
 
                 chainstate_ref
                     .del_block_indices_of_non_persisted_blocks(
-                        non_persisted_block_indices.into_iter().rev(),
+                        non_persisted_block_indices.into_iter(),
                     )
-                    .map_err(|err| BlockInvalidatorError::DelBlockIndicesError(err))?;
+                    .map_err(BlockInvalidatorError::DelBlockIndicesError)?;
 
                 Ok(())
             },

--- a/chainstate/src/detail/block_invalidation/mod.rs
+++ b/chainstate/src/detail/block_invalidation/mod.rs
@@ -66,7 +66,7 @@ impl<'a, S: BlockchainStorage, V: TransactionVerificationStrategy> BlockInvalida
             root_block_id.into()
         )?);
         let block_indices = chainstate_ref
-            .collect_block_indices_in_branch_sorted_by_height(root_block_id)
+            .collect_block_indices_in_branch_sorted_by_height(root_block_id, true)
             .map_err(BlockInvalidatorError::BlockIndicesForBranchQueryError)?;
         Ok(block_indices)
     }
@@ -279,7 +279,7 @@ impl<'a, S: BlockchainStorage, V: TransactionVerificationStrategy> BlockInvalida
                 self.chainstate.make_db_tx_ro().map_err(BlockInvalidatorError::from)?;
 
             chainstate_ref
-                .collect_block_indices_in_branch_sorted_by_height(block_id)
+                .collect_block_indices_in_branch_sorted_by_height(block_id, true)
                 .map_err(BlockInvalidatorError::BlockIndicesForBranchQueryError)?
         };
 

--- a/chainstate/src/detail/chainstateref/consistency_checker.rs
+++ b/chainstate/src/detail/chainstateref/consistency_checker.rs
@@ -59,7 +59,7 @@ impl<'a, DbTx: BlockchainStorageRead> ConsistencyChecker<'a, DbTx> {
         });
         let min_height_with_allowed_reorg =
             db_tx.get_min_height_with_allowed_reorg()?.unwrap_or(0.into());
-        let leaf_block_ids = db_tx.get_leaf_block_ids()?;
+        let leaf_block_ids = db_tx.get_leaf_block_ids(BlockHeight::zero())?;
 
         Ok(Self {
             db_tx,

--- a/chainstate/src/detail/chainstateref/in_memory_reorg.rs
+++ b/chainstate/src/detail/chainstateref/in_memory_reorg.rs
@@ -136,7 +136,7 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         let mut tx_verifier = TransactionVerifier::new(self, self.chain_config);
         let mut epoch_data_cache = EpochDataCache::new(&self.db_tx);
 
-        // Disconnect the current chain if it is not a genesis
+        // Disconnect the current chain if it is not the genesis
         if let GenBlockId::Block(cur_tip) = cur_tip.classify(self.chain_config) {
             let cur_tip_index = self.get_existing_block_index(&cur_tip)?;
 

--- a/chainstate/src/detail/chainstateref/mod.rs
+++ b/chainstate/src/detail/chainstateref/mod.rs
@@ -1472,7 +1472,7 @@ impl<'a, S: BlockchainStorageWrite, V: TransactionVerificationStrategy> Chainsta
         let old_leaf_block_ids = self.db_tx.get_leaf_block_ids()?;
         let mut remaining_leaf_block_ids = old_leaf_block_ids.clone();
 
-        for block_index in tree.iter_all() {
+        for block_index in tree.iter_all_block_indices() {
             let block_id = *block_index.block_id();
 
             // Note: here we're being extra-cautious about someone mis-using this function, so we only panic in

--- a/chainstate/src/detail/error.rs
+++ b/chainstate/src/detail/error.rs
@@ -25,7 +25,7 @@ use super::{
     },
 };
 use chainstate_storage::ChainstateStorageVersion;
-use chainstate_types::{GetAncestorError, PropertyQueryError};
+use chainstate_types::{GetAncestorError, InMemoryBlockTreeError, PropertyQueryError};
 use common::{
     chain::{
         block::{block_body::BlockMerkleTreeError, timestamp::BlockTimestamp},
@@ -111,6 +111,9 @@ pub enum BlockError {
 
     #[error("Unexpected block height range: first = {0}, second = {1}")]
     UnexpectedHeightRange(BlockHeight, BlockHeight),
+
+    #[error("In-memory block tree error: {0}")]
+    InMemoryBlockTreeError(#[from] InMemoryBlockTreeError),
 }
 
 // Note: this enum isn't supposed to represent a complete error; this is why its elements

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -419,9 +419,8 @@ impl BlockProcessingErrorClassification for PropertyQueryError {
             | PropertyQueryError::BlockForHeightNotFound(_)
             | PropertyQueryError::GenesisHeaderRequested
             | PropertyQueryError::InvalidStartingBlockHeightForMainchainBlocks(_)
-            | PropertyQueryError::InvalidBlockHeightRange { .. } => {
-                BlockProcessingErrorClass::General
-            }
+            | PropertyQueryError::InvalidBlockHeightRange { .. }
+            | PropertyQueryError::InMemoryBlockTreeError(_) => BlockProcessingErrorClass::General,
             // Note: these errors are strange - sometimes they don't look like General, judging
             // by the code that uses them. But other times some of them seem to just wrap storage
             // errors.

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -110,7 +110,8 @@ impl BlockProcessingErrorClassification for BlockError {
             | BlockError::BestBlockIndexQueryError(_)
             | BlockError::BlockIndexQueryError(_, _)
             | BlockError::IsBlockInMainChainQueryError(_, _)
-            | BlockError::MinHeightForReorgQueryError(_) => BlockProcessingErrorClass::General,
+            | BlockError::MinHeightForReorgQueryError(_)
+            | BlockError::InMemoryBlockTreeError(_) => BlockProcessingErrorClass::General,
 
             BlockError::PrevBlockNotFoundForNewBlock(_) => {
                 BlockProcessingErrorClass::TemporarilyBadBlock

--- a/chainstate/src/detail/in_memory_block_tree.rs
+++ b/chainstate/src/detail/in_memory_block_tree.rs
@@ -1,0 +1,422 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chainstate_storage::BlockchainStorageRead;
+use chainstate_types::{BlockIndex, InMemoryBlockTreeError};
+use common::{
+    chain::{block::timestamp::BlockTimestamp, Block},
+    primitives::{BlockHeight, Id},
+};
+use indextree::{Arena, NodeId};
+use utils::{debug_panic_or_log, log_error};
+
+use crate::TransactionVerificationStrategy;
+
+use super::chainstateref::ChainstateRef;
+
+/// Zero or more `BlockIndex` trees sharing the same arena.
+pub struct InMemoryBlockTrees {
+    arena: Arena<BlockIndex>,
+    roots: BTreeMap<Id<Block>, NodeId>,
+}
+
+impl InMemoryBlockTrees {
+    fn new(arena: Arena<BlockIndex>, roots: BTreeMap<Id<Block>, NodeId>) -> InMemoryBlockTrees {
+        Self { arena, roots }
+    }
+
+    #[allow(unused)]
+    pub fn arena(&self) -> &Arena<BlockIndex> {
+        &self.arena
+    }
+
+    #[allow(unused)]
+    pub fn roots(&self) -> &BTreeMap<Id<Block>, NodeId> {
+        &self.roots
+    }
+
+    pub fn into_single_tree(self, root_block_id: &Id<Block>) -> Option<InMemoryBlockTree> {
+        self.roots
+            .get(root_block_id)
+            .map(|root_node_id| InMemoryBlockTree::new(self.arena, *root_node_id))
+    }
+
+    pub fn iter_trees(&self) -> impl Iterator<Item = InMemoryBlockTreeRef<'_>> {
+        self.roots
+            .values()
+            .map(|node_id| InMemoryBlockTreeRef::new(&self.arena, *node_id))
+    }
+
+    pub fn as_by_height_block_id_map(
+        &self,
+    ) -> Result<BTreeMap<BlockHeight, BTreeSet<Id<Block>>>, InMemoryBlockTreeError> {
+        let mut result = BTreeMap::<BlockHeight, BTreeSet<Id<Block>>>::new();
+
+        for tree in self.iter_trees() {
+            for block_index in tree.iter_all() {
+                result
+                    .entry(block_index.block_height())
+                    .or_default()
+                    .insert(*block_index.block_id());
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn as_by_timestamp_block_id_map(
+        &self,
+    ) -> Result<BTreeMap<BlockTimestamp, BTreeSet<Id<Block>>>, InMemoryBlockTreeError> {
+        let mut result = BTreeMap::<BlockTimestamp, BTreeSet<Id<Block>>>::new();
+
+        for tree in self.iter_trees() {
+            for block_index in tree.iter_all() {
+                result
+                    .entry(block_index.block_timestamp())
+                    .or_default()
+                    .insert(*block_index.block_id());
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+/// A "reference" to a single `BlockIndex` tree.
+pub struct InMemoryBlockTreeRef<'a> {
+    arena: &'a Arena<BlockIndex>,
+    root_id: NodeId,
+}
+
+impl<'a> InMemoryBlockTreeRef<'a> {
+    fn new(arena: &'a Arena<BlockIndex>, root_id: NodeId) -> Self {
+        Self { arena, root_id }
+    }
+
+    #[allow(unused)]
+    pub fn arena(&self) -> &Arena<BlockIndex> {
+        self.arena
+    }
+
+    #[allow(unused)]
+    pub fn root_id(&self) -> NodeId {
+        self.root_id
+    }
+
+    /// Return an iterator over the entire tree, for depth-first traversal.
+    /// A parent will always be visited before its children.
+    /// The first visited block will always be the root block.
+    pub fn iter_all(&self) -> impl Iterator<Item = &'a BlockIndex> {
+        self.root_id.descendants(self.arena).map(|node_id| {
+            self.arena
+                .get(node_id)
+                .expect("Node being iterated over must be present in the arena")
+                .get()
+        })
+    }
+
+    /// Same as iter_all, but the root is excluded.
+    pub fn iter_children(&self) -> impl Iterator<Item = &'a BlockIndex> {
+        self.iter_all().skip(1)
+    }
+
+    pub fn root_block_index(&self) -> &'a BlockIndex {
+        self.arena
+            .get(self.root_id)
+            .expect("Inconsistent InMemoryBlockTree - root node is not in the arena")
+            .get()
+    }
+
+    /// Iterate over all nodes, depth first, and call the provided function on each node.
+    /// If the function returns false, the corresponding subtree will not be descended into.
+    pub fn for_all<E: std::error::Error>(
+        &self,
+        mut handler: impl FnMut(InMemoryBlockTreeRef<'a>) -> Result<bool, E>,
+    ) -> Result<(), E> {
+        indextree_utils::for_all_depth_first(self.arena, self.root_id, |node_id| {
+            handler(InMemoryBlockTreeRef::new(self.arena, node_id))
+        })
+    }
+}
+
+/// A single `BlockIndex` tree.
+pub struct InMemoryBlockTree {
+    arena: Arena<BlockIndex>,
+    root_id: NodeId,
+}
+
+impl InMemoryBlockTree {
+    fn new(arena: Arena<BlockIndex>, root_id: NodeId) -> InMemoryBlockTree {
+        Self { arena, root_id }
+    }
+
+    #[allow(unused)]
+    pub fn arena(&self) -> &Arena<BlockIndex> {
+        &self.arena
+    }
+
+    #[allow(unused)]
+    pub fn root_id(&self) -> NodeId {
+        self.root_id
+    }
+
+    pub fn as_ref(&self) -> InMemoryBlockTreeRef<'_> {
+        InMemoryBlockTreeRef::new(&self.arena, self.root_id)
+    }
+
+    pub fn iterate_all(&self) -> impl Iterator<Item = &BlockIndex> {
+        self.as_ref().iter_all()
+    }
+
+    pub fn iterate_children(&self) -> impl Iterator<Item = &BlockIndex> {
+        self.as_ref().iter_children()
+    }
+
+    pub fn root_block_index(&self) -> &BlockIndex {
+        self.as_ref().root_block_index()
+    }
+
+    pub fn for_all<E: std::error::Error>(
+        &self,
+        handler: impl FnMut(InMemoryBlockTreeRef<'_>) -> Result<bool, E>,
+    ) -> Result<(), E> {
+        self.as_ref().for_all(handler)
+    }
+}
+
+fn append_child<T>(
+    parent: NodeId,
+    child: NodeId,
+    arena: &mut Arena<T>,
+) -> Result<(), InMemoryBlockTreeError> {
+    parent
+        .checked_append(child, arena)
+        .map_err(|err| InMemoryBlockTreeError::IndexTreeNodeError(err.to_string()))
+}
+
+/// Iterate starting from each leaf block downwards and collect the corresponding block indices.
+/// The `is_depth_ok` function is called for each traversed BlockIndex; it's supposed to
+/// check the "depth" of the given block (i.e. some property that changes strictly monotonically
+/// when going from child to parent, such as the height or the timestamp) and return true if
+/// the caller is still interested in blocks at this "depth" or false if it is not.
+#[log_error]
+pub fn get_block_tree_top<S, V>(
+    chainstate_ref: &ChainstateRef<S, V>,
+    is_depth_ok: impl Fn(&BlockIndex) -> bool,
+    include_non_persisted: bool,
+) -> Result<InMemoryBlockTrees, InMemoryBlockTreeError>
+where
+    S: BlockchainStorageRead,
+    V: TransactionVerificationStrategy,
+{
+    let mut arena = Arena::new();
+    let mut roots = BTreeMap::new();
+
+    let mut seen_blocks = BTreeMap::<Id<Block>, NodeId>::new();
+
+    let leaf_block_ids = chainstate_ref.get_leaf_block_ids()?;
+
+    for leaf_block_id in leaf_block_ids {
+        let leaf_block_index = chainstate_ref.get_existing_block_index(&leaf_block_id)?;
+
+        let effective_leaf_block_index = if !include_non_persisted {
+            if let Some(block_index) =
+                chainstate_ref.find_first_persisted_parent(leaf_block_index, &is_depth_ok)?
+            {
+                block_index
+            } else {
+                continue;
+            }
+        } else {
+            leaf_block_index
+        };
+
+        if !is_depth_ok(&effective_leaf_block_index) {
+            continue;
+        }
+
+        let effective_leaf_block_id = effective_leaf_block_index.block_id();
+
+        if seen_blocks.contains_key(effective_leaf_block_id) {
+            continue;
+        }
+
+        let mut prev_block_id = *effective_leaf_block_index.prev_block_id();
+        let mut branch_root_block_id = *effective_leaf_block_id;
+        let mut branch_root_node_id = arena.new_node(effective_leaf_block_index);
+
+        let is_standalone_branch = loop {
+            let cur_block_id = if let Some(non_genesis_parent_id) =
+                prev_block_id.classify(chainstate_ref.chain_config()).chain_block_id()
+            {
+                non_genesis_parent_id
+            } else {
+                break true;
+            };
+
+            let cur_block_index = chainstate_ref.get_existing_block_index(&cur_block_id)?;
+            prev_block_id = *cur_block_index.prev_block_id();
+
+            if !is_depth_ok(&cur_block_index) {
+                break true;
+            }
+
+            if let Some(existing_node_id) = seen_blocks.get(&cur_block_id) {
+                append_child(*existing_node_id, branch_root_node_id, &mut arena)?;
+                break false;
+            }
+
+            let cur_node_id = arena.new_node(cur_block_index);
+            append_child(cur_node_id, branch_root_node_id, &mut arena)?;
+            branch_root_block_id = cur_block_id;
+            branch_root_node_id = cur_node_id;
+
+            seen_blocks.insert(cur_block_id, cur_node_id);
+        };
+
+        if is_standalone_branch {
+            roots.insert(branch_root_block_id, branch_root_node_id);
+        }
+    }
+
+    Ok(InMemoryBlockTrees::new(arena, roots))
+}
+
+/// Collect a single branch of the block index tree.
+#[log_error]
+pub fn get_block_tree_branch<S, V>(
+    chainstate_ref: &ChainstateRef<S, V>,
+    root_block_id: &Id<Block>,
+    include_non_persisted: bool,
+) -> Result<InMemoryBlockTree, InMemoryBlockTreeError>
+where
+    S: BlockchainStorageRead,
+    V: TransactionVerificationStrategy,
+{
+    let root_block_index = chainstate_ref.get_existing_block_index(root_block_id)?;
+    let root_block_height = root_block_index.block_height();
+
+    let trees = get_block_tree_top(
+        chainstate_ref,
+        |block_index| block_index.block_height() >= root_block_height,
+        include_non_persisted,
+    )?;
+    let tree = trees.into_single_tree(root_block_id);
+
+    if let Some(tree) = tree {
+        Ok(tree)
+    } else {
+        debug_panic_or_log!("Expecting {root_block_id} to be among found subtrees but it's not");
+
+        Err(InMemoryBlockTreeError::InvariantError(format!(
+            "subtree missing for block {}",
+            *root_block_id
+        )))
+    }
+}
+
+mod indextree_utils {
+    use indextree::{Arena, NodeId};
+
+    pub fn for_all_depth_first<T, E: std::error::Error>(
+        arena: &Arena<T>,
+        root_id: NodeId,
+        mut handler: impl FnMut(NodeId) -> Result<bool, E>,
+    ) -> Result<(), E> {
+        if !handler(root_id)? {
+            return Ok(());
+        }
+
+        let mut stack = Vec::new();
+        stack.push(root_id.children(arena));
+
+        while !stack.is_empty() {
+            let cur_node_id = stack.last_mut().expect("The stack is known to be non-empty").next();
+
+            if let Some(cur_node_id) = cur_node_id {
+                if handler(cur_node_id)? {
+                    stack.push(cur_node_id.children(arena));
+                }
+            } else {
+                stack.pop();
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_for_all_depth_first() {
+            // a1---a2---a3---a4---a5
+            //  \---c1---c2    \---b1
+            //       \---d1---d2
+
+            let mut arena = Arena::new();
+
+            let a1 = arena.new_node(1);
+            let a2 = arena.new_node(2);
+            let a3 = arena.new_node(3);
+            let a4 = arena.new_node(4);
+            let a5 = arena.new_node(5);
+            let b1 = arena.new_node(11);
+            let c1 = arena.new_node(111);
+            let c2 = arena.new_node(222);
+            let d1 = arena.new_node(1111);
+            let d2 = arena.new_node(2222);
+
+            a1.checked_append(a2, &mut arena).unwrap();
+            a1.checked_append(c1, &mut arena).unwrap();
+            a2.checked_append(a3, &mut arena).unwrap();
+            a3.checked_append(a4, &mut arena).unwrap();
+            a4.checked_append(a5, &mut arena).unwrap();
+            a4.checked_append(b1, &mut arena).unwrap();
+            c1.checked_append(c2, &mut arena).unwrap();
+            c1.checked_append(d1, &mut arena).unwrap();
+            d1.checked_append(d2, &mut arena).unwrap();
+
+            let result = for_all_depth_first_collect(&arena, a1, |_| true);
+            let expected = [1, 2, 3, 4, 5, 11, 111, 222, 1111, 2222];
+            assert_eq!(result, expected);
+
+            // Don't descent into a3
+            let result = for_all_depth_first_collect(&arena, a1, |val| val != 3);
+            let expected = [1, 2, 3, 111, 222, 1111, 2222];
+            assert_eq!(result, expected);
+        }
+
+        fn for_all_depth_first_collect<T: Copy>(
+            arena: &Arena<T>,
+            root_id: NodeId,
+            handler: impl Fn(T) -> bool,
+        ) -> Vec<T> {
+            let mut result = Vec::new();
+
+            for_all_depth_first(arena, root_id, |node_id| {
+                let val = *arena.get(node_id).unwrap().get();
+                result.push(val);
+                std::io::Result::Ok(handler(val))
+            })
+            .unwrap();
+
+            result
+        }
+    }
+}

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -77,7 +77,7 @@ pub use self::{
     median_time::calculate_median_time_past_from_blocktimestamps, median_time::MEDIAN_TIME_SPAN,
 };
 pub use chainstate_types::Locator;
-pub use chainstateref::NonZeroPoolBalances;
+pub use chainstateref::{BlockValidity, NonZeroPoolBalances};
 pub use error::{
     BlockError, CheckBlockError, CheckBlockTransactionsError, DbCommittingContext,
     InitializationError, OrphanCheckError, StorageCompatibilityCheckError,

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -24,6 +24,7 @@ pub mod ban_score;
 pub mod block_checking;
 pub mod block_invalidation;
 pub mod bootstrap;
+pub mod in_memory_block_tree;
 pub mod query;
 pub mod tx_verification_strategy;
 

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, num::NonZeroUsize};
+use std::num::NonZeroUsize;
 
 use chainstate_storage::BlockchainStorageRead;
 use chainstate_types::{BlockIndex, GenBlockIndex, Locator, PropertyQueryError};
@@ -31,7 +31,10 @@ use common::{
 use tokens_accounting::TokensAccountingStorageRead;
 use utils::ensure;
 
-use super::{chainstateref, tx_verification_strategy::TransactionVerificationStrategy};
+use super::{
+    chainstateref, in_memory_block_tree::InMemoryBlockTrees,
+    tx_verification_strategy::TransactionVerificationStrategy,
+};
 
 pub fn locator_tip_distances() -> impl Iterator<Item = BlockDistance> {
     itertools::iterate(0, |&i| std::cmp::max(1, i * 2)).map(BlockDistance::new)
@@ -387,22 +390,22 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
         self.chainstate_ref.get_block_id_tree_as_list()
     }
 
-    pub fn get_block_tree_top_by_height(
+    pub fn get_block_tree_top_starting_from_height(
         &self,
-        start_from: BlockHeight,
+        min_height: BlockHeight,
         include_non_persisted: bool,
-    ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, PropertyQueryError> {
+    ) -> Result<InMemoryBlockTrees, PropertyQueryError> {
         self.chainstate_ref
-            .get_block_tree_top_by_height(start_from, include_non_persisted)
+            .get_block_tree_top_starting_from_height(min_height, include_non_persisted)
     }
 
-    pub fn get_block_tree_top_by_timestamp(
+    pub fn get_block_tree_top_starting_from_timestamp(
         &self,
-        start_from: BlockTimestamp,
+        min_timestamp: BlockTimestamp,
         include_non_persisted: bool,
-    ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, PropertyQueryError> {
+    ) -> Result<InMemoryBlockTrees, PropertyQueryError> {
         self.chainstate_ref
-            .get_block_tree_top_by_timestamp(start_from, include_non_persisted)
+            .get_block_tree_top_starting_from_timestamp(min_timestamp, include_non_persisted)
     }
 
     pub fn get_token_data(

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -390,15 +390,19 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     pub fn get_block_tree_top_by_height(
         &self,
         start_from: BlockHeight,
+        include_non_persisted: bool,
     ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, PropertyQueryError> {
-        self.chainstate_ref.get_block_tree_top_by_height(start_from)
+        self.chainstate_ref
+            .get_block_tree_top_by_height(start_from, include_non_persisted)
     }
 
     pub fn get_block_tree_top_by_timestamp(
         &self,
         start_from: BlockTimestamp,
+        include_non_persisted: bool,
     ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, PropertyQueryError> {
-        self.chainstate_ref.get_block_tree_top_by_timestamp(start_from)
+        self.chainstate_ref
+            .get_block_tree_top_by_timestamp(start_from, include_non_persisted)
     }
 
     pub fn get_token_data(

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::num::NonZeroUsize;
+use std::{collections::BTreeMap, num::NonZeroUsize};
 
 use chainstate_storage::BlockchainStorageRead;
 use chainstate_types::{BlockIndex, GenBlockIndex, Locator, PropertyQueryError};
 use common::{
     chain::{
-        block::{signed_block_header::SignedBlockHeader, BlockReward},
+        block::{signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp, BlockReward},
         tokens::{
             NftIssuance, RPCFungibleTokenInfo, RPCIsTokenFrozen, RPCNonFungibleTokenInfo,
             RPCTokenInfo, TokenAuxiliaryData, TokenId,
@@ -385,6 +385,20 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
 
     pub fn get_block_id_tree_as_list(&self) -> Result<Vec<Id<Block>>, PropertyQueryError> {
         self.chainstate_ref.get_block_id_tree_as_list()
+    }
+
+    pub fn get_block_tree_top_by_height(
+        &self,
+        start_from: BlockHeight,
+    ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, PropertyQueryError> {
+        self.chainstate_ref.get_block_tree_top_by_height(start_from)
+    }
+
+    pub fn get_block_tree_top_by_timestamp(
+        &self,
+        start_from: BlockTimestamp,
+    ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, PropertyQueryError> {
+        self.chainstate_ref.get_block_tree_top_by_timestamp(start_from)
     }
 
     pub fn get_token_data(

--- a/chainstate/src/detail/query.rs
+++ b/chainstate/src/detail/query.rs
@@ -31,6 +31,8 @@ use common::{
 use tokens_accounting::TokensAccountingStorageRead;
 use utils::ensure;
 
+use crate::BlockValidity;
+
 use super::{
     chainstateref, in_memory_block_tree::InMemoryBlockTrees,
     tx_verification_strategy::TransactionVerificationStrategy,
@@ -393,19 +395,19 @@ impl<'a, S: BlockchainStorageRead, V: TransactionVerificationStrategy> Chainstat
     pub fn get_block_tree_top_starting_from_height(
         &self,
         min_height: BlockHeight,
-        include_non_persisted: bool,
+        block_validity: BlockValidity,
     ) -> Result<InMemoryBlockTrees, PropertyQueryError> {
         self.chainstate_ref
-            .get_block_tree_top_starting_from_height(min_height, include_non_persisted)
+            .get_block_tree_top_starting_from_height(min_height, block_validity)
     }
 
     pub fn get_block_tree_top_starting_from_timestamp(
         &self,
         min_timestamp: BlockTimestamp,
-        include_non_persisted: bool,
+        block_validity: BlockValidity,
     ) -> Result<InMemoryBlockTrees, PropertyQueryError> {
         self.chainstate_ref
-            .get_block_tree_top_starting_from_timestamp(min_timestamp, include_non_persisted)
+            .get_block_tree_top_starting_from_timestamp(min_timestamp, block_validity)
     }
 
     pub fn get_token_data(

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -16,8 +16,8 @@
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 
 use crate::{
-    detail::BlockSource, ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent,
-    InMemoryBlockTrees, NonZeroPoolBalances,
+    detail::BlockSource, BlockValidity, ChainInfo, ChainstateConfig, ChainstateError,
+    ChainstateEvent, InMemoryBlockTrees, NonZeroPoolBalances,
 };
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex, Locator};
 use common::{
@@ -236,22 +236,18 @@ pub trait ChainstateInterface: Send + Sync {
 
     /// Return block indices of blocks with heights bigger than or equal to the specified one,
     /// as a set of zero or more trees.
-    /// If `include_non_persisted` is false, indices of non-persisted blocks will not be included in the result.
-    // TODO: a persisted block can still be invalid. Should we only return valid blocks here?
     fn get_block_tree_top_starting_from_height(
         &self,
         min_height: BlockHeight,
-        include_non_persisted: bool,
+        block_validity: BlockValidity,
     ) -> Result<InMemoryBlockTrees, ChainstateError>;
 
     /// Return block indices of blocks with timestamps bigger than or equal to the specified one,
     /// as a set of zero or more trees.
-    /// If `include_non_persisted` is false, indices of non-persisted blocks will not be included in the result.
-    // TODO: a persisted block can still be invalid. Should we only return valid blocks here?
     fn get_block_tree_top_starting_from_timestamp(
         &self,
         min_timestamp: BlockTimestamp,
-        include_non_persisted: bool,
+        block_validity: BlockValidity,
     ) -> Result<InMemoryBlockTrees, ChainstateError>;
 
     /// Imports a bootstrap file exported with `export_bootstrap_stream`.

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -230,8 +230,23 @@ pub trait ChainstateInterface: Send + Sync {
     /// Returns a list of all block ids in mainchain in order (starting from block of height 1, hence the result length is best_height - 1).
     fn get_mainchain_blocks_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
 
-    /// Returns a list of all blocks in the block tree, including orphans. The length cannot be predicted before the call.
+    /// Returns a list of all blocks in the block tree. The length cannot be predicted before the call.
+    /// The result will be sorted by height.
     fn get_block_id_tree_as_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
+
+    /// Return ids of all blocks with heights bigger than or equal to the specified one,
+    /// grouped by height.
+    fn get_block_tree_top_by_height(
+        &self,
+        start_from: BlockHeight,
+    ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError>;
+
+    /// Return ids of all blocks with timestamps bigger than or equal to the specified one,
+    /// grouped by timestamp.
+    fn get_block_tree_top_by_timestamp(
+        &self,
+        start_from: BlockTimestamp,
+    ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, ChainstateError>;
 
     /// Imports a bootstrap file exported with `export_bootstrap_stream`.
     fn import_bootstrap_stream<'a>(

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -230,18 +230,20 @@ pub trait ChainstateInterface: Send + Sync {
     /// Returns a list of all block ids in mainchain in order (starting from block of height 1, hence the result length is best_height - 1).
     fn get_mainchain_blocks_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
 
-    /// Returns a list of all blocks in the block tree. The length cannot be predicted before the call.
+    /// Returns a list of all persisted blocks in the block tree. The length cannot be predicted before the call.
     /// The result will be sorted by height.
     fn get_block_id_tree_as_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
 
-    /// Return ids of all blocks with heights bigger than or equal to the specified one,
+    /// Return ids of all persisted blocks with heights bigger than or equal to the specified one,
     /// grouped by height.
+    // TODO: a persisted block can still be invalid. Should we only return valid blocks here?
+    // Same for get_block_tree_top_by_timestamp below (and possibly for get_block_id_tree_as_list too).
     fn get_block_tree_top_by_height(
         &self,
         start_from: BlockHeight,
     ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError>;
 
-    /// Return ids of all blocks with timestamps bigger than or equal to the specified one,
+    /// Return ids of all persisted blocks with timestamps bigger than or equal to the specified one,
     /// grouped by timestamp.
     fn get_block_tree_top_by_timestamp(
         &self,

--- a/chainstate/src/interface/chainstate_interface.rs
+++ b/chainstate/src/interface/chainstate_interface.rs
@@ -17,7 +17,7 @@ use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 
 use crate::{
     detail::BlockSource, ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent,
-    NonZeroPoolBalances,
+    InMemoryBlockTrees, NonZeroPoolBalances,
 };
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex, Locator};
 use common::{
@@ -234,21 +234,25 @@ pub trait ChainstateInterface: Send + Sync {
     /// The result will be sorted by height.
     fn get_block_id_tree_as_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
 
-    /// Return ids of all persisted blocks with heights bigger than or equal to the specified one,
-    /// grouped by height.
+    /// Return block indices of blocks with heights bigger than or equal to the specified one,
+    /// as a set of zero or more trees.
+    /// If `include_non_persisted` is false, indices of non-persisted blocks will not be included in the result.
     // TODO: a persisted block can still be invalid. Should we only return valid blocks here?
-    // Same for get_block_tree_top_by_timestamp below (and possibly for get_block_id_tree_as_list too).
-    fn get_block_tree_top_by_height(
+    fn get_block_tree_top_starting_from_height(
         &self,
-        start_from: BlockHeight,
-    ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError>;
+        min_height: BlockHeight,
+        include_non_persisted: bool,
+    ) -> Result<InMemoryBlockTrees, ChainstateError>;
 
-    /// Return ids of all persisted blocks with timestamps bigger than or equal to the specified one,
-    /// grouped by timestamp.
-    fn get_block_tree_top_by_timestamp(
+    /// Return block indices of blocks with timestamps bigger than or equal to the specified one,
+    /// as a set of zero or more trees.
+    /// If `include_non_persisted` is false, indices of non-persisted blocks will not be included in the result.
+    // TODO: a persisted block can still be invalid. Should we only return valid blocks here?
+    fn get_block_tree_top_starting_from_timestamp(
         &self,
-        start_from: BlockTimestamp,
-    ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, ChainstateError>;
+        min_timestamp: BlockTimestamp,
+        include_non_persisted: bool,
+    ) -> Result<InMemoryBlockTrees, ChainstateError>;
 
     /// Imports a bootstrap file exported with `export_bootstrap_stream`.
     fn import_bootstrap_stream<'a>(

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -32,7 +32,10 @@ use chainstate_storage::BlockchainStorage;
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex, PropertyQueryError};
 use common::{
     chain::{
-        block::{signed_block_header::SignedBlockHeader, Block, BlockReward, GenBlock},
+        block::{
+            signed_block_header::SignedBlockHeader, timestamp::BlockTimestamp, Block, BlockReward,
+            GenBlock,
+        },
         config::ChainConfig,
         tokens::{RPCTokenInfo, TokenAuxiliaryData, TokenId},
         AccountNonce, AccountType, DelegationId, PoolId, Transaction, TxInput, TxOutput,
@@ -561,6 +564,30 @@ where
             .query()
             .map_err(ChainstateError::from)?
             .get_block_id_tree_as_list()
+            .map_err(ChainstateError::FailedToReadProperty)
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn get_block_tree_top_by_height(
+        &self,
+        start_from: BlockHeight,
+    ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError> {
+        self.chainstate
+            .query()
+            .map_err(ChainstateError::from)?
+            .get_block_tree_top_by_height(start_from)
+            .map_err(ChainstateError::FailedToReadProperty)
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn get_block_tree_top_by_timestamp(
+        &self,
+        start_from: BlockTimestamp,
+    ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, ChainstateError> {
+        self.chainstate
+            .query()
+            .map_err(ChainstateError::from)?
+            .get_block_tree_top_by_timestamp(start_from)
             .map_err(ChainstateError::FailedToReadProperty)
     }
 

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -25,8 +25,8 @@ use crate::{
         tx_verification_strategy::TransactionVerificationStrategy,
         BlockSource, OrphanBlocksRef,
     },
-    ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent, ChainstateInterface,
-    InMemoryBlockTrees, Locator, NonZeroPoolBalances,
+    BlockValidity, ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent,
+    ChainstateInterface, InMemoryBlockTrees, Locator, NonZeroPoolBalances,
 };
 use chainstate_storage::BlockchainStorage;
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex, PropertyQueryError};
@@ -571,12 +571,12 @@ where
     fn get_block_tree_top_starting_from_height(
         &self,
         min_height: BlockHeight,
-        include_non_persisted: bool,
+        block_validity: BlockValidity,
     ) -> Result<InMemoryBlockTrees, ChainstateError> {
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
-            .get_block_tree_top_starting_from_height(min_height, include_non_persisted)
+            .get_block_tree_top_starting_from_height(min_height, block_validity)
             .map_err(ChainstateError::FailedToReadProperty)
     }
 
@@ -584,12 +584,12 @@ where
     fn get_block_tree_top_starting_from_timestamp(
         &self,
         min_timestamp: BlockTimestamp,
-        include_non_persisted: bool,
+        block_validity: BlockValidity,
     ) -> Result<InMemoryBlockTrees, ChainstateError> {
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
-            .get_block_tree_top_starting_from_timestamp(min_timestamp, include_non_persisted)
+            .get_block_tree_top_starting_from_timestamp(min_timestamp, block_validity)
             .map_err(ChainstateError::FailedToReadProperty)
     }
 

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -575,7 +575,7 @@ where
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
-            .get_block_tree_top_by_height(start_from)
+            .get_block_tree_top_by_height(start_from, false)
             .map_err(ChainstateError::FailedToReadProperty)
     }
 
@@ -587,7 +587,7 @@ where
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
-            .get_block_tree_top_by_timestamp(start_from)
+            .get_block_tree_top_by_timestamp(start_from, false)
             .map_err(ChainstateError::FailedToReadProperty)
     }
 

--- a/chainstate/src/interface/chainstate_interface_impl.rs
+++ b/chainstate/src/interface/chainstate_interface_impl.rs
@@ -25,8 +25,8 @@ use crate::{
         tx_verification_strategy::TransactionVerificationStrategy,
         BlockSource, OrphanBlocksRef,
     },
-    ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent, ChainstateInterface, Locator,
-    NonZeroPoolBalances,
+    ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent, ChainstateInterface,
+    InMemoryBlockTrees, Locator, NonZeroPoolBalances,
 };
 use chainstate_storage::BlockchainStorage;
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex, PropertyQueryError};
@@ -568,26 +568,28 @@ where
     }
 
     #[tracing::instrument(skip_all)]
-    fn get_block_tree_top_by_height(
+    fn get_block_tree_top_starting_from_height(
         &self,
-        start_from: BlockHeight,
-    ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError> {
+        min_height: BlockHeight,
+        include_non_persisted: bool,
+    ) -> Result<InMemoryBlockTrees, ChainstateError> {
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
-            .get_block_tree_top_by_height(start_from, false)
+            .get_block_tree_top_starting_from_height(min_height, include_non_persisted)
             .map_err(ChainstateError::FailedToReadProperty)
     }
 
     #[tracing::instrument(skip_all)]
-    fn get_block_tree_top_by_timestamp(
+    fn get_block_tree_top_starting_from_timestamp(
         &self,
-        start_from: BlockTimestamp,
-    ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, ChainstateError> {
+        min_timestamp: BlockTimestamp,
+        include_non_persisted: bool,
+    ) -> Result<InMemoryBlockTrees, ChainstateError> {
         self.chainstate
             .query()
             .map_err(ChainstateError::from)?
-            .get_block_tree_top_by_timestamp(start_from, false)
+            .get_block_tree_top_starting_from_timestamp(min_timestamp, include_non_persisted)
             .map_err(ChainstateError::FailedToReadProperty)
     }
 

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -304,6 +304,20 @@ where
         self.deref().get_block_id_tree_as_list()
     }
 
+    fn get_block_tree_top_by_height(
+        &self,
+        start_from: BlockHeight,
+    ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError> {
+        self.deref().get_block_tree_top_by_height(start_from)
+    }
+
+    fn get_block_tree_top_by_timestamp(
+        &self,
+        start_from: BlockTimestamp,
+    ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, ChainstateError> {
+        self.deref().get_block_tree_top_by_timestamp(start_from)
+    }
+
     fn import_bootstrap_stream<'a>(
         &mut self,
         reader: std::io::BufReader<Box<dyn std::io::Read + Send + 'a>>,

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -37,8 +37,8 @@ use utils_networking::broadcaster;
 use utxo::Utxo;
 
 use crate::{
-    chainstate_interface::ChainstateInterface, BlockSource, ChainInfo, ChainstateConfig,
-    ChainstateError, ChainstateEvent, InMemoryBlockTrees, NonZeroPoolBalances,
+    chainstate_interface::ChainstateInterface, BlockSource, BlockValidity, ChainInfo,
+    ChainstateConfig, ChainstateError, ChainstateEvent, InMemoryBlockTrees, NonZeroPoolBalances,
 };
 
 impl<T: Deref + DerefMut + Send + Sync> ChainstateInterface for T
@@ -307,19 +307,18 @@ where
     fn get_block_tree_top_starting_from_height(
         &self,
         min_height: BlockHeight,
-        include_non_persisted: bool,
+        block_validity: BlockValidity,
     ) -> Result<InMemoryBlockTrees, ChainstateError> {
-        self.deref()
-            .get_block_tree_top_starting_from_height(min_height, include_non_persisted)
+        self.deref().get_block_tree_top_starting_from_height(min_height, block_validity)
     }
 
     fn get_block_tree_top_starting_from_timestamp(
         &self,
         min_timestamp: BlockTimestamp,
-        include_non_persisted: bool,
+        block_validity: BlockValidity,
     ) -> Result<InMemoryBlockTrees, ChainstateError> {
         self.deref()
-            .get_block_tree_top_starting_from_timestamp(min_timestamp, include_non_persisted)
+            .get_block_tree_top_starting_from_timestamp(min_timestamp, block_validity)
     }
 
     fn import_bootstrap_stream<'a>(

--- a/chainstate/src/interface/chainstate_interface_impl_delegation.rs
+++ b/chainstate/src/interface/chainstate_interface_impl_delegation.rs
@@ -38,7 +38,7 @@ use utxo::Utxo;
 
 use crate::{
     chainstate_interface::ChainstateInterface, BlockSource, ChainInfo, ChainstateConfig,
-    ChainstateError, ChainstateEvent, NonZeroPoolBalances,
+    ChainstateError, ChainstateEvent, InMemoryBlockTrees, NonZeroPoolBalances,
 };
 
 impl<T: Deref + DerefMut + Send + Sync> ChainstateInterface for T
@@ -304,18 +304,22 @@ where
         self.deref().get_block_id_tree_as_list()
     }
 
-    fn get_block_tree_top_by_height(
+    fn get_block_tree_top_starting_from_height(
         &self,
-        start_from: BlockHeight,
-    ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError> {
-        self.deref().get_block_tree_top_by_height(start_from)
+        min_height: BlockHeight,
+        include_non_persisted: bool,
+    ) -> Result<InMemoryBlockTrees, ChainstateError> {
+        self.deref()
+            .get_block_tree_top_starting_from_height(min_height, include_non_persisted)
     }
 
-    fn get_block_tree_top_by_timestamp(
+    fn get_block_tree_top_starting_from_timestamp(
         &self,
-        start_from: BlockTimestamp,
-    ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, ChainstateError> {
-        self.deref().get_block_tree_top_by_timestamp(start_from)
+        min_timestamp: BlockTimestamp,
+        include_non_persisted: bool,
+    ) -> Result<InMemoryBlockTrees, ChainstateError> {
+        self.deref()
+            .get_block_tree_top_starting_from_timestamp(min_timestamp, include_non_persisted)
     }
 
     fn import_bootstrap_stream<'a>(

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -38,8 +38,7 @@ pub use crate::{
         block_invalidation::BlockInvalidatorError,
         calculate_median_time_past, calculate_median_time_past_from_blocktimestamps,
         in_memory_block_tree::{
-            InMemoryBlockTree, InMemoryBlockTreeNodeId, InMemoryBlockTreeNodeRef,
-            InMemoryBlockTreeRef, InMemoryBlockTrees,
+            InMemoryBlockTree, InMemoryBlockTreeNodeId, InMemoryBlockTreeRef, InMemoryBlockTrees,
         },
         BlockError, BlockProcessingErrorClass, BlockProcessingErrorClassification, BlockSource,
         BlockValidity, ChainInfo, CheckBlockError, CheckBlockTransactionsError,

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -34,12 +34,14 @@ use interface::chainstate_interface_impl;
 pub use crate::{
     config::{ChainstateConfig, MaxTipAge},
     detail::{
-        ban_score, block_invalidation::BlockInvalidatorError, calculate_median_time_past,
-        calculate_median_time_past_from_blocktimestamps, BlockError, BlockProcessingErrorClass,
-        BlockProcessingErrorClassification, BlockSource, ChainInfo, CheckBlockError,
-        CheckBlockTransactionsError, ConnectTransactionError, IOPolicyError, InitializationError,
-        Locator, NonZeroPoolBalances, OrphanCheckError, SpendStakeError,
-        StorageCompatibilityCheckError, TokenIssuanceError, TokensError,
+        ban_score,
+        block_invalidation::BlockInvalidatorError,
+        calculate_median_time_past, calculate_median_time_past_from_blocktimestamps,
+        in_memory_block_tree::{InMemoryBlockTree, InMemoryBlockTreeRef, InMemoryBlockTrees},
+        BlockError, BlockProcessingErrorClass, BlockProcessingErrorClassification, BlockSource,
+        ChainInfo, CheckBlockError, CheckBlockTransactionsError, ConnectTransactionError,
+        IOPolicyError, InitializationError, Locator, NonZeroPoolBalances, OrphanCheckError,
+        SpendStakeError, StorageCompatibilityCheckError, TokenIssuanceError, TokensError,
         TransactionVerifierStorageError, MEDIAN_TIME_SPAN,
     },
 };

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -39,10 +39,10 @@ pub use crate::{
         calculate_median_time_past, calculate_median_time_past_from_blocktimestamps,
         in_memory_block_tree::{InMemoryBlockTree, InMemoryBlockTreeRef, InMemoryBlockTrees},
         BlockError, BlockProcessingErrorClass, BlockProcessingErrorClassification, BlockSource,
-        ChainInfo, CheckBlockError, CheckBlockTransactionsError, ConnectTransactionError,
-        IOPolicyError, InitializationError, Locator, NonZeroPoolBalances, OrphanCheckError,
-        SpendStakeError, StorageCompatibilityCheckError, TokenIssuanceError, TokensError,
-        TransactionVerifierStorageError, MEDIAN_TIME_SPAN,
+        BlockValidity, ChainInfo, CheckBlockError, CheckBlockTransactionsError,
+        ConnectTransactionError, IOPolicyError, InitializationError, Locator, NonZeroPoolBalances,
+        OrphanCheckError, SpendStakeError, StorageCompatibilityCheckError, TokenIssuanceError,
+        TokensError, TransactionVerifierStorageError, MEDIAN_TIME_SPAN,
     },
 };
 pub use chainstate_types::{BlockIndex, GenBlockIndex, PropertyQueryError};

--- a/chainstate/src/lib.rs
+++ b/chainstate/src/lib.rs
@@ -37,7 +37,10 @@ pub use crate::{
         ban_score,
         block_invalidation::BlockInvalidatorError,
         calculate_median_time_past, calculate_median_time_past_from_blocktimestamps,
-        in_memory_block_tree::{InMemoryBlockTree, InMemoryBlockTreeRef, InMemoryBlockTrees},
+        in_memory_block_tree::{
+            InMemoryBlockTree, InMemoryBlockTreeNodeId, InMemoryBlockTreeNodeRef,
+            InMemoryBlockTreeRef, InMemoryBlockTrees,
+        },
         BlockError, BlockProcessingErrorClass, BlockProcessingErrorClassification, BlockSource,
         BlockValidity, ChainInfo, CheckBlockError, CheckBlockTransactionsError,
         ConnectTransactionError, IOPolicyError, InitializationError, Locator, NonZeroPoolBalances,

--- a/chainstate/storage/src/internal/store_tx/read_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/read_impls.rs
@@ -146,6 +146,18 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRo<'st, B
     }
 
     #[log_error]
+    fn get_leaf_block_ids(&self) -> crate::Result<BTreeSet<Id<Block>>> {
+        let map = self.0.get::<db::DBLeafBlockIds, _>();
+        let items = map.prefix_iter_keys(&())?;
+        Ok(items.collect::<BTreeSet<_>>())
+    }
+
+    #[log_error]
+    fn is_leaf_block(&self, block_id: &Id<Block>) -> crate::Result<bool> {
+        Ok(self.read::<db::DBLeafBlockIds, _, _>(block_id)?.is_some())
+    }
+
+    #[log_error]
     fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>> {
         self.read::<db::DBUtxosBlockUndo, _, _>(id)
     }
@@ -424,6 +436,18 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     #[log_error]
     fn get_block_id_by_height(&self, height: &BlockHeight) -> crate::Result<Option<Id<GenBlock>>> {
         self.read::<db::DBBlockByHeight, _, _>(height)
+    }
+
+    #[log_error]
+    fn get_leaf_block_ids(&self) -> crate::Result<BTreeSet<Id<Block>>> {
+        let map = self.get_map::<db::DBLeafBlockIds, _>()?;
+        let items = map.prefix_iter_keys(&())?;
+        Ok(items.collect::<BTreeSet<_>>())
+    }
+
+    #[log_error]
+    fn is_leaf_block(&self, block_id: &Id<Block>) -> crate::Result<bool> {
+        Ok(self.read::<db::DBLeafBlockIds, _, _>(block_id)?.is_some())
     }
 
     #[log_error]

--- a/chainstate/storage/src/internal/store_tx/read_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/read_impls.rs
@@ -181,7 +181,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRo<'st, B
     }
 
     #[log_error]
-    fn get_block_tree_by_height(
+    fn get_block_tree_by_height_traversing_entire_index(
         &self,
         start_from: BlockHeight,
     ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>> {
@@ -474,7 +474,7 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     }
 
     #[log_error]
-    fn get_block_tree_by_height(
+    fn get_block_tree_by_height_traversing_entire_index(
         &self,
         start_from: BlockHeight,
     ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>> {

--- a/chainstate/storage/src/internal/store_tx/read_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/read_impls.rs
@@ -181,21 +181,11 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRo<'st, B
     }
 
     #[log_error]
-    fn get_block_tree_by_height_traversing_entire_index(
-        &self,
-        start_from: BlockHeight,
-    ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>> {
+    fn iterate_block_index(&self) -> crate::Result<impl Iterator<Item = BlockIndex>> {
         let map = self.0.get::<db::DBBlockIndex, _>();
-        let items = map.prefix_iter_decoded(&())?;
+        let iter = map.prefix_iter_decoded(&())?.map(|(_, block_index)| block_index);
 
-        let mut result = BTreeMap::<BlockHeight, Vec<Id<Block>>>::new();
-        for (_, bi) in items {
-            if bi.block_height() >= start_from {
-                result.entry(bi.block_height()).or_default().push(*bi.block_id());
-            }
-        }
-
-        Ok(result)
+        Ok(iter)
     }
 
     #[log_error]
@@ -474,21 +464,11 @@ impl<'st, B: storage::Backend> BlockchainStorageRead for super::StoreTxRw<'st, B
     }
 
     #[log_error]
-    fn get_block_tree_by_height_traversing_entire_index(
-        &self,
-        start_from: BlockHeight,
-    ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>> {
+    fn iterate_block_index(&self) -> crate::Result<impl Iterator<Item = BlockIndex>> {
         let map = self.get_map::<db::DBBlockIndex, _>()?;
-        let items = map.prefix_iter_decoded(&())?;
+        let iter = map.prefix_iter_decoded(&())?.map(|(_, block_index)| block_index);
 
-        let mut result = BTreeMap::<BlockHeight, Vec<Id<Block>>>::new();
-        for (_, bi) in items {
-            if bi.block_height() >= start_from {
-                result.entry(bi.block_height()).or_default().push(*bi.block_id());
-            }
-        }
-
-        Ok(result)
+        Ok(iter)
     }
 
     #[log_error]

--- a/chainstate/storage/src/internal/store_tx/write_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/write_impls.rs
@@ -96,6 +96,15 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
     }
 
     #[log_error]
+    fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> crate::Result<()> {
+        if is_leaf {
+            self.write::<db::DBLeafBlockIds, _, _, _>(block_id, ())
+        } else {
+            self.del::<db::DBLeafBlockIds, _, _>(block_id)
+        }
+    }
+
+    #[log_error]
     fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> crate::Result<()> {
         self.write::<db::DBUtxosBlockUndo, _, _, _>(id, undo)
     }

--- a/chainstate/storage/src/internal/store_tx/write_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/write_impls.rs
@@ -14,7 +14,10 @@
 // limitations under the License.
 
 use super::{well_known, StoreTxRw};
-use crate::{BlockchainStorageWrite, ChainstateStorageVersion, SealedStorageTag, TipStorageTag};
+use crate::{
+    schema::DBLeafBlockIdsMapKey, BlockchainStorageWrite, ChainstateStorageVersion,
+    SealedStorageTag, TipStorageTag,
+};
 use chainstate_types::{BlockIndex, EpochData, EpochStorageWrite};
 use common::{
     chain::{
@@ -96,11 +99,12 @@ impl<'st, B: storage::Backend> BlockchainStorageWrite for StoreTxRw<'st, B> {
     }
 
     #[log_error]
-    fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> crate::Result<()> {
+    fn mark_as_leaf(&mut self, block_index: &BlockIndex, is_leaf: bool) -> crate::Result<()> {
+        let key = DBLeafBlockIdsMapKey::from_block_index(block_index);
         if is_leaf {
-            self.write::<db::DBLeafBlockIds, _, _, _>(block_id, ())
+            self.write::<db::DBLeafBlockIds, _, _, _>(key, ())
         } else {
-            self.del::<db::DBLeafBlockIds, _, _>(block_id)
+            self.del::<db::DBLeafBlockIds, _, _>(key)
         }
     }
 

--- a/chainstate/storage/src/internal/test.rs
+++ b/chainstate/storage/src/internal/test.rs
@@ -69,7 +69,7 @@ fn assert_leaves<DbTx: BlockchainStorageRead>(db_tx: &DbTx, expected: &[Id<Block
 
 fn assert_non_leaves<DbTx: BlockchainStorageRead>(db_tx: &DbTx, expected: &[Id<Block>]) {
     for leaf in expected {
-        assert!(!db_tx.is_leaf_block(&leaf).unwrap());
+        assert!(!db_tx.is_leaf_block(leaf).unwrap());
     }
 }
 

--- a/chainstate/storage/src/internal/version.rs
+++ b/chainstate/storage/src/internal/version.rs
@@ -19,7 +19,7 @@ use serialization::{Decode, Encode};
 pub struct ChainstateStorageVersion(u32);
 
 impl ChainstateStorageVersion {
-    pub const CURRENT: Self = Self(10);
+    pub const CURRENT: Self = Self(11);
 
     pub fn new(value: u32) -> Self {
         Self(value)

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -117,8 +117,9 @@ pub trait BlockchainStorageRead:
     /// Get token id by id of the creation tx
     fn get_token_id(&self, tx_id: &Id<Transaction>) -> crate::Result<Option<TokenId>>;
 
-    /// Get block tree as height vs ids
-    fn get_block_tree_by_height(
+    /// Get block tree as height vs ids.
+    /// The function will iterate over the entire block index map.
+    fn get_block_tree_by_height_traversing_entire_index(
         &self,
         start_from: BlockHeight,
     ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>>;

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -107,7 +107,7 @@ pub trait BlockchainStorageRead:
     fn get_leaf_block_ids(&self) -> Result<BTreeSet<Id<Block>>>;
 
     /// Return true if the specified block id is in the leaf block ids set.
-    fn is_leaf_block(&self, block_id: &Id<Block>) -> Result<bool>; // FIXME remove?
+    fn is_leaf_block(&self, block_id: &Id<Block>) -> Result<bool>;
 
     fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -103,11 +103,11 @@ pub trait BlockchainStorageRead:
     /// Get mainchain block by its height
     fn get_block_id_by_height(&self, height: &BlockHeight) -> crate::Result<Option<Id<GenBlock>>>;
 
-    /// Get ids of all leaf blocks.
-    fn get_leaf_block_ids(&self) -> Result<BTreeSet<Id<Block>>>;
+    /// Get ids of all leaf blocks, whose height is not less than the specified minimum.
+    fn get_leaf_block_ids(&self, min_height: BlockHeight) -> Result<BTreeSet<Id<Block>>>;
 
-    /// Return true if the specified block id is in the leaf block ids set.
-    fn is_leaf_block(&self, block_id: &Id<Block>) -> Result<bool>;
+    /// Return true if the specified block is in the leaf block ids set.
+    fn is_leaf_block(&self, block_index: &BlockIndex) -> Result<bool>;
 
     fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 
@@ -201,8 +201,8 @@ pub trait BlockchainStorageWrite:
         block_id: &Id<GenBlock>,
     ) -> Result<()>;
 
-    /// Mark the specified block id as a leaf or non-leaf, depending on the `is_leaf` parameter.
-    fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> Result<()>;
+    /// Mark the specified block as a leaf or non-leaf, depending on the `is_leaf` parameter.
+    fn mark_as_leaf(&mut self, block_index: &BlockIndex, is_leaf: bool) -> Result<()>;
 
     /// Remove block id from given mainchain height
     fn del_block_id_at_height(&mut self, height: &BlockHeight) -> Result<()>;

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -117,12 +117,8 @@ pub trait BlockchainStorageRead:
     /// Get token id by id of the creation tx
     fn get_token_id(&self, tx_id: &Id<Transaction>) -> crate::Result<Option<TokenId>>;
 
-    /// Get block tree as height vs ids.
-    /// The function will iterate over the entire block index map.
-    fn get_block_tree_by_height_traversing_entire_index(
-        &self,
-        start_from: BlockHeight,
-    ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>>;
+    /// Iterate the entire block index.
+    fn iterate_block_index(&self) -> crate::Result<impl Iterator<Item = BlockIndex>>;
 
     /// Get tokens accounting undo for specific block
     fn get_tokens_accounting_undo(

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -103,6 +103,12 @@ pub trait BlockchainStorageRead:
     /// Get mainchain block by its height
     fn get_block_id_by_height(&self, height: &BlockHeight) -> crate::Result<Option<Id<GenBlock>>>;
 
+    /// Get ids of all leaf blocks.
+    fn get_leaf_block_ids(&self) -> Result<BTreeSet<Id<Block>>>;
+
+    /// Return true if the specified block id is in the leaf block ids set.
+    fn is_leaf_block(&self, block_id: &Id<Block>) -> Result<bool>; // FIXME remove?
+
     fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 
     /// Get token creation tx
@@ -197,6 +203,9 @@ pub trait BlockchainStorageWrite:
         height: &BlockHeight,
         block_id: &Id<GenBlock>,
     ) -> Result<()>;
+
+    /// Mark the specified block id as a leaf or a non-leaf, depending on the `is_leaf` parameter.
+    fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> Result<()>;
 
     /// Remove block id from given mainchain height
     fn del_block_id_at_height(&mut self, height: &BlockHeight) -> Result<()>;

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -201,7 +201,7 @@ pub trait BlockchainStorageWrite:
         block_id: &Id<GenBlock>,
     ) -> Result<()>;
 
-    /// Mark the specified block id as a leaf or a non-leaf, depending on the `is_leaf` parameter.
+    /// Mark the specified block id as a leaf or non-leaf, depending on the `is_leaf` parameter.
     fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> Result<()>;
 
     /// Remove block id from given mainchain height

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -47,6 +47,12 @@ mockall::mock! {
     /// A mock object for blockchain storage
     pub Store {}
 
+    // Note: mockall doesn't like `Result<impl Iterator<Item = BlockIndex>>` which is returned
+    // from `iterate_block_index`, so we have to return `Box` instead'. This triggers the warning
+    // "impl trait in impl method signature does not match trait method signature", which
+    // we silence here.
+    // Same in other places below.
+    #[allow(refining_impl_trait)]
     impl crate::BlockchainStorageRead for Store {
         fn get_storage_version(&self) -> crate::Result<Option<ChainstateStorageVersion>>;
         fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>>;
@@ -79,10 +85,7 @@ mockall::mock! {
             id: Id<Block>,
         ) -> crate::Result<Option<accounting::BlockUndo<TokenAccountingUndo>>>;
 
-        fn get_block_tree_by_height_traversing_entire_index(
-            &self,
-            start_from: BlockHeight,
-        ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>>;
+        fn iterate_block_index(&self) -> crate::Result<Box<dyn Iterator<Item = BlockIndex>>>;
 
         fn get_pos_accounting_undo(&self, id: Id<Block>) -> crate::Result<Option<accounting::BlockUndo<PoSAccountingUndo>>>;
 
@@ -327,6 +330,7 @@ mockall::mock! {
     /// A mock object for blockchain storage transaction
     pub StoreTxRo {}
 
+    #[allow(refining_impl_trait)]
     impl crate::BlockchainStorageRead for StoreTxRo {
         fn get_storage_version(&self) -> crate::Result<Option<ChainstateStorageVersion>>;
         fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>>;
@@ -352,10 +356,8 @@ mockall::mock! {
 
         fn get_token_aux_data(&self, token_id: &TokenId) -> crate::Result<Option<TokenAuxiliaryData>>;
         fn get_token_id(&self, tx_id: &Id<Transaction>) -> crate::Result<Option<TokenId>>;
-        fn get_block_tree_by_height_traversing_entire_index(
-            &self,
-            start_from: BlockHeight,
-        ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>>;
+
+        fn iterate_block_index(&self) -> crate::Result<Box<dyn Iterator<Item = BlockIndex>>>;
 
         fn get_tokens_accounting_undo(&self, id: Id<Block>) -> crate::Result<Option<accounting::BlockUndo<TokenAccountingUndo>>>;
 
@@ -448,6 +450,7 @@ mockall::mock! {
     /// A mock object for blockchain storage transaction
     pub StoreTxRw {}
 
+    #[allow(refining_impl_trait)]
     impl crate::BlockchainStorageRead for StoreTxRw {
         fn get_storage_version(&self) -> crate::Result<Option<ChainstateStorageVersion>>;
         fn get_magic_bytes(&self) -> crate::Result<Option<MagicBytes>>;
@@ -474,10 +477,8 @@ mockall::mock! {
         fn get_token_aux_data(&self, token_id: &TokenId) -> crate::Result<Option<TokenAuxiliaryData>>;
         fn get_token_id(&self, tx_id: &Id<Transaction>) -> crate::Result<Option<TokenId>>;
         fn get_tokens_accounting_undo(&self, id: Id<Block>) -> crate::Result<Option<accounting::BlockUndo<TokenAccountingUndo>>>;
-        fn get_block_tree_by_height_traversing_entire_index(
-            &self,
-            start_from: BlockHeight,
-        ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>>;
+
+        fn iterate_block_index(&self) -> crate::Result<Box<dyn Iterator<Item = BlockIndex>>>;
 
         fn get_pos_accounting_undo(&self, id: Id<Block>) -> crate::Result<Option<accounting::BlockUndo<PoSAccountingUndo>>>;
 

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -47,7 +47,7 @@ mockall::mock! {
     /// A mock object for blockchain storage
     pub Store {}
 
-    // Note: mockall doesn't like `Result<impl Iterator<Item = BlockIndex>>` which is returned
+    // Note: mockall doesn't like `Result<impl Iterator<Item = BlockIndex>>` that is returned
     // from `iterate_block_index`, so we have to return `Box` instead'. This triggers the warning
     // "impl trait in impl method signature does not match trait method signature", which
     // we silence here.

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -71,8 +71,8 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> crate::Result<Option<Id<GenBlock>>>;
 
-        fn get_leaf_block_ids(&self) -> crate::Result<BTreeSet<Id<Block>>>;
-        fn is_leaf_block(&self, block_id: &Id<Block>) -> crate::Result<bool>;
+        fn get_leaf_block_ids(&self, min_height: BlockHeight) -> crate::Result<BTreeSet<Id<Block>>>;
+        fn is_leaf_block(&self, block_index: &BlockIndex) -> crate::Result<bool>;
 
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 
@@ -186,7 +186,7 @@ mockall::mock! {
 
         fn del_block_id_at_height(&mut self, height: &BlockHeight) -> crate::Result<()>;
 
-        fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> crate::Result<()>;
+        fn mark_as_leaf(&mut self, block_index: &BlockIndex, is_leaf: bool) -> crate::Result<()>;
 
         fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> crate::Result<()>;
         fn del_undo_data(&mut self, id: Id<Block>) -> crate::Result<()>;
@@ -349,8 +349,8 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> crate::Result<Option<Id<GenBlock>>>;
 
-        fn get_leaf_block_ids(&self) -> crate::Result<BTreeSet<Id<Block>>>;
-        fn is_leaf_block(&self, block_id: &Id<Block>) -> crate::Result<bool>;
+        fn get_leaf_block_ids(&self, min_height: BlockHeight) -> crate::Result<BTreeSet<Id<Block>>>;
+        fn is_leaf_block(&self, block_index: &BlockIndex) -> crate::Result<bool>;
 
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 
@@ -469,8 +469,8 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> crate::Result<Option<Id<GenBlock>>>;
 
-        fn get_leaf_block_ids(&self) -> crate::Result<BTreeSet<Id<Block>>>;
-        fn is_leaf_block(&self, block_id: &Id<Block>) -> crate::Result<bool>;
+        fn get_leaf_block_ids(&self, min_height: BlockHeight) -> crate::Result<BTreeSet<Id<Block>>>;
+        fn is_leaf_block(&self, block_index: &BlockIndex) -> crate::Result<bool>;
 
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 
@@ -577,7 +577,7 @@ mockall::mock! {
             block_id: &Id<GenBlock>,
         ) -> crate::Result<()>;
 
-        fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> crate::Result<()>;
+        fn mark_as_leaf(&mut self, block_index: &BlockIndex, is_leaf: bool) -> crate::Result<()>;
 
         fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> crate::Result<()>;
         fn del_undo_data(&mut self, id: Id<Block>) -> crate::Result<()>;

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -79,7 +79,7 @@ mockall::mock! {
             id: Id<Block>,
         ) -> crate::Result<Option<accounting::BlockUndo<TokenAccountingUndo>>>;
 
-        fn get_block_tree_by_height(
+        fn get_block_tree_by_height_traversing_entire_index(
             &self,
             start_from: BlockHeight,
         ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>>;
@@ -352,7 +352,7 @@ mockall::mock! {
 
         fn get_token_aux_data(&self, token_id: &TokenId) -> crate::Result<Option<TokenAuxiliaryData>>;
         fn get_token_id(&self, tx_id: &Id<Transaction>) -> crate::Result<Option<TokenId>>;
-        fn get_block_tree_by_height(
+        fn get_block_tree_by_height_traversing_entire_index(
             &self,
             start_from: BlockHeight,
         ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>>;
@@ -474,7 +474,7 @@ mockall::mock! {
         fn get_token_aux_data(&self, token_id: &TokenId) -> crate::Result<Option<TokenAuxiliaryData>>;
         fn get_token_id(&self, tx_id: &Id<Transaction>) -> crate::Result<Option<TokenId>>;
         fn get_tokens_accounting_undo(&self, id: Id<Block>) -> crate::Result<Option<accounting::BlockUndo<TokenAccountingUndo>>>;
-        fn get_block_tree_by_height(
+        fn get_block_tree_by_height_traversing_entire_index(
             &self,
             start_from: BlockHeight,
         ) -> crate::Result<BTreeMap<BlockHeight, Vec<Id<Block>>>>;

--- a/chainstate/storage/src/mock/mock_impl.rs
+++ b/chainstate/storage/src/mock/mock_impl.rs
@@ -65,6 +65,9 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> crate::Result<Option<Id<GenBlock>>>;
 
+        fn get_leaf_block_ids(&self) -> crate::Result<BTreeSet<Id<Block>>>;
+        fn is_leaf_block(&self, block_id: &Id<Block>) -> crate::Result<bool>;
+
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 
         fn get_token_aux_data(&self, token_id: &TokenId) -> crate::Result<Option<TokenAuxiliaryData>>;
@@ -179,6 +182,8 @@ mockall::mock! {
         ) -> crate::Result<()>;
 
         fn del_block_id_at_height(&mut self, height: &BlockHeight) -> crate::Result<()>;
+
+        fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> crate::Result<()>;
 
         fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> crate::Result<()>;
         fn del_undo_data(&mut self, id: Id<Block>) -> crate::Result<()>;
@@ -340,6 +345,9 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> crate::Result<Option<Id<GenBlock>>>;
 
+        fn get_leaf_block_ids(&self) -> crate::Result<BTreeSet<Id<Block>>>;
+        fn is_leaf_block(&self, block_id: &Id<Block>) -> crate::Result<bool>;
+
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 
         fn get_token_aux_data(&self, token_id: &TokenId) -> crate::Result<Option<TokenAuxiliaryData>>;
@@ -458,6 +466,9 @@ mockall::mock! {
             height: &BlockHeight,
         ) -> crate::Result<Option<Id<GenBlock>>>;
 
+        fn get_leaf_block_ids(&self) -> crate::Result<BTreeSet<Id<Block>>>;
+        fn is_leaf_block(&self, block_id: &Id<Block>) -> crate::Result<bool>;
+
         fn get_undo_data(&self, id: Id<Block>) -> crate::Result<Option<UtxosBlockUndo>>;
 
         fn get_token_aux_data(&self, token_id: &TokenId) -> crate::Result<Option<TokenAuxiliaryData>>;
@@ -564,6 +575,8 @@ mockall::mock! {
             height: &BlockHeight,
             block_id: &Id<GenBlock>,
         ) -> crate::Result<()>;
+
+        fn mark_as_leaf(&mut self, block_id: &Id<Block>, is_leaf: bool) -> crate::Result<()>;
 
         fn set_undo_data(&mut self, id: Id<Block>, undo: &UtxosBlockUndo) -> crate::Result<()>;
         fn del_undo_data(&mut self, id: Id<Block>) -> crate::Result<()>;

--- a/chainstate/storage/src/schema.rs
+++ b/chainstate/storage/src/schema.rs
@@ -42,6 +42,11 @@ storage::decl_schema! {
         pub DBBlockIndex: Map<Id<Block>, BlockIndex>,
         /// Storage for block IDs indexed by block height.
         pub DBBlockByHeight: Map<BlockHeight, Id<GenBlock>>,
+        /// The set of ids of blocks (both valid and invalid) that don't have children.
+        /// If the set is empty, then genesis is the only leaf block.
+        /// Note that the set may or may not contain the current main chain tip - the tip
+        /// may have invalid children, in which case it won't be marked as a leaf.
+        pub DBLeafBlockIds: Map<Id<Block>, ()>,
         /// Store for Utxo Entries
         pub DBUtxo: Map<UtxoOutPoint, Utxo>,
         /// Store for utxo BlockUndo

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 use chainstate_storage::{
     BlockchainStorageRead, BlockchainStorageWrite, TransactionRw, Transactional,
@@ -498,6 +501,10 @@ impl TestFramework {
 
         tx_rw.set_block_index(&block_idx).unwrap();
         tx_rw.commit().unwrap();
+    }
+
+    pub fn leaf_block_ids(&self) -> BTreeSet<Id<Block>> {
+        self.storage.transaction_ro().unwrap().get_leaf_block_ids().unwrap()
     }
 
     pub fn on_pool_created(

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -503,8 +503,8 @@ impl TestFramework {
         tx_rw.commit().unwrap();
     }
 
-    pub fn leaf_block_ids(&self) -> BTreeSet<Id<Block>> {
-        self.storage.transaction_ro().unwrap().get_leaf_block_ids().unwrap()
+    pub fn leaf_block_ids(&self, min_height: BlockHeight) -> BTreeSet<Id<Block>> {
+        self.storage.transaction_ro().unwrap().get_leaf_block_ids(min_height).unwrap()
     }
 
     pub fn on_pool_created(

--- a/chainstate/test-framework/src/framework.rs
+++ b/chainstate/test-framework/src/framework.rs
@@ -500,15 +500,6 @@ impl TestFramework {
         tx_rw.commit().unwrap();
     }
 
-    // Delete the block and its index
-    pub fn purge_block(&mut self, block_id: &Id<Block>) {
-        let mut tx_rw = self.storage.transaction_rw(None).unwrap();
-
-        tx_rw.del_block(*block_id).unwrap();
-        tx_rw.del_block_index(*block_id).unwrap();
-        tx_rw.commit().unwrap();
-    }
-
     pub fn on_pool_created(
         &mut self,
         pool_id: PoolId,

--- a/chainstate/test-suite/src/tests/block_invalidation.rs
+++ b/chainstate/test-suite/src/tests/block_invalidation.rs
@@ -919,9 +919,8 @@ fn test_reset_bad_stale_tip_status_and_add_blocks(#[case] seed: Seed, #[case] sb
         assert!(result.is_ok());
 
         // Add a "temporary" block on top of a1 to trigger a reorg to it, so that it is marked as invalid.
-        let (tmp_id, result) = process_block(&mut tf, &a1_id.into(), &mut rng);
+        let (_tmp_id, result) = process_block(&mut tf, &a1_id.into(), &mut rng);
         assert!(result.is_err());
-        tf.purge_block(&tmp_id);
 
         let (m2_id, result) = process_block(&mut tf, &m1_id.into(), &mut rng);
         assert!(result.is_ok());

--- a/chainstate/test-suite/src/tests/block_tree_retrieval.rs
+++ b/chainstate/test-suite/src/tests/block_tree_retrieval.rs
@@ -449,15 +449,15 @@ fn assert_leaves(tf: &TestFramework, min_height: BlockHeight, expected: &[Id<Blo
 
 fn check_tree_consistency(tree: InMemoryBlockTreeRef<'_>) {
     // Check that the root has no parent.
-    let root_node = tree.node(tree.root_id()).unwrap();
-    assert!(root_node.parent().is_none());
+    let root_node = tree.node(tree.root_node_id()).unwrap();
+    assert!(root_node.parent().unwrap().is_none());
 
-    for child_node_id in tree.iter_child_ids() {
+    for child_node_id in tree.all_child_node_ids_iter() {
         let child_node = tree.node(child_node_id).unwrap();
-        let parent_node_id = child_node.parent().unwrap();
+        let parent_node_id = child_node.parent().unwrap().unwrap();
         let parent_node = tree.node(parent_node_id).unwrap();
-        let child_block_index = child_node.get();
-        let parent_block_index = parent_node.get();
+        let child_block_index = child_node.block_index();
+        let parent_block_index = parent_node.block_index();
         assert_eq!(
             child_block_index.prev_block_id(),
             <&_ as Into<&Id<GenBlock>>>::into(parent_block_index.block_id())
@@ -466,7 +466,7 @@ fn check_tree_consistency(tree: InMemoryBlockTreeRef<'_>) {
 }
 
 fn check_trees_consistency(trees: &InMemoryBlockTrees) {
-    for tree in trees.iter_trees() {
+    for tree in trees.trees_iter() {
         check_tree_consistency(tree);
     }
 }

--- a/chainstate/test-suite/src/tests/block_tree_retrieval.rs
+++ b/chainstate/test-suite/src/tests/block_tree_retrieval.rs
@@ -417,14 +417,13 @@ fn assert_leaves(tf: &TestFramework, expected: &[Id<Block>]) {
 
 fn check_tree_consistency(tree: InMemoryBlockTreeRef<'_>) {
     // Check that the root has no parent.
-    let root_node = tree.arena().get(tree.root_id()).unwrap();
+    let root_node = tree.node(tree.root_id()).unwrap();
     assert!(root_node.parent().is_none());
 
-    // Note: `descendants` also includes the node itself as the 1st element, so we must skip it.
-    for child_node_id in tree.root_id().descendants(tree.arena()).skip(1) {
-        let child_node = tree.arena().get(child_node_id).unwrap();
+    for child_node_id in tree.iter_child_ids() {
+        let child_node = tree.node(child_node_id).unwrap();
         let parent_node_id = child_node.parent().unwrap();
-        let parent_node = tree.arena().get(parent_node_id).unwrap();
+        let parent_node = tree.node(parent_node_id).unwrap();
         let child_block_index = child_node.get();
         let parent_block_index = parent_node.get();
         assert_eq!(

--- a/chainstate/test-suite/src/tests/block_tree_retrieval.rs
+++ b/chainstate/test-suite/src/tests/block_tree_retrieval.rs
@@ -449,15 +449,12 @@ fn assert_leaves(tf: &TestFramework, min_height: BlockHeight, expected: &[Id<Blo
 
 fn check_tree_consistency(tree: InMemoryBlockTreeRef<'_>) {
     // Check that the root has no parent.
-    let root_node = tree.node(tree.root_node_id()).unwrap();
-    assert!(root_node.parent().unwrap().is_none());
+    assert!(tree.get_parent(tree.root_node_id()).unwrap().is_none());
 
     for child_node_id in tree.all_child_node_ids_iter() {
-        let child_node = tree.node(child_node_id).unwrap();
-        let parent_node_id = child_node.parent().unwrap().unwrap();
-        let parent_node = tree.node(parent_node_id).unwrap();
-        let child_block_index = child_node.block_index();
-        let parent_block_index = parent_node.block_index();
+        let parent_node_id = tree.get_parent(child_node_id).unwrap().unwrap();
+        let child_block_index = tree.get_block_index(child_node_id).unwrap();
+        let parent_block_index = tree.get_block_index(parent_node_id).unwrap();
         assert_eq!(
             child_block_index.prev_block_id(),
             <&_ as Into<&Id<GenBlock>>>::into(parent_block_index.block_id())

--- a/chainstate/test-suite/src/tests/block_tree_retrieval.rs
+++ b/chainstate/test-suite/src/tests/block_tree_retrieval.rs
@@ -56,7 +56,8 @@ fn block_tree_retrieval(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
         let genesis_id = tf.genesis().get_id();
 
-        assert_leaves(&tf, &[]);
+        assert_leaves(&tf, BlockHeight::new(0), &[]);
+        assert_leaves(&tf, BlockHeight::new(1), &[]);
 
         // The block timestamps will be as follows:
         // G--m0--m1--m2
@@ -68,51 +69,82 @@ fn block_tree_retrieval(#[case] seed: Seed) {
 
         let (m0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
         assert!(result.is_ok());
-        assert_leaves(&tf, &[m0_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m0_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m0_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[]);
 
         let (a0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
         assert!(result.is_ok());
-        assert_leaves(&tf, &[m0_id, a0_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m0_id, a0_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m0_id, a0_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[]);
 
         tf.time_value.as_ref().unwrap().fetch_add(1);
 
         let (m1_id, result) = process_block(&mut tf, &m0_id.into(), &mut rng);
         assert!(result.is_ok());
-        assert_leaves(&tf, &[m1_id, a0_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m1_id, a0_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m1_id, a0_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[m1_id]);
+        assert_leaves(&tf, BlockHeight::new(3), &[]);
 
         let (b0_id, b0_tx_id, result) =
             process_block_split_parent_reward(&mut tf, &m0_id.into(), &mut rng);
         assert!(result.is_ok());
-        assert_leaves(&tf, &[m1_id, a0_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m1_id, a0_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m1_id, a0_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[m1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(3), &[]);
 
         tf.time_value.as_ref().unwrap().fetch_add(1);
 
         let (a1_id, result) = process_block(&mut tf, &a0_id.into(), &mut rng);
         assert!(result.is_ok());
-        assert_leaves(&tf, &[m1_id, a1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m1_id, a1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m1_id, a1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[m1_id, a1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(3), &[]);
 
         let (m2_id, result) = process_block(&mut tf, &m1_id.into(), &mut rng);
         assert!(result.is_ok());
-        assert_leaves(&tf, &[m2_id, a1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m2_id, a1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m2_id, a1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[m2_id, a1_id, b0_id]);
+        assert_leaves(&tf, BlockHeight::new(3), &[m2_id]);
+        assert_leaves(&tf, BlockHeight::new(4), &[]);
 
         tf.time_value.as_ref().unwrap().fetch_add(1);
 
         let (b1_id, result) =
             process_block_spend_tx(&mut tf, &b0_id.into(), &b0_tx_id, 1, &mut rng);
         assert!(result.is_ok());
-        assert_leaves(&tf, &[m2_id, a1_id, b1_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m2_id, a1_id, b1_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m2_id, a1_id, b1_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[m2_id, a1_id, b1_id]);
+        assert_leaves(&tf, BlockHeight::new(3), &[m2_id, b1_id]);
+        assert_leaves(&tf, BlockHeight::new(4), &[]);
 
         tf.time_value.as_ref().unwrap().fetch_add(1);
 
         let (b2_id, result) = process_block(&mut tf, &b1_id.into(), &mut rng);
         assert!(result.is_err());
-        assert_leaves(&tf, &[m2_id, a1_id, b2_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m2_id, a1_id, b2_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m2_id, a1_id, b2_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[m2_id, a1_id, b2_id]);
+        assert_leaves(&tf, BlockHeight::new(3), &[m2_id, b2_id]);
+        assert_leaves(&tf, BlockHeight::new(4), &[b2_id]);
+        assert_leaves(&tf, BlockHeight::new(5), &[]);
 
         tf.time_value.as_ref().unwrap().fetch_add(1);
 
         let (c1_id, result) = process_block(&mut tf, &b1_id.into(), &mut rng);
         assert!(result.is_err());
-        assert_leaves(&tf, &[m2_id, a1_id, b2_id, c1_id]);
+        assert_leaves(&tf, BlockHeight::new(0), &[m2_id, a1_id, b2_id, c1_id]);
+        assert_leaves(&tf, BlockHeight::new(1), &[m2_id, a1_id, b2_id, c1_id]);
+        assert_leaves(&tf, BlockHeight::new(2), &[m2_id, a1_id, b2_id, c1_id]);
+        assert_leaves(&tf, BlockHeight::new(3), &[m2_id, b2_id, c1_id]);
+        assert_leaves(&tf, BlockHeight::new(4), &[b2_id, c1_id]);
+        assert_leaves(&tf, BlockHeight::new(5), &[]);
 
         log::debug!("m0_id = {m0_id}, m1_id = {m1_id}, m2_id = {m2_id}, a0_id = {a0_id}, a1_id = {a1_id}, b0_id = {b0_id}, b1_id = {b1_id}, b2_id = {b2_id}, c1_id = {c1_id}");
 
@@ -409,9 +441,9 @@ fn block_tree_retrieval(#[case] seed: Seed) {
     });
 }
 
-fn assert_leaves(tf: &TestFramework, expected: &[Id<Block>]) {
+fn assert_leaves(tf: &TestFramework, min_height: BlockHeight, expected: &[Id<Block>]) {
     let expected = expected.iter().copied().collect::<BTreeSet<_>>();
-    let actual = tf.leaf_block_ids();
+    let actual = tf.leaf_block_ids(min_height);
     assert_eq!(actual, expected);
 }
 

--- a/chainstate/test-suite/src/tests/block_tree_retrieval.rs
+++ b/chainstate/test-suite/src/tests/block_tree_retrieval.rs
@@ -1,0 +1,243 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use itertools::Itertools;
+use rstest::rstest;
+
+use chainstate_test_framework::TestFramework;
+use chainstate_types::BlockValidationStage;
+use common::{
+    chain::{block::timestamp::BlockTimestamp, Block},
+    primitives::{BlockHeight, Id, Idable},
+};
+use test_utils::random::{make_seedable_rng, Seed};
+
+use crate::tests::helpers::{
+    block_creation_helpers::{
+        process_block, process_block_spend_tx, process_block_split_parent_reward,
+    },
+    block_status_helpers::{
+        assert_bad_blocks_at_stage, assert_blocks_with_bad_parent_at_stage,
+        assert_fully_valid_blocks, assert_ok_blocks_at_stage,
+    },
+};
+use logging::log;
+use utils::sorted::Sorted;
+
+// Create the following block tree:
+// /----a0----a1
+// G----m0----m1----m2
+//      \-----b0---!b1---!b2
+// where b1 is invalid and persisted and b2 is invalid and non-persisted, checking leaf blocks at each step.
+// After that, check that get_block_id_tree_as_list, get_block_tree_top_by_height and
+// get_block_tree_top_by_timestamp return what they are supposed to.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn foo(#[case] seed: Seed) {
+    utils::concurrency::model(move || {
+        let mut rng = make_seedable_rng(seed);
+        let mut tf = TestFramework::builder(&mut rng).build();
+        let genesis_id = tf.genesis().get_id();
+
+        assert_leaves(&tf, &[]);
+
+        // The block timestamps will be as follows:
+        // G--m0--m1--m2
+        //    a0------a1
+        //        b0------b1--b2
+
+        tf.time_value.as_ref().unwrap().fetch_add(1);
+
+        let (m0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
+        assert!(result.is_ok());
+        assert_leaves(&tf, &[m0_id]);
+
+        let (a0_id, result) = process_block(&mut tf, &genesis_id.into(), &mut rng);
+        assert!(result.is_ok());
+        assert_leaves(&tf, &[m0_id, a0_id]);
+
+        tf.time_value.as_ref().unwrap().fetch_add(1);
+
+        let (m1_id, result) = process_block(&mut tf, &m0_id.into(), &mut rng);
+        assert!(result.is_ok());
+        assert_leaves(&tf, &[m1_id, a0_id]);
+
+        let (b0_id, b0_tx_id, result) =
+            process_block_split_parent_reward(&mut tf, &m0_id.into(), &mut rng);
+        assert!(result.is_ok());
+        assert_leaves(&tf, &[m1_id, a0_id, b0_id]);
+
+        tf.time_value.as_ref().unwrap().fetch_add(1);
+
+        let (a1_id, result) = process_block(&mut tf, &a0_id.into(), &mut rng);
+        assert!(result.is_ok());
+        assert_leaves(&tf, &[m1_id, a1_id, b0_id]);
+
+        let (m2_id, result) = process_block(&mut tf, &m1_id.into(), &mut rng);
+        assert!(result.is_ok());
+        assert_leaves(&tf, &[m2_id, a1_id, b0_id]);
+
+        tf.time_value.as_ref().unwrap().fetch_add(1);
+
+        let (b1_id, result) =
+            process_block_spend_tx(&mut tf, &b0_id.into(), &b0_tx_id, 1, &mut rng);
+        assert!(result.is_ok());
+        assert_leaves(&tf, &[m2_id, a1_id, b1_id]);
+
+        tf.time_value.as_ref().unwrap().fetch_add(1);
+
+        let (b2_id, result) = process_block(&mut tf, &b1_id.into(), &mut rng);
+        assert!(result.is_err());
+        assert_leaves(&tf, &[m2_id, a1_id, b2_id]);
+
+        log::debug!("m0_id = {m0_id}, m1_id = {m1_id}, m2_id = {m2_id}, a0_id = {a0_id}, a1_id = {a1_id}, b0_id = {b0_id}, b1_id = {b1_id}, b2_id = {b2_id}");
+
+        // Sanity check - ensure that all blocks are valid, except b1 and b2, and that b2 is not persisted.
+        assert_fully_valid_blocks(&tf, &[m0_id, m1_id, m2_id]);
+        assert_ok_blocks_at_stage(
+            &tf,
+            &[a0_id, a1_id, b0_id],
+            BlockValidationStage::CheckBlockOk,
+        );
+        assert_bad_blocks_at_stage(&tf, &[b1_id], BlockValidationStage::CheckBlockOk);
+        assert_blocks_with_bad_parent_at_stage(&tf, &[b2_id], BlockValidationStage::CheckBlockOk);
+
+        let block_id_tree_as_list = tf.chainstate.get_block_id_tree_as_list().unwrap();
+        assert_eq!(
+            block_id_tree_as_list.sorted(),
+            [m0_id, m1_id, m2_id, a0_id, a1_id, b0_id, b1_id]
+                .into_iter()
+                .sorted()
+                .collect_vec()
+        );
+        assert!(!tf.block_index(&b2_id).is_persisted());
+
+        assert_block_tree_top_by_height(&tf, 5.into(), &[]);
+        assert_block_tree_top_by_height(&tf, 4.into(), &[]);
+        assert_block_tree_top_by_height(&tf, 3.into(), &[(3.into(), &[m2_id, b1_id])]);
+        assert_block_tree_top_by_height(
+            &tf,
+            2.into(),
+            &[(3.into(), &[m2_id, b1_id]), (2.into(), &[m1_id, a1_id, b0_id])],
+        );
+        assert_block_tree_top_by_height(
+            &tf,
+            1.into(),
+            &[
+                (3.into(), &[m2_id, b1_id]),
+                (2.into(), &[m1_id, a1_id, b0_id]),
+                (1.into(), &[m0_id, a0_id]),
+            ],
+        );
+        assert_block_tree_top_by_height(
+            &tf,
+            0.into(),
+            &[
+                (3.into(), &[m2_id, b1_id]),
+                (2.into(), &[m1_id, a1_id, b0_id]),
+                (1.into(), &[m0_id, a0_id]),
+            ],
+        );
+
+        // Sanity check: ensure timestamps are as expected.
+        let ts0 = tf.genesis().timestamp();
+        let ts1 = tf.block_index(&m0_id).block_timestamp();
+        assert_eq!(ts1, tf.block_index(&a0_id).block_timestamp());
+        let ts2 = tf.block_index(&m1_id).block_timestamp();
+        assert_eq!(ts2, tf.block_index(&b0_id).block_timestamp());
+        let ts3 = tf.block_index(&m2_id).block_timestamp();
+        assert_eq!(ts3, tf.block_index(&a1_id).block_timestamp());
+        let ts4 = tf.block_index(&b1_id).block_timestamp();
+        let ts5 = tf.block_index(&b2_id).block_timestamp();
+        assert!(ts5 > ts4 && ts4 > ts3 && ts3 > ts2 && ts2 > ts1 && ts1 > ts0);
+
+        assert_block_tree_top_by_timestamp(&tf, ts5.add_int_seconds(1).unwrap(), &[]);
+        assert_block_tree_top_by_timestamp(&tf, ts5, &[]);
+        assert_block_tree_top_by_timestamp(&tf, ts4, &[(ts4, &[b1_id])]);
+        assert_block_tree_top_by_timestamp(&tf, ts3, &[(ts4, &[b1_id]), (ts3, &[m2_id, a1_id])]);
+        assert_block_tree_top_by_timestamp(
+            &tf,
+            ts2,
+            &[(ts4, &[b1_id]), (ts3, &[m2_id, a1_id]), (ts2, &[m1_id, b0_id])],
+        );
+        assert_block_tree_top_by_timestamp(
+            &tf,
+            ts1,
+            &[
+                (ts4, &[b1_id]),
+                (ts3, &[m2_id, a1_id]),
+                (ts2, &[m1_id, b0_id]),
+                (ts1, &[m0_id, a0_id]),
+            ],
+        );
+        assert_block_tree_top_by_timestamp(
+            &tf,
+            ts1,
+            &[
+                (ts4, &[b1_id]),
+                (ts3, &[m2_id, a1_id]),
+                (ts2, &[m1_id, b0_id]),
+                (ts1, &[m0_id, a0_id]),
+            ],
+        );
+    });
+}
+
+fn assert_leaves(tf: &TestFramework, expected: &[Id<Block>]) {
+    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+    let actual = tf.leaf_block_ids();
+    assert_eq!(actual, expected);
+}
+
+fn assert_block_tree_top_by_height(
+    tf: &TestFramework,
+    start_from: BlockHeight,
+    expected: &[(BlockHeight, &[Id<Block>])],
+) {
+    let expected = expected
+        .iter()
+        .map(|(height, ids)| (*height, ids.iter().copied().collect::<BTreeSet<_>>()))
+        .collect::<BTreeMap<_, _>>();
+
+    let actual = tf.chainstate.get_block_tree_top_by_height(start_from).unwrap();
+    let actual = actual
+        .iter()
+        .map(|(height, ids)| (*height, ids.iter().copied().collect::<BTreeSet<_>>()))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(actual, expected);
+}
+
+fn assert_block_tree_top_by_timestamp(
+    tf: &TestFramework,
+    start_from: BlockTimestamp,
+    expected: &[(BlockTimestamp, &[Id<Block>])],
+) {
+    let expected = expected
+        .iter()
+        .map(|(height, ids)| (*height, ids.iter().copied().collect::<BTreeSet<_>>()))
+        .collect::<BTreeMap<_, _>>();
+
+    let actual = tf.chainstate.get_block_tree_top_by_timestamp(start_from).unwrap();
+    let actual = actual
+        .iter()
+        .map(|(height, ids)| (*height, ids.iter().copied().collect::<BTreeSet<_>>()))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(actual, expected);
+}

--- a/chainstate/test-suite/src/tests/block_tree_retrieval.rs
+++ b/chainstate/test-suite/src/tests/block_tree_retrieval.rs
@@ -48,7 +48,7 @@ use utils::sorted::Sorted;
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn foo(#[case] seed: Seed) {
+fn block_tree_retrieval(#[case] seed: Seed) {
     utils::concurrency::model(move || {
         let mut rng = make_seedable_rng(seed);
         let mut tf = TestFramework::builder(&mut rng).build();

--- a/chainstate/test-suite/src/tests/mod.rs
+++ b/chainstate/test-suite/src/tests/mod.rs
@@ -29,6 +29,7 @@ use test_utils::random::{make_seedable_rng, Seed};
 mod basic_tests;
 mod block_invalidation;
 mod block_status;
+mod block_tree_retrieval;
 mod bootstrap;
 mod chainstate_accounting_storage_tests;
 mod chainstate_storage_tests;

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -190,6 +190,7 @@ fn stake_pool_reorg(
                 let mut db_tx = storage.transaction_rw(None).unwrap();
                 db_tx.set_block_index(&block_a_index).unwrap();
                 db_tx.add_block(&block_a).unwrap();
+                db_tx.mark_as_leaf(&block_a.get_id(), true).unwrap();
 
                 // reorg leaves a trace in delta index
                 // because deltas are only removed on undo if the entire epoch is disconnected;

--- a/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
+++ b/chainstate/test-suite/src/tests/pos_accounting_reorg.rs
@@ -190,7 +190,7 @@ fn stake_pool_reorg(
                 let mut db_tx = storage.transaction_rw(None).unwrap();
                 db_tx.set_block_index(&block_a_index).unwrap();
                 db_tx.add_block(&block_a).unwrap();
-                db_tx.mark_as_leaf(&block_a.get_id(), true).unwrap();
+                db_tx.mark_as_leaf(&block_a_index, true).unwrap();
 
                 // reorg leaves a trace in delta index
                 // because deltas are only removed on undo if the entire epoch is disconnected;

--- a/chainstate/test-suite/src/tests/tx_verification_simulation.rs
+++ b/chainstate/test-suite/src/tests/tx_verification_simulation.rs
@@ -144,7 +144,7 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
                 db_tx.add_block(block).unwrap();
             }
 
-            db_tx.mark_as_leaf(&all_blocks.last().unwrap().0.get_id(), true).unwrap();
+            db_tx.mark_as_leaf(&all_blocks.last().unwrap().1, true).unwrap();
             db_tx.commit().unwrap();
         }
 

--- a/chainstate/test-suite/src/tests/tx_verification_simulation.rs
+++ b/chainstate/test-suite/src/tests/tx_verification_simulation.rs
@@ -139,10 +139,12 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
         // After reorg only blocks and block indexes are left from the original chain
         {
             let mut db_tx = reference_tf.storage.transaction_rw(None).unwrap();
-            for (block, block_index) in all_blocks {
-                db_tx.set_block_index(&block_index).unwrap();
-                db_tx.add_block(&block).unwrap();
+            for (block, block_index) in &all_blocks {
+                db_tx.set_block_index(block_index).unwrap();
+                db_tx.add_block(block).unwrap();
             }
+
+            db_tx.mark_as_leaf(&all_blocks.last().unwrap().0.get_id(), true).unwrap();
             db_tx.commit().unwrap();
         }
 

--- a/chainstate/types/Cargo.toml
+++ b/chainstate/types/Cargo.toml
@@ -17,6 +17,7 @@ storage = { path = "../../storage/" }
 derive_more.workspace = true
 enum-iterator.workspace = true
 generic-array.workspace = true
+indextree.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
 parity-scale-codec.workspace = true

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -56,6 +56,29 @@ pub enum PropertyQueryError {
         start: BlockHeight,
         end: BlockHeight,
     },
+    #[error(transparent)]
+    InMemoryBlockTreeError(#[from] InMemoryBlockTreeError),
+}
+
+// TODO: ideally, this error shouldn't be here, it should be in the `chainstate` crate itself;
+// it only exists here because we need to include it into `PropertyQueryError`.
+// Perhaps the latter should also be put inside the `chainstate` crate.
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
+pub enum InMemoryBlockTreeError {
+    // Note: `PropertyQueryError` itself may contain `InMemoryBlockTreeError`, so here we must box it.
+    #[error("Error querying property: {0}")]
+    PropertyQueryError(Box<PropertyQueryError>),
+    #[error("Invariant error: {0}")]
+    InvariantError(String),
+    // Note: String is used to avoid putting indextree::NodeError here, which is non-comparable.
+    #[error("Index tree node error: {0}")]
+    IndexTreeNodeError(String),
+}
+
+impl From<PropertyQueryError> for InMemoryBlockTreeError {
+    fn from(value: PropertyQueryError) -> Self {
+        InMemoryBlockTreeError::PropertyQueryError(Box::new(value))
+    }
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -68,8 +68,6 @@ pub enum InMemoryBlockTreeError {
     // Note: `PropertyQueryError` itself may contain `InMemoryBlockTreeError`, so here we must box it.
     #[error("Error querying property: {0}")]
     PropertyQueryError(Box<PropertyQueryError>),
-    #[error("Invariant error: {0}")]
-    InvariantError(String),
     // Note: String is used to avoid putting indextree::NodeError here, which is non-comparable.
     #[error("Index tree node error: {0}")]
     IndexTreeNodeError(String),
@@ -83,6 +81,8 @@ pub enum InMemoryBlockTreeError {
         nodes_branch_root: indextree::NodeId,
         actual_branch_root: indextree::NodeId,
     },
+    #[error("Block id {0} doesn't correspond to any root node")]
+    BlockIdDoesntCorrespondToRoot(Id<Block>),
 }
 
 impl From<PropertyQueryError> for InMemoryBlockTreeError {

--- a/chainstate/types/src/error.rs
+++ b/chainstate/types/src/error.rs
@@ -73,6 +73,16 @@ pub enum InMemoryBlockTreeError {
     // Note: String is used to avoid putting indextree::NodeError here, which is non-comparable.
     #[error("Index tree node error: {0}")]
     IndexTreeNodeError(String),
+    #[error("Node for id {0} is not in the arena")]
+    NodeNotInArena(indextree::NodeId),
+    #[error("Non-root node {0} has no parent")]
+    NonRootWithoutParent(indextree::NodeId),
+    #[error("Node {node_id} belongs to the branch at {nodes_branch_root} but this branch is at {actual_branch_root}")]
+    NodeNotInBranch {
+        node_id: indextree::NodeId,
+        nodes_branch_root: indextree::NodeId,
+        actual_branch_root: indextree::NodeId,
+    },
 }
 
 impl From<PropertyQueryError> for InMemoryBlockTreeError {

--- a/chainstate/types/src/lib.rs
+++ b/chainstate/types/src/lib.rs
@@ -28,8 +28,7 @@ pub use crate::{
     epoch_data_cache::{
         ConsumedEpochDataCache, EpochDataCache, EpochStorageRead, EpochStorageWrite,
     },
-    error::GetAncestorError,
-    error::PropertyQueryError,
+    error::{GetAncestorError, InMemoryBlockTreeError, PropertyQueryError},
     gen_block_index::GenBlockIndex,
     height_skip::get_skip_height,
     locator::Locator,

--- a/common/src/primitives/height.rs
+++ b/common/src/primitives/height.rs
@@ -18,7 +18,7 @@ use std::ops::{Add, Sub};
 
 use serialization::{Decode, Encode};
 
-type HeightIntType = u64;
+pub type BlockHeightIntType = u64;
 type DistanceIntType = i64;
 
 #[derive(
@@ -35,7 +35,7 @@ type DistanceIntType = i64;
     serde::Deserialize,
     rpc_description::HasValueHint,
 )]
-pub struct BlockHeight(#[codec(compact)] HeightIntType);
+pub struct BlockHeight(#[codec(compact)] BlockHeightIntType);
 
 // Display should be defined for thiserror crate
 impl fmt::Display for BlockHeight {
@@ -51,14 +51,14 @@ impl std::str::FromStr for BlockHeight {
     }
 }
 
-impl From<BlockHeight> for HeightIntType {
-    fn from(block_height: BlockHeight) -> HeightIntType {
+impl From<BlockHeight> for BlockHeightIntType {
+    fn from(block_height: BlockHeight) -> BlockHeightIntType {
         block_height.0
     }
 }
 
-impl From<HeightIntType> for BlockHeight {
-    fn from(w: HeightIntType) -> BlockHeight {
+impl From<BlockHeightIntType> for BlockHeight {
+    fn from(w: BlockHeightIntType) -> BlockHeight {
         BlockHeight(w)
     }
 }
@@ -130,9 +130,9 @@ impl Sub<BlockHeight> for BlockHeight {
 impl BlockHeight {
     const ZERO: BlockHeight = BlockHeight(0);
     const ONE: BlockHeight = BlockHeight(1);
-    const MAX: BlockHeight = BlockHeight(HeightIntType::MAX);
+    const MAX: BlockHeight = BlockHeight(BlockHeightIntType::MAX);
 
-    pub const fn new(height: HeightIntType) -> Self {
+    pub const fn new(height: BlockHeightIntType) -> Self {
         Self(height)
     }
 
@@ -148,7 +148,7 @@ impl BlockHeight {
         BlockHeight::MAX
     }
 
-    pub fn checked_add(&self, rhs: HeightIntType) -> Option<Self> {
+    pub fn checked_add(&self, rhs: BlockHeightIntType) -> Option<Self> {
         self.0.checked_add(rhs).map(Self::new)
     }
 
@@ -160,7 +160,7 @@ impl BlockHeight {
         self.0.checked_sub(1).map(Self)
     }
 
-    pub const fn into_int(self) -> HeightIntType {
+    pub const fn into_int(self) -> BlockHeightIntType {
         self.0
     }
 
@@ -275,18 +275,18 @@ mod tests {
 
     #[test]
     fn basic_arithmetic_high() {
-        let h_halfmax = BlockHeight::new(HeightIntType::MAX / 2);
+        let h_halfmax = BlockHeight::new(BlockHeightIntType::MAX / 2);
         let d_max = BlockDistance::new(DistanceIntType::MAX);
         let d_m1 = BlockDistance::new(-1);
         let d_0 = BlockDistance::new(0);
         let d_p1 = BlockDistance::new(1);
         assert_eq!(
             (h_halfmax + d_m1).unwrap(),
-            BlockHeight::new(HeightIntType::MAX / 2 - 1)
+            BlockHeight::new(BlockHeightIntType::MAX / 2 - 1)
         );
         assert_eq!(
             (h_halfmax + d_0).unwrap(),
-            BlockHeight::new(HeightIntType::MAX / 2)
+            BlockHeight::new(BlockHeightIntType::MAX / 2)
         );
         assert_eq!(
             (d_max + d_m1).unwrap(),
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn basic_arithmetic_hit_max() {
-        let h_halfmax = BlockHeight::new(HeightIntType::MAX / 2);
+        let h_halfmax = BlockHeight::new(BlockHeightIntType::MAX / 2);
         let d_p1 = BlockDistance::new(1);
         let _ = h_halfmax + d_p1;
     }

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -16,7 +16,8 @@
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 
 use chainstate::{
-    BlockSource, ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent, Locator,
+    BlockSource, ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent, InMemoryBlockTrees,
+    Locator,
 };
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex};
 use common::{
@@ -156,14 +157,16 @@ mockall::mock! {
         ) -> Result<Vec<Option<Amount>>, ChainstateError>;
         fn get_mainchain_blocks_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
         fn get_block_id_tree_as_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
-        fn get_block_tree_top_by_height(
+        fn get_block_tree_top_starting_from_height(
             &self,
-            start_from: BlockHeight,
-        ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError>;
-        fn get_block_tree_top_by_timestamp(
+            min_height: BlockHeight,
+            include_non_persisted: bool,
+        ) -> Result<InMemoryBlockTrees, ChainstateError>;
+        fn get_block_tree_top_starting_from_timestamp(
             &self,
-            start_from: BlockTimestamp,
-        ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, ChainstateError>;
+            min_timestamp: BlockTimestamp,
+            include_non_persisted: bool,
+        ) -> Result<InMemoryBlockTrees, ChainstateError>;
         fn import_bootstrap_stream<'a>(
             &'a mut self,
             reader: std::io::BufReader<Box<dyn std::io::Read + Send + 'a>>,

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -156,6 +156,14 @@ mockall::mock! {
         ) -> Result<Vec<Option<Amount>>, ChainstateError>;
         fn get_mainchain_blocks_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
         fn get_block_id_tree_as_list(&self) -> Result<Vec<Id<Block>>, ChainstateError>;
+        fn get_block_tree_top_by_height(
+            &self,
+            start_from: BlockHeight,
+        ) -> Result<BTreeMap<BlockHeight, Vec<Id<Block>>>, ChainstateError>;
+        fn get_block_tree_top_by_timestamp(
+            &self,
+            start_from: BlockTimestamp,
+        ) -> Result<BTreeMap<BlockTimestamp, Vec<Id<Block>>>, ChainstateError>;
         fn import_bootstrap_stream<'a>(
             &'a mut self,
             reader: std::io::BufReader<Box<dyn std::io::Read + Send + 'a>>,

--- a/mocks/src/chainstate.rs
+++ b/mocks/src/chainstate.rs
@@ -16,8 +16,8 @@
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 
 use chainstate::{
-    BlockSource, ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent, InMemoryBlockTrees,
-    Locator,
+    BlockSource, BlockValidity, ChainInfo, ChainstateConfig, ChainstateError, ChainstateEvent,
+    InMemoryBlockTrees, Locator,
 };
 use chainstate_types::{BlockIndex, EpochData, GenBlockIndex};
 use common::{
@@ -160,12 +160,12 @@ mockall::mock! {
         fn get_block_tree_top_starting_from_height(
             &self,
             min_height: BlockHeight,
-            include_non_persisted: bool,
+            block_validity: BlockValidity,
         ) -> Result<InMemoryBlockTrees, ChainstateError>;
         fn get_block_tree_top_starting_from_timestamp(
             &self,
             min_timestamp: BlockTimestamp,
-            include_non_persisted: bool,
+            block_validity: BlockValidity,
         ) -> Result<InMemoryBlockTrees, ChainstateError>;
         fn import_bootstrap_stream<'a>(
             &'a mut self,

--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -332,7 +332,7 @@ where
                 }) = hello_response
                 else {
                     if let Message::WillDisconnect(msg) = hello_response {
-                        log::warn!(
+                        log::info!(
                             "Peer {} is going to disconnect us with the reason: '{}'",
                             self.peer_id,
                             msg.reason

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -1570,7 +1570,7 @@ where
     }
 
     fn handle_will_disconnect_messgae(&mut self, peer_id: PeerId, msg: WillDisconnectMessage) {
-        log::warn!(
+        log::info!(
             "Peer {peer_id} is going to disconnect us with the reason: {}",
             msg.reason
         );


### PR DESCRIPTION
Chainstate db now maintains a set of "leaf" block ids, which are blocks without children. This is used to implement the functions `get_block_tree_top_by_height`/`get_block_tree_top_by_timestamp` in a more efficient way.

Also, it turned out that `get_block_id_tree_as_list`, which is used for bootstrapping, could return ids of non-persisted blocks. So, if such a block was encountered, bootstrapping would fail. This is also fixed.