### PR TITLE
Make `PoSAccountingStorageRead` supertrait of `TransactionVerifierStorageRef`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "parity-scale-codec",
+ "pos-accounting",
  "serialization",
  "static_assertions",
  "storage",
@@ -5376,7 +5377,6 @@ name = "pos-accounting"
 version = "0.5.1"
 dependencies = [
  "accounting",
- "chainstate-types",
  "common",
  "crypto",
  "parity-scale-codec",

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -492,7 +492,6 @@ impl BanScore for pos_accounting::Error {
     fn ban_score(&self) -> u32 {
         use pos_accounting::Error as E;
         match self {
-            E::StorageError(_) => 0,
             E::AccountingError(_) => 100,
             E::InvariantErrorPoolBalanceAlreadyExists => 100,
             E::InvariantErrorPoolDataAlreadyExists => 100,
@@ -524,6 +523,7 @@ impl BanScore for pos_accounting::Error {
             E::InvariantErrorDelegationUndoFailedDataNotFound(_) => 100,
             E::DuplicatesInDeltaAndUndo => 100,
             E::ViewFail => 0,
+            E::StorageWrite => 0,
             E::IncreaseStakerRewardsOfNonexistingPool => 100,
             E::StakerBalanceOverflow => 100,
             E::InvariantErrorIncreasePledgeUndoFailedPoolBalanceNotFound => 100,

--- a/chainstate/src/detail/chainstateref/epoch_seal.rs
+++ b/chainstate/src/detail/chainstateref/epoch_seal.rs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chainstate_storage::{BlockchainStorageWrite, SealedStorageTag};
+use chainstate_storage::BlockchainStorageWrite;
 use chainstate_types::{
     pos_randomness::{PoSRandomness, PoSRandomnessError},
-    EpochData, EpochStorageRead, EpochStorageWrite,
+    EpochData, EpochStorageRead, EpochStorageWrite, SealedStorageTag,
 };
 use common::{
     chain::{
@@ -158,7 +158,8 @@ fn create_randomness_from_block<S, P>(
 ) -> Result<PoSRandomness, EpochSealError>
 where
     S: EpochStorageRead,
-    P: PoSAccountingView<Error = pos_accounting::Error>,
+    P: PoSAccountingView,
+    EpochSealError: From<<P as PoSAccountingView>::Error>,
 {
     let reward_output = block
         .block_reward()
@@ -222,7 +223,8 @@ pub fn update_epoch_data<S, P>(
 ) -> Result<(), EpochSealError>
 where
     S: EpochStorageWrite,
-    P: PoSAccountingView<Error = pos_accounting::Error>,
+    P: PoSAccountingView,
+    EpochSealError: From<<P as PoSAccountingView>::Error>,
 {
     match block_op {
         BlockStateEventWithIndex::Connect(tip_height, tip) => {
@@ -271,8 +273,8 @@ mod tests {
     use std::num::NonZeroU64;
 
     use super::*;
-    use chainstate_storage::{mock::MockStoreTxRw, TipStorageTag};
-    use chainstate_types::{vrf_tools::construct_transcript, EpochDataCache};
+    use chainstate_storage::mock::MockStoreTxRw;
+    use chainstate_types::{vrf_tools::construct_transcript, EpochDataCache, TipStorageTag};
     use common::{
         chain::{
             block::{consensus_data::PoSData, timestamp::BlockTimestamp, BlockReward},

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -812,7 +812,7 @@ impl BlockProcessingErrorClassification for pos_accounting::Error {
 
         match self {
             // Use "General" for consistency with the zero ban score.
-            Error::ViewFail => BlockProcessingErrorClass::General,
+            Error::ViewFail | Error::StorageWrite => BlockProcessingErrorClass::General,
 
             Error::InvariantErrorPoolBalanceAlreadyExists
             | Error::InvariantErrorPoolDataAlreadyExists
@@ -855,7 +855,6 @@ impl BlockProcessingErrorClassification for pos_accounting::Error {
                 BlockProcessingErrorClass::BadBlock
             }
 
-            Error::StorageError(err) => err.classify(),
             Error::AccountingError(err) => err.classify(),
         }
     }

--- a/chainstate/src/detail/mod.rs
+++ b/chainstate/src/detail/mod.rs
@@ -41,12 +41,11 @@ use self::{
 };
 use crate::{BlockInvalidatorError, ChainstateConfig, ChainstateEvent};
 use chainstate_storage::{
-    BlockchainStorage, BlockchainStorageRead, BlockchainStorageWrite, SealedStorageTag,
-    TipStorageTag, TransactionRw, Transactional,
+    BlockchainStorage, BlockchainStorageRead, BlockchainStorageWrite, TransactionRw, Transactional,
 };
 use chainstate_types::{
     pos_randomness::PoSRandomness, BlockIndex, BlockStatus, BlockValidationStage, EpochData,
-    EpochStorageWrite, PropertyQueryError,
+    EpochStorageWrite, PropertyQueryError, SealedStorageTag, TipStorageTag,
 };
 use chainstateref::{ChainstateRef, ReorgError};
 use common::{

--- a/chainstate/storage/src/internal/mod.rs
+++ b/chainstate/storage/src/internal/mod.rs
@@ -20,6 +20,7 @@ mod expensive;
 
 use std::collections::BTreeMap;
 
+use chainstate_types::{SealedStorageTag, TipStorageTag};
 use common::{
     chain::{ChainConfig, DelegationId, PoolId},
     primitives::Amount,
@@ -31,7 +32,7 @@ use utils::log_error;
 
 use crate::{
     schema::Schema, BlockchainStorage, BlockchainStorageRead, BlockchainStorageWrite,
-    SealedStorageTag, TipStorageTag, TransactionRw, Transactional,
+    TransactionRw, Transactional,
 };
 
 pub use store_tx::{StoreTxRo, StoreTxRw};
@@ -113,6 +114,8 @@ impl<'tx, B: storage::Backend + 'tx> Transactional<'tx> for Store<B> {
 impl<B: storage::Backend + 'static> BlockchainStorage for Store<B> {}
 
 impl<B: storage::Backend> PoSAccountingStorageRead<TipStorageTag> for Store<B> {
+    type Error = crate::Error;
+
     #[log_error]
     fn get_pool_balance(&self, pool_id: PoolId) -> crate::Result<Option<Amount>> {
         let tx = self.transaction_ro()?;
@@ -160,6 +163,8 @@ impl<B: storage::Backend> PoSAccountingStorageRead<TipStorageTag> for Store<B> {
 }
 
 impl<B: storage::Backend> PoSAccountingStorageRead<SealedStorageTag> for Store<B> {
+    type Error = crate::Error;
+
     #[log_error]
     fn get_pool_balance(&self, pool_id: PoolId) -> crate::Result<Option<Amount>> {
         let tx = self.transaction_ro()?;

--- a/chainstate/storage/src/internal/store_tx/read_impls.rs
+++ b/chainstate/storage/src/internal/store_tx/read_impls.rs
@@ -16,7 +16,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::db;
-use chainstate_types::{BlockIndex, EpochData, EpochStorageRead};
+use chainstate_types::{BlockIndex, EpochData, EpochStorageRead, SealedStorageTag, TipStorageTag};
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockReward},
@@ -38,7 +38,7 @@ use tokens_accounting::{TokenAccountingUndo, TokensAccountingStorageRead};
 use utils::log_error;
 use utxo::{Utxo, UtxosBlockUndo, UtxosStorageRead};
 
-use crate::{BlockchainStorageRead, ChainstateStorageVersion, SealedStorageTag, TipStorageTag};
+use crate::{BlockchainStorageRead, ChainstateStorageVersion};
 
 use super::well_known;
 
@@ -271,6 +271,8 @@ impl<'st, B: storage::Backend> UtxosStorageRead for super::StoreTxRo<'st, B> {
 impl<'st, B: storage::Backend> PoSAccountingStorageRead<TipStorageTag>
     for super::StoreTxRo<'st, B>
 {
+    type Error = crate::Error;
+
     #[log_error]
     fn get_pool_balance(&self, pool_id: PoolId) -> crate::Result<Option<Amount>> {
         self.read::<db::DBAccountingPoolBalancesTip, _, _>(pool_id)
@@ -317,6 +319,8 @@ impl<'st, B: storage::Backend> PoSAccountingStorageRead<TipStorageTag>
 impl<'st, B: storage::Backend> PoSAccountingStorageRead<SealedStorageTag>
     for super::StoreTxRo<'st, B>
 {
+    type Error = crate::Error;
+
     #[log_error]
     fn get_pool_balance(&self, pool_id: PoolId) -> crate::Result<Option<Amount>> {
         self.read::<db::DBAccountingPoolBalancesSealed, _, _>(pool_id)
@@ -584,6 +588,8 @@ impl<'st, B: storage::Backend> UtxosStorageRead for super::StoreTxRw<'st, B> {
 impl<'st, B: storage::Backend> PoSAccountingStorageRead<TipStorageTag>
     for super::StoreTxRw<'st, B>
 {
+    type Error = crate::Error;
+
     #[log_error]
     fn get_pool_balance(&self, pool_id: PoolId) -> crate::Result<Option<Amount>> {
         self.read::<db::DBAccountingPoolBalancesTip, _, _>(pool_id)
@@ -630,6 +636,8 @@ impl<'st, B: storage::Backend> PoSAccountingStorageRead<TipStorageTag>
 impl<'st, B: storage::Backend> PoSAccountingStorageRead<SealedStorageTag>
     for super::StoreTxRw<'st, B>
 {
+    type Error = crate::Error;
+
     #[log_error]
     fn get_pool_balance(&self, pool_id: PoolId) -> crate::Result<Option<Amount>> {
         self.read::<db::DBAccountingPoolBalancesSealed, _, _>(pool_id)

--- a/chainstate/storage/src/lib.rs
+++ b/chainstate/storage/src/lib.rs
@@ -23,7 +23,9 @@ pub mod schema;
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use chainstate_types::{BlockIndex, EpochStorageRead, EpochStorageWrite};
+use chainstate_types::{
+    BlockIndex, EpochStorageRead, EpochStorageWrite, SealedStorageTag, TipStorageTag,
+};
 use common::{
     chain::{
         block::{signed_block_header::SignedBlockHeader, BlockReward},
@@ -56,20 +58,14 @@ pub mod inmemory {
     pub type Store = super::Store<storage_inmemory::InMemory>;
 }
 
-pub struct TipStorageTag;
-impl pos_accounting::StorageTag for TipStorageTag {}
-
-pub struct SealedStorageTag;
-impl pos_accounting::StorageTag for SealedStorageTag {}
-
 /// Queries on persistent blockchain data
 pub trait BlockchainStorageRead:
     UtxosStorageRead<Error = crate::Error>
-    + PoSAccountingStorageRead<SealedStorageTag>
-    + PoSAccountingStorageRead<TipStorageTag>
-    + EpochStorageRead
+    + PoSAccountingStorageRead<SealedStorageTag, Error = crate::Error>
+    + PoSAccountingStorageRead<TipStorageTag, Error = crate::Error>
     + TokensAccountingStorageRead<Error = crate::Error>
     + OrdersAccountingStorageRead<Error = crate::Error>
+    + EpochStorageRead
 {
     // TODO: below (and in lots of other places too) Id is sometimes passes by ref and sometimes
     // by value. It's better to choose one "canonical" approach and use it everywhere.

--- a/chainstate/storage/src/mock/mock_impl_accounting.rs
+++ b/chainstate/storage/src/mock/mock_impl_accounting.rs
@@ -145,6 +145,7 @@ pub trait PoSAccountingStorageWriteSealed: PoSAccountingStorageReadSealed {
 macro_rules! impl_sealed_read_ops {
     ($StoreType:ident) => {
         impl PoSAccountingStorageRead<crate::SealedStorageTag> for $StoreType {
+            type Error = crate::Error;
             fn get_pool_balance(&self, pool_id: PoolId) -> crate::Result<Option<Amount>> {
                 self.get_pool_balance_sealed(pool_id)
             }
@@ -183,6 +184,7 @@ macro_rules! impl_sealed_read_ops {
 macro_rules! impl_tip_read_ops {
     ($StoreType:ident) => {
         impl PoSAccountingStorageRead<crate::TipStorageTag> for $StoreType {
+            type Error = crate::Error;
             fn get_pool_balance(&self, pool_id: PoolId) -> crate::Result<Option<Amount>> {
                 self.get_pool_balance_tip(pool_id)
             }

--- a/chainstate/test-framework/src/utils.rs
+++ b/chainstate/test-framework/src/utils.rs
@@ -18,8 +18,8 @@ use crate::{
     signature_destination_getter::SignatureDestinationGetter, TestFramework,
 };
 use chainstate::{BlockIndex, GenBlockIndex};
-use chainstate_storage::{BlockchainStorageRead, TipStorageTag};
-use chainstate_types::pos_randomness::PoSRandomness;
+use chainstate_storage::BlockchainStorageRead;
+use chainstate_types::{pos_randomness::PoSRandomness, TipStorageTag};
 use common::{
     chain::{
         block::{consensus_data::PoSData, timestamp::BlockTimestamp, BlockRewardTransactable},

--- a/chainstate/test-suite/src/tests/delegation_tests.rs
+++ b/chainstate/test-suite/src/tests/delegation_tests.rs
@@ -14,11 +14,12 @@
 // limitations under the License.
 
 use chainstate::{BlockError, ChainstateError, ConnectTransactionError, IOPolicyError};
-use chainstate_storage::{TipStorageTag, Transactional};
+use chainstate_storage::Transactional;
 use chainstate_test_framework::{
     create_stake_pool_data_with_all_reward_to_staker, empty_witness, get_output_value,
     TestFramework, TestStore, TransactionBuilder,
 };
+use chainstate_types::TipStorageTag;
 use common::{
     chain::{
         config::create_unit_test_config,

--- a/chainstate/test-suite/src/tests/get_stake_pool_balances_at_heights.rs
+++ b/chainstate/test-suite/src/tests/get_stake_pool_balances_at_heights.rs
@@ -18,11 +18,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use rstest::rstest;
 
 use chainstate::ChainstateConfig;
-use chainstate_storage::TipStorageTag;
 use chainstate_test_framework::{
     create_custom_genesis_with_stake_pool, create_stake_pool_data_with_all_reward_to_staker,
     empty_witness, PoSBlockBuilder, TestFramework, TransactionBuilder, UtxoForSpending,
 };
+use chainstate_types::TipStorageTag;
 use common::{
     chain::{
         self, config::ChainType, output_value::OutputValue, timelock::OutputTimeLock, AccountNonce,

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -21,7 +21,7 @@ use chainstate::{
     chainstate_interface::ChainstateInterface, BlockError, BlockSource, ChainstateError,
     CheckBlockError, ConnectTransactionError, SpendStakeError,
 };
-use chainstate_storage::{TipStorageTag, Transactional};
+use chainstate_storage::Transactional;
 use chainstate_test_framework::{
     anyonecanspend_address, create_stake_pool_data_with_all_reward_to_staker, empty_witness,
     TestFramework, TransactionBuilder,
@@ -29,7 +29,7 @@ use chainstate_test_framework::{
 use chainstate_types::{
     pos_randomness::{PoSRandomness, PoSRandomnessError},
     vrf_tools::{construct_transcript, ProofOfStakeVRFError},
-    EpochStorageRead,
+    EpochStorageRead, TipStorageTag,
 };
 use common::{
     chain::{

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -15,11 +15,11 @@
 
 use chainstate::{BlockError, ChainstateError, ConnectTransactionError, IOPolicyError};
 use chainstate::{BlockSource, CheckBlockError};
-use chainstate_storage::TipStorageTag;
 use chainstate_test_framework::{
     anyonecanspend_address, create_stake_pool_data_with_all_reward_to_staker, empty_witness,
     get_output_value, TestFramework, TransactionBuilder,
 };
+use chainstate_types::TipStorageTag;
 use common::primitives::BlockHeight;
 use common::{
     chain::{

--- a/chainstate/tx-verifier/src/transaction_verifier/flush.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/flush.rs
@@ -19,6 +19,7 @@ use super::{
     CachedOperation, TransactionVerifierDelta,
 };
 use orders_accounting::FlushableOrdersAccountingView;
+use pos_accounting::FlushablePoSAccountingView;
 use tokens_accounting::FlushableTokensAccountingView;
 use utxo::FlushableUtxoView;
 
@@ -68,7 +69,7 @@ where
     <S as TransactionVerifierStorageRef>::Error: From<<S as FlushableUtxoView>::Error>,
     <S as TransactionVerifierStorageRef>::Error: From<<S as FlushableTokensAccountingView>::Error>,
     <S as TransactionVerifierStorageRef>::Error: From<<S as FlushableOrdersAccountingView>::Error>,
-    <S as TransactionVerifierStorageRef>::Error: From<pos_accounting::Error>,
+    <S as TransactionVerifierStorageRef>::Error: From<<S as FlushablePoSAccountingView>::Error>,
 {
     flush_tokens(storage, &consumed.token_issuance_cache)?;
 

--- a/chainstate/tx-verifier/src/transaction_verifier/storage.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/storage.rs
@@ -15,7 +15,7 @@
 
 use std::ops::Deref;
 
-use chainstate_types::{storage_result, GenBlockIndex};
+use chainstate_types::{storage_result, GenBlockIndex, TipStorageTag};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
@@ -27,7 +27,7 @@ use orders_accounting::{
     FlushableOrdersAccountingView, OrdersAccountingStorageRead, OrdersAccountingUndo,
 };
 use pos_accounting::{
-    FlushablePoSAccountingView, PoSAccountingDeltaData, PoSAccountingUndo, PoSAccountingView,
+    FlushablePoSAccountingView, PoSAccountingDeltaData, PoSAccountingStorageRead, PoSAccountingUndo,
 };
 use thiserror::Error;
 use tokens_accounting::{
@@ -66,10 +66,11 @@ pub enum TransactionVerifierStorageError {
     OrdersAccountingError(#[from] orders_accounting::Error),
 }
 
-// TODO(Gosha): PoSAccountingView should be replaced with PoSAccountingStorageRead in which the
-//              return error type can handle both storage_result::Error and pos_accounting::Error
 pub trait TransactionVerifierStorageRef:
-    UtxosStorageRead + PoSAccountingView + TokensAccountingStorageRead + OrdersAccountingStorageRead
+    UtxosStorageRead
+    + PoSAccountingStorageRead<TipStorageTag>
+    + TokensAccountingStorageRead
+    + OrdersAccountingStorageRead
 {
     type Error: std::error::Error;
 

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_read.rs
@@ -29,7 +29,7 @@ use common::{
     primitives::H256,
 };
 use mockall::predicate::eq;
-use pos_accounting::PoSAccountingView;
+use pos_accounting::PoSAccountingStorageRead;
 use rstest::rstest;
 use test_utils::random::Seed;
 use tokens_accounting::{FungibleTokenData, TokensAccountingStorageRead};
@@ -421,17 +421,17 @@ fn hierarchy_test_stake_pool(#[case] seed: Seed) {
         .expect_get_pool_balance()
         .with(eq(pool_id_0))
         .times(2)
-        .return_const(Ok(pool_balance0));
+        .return_const(Ok(Some(pool_balance0)));
     store
         .expect_get_pool_balance()
         .with(eq(pool_id_1))
         .times(3)
-        .return_const(Ok(Amount::ZERO));
+        .return_const(Ok(None));
     store
         .expect_get_pool_balance()
         .with(eq(pool_id_2))
         .times(3)
-        .return_const(Ok(Amount::ZERO));
+        .return_const(Ok(None));
 
     store
         .expect_get_pool_data()
@@ -501,25 +501,28 @@ fn hierarchy_test_stake_pool(#[case] seed: Seed) {
     // fetch pool balances
     assert_eq!(
         verifier1.get_pool_balance(pool_id_0).unwrap(),
-        pool_balance0
+        Some(pool_balance0)
     );
     assert_eq!(
         verifier1.get_pool_balance(pool_id_1).unwrap(),
-        pool_balance1
+        Some(pool_balance1)
     );
-    assert_eq!(verifier1.get_pool_balance(pool_id_2).unwrap(), Amount::ZERO);
+    assert_eq!(
+        verifier1.get_pool_balance(pool_id_2).unwrap(),
+        Some(Amount::ZERO)
+    );
 
     assert_eq!(
         verifier2.get_pool_balance(pool_id_0).unwrap(),
-        pool_balance0
+        Some(pool_balance0)
     );
     assert_eq!(
         verifier2.get_pool_balance(pool_id_1).unwrap(),
-        pool_balance1
+        Some(pool_balance1)
     );
     assert_eq!(
         verifier2.get_pool_balance(pool_id_2).unwrap(),
-        pool_balance2
+        Some(pool_balance2)
     );
 
     // fetch pool data
@@ -783,29 +786,29 @@ fn hierarchy_test_tokens_v1(#[case] seed: Seed) {
 
     // fetch pool balances
     assert_eq!(
-        verifier1.get_circulating_supply(&token_id_0).unwrap().as_ref(),
-        Some(&supply0)
+        verifier1.get_circulating_supply(&token_id_0).unwrap(),
+        Some(supply0)
     );
     assert_eq!(
-        verifier1.get_circulating_supply(&token_id_1).unwrap().as_ref(),
-        Some(&supply1)
+        verifier1.get_circulating_supply(&token_id_1).unwrap(),
+        Some(supply1)
     );
     assert_eq!(
-        verifier1.get_circulating_supply(&token_id_2).unwrap().as_ref(),
-        None
+        verifier1.get_circulating_supply(&token_id_2).unwrap(),
+        Some(Amount::ZERO)
     );
 
     assert_eq!(
-        verifier2.get_circulating_supply(&token_id_0).unwrap().as_ref(),
-        Some(&supply0)
+        verifier2.get_circulating_supply(&token_id_0).unwrap(),
+        Some(supply0)
     );
     assert_eq!(
-        verifier2.get_circulating_supply(&token_id_1).unwrap().as_ref(),
-        Some(&supply1)
+        verifier2.get_circulating_supply(&token_id_1).unwrap(),
+        Some(supply1)
     );
     assert_eq!(
-        verifier2.get_circulating_supply(&token_id_2).unwrap().as_ref(),
-        Some(&supply2)
+        verifier2.get_circulating_supply(&token_id_2).unwrap(),
+        Some(supply2)
     );
 
     // fetch pool data

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/hierarchy_write.rs
@@ -701,12 +701,12 @@ fn pos_accounting_stake_pool_set_hierarchy(#[case] seed: Seed) {
         .expect_get_pool_balance()
         .with(eq(pool_id_1))
         .times(1)
-        .return_const(Ok(Amount::ZERO));
+        .return_const(Ok(None));
     store
         .expect_get_pool_balance()
         .with(eq(pool_id_2))
         .times(1)
-        .return_const(Ok(Amount::ZERO));
+        .return_const(Ok(None));
 
     store.expect_get_pool_data().with(eq(pool_id_1)).times(1).return_const(Ok(None));
     store.expect_get_pool_data().with(eq(pool_id_2)).times(1).return_const(Ok(None));
@@ -772,7 +772,7 @@ fn pos_accounting_stake_pool_undo_set_hierarchy(#[case] seed: Seed) {
         .times(1)
         .return_const(Ok(DeltaMergeUndo::new()));
 
-    store.expect_get_pool_balance().return_const(Ok(Amount::ZERO));
+    store.expect_get_pool_balance().return_const(Ok(None));
     store.expect_get_pool_data().return_const(Ok(None));
     store.expect_get_delegation_data().return_const(Ok(None));
 
@@ -883,7 +883,7 @@ fn pos_accounting_stake_pool_and_delegation_undo_set_hierarchy(#[case] seed: See
         .times(1)
         .return_const(Ok(DeltaMergeUndo::new()));
 
-    store.expect_get_pool_balance().return_const(Ok(Amount::ZERO));
+    store.expect_get_pool_balance().return_const(Ok(None));
     store.expect_get_pool_data().return_const(Ok(None));
     store.expect_get_delegation_data().return_const(Ok(None));
 
@@ -1001,7 +1001,7 @@ fn pos_accounting_stake_pool_undo_del_hierarchy(#[case] seed: Seed) {
         .times(1)
         .return_const(Ok(DeltaMergeUndo::new()));
 
-    store.expect_get_pool_balance().return_const(Ok(Amount::ZERO));
+    store.expect_get_pool_balance().return_const(Ok(None));
     store.expect_get_pool_data().return_const(Ok(None));
 
     store

--- a/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tests/mock.rs
@@ -25,7 +25,7 @@ use super::{
     },
     CachedUtxosBlockUndo,
 };
-use chainstate_types::{storage_result, GenBlockIndex};
+use chainstate_types::{storage_result, GenBlockIndex, TipStorageTag};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
@@ -40,7 +40,7 @@ use orders_accounting::{
 };
 use pos_accounting::{
     DelegationData, DeltaMergeUndo, FlushablePoSAccountingView, PoSAccountingDeltaData,
-    PoSAccountingUndo, PoSAccountingView, PoolData,
+    PoSAccountingStorageRead, PoSAccountingUndo, PoolData,
 };
 use tokens_accounting::{
     FlushableTokensAccountingView, TokenAccountingUndo, TokenData, TokensAccountingDeltaData,
@@ -179,15 +179,14 @@ mockall::mock! {
         fn batch_write(&mut self, utxos: ConsumedUtxoCache) -> Result<(), utxo::Error>;
     }
 
-    impl PoSAccountingView for Store {
+    impl PoSAccountingStorageRead<TipStorageTag> for Store {
         type Error = pos_accounting::Error;
-        fn pool_exists(&self, pool_id: PoolId) -> Result<bool, pos_accounting::Error>;
-        fn get_pool_balance(&self, pool_id: PoolId) -> Result<Amount, pos_accounting::Error>;
+        fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, pos_accounting::Error>;
         fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, pos_accounting::Error>;
         fn get_delegation_balance(
             &self,
             delegation_id: DelegationId,
-        ) -> Result<Amount, pos_accounting::Error>;
+        ) -> Result<Option<Amount>, pos_accounting::Error>;
         fn get_delegation_data(
             &self,
             delegation_id: DelegationId,
@@ -200,10 +199,11 @@ mockall::mock! {
             &self,
             pool_id: PoolId,
             delegation_id: DelegationId,
-        ) -> Result<Amount, pos_accounting::Error>;
+        ) -> Result<Option<Amount>, pos_accounting::Error>;
     }
 
     impl FlushablePoSAccountingView for Store {
+        type Error = pos_accounting::Error;
         fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<DeltaMergeUndo, pos_accounting::Error>;
     }
 

--- a/chainstate/types/Cargo.toml
+++ b/chainstate/types/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 common = { path = "../../common/" }
 crypto = { path = "../../crypto" }
 logging = { path = '../../logging' }
+pos-accounting = { path = "../../pos-accounting" }
 serialization = { path = "../../serialization" }
 storage = { path = "../../storage/" }
 

--- a/chainstate/types/src/lib.rs
+++ b/chainstate/types/src/lib.rs
@@ -46,3 +46,9 @@ mod error;
 mod gen_block_index;
 mod height_skip;
 mod locator;
+
+pub struct TipStorageTag;
+impl pos_accounting::StorageTag for TipStorageTag {}
+
+pub struct SealedStorageTag;
+impl pos_accounting::StorageTag for SealedStorageTag {}

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -364,8 +364,8 @@ impl MempoolBanScore for pos_accounting::Error {
             E::InvariantErrorIncreaseStakerRewardUndoFailedPoolBalanceNotFound => 0,
 
             // Internal errors
-            E::StorageError(_) => 0,
             E::ViewFail => 0,
+            E::StorageWrite => 0,
         }
     }
 }

--- a/mempool/src/pool/tx_pool/tx_verifier/chainstate_handle.rs
+++ b/mempool/src/pool/tx_pool/tx_verifier/chainstate_handle.rs
@@ -23,7 +23,7 @@ use chainstate::{
     },
     ChainstateError,
 };
-use chainstate_types::storage_result;
+use chainstate_types::{storage_result, TipStorageTag};
 use common::{
     chain::{
         tokens::{TokenAuxiliaryData, TokenId},
@@ -33,7 +33,9 @@ use common::{
     primitives::{Amount, Id},
 };
 use orders_accounting::{OrdersAccountingStorageRead, OrdersAccountingUndo, OrdersAccountingView};
-use pos_accounting::{DelegationData, PoSAccountingUndo, PoSAccountingView, PoolData};
+use pos_accounting::{
+    DelegationData, PoSAccountingStorageRead, PoSAccountingUndo, PoSAccountingView, PoolData,
+};
 use subsystem::blocking::BlockingHandle;
 use tokens_accounting::{TokenAccountingUndo, TokensAccountingStorageRead, TokensAccountingView};
 use utils::shallow_clone::ShallowClone;
@@ -182,6 +184,44 @@ impl PoSAccountingView for ChainstateHandle {
             c.get_stake_pool_delegation_share(pool_id, delegation_id)
                 .map(|v| v.unwrap_or(Amount::ZERO))
         })
+    }
+}
+
+impl PoSAccountingStorageRead<TipStorageTag> for ChainstateHandle {
+    type Error = Error;
+
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Error> {
+        self.call(move |c| c.get_stake_pool_balance(pool_id))
+    }
+
+    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Error> {
+        self.call(move |c| c.get_stake_pool_data(pool_id))
+    }
+
+    fn get_pool_delegations_shares(
+        &self,
+        pool_id: PoolId,
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Error> {
+        self.call(move |c| c.get_stake_pool_delegations_shares(pool_id))
+    }
+
+    fn get_delegation_balance(&self, delegation_id: DelegationId) -> Result<Option<Amount>, Error> {
+        self.call(move |c| c.get_stake_delegation_balance(delegation_id))
+    }
+
+    fn get_delegation_data(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<DelegationData>, Error> {
+        self.call(move |c| c.get_stake_delegation_data(delegation_id))
+    }
+
+    fn get_pool_delegation_share(
+        &self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, Error> {
+        self.call(move |c| c.get_stake_pool_delegation_share(pool_id, delegation_id))
     }
 }
 

--- a/pos-accounting/Cargo.toml
+++ b/pos-accounting/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 
 [dependencies]
 accounting = { path = "../accounting" }
-chainstate-types = { path = "../chainstate/types" }
 common = { path = "../common" }
 crypto = { path = "../crypto" }
 randomness = { path = "../randomness" }

--- a/pos-accounting/src/error.rs
+++ b/pos-accounting/src/error.rs
@@ -17,8 +17,6 @@ use common::chain::DelegationId;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub enum Error {
-    #[error("Accounting storage error")]
-    StorageError(#[from] chainstate_types::storage_result::Error),
     #[error("Base accounting error: {0}")]
     AccountingError(#[from] accounting::Error),
     #[error("Pool already exists by balance")]
@@ -102,6 +100,8 @@ pub enum Error {
     //      https://github.com/mintlayer/mintlayer-core/issues/811
     #[error("PoS accounting view query failed")]
     ViewFail,
+    #[error("PoS accounting storage write failed")]
+    StorageWrite,
 }
 
 pub type Result<T> = core::result::Result<T, Error>;

--- a/pos-accounting/src/lib.rs
+++ b/pos-accounting/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::{
         view::{FlushablePoSAccountingView, PoSAccountingView},
     },
     storage::{
-        in_memory::InMemoryPoSAccounting, PoSAccountingStorageRead, PoSAccountingStorageWrite,
-        StorageTag,
+        in_memory::InMemoryPoSAccounting, DefaultStorageTag, PoSAccountingStorageRead,
+        PoSAccountingStorageWrite, StorageTag,
     },
 };

--- a/pos-accounting/src/pool/delta/view_impl.rs
+++ b/pos-accounting/src/pool/delta/view_impl.rs
@@ -153,7 +153,12 @@ impl<P: PoSAccountingView> PoSAccountingView for PoSAccountingDelta<P> {
 }
 
 impl<P: PoSAccountingView> FlushablePoSAccountingView for PoSAccountingDelta<P> {
-    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<DeltaMergeUndo, Error> {
+    type Error = crate::Error;
+
+    fn batch_write_delta(
+        &mut self,
+        data: PoSAccountingDeltaData,
+    ) -> Result<DeltaMergeUndo, Self::Error> {
         self.merge_with_delta(data)
     }
 }

--- a/pos-accounting/src/pool/storage/mod.rs
+++ b/pos-accounting/src/pool/storage/mod.rs
@@ -19,7 +19,6 @@ use accounting::{
     combine_amount_delta, combine_data_with_delta, DeltaAmountCollection, DeltaDataCollection,
     DeltaDataUndoCollection,
 };
-use chainstate_types::storage_result;
 use common::primitives::{amount::SignedAmount, Amount};
 
 use crate::{
@@ -147,9 +146,9 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingDB<S, T> {
     ) -> Result<DeltaAmountCollection<K>, Error>
     where
         Iter: Iterator<Item = (K, SignedAmount)>,
-        Getter: Fn(&S, K) -> Result<Option<Amount>, storage_result::Error>,
-        Setter: FnMut(&mut S, K, Amount) -> Result<(), storage_result::Error>,
-        Deleter: FnMut(&mut S, K) -> Result<(), storage_result::Error>,
+        Getter: Fn(&S, K) -> Result<Option<Amount>, S::Error>,
+        Setter: FnMut(&mut S, K, Amount) -> Result<(), S::Error>,
+        Deleter: FnMut(&mut S, K) -> Result<(), S::Error>,
     {
         let mut store = BorrowedStorageValue::new(&mut self.store, getter, setter, deleter);
         let undo = iter
@@ -176,9 +175,9 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingDB<S, T> {
         deleter: Deleter,
     ) -> Result<DeltaDataUndoCollection<K, V>, Error>
     where
-        Getter: Fn(&S, K) -> Result<Option<V>, storage_result::Error>,
-        Setter: FnMut(&mut S, K, &V) -> Result<(), storage_result::Error>,
-        Deleter: FnMut(&mut S, K) -> Result<(), storage_result::Error>,
+        Getter: Fn(&S, K) -> Result<Option<V>, S::Error>,
+        Setter: FnMut(&mut S, K, &V) -> Result<(), S::Error>,
+        Deleter: FnMut(&mut S, K) -> Result<(), S::Error>,
     {
         let mut store = BorrowedStorageValue::new(&mut self.store, getter, setter, deleter);
         let undo = delta
@@ -205,9 +204,9 @@ impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> PoSAccountingDB<S, T> {
         deleter: Deleter,
     ) -> Result<(), Error>
     where
-        Getter: Fn(&S, K) -> Result<Option<V>, storage_result::Error>,
-        Setter: FnMut(&mut S, K, &V) -> Result<(), storage_result::Error>,
-        Deleter: FnMut(&mut S, K) -> Result<(), storage_result::Error>,
+        Getter: Fn(&S, K) -> Result<Option<V>, S::Error>,
+        Setter: FnMut(&mut S, K, &V) -> Result<(), S::Error>,
+        Deleter: FnMut(&mut S, K) -> Result<(), S::Error>,
     {
         let mut store = BorrowedStorageValue::new(&mut self.store, getter, setter, deleter);
         undo.consume().into_iter().try_for_each(|(id, delta)| {

--- a/pos-accounting/src/pool/storage/view_impls.rs
+++ b/pos-accounting/src/pool/storage/view_impls.rs
@@ -21,7 +21,6 @@ use common::{
 };
 
 use crate::{
-    error::Error,
     pool::{
         delegation::DelegationData,
         delta::data::PoSAccountingDeltaData,
@@ -33,60 +32,110 @@ use crate::{
 };
 
 impl<S: PoSAccountingStorageRead<T>, T: StorageTag> PoSAccountingView for PoSAccountingDB<S, T> {
-    type Error = Error;
+    type Error = S::Error;
 
-    fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Error> {
-        self.get_pool_data(pool_id).map(|v| v.is_some())
+    fn pool_exists(&self, pool_id: PoolId) -> Result<bool, Self::Error> {
+        PoSAccountingView::get_pool_data(self, pool_id).map(|v| v.is_some())
     }
 
-    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Amount, Error> {
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Amount, Self::Error> {
         self.store
             .get_pool_balance(pool_id)
             .map(|v| v.unwrap_or(Amount::ZERO))
-            .map_err(Error::from)
+            .map_err(Self::Error::from)
     }
 
-    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Error> {
-        self.store.get_pool_data(pool_id).map_err(Error::from)
+    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Self::Error> {
+        self.store.get_pool_data(pool_id).map_err(Self::Error::from)
     }
 
     fn get_pool_delegations_shares(
         &self,
         pool_id: PoolId,
-    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Error> {
-        self.store.get_pool_delegations_shares(pool_id).map_err(Error::from)
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Self::Error> {
+        self.store.get_pool_delegations_shares(pool_id).map_err(Self::Error::from)
     }
 
-    fn get_delegation_balance(&self, delegation_id: DelegationId) -> Result<Amount, Error> {
+    fn get_delegation_balance(&self, delegation_id: DelegationId) -> Result<Amount, Self::Error> {
         self.store
             .get_delegation_balance(delegation_id)
             .map(|v| v.unwrap_or(Amount::ZERO))
-            .map_err(Error::from)
+            .map_err(Self::Error::from)
     }
 
     fn get_delegation_data(
         &self,
         delegation_id: DelegationId,
-    ) -> Result<Option<DelegationData>, Error> {
-        self.store.get_delegation_data(delegation_id).map_err(Error::from)
+    ) -> Result<Option<DelegationData>, Self::Error> {
+        self.store.get_delegation_data(delegation_id).map_err(Self::Error::from)
     }
 
     fn get_pool_delegation_share(
         &self,
         pool_id: PoolId,
         delegation_id: DelegationId,
-    ) -> Result<Amount, Error> {
+    ) -> Result<Amount, Self::Error> {
         self.store
             .get_pool_delegation_share(pool_id, delegation_id)
             .map(|v| v.unwrap_or(Amount::ZERO))
-            .map_err(Error::from)
+            .map_err(Self::Error::from)
     }
 }
 
 impl<S: PoSAccountingStorageWrite<T>, T: StorageTag> FlushablePoSAccountingView
     for PoSAccountingDB<S, T>
 {
-    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<DeltaMergeUndo, Error> {
+    type Error = crate::Error;
+
+    fn batch_write_delta(
+        &mut self,
+        data: PoSAccountingDeltaData,
+    ) -> Result<DeltaMergeUndo, Self::Error> {
         self.merge_with_delta(data)
+    }
+}
+
+impl<S: PoSAccountingStorageRead<T>, T: StorageTag> PoSAccountingStorageRead
+    for PoSAccountingDB<S, T>
+{
+    type Error = S::Error;
+
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {
+        self.store.get_pool_balance(pool_id).map_err(Self::Error::from)
+    }
+
+    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Self::Error> {
+        self.store.get_pool_data(pool_id).map_err(Self::Error::from)
+    }
+
+    fn get_pool_delegations_shares(
+        &self,
+        pool_id: PoolId,
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Self::Error> {
+        self.store.get_pool_delegations_shares(pool_id).map_err(Self::Error::from)
+    }
+
+    fn get_delegation_balance(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, Self::Error> {
+        self.store.get_delegation_balance(delegation_id).map_err(Self::Error::from)
+    }
+
+    fn get_delegation_data(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<DelegationData>, Self::Error> {
+        self.store.get_delegation_data(delegation_id).map_err(Self::Error::from)
+    }
+
+    fn get_pool_delegation_share(
+        &self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, Self::Error> {
+        self.store
+            .get_pool_delegation_share(pool_id, delegation_id)
+            .map_err(Self::Error::from)
     }
 }

--- a/pos-accounting/src/pool/view.rs
+++ b/pos-accounting/src/pool/view.rs
@@ -20,7 +20,7 @@ use common::{
     primitives::Amount,
 };
 
-use crate::{error::Error, DeltaMergeUndo};
+use crate::DeltaMergeUndo;
 
 use super::{delegation::DelegationData, delta::data::PoSAccountingDeltaData, pool_data::PoolData};
 
@@ -53,7 +53,12 @@ pub trait PoSAccountingView {
 }
 
 pub trait FlushablePoSAccountingView {
-    fn batch_write_delta(&mut self, data: PoSAccountingDeltaData) -> Result<DeltaMergeUndo, Error>;
+    type Error: std::error::Error;
+
+    fn batch_write_delta(
+        &mut self,
+        data: PoSAccountingDeltaData,
+    ) -> Result<DeltaMergeUndo, Self::Error>;
 }
 
 impl<T> PoSAccountingView for T

--- a/pos-accounting/src/storage/in_memory.rs
+++ b/pos-accounting/src/storage/in_memory.rs
@@ -15,7 +15,6 @@
 
 use std::collections::BTreeMap;
 
-use chainstate_types::storage_result::Error;
 use common::{
     chain::{DelegationId, PoolId},
     primitives::{Amount, H256},
@@ -145,14 +144,16 @@ impl InMemoryPoSAccounting {
 }
 
 impl PoSAccountingStorageRead for InMemoryPoSAccounting {
-    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Error> {
+    type Error = crate::Error;
+
+    fn get_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {
         Ok(self.pool_balances.get(&pool_id).copied())
     }
 
     fn get_pool_delegations_shares(
         &self,
         pool_id: PoolId,
-    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Error> {
+    ) -> Result<Option<BTreeMap<DelegationId, Amount>>, Self::Error> {
         let range_start = (pool_id, DelegationId::new(H256::zero()));
         let range_end = (pool_id, DelegationId::new(H256::repeat_byte(0xFF)));
         let range = self.pool_delegation_shares.range(range_start..=range_end);
@@ -167,11 +168,14 @@ impl PoSAccountingStorageRead for InMemoryPoSAccounting {
     fn get_delegation_data(
         &self,
         delegation_id: DelegationId,
-    ) -> Result<Option<DelegationData>, Error> {
+    ) -> Result<Option<DelegationData>, Self::Error> {
         Ok(self.delegation_data.get(&delegation_id).cloned())
     }
 
-    fn get_delegation_balance(&self, delegation_id: DelegationId) -> Result<Option<Amount>, Error> {
+    fn get_delegation_balance(
+        &self,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, Self::Error> {
         Ok(self.delegation_balances.get(&delegation_id).copied())
     }
 
@@ -179,22 +183,22 @@ impl PoSAccountingStorageRead for InMemoryPoSAccounting {
         &self,
         pool_id: PoolId,
         delegation_id: DelegationId,
-    ) -> Result<Option<Amount>, Error> {
+    ) -> Result<Option<Amount>, Self::Error> {
         Ok(self.pool_delegation_shares.get(&(pool_id, delegation_id)).copied())
     }
 
-    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Error> {
+    fn get_pool_data(&self, pool_id: PoolId) -> Result<Option<PoolData>, Self::Error> {
         Ok(self.pool_data.get(&pool_id).cloned())
     }
 }
 
 impl PoSAccountingStorageWrite for InMemoryPoSAccounting {
-    fn set_pool_balance(&mut self, pool_id: PoolId, amount: Amount) -> Result<(), Error> {
+    fn set_pool_balance(&mut self, pool_id: PoolId, amount: Amount) -> Result<(), Self::Error> {
         self.pool_balances.insert(pool_id, amount);
         Ok(())
     }
 
-    fn del_pool_balance(&mut self, pool_id: PoolId) -> Result<(), Error> {
+    fn del_pool_balance(&mut self, pool_id: PoolId) -> Result<(), Self::Error> {
         self.pool_balances.remove(&pool_id);
         Ok(())
     }
@@ -203,12 +207,15 @@ impl PoSAccountingStorageWrite for InMemoryPoSAccounting {
         &mut self,
         delegation_target: DelegationId,
         amount: Amount,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Self::Error> {
         self.delegation_balances.insert(delegation_target, amount);
         Ok(())
     }
 
-    fn del_delegation_balance(&mut self, delegation_target: DelegationId) -> Result<(), Error> {
+    fn del_delegation_balance(
+        &mut self,
+        delegation_target: DelegationId,
+    ) -> Result<(), Self::Error> {
         self.delegation_balances.remove(&delegation_target);
         Ok(())
     }
@@ -218,7 +225,7 @@ impl PoSAccountingStorageWrite for InMemoryPoSAccounting {
         pool_id: PoolId,
         delegation_id: DelegationId,
         amount: Amount,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Self::Error> {
         self.pool_delegation_shares.insert((pool_id, delegation_id), amount);
         Ok(())
     }
@@ -227,7 +234,7 @@ impl PoSAccountingStorageWrite for InMemoryPoSAccounting {
         &mut self,
         pool_id: PoolId,
         delegation_id: DelegationId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Self::Error> {
         self.pool_delegation_shares.remove(&(pool_id, delegation_id));
         Ok(())
     }
@@ -236,22 +243,22 @@ impl PoSAccountingStorageWrite for InMemoryPoSAccounting {
         &mut self,
         delegation_id: DelegationId,
         delegation_data: &DelegationData,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Self::Error> {
         self.delegation_data.insert(delegation_id, delegation_data.clone());
         Ok(())
     }
 
-    fn del_delegation_data(&mut self, delegation_id: DelegationId) -> Result<(), Error> {
+    fn del_delegation_data(&mut self, delegation_id: DelegationId) -> Result<(), Self::Error> {
         self.delegation_data.remove(&delegation_id);
         Ok(())
     }
 
-    fn set_pool_data(&mut self, pool_id: PoolId, pool_data: &PoolData) -> Result<(), Error> {
+    fn set_pool_data(&mut self, pool_id: PoolId, pool_data: &PoolData) -> Result<(), Self::Error> {
         self.pool_data.insert(pool_id, pool_data.clone());
         Ok(())
     }
 
-    fn del_pool_data(&mut self, pool_id: PoolId) -> Result<(), Error> {
+    fn del_pool_data(&mut self, pool_id: PoolId) -> Result<(), Self::Error> {
         self.pool_data.remove(&pool_id);
         Ok(())
     }


### PR DESCRIPTION
For historical reasons `PoSAccountingView` was a supertrait, unlike other traits from crates like utxo or tokens. There was a todo for it.
This inconsistency was not so important for me until in PR #1793 I had to use View in `chainstate_interface_impl` and treat 0 as None while reading from DB which is not cool.

Now all supertraits of  `TransactionVerifierStorageRef` are `*StorageRead`

Fixes #569 