### PR TITLE
Implement in_mem_block_tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "static_assertions",
  "storage",
  "thiserror",
+ "utils-in-mem-item-tree",
 ]
 
 [[package]]
@@ -3454,6 +3455,12 @@ dependencies = [
  "hashbrown 0.14.5",
  "serde",
 ]
+
+[[package]]
+name = "indextree"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6f7e29c1619ec492f411b021ac9f30649d5f522ca6f287f2467ee48c8dfe10"
 
 [[package]]
 name = "indoc"
@@ -8178,6 +8185,19 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "utils-in-mem-item-tree"
+version = "0.5.1"
+dependencies = [
+ "derive_more",
+ "indextree",
+ "itertools 0.13.0",
+ "logging",
+ "test-utils",
+ "thiserror",
+ "utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
   "test-utils",                         # Various utilities for tests.
   "tokens-accounting",                  # Tokens accounting
   "utils",                              # Various utilities.
+  "utils/in_mem_item_tree",             # Tree of items that already have parent-child relationship, e.g. BlockIndex.
   "utils/networking",                   # Various async/tokio utilities.
   "utxo",                               # Utxo and related utilities (cache, undo, etc.).
   "wallet",                             # Wallet primitives.
@@ -169,6 +170,7 @@ hex-literal = "0.4"
 hmac = "0.12"
 iced = "0.12"
 iced_aw = "0.9"
+indextree = "4.6"
 indoc = "2.0"
 itertools = "0.13"
 jsonrpsee = { version = "0.22", default-features = false }

--- a/chainstate/types/Cargo.toml
+++ b/chainstate/types/Cargo.toml
@@ -13,6 +13,7 @@ crypto = { path = "../../crypto" }
 logging = { path = '../../logging' }
 serialization = { path = "../../serialization" }
 storage = { path = "../../storage/" }
+utils-in-mem-item-tree = { path = "../../utils/in_mem_item_tree" }
 
 derive_more.workspace = true
 enum-iterator.workspace = true

--- a/chainstate/types/src/gen_block_index.rs
+++ b/chainstate/types/src/gen_block_index.rs
@@ -16,7 +16,10 @@
 use std::sync::Arc;
 
 use common::{
-    chain::{block::timestamp::BlockTimestamp, ChainConfig, GenBlock, Genesis},
+    chain::{
+        block::timestamp::BlockTimestamp, gen_block::GenBlockIdConverter, ChainConfig, GenBlock,
+        Genesis,
+    },
     primitives::{id::WithId, BlockHeight, Id, Idable},
     Uint256,
 };
@@ -123,3 +126,16 @@ impl From<BlockIndex> for GenBlockIndex {
 
 // Forbid implementing Eq and PartialEq for GenBlockIndex.
 assert_not_impl_any!(GenBlockIndex: Eq, PartialEq);
+
+impl utils_in_mem_item_tree::primitives::DataItem for BlockIndex {
+    type Id = Id<GenBlock>;
+    type IdClassifier = GenBlockIdConverter;
+
+    fn item_id(&self) -> &Id<GenBlock> {
+        self.block_id().into()
+    }
+
+    fn parent_item_id(&self, block_classifier: &Self::IdClassifier) -> Option<&Id<GenBlock>> {
+        block_classifier.to_chain_block_id(self.prev_block_id()).map(|id| id.into())
+    }
+}

--- a/common/src/chain/gen_block.rs
+++ b/common/src/chain/gen_block.rs
@@ -118,3 +118,24 @@ impl GenBlockId {
         }
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct GenBlockIdConverter {
+    genesis_block_id: Id<GenBlock>,
+}
+
+impl GenBlockIdConverter {
+    pub fn new(chain_config: &crate::chain::config::ChainConfig) -> Self {
+        Self {
+            genesis_block_id: chain_config.genesis_block_id(),
+        }
+    }
+
+    pub fn to_chain_block_id<'a>(&self, id: &'a Id<GenBlock>) -> Option<&'a Id<Block>> {
+        if id.to_hash() == self.genesis_block_id.to_hash() {
+            None
+        } else {
+            Some(Id::<Block>::ref_cast(id.as_hash()))
+        }
+    }
+}

--- a/utils/in_mem_item_tree/Cargo.toml
+++ b/utils/in_mem_item_tree/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "utils-in-mem-item-tree"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+logging = { path = "../../logging/" }
+utils = { path = ".." }
+
+derive_more.workspace = true
+indextree.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+test-utils = { path = "../../test-utils" }
+
+itertools.workspace = true

--- a/utils/in_mem_item_tree/src/lib.rs
+++ b/utils/in_mem_item_tree/src/lib.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Here we have various types intended to represent trees of items that already have a parent-child
+//! relationship (such as blocks or block-like structs, like chainstate's `BlockIndex`).
+
+pub mod primitives;
+pub mod tree_wrappers;
+
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    #[error(transparent)]
+    PrimitivesError(#[from] primitives::Error),
+    #[error(transparent)]
+    TreeWrappersError(#[from] tree_wrappers::Error),
+}

--- a/utils/in_mem_item_tree/src/primitives/arena.rs
+++ b/utils/in_mem_item_tree/src/primitives/arena.rs
@@ -1,0 +1,173 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use utils::debug_panic_or_log;
+
+use super::{
+    detail::{ItemIdMapHolder, ModificationObserver},
+    node_id::NodeId,
+    node_ref::{NodeMut, NodeRef},
+    DataItem, Error, Flavor,
+};
+
+/// The wrapper for `indextree::Arena`.
+#[derive(Clone, Debug)]
+pub struct Arena<T: DataItem, F: Flavor> {
+    pub(super) arena: indextree::Arena<T>,
+    pub(super) modification_observer: F::ModificationObserver<T>,
+    pub(super) id_classifier: <T as DataItem>::IdClassifier,
+}
+
+impl<T: DataItem, F: Flavor> Arena<T, F> {
+    /// Creates a new empty `Arena`.
+    pub fn new(id_classifier: <T as DataItem>::IdClassifier) -> Self
+    where
+        F::ModificationObserver<T>: Default,
+    {
+        Self {
+            arena: indextree::Arena::new(),
+            modification_observer: Default::default(),
+            id_classifier,
+        }
+    }
+
+    /// Creates a new empty Arena with enough capacity to store `n` nodes.
+    pub fn with_capacity(n: usize, id_classifier: <T as DataItem>::IdClassifier) -> Self
+    where
+        F::ModificationObserver<T>: Default,
+    {
+        Self {
+            arena: indextree::Arena::with_capacity(n),
+            modification_observer: Default::default(),
+            id_classifier,
+        }
+    }
+
+    /// Returns the number of nodes the arena can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.arena.capacity()
+    }
+
+    /// Reserves capacity for `additional` more nodes to be inserted.
+    pub fn reserve(&mut self, additional: usize) {
+        self.arena.reserve(additional);
+    }
+
+    /// Retrieves the `NodeId` corresponding to a node in the `Arena`.
+    pub fn get_node_id(&self, node: NodeRef<'_, T>) -> Option<NodeId> {
+        self.arena.get_node_id(node.0).map(NodeId)
+    }
+
+    /// Creates a new node from its associated data.
+    ///
+    /// Note that this will re-use a previously removed node, if any.
+    pub fn new_node(&mut self, data: T) -> Result<NodeId, Error> {
+        let item_id = *data.item_id();
+        let node_id = NodeId(self.arena.new_node(data));
+        match self.modification_observer.on_node_added(node_id, item_id) {
+            Ok(()) => Ok(node_id),
+            Err(err) => {
+                // Remove the newly created node to prevent inconsistency between the observer and the arena.
+                node_id.0.remove(&mut self.arena);
+                Err(err)
+            }
+        }
+    }
+
+    /// Returns the number of nodes in the arena, including the removed ones.
+    pub fn count(&self) -> usize {
+        self.arena.count()
+    }
+
+    /// Equivalent to `self.count() == 0`.
+    pub fn is_empty(&self) -> bool {
+        self.arena.is_empty()
+    }
+
+    /// Returns a reference to the node with the given id or None if it's not in the arena.
+    ///
+    /// Note: unlike the wrapped `indextree`'s function, we don't return removed nodes here
+    /// (if we allowed this, `NodeRef`/`NodeMut`'s `get` methods would panic if called on
+    /// a removed node).
+    pub fn get(&self, id: NodeId) -> Option<NodeRef<'_, T>> {
+        self.arena.get(id.0).filter(|node| !node.is_removed()).map(NodeRef)
+    }
+
+    /// Returns a reference to the node with the given id or an error if it's not in the arena.
+    ///
+    /// Same as in `get`, removed nodes are never returned.
+    pub fn get_existing(&self, id: NodeId) -> Result<NodeRef<'_, T>, Error> {
+        let node = self.arena.get(id.0).ok_or(Error::NodeIdNotInArena(id))?;
+        if node.is_removed() {
+            Err(Error::NodeIsRemoved(id))
+        } else {
+            Ok(NodeRef(node))
+        }
+    }
+
+    /// Returns a mutable reference to the node with the given id or None if it's not in the arena.
+    ///
+    /// Same as in `get`, removed nodes are never returned.
+    pub fn get_mut(&mut self, id: NodeId) -> Option<NodeMut<'_, T>> {
+        self.arena.get_mut(id.0).filter(|node| !node.is_removed()).map(NodeMut)
+    }
+
+    /// Returns a mutable reference to the node with the given id or an error if it's not in the arena.
+    ///
+    /// Same as in `get`, removed nodes are never returned.
+    pub fn get_existing_mut(&mut self, id: NodeId) -> Result<NodeMut<'_, T>, Error> {
+        let node = self.arena.get_mut(id.0).ok_or(Error::NodeIdNotInArena(id))?;
+        if node.is_removed() {
+            Err(Error::NodeIsRemoved(id))
+        } else {
+            Ok(NodeMut(node))
+        }
+    }
+
+    // Note: we don't expose `indextree::Arena::iter` and `iter_mut`, which iterate over all
+    // nodes in the arena, including the removed ones. If we decide to expose them in the future,
+    // we'll have to either filter out removed nodes or modify the interface of `NodeRef`/`NodeMut`
+    // (so that e.g. the "get" methods return an `Option`, where `Some` corresponds to
+    // an existing node and `None` to a removed one).
+
+    /// Clears all the nodes in the arena, but retains its allocated capacity.
+    ///
+    /// Note that this does not marks all nodes as removed, but completely removes them from
+    /// the arena storage, thus invalidating all the node ids that were previously created.
+    pub fn clear(&mut self) {
+        self.arena.clear();
+        self.modification_observer.on_whole_arena_cleared();
+    }
+
+    /// Returns a node id given a item id. The availability of this method depends on the arena's
+    /// `Flavor`.
+    pub fn node_id_by_item_id(&self, item_id: &<T as DataItem>::Id) -> Option<NodeId>
+    where
+        F::ModificationObserver<T>: ItemIdMapHolder<T>,
+    {
+        self.modification_observer.item_id_map().get(item_id).copied()
+    }
+
+    // Note: this must be called before the subtree has been removed.
+    pub(super) fn on_subtree_removal(&mut self, node_id: NodeId) {
+        for descendant_id in node_id.0.descendants(&self.arena) {
+            if let Some(node) = self.arena.get(descendant_id) {
+                self.modification_observer.on_node_removed(node.get().item_id());
+            } else {
+                debug_panic_or_log!("node id {descendant_id} isn't in the arena");
+            }
+        }
+    }
+}

