### PR TITLE
Fix spending htlc output in api server

### DIFF
--- a/api-server/api-server-common/src/storage/impls/mod.rs
+++ b/api-server/api-server-common/src/storage/impls/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const CURRENT_STORAGE_VERSION: u32 = 14;
+pub const CURRENT_STORAGE_VERSION: u32 = 15;
 
 pub mod in_memory;
 pub mod postgres;

--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -1957,11 +1957,11 @@ fn get_tx_output_destination(txo: &TxOutput) -> Option<&Destination> {
         | TxOutput::IssueNft(_, _, d)
         | TxOutput::ProduceBlockFromStake(d, _) => Some(d),
         TxOutput::CreateStakePool(_, data) => Some(data.decommission_key()),
+        TxOutput::Htlc(_, htlc) => Some(&htlc.spend_key),
         TxOutput::IssueFungibleToken(_)
         | TxOutput::Burn(_)
         | TxOutput::DelegateStaking(_, _)
         | TxOutput::DataDeposit(_)
-        | TxOutput::Htlc(_, _)
         | TxOutput::CreateOrder(_) => None,
     }
 }

--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -595,7 +595,9 @@ async fn calculate_fees<T: ApiServerStorageWrite>(
             .zip(input_utxos.iter())
             .filter_map(|(inp, utxo)| match inp {
                 TxInput::Utxo(_) => match utxo.as_ref().expect("must be present") {
-                    TxOutput::Transfer(v, _) | TxOutput::LockThenTransfer(v, _, _) => match v {
+                    TxOutput::Transfer(v, _)
+                    | TxOutput::LockThenTransfer(v, _, _)
+                    | TxOutput::Htlc(v, _) => match v {
                         OutputValue::TokenV1(token_id, _) => Some(*token_id),
                         OutputValue::Coin(_) | OutputValue::TokenV0(_) => None,
                     },
@@ -607,8 +609,7 @@ async fn calculate_fees<T: ApiServerStorageWrite>(
                     | TxOutput::CreateDelegationId(_, _)
                     | TxOutput::IssueFungibleToken(_)
                     | TxOutput::ProduceBlockFromStake(_, _)
-                    | TxOutput::Htlc(_, _)
-                    | TxOutput::CreateOrder(_) => None,
+                    | TxOutput::CreateOrder(_) => None, // TODO(orders)
                 },
                 TxInput::Account(_) => None,
                 TxInput::AccountCommand(_, cmd) => match cmd {

--- a/api-server/scanner-lib/src/blockchain_state/mod.rs
+++ b/api-server/scanner-lib/src/blockchain_state/mod.rs
@@ -1314,7 +1314,16 @@ async fn update_tables_from_transaction_inputs<T: ApiServerStorageWrite>(
                             )
                             .await;
                         }
-                        TxOutput::Htlc(_, _) => {} // TODO(HTLC)
+                        TxOutput::Htlc(_, htlc) => {
+                            let address =
+                                Address::<Destination>::new(&chain_config, htlc.spend_key)
+                                    .expect("Unable to encode destination");
+
+                            address_transactions
+                                .entry(address.clone())
+                                .or_default()
+                                .insert(tx.get_id());
+                        }
                         TxOutput::LockThenTransfer(output_value, destination, _)
                         | TxOutput::Transfer(output_value, destination) => {
                             let address = Address::<Destination>::new(&chain_config, destination)
@@ -1729,7 +1738,27 @@ async fn update_tables_from_transaction_outputs<T: ApiServerStorageWrite>(
                         .expect("Unable to set locked utxo");
                 }
             }
-            TxOutput::Htlc(_, _) => {} // TODO(HTLC)
+            TxOutput::Htlc(output_value, htlc) => {
+                let address = Address::<Destination>::new(&chain_config, htlc.spend_key.clone())
+                    .expect("Unable to encode destination");
+
+                address_transactions.entry(address.clone()).or_default().insert(transaction_id);
+
+                let token_decimals = match output_value {
+                    OutputValue::Coin(_) | OutputValue::TokenV0(_) => None,
+                    OutputValue::TokenV1(token_id, _) => {
+                        Some(token_decimals(*token_id, &BTreeMap::new(), db_tx).await?.1)
+                    }
+                };
+
+                let outpoint =
+                    UtxoOutPoint::new(OutPointSourceId::Transaction(transaction_id), idx as u32);
+                let utxo = Utxo::new(output.clone(), token_decimals, false);
+                db_tx
+                    .set_utxo_at_height(outpoint, utxo, address.as_str(), block_height)
+                    .await
+                    .expect("Unable to set utxo");
+            }
             TxOutput::CreateOrder(_) => {
                 // TODO(orders)
             }
@@ -1932,7 +1961,7 @@ fn get_tx_output_destination(txo: &TxOutput) -> Option<&Destination> {
         | TxOutput::Burn(_)
         | TxOutput::DelegateStaking(_, _)
         | TxOutput::DataDeposit(_)
+        | TxOutput::Htlc(_, _)
         | TxOutput::CreateOrder(_) => None,
-        TxOutput::Htlc(_, _) => None, // TODO(HTLC)
     }
 }

--- a/api-server/scanner-lib/src/sync/tests/simulation.rs
+++ b/api-server/scanner-lib/src/sync/tests/simulation.rs
@@ -332,7 +332,7 @@ async fn simulation(
             let mut block_builder = tf.make_pos_block_builder().with_random_staking_pool(&mut rng);
 
             for _ in 0..rng.gen_range(10..max_tx_per_block) {
-                block_builder = block_builder.add_test_transaction(&mut rng, false, false);
+                block_builder = block_builder.add_test_transaction(&mut rng, false);
             }
 
             let block = block_builder.build(&mut rng);

--- a/api-server/stack-test-suite/tests/v2/block.rs
+++ b/api-server/stack-test-suite/tests/v2/block.rs
@@ -157,7 +157,7 @@ async fn ok(#[case] seed: Seed) {
                     "transactions": block.transactions()
                                         .iter()
                                         .zip(tx_additional_data.iter())
-                                        .map(|(tx, additinal_data)| tx_to_json(tx.transaction(), additinal_data, tf.chain_config()))
+                                        .map(|(tx, additional_data)| tx_to_json(tx.transaction(), additional_data, tf.chain_config()))
                                         .collect::<Vec<_>>(),
                 },
             });

--- a/api-server/stack-test-suite/tests/v2/htlc.rs
+++ b/api-server/stack-test-suite/tests/v2/htlc.rs
@@ -1,0 +1,352 @@
+// Copyright (c) 2024 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::chain::{
+    classic_multisig::ClassicMultisigChallenge,
+    htlc::HtlcSecret,
+    htlc::{HashedTimelockContract, HtlcSecretHash},
+    signature::{
+        inputsig::{
+            classical_multisig::authorize_classical_multisig::AuthorizedClassicalMultisigSpend,
+            htlc::{
+                produce_classical_multisig_signature_for_htlc_input,
+                produce_uniparty_signature_for_htlc_input,
+            },
+        },
+        sighash::signature_hash,
+    },
+    ChainConfig,
+};
+use crypto::key::PublicKey;
+use serialization::Encode;
+
+use super::*;
+
+fn create_htlc(
+    chain_config: &ChainConfig,
+    alice_pk: &PublicKey,
+    bob_pk: &PublicKey,
+    secret_hash: HtlcSecretHash,
+) -> (HashedTimelockContract, ClassicMultisigChallenge) {
+    let refund_challenge = ClassicMultisigChallenge::new(
+        chain_config,
+        utils::const_nz_u8!(2),
+        vec![alice_pk.clone(), bob_pk.clone()],
+    )
+    .unwrap();
+    let destination_multisig: PublicKeyHash = (&refund_challenge).into();
+
+    let htlc = HashedTimelockContract {
+        secret_hash,
+        spend_key: Destination::PublicKeyHash(bob_pk.into()),
+        refund_timelock: OutputTimeLock::ForBlockCount(0),
+        refund_key: Destination::ClassicMultisig(destination_multisig),
+    };
+    (htlc, refund_challenge)
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test]
+async fn spend(#[case] seed: Seed) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let web_server_state = {
+            let mut rng = make_seedable_rng(seed);
+
+            let secret = HtlcSecret::new_from_rng(&mut rng);
+
+            let (_, alice_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+            let (bob_sk, bob_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+
+            let chain_config = create_unit_test_config();
+
+            let chainstate_blocks = {
+                let mut tf = TestFramework::builder(&mut rng)
+                    .with_chain_config(chain_config.clone())
+                    .build();
+
+                // Create htlc
+                let (htlc, _) = create_htlc(&chain_config, &alice_pk, &bob_pk, secret.hash());
+                let tx_1 = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(chain_config.genesis_block_id().into(), 0),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(TxOutput::Htlc(
+                        OutputValue::Coin(Amount::from_atoms(100)),
+                        Box::new(htlc),
+                    ))
+                    .build();
+                let tx_1_id = tx_1.transaction().get_id();
+
+                let block1 = tf.make_block_builder().add_transaction(tx_1.clone()).build(&mut rng);
+                tf.process_block(block1.clone(), BlockSource::Local).unwrap();
+
+                // Spend htlc
+                let tx2 = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(tx_1_id.into(), 0),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(TxOutput::Transfer(
+                        OutputValue::Coin(Amount::from_atoms(100)),
+                        Destination::AnyoneCanSpend,
+                    ))
+                    .build()
+                    .take_transaction();
+
+                let input_sign = produce_uniparty_signature_for_htlc_input(
+                    &bob_sk,
+                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    Destination::PublicKeyHash((&PublicKey::from_private_key(&bob_sk)).into()),
+                    &tx2,
+                    &[Some(&tx_1.transaction().outputs()[0])],
+                    0,
+                    secret,
+                    &mut rng,
+                )
+                .unwrap();
+
+                let block2 = tf
+                    .make_block_builder()
+                    .add_transaction(
+                        SignedTransaction::new(tx2, vec![InputWitness::Standard(input_sign)])
+                            .unwrap(),
+                    )
+                    .build(&mut rng);
+                tf.process_block(block2.clone(), BlockSource::Local).unwrap();
+
+                _ = tx.send((
+                    block1.get_id().to_hash().encode_hex::<String>(),
+                    block2.get_id().to_hash().encode_hex::<String>(),
+                ));
+
+                vec![block1, block2]
+            };
+
+            let storage = {
+                let mut storage = TransactionalApiServerInMemoryStorage::new(&chain_config);
+
+                let mut db_tx = storage.transaction_rw().await.unwrap();
+                db_tx.reinitialize_storage(&chain_config).await.unwrap();
+                db_tx.commit().await.unwrap();
+
+                storage
+            };
+
+            let chain_config = Arc::new(chain_config);
+            let mut local_node = BlockchainState::new(Arc::clone(&chain_config), storage);
+            local_node.scan_genesis(chain_config.genesis_block()).await.unwrap();
+            local_node.scan_blocks(BlockHeight::new(0), chainstate_blocks).await.unwrap();
+
+            ApiServerWebServerState {
+                db: Arc::new(local_node.storage().clone_storage().await),
+                chain_config: Arc::clone(&chain_config),
+                rpc: Arc::new(DummyRPC {}),
+                cached_values: Arc::new(CachedValues {
+                    feerate_points: RwLock::new((get_time(), vec![])),
+                }),
+                time_getter: Default::default(),
+            }
+        };
+
+        web_server(listener, web_server_state, true).await
+    });
+
+    let (block1_id, block2_id) = rx.await.unwrap();
+    let url = format!("/api/v2/block/{block1_id}");
+
+    // Given that the listener port is open, this will block until a
+    // response is made (by the web server, which takes the listener
+    // over)
+    let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let url = format!("/api/v2/block/{block2_id}");
+    let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    task.abort();
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test]
+async fn refund(#[case] seed: Seed) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+    let addr = listener.local_addr().unwrap();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let task = tokio::spawn(async move {
+        let web_server_state = {
+            let mut rng = make_seedable_rng(seed);
+
+            let secret = HtlcSecret::new_from_rng(&mut rng);
+
+            let (alice_sk, alice_pk) =
+                PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+            let (bob_sk, bob_pk) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
+
+            let chain_config = create_unit_test_config();
+
+            let chainstate_blocks = {
+                let mut tf = TestFramework::builder(&mut rng)
+                    .with_chain_config(chain_config.clone())
+                    .build();
+
+                // Create htlc
+                let (htlc, refund_challenge) =
+                    create_htlc(&chain_config, &alice_pk, &bob_pk, secret.hash());
+                let tx_1 = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(chain_config.genesis_block_id().into(), 0),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(TxOutput::Htlc(
+                        OutputValue::Coin(Amount::from_atoms(100)),
+                        Box::new(htlc),
+                    ))
+                    .build();
+                let tx_1_id = tx_1.transaction().get_id();
+
+                let block1 = tf.make_block_builder().add_transaction(tx_1.clone()).build(&mut rng);
+                tf.process_block(block1.clone(), BlockSource::Local).unwrap();
+
+                // Spend htlc
+                let tx2 = TransactionBuilder::new()
+                    .add_input(
+                        TxInput::from_utxo(tx_1_id.into(), 0),
+                        InputWitness::NoSignature(None),
+                    )
+                    .add_output(TxOutput::Transfer(
+                        OutputValue::Coin(Amount::from_atoms(100)),
+                        Destination::AnyoneCanSpend,
+                    ))
+                    .build()
+                    .take_transaction();
+
+                let authorization = {
+                    let mut authorization =
+                        AuthorizedClassicalMultisigSpend::new_empty(refund_challenge);
+
+                    let sighash = signature_hash(
+                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        &tx2,
+                        &[Some(&tx_1.transaction().outputs()[0])],
+                        0,
+                    )
+                    .unwrap();
+                    let sighash = sighash.encode();
+
+                    let signature = alice_sk.sign_message(&sighash, &mut rng).unwrap();
+                    authorization.add_signature(0, signature);
+                    let signature = bob_sk.sign_message(&sighash, &mut rng).unwrap();
+                    authorization.add_signature(1, signature);
+
+                    authorization
+                };
+
+                let input_sign = produce_classical_multisig_signature_for_htlc_input(
+                    &chain_config,
+                    &authorization,
+                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    &tx2,
+                    &[Some(&tx_1.transaction().outputs()[0])],
+                    0,
+                )
+                .unwrap();
+
+                let block2 = tf
+                    .make_block_builder()
+                    .add_transaction(
+                        SignedTransaction::new(tx2, vec![InputWitness::Standard(input_sign)])
+                            .unwrap(),
+                    )
+                    .build(&mut rng);
+                tf.process_block(block2.clone(), BlockSource::Local).unwrap();
+
+                _ = tx.send((
+                    block1.get_id().to_hash().encode_hex::<String>(),
+                    block2.get_id().to_hash().encode_hex::<String>(),
+                ));
+
+                vec![block1, block2]
+            };
+
+            let storage = {
+                let mut storage = TransactionalApiServerInMemoryStorage::new(&chain_config);
+
+                let mut db_tx = storage.transaction_rw().await.unwrap();
+                db_tx.reinitialize_storage(&chain_config).await.unwrap();
+                db_tx.commit().await.unwrap();
+
+                storage
+            };
+
+            let chain_config = Arc::new(chain_config);
+            let mut local_node = BlockchainState::new(Arc::clone(&chain_config), storage);
+            local_node.scan_genesis(chain_config.genesis_block()).await.unwrap();
+            local_node.scan_blocks(BlockHeight::new(0), chainstate_blocks).await.unwrap();
+
+            ApiServerWebServerState {
+                db: Arc::new(local_node.storage().clone_storage().await),
+                chain_config: Arc::clone(&chain_config),
+                rpc: Arc::new(DummyRPC {}),
+                cached_values: Arc::new(CachedValues {
+                    feerate_points: RwLock::new((get_time(), vec![])),
+                }),
+                time_getter: Default::default(),
+            }
+        };
+
+        web_server(listener, web_server_state, true).await
+    });
+
+    let (block1_id, block2_id) = rx.await.unwrap();
+    let url = format!("/api/v2/block/{block1_id}");
+
+    // Given that the listener port is open, this will block until a
+    // response is made (by the web server, which takes the listener
+    // over)
+    let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    let url = format!("/api/v2/block/{block2_id}");
+    let response = reqwest::get(format!("http://{}:{}{url}", addr.ip(), addr.port()))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+
+    task.abort();
+}

