### PR TITLE
Provide `Amount` instead of `OutputValue` to `FillOrder` command

### DIFF
--- a/api-server/stack-test-suite/tests/v2/transaction.rs
+++ b/api-server/stack-test-suite/tests/v2/transaction.rs
@@ -194,7 +194,7 @@ async fn multiple_tx_in_same_block(#[case] seed: Seed) {
                 "is_replaceable": transaction.is_replaceable(),
                 "flags": transaction.flags(),
                 "inputs": transaction.inputs().iter().zip(utxos).map(|(inp, utxo)| json!({
-                    "input": tx_input_to_json(inp, &chain_config, &TokenDecimals::Single(None)),
+                    "input": tx_input_to_json(inp, &chain_config),
                     "utxo": utxo.as_ref().map(|txo| txoutput_to_json(txo, &chain_config, &TokenDecimals::Single(None))),
                     })).collect::<Vec<_>>(),
                 "outputs": transaction.outputs()
@@ -338,7 +338,7 @@ async fn ok(#[case] seed: Seed) {
                 "is_replaceable": transaction.is_replaceable(),
                 "flags": transaction.flags(),
                 "inputs": transaction.inputs().iter().zip(utxos).map(|(inp, utxo)| json!({
-                    "input": tx_input_to_json(inp, &chain_config, &TokenDecimals::Single(None)),
+                    "input": tx_input_to_json(inp, &chain_config),
                     "utxo": utxo.as_ref().map(|txo| txoutput_to_json(txo, &chain_config, &TokenDecimals::Single(None))),
                     })).collect::<Vec<_>>(),
                 "outputs": transaction.outputs()

--- a/api-server/web-server/src/api/json_helpers.rs
+++ b/api-server/web-server/src/api/json_helpers.rs
@@ -254,11 +254,7 @@ pub fn utxo_outpoint_to_json(utxo: &UtxoOutPoint) -> serde_json::Value {
     }
 }
 
-pub fn tx_input_to_json(
-    inp: &TxInput,
-    chain_config: &ChainConfig,
-    token_decimals: &TokenDecimals,
-) -> serde_json::Value {
+pub fn tx_input_to_json(inp: &TxInput, chain_config: &ChainConfig) -> serde_json::Value {
     match inp {
         TxInput::Utxo(utxo) => match utxo.source_id() {
             OutPointSourceId::Transaction(tx_id) => {
@@ -357,7 +353,8 @@ pub fn tx_input_to_json(
                     "input_type": "AccountCommand",
                     "command": "FillOrder",
                     "order_id": Address::new(chain_config, *order_id).expect("addressable").to_string(),
-                    "fill_value": outputvalue_to_json(fill, chain_config, token_decimals),
+                    // TODO(orders)
+                    "fill_atoms": json!({"atoms": fill.into_atoms().to_string()}),
                     "destination": Address::new(chain_config, dest.clone()).expect("no error").as_str(),
                 })
             }
@@ -385,7 +382,7 @@ pub fn tx_to_json(
     "flags": tx.flags(),
     "fee": amount_to_json(additional_info.fee, chain_config.coin_decimals()),
     "inputs": tx.inputs().iter().zip(additional_info.input_utxos.iter()).map(|(inp, utxo)| json!({
-        "input": tx_input_to_json(inp, chain_config, &(&additional_info.token_decimals).into()),
+        "input": tx_input_to_json(inp, chain_config),
         "utxo": utxo.as_ref().map(|txo| txoutput_to_json(txo, chain_config, &(&additional_info.token_decimals).into())),
         })).collect::<Vec<_>>(),
     "outputs": tx.outputs()

--- a/chainstate/constraints-value-accumulator/src/tests/orders_constraints.rs
+++ b/chainstate/constraints-value-accumulator/src/tests/orders_constraints.rs
@@ -293,7 +293,7 @@ fn fill_order_constraints(#[case] seed: Seed) {
                 AccountNonce::new(0),
                 AccountCommand::FillOrder(
                     order_id,
-                    OutputValue::TokenV1(token_id, (ask_amount + Amount::from_atoms(1)).unwrap()),
+                    (ask_amount + Amount::from_atoms(1)).unwrap(),
                     Destination::AnyoneCanSpend,
                 ),
             ),
@@ -335,11 +335,7 @@ fn fill_order_constraints(#[case] seed: Seed) {
             )),
             TxInput::AccountCommand(
                 AccountNonce::new(0),
-                AccountCommand::FillOrder(
-                    order_id,
-                    OutputValue::Coin(ask_amount),
-                    Destination::AnyoneCanSpend,
-                ),
+                AccountCommand::FillOrder(order_id, ask_amount, Destination::AnyoneCanSpend),
             ),
         ];
         let input_utxos = vec![
@@ -360,10 +356,7 @@ fn fill_order_constraints(#[case] seed: Seed) {
             &input_utxos,
         );
 
-        assert_eq!(
-            result.unwrap_err(),
-            Error::OrdersAccountingError(orders_accounting::Error::CurrencyMismatch)
-        );
+        assert_eq!(result.unwrap_err(), Error::AttemptToViolateFeeRequirements);
     }
 
     // try to print coins in output
@@ -375,11 +368,7 @@ fn fill_order_constraints(#[case] seed: Seed) {
             )),
             TxInput::AccountCommand(
                 AccountNonce::new(0),
-                AccountCommand::FillOrder(
-                    order_id,
-                    OutputValue::TokenV1(token_id, ask_amount),
-                    Destination::AnyoneCanSpend,
-                ),
+                AccountCommand::FillOrder(order_id, ask_amount, Destination::AnyoneCanSpend),
             ),
         ];
         let input_utxos = vec![
@@ -427,11 +416,7 @@ fn fill_order_constraints(#[case] seed: Seed) {
             )),
             TxInput::AccountCommand(
                 AccountNonce::new(0),
-                AccountCommand::FillOrder(
-                    order_id,
-                    OutputValue::TokenV1(token_id, ask_amount),
-                    Destination::AnyoneCanSpend,
-                ),
+                AccountCommand::FillOrder(order_id, ask_amount, Destination::AnyoneCanSpend),
             ),
         ];
         let input_utxos = vec![
@@ -484,11 +469,7 @@ fn fill_order_constraints(#[case] seed: Seed) {
             )),
             TxInput::AccountCommand(
                 AccountNonce::new(0),
-                AccountCommand::FillOrder(
-                    order_id,
-                    OutputValue::TokenV1(token_id, ask_amount),
-                    Destination::AnyoneCanSpend,
-                ),
+                AccountCommand::FillOrder(order_id, ask_amount, Destination::AnyoneCanSpend),
             ),
         ];
         let input_utxos = vec![
@@ -539,11 +520,7 @@ fn fill_order_constraints(#[case] seed: Seed) {
         )),
         TxInput::AccountCommand(
             AccountNonce::new(0),
-            AccountCommand::FillOrder(
-                order_id,
-                OutputValue::TokenV1(token_id, ask_amount),
-                Destination::AnyoneCanSpend,
-            ),
+            AccountCommand::FillOrder(order_id, ask_amount, Destination::AnyoneCanSpend),
         ),
     ];
     let input_utxos = vec![

--- a/chainstate/src/detail/ban_score.rs
+++ b/chainstate/src/detail/ban_score.rs
@@ -674,7 +674,6 @@ impl BanScore for orders_accounting::Error {
             Error::InvariantOrderDataExistForConcludeUndo(_) => 100,
             Error::InvariantOrderAskBalanceExistForConcludeUndo(_) => 100,
             Error::InvariantOrderGiveBalanceExistForConcludeUndo(_) => 100,
-            Error::CurrencyMismatch => 100,
             Error::OrderOverflow(_) => 100,
             Error::OrderOverbid(_, _, _) => 100,
             Error::AttemptedConcludeNonexistingOrderData(_) => 100,

--- a/chainstate/src/detail/error_classification.rs
+++ b/chainstate/src/detail/error_classification.rs
@@ -909,7 +909,6 @@ impl BlockProcessingErrorClassification for orders_accounting::Error {
             | Error::InvariantOrderDataExistForConcludeUndo(_)
             | Error::InvariantOrderAskBalanceExistForConcludeUndo(_)
             | Error::InvariantOrderGiveBalanceExistForConcludeUndo(_)
-            | Error::CurrencyMismatch
             | Error::OrderOverflow(_)
             | Error::OrderOverbid(_, _, _)
             | Error::AttemptedConcludeNonexistingOrderData(_)

--- a/chainstate/src/rpc/types/account.rs
+++ b/chainstate/src/rpc/types/account.rs
@@ -23,8 +23,6 @@ use common::{
 };
 use rpc::types::RpcHexString;
 
-use super::output::RpcOutputValue;
-
 #[derive(Debug, Clone, serde::Serialize, rpc_description::HasValueHint)]
 #[serde(tag = "type", content = "content")]
 pub enum RpcAccountSpending {
@@ -84,7 +82,7 @@ pub enum RpcAccountCommand {
     },
     FillOrder {
         order_id: RpcAddress<OrderId>,
-        fill_value: RpcOutputValue,
+        fill_value: RpcAmountOut,
         destination: RpcAddress<Destination>,
     },
 }
@@ -129,7 +127,7 @@ impl RpcAccountCommand {
             },
             AccountCommand::FillOrder(id, fill, dest) => RpcAccountCommand::FillOrder {
                 order_id: RpcAddress::new(chain_config, *id)?,
-                fill_value: RpcOutputValue::new(chain_config, fill.clone())?,
+                fill_value: RpcAmountOut::from_amount(*fill, chain_config.coin_decimals()),
                 destination: RpcAddress::new(chain_config, dest.clone())?,
             },
         };

--- a/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/outputs_utils.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/input_output_policy/tests/outputs_utils.rs
@@ -158,11 +158,7 @@ pub fn all_account_inputs() -> [TxInput; 9] {
         ),
         TxInput::from_command(
             AccountNonce::new(0),
-            AccountCommand::FillOrder(
-                OrderId::zero(),
-                OutputValue::Coin(Amount::ZERO),
-                Destination::AnyoneCanSpend,
-            ),
+            AccountCommand::FillOrder(OrderId::zero(), Amount::ZERO, Destination::AnyoneCanSpend),
         ),
     ]
 }