--- a/utils/in_mem_item_tree/src/primitives/detail.rs
+++ b/utils/in_mem_item_tree/src/primitives/detail.rs
@@ -1,0 +1,262 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use utils::{debug_assert_or_log, displayable_option::DisplayableOption, ensure};
+
+use super::{arena::Arena, node_id::NodeId, DataItem, Error, Flavor};
+
+/// The trait that is referenced by the `Flavor` trait. `Arena` holds an instance of such
+/// an observer and notifies it about the corresponding modifications.
+pub trait ModificationObserver<T: DataItem>: Clone + std::fmt::Debug + Default {
+    fn on_node_added(&mut self, node_id: NodeId, item_id: <T as DataItem>::Id)
+        -> Result<(), Error>;
+    fn on_node_removed(&mut self, item_id: &<T as DataItem>::Id);
+    fn on_whole_arena_cleared(&mut self);
+}
+
+/// `Arena` uses this trait to get access to the item-id-to-node-id map that is held within
+///  the observer, if any.
+pub trait ItemIdMapHolder<T: DataItem> {
+    fn item_id_map(&self) -> &BTreeMap<<T as DataItem>::Id, NodeId>;
+}
+
+/// This is the observer that always holds the item-id-to-node-id map, which allows `Arena`
+/// to implement some extra methods.
+pub struct TrackingModificationObserver<T: DataItem>(BTreeMap<<T as DataItem>::Id, NodeId>);
+
+impl<T: DataItem> ModificationObserver<T> for TrackingModificationObserver<T> {
+    fn on_node_added(
+        &mut self,
+        node_id: NodeId,
+        item_id: <T as DataItem>::Id,
+    ) -> Result<(), Error> {
+        use std::collections::btree_map::Entry;
+
+        match self.0.entry(item_id) {
+            Entry::Vacant(e) => {
+                e.insert(node_id);
+                Ok(())
+            }
+            Entry::Occupied(_) => Err(Error::ItemAlreadyInArena {
+                item_id: item_id.to_string(),
+            }),
+        }
+    }
+
+    fn on_node_removed(&mut self, item_id: &<T as DataItem>::Id) {
+        let removed = self.0.remove(item_id).is_some();
+        debug_assert_or_log!(removed, "item id {item_id} wasn't in the map");
+    }
+
+    fn on_whole_arena_cleared(&mut self) {
+        self.0.clear();
+    }
+}
+
+// Implement Default/Debug/Clone by hand, because `derive` would automatically add the corresponding
+// trait bounds for T, which we don't need.
+impl<T: DataItem> Default for TrackingModificationObserver<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+impl<T: DataItem> std::fmt::Debug for TrackingModificationObserver<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("TrackingModificationObserver").field(&self.0).finish()
+    }
+}
+impl<T: DataItem> Clone for TrackingModificationObserver<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: DataItem> ItemIdMapHolder<T> for TrackingModificationObserver<T> {
+    fn item_id_map(&self) -> &BTreeMap<<T as DataItem>::Id, NodeId> {
+        &self.0
+    }
+}
+
+/// This is the observer that only holds the item-id-to-node-id map in debug builds, to perform
+/// the corresponding runtime checks.
+pub struct DebugOnlyTrackingModificationObserver<T: DataItem> {
+    #[cfg(debug_assertions)]
+    inner: TrackingModificationObserver<T>,
+    #[cfg(not(debug_assertions))]
+    inner: std::marker::PhantomData<T>,
+}
+
+impl<T: DataItem> DebugOnlyTrackingModificationObserver<T> {
+    #[cfg(all(test, debug_assertions))]
+    pub fn inner(&self) -> &TrackingModificationObserver<T> {
+        &self.inner
+    }
+}
+
+impl<T: DataItem> ModificationObserver<T> for DebugOnlyTrackingModificationObserver<T> {
+    fn on_node_added(
+        &mut self,
+        node_id: NodeId,
+        item_id: <T as DataItem>::Id,
+    ) -> Result<(), Error> {
+        #[cfg(debug_assertions)]
+        {
+            self.inner.on_node_added(node_id, item_id)
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            Ok(())
+        }
+    }
+
+    fn on_node_removed(&mut self, item_id: &<T as DataItem>::Id) {
+        #[cfg(debug_assertions)]
+        {
+            self.inner.on_node_removed(item_id);
+        }
+    }
+
+    fn on_whole_arena_cleared(&mut self) {
+        #[cfg(debug_assertions)]
+        {
+            self.inner.on_whole_arena_cleared();
+        }
+    }
+}
+
+// Implement Default/Debug/Clone by hand, because `derive` would automatically add the corresponding
+// trait bounds for T, which we don't need.
+impl<T: DataItem> Default for DebugOnlyTrackingModificationObserver<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
+impl<T: DataItem> std::fmt::Debug for DebugOnlyTrackingModificationObserver<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DebugOnlyTrackingModificationObserver")
+            .field(&self.inner)
+            .finish()
+    }
+}
+impl<T: DataItem> Clone for DebugOnlyTrackingModificationObserver<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// A temporary error type, for use in the following scenario:
+/// You have a utility module with a function that tries to be error-agnostic and that accepts a callback:
+/// ```ignore
+///     enum MyModuleErrorType { ... }
+///
+///     fn func<E>(callback: Fn(X) -> Result<Y, E>) -> Result<(), E>
+///     where
+///         E: Error + From<MyModuleErrorType> { ...
+/// ```
+/// The intent is that you want the caller to be able to return its own higher-level error type
+/// from the callback, which will then be propagated out of the function; the function itself,
+/// on the other hand,  may produce errors from `MyModuleErrorType`, which will be converted
+/// to `E` via `From`.
+///
+/// Then, in another module you need a function that wraps the previous one:
+/// ```ignore
+///     enum WrapperModuleErrorType { InnerError(#[from] MyModuleErrorType), ... }
+///
+///     fn wrapper_func<E>(callback: Fn(X) -> Result<Y, E>) -> Result<(), E>
+///     where
+///         E: Error + From<WrapperModuleErrorType> { // call `func` somehow
+/// ```
+/// Unfortunately, the above won't work unless you require that `E` implements `From<MyModuleErrorType>`.
+/// If this is not what you want, you may use `TmpError` as a temporary error holder:
+/// ```ignore
+///     fn wrapper_func<E>(callback: Fn(X) -> Result<Y, E>) -> Result<(), E>
+///     where
+///         E: Error + From<WrapperModuleErrorType>
+///     {
+///         func(|xxx| -> Result<_, TmpError<E, MyModuleErrorType>> {
+///             callback(xxx).map_err(TmpError::OuterError)
+///         })
+///         .map_err(|err| err.into_outer_error_via::<WrapperModuleErrorType>())
+///     }
+/// ```
+// TODO move it elsewhere
+#[derive(thiserror::Error, Debug)]
+pub enum TmpError<OuterError, InnerError>
+where
+    OuterError: std::error::Error,
+    InnerError: std::error::Error,
+{
+    #[error(transparent)]
+    OuterError(OuterError),
+    #[error(transparent)]
+    InnerError(#[from] InnerError),
+}
+
+impl<OuterError, InnerError> TmpError<OuterError, InnerError>
+where
+    OuterError: std::error::Error,
+    InnerError: std::error::Error,
+{
+    pub fn into_outer_error_via<IntermediateError>(self) -> OuterError
+    where
+        OuterError: From<IntermediateError>,
+        IntermediateError: From<InnerError>,
+    {
+        match self {
+            TmpError::OuterError(err) => err,
+            TmpError::InnerError(err) => {
+                let interm_err: IntermediateError = err.into();
+                interm_err.into()
+            }
+        }
+    }
+}
+
+pub fn ensure_parent_child_items<T: DataItem>(
+    parent: &T,
+    child: &T,
+    id_classifier: &<T as DataItem>::IdClassifier,
+) -> Result<(), Error> {
+    let childs_parent_item_id = child.parent_item_id(id_classifier);
+    ensure!(
+        childs_parent_item_id.is_some_and(|parent_id| parent_id == parent.item_id()),
+        Error::NotParentChild {
+            child_item_id: child.item_id().to_string(),
+            childs_parent_item_id: childs_parent_item_id.as_displayable().to_string(),
+            expected_parent_item_id: parent.item_id().to_string()
+        }
+    );
+    Ok(())
+}
+
+pub fn ensure_parent_child<T, F>(
+    parent_id: NodeId,
+    child_id: NodeId,
+    arena: &Arena<T, F>,
+) -> Result<(), Error>
+where
+    T: DataItem,
+    F: Flavor,
+{
+    let parent_node = arena.get_existing(parent_id)?;
+    let child_node = arena.get_existing(child_id)?;
+    ensure_parent_child_items(parent_node.get(), child_node.get(), &arena.id_classifier)
+}

--- a/utils/in_mem_item_tree/src/primitives/indextree_utils.rs
+++ b/utils/in_mem_item_tree/src/primitives/indextree_utils.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use indextree::{Arena, NodeId};
+
+use utils::ensure;
+
+/// Starting from the specified node, iterate over the corresponding subtree, depth first, and call
+/// the provided function on each node.
+/// If the function returns false, the corresponding subtree will not be descended into.
+/// Note: removed nodes are never iterated over; if the passed `root_id` refers to a removed node,
+/// the function won't be called even once.
+pub fn for_all_nodes_depth_first<T, E>(
+    arena: &Arena<T>,
+    root_id: NodeId,
+    mut handler: impl FnMut(NodeId) -> Result<bool, E>,
+) -> Result<(), E>
+where
+    E: std::error::Error + From<Error>,
+{
+    ensure!(!root_id.is_removed(arena), Error::NodeIsRemoved(root_id));
+
+    if !handler(root_id)? {
+        return Ok(());
+    }
+
+    let mut stack = Vec::new();
+    stack.push(root_id.children(arena));
+
+    while !stack.is_empty() {
+        let cur_node_id = stack.last_mut().expect("The stack is known to be non-empty").next();
+
+        if let Some(cur_node_id) = cur_node_id {
+            if handler(cur_node_id)? {
+                stack.push(cur_node_id.children(arena));
+            }
+        } else {
+            stack.pop();
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    #[error("Node id {0} is removed")]
+    NodeIsRemoved(NodeId),
+}
+
+#[cfg(test)]
+mod tests {
+    use ::test_utils::assert_matches;
+
+    use super::*;
+
+    #[test]
+    fn test_for_all_depth_first() {
+        // a1---a2---a3---a4---a5
+        //  \---c1---c2    \---b1
+        //       \---d1---d2
+
+        let mut arena = Arena::new();
+
+        let a1 = arena.new_node(1);
+        let a2 = arena.new_node(2);
+        let a3 = arena.new_node(3);
+        let a4 = arena.new_node(4);
+        let a5 = arena.new_node(5);
+        let b1 = arena.new_node(11);
+        let c1 = arena.new_node(111);
+        let c2 = arena.new_node(222);
+        let d1 = arena.new_node(1111);
+        let d2 = arena.new_node(2222);
+
+        a1.checked_append(a2, &mut arena).unwrap();
+        a1.checked_append(c1, &mut arena).unwrap();
+        a2.checked_append(a3, &mut arena).unwrap();
+        a3.checked_append(a4, &mut arena).unwrap();
+        a4.checked_append(a5, &mut arena).unwrap();
+        a4.checked_append(b1, &mut arena).unwrap();
+        c1.checked_append(c2, &mut arena).unwrap();
+        c1.checked_append(d1, &mut arena).unwrap();
+        d1.checked_append(d2, &mut arena).unwrap();
+
+        let result = for_all_nodes_depth_first_collect(&arena, a1, |_| true).unwrap();
+        let expected = [1, 2, 3, 4, 5, 11, 111, 222, 1111, 2222];
+        assert_eq!(result, expected);
+
+        // Don't descent into a3
+        let result = for_all_nodes_depth_first_collect(&arena, a1, |val| val != 3).unwrap();
+        let expected = [1, 2, 3, 111, 222, 1111, 2222];
+        assert_eq!(result, expected);
+
+        // Remove a4.
+        a4.remove_subtree(&mut arena);
+        // a4, a5, b1 are no longer returned.
+        let result = for_all_nodes_depth_first_collect(&arena, a1, |_| true).unwrap();
+        let expected = [1, 2, 3, 111, 222, 1111, 2222];
+        assert_eq!(result, expected);
+
+        // Iterate starting from a4, an error should be returned.
+        assert_matches!(
+            for_all_nodes_depth_first_collect(&arena, a4, |_| true),
+            Err(Error::NodeIsRemoved(_))
+        );
+    }
+
+    fn for_all_nodes_depth_first_collect<T: Copy>(
+        arena: &Arena<T>,
+        root_id: NodeId,
+        handler: impl Fn(T) -> bool,
+    ) -> Result<Vec<T>, Error> {
+        let mut vec = Vec::new();
+
+        let result = for_all_nodes_depth_first(arena, root_id, |node_id| -> Result<_, Error> {
+            let val = *arena.get(node_id).unwrap().get();
+            vec.push(val);
+            Ok(handler(val))
+        });
+
+        result.map(|_| vec)
+    }
+}

--- a/utils/in_mem_item_tree/src/primitives/mod.rs
+++ b/utils/in_mem_item_tree/src/primitives/mod.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Wrappers for `indextree` primitives intended to represent a tree of items that already
+//! have a parent-child relationship.
+//! The following guarantees are provided:
+//! 1) If two tree nodes are a parent and a child, then the corresponding items must also
+//! be a parent and a child. Note that the opposite is not true - you are allowed to have
+//! a parent and child items whose corresponding tree nodes are not connected.
+//! 2) For each item id there can be at most one node in the arena corresponding to it.
+//! Since this guarantee requires the additional overhead of maintaining the item-id-to-node-id
+//! map, the user has the option of enforcing it in debug builds only; this is controlled via
+//! one of the generic parameters of `Arena`.
+
+mod arena;
+mod detail;
+mod node_id;
+mod node_ref;
+
+pub mod indextree_utils;
+
+use std::fmt::{Debug, Display};
+
+pub use arena::Arena;
+pub use detail::{ItemIdMapHolder, TmpError};
+pub use node_id::NodeId;
+pub use node_ref::{NodeMut, NodeRef};
+
+/// This represents the node's data item.
+/// Note: the code in this module relies on the fact that the returned ids will never change.
+/// So, implementors of this trait should avoid having mutators for the corresponding fields
+/// (or be extra-careful about accidental mutations).
+pub trait DataItem {
+    type Id: Clone + Copy + Debug + Display + Ord;
+
+    /// Some kind of external object that might be needed by `DataItem`'s implementor to be able
+    /// to produce `Option<&Id>` in `parent_item_id`. E.g. chainstate's `BlockIndex` references its
+    /// parent simply as `Id<GenBlock>`; in order to check whether it's the genesis, one needs access
+    /// to `ChainConfig`, which the classifier may hold in this case.
+    type IdClassifier: Clone + Debug;
+
+    /// Return the id of the item itself.
+    fn item_id(&self) -> &Self::Id;
+
+    /// Return the id of the items's parent or `None` if the item has no parent.
+    /// Note that the exact meaning of `None` may differ depending on the implementor. E.g. if it's
+    /// the chainstate's `GenBlockIndex`, then the tree may contain the genesis itself, so having
+    /// `None` as the parent will mean that this node is the genesis. If it's `BlockIndex`, then
+    /// the tree may not contain the genesis, so having `None` as the parent will mean that this
+    /// node's parent is the genesis.
+    fn parent_item_id(&self, id_classifier: &Self::IdClassifier) -> Option<&Self::Id>;
+}
+
+/// The "flavor" that is used as a generic parameter for the `Arena`.
+pub trait Flavor {
+    /// The modification observer, which is informed about nodes' additions and removals.
+    type ModificationObserver<T: DataItem>: detail::ModificationObserver<T>;
+}
+
+/// The favor that maintains the item-id-to-node-id map in both debug and release builds.
+pub struct WithItemIdToNodeIdMap;
+
+impl Flavor for WithItemIdToNodeIdMap {
+    type ModificationObserver<T: DataItem> = detail::TrackingModificationObserver<T>;
+}
+
+/// The favor that maintains the item-id-to-node-id map only in debug builds.
+pub struct WithDebugOnlyChecks;
+
+impl Flavor for WithDebugOnlyChecks {
+    type ModificationObserver<T: DataItem> = detail::DebugOnlyTrackingModificationObserver<T>;
+}
+
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    // Note: `indextree::NodeError` doesn't implement Eq/PartialEq, so we store a string instead.
+    #[error("Index tree error: {0}")]
+    IndexTreeError(String),
+    #[error("Index tree utils error: {0}")]
+    IndexTreeUtilsError(#[from] indextree_utils::Error),
+    #[error("Node id {0} is not in arena")]
+    NodeIdNotInArena(NodeId),
+    #[error("Node id {0} is removed")]
+    NodeIsRemoved(NodeId),
+    #[error(
+        "Item {child_item_id} has parent {childs_parent_item_id} instead of expected {expected_parent_item_id}",
+    )]
+    NotParentChild {
+        child_item_id: String,
+        childs_parent_item_id: String,
+        expected_parent_item_id: String,
+    },
+    #[error("Item id {item_id} is already in the arena")]
+    ItemAlreadyInArena { item_id: String },
+}
+
+impl From<indextree::NodeError> for Error {
+    fn from(err: indextree::NodeError) -> Self {
+        Error::IndexTreeError(err.to_string())
+    }
+}
+
+pub fn for_all_nodes_depth_first<T, F, E>(
+    arena: &Arena<T, F>,
+    root_id: NodeId,
+    mut handler: impl FnMut(NodeId) -> Result<bool, E>,
+) -> Result<(), E>
+where
+    T: DataItem,
+    F: Flavor,
+    E: std::error::Error + From<Error>,
+{
+    indextree_utils::for_all_nodes_depth_first(
+        &arena.arena,
+        root_id.0,
+        |node_id| -> Result<_, TmpError<E, indextree_utils::Error>> {
+            handler(NodeId(node_id)).map_err(TmpError::OuterError)
+        },
+    )
+    .map_err(|err| err.into_outer_error_via::<Error>())
+}
+
+#[cfg(test)]
+mod tests;

--- a/utils/in_mem_item_tree/src/primitives/node_id.rs
+++ b/utils/in_mem_item_tree/src/primitives/node_id.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{arena::Arena, detail::ensure_parent_child, DataItem, Error, Flavor};
+
+/// The wrapper for `indextree::NodeId`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, derive_more::Display)]
+pub struct NodeId(pub(super) indextree::NodeId);
+
+impl NodeId {
+    /// Return true if the corresponding node is removed.
+    pub fn is_removed<T, F>(self, arena: &Arena<T, F>) -> bool
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.is_removed(&arena.arena)
+    }
+
+    /// Returns an iterator of IDs of this node and its ancestors.
+    ///
+    /// Use `.skip(1)` or call `.next()` once on the iterator to skip the node itself.
+    ///
+    /// See [indextree::NodeId::ancestors](https://docs.rs/indextree/latest/indextree/struct.NodeId.html#method.ancestors).
+    pub fn ancestors<T, F>(self, arena: &Arena<T, F>) -> impl Iterator<Item = NodeId> + '_
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.ancestors(&arena.arena).map(NodeId)
+    }
+
+    /// Returns an iterator of IDs of this node and its predecessors (i.e. the node, then its
+    /// preceding siblings, then its ancestor, then ancestor's preceding siblings etc).
+    ///
+    /// Use .skip(1) or call .next() once on the iterator to skip the node itself.
+    ///
+    /// See [indextree::NodeId::predecessors](https://docs.rs/indextree/latest/indextree/struct.NodeId.html#method.predecessors).
+    pub fn predecessors<T, F>(self, arena: &Arena<T, F>) -> impl Iterator<Item = NodeId> + '_
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.predecessors(&arena.arena).map(NodeId)
+    }
+
+    /// Returns an iterator of IDs of this node and the siblings before it.
+    ///
+    /// Use .skip(1) or call .next() once on the iterator to skip the node itself.
+    ///
+    /// See [indextree::NodeId::preceding_siblings](https://docs.rs/indextree/latest/indextree/struct.NodeId.html#method.preceding_siblings).
+    pub fn preceding_siblings<T, F>(self, arena: &Arena<T, F>) -> impl Iterator<Item = NodeId> + '_
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.preceding_siblings(&arena.arena).map(NodeId)
+    }
+
+    /// Returns an iterator of IDs of this node and the siblings after it.
+    ///
+    /// Use .skip(1) or call .next() once on the iterator to skip the node itself.
+    ///
+    /// See [indextree::NodeId::following_siblings](https://docs.rs/indextree/latest/indextree/struct.NodeId.html#method.following_siblings).
+    pub fn following_siblings<T, F>(self, arena: &Arena<T, F>) -> impl Iterator<Item = NodeId> + '_
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.following_siblings(&arena.arena).map(NodeId)
+    }
+
+    /// Returns an iterator of IDs of this node's children.
+    ///
+    /// See [indextree::NodeId::children](https://docs.rs/indextree/latest/indextree/struct.NodeId.html#method.children).
+    pub fn children<T, F>(self, arena: &Arena<T, F>) -> impl Iterator<Item = NodeId> + '_
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.children(&arena.arena).map(NodeId)
+    }
+
+    /// Returns an iterator of IDs of this node's children, in reverse order.
+    ///
+    /// See [indextree::NodeId::reverse_children](https://docs.rs/indextree/latest/indextree/struct.NodeId.html#method.reverse_children).
+    pub fn reverse_children<T, F>(self, arena: &Arena<T, F>) -> impl Iterator<Item = NodeId> + '_
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.reverse_children(&arena.arena).map(NodeId)
+    }
+
+    /// An iterator of the IDs of a given node and its descendants, as a pre-order depth-first search where children are visited in insertion order.
+    ///
+    /// Parent nodes appear before the descendants. Use .skip(1) or call .next() once on the iterator to skip the node itself.
+    ///
+    /// See [indextree::NodeId::descendants](https://docs.rs/indextree/latest/indextree/struct.NodeId.html#method.descendants).
+    pub fn descendants<T, F>(self, arena: &Arena<T, F>) -> impl Iterator<Item = NodeId> + '_
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.descendants(&arena.arena).map(NodeId)
+    }
+
+    /// Detaches a node from its parent.
+    pub fn detach_from_parent<T, F>(self, arena: &mut Arena<T, F>) -> Result<(), Error>
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        self.0.detach(&mut arena.arena);
+        Ok(())
+    }
+
+    /// Appends a new child to this node, after existing children.
+    pub fn append_child<T, F>(self, new_child: NodeId, arena: &mut Arena<T, F>) -> Result<(), Error>
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        ensure_parent_child(self, new_child, &*arena)?;
+        self.0.checked_append(new_child.0, &mut arena.arena)?;
+        Ok(())
+    }
+
+    /// Prepends a new child to this node, before existing children.
+    pub fn prepend_child<T, F>(
+        self,
+        new_child: NodeId,
+        arena: &mut Arena<T, F>,
+    ) -> Result<(), Error>
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        ensure_parent_child(self, new_child, &*arena)?;
+        self.0.checked_prepend(new_child.0, &mut arena.arena)?;
+        Ok(())
+    }
+
+    /// Removes a node and its descendants from the arena.
+    ///
+    /// See [indextree::NodeId::remove_subtree](https://docs.rs/indextree/latest/indextree/struct.NodeId.html#method.remove_subtree).
+    pub fn remove_subtree<T, F>(self, arena: &mut Arena<T, F>) -> Result<(), Error>
+    where
+        T: DataItem,
+        F: Flavor,
+    {
+        // Ensure the node exists in the arena, otherwise `on_subtree_removal` may panic.
+        arena.get_existing(self)?;
+
+        arena.on_subtree_removal(self);
+        self.0.remove_subtree(&mut arena.arena);
+        Ok(())
+    }
+}