--- a/api-server/stack-test-suite/tests/v2/mod.rs
+++ b/api-server/stack-test-suite/tests/v2/mod.rs
@@ -25,6 +25,7 @@ mod chain_at_height;
 mod chain_tip;
 mod feerate;
 mod helpers;
+mod htlc;
 mod nft;
 mod pool;
 mod pool_block_stats;

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -138,7 +138,6 @@ impl<'f> BlockBuilder<'f> {
     pub fn add_test_transaction(
         mut self,
         rng: &mut (impl Rng + CryptoRng),
-        support_htlc: bool,
         support_orders: bool,
     ) -> Self {
         let utxo_set = self
@@ -169,7 +168,6 @@ impl<'f> BlockBuilder<'f> {
                 &self.orders_accounting_store,
                 None,
                 account_nonce_getter,
-                support_htlc,
                 support_orders,
             )
             .make(

--- a/chainstate/test-framework/src/pos_block_builder.rs
+++ b/chainstate/test-framework/src/pos_block_builder.rs
@@ -378,7 +378,6 @@ impl<'f> PoSBlockBuilder<'f> {
     pub fn add_test_transaction(
         mut self,
         rng: &mut (impl Rng + CryptoRng),
-        support_htlc: bool,
         support_orders: bool,
     ) -> Self {
         let utxo_set = self
@@ -409,7 +408,6 @@ impl<'f> PoSBlockBuilder<'f> {
                 &self.orders_accounting_store,
                 self.staking_pool,
                 account_nonce_getter,
-                support_htlc,
                 support_orders,
             )
             .make(

--- a/chainstate/test-suite/src/tests/tx_verification_simulation.rs
+++ b/chainstate/test-suite/src/tests/tx_verification_simulation.rs
@@ -115,7 +115,7 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
             let mut block_builder = tf.make_pos_block_builder().with_random_staking_pool(&mut rng);
 
             for _ in 0..rng.gen_range(10..max_tx_per_block) {
-                block_builder = block_builder.add_test_transaction(&mut rng, true, true);
+                block_builder = block_builder.add_test_transaction(&mut rng, true);
             }
 
             let block = block_builder.build(&mut rng);
@@ -152,7 +152,7 @@ fn simulation(#[case] seed: Seed, #[case] max_blocks: usize, #[case] max_tx_per_
             let mut block_builder = tf2.make_pos_block_builder().with_random_staking_pool(&mut rng);
 
             for _ in 0..rng.gen_range(10..max_tx_per_block) {
-                block_builder = block_builder.add_test_transaction(&mut rng, true, true);
+                block_builder = block_builder.add_test_transaction(&mut rng, true);
             }
 
             let block = block_builder.build(&mut rng);

--- a/wallet/src/account/transaction_list/mod.rs
+++ b/wallet/src/account/transaction_list/mod.rs
@@ -114,7 +114,6 @@ fn own_output(key_chain: &AccountKeyChainImpl, output: &TxOutput) -> bool {
         TxOutput::Transfer(_, dest) | TxOutput::LockThenTransfer(_, dest, _) => KeyPurpose::ALL
             .iter()
             .any(|purpose| key_chain.get_leaf_key_chain(*purpose).is_destination_mine(dest)),
-        TxOutput::Htlc(_, _) => false, // TODO(HTLC)
         TxOutput::Burn(_)
         | TxOutput::CreateStakePool(_, _)
         | TxOutput::ProduceBlockFromStake(_, _)
@@ -123,6 +122,7 @@ fn own_output(key_chain: &AccountKeyChainImpl, output: &TxOutput) -> bool {
         | TxOutput::IssueFungibleToken(_)
         | TxOutput::IssueNft(_, _, _)
         | TxOutput::DataDeposit(_)
+        | TxOutput::Htlc(_, _)
         | TxOutput::CreateOrder(_) => false,
     }
 }


### PR DESCRIPTION
Was causing `MissingOutputOrSpent` because Htlc outputs were ignored and not added to the db.

Also enabled htlc for api server's simulation.