--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use serialization::{Decode, Encode};
 
-use super::{output_value::OutputValue, Destination};
+use super::Destination;
 
 /// Type of an account that can be used to identify series of spending from an account
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Encode, Decode)]
@@ -116,10 +116,14 @@ pub enum AccountCommand {
     // Change the authority who can authorize operations for a token
     #[codec(index = 5)]
     ChangeTokenAuthority(TokenId, Destination),
+    // Close an order and withdraw all remaining funds from both give and ask balances.
+    // Only the address specified as `conclude_key` can authorize this command.
     #[codec(index = 6)]
     ConcludeOrder(OrderId),
+    // Satisfy an order completely or partially.
+    // Second parameter is an amount provided to fill an order which corresponds to order's ask currency.
     #[codec(index = 7)]
-    FillOrder(OrderId, OutputValue, Destination),
+    FillOrder(OrderId, Amount, Destination),
     // Change token metadata uri
     #[codec(index = 8)]
     ChangeTokenMetadataUri(TokenId, Vec<u8>),

--- a/mempool/src/error/ban_score.rs
+++ b/mempool/src/error/ban_score.rs
@@ -512,7 +512,6 @@ impl MempoolBanScore for orders_accounting::Error {
             Error::InvariantOrderGiveBalanceExistForConcludeUndo(_) => 100,
             Error::InvariantNonzeroAskBalanceForMissingOrder(_) => 100,
             Error::InvariantNonzeroGiveBalanceForMissingOrder(_) => 100,
-            Error::CurrencyMismatch => 100,
             Error::OrderOverflow(_) => 100,
             Error::OrderOverbid(_, _, _) => 100,
             Error::AttemptedConcludeNonexistingOrderData(_) => 0,

--- a/mintscript/src/tests/translate/mod.rs
+++ b/mintscript/src/tests/translate/mod.rs
@@ -255,8 +255,7 @@ fn conclude_order(id: OrderId) -> TestInputInfo {
 }
 
 fn fill_order(id: OrderId) -> TestInputInfo {
-    let command =
-        AccountCommand::FillOrder(id, OutputValue::Coin(Amount::from_atoms(1)), dest_pk(0x4));
+    let command = AccountCommand::FillOrder(id, Amount::from_atoms(1), dest_pk(0x4));
     TestInputInfo::AccountCommand { command }
 }
 

--- a/orders-accounting/src/cache.rs
+++ b/orders-accounting/src/cache.rs
@@ -202,11 +202,15 @@ impl<P: OrdersAccountingView> OrdersAccountingOperations for OrdersAccountingCac
         }))
     }
 