--- a/utils/in_mem_item_tree/src/primitives/node_ref.rs
+++ b/utils/in_mem_item_tree/src/primitives/node_ref.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::node_id::NodeId;
+
+/// The wrapper for an immutable reference to `indextree::Node`.
+///
+/// Note that unlike the wrapped `indextree::Node`, this can never refer to a removed node,
+/// so we don't expose the `is_removed` function.
+#[derive(Copy, Clone, Debug)]
+pub struct NodeRef<'a, T>(pub(super) &'a indextree::Node<T>);
+
+impl<'a, T> NodeRef<'a, T> {
+    pub fn get(&self) -> &'a T {
+        self.0.get()
+    }
+
+    pub fn parent(&self) -> Option<NodeId> {
+        self.0.parent().map(NodeId)
+    }
+
+    pub fn first_child(&self) -> Option<NodeId> {
+        self.0.first_child().map(NodeId)
+    }
+
+    pub fn last_child(&self) -> Option<NodeId> {
+        self.0.last_child().map(NodeId)
+    }
+
+    pub fn previous_sibling(&self) -> Option<NodeId> {
+        self.0.previous_sibling().map(NodeId)
+    }
+
+    pub fn next_sibling(&self) -> Option<NodeId> {
+        self.0.next_sibling().map(NodeId)
+    }
+}
+
+/// The wrapper for a mutable reference to `indextree::Node`.
+///
+/// Same as `NodeRef`, this can never refer to a removed node.
+#[derive(Debug)]
+pub struct NodeMut<'a, T>(pub(super) &'a mut indextree::Node<T>);
+
+impl<'a, T> NodeMut<'a, T> {
+    pub fn get_mut(&mut self) -> &mut T {
+        self.0.get_mut()
+    }
+
+    pub fn parent(&self) -> Option<NodeId> {
+        self.0.parent().map(NodeId)
+    }
+
+    pub fn first_child(&self) -> Option<NodeId> {
+        self.0.first_child().map(NodeId)
+    }
+
+    pub fn last_child(&self) -> Option<NodeId> {
+        self.0.last_child().map(NodeId)
+    }
+
+    pub fn previous_sibling(&self) -> Option<NodeId> {
+        self.0.previous_sibling().map(NodeId)
+    }
+
+    pub fn next_sibling(&self) -> Option<NodeId> {
+        self.0.next_sibling().map(NodeId)
+    }
+}
+
+impl<'a, T> From<NodeMut<'a, T>> for NodeRef<'a, T> {
+    fn from(value: NodeMut<'a, T>) -> Self {
+        Self(&*value.0)
+    }
+}

