### PR TITLE
log_error improvements

### DIFF
--- a/p2p/src/net/default_backend/peer.rs
+++ b/p2p/src/net/default_backend/peer.rs
@@ -332,7 +332,7 @@ where
                 }) = hello_response
                 else {
                     if let Message::WillDisconnect(msg) = hello_response {
-                        log::warn!(
+                        log::info!(
                             "Peer {} is going to disconnect us with the reason: '{}'",
                             self.peer_id,
                             msg.reason

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -1570,7 +1570,7 @@ where
     }
 
     fn handle_will_disconnect_messgae(&mut self, peer_id: PeerId, msg: WillDisconnectMessage) {
-        log::warn!(
+        log::info!(
             "Peer {peer_id} is going to disconnect us with the reason: {}",
             msg.reason
         );

--- a/utils/log_error/src/lib.rs
+++ b/utils/log_error/src/lib.rs
@@ -151,10 +151,10 @@ pub fn log_error(args: TokenStream, item: TokenStream) -> TokenStream {
                 let result = (move || #block)();
 
                 if let Err(ref err) = result {
-                    utils::log_utils::log(
+                    utils::mintlayer_core_log_error_support::log(
                         err,
                         "log_error",
-                        logging::log::Level::#log_level_tok,
+                        utils::mintlayer_core_log_error_support::Level::#log_level_tok,
                         std::panic::Location::caller()
                     );
                 }
@@ -224,10 +224,10 @@ pub fn log_error(args: TokenStream, item: TokenStream) -> TokenStream {
                     )().await;
 
                     if let Err(ref err) = result {
-                        utils::log_utils::log(
+                        utils::mintlayer_core_log_error_support::log(
                             err,
                             "log_error",
-                            logging::log::Level::#log_level_tok,
+                            utils::mintlayer_core_log_error_support::Level::#log_level_tok,
                             caller_location
                         );
                     }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -48,3 +48,13 @@ mod concurrency_impl;
 pub use concurrency_impl::*;
 
 pub use log_error::log_error;
+
+// The internals of the `log_error` macro will refer to other parts of the repository as
+// `utils::mintlayer_core_log_error_support::...`. The purpose of this is allow external projects
+// to use `log_error` without polluting their namespaces with core-specific generic names.
+// Note: the external project will have to depend on the `fix_hidden_lifetime_bug` crate explicitly
+// anyway (re-exporting it here won't help).
+pub mod mintlayer_core_log_error_support {
+    pub use crate::log_utils::log;
+    pub use logging::log::Level;
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -52,9 +52,10 @@ pub use log_error::log_error;
 // The internals of the `log_error` macro will refer to other parts of the repository as
 // `utils::mintlayer_core_log_error_support::...`. The purpose of this is allow external projects
 // to use `log_error` without polluting their namespaces with core-specific generic names.
-// Note: the external project will have to depend on the `fix_hidden_lifetime_bug` crate explicitly
-// anyway (re-exporting it here won't help).
 pub mod mintlayer_core_log_error_support {
     pub use crate::log_utils::log;
     pub use logging::log::Level;
+
+    // This is a 3rd-party crate that is used inside `log_error`.
+    pub use fix_hidden_lifetime_bug;
 }

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -1948,9 +1948,10 @@ EITHER OF
 
 Set the lookahead size for key generation.
 
-Lookahead size (or called gap) is the number of addresses to generate and the blockchain for incoming transactions to them
-after the last address that was seen to contain a transaction on the blockchain.
-Do not attempt to reduce the size of this value unless you're sure there are no incoming transactions in these addresses.
+The lookahead size, also known as the gap limit, determines the number of addresses
+to generate and monitor on the blockchain for incoming transactions, following the last
+known address with a transaction.
+Only reduce this value if you are certain there are no incoming transactions on these addresses.
 
 
 Parameters:

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -115,9 +115,10 @@ trait ColdWalletRpc {
 
     /// Set the lookahead size for key generation.
     ///
-    /// Lookahead size (or called gap) is the number of addresses to generate and the blockchain for incoming transactions to them
-    /// after the last address that was seen to contain a transaction on the blockchain.
-    /// Do not attempt to reduce the size of this value unless you're sure there are no incoming transactions in these addresses.
+    /// The lookahead size, also known as the gap limit, determines the number of addresses
+    /// to generate and monitor on the blockchain for incoming transactions, following the last
+    /// known address with a transaction.
+    /// Only reduce this value if you are certain there are no incoming transactions on these addresses.
     #[method(name = "wallet_set_lookahead_size")]
     async fn set_lookahead_size(
         &self,


### PR DESCRIPTION
An Improvement in the `log_error` macro that allows to work around some compilation issues with async functions.

Also, some minor changes from https://github.com/mintlayer/mintlayer-core/pull/1796 have been moved to this PR.