### PR TITLE
Command to "undiscourage" previously discouraged peers

### DIFF
--- a/node-daemon/docs/RPC.md
+++ b/node-daemon/docs/RPC.md
@@ -969,7 +969,10 @@ nothing
 
 List peers that have been discouraged.
 
-Discouraged peers are peers that have misbehaved in the network.
+Discouragement is similar to banning, except that inbound connections from such peers
+are still allowed.
+
+Peers are discouraged automatically if they misbehave.
 
 
 Parameters:
@@ -986,6 +989,21 @@ Returns:
         nanos number,
     ] },
 ], .. ]
+```
+
+### Method `p2p_undiscourage`
+
+Undiscourage a previously discouraged peer by their IP address.
+
+
+Parameters:
+```
+{ "address": string }
+```
+
+Returns:
+```
+nothing
 ```
 
 ### Method `p2p_get_peer_count`

--- a/p2p/src/interface/p2p_interface.rs
+++ b/p2p/src/interface/p2p_interface.rs
@@ -36,6 +36,7 @@ pub trait P2pInterface: Send + Sync {
     async fn unban(&mut self, addr: BannableAddress) -> crate::Result<()>;
 
     async fn list_discouraged(&self) -> crate::Result<Vec<(BannableAddress, Time)>>;
+    async fn undiscourage(&mut self, addr: BannableAddress) -> crate::Result<()>;
 
     async fn get_peer_count(&self) -> crate::Result<usize>;
     async fn get_bind_addresses(&self) -> crate::Result<Vec<SocketAddress>>;

--- a/p2p/src/interface/p2p_interface_impl.rs
+++ b/p2p/src/interface/p2p_interface_impl.rs
@@ -97,6 +97,14 @@ where
         response_receiver.await?
     }
 
+    async fn undiscourage(&mut self, addr: BannableAddress) -> crate::Result<()> {
+        let (response_sender, response_receiver) = oneshot_nofail::channel();
+        self.peer_mgr_event_sender
+            .send(PeerManagerEvent::Undiscourage(addr, response_sender))
+            .map_err(|_| P2pError::ChannelClosed)?;
+        response_receiver.await?
+    }
+
     async fn list_discouraged(&self) -> crate::Result<Vec<(BannableAddress, Time)>> {
         let (response_sender, response_receiver) = oneshot_nofail::channel();
         self.peer_mgr_event_sender

--- a/p2p/src/interface/p2p_interface_impl_delegation.rs
+++ b/p2p/src/interface/p2p_interface_impl_delegation.rs
@@ -60,6 +60,10 @@ impl<T: Deref<Target = dyn P2pInterface> + DerefMut<Target = dyn P2pInterface> +
         self.deref().list_discouraged().await
     }
 
+    async fn undiscourage(&mut self, addr: BannableAddress) -> crate::Result<()> {
+        self.deref_mut().undiscourage(addr).await
+    }
+
     async fn get_peer_count(&self) -> crate::Result<usize> {
         self.deref().get_peer_count().await
     }

--- a/p2p/src/peer_manager/mod.rs
+++ b/p2p/src/peer_manager/mod.rs
@@ -1664,6 +1664,10 @@ where
             PeerManagerEvent::ListDiscouraged(response_sender) => {
                 response_sender.send(self.peerdb.list_discouraged().collect())
             }
+            PeerManagerEvent::Undiscourage(address, response_sender) => {
+                self.peerdb.undiscourage(&address);
+                response_sender.send(Ok(()));
+            }
             PeerManagerEvent::EnableNetworking {
                 enable,
                 response_sender,

--- a/p2p/src/peer_manager/peerdb/mod.rs
+++ b/p2p/src/peer_manager/peerdb/mod.rs
@@ -604,6 +604,13 @@ impl<S: PeerDbStorage> PeerDb<S> {
         self.discouraged_addresses.insert(address, discourage_till);
     }
 
+    pub fn undiscourage(&mut self, address: &BannableAddress) {
+        update_db(&self.storage, |tx| tx.del_discouraged_address(address))
+            .expect("removing discouraged address is expected to succeed");
+
+        self.discouraged_addresses.remove(address);
+    }
+
     pub fn is_address_banned_or_discouraged(&self, address: &BannableAddress) -> bool {
         self.is_address_banned(address) || self.is_address_discouraged(address)
     }

--- a/p2p/src/peer_manager_event.rs
+++ b/p2p/src/peer_manager_event.rs
@@ -109,6 +109,7 @@ pub enum PeerManagerEvent {
     Unban(BannableAddress, oneshot_nofail::Sender<crate::Result<()>>),
 
     ListDiscouraged(oneshot_nofail::Sender<Vec<(BannableAddress, Time)>>),
+    Undiscourage(BannableAddress, oneshot_nofail::Sender<crate::Result<()>>),
 
     EnableNetworking {
         enable: bool,

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -56,9 +56,16 @@ trait P2pRpc {
 
     /// List peers that have been discouraged.
     ///
-    /// Discouraged peers are peers that have misbehaved in the network.
+    /// Discouragement is similar to banning, except that inbound connections from such peers
+    /// are still allowed.
+    ///
+    /// Peers are discouraged automatically if they misbehave.
     #[method(name = "list_discouraged")]
     async fn list_discouraged(&self) -> RpcResult<Vec<(BannableAddress, Time)>>;
+
+    /// Undiscourage a previously discouraged peer by their IP address.
+    #[method(name = "undiscourage")]
+    async fn undiscourage(&self, address: BannableAddress) -> RpcResult<()>;
 
     /// Get the number of peers connected to this node.
     #[method(name = "get_peer_count")]
@@ -132,6 +139,11 @@ impl P2pRpcServer for super::P2pHandle {
 
     async fn list_discouraged(&self) -> RpcResult<Vec<(BannableAddress, Time)>> {
         let res = self.call_async(|this| this.list_discouraged()).await;
+        rpc::handle_result(res)
+    }
+
+    async fn undiscourage(&self, address: BannableAddress) -> RpcResult<()> {
+        let res = self.call_async_mut(move |this| this.undiscourage(address)).await;
         rpc::handle_result(res)
     }
 

--- a/p2p/src/sync/tests/helpers/mod.rs
+++ b/p2p/src/sync/tests/helpers/mod.rs
@@ -358,6 +358,7 @@ impl TestNode {
                     | PeerManagerEvent::Ban(_, _, _)
                     | PeerManagerEvent::Unban(_, _)
                     | PeerManagerEvent::ListDiscouraged(_)
+                    | PeerManagerEvent::Undiscourage(_, _)
                     | PeerManagerEvent::EnableNetworking { .. }
                     | PeerManagerEvent::GenericQuery(_)
                     | PeerManagerEvent::GenericMut(_) => {
@@ -642,6 +643,7 @@ pub enum PeerManagerEventDesc {
     Ban(BannableAddress, Duration),
     Unban(BannableAddress),
     ListDiscouraged,
+    Undiscourage(BannableAddress),
     EnableNetworking {
         enable: bool,
     },
@@ -695,6 +697,7 @@ impl From<&PeerManagerEvent> for PeerManagerEventDesc {
             PeerManagerEvent::Ban(addr, duration, _) => PeerManagerEventDesc::Ban(*addr, *duration),
             PeerManagerEvent::Unban(addr, _) => PeerManagerEventDesc::Unban(*addr),
             PeerManagerEvent::ListDiscouraged(_) => PeerManagerEventDesc::ListDiscouraged,
+            PeerManagerEvent::Undiscourage(addr, _) => PeerManagerEventDesc::Undiscourage(*addr),
             PeerManagerEvent::EnableNetworking {
                 enable,
                 response_sender: _,

--- a/p2p/src/sync/tests/helpers/test_node_group.rs
+++ b/p2p/src/sync/tests/helpers/test_node_group.rs
@@ -324,6 +324,7 @@ impl TestNodeGroup {
                         | PeerManagerEvent::Ban(_, _, _)
                         | PeerManagerEvent::Unban(_, _)
                         | PeerManagerEvent::ListDiscouraged(_)
+                        | PeerManagerEvent::Undiscourage(_, _)
                         | PeerManagerEvent::EnableNetworking { .. }
                         | PeerManagerEvent::GenericQuery(_)
                         | PeerManagerEvent::GenericMut(_) => {

--- a/wallet/wallet-cli-commands/src/command_handler/mod.rs
+++ b/wallet/wallet-cli-commands/src/command_handler/mod.rs
@@ -1718,6 +1718,10 @@ where
 
                 Ok(ConsoleCommand::Print(msg))
             }
+            WalletCommand::Undiscourage { address } => {
+                self.wallet().await?.undiscourage_address(address).await?;
+                Ok(ConsoleCommand::Print("Success".to_owned()))
+            }
 
             WalletCommand::PeerCount => {
                 let peer_count = self.wallet().await?.peer_count().await?;

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -654,6 +654,9 @@ pub enum WalletCommand {
     #[clap(name = "node-list-discouraged-peers")]
     ListDiscouraged,
 
+    #[clap(name = "node-undiscourage-peer-address")]
+    Undiscourage { address: BannableAddress },
+
     #[clap(name = "node-peer-count")]
     PeerCount,
 

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -382,6 +382,9 @@ impl NodeInterface for MockNode {
     async fn p2p_list_discouraged(&self) -> Result<Vec<(BannableAddress, Time)>, Self::Error> {
         unreachable!()
     }
+    async fn p2p_undiscourage(&self, _address: BannableAddress) -> Result<(), Self::Error> {
+        unreachable!()
+    }
     async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error> {
         unreachable!()
     }

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -370,6 +370,10 @@ impl NodeInterface for WalletHandlesClient {
         let list = self.p2p.call_async(move |this| this.list_discouraged()).await??;
         Ok(list)
     }
+    async fn p2p_undiscourage(&self, address: BannableAddress) -> Result<(), Self::Error> {
+        self.p2p.call_async_mut(move |this| this.undiscourage(address)).await??;
+        Ok(())
+    }
 
     async fn p2p_get_connected_peers(&self) -> Result<Vec<ConnectedPeer>, Self::Error> {
         let peers = self.p2p.call_async(move |this| this.get_connected_peers()).await??;

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -117,6 +117,7 @@ pub trait NodeInterface {
     ) -> Result<(), Self::Error>;
     async fn p2p_unban(&self, address: BannableAddress) -> Result<(), Self::Error>;
     async fn p2p_list_discouraged(&self) -> Result<Vec<(BannableAddress, Time)>, Self::Error>;
+    async fn p2p_undiscourage(&self, address: BannableAddress) -> Result<(), Self::Error>;
     async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error>;
     async fn p2p_get_connected_peers(&self) -> Result<Vec<ConnectedPeer>, Self::Error>;
     async fn p2p_get_reserved_nodes(&self) -> Result<Vec<SocketAddress>, Self::Error>;

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -306,6 +306,11 @@ impl NodeInterface for NodeRpcClient {
             .await
             .map_err(NodeRpcError::ResponseError)
     }
+    async fn p2p_undiscourage(&self, address: BannableAddress) -> Result<(), Self::Error> {
+        P2pRpcClient::undiscourage(&self.http_client, address)
+            .await
+            .map_err(NodeRpcError::ResponseError)
+    }
 
     async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error> {
         P2pRpcClient::get_peer_count(&self.http_client)

--- a/wallet/wallet-node-client/src/rpc_client/cold_wallet_client.rs
+++ b/wallet/wallet-node-client/src/rpc_client/cold_wallet_client.rs
@@ -229,6 +229,10 @@ impl NodeInterface for ColdWalletClient {
         Err(ColdWalletRpcError::NotAvailable)
     }
 
+    async fn p2p_undiscourage(&self, _address: BannableAddress) -> Result<(), Self::Error> {
+        Err(ColdWalletRpcError::NotAvailable)
+    }
+
     async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error> {
         Err(ColdWalletRpcError::NotAvailable)
     }

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -1215,6 +1215,13 @@ impl<N: NodeInterface + Clone + Send + Sync + Debug + 'static> WalletInterface
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 
+    async fn undiscourage_address(&self, address: BannableAddress) -> Result<(), Self::Error> {
+        self.wallet_rpc
+            .undiscourage_address(address)
+            .await
+            .map_err(WalletRpcHandlesClientError::WalletRpcError)
+    }
+
     async fn peer_count(&self) -> Result<usize, Self::Error> {
         self.wallet_rpc
             .peer_count()

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -1089,6 +1089,12 @@ impl WalletInterface for ClientWalletRpc {
             .map_err(WalletRpcError::ResponseError)
     }
 
+    async fn undiscourage_address(&self, address: BannableAddress) -> Result<(), Self::Error> {
+        WalletRpcClient::undiscourage_address(&self.http_client, address)
+            .await
+            .map_err(WalletRpcError::ResponseError)
+    }
+
     async fn peer_count(&self) -> Result<usize, Self::Error> {
         WalletRpcClient::peer_count(&self.http_client)
             .await

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -544,6 +544,8 @@ pub trait WalletInterface {
         &self,
     ) -> Result<Vec<(BannableAddress, common::primitives::time::Time)>, Self::Error>;
 
+    async fn undiscourage_address(&self, address: BannableAddress) -> Result<(), Self::Error>;
+
     async fn peer_count(&self) -> Result<usize, Self::Error>;
 
     async fn connected_peers(&self) -> Result<Vec<ConnectedPeer>, Self::Error>;

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -2194,6 +2194,21 @@ Returns:
 ], .. ]
 ```
 