--- a/utils/in_mem_item_tree/src/primitives/tests.rs
+++ b/utils/in_mem_item_tree/src/primitives/tests.rs
@@ -1,0 +1,460 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use itertools::Itertools;
+
+use ::test_utils::assert_matches;
+
+use super::{
+    arena::Arena, detail::ItemIdMapHolder, node_id::NodeId, DataItem, Error, Flavor,
+    WithDebugOnlyChecks, WithItemIdToNodeIdMap,
+};
+
+type TestItemId = u64;
+
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+struct TestItem {
+    id: TestItemId,
+    parent_id: TestItemId,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TestIdClassifier {
+    genesis_id: TestItemId,
+}
+
+impl DataItem for TestItem {
+    type Id = TestItemId;
+    type IdClassifier = TestIdClassifier;
+
+    fn item_id(&self) -> &Self::Id {
+        &self.id
+    }
+
+    fn parent_item_id(&self, id_classifier: &TestIdClassifier) -> Option<&Self::Id> {
+        (self.parent_id != id_classifier.genesis_id).then_some(&self.parent_id)
+    }
+}
+
+fn test_item(id: TestItemId, parent_id: TestItemId) -> TestItem {
+    TestItem { id, parent_id }
+}
+
+fn test_impl<F: Flavor>(
+    observer_map_getter: impl Fn(&Arena<TestItem, F>) -> &BTreeMap<TestItemId, NodeId>,
+    node_id_by_item_id_getter: impl Fn(&Arena<TestItem, F>, TestItemId) -> Option<NodeId>,
+) {
+    let genesis_id = 12345;
+    let id_classifier = TestIdClassifier { genesis_id };
+
+    let mut arena = Arena::<TestItem, F>::new(id_classifier);
+    assert_eq!(arena.capacity(), 0);
+    arena.reserve(1000);
+    assert!(arena.capacity() >= 1000);
+    let mut arena = Arena::<TestItem, F>::with_capacity(1000, id_classifier);
+    assert!(arena.capacity() >= 1000);
+    assert_eq!(arena.count(), 0);
+    assert!(arena.is_empty());
+
+    let node1 = arena.new_node(test_item(1, genesis_id)).unwrap();
+    assert!(!node1.is_removed(&arena));
+    assert!(!arena.is_empty());
+    assert_eq!(arena.count(), 1);
+    assert_eq!(observer_map_getter(&arena), &BTreeMap::from([(1, node1)]));
+    let mut node1_mut = arena.get_mut(node1).unwrap();
+    assert_eq!(node1_mut.get_mut(), &test_item(1, genesis_id));
+    assert_eq!(node1_mut.parent(), None);
+    assert_eq!(node1_mut.first_child(), None);
+    assert_eq!(node1_mut.last_child(), None);
+    assert_eq!(node1_mut.previous_sibling(), None);
+    assert_eq!(node1_mut.next_sibling(), None);
+    // Check that the "gen" functions all return the same pointer.
+    let node1_ptr1 = node1_mut.0 as *const _;
+    let node1_ptr2 = arena.get_existing_mut(node1).unwrap().0 as *const _;
+    let node1_ptr3 = arena.get(node1).unwrap().0 as *const _;
+    let node1_ptr4 = arena.get_existing(node1).unwrap().0 as *const _;
+    assert!(node1_ptr1 == node1_ptr2);
+    assert!(node1_ptr1 == node1_ptr3);
+    assert!(node1_ptr1 == node1_ptr4);
+    // Check get_node_id.
+    assert_eq!(arena.get_node_id(arena.get(node1).unwrap()).unwrap(), node1);
+
+    // Adding a new node corresponding to an existing item id should fail.
+    assert_matches!(
+        arena.new_node(test_item(1, genesis_id)),
+        Err(Error::ItemAlreadyInArena { .. })
+    );
+    assert_eq!(observer_map_getter(&arena), &BTreeMap::from([(1, node1)]));
+
+    // Add more nodes, using item 1 as the parent.
+    let node11 = arena.new_node(test_item(11, 1)).unwrap();
+    assert!(!node11.is_removed(&arena));
+    assert!(!arena.is_empty());
+    assert_eq!(arena.count(), 2);
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([(1, node1), (11, node11)])
+    );
+    let node12 = arena.new_node(test_item(12, 1)).unwrap();
+    assert!(!node12.is_removed(&arena));
+    assert!(!arena.is_empty());
+    assert_eq!(arena.count(), 3);
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([(1, node1), (11, node11), (12, node12)])
+    );
+    let node13 = arena.new_node(test_item(13, 1)).unwrap();
+    assert!(!node13.is_removed(&arena));
+    assert!(!arena.is_empty());
+    assert_eq!(arena.count(), 4);
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([(1, node1), (11, node11), (12, node12), (13, node13)])
+    );
+    // Add a node, using an unknown item 9 as the parent.
+    let node91 = arena.new_node(test_item(91, 9)).unwrap();
+    assert!(!node91.is_removed(&arena));
+    assert!(!arena.is_empty());
+    assert_eq!(arena.count(), 5);
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([(1, node1), (11, node11), (12, node12), (13, node13), (91, node91)])
+    );
+
+    // Set node1x as children of node1 using both append_child and prepend_child.
+    node1.append_child(node12, &mut arena).unwrap();
+    node1.prepend_child(node11, &mut arena).unwrap();
+    node1.append_child(node13, &mut arena).unwrap();
+    // Doing the same for node91 should fail.
+    assert_matches!(
+        node1.append_child(node91, &mut arena),
+        Err(Error::NotParentChild { .. })
+    );
+    assert_matches!(
+        node1.prepend_child(node91, &mut arena),
+        Err(Error::NotParentChild { .. })
+    );
+    // Check `children` and `reverse_children`
+    assert_eq!(
+        node1.children(&arena).collect_vec(),
+        &[node11, node12, node13]
+    );
+    assert_eq!(
+        node1.reverse_children(&arena).collect_vec(),
+        &[node13, node12, node11]
+    );
+    // Check node1 accessors again, now first_child and last_child shouldn't be None.
+    let node1_ref = arena.get(node1).unwrap();
+    assert_eq!(node1_ref.get(), &test_item(1, genesis_id));
+    assert_eq!(node1_ref.parent(), None);
+    assert_eq!(node1_ref.first_child(), Some(node11));
+    assert_eq!(node1_ref.last_child(), Some(node13));
+    assert_eq!(node1_ref.previous_sibling(), None);
+    assert_eq!(node1_ref.next_sibling(), None);
+    // Do the same for node12; previous_sibling/next_sibling shouldn't be None.
+    let node12_ref = arena.get(node12).unwrap();
+    assert_eq!(node12_ref.get(), &test_item(12, 1));
+    assert_eq!(node12_ref.parent(), Some(node1));
+    assert_eq!(node12_ref.first_child(), None);
+    assert_eq!(node12_ref.last_child(), None);
+    assert_eq!(node12_ref.previous_sibling(), Some(node11));
+    assert_eq!(node12_ref.next_sibling(), Some(node13));
+
+    // Check get_node_id for node1 again, and also for node12.
+    assert_eq!(arena.get_node_id(arena.get(node1).unwrap()).unwrap(), node1);
+    assert_eq!(
+        arena.get_node_id(arena.get(node12).unwrap()).unwrap(),
+        node12
+    );
+
+    // Detach node12 from its parent, check accessors again.
+    node12.detach_from_parent(&mut arena).unwrap();
+    let node1_ref = arena.get(node1).unwrap();
+    assert_eq!(node1_ref.get(), &test_item(1, genesis_id));
+    assert_eq!(node1_ref.parent(), None);
+    assert_eq!(node1_ref.first_child(), Some(node11));
+    assert_eq!(node1_ref.last_child(), Some(node13));
+    assert_eq!(node1_ref.previous_sibling(), None);
+    assert_eq!(node1_ref.next_sibling(), None);
+    // node12 has no parent and no siblings
+    let node12_ref = arena.get(node12).unwrap();
+    assert_eq!(node12_ref.get(), &test_item(12, 1));
+    assert_eq!(node12_ref.parent(), None);
+    assert_eq!(node12_ref.first_child(), None);
+    assert_eq!(node12_ref.last_child(), None);
+    assert_eq!(node12_ref.previous_sibling(), None);
+    assert_eq!(node12_ref.next_sibling(), None);
+
+    // The observer's map hasn't been affected.
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([(1, node1), (11, node11), (12, node12), (13, node13), (91, node91)])
+    );
+
+    // Append node12 again.
+    node1.append_child(node12, &mut arena).unwrap();
+    let node1_ref = arena.get(node1).unwrap();
+    assert_eq!(node1_ref.get(), &test_item(1, genesis_id));
+    assert_eq!(node1_ref.parent(), None);
+    assert_eq!(node1_ref.first_child(), Some(node11));
+    // Note: node12 is now the last child.
+    assert_eq!(node1_ref.last_child(), Some(node12));
+    assert_eq!(node1_ref.previous_sibling(), None);
+    assert_eq!(node1_ref.next_sibling(), None);
+    // Do the same for node12; previous_sibling/next_sibling shouldn't be None.
+    let node12_ref = arena.get(node12).unwrap();
+    assert_eq!(node12_ref.get(), &test_item(12, 1));
+    assert_eq!(node12_ref.parent(), Some(node1));
+    assert_eq!(node12_ref.first_child(), None);
+    assert_eq!(node12_ref.last_child(), None);
+    assert_eq!(node12_ref.previous_sibling(), Some(node13));
+    assert_eq!(node12_ref.next_sibling(), None);
+
+    // Add a child to node12.
+    let node121 = arena.new_node(test_item(121, 12)).unwrap();
+    assert!(!node121.is_removed(&arena));
+    assert!(!arena.is_empty());
+    assert_eq!(arena.count(), 6);
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([
+            (1, node1),
+            (11, node11),
+            (12, node12),
+            (13, node13),
+            (91, node91),
+            (121, node121),
+        ])
+    );
+    node12.append_child(node121, &mut arena).unwrap();
+
+    // Check ancestors/predecessors on node121.
+    assert_eq!(
+        node121.ancestors(&arena).collect_vec(),
+        &[node121, node12, node1]
+    );
+    assert_eq!(
+        node121.predecessors(&arena).collect_vec(),
+        &[node121, node12, node13, node11, node1]
+    );
+    // Check preceding_siblings/following_siblings on node12 and node13.
+    assert_eq!(
+        node12.preceding_siblings(&arena).collect_vec(),
+        &[node12, node13, node11]
+    );
+    assert_eq!(
+        node13.preceding_siblings(&arena).collect_vec(),
+        &[node13, node11]
+    );
+    assert_eq!(node12.following_siblings(&arena).collect_vec(), &[node12]);
+    assert_eq!(
+        node13.following_siblings(&arena).collect_vec(),
+        &[node13, node12]
+    );
+    // Check descendants on node1.
+    assert_eq!(
+        node1.descendants(&arena).collect_vec(),
+        &[node1, node11, node13, node12, node121]
+    );
+
+    // Create a node and remove it immediately
+    let node122 = arena.new_node(test_item(122, 12)).unwrap();
+    assert!(!node122.is_removed(&arena));
+    assert!(!arena.is_empty());
+    assert_eq!(arena.count(), 7);
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([
+            (1, node1),
+            (11, node11),
+            (12, node12),
+            (13, node13),
+            (91, node91),
+            (121, node121),
+            (122, node122),
+        ])
+    );
+    // The "get" functions have already been tested above, so only check that they return Some/Ok here.
+    assert!(arena.get(node122).is_some());
+    assert!(arena.get_existing(node122).is_ok());
+    assert!(arena.get_mut(node122).is_some());
+    assert!(arena.get_existing_mut(node122).is_ok());
+    // Now remove the node.
+    node122.remove_subtree(&mut arena).unwrap();
+    assert!(node122.is_removed(&arena));
+    assert!(!arena.is_empty());
+    // The arena nodes count stays the same.
+    assert_eq!(arena.count(), 7);
+    // The "get" functions should now fail.
+    assert!(arena.get(node122).is_none());
+    assert_matches!(arena.get_existing(node122), Err(Error::NodeIsRemoved(_)));
+    assert!(arena.get_mut(node122).is_none());
+    assert_matches!(
+        arena.get_existing_mut(node122),
+        Err(Error::NodeIsRemoved(_))
+    );
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([
+            (1, node1),
+            (11, node11),
+            (12, node12),
+            (13, node13),
+            (91, node91),
+            (121, node121),
+        ])
+    );
+
+    // Appending/prepending the removed node fails with an error.
+    assert_matches!(
+        node12.append_child(node122, &mut arena),
+        Err(Error::NodeIsRemoved(_))
+    );
+    assert_matches!(
+        node12.prepend_child(node122, &mut arena),
+        Err(Error::NodeIsRemoved(_))
+    );
+
+    let non_existent_node_id = {
+        let mut other_arena = Arena::<TestItem, F>::new(id_classifier);
+
+        let mut last_node_id = None;
+        for i in 0..100 {
+            last_node_id = Some(other_arena.new_node(test_item(i, genesis_id)).unwrap());
+        }
+
+        last_node_id.unwrap()
+    };
+
+    // Appending/prepending a non-existent node id fails with an error.
+    assert_matches!(
+        node12.append_child(non_existent_node_id, &mut arena),
+        Err(Error::NodeIdNotInArena(_))
+    );
+    assert_matches!(
+        node12.prepend_child(non_existent_node_id, &mut arena),
+        Err(Error::NodeIdNotInArena(_))
+    );
+
+    // Create a new node after the removal. The previously removed node must be reused.
+    let node123 = arena.new_node(test_item(123, 12)).unwrap();
+    // The node id is different from the removed one.
+    assert!(node123 != node122);
+    // node122 is still removed, node123 is not
+    assert!(node122.is_removed(&arena));
+    assert!(!node123.is_removed(&arena));
+    assert!(!arena.is_empty());
+    // But the number of nodes int he arena hasn't changed.
+    assert_eq!(arena.count(), 7);
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([
+            (1, node1),
+            (11, node11),
+            (12, node12),
+            (13, node13),
+            (91, node91),
+            (121, node121),
+            (123, node123),
+        ])
+    );
+    node12.append_child(node123, &mut arena).unwrap();
+
+    // Try removing a non-existent subtree.
+    assert_matches!(
+        non_existent_node_id.remove_subtree(&mut arena),
+        Err(Error::NodeIdNotInArena(_))
+    );
+
+    // Check node_id_by_item_id
+    assert_eq!(node_id_by_item_id_getter(&arena, 1), Some(node1));
+    assert_eq!(node_id_by_item_id_getter(&arena, 91), Some(node91));
+    assert_eq!(node_id_by_item_id_getter(&arena, 11), Some(node11));
+    assert_eq!(node_id_by_item_id_getter(&arena, 12), Some(node12));
+    assert_eq!(node_id_by_item_id_getter(&arena, 13), Some(node13));
+    assert_eq!(node_id_by_item_id_getter(&arena, 121), Some(node121));
+    assert_eq!(node_id_by_item_id_getter(&arena, 122), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 123), Some(node123));
+
+    // Remove the whole node1 subtree.
+    node1.remove_subtree(&mut arena).unwrap();
+    // The number of nodes stays he same.
+    assert!(!arena.is_empty());
+    assert_eq!(arena.count(), 7);
+    assert!(!node91.is_removed(&arena));
+    assert!(node1.is_removed(&arena));
+    assert!(node11.is_removed(&arena));
+    assert!(node12.is_removed(&arena));
+    assert!(node13.is_removed(&arena));
+    assert!(node121.is_removed(&arena));
+    assert!(node122.is_removed(&arena));
+    assert!(node123.is_removed(&arena));
+    assert_eq!(
+        observer_map_getter(&arena),
+        &BTreeMap::from([(91, node91),])
+    );
+
+    // Check node_id_by_item_id again
+    assert_eq!(node_id_by_item_id_getter(&arena, 1), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 91), Some(node91));
+    assert_eq!(node_id_by_item_id_getter(&arena, 11), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 12), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 13), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 121), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 122), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 123), None);
+
+    // Clear the entire arena.
+    arena.clear();
+    // Now it's empty again
+    assert!(arena.is_empty());
+    assert_eq!(arena.count(), 0);
+    assert_eq!(observer_map_getter(&arena), &BTreeMap::new());
+
+    // Check node_id_by_item_id again
+    assert_eq!(node_id_by_item_id_getter(&arena, 1), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 91), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 11), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 12), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 13), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 121), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 122), None);
+    assert_eq!(node_id_by_item_id_getter(&arena, 123), None);
+}
+
+#[test]
+fn test() {
+    test_impl::<WithItemIdToNodeIdMap>(
+        |arena| arena.modification_observer.item_id_map(),
+        |arena, item_id| {
+            let node_id_by_item_id = arena.node_id_by_item_id(&item_id);
+            let node_id_in_map = arena.modification_observer.item_id_map().get(&item_id).copied();
+            assert_eq!(node_id_by_item_id, node_id_in_map);
+            node_id_by_item_id
+        },
+    );
+
+    #[cfg(debug_assertions)]
+    {
+        test_impl::<WithDebugOnlyChecks>(
+            |arena| arena.modification_observer.inner().item_id_map(),
+            |arena, item_id| {
+                arena.modification_observer.inner().item_id_map().get(&item_id).copied()
+            },
+        );
+    }
+}