-    fn fill_order(&mut self, id: OrderId, fill_value: OutputValue) -> Result<OrdersAccountingUndo> {
-        log::debug!("Filling an order: {:?} {:?}", id, fill_value);
+    fn fill_order(&mut self, id: OrderId, fill_amount: Amount) -> Result<OrdersAccountingUndo> {
+        log::debug!("Filling an order: {:?} {:?}", id, fill_amount);
 
-        let fill_amount = output_value_amount(&fill_value)?;
-        let filled_amount = calculate_fill_order(self, id, &fill_value)?;
+        ensure!(
+            self.get_order_data(&id)?.is_some(),
+            Error::OrderDataNotFound(id)
+        );
+
+        let filled_amount = calculate_fill_order(self, id, fill_amount)?;
 
         self.data.give_balances.sub_unsigned(id, filled_amount)?;
         self.data.ask_balances.sub_unsigned(id, fill_amount)?;

--- a/orders-accounting/src/error.rs
+++ b/orders-accounting/src/error.rs
@@ -43,8 +43,6 @@ pub enum Error {
     InvariantNonzeroAskBalanceForMissingOrder(OrderId),
     #[error("Give balance for non-existing order `{0}` is not zero")]
     InvariantNonzeroGiveBalanceForMissingOrder(OrderId),
-    #[error("Coin type mismatch")]
-    CurrencyMismatch,
     #[error("Order overflow: `{0}`")]
     OrderOverflow(OrderId),
     #[error("Order `{0}` can provide `{1:?}` amount; but attempted to fill `{2:?}`")]

--- a/orders-accounting/src/operations.rs
+++ b/orders-accounting/src/operations.rs
@@ -15,7 +15,7 @@
 
 use accounting::DataDeltaUndo;
 use common::{
-    chain::{output_value::OutputValue, OrderData, OrderId},
+    chain::{OrderData, OrderId},
     primitives::Amount,
 };
 use serialization::{Decode, Encode};
@@ -57,7 +57,7 @@ pub enum OrdersAccountingUndo {
 pub trait OrdersAccountingOperations {
     fn create_order(&mut self, id: OrderId, data: OrderData) -> Result<OrdersAccountingUndo>;
     fn conclude_order(&mut self, id: OrderId) -> Result<OrdersAccountingUndo>;
-    fn fill_order(&mut self, id: OrderId, value: OutputValue) -> Result<OrdersAccountingUndo>;
+    fn fill_order(&mut self, id: OrderId, fill_amount: Amount) -> Result<OrdersAccountingUndo>;
 
     fn undo(&mut self, undo_data: OrdersAccountingUndo) -> Result<()>;
 }


### PR DESCRIPTION
Providing `OutputValue` (i.e. currency + amount) to the `AccountCommand::FillOrder` is redundant. Order can be filled with only particular currency defined on creation by `OrderData`.
As a result check for currency mismatch can be removed from `orders-accounting`, making it one rule less in the code. 

At the moment this change can be done without a fork because orders are not activated. 