### PR TITLE
Support hashlock check in mintscript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4334,6 +4334,7 @@ dependencies = [
  "common",
  "crypto",
  "expect-test",
+ "hex",
  "pos-accounting",
  "rstest",
  "serialization",

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -177,10 +177,10 @@ impl BanScore for mintscript::translate::TranslationError {
     }
 }
 
-impl<SE, TE: BanScore> BanScore for mintscript::script::ScriptError<SE, TE> {
+impl<SE, TE: BanScore, HE> BanScore for mintscript::script::ScriptError<SE, TE, HE> {
     fn ban_score(&self) -> u32 {
         match self {
-            Self::Threshold(_) | Self::Signature(_) => 100,
+            Self::Threshold(_) | Self::Signature(_) | Self::Hashlock(_) => 100,
             Self::Timelock(e) => e.ban_score(),
         }
     }

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -353,10 +353,11 @@ impl BlockProcessingErrorClassification for mintscript::translate::TranslationEr
     }
 }
 
-impl<SE, TE> BlockProcessingErrorClassification for mintscript::script::ScriptError<SE, TE>
+impl<SE, TE, HE> BlockProcessingErrorClassification for mintscript::script::ScriptError<SE, TE, HE>
 where
     SE: BlockProcessingErrorClassification,
     TE: BlockProcessingErrorClassification,
+    HE: BlockProcessingErrorClassification,
 {
     fn classify(&self) -> BlockProcessingErrorClass {
         match self {
@@ -364,6 +365,7 @@ where
 
             Self::Signature(e) => e.classify(),
             Self::Timelock(e) => e.classify(),
+            Self::Hashlock(e) => e.classify(),
         }
     }
 }
@@ -380,6 +382,14 @@ where
             | Self::TimestampArith => BlockProcessingErrorClass::BadBlock,
 
             Self::Context(e) => e.classify(),
+        }
+    }
+}
+
+impl BlockProcessingErrorClassification for mintscript::checker::HashlockError {
+    fn classify(&self) -> BlockProcessingErrorClass {
+        match self {
+            Self::IncorrectHashSize | Self::HashMismatch => BlockProcessingErrorClass::BadBlock,
         }
     }
 }

--- a/chainstate/tx-verifier/src/transaction_verifier/input_check/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_check/mod.rs
@@ -25,8 +25,8 @@ use common::{
     primitives::{BlockHeight, Id},
 };
 use mintscript::{
-    translate::InputInfoProvider, InputInfo, SignatureContext, TimelockContext, TranslateInput,
-    WitnessScript,
+    checker::HashlockError, translate::InputInfoProvider, InputInfo, SignatureContext,
+    TimelockContext, TranslateInput, WitnessScript,
 };
 
 use crate::TransactionVerifierStorageRef;
@@ -34,7 +34,8 @@ use crate::TransactionVerifierStorageRef;
 use super::TransactionSourceForConnect;
 
 pub type TimelockError = mintscript::checker::TimelockError<TimelockContextError>;