--- a/utils/in_mem_item_tree/src/tree_wrappers.rs
+++ b/utils/in_mem_item_tree/src/tree_wrappers.rs
@@ -1,0 +1,420 @@
+// Copyright (c) 2021-2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Here we have several wrapper types that hold the arena, as well as one or more ids of
+//! "root" nodes, and provide higher-level read-only access to the contained tree.
+//! The intent is to be able to represent the result of some calculation that can no longer
+//! be modified, while still being able to "narrow" it down by referencing only a portion
+//! of the tree. To make the latter safer, we also require that node ids that are used
+//! to access internals of a particular "Tree" object must be obtained from that very object
+//! (and, for example, not from its subtree, or from a bigger tree that contains this particular
+//! one).
+//!
+//! We have the following types here:
+//! * `Trees` - this represents one or more unrelated trees that share the same arena.
+//! This type may be needed when collecting the "top" of a block tree starting from
+//! a particular height, which may produce multiple branches without a common root.
+//! * `Tree` - this represents a single tree and can be produced from `Trees`
+//! by choosing one of its roots.
+//! * `TreeRef` - this represents a reference to a particular branch of a tree.
+//! * `TreeNodeId` - this wraps `NodeId` of the corresponding node but also holds `NodeId`
+//! of the root of the tree that it has been obtained from; methods of "Tree" objects that
+//! accept `TreeNodeId` will fail if the root id stored inside it doesn't match "Tree"'s
+//! own root.
+
+use std::collections::BTreeMap;
+
+use utils::ensure;
+
+use super::primitives::{
+    self, for_all_nodes_depth_first, indextree_utils, Arena, DataItem, Flavor, NodeId, TmpError,
+};
+
+/// The wrapped `NodeId`.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct TreeNodeId {
+    node_id: NodeId,
+    branch_root_node_id: NodeId,
+}
+
+impl TreeNodeId {
+    fn new_root(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            branch_root_node_id: node_id,
+        }
+    }
+}
+
+/// Zero or more trees sharing the same arena.
+#[derive(Clone)]
+pub struct Trees<T: DataItem, F: Flavor> {
+    arena: Arena<T, F>,
+    roots: BTreeMap<<T as DataItem>::Id, NodeId>,
+}
+
+impl<T, F> Trees<T, F>
+where
+    T: DataItem,
+    F: Flavor,
+{
+    /// Create a new `Trees` object expecting all the passed roots to be actual roots, i.e. nodes
+    /// without a parent.
+    pub fn with_actual_roots(
+        arena: Arena<T, F>,
+        roots: BTreeMap<<T as DataItem>::Id, NodeId>,
+    ) -> Result<Self, Error> {
+        Self::ensure_actual_roots(&arena, &roots)?;
+        Ok(Self { arena, roots })
+    }
+
+    /// Same as `with_actual_roots`, but panic in debug builds instead of returning an error.
+    pub fn with_actual_roots_unchecked(
+        arena: Arena<T, F>,
+        roots: BTreeMap<<T as DataItem>::Id, NodeId>,
+    ) -> Self {
+        debug_assert_eq!(Self::ensure_actual_roots(&arena, &roots), Ok(()));
+        Self { arena, roots }
+    }
+
+    /// Ensure that all roots are present in the arena and are actual roots, i.e. nodes
+    /// without parents.
+    fn ensure_actual_roots(
+        arena: &Arena<T, F>,
+        roots: &BTreeMap<<T as DataItem>::Id, NodeId>,
+    ) -> Result<(), Error> {
+        for node_id in roots.values() {
+            ensure_is_root(arena, *node_id)?;
+        }
+
+        Ok(())
+    }
+
+    /// Return an iterator over the roots.
+    pub fn roots_iter(&self) -> impl Iterator<Item = (&<T as DataItem>::Id, TreeNodeId)> {
+        self.roots
+            .iter()
+            .map(|(item_id, node_id)| (item_id, TreeNodeId::new_root(*node_id)))
+    }
+
+    /// Return the number if roots.
+    pub fn roots_count(&self) -> usize {
+        self.roots.len()
+    }
+
+    /// Turn itself into a single tree corresponding to the specified item id.
+    /// Note that the other trees will still occupy space in the arena.
+    pub fn into_single_tree(self, root_item_id: &<T as DataItem>::Id) -> Result<Tree<T, F>, Error> {
+        let root_node_id =
+            *self
+                .roots
+                .get(root_item_id)
+                .ok_or_else(|| Error::ItemIdDoesntCorrespondToRoot {
+                    item_id: root_item_id.to_string(),
+                })?;
+
+        Ok(Tree::with_actual_root_unchecked(self.arena, root_node_id))
+    }
+
+    /// Return a single tree as a reference.
+    pub fn single_tree(
+        &self,
+        root_item_id: &<T as DataItem>::Id,
+    ) -> Result<TreeRef<'_, T, F>, Error> {
+        let root_node_id =
+            *self
+                .roots
+                .get(root_item_id)
+                .ok_or_else(|| Error::ItemIdDoesntCorrespondToRoot {
+                    item_id: root_item_id.to_string(),
+                })?;
+
+        Ok(TreeRef::new_unchecked(&self.arena, root_node_id))
+    }
+
+    /// Return an iterator over trees as `TreeRef`s.
+    pub fn trees_iter(&self) -> impl Iterator<Item = TreeRef<'_, T, F>> {
+        self.roots.values().map(|node_id| TreeRef::new_unchecked(&self.arena, *node_id))
+    }
+
+    /// Return an iterator over all items in the tree.
+    pub fn all_items_iter(&self) -> impl Iterator<Item = &'_ T> {
+        self.trees_iter().flat_map(|tree| tree.all_items_iter())
+    }
+}
+
+/// A single tree.
+#[derive(Clone)]
+pub struct Tree<T: DataItem, F: Flavor> {
+    arena: Arena<T, F>,
+    root_id: NodeId,
+}
+
+impl<T, F> Tree<T, F>
+where
+    T: DataItem,
+    F: Flavor,
+{
+    /// Create a new `Tree` object expecting the passed root to be an actual root, i.e. a node
+    /// without a parent.
+    pub fn with_actual_root(arena: Arena<T, F>, root_id: NodeId) -> Result<Self, Error> {
+        ensure_is_root(&arena, root_id)?;
+        Ok(Self { arena, root_id })
+    }
+
+    /// Same as `with_actual_root`, but panic in debug builds instead of returning an error.
+    pub fn with_actual_root_unchecked(arena: Arena<T, F>, root_id: NodeId) -> Self {
+        debug_assert_eq!(ensure_is_root(&arena, root_id), Ok(()));
+        Self { arena, root_id }
+    }
+
+    /// Return the id of the root node.
+    pub fn root_node_id(&self) -> TreeNodeId {
+        TreeNodeId::new_root(self.root_id)
+    }
+
+    /// Return the data item corresponding to the root.
+    pub fn root_item(&self) -> Result<&T, Error> {
+        Ok(self.arena.get_existing(self.root_id)?.get())
+    }
+
+    /// Return self as `TreeRef`.
+    pub fn as_ref(&self) -> TreeRef<'_, T, F> {
+        TreeRef::new_unchecked(&self.arena, self.root_id)
+    }
+
+    // The following functions just delegate to `TreeRef`, for convenience.
+
+    pub fn get_parent(&self, node_id: TreeNodeId) -> Result<Option<TreeNodeId>, Error> {
+        self.as_ref().get_parent(node_id)
+    }
+
+    pub fn get_item(&self, node_id: TreeNodeId) -> Result<&T, Error> {
+        self.as_ref().get_item(node_id)
+    }
+
+    pub fn subtree(&self, node_id: TreeNodeId) -> Result<TreeRef<'_, T, F>, Error> {
+        self.as_ref().subtree(node_id)
+    }
+
+    pub fn child_node_ids_iter_for(
+        &self,
+        node_id: TreeNodeId,
+    ) -> Result<impl Iterator<Item = TreeNodeId> + '_, Error> {
+        self.as_ref().child_node_ids_iter_for(node_id)
+    }
+
+    pub fn all_node_ids_iter(&self) -> impl Iterator<Item = TreeNodeId> + '_ {
+        self.as_ref().all_node_ids_iter()
+    }
+
+    pub fn all_items_iter(&self) -> impl Iterator<Item = &T> {
+        self.as_ref().all_items_iter()
+    }
+
+    pub fn for_all_node_ids_until<E>(
+        &self,
+        handler: impl FnMut(TreeNodeId) -> Result<bool, E>,
+    ) -> Result<(), E>
+    where
+        E: std::error::Error + From<Error>,
+    {
+        self.as_ref().for_all_node_ids_until(handler)
+    }
+}
+
+/// A "reference" to a single tree.
+#[derive(Clone, Copy)]
+pub struct TreeRef<'a, T: DataItem, F: Flavor> {
+    arena: &'a Arena<T, F>,
+    root_id: NodeId,
+}
+
+impl<'a, T, F> TreeRef<'a, T, F>
+where
+    T: DataItem,
+    F: Flavor,
+{
+    /// Create a new `TreeRef` object ensuring that the passed root is in the arena.
+    pub fn new(arena: &'a Arena<T, F>, root_id: NodeId) -> Result<Self, Error> {
+        ensure_node_in_arena(arena, root_id)?;
+        Ok(Self { arena, root_id })
+    }
+
+    /// Same as `new`, but panic in debug builds instead of returning an error.
+    pub fn new_unchecked(arena: &'a Arena<T, F>, root_id: NodeId) -> Self {
+        debug_assert_eq!(ensure_node_in_arena(arena, root_id), Ok(()));
+
+        Self { arena, root_id }
+    }
+
+    /// Return the id of the root node.
+    pub fn root_node_id(&self) -> TreeNodeId {
+        TreeNodeId::new_root(self.root_id)
+    }
+
+    /// Return the data item corresponding to the root.
+    pub fn root_item(&self) -> Result<&'a T, Error> {
+        Ok(self.arena.get_existing(self.root_id)?.get())
+    }
+
+    /// Return the id of parent of the specified node in the context of the current tree.
+    /// I.e. if the passed `node_id` corresponds to the current tree's root, `None` will be
+    /// returned even if it has a parent.
+    pub fn get_parent(&self, node_id: TreeNodeId) -> Result<Option<TreeNodeId>, Error> {
+        self.ensure_node_in_subtree(node_id)?;
+
+        let result = if node_id.node_id == self.root_id {
+            None
+        } else {
+            let node = self.arena.get_existing(node_id.node_id)?;
+            let parent_id = node.parent().ok_or(Error::NonRootWithoutParent(node_id.node_id))?;
+            Some(TreeNodeId {
+                node_id: parent_id,
+                branch_root_node_id: self.root_id,
+            })
+        };
+
+        Ok(result)
+    }
+
+    /// Return the item corresponding to the given node id.
+    pub fn get_item(&self, node_id: TreeNodeId) -> Result<&'a T, Error> {
+        self.ensure_node_in_subtree(node_id)?;
+        let node = self.arena.get_existing(node_id.node_id)?;
+        Ok(node.get())
+    }
+
+    /// Return a subtree starting at the specified node id, as a `TreeRef`.
+    pub fn subtree(&self, node_id: TreeNodeId) -> Result<TreeRef<'a, T, F>, Error> {
+        self.ensure_node_in_subtree(node_id)?;
+        Ok(Self::new_unchecked(self.arena, node_id.node_id))
+    }
+
+    /// Return an iterator over node ids of direct children of the given node.
+    pub fn child_node_ids_iter_for(
+        &self,
+        node_id: TreeNodeId,
+    ) -> Result<impl Iterator<Item = TreeNodeId> + 'a, Error> {
+        self.ensure_node_in_subtree(node_id)?;
+
+        let branch_root_node_id = self.root_id;
+        Ok(
+            node_id.node_id.children(self.arena).map(move |child_id| TreeNodeId {
+                node_id: child_id,
+                branch_root_node_id,
+            }),
+        )
+    }
+
+    /// Return an iterator over the entire tree, for depth-first traversal.
+    /// A parent will always be visited before its children.
+    /// The first visited item will always be the root item.
+    pub fn all_node_ids_iter(&self) -> impl Iterator<Item = TreeNodeId> + 'a {
+        let branch_root_node_id = self.root_id;
+        self.root_id.descendants(self.arena).map(move |child_id| TreeNodeId {
+            node_id: child_id,
+            branch_root_node_id,
+        })
+    }
+
+    /// Same as `all_node_ids_iter`, but return references to data items instead of node ids.
+    pub fn all_items_iter(&self) -> impl Iterator<Item = &'a T> {
+        self.all_node_ids_iter().map(|node_id| {
+            self.arena
+                .get(node_id.node_id)
+                .expect("Node being iterated over must be present in the arena")
+                .get()
+        })
+    }
+
+    /// Iterate over all nodes, depth first, and call the provided function on each node.
+    /// If the function returns false, the corresponding subtree will not be descended into.
+    pub fn for_all_node_ids_until<E>(
+        &self,
+        mut handler: impl FnMut(TreeNodeId) -> Result<bool, E>,
+    ) -> Result<(), E>
+    where
+        E: std::error::Error + From<Error>,
+    {
+        for_all_nodes_depth_first(
+            self.arena,
+            self.root_id,
+            |node_id| -> Result<_, TmpError<E, primitives::Error>> {
+                handler(TreeNodeId {
+                    node_id,
+                    branch_root_node_id: self.root_id,
+                })
+                .map_err(TmpError::OuterError)
+            },
+        )
+        .map_err(|err| err.into_outer_error_via::<Error>())
+    }
+
+    fn ensure_node_in_subtree(&self, node_id: TreeNodeId) -> Result<(), Error> {
+        if node_id.branch_root_node_id == self.root_id {
+            Ok(())
+        } else {
+            Err(Error::NodeNotInBranch {
+                node_id: node_id.node_id,
+                nodes_branch_root: node_id.branch_root_node_id,
+                actual_branch_root: self.root_id,
+            })
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
+pub enum Error {
+    #[error(transparent)]
+    PrimitivesError(#[from] primitives::Error),
+    #[error("Index tree utils error: {0}")]
+    IndexTreeUtilsError(#[from] indextree_utils::Error),
+    #[error("Item id {item_id} doesn't correspond to any root node")]
+    ItemIdDoesntCorrespondToRoot { item_id: String },
+    #[error("Root node {0} has a parent")]
+    RootWithParent(NodeId),
+    #[error("Non-root node {0} has no parent")]
+    NonRootWithoutParent(NodeId),
+    #[error("Node {node_id} belongs to the branch at {nodes_branch_root} but this branch is at {actual_branch_root}")]
+    NodeNotInBranch {
+        node_id: NodeId,
+        nodes_branch_root: NodeId,
+        actual_branch_root: NodeId,
+    },
+}
+
+fn ensure_node_in_arena<T, F>(arena: &Arena<T, F>, node_id: NodeId) -> Result<(), Error>
+where
+    T: DataItem,
+    F: Flavor,
+{
+    arena.get_existing(node_id)?;
+    Ok(())
+}
+
+// Ensure that the root is present in the arena and is an actual root, i.e. a node without a parent.
+fn ensure_is_root<T, F>(arena: &Arena<T, F>, node_id: NodeId) -> Result<(), Error>
+where
+    T: DataItem,
+    F: Flavor,
+{
+    ensure!(
+        arena.get_existing(node_id)?.parent().is_none(),
+        Error::RootWithParent(node_id)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This is the generalized version of the "in-memory block tree" from #1768 . The corresponding `Trees`/`Tree`/`TreeRef` structs are in `tree_wrappers.rs`. However, I also had to wrap all `indextree`'s primitives (which are in the `primitives` module), so that they can be exposed to the user and still maintain the required guarantees (i.e. that a parent/child nodes will always correspond to parent/child blocks).