+### Method `node_undiscourage_peer_address`
+
+Undiscourage address in the node
+
+
+Parameters:
+```
+{ "address": string }
+```
+
+Returns:
+```
+nothing
+```
+
 ### Method `node_peer_count`
 
 Get the number of connected peer in the node

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -787,6 +787,10 @@ trait WalletRpc {
         &self,
     ) -> rpc::RpcResult<Vec<(BannableAddress, common::primitives::time::Time)>>;
 
+    /// Undiscourage address in the node
+    #[method(name = "node_undiscourage_peer_address")]
+    async fn undiscourage_address(&self, address: BannableAddress) -> rpc::RpcResult<()>;
+
     /// Get the number of connected peer in the node
     #[method(name = "node_peer_count")]
     async fn peer_count(&self) -> rpc::RpcResult<usize>;

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -2172,6 +2172,10 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         self.node.p2p_list_discouraged().await.map_err(RpcError::RpcError)
     }
 
+    pub async fn undiscourage_address(&self, address: BannableAddress) -> WRpcResult<(), N> {
+        self.node.p2p_undiscourage(address).await.map_err(RpcError::RpcError)
+    }
+
     pub async fn peer_count(&self) -> WRpcResult<usize, N> {
         self.node.p2p_get_peer_count().await.map_err(RpcError::RpcError)
     }

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -1185,6 +1185,10 @@ impl<N: NodeInterface + Clone + Send + Sync + Debug + 'static> WalletRpcServer f
         rpc::handle_result(self.list_discouraged().await)
     }
 
+    async fn undiscourage_address(&self, address: BannableAddress) -> rpc::RpcResult<()> {
+        rpc::handle_result(self.undiscourage_address(address).await)
+    }
+
     async fn peer_count(&self) -> rpc::RpcResult<usize> {
         rpc::handle_result(self.peer_count().await)
     }


### PR DESCRIPTION
A useful command to have.

I also had to run `cargo update` because `cargo deny` was complaining about a vulnerability in the `idna` crate.