-pub type ScriptError = mintscript::script::ScriptError<DestinationSigError, TimelockError>;
+pub type ScriptError =
+    mintscript::script::ScriptError<DestinationSigError, TimelockError, HashlockError>;
 
 #[derive(PartialEq, Eq, Clone, thiserror::Error, Debug)]
 pub enum InputCheckErrorPayload {
@@ -51,8 +52,10 @@ pub enum InputCheckErrorPayload {
     Verification(#[from] ScriptError),
 }
 
-impl From<mintscript::script::ScriptError<Infallible, TimelockError>> for InputCheckErrorPayload {
-    fn from(value: mintscript::script::ScriptError<Infallible, TimelockError>) -> Self {
+impl From<mintscript::script::ScriptError<Infallible, TimelockError, Infallible>>
+    for InputCheckErrorPayload
+{
+    fn from(value: mintscript::script::ScriptError<Infallible, TimelockError, Infallible>) -> Self {
         Self::Verification(value.errs_into())
     }
 }

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -202,11 +202,12 @@ impl MempoolBanScore for mintscript::translate::TranslationError {
     }
 }
 
-impl<SE, TE: BanScore> MempoolBanScore for mintscript::script::ScriptError<SE, TE> {
+impl<SE, TE: BanScore, HE> MempoolBanScore for mintscript::script::ScriptError<SE, TE, HE> {
     fn mempool_ban_score(&self) -> u32 {
         match self {
             Self::Threshold(_) => 100,
             Self::Signature(_) => 100,
+            Self::Hashlock(_) => 100,
             Self::Timelock(e) => e.ban_score(),
         }
     }

--- a/mintscript/Cargo.toml
+++ b/mintscript/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [dependencies]
 common = { path = "../common" }
+crypto = { path = "../crypto" }
 pos-accounting = { path = "../pos-accounting" }
 serialization = { path = "../serialization" }
 tokens-accounting = { path = "../tokens-accounting" }

--- a/mintscript/Cargo.toml
+++ b/mintscript/Cargo.toml
@@ -25,5 +25,6 @@ crypto = { path = '../crypto' }
 test-utils = { path = '../test-utils' }
 serialization = { path = '../serialization' }
 
+hex.workspace = true
 rstest.workspace = true
 expect-test.workspace = true

--- a/mintscript/src/checker/hashlock.rs
+++ b/mintscript/src/checker/hashlock.rs
@@ -15,7 +15,7 @@
 
 use crypto::hash::{self, hash};
 
-use crate::script::HashType;
+use crate::script::HashChallenge;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub enum HashlockError {
@@ -37,7 +37,7 @@ pub trait HashlockChecker {
 
     fn check_hashlock(
         &mut self,
-        hash_type: &HashType,
+        hash_challenge: &HashChallenge,
         preimage: &[u8; 32],
     ) -> Result<(), Self::Error>;
 }
@@ -49,7 +49,7 @@ impl HashlockChecker for NoOpHashlockChecker {
 
     fn check_hashlock(
         &mut self,
-        _hash_type: &HashType,
+        _hash_challenge: &HashChallenge,
         _preimage: &[u8; 32],
     ) -> Result<(), Self::Error> {
         Ok(())
@@ -63,19 +63,19 @@ impl HashlockChecker for StandardHashlockChecker {
 
     fn check_hashlock(
         &mut self,
-        hash_type: &HashType,
+        hash_challenge: &HashChallenge,
         preimage: &[u8; 32],
     ) -> Result<(), Self::Error> {
-        match hash_type {
-            HashType::HASH160(expected_hash) => {
+        match hash_challenge {
+            HashChallenge::HASH160(expected_hash) => {
                 let actual_hash = hash::<hash::Ripemd160, _>(hash::<hash::Sha256, _>(preimage));
 
                 ensure_hashes_equal(actual_hash.as_slice(), expected_hash)?;
             }
-            HashType::RIPEMD160(_)
-            | HashType::SHA1(_)
-            | HashType::SHA256(_)
-            | HashType::HASH256(_) => {
+            HashChallenge::RIPEMD160(_)
+            | HashChallenge::SHA1(_)
+            | HashChallenge::SHA256(_)
+            | HashChallenge::HASH256(_) => {
                 unimplemented!()
             }
         }

--- a/mintscript/src/checker/hashlock.rs
+++ b/mintscript/src/checker/hashlock.rs
@@ -67,15 +67,15 @@ impl HashlockChecker for StandardHashlockChecker {
         preimage: &[u8; 32],
     ) -> Result<(), Self::Error> {
         match hash_challenge {
-            HashChallenge::HASH160(expected_hash) => {
+            HashChallenge::Hash160(expected_hash) => {
                 let actual_hash = hash::<hash::Ripemd160, _>(hash::<hash::Sha256, _>(preimage));
 
                 ensure_hashes_equal(actual_hash.as_slice(), expected_hash)?;
             }
-            HashChallenge::RIPEMD160(_)
-            | HashChallenge::SHA1(_)
-            | HashChallenge::SHA256(_)
-            | HashChallenge::HASH256(_) => {
+            HashChallenge::Ripemd160(_)
+            | HashChallenge::Sha1(_)
+            | HashChallenge::Sha256(_)
+            | HashChallenge::Hash256(_) => {
                 unimplemented!()
             }
         }

--- a/mintscript/src/checker/hashlock.rs
+++ b/mintscript/src/checker/hashlock.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crypto::hash::{self, hash};
+use utils::ensure;
+
+use crate::script::HashType;
+
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
+pub enum HashlockError {
+    #[error("Hash provided doesn't match the type")]
+    IncorrectHashSize,
+
+    #[error("Preimage doesn't match the hash")]
+    HashMismatch,
+}
+
+impl From<std::convert::Infallible> for HashlockError {
+    fn from(value: std::convert::Infallible) -> Self {
+        match value {}
+    }
+}
+
+pub trait HashlockChecker {
+    type Error: std::error::Error;
+
+    fn check_hashlock(
+        &mut self,
+        hash_type: HashType,
+        hash: &[u8],
+        preimage: &[u8],
+    ) -> Result<(), Self::Error>;
+}
+
+pub struct NoOpHashlockChecker;
+
+impl HashlockChecker for NoOpHashlockChecker {
+    type Error = std::convert::Infallible;
+
+    fn check_hashlock(
+        &mut self,
+        _hash_type: HashType,
+        _hash: &[u8],
+        _preimage: &[u8],
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+pub struct StandardHashlockChecker;
+
+impl HashlockChecker for StandardHashlockChecker {
+    type Error = HashlockError;
+
+    fn check_hashlock(
+        &mut self,
+        hash_type: HashType,
+        expected_hash: &[u8],
+        preimage: &[u8],
+    ) -> Result<(), Self::Error> {
+        match hash_type {
+            HashType::HASH160 => {
+                ensure!(expected_hash.len() == 20, HashlockError::IncorrectHashSize);
+
+                let actual_hash = hash::<hash::Ripemd160, _>(hash::<hash::Sha256, _>(preimage));
+
+                (actual_hash.as_slice() == expected_hash)
+                    .then_some(())
+                    .ok_or(HashlockError::HashMismatch)
+            }
+            HashType::RIPEMD160 | HashType::SHA1 | HashType::SHA256 | HashType::HASH256 => {
+                unimplemented!()
+            }
+        }
+    }
+}

--- a/mintscript/src/checker/mod.rs
+++ b/mintscript/src/checker/mod.rs
@@ -125,9 +125,9 @@ where
 
     fn visit_hashlock(
         &mut self,
-        hash_type: &crate::script::HashType,
+        hash_challenge: &crate::script::HashChallenge,
         preimage: &[u8; 32],
     ) -> Result<(), Self::HashlockError> {
-        self.hashlock_checker.check_hashlock(hash_type, preimage)
+        self.hashlock_checker.check_hashlock(hash_challenge, preimage)
     }
 }

--- a/mintscript/src/checker/mod.rs
+++ b/mintscript/src/checker/mod.rs
@@ -125,10 +125,9 @@ where
 
     fn visit_hashlock(
         &mut self,
-        hash_type: crate::script::HashType,
-        hash: &[u8],
-        preimage: &[u8],
+        hash_type: &crate::script::HashType,
+        preimage: &[u8; 32],
     ) -> Result<(), Self::HashlockError> {
-        self.hashlock_checker.check_hashlock(hash_type, hash, preimage)
+        self.hashlock_checker.check_hashlock(hash_type, preimage)
     }
 }

--- a/mintscript/src/script/display.rs
+++ b/mintscript/src/script/display.rs
@@ -78,11 +78,11 @@ impl WitnessScript {
                     write!(f, "{algo}(0x{hash}, 0x{preimage})")
                 };
                 match hash_challenge {
-                    HashChallenge::RIPEMD160(hash) => write_fn("RIPEMD160", hash.as_slice()),
-                    HashChallenge::SHA1(hash) => write_fn("SHA1", hash.as_slice()),
-                    HashChallenge::SHA256(hash) => write_fn("SHA256", hash.as_slice()),
-                    HashChallenge::HASH160(hash) => write_fn("HASH160", hash.as_slice()),
-                    HashChallenge::HASH256(hash) => write_fn("HASH256", hash.as_slice()),
+                    HashChallenge::Ripemd160(hash) => write_fn("Ripemd160", hash.as_slice()),
+                    HashChallenge::Sha1(hash) => write_fn("Sha1", hash.as_slice()),
+                    HashChallenge::Sha256(hash) => write_fn("Sha256", hash.as_slice()),
+                    HashChallenge::Hash160(hash) => write_fn("Hash160", hash.as_slice()),
+                    HashChallenge::Hash256(hash) => write_fn("Hash256", hash.as_slice()),
                 }
             }
         }

--- a/mintscript/src/script/display.rs
+++ b/mintscript/src/script/display.rs
@@ -66,6 +66,15 @@ impl WitnessScript {
                 OutputTimeLock::ForBlockCount(c) => write!(f, "after_blocks({c})"),
                 OutputTimeLock::ForSeconds(s) => write!(f, "after_seconds({s})"),
             },
+            WitnessScript::HashLock {
+                hash_type,
+                hash,
+                preimage,
+            } => {
+                let hash = HexEncoded::new(hash);
+                let preimage = HexEncoded::new(preimage);
+                write!(f, "{hash_type:?}(0x{hash}, 0x{preimage})")
+            }
         }
     }
 }

--- a/mintscript/src/script/display.rs
+++ b/mintscript/src/script/display.rs
@@ -18,6 +18,8 @@ use std::fmt;
 use common::chain::timelock::OutputTimeLock;
 use serialization::hex_encoded::HexEncoded;
 
+use crate::script::HashType;
+
 use super::{DissatisfiedScript, ScriptCondition, Threshold, WitnessScript};
 
 impl Threshold {
@@ -68,12 +70,20 @@ impl WitnessScript {
             },
             WitnessScript::HashLock {
                 hash_type,
-                hash,
                 preimage,
             } => {
-                let hash = HexEncoded::new(hash);
                 let preimage = HexEncoded::new(preimage);
-                write!(f, "{hash_type:?}(0x{hash}, 0x{preimage})")
+                let mut write_fn = |algo: &str, hash: &[u8]| {
+                    let hash = HexEncoded::new(hash);
+                    write!(f, "{algo}(0x{hash}, 0x{preimage})")
+                };
+                match hash_type {
+                    HashType::RIPEMD160(hash) => write_fn("RIPEMD160", hash.as_slice()),
+                    HashType::SHA1(hash) => write_fn("SHA1", hash.as_slice()),
+                    HashType::SHA256(hash) => write_fn("SHA256", hash.as_slice()),
+                    HashType::HASH160(hash) => write_fn("HASH160", hash.as_slice()),
+                    HashType::HASH256(hash) => write_fn("HASH256", hash.as_slice()),
+                }
             }
         }
     }

--- a/mintscript/src/script/display.rs
+++ b/mintscript/src/script/display.rs
@@ -18,7 +18,7 @@ use std::fmt;
 use common::chain::timelock::OutputTimeLock;
 use serialization::hex_encoded::HexEncoded;
 
-use crate::script::HashType;
+use crate::script::HashChallenge;
 
 use super::{DissatisfiedScript, ScriptCondition, Threshold, WitnessScript};
 
@@ -69,7 +69,7 @@ impl WitnessScript {
                 OutputTimeLock::ForSeconds(s) => write!(f, "after_seconds({s})"),
             },
             WitnessScript::HashLock {
-                hash_type,
+                hash_challenge,
                 preimage,
             } => {
                 let preimage = HexEncoded::new(preimage);
@@ -77,12 +77,12 @@ impl WitnessScript {
                     let hash = HexEncoded::new(hash);
                     write!(f, "{algo}(0x{hash}, 0x{preimage})")
                 };
-                match hash_type {
-                    HashType::RIPEMD160(hash) => write_fn("RIPEMD160", hash.as_slice()),
-                    HashType::SHA1(hash) => write_fn("SHA1", hash.as_slice()),
-                    HashType::SHA256(hash) => write_fn("SHA256", hash.as_slice()),
-                    HashType::HASH160(hash) => write_fn("HASH160", hash.as_slice()),
-                    HashType::HASH256(hash) => write_fn("HASH256", hash.as_slice()),
+                match hash_challenge {
+                    HashChallenge::RIPEMD160(hash) => write_fn("RIPEMD160", hash.as_slice()),
+                    HashChallenge::SHA1(hash) => write_fn("SHA1", hash.as_slice()),
+                    HashChallenge::SHA256(hash) => write_fn("SHA256", hash.as_slice()),
+                    HashChallenge::HASH160(hash) => write_fn("HASH160", hash.as_slice()),
+                    HashChallenge::HASH256(hash) => write_fn("HASH256", hash.as_slice()),
                 }
             }
         }

--- a/mintscript/src/script/mod.rs
+++ b/mintscript/src/script/mod.rs
@@ -122,12 +122,26 @@ impl Threshold {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum HashType {
+    RIPEMD160,
+    SHA1,
+    SHA256,
+    HASH160,
+    HASH256,
+}
+
 /// Script together with witness data presumably satisfying the script.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum WitnessScript {
     Threshold(Threshold),
     Signature(Destination, InputWitness),
     Timelock(OutputTimeLock),
+    HashLock {
+        hash_type: HashType,
+        hash: Vec<u8>,
+        preimage: Vec<u8>,
+    },
 }
 
 impl WitnessScript {
@@ -142,6 +156,15 @@ impl WitnessScript {
     /// Construct a timelock condition
     pub const fn timelock(tl: OutputTimeLock) -> Self {
         Self::Timelock(tl)
+    }
+
+    /// Construct a hashlock condition
+    pub const fn hashlock(hash_type: HashType, hash: Vec<u8>, preimage: Vec<u8>) -> Self {
+        Self::HashLock {
+            hash_type,
+            hash,
+            preimage,
+        }
     }
 
     /// Construct a threshold. See [Threshold::new_unchecked].

--- a/mintscript/src/script/mod.rs
+++ b/mintscript/src/script/mod.rs
@@ -124,11 +124,11 @@ impl Threshold {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum HashChallenge {
-    RIPEMD160([u8; 20]),
-    SHA1([u8; 20]),
-    SHA256([u8; 32]),
-    HASH160([u8; 20]),
-    HASH256([u8; 32]),
+    Ripemd160([u8; 20]),
+    Sha1([u8; 20]),
+    Sha256([u8; 32]),
+    Hash160([u8; 20]),
+    Hash256([u8; 32]),
 }
 
 /// Script together with witness data presumably satisfying the script.

--- a/mintscript/src/script/mod.rs
+++ b/mintscript/src/script/mod.rs
@@ -122,13 +122,13 @@ impl Threshold {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum HashType {
-    RIPEMD160,
-    SHA1,
-    SHA256,
-    HASH160,
-    HASH256,
+    RIPEMD160([u8; 20]),
+    SHA1([u8; 20]),
+    SHA256([u8; 32]),
+    HASH160([u8; 20]),
+    HASH256([u8; 32]),
 }
 
 /// Script together with witness data presumably satisfying the script.
@@ -139,8 +139,7 @@ pub enum WitnessScript {
     Timelock(OutputTimeLock),
     HashLock {
         hash_type: HashType,
-        hash: Vec<u8>,
-        preimage: Vec<u8>,
+        preimage: [u8; 32],
     },
 }
 
@@ -159,10 +158,9 @@ impl WitnessScript {
     }
 
     /// Construct a hashlock condition
-    pub const fn hashlock(hash_type: HashType, hash: Vec<u8>, preimage: Vec<u8>) -> Self {
+    pub const fn hashlock(hash_type: HashType, preimage: [u8; 32]) -> Self {
         Self::HashLock {
             hash_type,
-            hash,
             preimage,
         }
     }

--- a/mintscript/src/script/mod.rs
+++ b/mintscript/src/script/mod.rs
@@ -123,7 +123,7 @@ impl Threshold {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum HashType {
+pub enum HashChallenge {
     RIPEMD160([u8; 20]),
     SHA1([u8; 20]),
     SHA256([u8; 32]),
@@ -138,7 +138,7 @@ pub enum WitnessScript {
     Signature(Destination, InputWitness),
     Timelock(OutputTimeLock),
     HashLock {
-        hash_type: HashType,
+        hash_challenge: HashChallenge,
         preimage: [u8; 32],
     },
 }
@@ -158,9 +158,9 @@ impl WitnessScript {
     }
 
     /// Construct a hashlock condition
-    pub const fn hashlock(hash_type: HashType, preimage: [u8; 32]) -> Self {
+    pub const fn hashlock(hash_challenge: HashChallenge, preimage: [u8; 32]) -> Self {
         Self::HashLock {
-            hash_type,
+            hash_challenge,
             preimage,
         }
     }

--- a/mintscript/src/script/verify.rs
+++ b/mintscript/src/script/verify.rs
@@ -48,9 +48,8 @@ pub trait ScriptVisitor {
     ///Check hashlock
     fn visit_hashlock(
         &mut self,
-        hash_type: HashType,
-        hash: &[u8],
-        preimage: &[u8],
+        hash_type: &HashType,
+        preimage: &[u8; 32],
     ) -> Result<(), Self::HashlockError>;
 }
 
@@ -109,10 +108,9 @@ impl WitnessScript {
                 }
                 Self::HashLock {
                     hash_type,
-                    hash,
                     preimage,
                 } => {
-                    v.visit_hashlock(*hash_type, hash, preimage).map_err(ScriptError::Hashlock)?;
+                    v.visit_hashlock(hash_type, preimage).map_err(ScriptError::Hashlock)?;
                 }
             }
         }

--- a/mintscript/src/script/verify.rs
+++ b/mintscript/src/script/verify.rs
@@ -17,7 +17,7 @@
 
 use common::chain::{signature::inputsig::InputWitness, timelock::OutputTimeLock, Destination};
 
-use super::{HashType, WitnessScript};
+use super::{HashChallenge, WitnessScript};
 
 /// A script processing object
 ///
@@ -48,7 +48,7 @@ pub trait ScriptVisitor {
     ///Check hashlock
     fn visit_hashlock(
         &mut self,
-        hash_type: &HashType,
+        hash_challenge: &HashChallenge,
         preimage: &[u8; 32],
     ) -> Result<(), Self::HashlockError>;
 }
@@ -107,10 +107,10 @@ impl WitnessScript {
                     eval_stack.extend(thresh.collect_satisfied()?.into_iter().rev());
                 }
                 Self::HashLock {
-                    hash_type,
+                    hash_challenge,
                     preimage,
                 } => {
-                    v.visit_hashlock(hash_type, preimage).map_err(ScriptError::Hashlock)?;
+                    v.visit_hashlock(hash_challenge, preimage).map_err(ScriptError::Hashlock)?;
                 }
             }
         }

--- a/mintscript/src/tests/checkers.rs
+++ b/mintscript/src/tests/checkers.rs
@@ -100,7 +100,9 @@ fn check_sig(#[case] seed: Seed) {
         let mut checker = MockContext::new(0, &bad_tx, &utxos).into_checker();
         match script.verify(&mut checker).expect_err("this should fail") {
             ScriptError::Signature(_e) => (),
-            e @ (ScriptError::Timelock(_) | ScriptError::Threshold(_)) => {
+            e @ (ScriptError::Timelock(_)
+            | ScriptError::Threshold(_)
+            | ScriptError::Hashlock(_)) => {
                 panic!("Unexpected error {e}")
             }
         }

--- a/mintscript/src/tests/hashlock_checker.rs
+++ b/mintscript/src/tests/hashlock_checker.rs
@@ -76,7 +76,7 @@ fn check_hashlock_160_ok(#[case] preimage: &str, #[case] hash: &str) {
     let hash = hex::decode(hash).unwrap().try_into().unwrap();
     let preimage = hex::decode(preimage).unwrap().try_into().unwrap();
 
-    let script = WitnessScript::hashlock(HashType::HASH160(hash), preimage);
+    let script = WitnessScript::hashlock(HashChallenge::HASH160(hash), preimage);
 
     let context = EmptyContext;
     let mut checker = crate::ScriptChecker::full(context);
@@ -91,7 +91,7 @@ fn check_hashlock_160_random_values_mismatch(#[case] seed: Seed) {
     let preimage: [u8; 32] = std::array::from_fn(|_| rng.gen::<u8>());
     let hash: [u8; 20] = std::array::from_fn(|_| rng.gen::<u8>());
 
-    let script = WitnessScript::hashlock(HashType::HASH160(hash), preimage);
+    let script = WitnessScript::hashlock(HashChallenge::HASH160(hash), preimage);
 
     let context = EmptyContext;
     let mut checker = crate::ScriptChecker::full(context);

--- a/mintscript/src/tests/hashlock_checker.rs
+++ b/mintscript/src/tests/hashlock_checker.rs
@@ -1,0 +1,117 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::checker::HashlockError;
+
+use super::*;
+
+struct EmptyContext;
+
+impl crate::SignatureContext for EmptyContext {
+    type Tx = SignedTransaction;
+
+    fn chain_config(&self) -> &ChainConfig {
+        unreachable!()
+    }
+
+    fn transaction(&self) -> &Self::Tx {
+        unreachable!()
+    }
+
+    fn input_utxos(&self) -> &[Option<&common::chain::TxOutput>] {
+        unreachable!()
+    }
+
+    fn input_num(&self) -> usize {
+        unreachable!()
+    }
+}
+
+impl crate::TimelockContext for EmptyContext {
+    type Error = std::convert::Infallible;
+
+    fn spending_height(&self) -> BlockHeight {
+        unreachable!()
+    }
+
+    fn spending_time(&self) -> BlockTimestamp {
+        unreachable!()
+    }
+
+    fn source_height(&self) -> Result<BlockHeight, Self::Error> {
+        unreachable!()
+    }
+
+    fn source_time(&self) -> Result<BlockTimestamp, Self::Error> {
+        unreachable!()
+    }
+}
+
+#[rstest::rstest]
+#[case([209, 246, 177, 232, 51, 84, 228, 19, 240, 217, 24, 152, 165, 219, 108, 141, 8, 142, 84, 141, 210, 128, 132, 209, 44, 87, 61, 197, 94, 173, 23, 113],
+       [157, 6, 130, 9, 15, 13, 14, 19, 25, 16, 83, 196, 241, 85, 78, 166, 172, 66, 16, 178])]
+#[case([210, 113, 99, 52, 113, 86, 243, 93, 79, 167, 173, 105, 136, 98, 82, 162, 163, 239, 167, 61, 196, 35, 89, 207, 141, 122, 124, 185, 158, 223, 164, 0],
+       [88, 191, 177, 197, 195, 183, 137, 75, 159, 176, 107, 61, 24, 82, 36, 199, 155, 216, 221, 120])]
+#[case([12, 237, 136, 255, 43, 219, 169, 22, 20, 191, 82, 182, 128, 215, 15, 34, 102, 213, 115, 23, 223, 192, 71, 46, 131, 197, 128, 252, 58, 102, 53, 79],
+       [87, 164, 129, 105, 180, 233, 129, 252, 145, 233, 128, 24, 187, 159, 207, 103, 26, 119, 80, 216])]
+fn check_hashlock_160(#[case] preimage: [u8; 32], #[case] hash: [u8; 20]) {
+    let script = WitnessScript::hashlock(HashType::HASH160, hash.to_vec(), preimage.to_vec());
+
+    let context = EmptyContext;
+    let mut checker = crate::ScriptChecker::full(context);
+    script.verify(&mut checker).unwrap();
+}
+
+#[rstest::rstest]
+#[case(Seed::from_entropy())]
+fn check_hashlock_160_random_values(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let preimage: [u8; 32] = std::array::from_fn(|_| rng.gen::<u8>());
+    let hash: [u8; 20] = std::array::from_fn(|_| rng.gen::<u8>());
+
+    let script = WitnessScript::hashlock(HashType::HASH160, hash.to_vec(), preimage.to_vec());
+
+    let context = EmptyContext;
+    let mut checker = crate::ScriptChecker::full(context);
+    assert_eq!(
+        script.verify(&mut checker).unwrap_err(),
+        ScriptError::Hashlock(HashlockError::HashMismatch)
+    );
+}
+
+#[rstest::rstest]
+#[case(Seed::from_entropy())]
+fn check_hashlock_160_wrong_preimage_size(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let preimage: [u8; 32] = std::array::from_fn(|_| rng.gen::<u8>());
+    let hash = {
+        let length1: usize = rng.gen_range(1..20);
+        let length2: usize = rng.gen_range(21..100);
+        let length = if rng.gen::<bool>() { length1 } else { length2 };
+        let random_vector: Vec<u8> = (0..length).map(|_| rng.gen()).collect();
+        random_vector
+    };
+
+    let script = WitnessScript::hashlock(HashType::HASH160, hash, preimage.to_vec());
+
+    let context = EmptyContext;
+    let mut checker = crate::ScriptChecker::full(context);
+    assert_eq!(
+        script.verify(&mut checker).unwrap_err(),
+        ScriptError::Hashlock(HashlockError::IncorrectHashSize)
+    );
+}

--- a/mintscript/src/tests/hashlock_checker.rs
+++ b/mintscript/src/tests/hashlock_checker.rs
@@ -76,7 +76,7 @@ fn check_hashlock_160_ok(#[case] preimage: &str, #[case] hash: &str) {
     let hash = hex::decode(hash).unwrap().try_into().unwrap();
     let preimage = hex::decode(preimage).unwrap().try_into().unwrap();
 
-    let script = WitnessScript::hashlock(HashChallenge::HASH160(hash), preimage);
+    let script = WitnessScript::hashlock(HashChallenge::Hash160(hash), preimage);
 
     let context = EmptyContext;
     let mut checker = crate::ScriptChecker::full(context);
@@ -91,7 +91,7 @@ fn check_hashlock_160_random_values_mismatch(#[case] seed: Seed) {
     let preimage: [u8; 32] = std::array::from_fn(|_| rng.gen::<u8>());
     let hash: [u8; 20] = std::array::from_fn(|_| rng.gen::<u8>());
 
-    let script = WitnessScript::hashlock(HashChallenge::HASH160(hash), preimage);
+    let script = WitnessScript::hashlock(HashChallenge::Hash160(hash), preimage);
 
     let context = EmptyContext;
     let mut checker = crate::ScriptChecker::full(context);

--- a/mintscript/src/tests/mod.rs
+++ b/mintscript/src/tests/mod.rs
@@ -43,5 +43,6 @@ type WS = WitnessScript;
 mod utils;
 
 mod checkers;
+mod hashlock_checker;
 mod script;
 mod translate;

--- a/mintscript/src/tests/script.rs
+++ b/mintscript/src/tests/script.rs
@@ -139,9 +139,8 @@ fn visit_order(#[case] script: WS) {
 
         fn visit_hashlock(
             &mut self,
-            _hash_type: crate::script::HashType,
-            _hash: &[u8],
-            _preimage: &[u8],
+            _hash_type: &crate::script::HashType,
+            _preimage: &[u8; 32],
         ) -> Result<(), Self::HashlockError> {
             unreachable!("Not used in this test")
         }

--- a/mintscript/src/tests/script.rs
+++ b/mintscript/src/tests/script.rs
@@ -121,8 +121,8 @@ fn visit_order(#[case] script: WS) {
 
     impl ScriptVisitor for LockLogger {
         type SignatureError = std::convert::Infallible;
-
         type TimelockError = std::convert::Infallible;
+        type HashlockError = std::convert::Infallible;
 
         fn visit_signature(
             &mut self,
@@ -135,6 +135,15 @@ fn visit_order(#[case] script: WS) {
         fn visit_timelock(&mut self, lock: &OutputTimeLock) -> Result<(), Self::TimelockError> {
             self.0.push(*lock);
             Ok(())
+        }
+
+        fn visit_hashlock(
+            &mut self,
+            _hash_type: crate::script::HashType,
+            _hash: &[u8],
+            _preimage: &[u8],
+        ) -> Result<(), Self::HashlockError> {
+            unreachable!("Not used in this test")
         }
     }
 

--- a/mintscript/src/tests/script.rs
+++ b/mintscript/src/tests/script.rs
@@ -139,7 +139,7 @@ fn visit_order(#[case] script: WS) {
 
         fn visit_hashlock(
             &mut self,
-            _hash_type: &crate::script::HashType,
+            _hash_challenge: &crate::script::HashChallenge,
             _preimage: &[u8; 32],
         ) -> Result<(), Self::HashlockError> {
             unreachable!("Not used in this test")


### PR DESCRIPTION
Only checker was implemented. Translation will be supported in the PR with atomic swaps where new TxOutput type is introduced.