### PR TITLE
Add missing tx fees tests

### DIFF
--- a/chainstate/test-suite/src/tests/orders_tests.rs
+++ b/chainstate/test-suite/src/tests/orders_tests.rs
@@ -106,9 +106,12 @@ fn create_order_check_storage(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
 
         let (token_id, tokens_outpoint, _) = issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -185,9 +188,12 @@ fn create_two_orders_same_tx(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
 
         let (token_id, tokens_outpoint, _) = issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let amount1 = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let amount2 = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let amount2 =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data_1 = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(amount1),
@@ -230,9 +236,12 @@ fn create_two_orders_same_block(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
 
         let (token_id, tokens_outpoint, _) = issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = Box::new(OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -276,9 +285,12 @@ fn create_order_check_currencies(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
 
         let (token_id, tokens_outpoint, _) = issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
 
         // Check coins for coins trade
         {
@@ -409,9 +421,12 @@ fn conclude_order_check_storage(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
 
         let (token_id, tokens_outpoint, _) = issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -461,9 +476,12 @@ fn conclude_order_multiple_txs(#[case] seed: Seed) {
         let mut tf = TestFramework::builder(&mut rng).build();
 
         let (token_id, tokens_outpoint, _) = issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -534,9 +552,12 @@ fn fill_order_check_storage(#[case] seed: Seed) {
 
         let (token_id, tokens_outpoint, coins_outpoint) =
             issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(10u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(10u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(10u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -647,9 +668,12 @@ fn fill_partially_then_conclude(#[case] seed: Seed) {
 
         let (token_id, tokens_outpoint, coins_outpoint) =
             issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -808,9 +832,12 @@ fn try_overbid_order_in_multiple_txs(#[case] seed: Seed) {
 
         let (token_id, tokens_outpoint, coins_outpoint) =
             issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -909,9 +936,12 @@ fn fill_completely_then_conclude(#[case] seed: Seed) {
 
         let (token_id, tokens_outpoint, coins_outpoint) =
             issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -1094,9 +1124,12 @@ fn conclude_order_check_signature(#[case] seed: Seed) {
         let (order_sk, order_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
 
         let (token_id, tokens_outpoint, _) = issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(1u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::PublicKey(order_pk.clone()),
             OutputValue::Coin(ask_amount),
@@ -1242,10 +1275,13 @@ fn reorg_before_create(#[case] seed: Seed) {
 
         let (token_id, tokens_outpoint, coins_outpoint) =
             issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
         let reorg_common_ancestor = tf.best_block_id();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(10u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(10u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -1331,9 +1367,12 @@ fn reorg_after_create(#[case] seed: Seed) {
 
         let (token_id, tokens_outpoint, coins_outpoint) =
             issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let ask_amount = Amount::from_atoms(rng.gen_range(10u128..1000));
-        let give_amount = Amount::from_atoms(rng.gen_range(10u128..1000));
+        let give_amount =
+            Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms()));
         let order_data = OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(ask_amount),
@@ -1477,11 +1516,16 @@ fn test_activation(#[case] seed: Seed) {
             .build();
 
         let (token_id, tokens_outpoint, _) = issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+        let tokens_circulating_supply =
+            tf.chainstate.get_token_circulating_supply(&token_id).unwrap().unwrap();
 
         let order_data = Box::new(OrderData::new(
             Destination::AnyoneCanSpend,
             OutputValue::Coin(Amount::from_atoms(rng.gen_range(1u128..1000))),
-            OutputValue::TokenV1(token_id, Amount::from_atoms(rng.gen_range(1u128..1000))),
+            OutputValue::TokenV1(
+                token_id,
+                Amount::from_atoms(rng.gen_range(1u128..=tokens_circulating_supply.into_atoms())),
+            ),
         ));
 
         // Try to produce order output before activation, check an error

--- a/test/functional/wallet_data_deposit.py
+++ b/test/functional/wallet_data_deposit.py
@@ -116,6 +116,7 @@ class WalletDataDeposit(BitcoinTestFramework):
 
             self.generate_block()
             assert_in("Success", await wallet.sync())
+            assert_in(f"Coins amount: 99", await wallet.get_balance())
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_nfts.py
+++ b/test/functional/wallet_nfts.py
@@ -158,6 +158,7 @@ class WalletNfts(BitcoinTestFramework):
 
             self.generate_block()
             assert_in("Success", await wallet.sync())
+            assert_in(f"Coins amount: 994", await wallet.get_balance())
 
 
             self.log.info(await wallet.get_balance())

--- a/test/functional/wallet_tokens.py
+++ b/test/functional/wallet_tokens.py
@@ -150,12 +150,14 @@ class WalletTokens(BitcoinTestFramework):
 
             self.generate_block()
             assert_in("Success", await wallet.sync())
+            assert_in("Coins amount: 100", await wallet.get_balance())
 
             amount_to_mint = random.randint(1, 10000)
             assert_in("The transaction was submitted successfully", await wallet.mint_tokens(token_id, address, amount_to_mint))
 
             self.generate_block()
             assert_in("Success", await wallet.sync())
+            assert_in("Coins amount: 50", await wallet.get_balance())
 
             assert_in(f"{token_id} amount: {amount_to_mint}", await wallet.get_balance())
 

--- a/test/functional/wallet_tokens_change_authority.py
+++ b/test/functional/wallet_tokens_change_authority.py
@@ -123,6 +123,7 @@ class WalletTokens(BitcoinTestFramework):
 
             self.generate_block()
             assert_in("Success", await wallet.sync())
+            assert_in("Coins amount: 900", await wallet.get_balance())
 
             assert_in("The transaction was submitted successfully", await wallet.mint_tokens(token_id, address, 10000))
 
@@ -130,6 +131,7 @@ class WalletTokens(BitcoinTestFramework):
             assert_in("Success", await wallet.sync())
 
             assert_in(f"{token_id} amount: 10000", await wallet.get_balance())
+            assert_in("Coins amount: 850", await wallet.get_balance())
 
             ## create a new account and send some tokens to it
             await wallet.create_new_account()
@@ -156,6 +158,7 @@ class WalletTokens(BitcoinTestFramework):
             if produce_block:
                 self.generate_block()
                 assert_in("Success", await wallet.sync())
+                assert_in("Coins amount: 230", await wallet.get_balance())
 
 
             # try to mint, unmint, lock, freeze and unfreeze

--- a/test/functional/wallet_tokens_freeze.py
+++ b/test/functional/wallet_tokens_freeze.py
@@ -123,12 +123,15 @@ class WalletTokens(BitcoinTestFramework):
 
             self.generate_block()
             assert_in("Success", await wallet.sync())
+            assert_in("Coins amount: 400", await wallet.get_balance())
 
             assert_in("The transaction was submitted successfully", await wallet.mint_tokens(token_id, address, 10000))
+
 
             self.generate_block()
             assert_in("Success", await wallet.sync())
 
+            assert_in("Coins amount: 350", await wallet.get_balance())
             assert_in(f"{token_id} amount: 10000", await wallet.get_balance())
 
             ## create a new account and send some tokens to it
@@ -152,6 +155,7 @@ class WalletTokens(BitcoinTestFramework):
             if random.choice([True, False]):
                 self.generate_block()
                 assert_in("Success", await wallet.sync())
+                assert_in("Coins amount: 300", await wallet.get_balance())
 
             # try to send tokens should fail
             output = await wallet.send_tokens_to_address(token_id, address, 1)
@@ -168,6 +172,7 @@ class WalletTokens(BitcoinTestFramework):
             if random.choice([True, False]):
                 self.generate_block()
                 assert_in("Success", await wallet.sync())
+                assert_in("Coins amount: 250", await wallet.get_balance())
 
             # sending tokens should work again
             output = await wallet.send_tokens_to_address(token_id, address, 1)


### PR DESCRIPTION
Missing tests that ensure that fees that are required to issue token, change supply etc. are burned and are not collected by staker in accumulated fee.