### PR TITLE
Refactor/tx additional info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8354,7 +8354,7 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.1.4"
-source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?branch=feature/mintlayer-pk#1768ae882544791239303dbe2e25e82f6dda0c81"
+source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?branch=feature/mintlayer-pk#04bd932277f0eeba3561f0adca45a0e11e724044"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8354,6 +8354,7 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.1.4"
+source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?branch=feature/mintlayer-pk#1768ae882544791239303dbe2e25e82f6dda0c81"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8354,7 +8354,6 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.1.4"
-source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?branch=feature/mintlayer-pk#c929c9a8f71ed9edfc679b96e3d4815fd8f3316b"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/common/src/chain/transaction/output/output_value.rs
+++ b/common/src/chain/transaction/output/output_value.rs
@@ -75,7 +75,14 @@ impl From<TokenIssuanceV0> for OutputValue {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, rpc_description::HasValueHint,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    rpc_description::HasValueHint,
 )]
 #[serde(tag = "type", content = "content")]
 pub enum RpcOutputValue {
@@ -104,6 +111,15 @@ impl RpcOutputValue {
         match self {
             RpcOutputValue::Coin { amount: _ } => None,
             RpcOutputValue::Token { id, amount: _ } => Some(*id),
+        }
+    }
+}
+
+impl From<RpcOutputValue> for OutputValue {
+    fn from(value: RpcOutputValue) -> Self {
+        match value {
+            RpcOutputValue::Coin { amount } => OutputValue::Coin(amount),
+            RpcOutputValue::Token { id, amount } => OutputValue::TokenV1(id, amount),
         }
     }
 }

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -206,21 +206,22 @@ def init_mintlayer_types():
                 ]
             },
 
-            "UtxoAdditionalInfo": {
+            "InfoId": {
+                "type": "enum",
+                "type_mapping": [
+                    ["TokenId", "H256"],
+                    ["PoolId", "H256"],
+                    ["OrderId", "H256"],
+                ],
+            },
+
+            "TxAdditionalInfo": {
                 "type": "enum",
                 "type_mapping": [
                     ["TokenInfo", "TokenAdditionalInfo"],
                     ["PoolInfo", "(Amount)"],
-                    ["AnyoneCanTake", ""], # TODO
+                    ["OrderInfo", ""], # TODO
                 ],
-            },
-
-            "UtxoWithAdditionalInfo": {
-                "type": "struct",
-                "type_mapping": [
-                    ["utxo", "TxOutput"],
-                    ["additional_info", "Option<UtxoAdditionalInfo>"],
-                ]
             },
 
             "StandardInputSignature": {
@@ -244,10 +245,10 @@ def init_mintlayer_types():
                 "type_mapping": [
                     ["tx", "TransactionV1"],
                     ["witnesses", "Vec<Option<InputWitness>>"],
-                    ["input_utxos", "Vec<Option<UtxoWithAdditionalInfo>>"],
+                    ["input_utxos", "Vec<Option<TxOutput>>"],
                     ["destinations", "Vec<Option<Destination>>"],
                     ["htlc_secrets", "Vec<Option<[u8; 32]>>"],
-                    ["output_additional_infos", "Vec<Option<UtxoAdditionalInfo>>"],
+                    ["additional_infos", "BTreeMap<InfoId, TxAdditionalInfo>"],
                 ]
             },
 

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -206,6 +206,23 @@ def init_mintlayer_types():
                 ]
             },
 
+            "PoolAdditionalInfo": {
+                "type": "struct",
+                "type_mapping": [
+                    ["staker_balance", "Amount"],
+                ]
+            },
+
+            "OrderAdditionalInfo": {
+                "type": "struct",
+                "type_mapping": [
+                    ["initially_asked", "OutputValue"],
+                    ["initially_given", "OutputValue"],
+                    ["ask_balance", "Amount"],
+                    ["give_balance", "Amount"],
+                ]
+            },
+
             "InfoId": {
                 "type": "enum",
                 "type_mapping": [
@@ -216,11 +233,11 @@ def init_mintlayer_types():
             },
 
             "TxAdditionalInfo": {
-                "type": "enum",
+                "type": "struct",
                 "type_mapping": [
-                    ["TokenInfo", "TokenAdditionalInfo"],
-                    ["PoolInfo", "(Amount)"],
-                    ["OrderInfo", ""], # TODO
+                    ["token_info", "BTreeMap<H256, TokenAdditionalInfo>"],
+                    ["pool_info", "BTreeMap<H256, PoolAdditionalInfo>"],
+                    ["order_info", "BTreeMap<H256, OrderAdditionalInfo>"],
                 ],
             },
 
@@ -248,7 +265,7 @@ def init_mintlayer_types():
                     ["input_utxos", "Vec<Option<TxOutput>>"],
                     ["destinations", "Vec<Option<Destination>>"],
                     ["htlc_secrets", "Vec<Option<[u8; 32]>>"],
-                    ["additional_infos", "BTreeMap<InfoId, TxAdditionalInfo>"],
+                    ["additional_infos", "TxAdditionalInfo"],
                 ]
             },
 

--- a/test/functional/wallet_htlc_refund.py
+++ b/test/functional/wallet_htlc_refund.py
@@ -187,7 +187,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
                 'input_utxos': alice_htlc_outputs,
                 'destinations': [refund_dest_obj, alice_htlc_change_dest],
                 'htlc_secrets': [None, None],
-                'additional_infos': []
+                'additional_infos': {'token_info': [], 'pool_info': [], 'order_info': []}
             }
             alice_refund_tx_hex = scalecodec.base.RuntimeConfiguration().create_scale_object('PartiallySignedTransaction').encode(alice_refund_ptx).to_hex()[2:]
 
@@ -216,7 +216,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
                 'input_utxos': bob_htlc_outputs,
                 'destinations': [refund_dest_obj, bob_htlc_change_dest],
                 'htlc_secrets': [None, None],
-                'additional_infos': []
+                'additional_infos': {'token_info': [], 'pool_info': [], 'order_info': []}
             }
             bob_refund_tx_hex = scalecodec.base.RuntimeConfiguration().create_scale_object('PartiallySignedTransaction').encode(bob_refund_ptx).to_hex()[2:]
 

--- a/test/functional/wallet_htlc_refund.py
+++ b/test/functional/wallet_htlc_refund.py
@@ -184,10 +184,10 @@ class WalletHtlcRefund(BitcoinTestFramework):
             alice_refund_ptx = {
                 'tx': tx['transaction'],
                 'witnesses': [None, None],
-                'input_utxos': [{'utxo': out, 'additional_info': None} for out in alice_htlc_outputs],
+                'input_utxos': alice_htlc_outputs,
                 'destinations': [refund_dest_obj, alice_htlc_change_dest],
                 'htlc_secrets': [None, None],
-                'output_additional_infos': [None]
+                'additional_infos': []
             }
             alice_refund_tx_hex = scalecodec.base.RuntimeConfiguration().create_scale_object('PartiallySignedTransaction').encode(alice_refund_ptx).to_hex()[2:]
 
@@ -213,10 +213,10 @@ class WalletHtlcRefund(BitcoinTestFramework):
             bob_refund_ptx = {
                 'tx': tx['transaction'],
                 'witnesses': [None, None],
-                'input_utxos': [{'utxo': out, 'additional_info': None} for out in bob_htlc_outputs],
+                'input_utxos': bob_htlc_outputs,
                 'destinations': [refund_dest_obj, bob_htlc_change_dest],
                 'htlc_secrets': [None, None],
-                'output_additional_infos': [None]
+                'additional_infos': []
             }
             bob_refund_tx_hex = scalecodec.base.RuntimeConfiguration().create_scale_object('PartiallySignedTransaction').encode(bob_refund_ptx).to_hex()[2:]
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -26,8 +26,7 @@ utils-networking = { path = "../utils/networking" }
 utxo = { path = "../utxo" }
 wallet-storage = { path = "./storage" }
 wallet-types = { path = "./types" }
-# trezor-client = { git = "https://github.com/mintlayer/mintlayer-trezor-firmware", branch = "feature/mintlayer-pk", features = ["bitcoin", "mintlayer"], optional = true }
-trezor-client = { path = "../../trezor-firmware/rust/trezor-client", features = ["bitcoin", "mintlayer"], optional = true }
+trezor-client = { git = "https://github.com/mintlayer/mintlayer-trezor-firmware", branch = "feature/mintlayer-pk", features = ["bitcoin", "mintlayer"], optional = true }
 
 bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
 hex.workspace = true
@@ -46,5 +45,3 @@ tempfile.workspace = true
 [features]
 trezor = ["dep:trezor-client", "wallet-types/trezor"]
 trezor-emulator = []
-
-default = ["trezor"]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -26,7 +26,8 @@ utils-networking = { path = "../utils/networking" }
 utxo = { path = "../utxo" }
 wallet-storage = { path = "./storage" }
 wallet-types = { path = "./types" }
-trezor-client = { git = "https://github.com/mintlayer/mintlayer-trezor-firmware", branch = "feature/mintlayer-pk", features = ["bitcoin", "mintlayer"], optional = true }
+# trezor-client = { git = "https://github.com/mintlayer/mintlayer-trezor-firmware", branch = "feature/mintlayer-pk", features = ["bitcoin", "mintlayer"], optional = true }
+trezor-client = { path = "../../trezor-firmware/rust/trezor-client", features = ["bitcoin", "mintlayer"], optional = true }
 
 bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
 hex.workspace = true
@@ -45,3 +46,5 @@ tempfile.workspace = true
 [features]
 trezor = ["dep:trezor-client", "wallet-types/trezor"]
 trezor-emulator = []
+
+default = ["trezor"]

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -38,7 +38,9 @@ use utils::ensure;
 pub use utxo_selector::UtxoSelectorError;
 use wallet_types::account_id::AccountPrefixedId;
 use wallet_types::account_info::{StandaloneAddressDetails, StandaloneAddresses};
-use wallet_types::partially_signed_transaction::{PartiallySignedTransaction, UtxoAdditionalInfo};
+use wallet_types::partially_signed_transaction::{
+    InfoId, PartiallySignedTransaction, TxAdditionalInfo,
+};
 use wallet_types::with_locked::WithLocked;
 
 use crate::account::utxo_selector::{select_coins, OutputGroup};
@@ -47,8 +49,7 @@ use crate::key_chain::{AccountKeyChains, KeyChainError, VRFAccountKeyChains};
 use crate::send_request::{
     make_address_output, make_address_output_from_delegation, make_address_output_token,
     make_decommission_stake_pool_output, make_mint_token_outputs, make_stake_output,
-    make_unmint_token_outputs, IssueNftArguments, PoolOrTokenId, SelectedInputs,
-    StakePoolDataArguments,
+    make_unmint_token_outputs, IssueNftArguments, SelectedInputs, StakePoolDataArguments,
 };
 use crate::wallet::WalletPoolsFilter;
 use crate::wallet_events::{WalletEvents, WalletEventsNoOp};
@@ -633,7 +634,7 @@ impl<K: AccountKeyChains> Account<K> {
         change_addresses: BTreeMap<Currency, Address<Destination>>,
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<(PartiallySignedTransaction, BTreeMap<Currency, Amount>)> {
         let mut request = self.select_inputs_for_send_request(
             request,

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -38,9 +38,7 @@ use utils::ensure;
 pub use utxo_selector::UtxoSelectorError;
 use wallet_types::account_id::AccountPrefixedId;
 use wallet_types::account_info::{StandaloneAddressDetails, StandaloneAddresses};
-use wallet_types::partially_signed_transaction::{
-    InfoId, PartiallySignedTransaction, TxAdditionalInfo,
-};
+use wallet_types::partially_signed_transaction::{PartiallySignedTransaction, TxAdditionalInfo};
 use wallet_types::with_locked::WithLocked;
 
 use crate::account::utxo_selector::{select_coins, OutputGroup};
@@ -634,7 +632,7 @@ impl<K: AccountKeyChains> Account<K> {
         change_addresses: BTreeMap<Currency, Address<Destination>>,
         median_time: BlockTimestamp,
         fee_rate: CurrentFeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<(PartiallySignedTransaction, BTreeMap<Currency, Amount>)> {
         let mut request = self.select_inputs_for_send_request(
             request,
@@ -648,7 +646,7 @@ impl<K: AccountKeyChains> Account<K> {
         )?;
 
         let fees = request.get_fees();
-        let ptx = request.into_partially_signed_tx(additional_utxo_infos)?;
+        let ptx = request.into_partially_signed_tx(additional_info)?;
 
         Ok((ptx, fees))
     }

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -29,9 +29,7 @@ use common::primitives::{Amount, BlockHeight};
 use crypto::vrf::VRFPublicKey;
 use utils::ensure;
 use wallet_types::currency::Currency;
-use wallet_types::partially_signed_transaction::{
-    InfoId, PartiallySignedTransaction, TxAdditionalInfo,
-};
+use wallet_types::partially_signed_transaction::{PartiallySignedTransaction, TxAdditionalInfo};
 
 use crate::account::PoolData;
 use crate::destination_getters::{get_tx_output_destination, HtlcSpendingCondition};
@@ -292,7 +290,7 @@ impl SendRequest {
 
     pub fn into_partially_signed_tx(
         self,
-        additional_info: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<PartiallySignedTransaction> {
         let num_inputs = self.inputs.len();
         let destinations = self.destinations.into_iter().map(Some).collect();

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -20,7 +20,7 @@ use common::address::Address;
 use common::chain::output_value::OutputValue;
 use common::chain::stakelock::StakePoolData;
 use common::chain::timelock::OutputTimeLock::ForBlockCount;
-use common::chain::tokens::{Metadata, NftIssuance, TokenId, TokenIssuance};
+use common::chain::tokens::{Metadata, TokenId, TokenIssuance};
 use common::chain::{
     ChainConfig, Destination, PoolId, Transaction, TxInput, TxOutput, UtxoOutPoint,
 };
@@ -30,18 +30,12 @@ use crypto::vrf::VRFPublicKey;
 use utils::ensure;
 use wallet_types::currency::Currency;
 use wallet_types::partially_signed_transaction::{
-    PartiallySignedTransaction, TokenAdditionalInfo, UtxoAdditionalInfo, UtxoWithAdditionalInfo,
+    InfoId, PartiallySignedTransaction, TxAdditionalInfo,
 };
 
 use crate::account::PoolData;
 use crate::destination_getters::{get_tx_output_destination, HtlcSpendingCondition};
 use crate::{WalletError, WalletResult};
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum PoolOrTokenId {
-    PoolId(PoolId),
-    TokenId(TokenId),
-}
 
 /// The `SendRequest` struct provides the necessary information to the wallet
 /// on the precise method of sending funds to a designated destination.
@@ -298,26 +292,11 @@ impl SendRequest {
 
     pub fn into_partially_signed_tx(
         self,
-        additional_info: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_info: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<PartiallySignedTransaction> {
         let num_inputs = self.inputs.len();
         let destinations = self.destinations.into_iter().map(Some).collect();
-        let utxos = self
-            .utxos
-            .into_iter()
-            .map(|utxo| {
-                utxo.map(|utxo| {
-                    let additional_info = find_additional_info(&utxo, additional_info)?;
-                    Ok(UtxoWithAdditionalInfo::new(utxo, additional_info))
-                })
-                .transpose()
-            })
-            .collect::<WalletResult<Vec<_>>>()?;
-        let output_additional_infos = self
-            .outputs
-            .iter()
-            .map(|utxo| find_additional_info(utxo, additional_info))
-            .collect::<WalletResult<Vec<_>>>()?;
+        let utxos = self.utxos;
         let tx = Transaction::new(self.flags, self.inputs, self.outputs)?;
 
         let ptx = PartiallySignedTransaction::new(
@@ -326,71 +305,9 @@ impl SendRequest {
             utxos,
             destinations,
             None,
-            output_additional_infos,
+            additional_info,
         )?;
         Ok(ptx)
-    }
-}
-
-/// Find additional data for TxOutput, mainly for UI purposes
-fn find_additional_info(
-    utxo: &TxOutput,
-    additional_info: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
-) -> Result<Option<UtxoAdditionalInfo>, WalletError> {
-    let additional_info = match utxo {
-        TxOutput::Burn(value)
-        | TxOutput::Htlc(value, _)
-        | TxOutput::Transfer(value, _)
-        | TxOutput::LockThenTransfer(value, _, _) => {
-            find_token_additional_info(value, additional_info)?.map(UtxoAdditionalInfo::TokenInfo)
-        }
-        TxOutput::CreateOrder(data) => {
-            let ask = find_token_additional_info(data.ask(), additional_info)?;
-            let give = find_token_additional_info(data.give(), additional_info)?;
-
-            Some(UtxoAdditionalInfo::CreateOrder { ask, give })
-        }
-        TxOutput::IssueNft(_, data, _) => {
-            Some(UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
-                num_decimals: 0,
-                ticker: match data.as_ref() {
-                    NftIssuance::V0(data) => data.metadata.ticker().clone(),
-                },
-            }))
-        }
-        TxOutput::CreateStakePool(_, data) => Some(UtxoAdditionalInfo::PoolInfo {
-            staker_balance: data.pledge(),
-        }),
-        TxOutput::ProduceBlockFromStake(_, pool_id) => additional_info
-            .get(&PoolOrTokenId::PoolId(*pool_id))
-            .ok_or(WalletError::MissingPoolAdditionalData(*pool_id))
-            .map(Some)?
-            .cloned(),
-        TxOutput::DataDeposit(_)
-        | TxOutput::IssueFungibleToken(_)
-        | TxOutput::DelegateStaking(_, _)
-        | TxOutput::CreateDelegationId(_, _) => None,
-    };
-    Ok(additional_info)
-}
-
-fn find_token_additional_info(
-    value: &OutputValue,
-    additional_info: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
-) -> WalletResult<Option<TokenAdditionalInfo>> {
-    match value {
-        OutputValue::Coin(_) | OutputValue::TokenV0(_) => Ok(None),
-        OutputValue::TokenV1(token_id, _) => additional_info
-            .get(&PoolOrTokenId::TokenId(*token_id))
-            .ok_or(WalletError::MissingTokenAdditionalData(*token_id))
-            .cloned()
-            .map(|data| match data {
-                UtxoAdditionalInfo::TokenInfo(data) => Ok(Some(data.clone())),
-                UtxoAdditionalInfo::PoolInfo { staker_balance: _ }
-                | UtxoAdditionalInfo::CreateOrder { ask: _, give: _ } => {
-                    Err(WalletError::MismatchedTokenAdditionalData(*token_id))
-                }
-            })?,
     }
 }
 

--- a/wallet/src/signer/mod.rs
+++ b/wallet/src/signer/mod.rs
@@ -83,8 +83,8 @@ pub enum SignerError {
     MissingDestinationInTransaction,
     #[error("Partially signed tx is missing UTXO type input's UTXO")]
     MissingUtxo,
-    #[error("Partially signed tx is missing extra info for UTXO")]
-    MissingUtxoExtraInfo,
+    #[error("Partially signed tx is missing extra info")]
+    MissingTxExtraInfo,
     #[error("Tokens V0 are not supported")]
     UnsupportedTokensV0,
     #[error("Invalid TxOutput type as UTXO, cannot be spent")]
@@ -93,6 +93,8 @@ pub enum SignerError {
     AddressError(#[from] AddressError),
     #[error("Signature error: {0}")]
     SignatureError(#[from] SignatureError),
+    #[error("Order was filled more than the available balance")]
+    OrderFillUnderflow,
 }
 
 type SignerResult<T> = Result<T, SignerError>;

--- a/wallet/src/signer/software_signer/mod.rs
+++ b/wallet/src/signer/software_signer/mod.rs
@@ -264,8 +264,7 @@ impl Signer for SoftwareSigner {
         Vec<SignatureStatus>,
         Vec<SignatureStatus>,
     )> {
-        let inputs_utxo_refs: Vec<_> =
-            ptx.input_utxos().iter().map(|u| u.as_ref().map(|x| &x.utxo)).collect();
+        let inputs_utxo_refs: Vec<_> = ptx.input_utxos().iter().map(|u| u.as_ref()).collect();
 
         let (witnesses, prev_statuses, new_statuses) = ptx
             .witnesses()

--- a/wallet/src/signer/software_signer/tests.rs
+++ b/wallet/src/signer/software_signer/tests.rs
@@ -437,7 +437,7 @@ fn sign_transaction(#[case] seed: Seed) {
         .with_outputs(outputs);
     let destinations = req.destinations().to_vec();
     let additional_info = BTreeMap::new();
-    let ptx = req.into_partially_signed_tx(&additional_info).unwrap();
+    let ptx = req.into_partially_signed_tx(additional_info).unwrap();
 
     let mut signer = SoftwareSigner::new(chain_config.clone(), DEFAULT_ACCOUNT_INDEX);
     let (ptx, _, _) = signer.sign_tx(ptx, account.key_chain(), &db_tx).unwrap();
@@ -688,7 +688,7 @@ fn fixed_signatures() {
         .with_outputs(outputs);
     let destinations = req.destinations().to_vec();
     let additional_info = BTreeMap::new();
-    let ptx = req.into_partially_signed_tx(&additional_info).unwrap();
+    let ptx = req.into_partially_signed_tx(additional_info).unwrap();
 
     let utxos_ref = utxos
         .iter()

--- a/wallet/src/signer/software_signer/tests.rs
+++ b/wallet/src/signer/software_signer/tests.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
 use std::ops::{Add, Div, Mul, Sub};
 
 use super::*;
@@ -42,6 +41,7 @@ use serialization::Encode;
 use test_utils::random::{make_seedable_rng, Seed};
 use wallet_storage::{DefaultBackend, Store, Transactional};
 use wallet_types::account_info::DEFAULT_ACCOUNT_INDEX;
+use wallet_types::partially_signed_transaction::TxAdditionalInfo;
 use wallet_types::seed_phrase::StoreSeedPhrase;
 use wallet_types::KeyPurpose::{Change, ReceiveFunds};
 
@@ -436,7 +436,7 @@ fn sign_transaction(#[case] seed: Seed) {
         .with_inputs_and_destinations(acc_inputs.into_iter().zip(acc_dests.clone()))
         .with_outputs(outputs);
     let destinations = req.destinations().to_vec();
-    let additional_info = BTreeMap::new();
+    let additional_info = TxAdditionalInfo::new();
     let ptx = req.into_partially_signed_tx(additional_info).unwrap();
 
     let mut signer = SoftwareSigner::new(chain_config.clone(), DEFAULT_ACCOUNT_INDEX);
@@ -687,7 +687,7 @@ fn fixed_signatures() {
         .with_inputs_and_destinations(acc_inputs.into_iter().zip(acc_dests.clone()))
         .with_outputs(outputs);
     let destinations = req.destinations().to_vec();
-    let additional_info = BTreeMap::new();
+    let additional_info = TxAdditionalInfo::new();
     let ptx = req.into_partially_signed_tx(additional_info).unwrap();
 
     let utxos_ref = utxos

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -74,7 +74,7 @@ use wallet_storage::{
 use wallet_types::account_info::{StandaloneAddressDetails, StandaloneAddresses};
 use wallet_types::chain_info::ChainInfo;
 use wallet_types::partially_signed_transaction::{
-    InfoId, PartiallySignedTransaction, PartiallySignedTransactionCreationError,
+    PartiallySignedTransaction, PartiallySignedTransactionCreationError, PoolAdditionalInfo,
     TokenAdditionalInfo, TxAdditionalInfo,
 };
 use wallet_types::seed_phrase::SerializableSeedPhrase;
@@ -1041,7 +1041,7 @@ where
     fn for_account_rw_unlocked_and_check_tx_generic<AddlData>(
         &mut self,
         account_index: U31,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
         f: impl FnOnce(
             &mut Account<P::K>,
             &mut StoreTxRwUnlocked<B>,
@@ -1055,7 +1055,7 @@ where
             |account, db_tx, chain_config, signer_provider| {
                 let (request, additional_data) = f(account, db_tx)?;
 
-                let ptx = request.into_partially_signed_tx(additional_utxo_infos)?;
+                let ptx = request.into_partially_signed_tx(additional_info)?;
 
                 let mut signer =
                     signer_provider.provide(Arc::new(chain_config.clone()), account_index);
@@ -1099,13 +1099,13 @@ where
     fn for_account_rw_unlocked_and_check_tx(
         &mut self,
         account_index: U31,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
         f: impl FnOnce(&mut Account<P::K>, &mut StoreTxRwUnlocked<B>) -> WalletResult<SendRequest>,
     ) -> WalletResult<SignedTransaction> {
         Ok(self
             .for_account_rw_unlocked_and_check_tx_generic(
                 account_index,
-                additional_utxo_infos,
+                additional_info,
                 |account, db_tx| Ok((f(account, db_tx)?, ())),
                 |err| err,
             )?
@@ -1408,7 +1408,7 @@ where
     ///    current_fee_rate is lower than the consolidate_fee_rate then the wallet will tend to
     ///    use and consolidate multiple smaller inputs, else if the current_fee_rate is higher it will
     ///    tend to use inputs with lowest fee.
-    /// * `additional_utxo_infos` - Any additional info for Tokens or Pools used in the UTXOs of
+    /// * `additional__info` - Any additional info for Tokens or Pools used in the UTXOs of
     ///    the transaction to be created
     ///
     /// # Returns
@@ -1423,7 +1423,7 @@ where
         change_addresses: BTreeMap<Currency, Address<Destination>>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         Ok(self
             .create_transaction_to_addresses_impl(
@@ -1434,7 +1434,7 @@ where
                 current_fee_rate,
                 consolidate_fee_rate,
                 |_s| (),
-                additional_utxo_infos,
+                additional_info,
             )?
             .0)
     }
@@ -1451,7 +1451,7 @@ where
         intent: String,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<(SignedTransaction, SignedTransactionIntent)> {
         let (signed_tx, input_destinations) = self.create_transaction_to_addresses_impl(
             account_index,
@@ -1461,7 +1461,7 @@ where
             current_fee_rate,
             consolidate_fee_rate,
             |send_request| send_request.destinations().to_owned(),
-            additional_utxo_infos,
+            additional_info,
         )?;
 
         let signed_intent = self.for_account_rw_unlocked(
@@ -1493,13 +1493,13 @@ where
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         additional_data_getter: impl Fn(&SendRequest) -> AddlData,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<(SignedTransaction, AddlData)> {
         let request = SendRequest::new().with_outputs(outputs);
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked_and_check_tx_generic(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 let send_request = account.process_send_request_and_sign(
                     db_tx,
@@ -1530,7 +1530,7 @@ where
         change_addresses: BTreeMap<Currency, Address<Destination>>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<(PartiallySignedTransaction, BTreeMap<Currency, Amount>)> {
         let request = SendRequest::new().with_outputs(outputs);
         let latest_median_time = self.latest_median_time;
@@ -1546,7 +1546,7 @@ where
                     current_fee_rate,
                     consolidate_fee_rate,
                 },
-                additional_utxo_infos,
+                additional_info,
             )
         })
     }
@@ -1557,18 +1557,16 @@ where
         destination: Destination,
         inputs: Vec<(UtxoOutPoint, TxOutput)>,
         current_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         let request = SendRequest::new().with_inputs(
             inputs.into_iter().map(|(outpoint, output)| (TxInput::Utxo(outpoint), output)),
             &|_| None,
         )?;
 
-        self.for_account_rw_unlocked_and_check_tx(
-            account_index,
-            additional_utxo_infos,
-            |account, _| account.sweep_addresses(destination, request, current_fee_rate),
-        )
+        self.for_account_rw_unlocked_and_check_tx(account_index, additional_info, |account, _| {
+            account.sweep_addresses(destination, request, current_fee_rate)
+        })
     }
 
     pub fn create_sweep_from_delegation_transaction(
@@ -1579,9 +1577,13 @@ where
         delegation_share: Amount,
         current_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
-        self.for_account_rw_unlocked_and_check_tx(account_index, BTreeMap::new(), |account, _| {
-            account.sweep_delegation(address, delegation_id, delegation_share, current_fee_rate)
-        })
+        self.for_account_rw_unlocked_and_check_tx(
+            account_index,
+            TxAdditionalInfo::new(),
+            |account, _| {
+                account.sweep_delegation(address, delegation_id, delegation_share, current_fee_rate)
+            },
+        )
     }
 
     pub fn create_transaction_to_addresses_from_delegation(
@@ -1593,15 +1595,19 @@ where
         delegation_share: Amount,
         current_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
-        self.for_account_rw_unlocked_and_check_tx(account_index, BTreeMap::new(), |account, _| {
-            account.spend_from_delegation(
-                address,
-                amount,
-                delegation_id,
-                delegation_share,
-                current_fee_rate,
-            )
-        })
+        self.for_account_rw_unlocked_and_check_tx(
+            account_index,
+            TxAdditionalInfo::new(),
+            |account, _| {
+                account.spend_from_delegation(
+                    address,
+                    amount,
+                    delegation_id,
+                    delegation_share,
+                    current_fee_rate,
+                )
+            },
+        )
     }
 
     pub fn mint_tokens(
@@ -1614,10 +1620,10 @@ where
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
-        let additional_utxo_infos = to_token_additional_info(token_info);
+        let additional_info = to_token_additional_info(token_info);
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.mint_tokens(
                     db_tx,
@@ -1643,10 +1649,10 @@ where
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
-        let additional_utxo_infos = to_token_additional_info(token_info);
+        let additional_info = to_token_additional_info(token_info);
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.unmint_tokens(
                     db_tx,
@@ -1670,10 +1676,10 @@ where
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
-        let additional_utxo_infos = to_token_additional_info(token_info);
+        let additional_info = to_token_additional_info(token_info);
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.lock_token_supply(
                     db_tx,
@@ -1697,10 +1703,10 @@ where
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
-        let additional_utxo_infos = to_token_additional_info(token_info);
+        let additional_info = to_token_additional_info(token_info);
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.freeze_token(
                     db_tx,
@@ -1724,10 +1730,10 @@ where
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
-        let additional_utxo_infos = to_token_additional_info(token_info);
+        let additional_info = to_token_additional_info(token_info);
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.unfreeze_token(
                     db_tx,
@@ -1751,10 +1757,10 @@ where
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
-        let additional_utxo_infos = to_token_additional_info(token_info);
+        let additional_info = to_token_additional_info(token_info);
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.change_token_authority(
                     db_tx,
@@ -1779,10 +1785,10 @@ where
         consolidate_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
-        let additional_utxo_infos = to_token_additional_info(token_info);
+        let additional_info = to_token_additional_info(token_info);
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.change_token_metadata_uri(
                     db_tx,
@@ -1829,7 +1835,7 @@ where
             BTreeMap::new(),
             current_fee_rate,
             consolidate_fee_rate,
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )?;
         let input0_outpoint = crate::utils::get_first_utxo_outpoint(tx.transaction().inputs())?;
         let delegation_id = make_delegation_id(input0_outpoint);
@@ -1852,7 +1858,7 @@ where
             BTreeMap::new(),
             current_fee_rate,
             consolidate_fee_rate,
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )?;
         let token_id =
             make_token_id(tx.transaction().inputs()).ok_or(WalletError::MissingTokenId)?;
@@ -1872,7 +1878,7 @@ where
 
         let signed_transaction = self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
             |account, db_tx| {
                 account.create_issue_nft_tx(
                     db_tx,
@@ -1902,14 +1908,12 @@ where
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
     ) -> WalletResult<SignedTransaction> {
-        let additional_utxo_infos = BTreeMap::from_iter([(
-            InfoId::PoolId(pool_id),
-            TxAdditionalInfo::PoolInfo { staker_balance },
-        )]);
+        let additional_info =
+            TxAdditionalInfo::with_pool_info(pool_id, PoolAdditionalInfo { staker_balance });
         Ok(self
             .for_account_rw_unlocked_and_check_tx_generic(
                 account_index,
-                additional_utxo_infos,
+                additional_info,
                 |account, db_tx| {
                     Ok((
                         account.decommission_stake_pool(
@@ -1935,10 +1939,8 @@ where
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
     ) -> WalletResult<PartiallySignedTransaction> {
-        let additional_utxo_infos = BTreeMap::from_iter([(
-            InfoId::PoolId(pool_id),
-            TxAdditionalInfo::PoolInfo { staker_balance },
-        )]);
+        let additional_info =
+            TxAdditionalInfo::with_pool_info(pool_id, PoolAdditionalInfo { staker_balance });
         self.for_account_rw_unlocked(
             account_index,
             |account, db_tx, chain_config, signer_provider| {
@@ -1950,7 +1952,7 @@ where
                     current_fee_rate,
                 )?;
 
-                let ptx = request.into_partially_signed_tx(additional_utxo_infos)?;
+                let ptx = request.into_partially_signed_tx(additional_info)?;
 
                 let mut signer =
                     signer_provider.provide(Arc::new(chain_config.clone()), account_index);
@@ -1971,12 +1973,12 @@ where
         htlc: HashedTimelockContract,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.create_htlc_tx(
                     db_tx,
@@ -2001,12 +2003,12 @@ where
         conclude_key: Address<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<(OrderId, SignedTransaction)> {
         let latest_median_time = self.latest_median_time;
         let tx = self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.create_order_tx(
                     db_tx,
@@ -2035,12 +2037,12 @@ where
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.create_conclude_order_tx(
                     db_tx,
@@ -2067,12 +2069,12 @@ where
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            additional_utxo_infos,
+            additional_info,
             |account, db_tx| {
                 account.create_fill_order_tx(
                     db_tx,
@@ -2296,16 +2298,14 @@ where
     }
 }
 
-fn to_token_additional_info(
-    token_info: &UnconfirmedTokenInfo,
-) -> BTreeMap<InfoId, TxAdditionalInfo> {
-    BTreeMap::from_iter([(
-        InfoId::TokenId(token_info.token_id()),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+fn to_token_additional_info(token_info: &UnconfirmedTokenInfo) -> TxAdditionalInfo {
+    TxAdditionalInfo::with_token_info(
+        token_info.token_id(),
+        TokenAdditionalInfo {
             num_decimals: token_info.num_decimals(),
             ticker: token_info.token_ticker().to_vec(),
-        }),
-    )])
+        },
+    )
 }
 
 impl<B, P> Wallet<B, P>
@@ -2348,7 +2348,7 @@ where
         let latest_median_time = self.latest_median_time;
         self.for_account_rw_unlocked_and_check_tx(
             account_index,
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
             |account, db_tx| {
                 account.create_stake_pool_tx(
                     db_tx,

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -998,7 +998,7 @@ fn wallet_accounts_creation() {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
 
@@ -1158,7 +1158,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         ),
         Err(WalletError::DatabaseError(
             wallet_storage::Error::WalletLocked
@@ -1176,7 +1176,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap();
     } else {
@@ -1206,7 +1206,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap();
     }
@@ -1234,7 +1234,7 @@ fn wallet_get_transaction(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
 
@@ -1294,7 +1294,7 @@ fn wallet_list_mainchain_transactions(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
 
@@ -1317,7 +1317,7 @@ fn wallet_list_mainchain_transactions(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
     let spend_from_tx_id = tx.transaction().get_id();
@@ -1372,7 +1372,7 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
                 BTreeMap::new(),
                 very_big_feerate,
                 very_big_feerate,
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap_err();
 
@@ -1400,7 +1400,7 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
             BTreeMap::new(),
             feerate,
             feerate,
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
 
@@ -1487,7 +1487,7 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap_err();
         assert_eq!(err, WalletError::CannotFindUtxo(missing_utxo.clone()));
@@ -1514,7 +1514,7 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
 
@@ -1552,7 +1552,7 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap_err();
 
@@ -1850,7 +1850,7 @@ fn send_to_unknown_delegation(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
 
@@ -1998,7 +1998,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
 
@@ -2265,7 +2265,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap();
         wallet
@@ -2330,7 +2330,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap();
         (issued_token_id, vec![nft_issuance_transaction, transfer_tx])
@@ -2368,13 +2368,13 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         Destination::PublicKeyHash(some_other_address),
     );
 
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(*token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        *token_id,
+        TokenAdditionalInfo {
             num_decimals: number_of_decimals,
             ticker: token_ticker.clone(),
-        }),
-    )]);
+        },
+    );
     let transfer_tokens_transaction = wallet
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
@@ -2501,7 +2501,7 @@ fn check_tokens_v0_are_ignored(#[case] seed: Seed) {
         BTreeMap::new(),
         FeeRate::from_amount_per_kb(Amount::ZERO),
         FeeRate::from_amount_per_kb(Amount::ZERO),
-        BTreeMap::new(),
+        TxAdditionalInfo::new(),
     );
 
     matches!(
@@ -2719,13 +2719,13 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
         Destination::PublicKeyHash(some_other_address),
     );
 
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let transfer_tokens_transaction = wallet
         .create_transaction_to_addresses(
             DEFAULT_ACCOUNT_INDEX,
@@ -3582,7 +3582,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
     wallet
@@ -3704,7 +3704,7 @@ fn wallet_multiple_transactions_in_single_block(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap();
         wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
@@ -3796,7 +3796,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap();
 
@@ -3832,7 +3832,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
     wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
@@ -3872,7 +3872,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap_err();
     assert_eq!(
@@ -3899,7 +3899,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
     wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
@@ -3984,7 +3984,7 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap();
         wallet
@@ -4362,7 +4362,7 @@ fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
         vec![Some(utxo)],
         vec![Some(addr.into_object())],
         None,
-        BTreeMap::new(),
+        TxAdditionalInfo::new(),
     )
     .unwrap();
     let stake_pool_transaction = wallet
@@ -4651,7 +4651,7 @@ fn sign_send_request_cold_wallet(#[case] seed: Seed) {
             [(Currency::Coin, cold_wallet_address.clone())].into(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
 
@@ -4754,7 +4754,7 @@ fn test_not_exhaustion_of_keys(#[case] seed: Seed) {
                 [].into(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .unwrap();
     }
@@ -4894,7 +4894,7 @@ fn test_add_standalone_multisig(#[case] seed: Seed) {
         vec![Some(tx.outputs()[0].clone())],
         vec![Some(multisig_address.as_object().clone())],
         None,
-        BTreeMap::new(),
+        TxAdditionalInfo::new(),
     )
     .unwrap();
 
@@ -4988,7 +4988,7 @@ fn create_htlc_and_spend(#[case] seed: Seed) {
             htlc.clone(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
     let create_htlc_tx_id = create_htlc_tx.transaction().get_id();
@@ -5047,7 +5047,7 @@ fn create_htlc_and_spend(#[case] seed: Seed) {
         spend_utxos,
         vec![Some(spend_key.into_object())],
         Some(vec![Some(secret)]),
-        BTreeMap::new(),
+        TxAdditionalInfo::new(),
     )
     .unwrap();
 
@@ -5128,7 +5128,7 @@ fn create_htlc_and_refund(#[case] seed: Seed) {
             htlc.clone(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            BTreeMap::new(),
+            TxAdditionalInfo::new(),
         )
         .unwrap();
     let create_htlc_tx_id = create_htlc_tx.transaction().get_id();
@@ -5146,7 +5146,7 @@ fn create_htlc_and_refund(#[case] seed: Seed) {
         refund_utxos,
         vec![Some(refund_key)],
         None,
-        BTreeMap::new(),
+        TxAdditionalInfo::new(),
     )
     .unwrap();
 
@@ -5315,13 +5315,13 @@ fn create_order(#[case] seed: Seed) {
     // Create an order selling tokens for coins
     let ask_value = OutputValue::Coin(Amount::from_atoms(111));
     let give_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let (_, create_order_tx) = wallet
         .create_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -5441,13 +5441,13 @@ fn create_order_and_conclude(#[case] seed: Seed) {
     // Create an order selling tokens for coins
     let ask_value = OutputValue::Coin(Amount::from_atoms(111));
     let give_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let (order_id, create_order_tx) = wallet
         .create_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -5485,13 +5485,13 @@ fn create_order_and_conclude(#[case] seed: Seed) {
     assert_eq!(coin_balance, expected_balance);
     assert!(token_balances.is_empty());
 
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let conclude_order_tx = wallet
         .create_conclude_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -5630,13 +5630,13 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
     let ask_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
     let sell_amount = Amount::from_atoms(1000);
     let give_value = OutputValue::Coin(sell_amount);
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let (order_id, create_order_tx) = wallet1
         .create_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -5688,13 +5688,13 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             Some(&(issued_token_id, token_amount_to_mint))
         );
     }
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
 
     // Fill order partially
     let fill_order_tx_1 = wallet2
@@ -5754,13 +5754,13 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
         nonce: Some(AccountNonce::new(0)),
     };
 
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let fill_order_tx_2 = wallet2
         .create_fill_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -5811,13 +5811,13 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
         ask_balance: Amount::ZERO,
         nonce: Some(AccountNonce::new(1)),
     };
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let conclude_order_tx = wallet1
         .create_conclude_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -5967,13 +5967,13 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
     let ask_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
     let sell_amount = Amount::from_atoms(1000);
     let give_value = OutputValue::Coin(sell_amount);
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let (order_id, create_order_tx) = wallet1
         .create_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -6026,13 +6026,13 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
         );
     }
 
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     // Fill order partially
     let fill_order_tx_1 = wallet2
         .create_fill_order_tx(
@@ -6091,13 +6091,13 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
         nonce: Some(AccountNonce::new(0)),
     };
 
-    let additional_info = BTreeMap::from_iter([(
-        InfoId::TokenId(issued_token_id),
-        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+    let additional_info = TxAdditionalInfo::with_token_info(
+        issued_token_id,
+        TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
-        }),
-    )]);
+        },
+    );
     let conclude_order_tx = wallet1
         .create_conclude_order_tx(
             DEFAULT_ACCOUNT_INDEX,

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -55,8 +55,7 @@ use wallet_storage::{schema, WalletStorageEncryptionRead};
 use wallet_types::{
     account_info::DEFAULT_ACCOUNT_INDEX,
     partially_signed_transaction::{
-        PartiallySignedTransaction, PartiallySignedTransactionCreationError, UtxoAdditionalInfo,
-        UtxoWithAdditionalInfo,
+        PartiallySignedTransaction, PartiallySignedTransactionCreationError, TxAdditionalInfo,
     },
     seed_phrase::{PassPhrase, StoreSeedPhrase},
     utxo_types::{UtxoState, UtxoType},
@@ -999,7 +998,7 @@ fn wallet_accounts_creation() {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
 
@@ -1159,7 +1158,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         ),
         Err(WalletError::DatabaseError(
             wallet_storage::Error::WalletLocked
@@ -1177,7 +1176,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap();
     } else {
@@ -1207,7 +1206,7 @@ fn locked_wallet_cant_sign_transaction(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap();
     }
@@ -1235,7 +1234,7 @@ fn wallet_get_transaction(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
 
@@ -1295,7 +1294,7 @@ fn wallet_list_mainchain_transactions(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
 
@@ -1318,7 +1317,7 @@ fn wallet_list_mainchain_transactions(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
     let spend_from_tx_id = tx.transaction().get_id();
@@ -1373,7 +1372,7 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
                 BTreeMap::new(),
                 very_big_feerate,
                 very_big_feerate,
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap_err();
 
@@ -1401,7 +1400,7 @@ fn wallet_transaction_with_fees(#[case] seed: Seed) {
             BTreeMap::new(),
             feerate,
             feerate,
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
 
@@ -1488,7 +1487,7 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap_err();
         assert_eq!(err, WalletError::CannotFindUtxo(missing_utxo.clone()));
@@ -1515,7 +1514,7 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
 
@@ -1553,7 +1552,7 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap_err();
 
@@ -1851,7 +1850,7 @@ fn send_to_unknown_delegation(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
 
@@ -1999,7 +1998,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
 
@@ -2266,7 +2265,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap();
         wallet
@@ -2331,7 +2330,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap();
         (issued_token_id, vec![nft_issuance_transaction, transfer_tx])
@@ -2370,8 +2369,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
     );
 
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(*token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(*token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: number_of_decimals,
             ticker: token_ticker.clone(),
         }),
@@ -2384,7 +2383,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info.clone(),
         )
         .unwrap();
     wallet
@@ -2438,7 +2437,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .err()
         .unwrap();
@@ -2502,7 +2501,7 @@ fn check_tokens_v0_are_ignored(#[case] seed: Seed) {
         BTreeMap::new(),
         FeeRate::from_amount_per_kb(Amount::ZERO),
         FeeRate::from_amount_per_kb(Amount::ZERO),
-        &BTreeMap::new(),
+        BTreeMap::new(),
     );
 
     matches!(
@@ -2721,8 +2720,8 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
     );
 
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -2735,7 +2734,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
 
@@ -3583,7 +3582,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
     wallet
@@ -3705,7 +3704,7 @@ fn wallet_multiple_transactions_in_single_block(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap();
         wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
@@ -3797,7 +3796,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap();
 
@@ -3833,7 +3832,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
     wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
@@ -3873,7 +3872,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap_err();
     assert_eq!(
@@ -3900,7 +3899,7 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             BTreeMap::new(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
     wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
@@ -3985,7 +3984,7 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
                 BTreeMap::new(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap();
         wallet
@@ -4357,14 +4356,13 @@ fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
     // remove the signatures and try to sign it again
     let tx = stake_pool_transaction.transaction().clone();
     let inps = tx.inputs().len();
-    let outs = tx.outputs().len();
     let ptx = PartiallySignedTransaction::new(
         tx,
         vec![None; inps],
-        vec![Some(UtxoWithAdditionalInfo::new(utxo, None))],
+        vec![Some(utxo)],
         vec![Some(addr.into_object())],
         None,
-        vec![None; outs],
+        BTreeMap::new(),
     )
     .unwrap();
     let stake_pool_transaction = wallet
@@ -4653,7 +4651,7 @@ fn sign_send_request_cold_wallet(#[case] seed: Seed) {
             [(Currency::Coin, cold_wallet_address.clone())].into(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
 
@@ -4756,7 +4754,7 @@ fn test_not_exhaustion_of_keys(#[case] seed: Seed) {
                 [].into(),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .unwrap();
     }
@@ -4890,14 +4888,13 @@ fn test_add_standalone_multisig(#[case] seed: Seed) {
         )],
     )
     .unwrap();
-    let outs = tx.outputs().len();
     let spend_multisig_tx = PartiallySignedTransaction::new(
         spend_multisig_tx,
         vec![None; 1],
-        vec![Some(UtxoWithAdditionalInfo::new(tx.outputs()[0].clone(), None))],
+        vec![Some(tx.outputs()[0].clone())],
         vec![Some(multisig_address.as_object().clone())],
         None,
-        vec![None; outs],
+        BTreeMap::new(),
     )
     .unwrap();
 
@@ -4991,7 +4988,7 @@ fn create_htlc_and_spend(#[case] seed: Seed) {
             htlc.clone(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
     let create_htlc_tx_id = create_htlc_tx.transaction().get_id();
@@ -5043,20 +5040,14 @@ fn create_htlc_and_spend(#[case] seed: Seed) {
         vec![TxOutput::Transfer(output_value, address2.into_object())],
     )
     .unwrap();
-    let spend_utxos = vec![create_htlc_tx
-        .transaction()
-        .outputs()
-        .first()
-        .cloned()
-        .map(|out| UtxoWithAdditionalInfo::new(out, None))];
-    let outs = create_htlc_tx.outputs().len();
+    let spend_utxos = vec![create_htlc_tx.transaction().outputs().first().cloned()];
     let spend_ptx = PartiallySignedTransaction::new(
         spend_tx,
         vec![None],
         spend_utxos,
         vec![Some(spend_key.into_object())],
         Some(vec![Some(secret)]),
-        vec![None; outs],
+        BTreeMap::new(),
     )
     .unwrap();
 
@@ -5137,7 +5128,7 @@ fn create_htlc_and_refund(#[case] seed: Seed) {
             htlc.clone(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &BTreeMap::new(),
+            BTreeMap::new(),
         )
         .unwrap();
     let create_htlc_tx_id = create_htlc_tx.transaction().get_id();
@@ -5148,20 +5139,14 @@ fn create_htlc_and_refund(#[case] seed: Seed) {
         vec![TxOutput::Transfer(output_value, address1.into_object())],
     )
     .unwrap();
-    let refund_utxos = vec![create_htlc_tx
-        .transaction()
-        .outputs()
-        .first()
-        .cloned()
-        .map(|out| UtxoWithAdditionalInfo::new(out, None))];
-    let outs = create_htlc_tx.outputs().len();
+    let refund_utxos = vec![create_htlc_tx.transaction().outputs().first().cloned()];
     let refund_ptx = PartiallySignedTransaction::new(
         refund_tx,
         vec![None],
         refund_utxos,
         vec![Some(refund_key)],
         None,
-        vec![None; outs],
+        BTreeMap::new(),
     )
     .unwrap();
 
@@ -5331,8 +5316,8 @@ fn create_order(#[case] seed: Seed) {
     let ask_value = OutputValue::Coin(Amount::from_atoms(111));
     let give_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -5345,7 +5330,7 @@ fn create_order(#[case] seed: Seed) {
             address2.clone(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
 
@@ -5457,8 +5442,8 @@ fn create_order_and_conclude(#[case] seed: Seed) {
     let ask_value = OutputValue::Coin(Amount::from_atoms(111));
     let give_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -5471,7 +5456,7 @@ fn create_order_and_conclude(#[case] seed: Seed) {
             address2.clone(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
     let order_info = RpcOrderInfo {
@@ -5501,8 +5486,8 @@ fn create_order_and_conclude(#[case] seed: Seed) {
     assert!(token_balances.is_empty());
 
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -5515,7 +5500,7 @@ fn create_order_and_conclude(#[case] seed: Seed) {
             None,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
 
@@ -5646,8 +5631,8 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
     let sell_amount = Amount::from_atoms(1000);
     let give_value = OutputValue::Coin(sell_amount);
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -5660,7 +5645,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             address1.clone(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
     let order_info = RpcOrderInfo {
@@ -5704,8 +5689,8 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
         );
     }
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -5721,7 +5706,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             None,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
 
@@ -5770,8 +5755,8 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
     };
 
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -5785,7 +5770,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             None,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
 
@@ -5827,8 +5812,8 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
         nonce: Some(AccountNonce::new(1)),
     };
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -5841,7 +5826,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             None,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
 
@@ -5983,8 +5968,8 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
     let sell_amount = Amount::from_atoms(1000);
     let give_value = OutputValue::Coin(sell_amount);
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -5997,7 +5982,7 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
             address1.clone(),
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
     let order_info = RpcOrderInfo {
@@ -6042,8 +6027,8 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
     }
 
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -6058,7 +6043,7 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
             None,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
 
@@ -6107,8 +6092,8 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
     };
 
     let additional_info = BTreeMap::from_iter([(
-        PoolOrTokenId::TokenId(issued_token_id),
-        UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+        InfoId::TokenId(issued_token_id),
+        TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
             ticker: unconfirmed_token_info.token_ticker().to_vec(),
         }),
@@ -6121,7 +6106,7 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
             None,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
-            &additional_info,
+            additional_info,
         )
         .unwrap();
 

--- a/wallet/wallet-cli-lib/src/lib.rs
+++ b/wallet/wallet-cli-lib/src/lib.rs
@@ -36,10 +36,11 @@ use node_comm::{make_cold_wallet_rpc_client, make_rpc_client, rpc_client::ColdWa
 use rpc::RpcAuthData;
 use tokio::sync::mpsc;
 use utils::{cookie::COOKIE_FILENAME, default_data_dir::default_data_dir_for_chain, ensure};
-use wallet_cli_commands::{
-    CliHardwareWalletType, ManageableWalletCommand, WalletCommand, WalletManagementCommand,
-};
+use wallet_cli_commands::{ManageableWalletCommand, WalletCommand, WalletManagementCommand};
 use wallet_rpc_lib::{cmdline::make_wallet_config, config::WalletRpcConfig, types::NodeInterface};
+
+#[cfg(feature = "trezor")]
+use wallet_cli_commands::CliHardwareWalletType;
 
 enum Mode {
     Interactive {

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -41,16 +41,13 @@ use wallet::signer::software_signer::SoftwareSignerProvider;
 use wallet::wallet::WalletPoolsFilter;
 use wallet::wallet_events::WalletEvents;
 use wallet::{Wallet, WalletError, WalletResult};
+use wallet_types::account_info::{StandaloneAddressDetails, StandaloneAddresses};
 use wallet_types::partially_signed_transaction::{PartiallySignedTransaction, TxAdditionalInfo};
 use wallet_types::seed_phrase::SerializableSeedPhrase;
 use wallet_types::signature_status::SignatureStatus;
 use wallet_types::utxo_types::{UtxoStates, UtxoTypes};
 use wallet_types::wallet_tx::TxData;
 use wallet_types::with_locked::WithLocked;
-use wallet_types::{
-    account_info::{StandaloneAddressDetails, StandaloneAddresses},
-    partially_signed_transaction::InfoId,
-};
 use wallet_types::{Currency, KeychainUsageState};
 
 #[cfg(feature = "trezor")]
@@ -787,7 +784,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         change_addresses: BTreeMap<Currency, Address<Destination>>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_transaction_to_addresses(
@@ -797,7 +794,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 change_addresses,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_transaction_to_addresses(
@@ -807,7 +804,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 change_addresses,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
         }
     }
@@ -818,7 +815,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         destination_address: Destination,
         filtered_inputs: Vec<(UtxoOutPoint, TxOutput)>,
         current_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_sweep_transaction(
@@ -826,7 +823,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 destination_address,
                 filtered_inputs,
                 current_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_sweep_transaction(
@@ -834,7 +831,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 destination_address,
                 filtered_inputs,
                 current_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
         }
     }
@@ -888,7 +885,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         change_addresses: BTreeMap<Currency, Address<Destination>>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<(PartiallySignedTransaction, BTreeMap<Currency, Amount>)> {
         match self {
             RuntimeWallet::Software(w) => w.create_unsigned_transaction_to_addresses(
@@ -899,7 +896,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 change_addresses,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_unsigned_transaction_to_addresses(
@@ -910,7 +907,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 change_addresses,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
         }
     }
@@ -1049,7 +1046,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         htlc: HashedTimelockContract,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_htlc_tx(
@@ -1058,7 +1055,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 htlc,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_htlc_tx(
@@ -1067,7 +1064,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 htlc,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
         }
     }
@@ -1081,7 +1078,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         conclude_key: Address<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<(OrderId, SignedTransaction)> {
         match self {
             RuntimeWallet::Software(w) => w.create_order_tx(
@@ -1091,7 +1088,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 conclude_key,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_order_tx(
@@ -1101,7 +1098,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 conclude_key,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
         }
     }
@@ -1115,7 +1112,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_conclude_order_tx(
@@ -1125,7 +1122,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 output_address,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_conclude_order_tx(
@@ -1135,7 +1132,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 output_address,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
         }
     }
@@ -1150,7 +1147,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_fill_order_tx(
@@ -1161,7 +1158,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 output_address,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_fill_order_tx(
@@ -1172,7 +1169,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 output_address,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
         }
     }
@@ -1216,7 +1213,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         intent: String,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<(SignedTransaction, SignedTransactionIntent)> {
         match self {
             RuntimeWallet::Software(w) => w.create_transaction_to_addresses_with_intent(
@@ -1227,7 +1224,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 intent,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_transaction_to_addresses_with_intent(
@@ -1238,7 +1235,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 intent,
                 current_fee_rate,
                 consolidate_fee_rate,
-                additional_utxo_infos,
+                additional_info,
             ),
         }
     }

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -35,19 +35,22 @@ use crypto::vrf::VRFPublicKey;
 use mempool::FeeRate;
 use wallet::account::transaction_list::TransactionList;
 use wallet::account::{CoinSelectionAlgo, DelegationData, PoolData, TxInfo, UnconfirmedTokenInfo};
-use wallet::send_request::{PoolOrTokenId, SelectedInputs, StakePoolDataArguments};
+use wallet::send_request::{SelectedInputs, StakePoolDataArguments};
 use wallet::signer::software_signer::SoftwareSignerProvider;
 
 use wallet::wallet::WalletPoolsFilter;
 use wallet::wallet_events::WalletEvents;
 use wallet::{Wallet, WalletError, WalletResult};
-use wallet_types::account_info::{StandaloneAddressDetails, StandaloneAddresses};
-use wallet_types::partially_signed_transaction::{PartiallySignedTransaction, UtxoAdditionalInfo};
+use wallet_types::partially_signed_transaction::{PartiallySignedTransaction, TxAdditionalInfo};
 use wallet_types::seed_phrase::SerializableSeedPhrase;
 use wallet_types::signature_status::SignatureStatus;
 use wallet_types::utxo_types::{UtxoStates, UtxoTypes};
 use wallet_types::wallet_tx::TxData;
 use wallet_types::with_locked::WithLocked;
+use wallet_types::{
+    account_info::{StandaloneAddressDetails, StandaloneAddresses},
+    partially_signed_transaction::InfoId,
+};
 use wallet_types::{Currency, KeychainUsageState};
 
 #[cfg(feature = "trezor")]
@@ -784,7 +787,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         change_addresses: BTreeMap<Currency, Address<Destination>>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_transaction_to_addresses(
@@ -815,7 +818,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         destination_address: Destination,
         filtered_inputs: Vec<(UtxoOutPoint, TxOutput)>,
         current_fee_rate: FeeRate,
-        additional_utxo_infos: BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_sweep_transaction(
@@ -823,7 +826,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 destination_address,
                 filtered_inputs,
                 current_fee_rate,
-                &additional_utxo_infos,
+                additional_utxo_infos,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_sweep_transaction(
@@ -831,7 +834,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 destination_address,
                 filtered_inputs,
                 current_fee_rate,
-                &additional_utxo_infos,
+                additional_utxo_infos,
             ),
         }
     }
@@ -885,7 +888,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         change_addresses: BTreeMap<Currency, Address<Destination>>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<(PartiallySignedTransaction, BTreeMap<Currency, Amount>)> {
         match self {
             RuntimeWallet::Software(w) => w.create_unsigned_transaction_to_addresses(
@@ -1046,7 +1049,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         htlc: HashedTimelockContract,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_htlc_tx(
@@ -1078,7 +1081,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         conclude_key: Address<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<(OrderId, SignedTransaction)> {
         match self {
             RuntimeWallet::Software(w) => w.create_order_tx(
@@ -1112,7 +1115,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_conclude_order_tx(
@@ -1147,7 +1150,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<SignedTransaction> {
         match self {
             RuntimeWallet::Software(w) => w.create_fill_order_tx(
@@ -1213,7 +1216,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         intent: String,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> WalletResult<(SignedTransaction, SignedTransactionIntent)> {
         match self {
             RuntimeWallet::Software(w) => w.create_transaction_to_addresses_with_intent(

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -40,7 +40,6 @@ use crypto::{
     vrf::VRFPublicKey,
 };
 use futures::{stream::FuturesUnordered, TryStreamExt};
-use itertools::Itertools;
 use logging::log;
 use mempool::FeeRate;
 use node_comm::node_traits::NodeInterface;
@@ -58,7 +57,7 @@ use wallet::{
 };
 use wallet_types::{
     partially_signed_transaction::{
-        InfoId, PartiallySignedTransaction, TokenAdditionalInfo, TxAdditionalInfo,
+        PartiallySignedTransaction, TokenAdditionalInfo, TxAdditionalInfo,
     },
     signature_status::SignatureStatus,
     utxo_types::{UtxoState, UtxoType},
@@ -158,15 +157,9 @@ where
     async fn filter_out_utxos_with_frozen_tokens(
         &self,
         input_utxos: Vec<(UtxoOutPoint, TxOutput)>,
-    ) -> Result<
-        (
-            Vec<(UtxoOutPoint, TxOutput)>,
-            BTreeMap<InfoId, TxAdditionalInfo>,
-        ),
-        ControllerError<T>,
-    > {
+    ) -> Result<(Vec<(UtxoOutPoint, TxOutput)>, TxAdditionalInfo), ControllerError<T>> {
         let mut result = vec![];
-        let mut additional_utxo_infos = BTreeMap::new();
+        let mut additional_info = TxAdditionalInfo::new();
         for utxo in input_utxos {
             let token_ids = get_referenced_token_ids(&utxo.1);
             if token_ids.is_empty() {
@@ -196,19 +189,19 @@ where
                 if ok_to_use {
                     result.push(utxo);
                     for token_info in token_infos {
-                        additional_utxo_infos.insert(
-                            InfoId::TokenId(token_info.token_id()),
-                            TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                        additional_info.add_token_info(
+                            token_info.token_id(),
+                            TokenAdditionalInfo {
                                 num_decimals: token_info.token_number_of_decimals(),
                                 ticker: token_info.token_ticker().to_vec(),
-                            }),
+                            },
                         );
                     }
                 }
             }
         }
 
-        Ok((result, additional_utxo_infos))
+        Ok((result, additional_info))
     }
 
     pub fn abandon_transaction(
@@ -531,7 +524,7 @@ where
                     BTreeMap::new(),
                     current_fee_rate,
                     consolidate_fee_rate,
-                    BTreeMap::new(),
+                    TxAdditionalInfo::new(),
                 )
             },
         )
@@ -563,7 +556,7 @@ where
                     BTreeMap::new(),
                     current_fee_rate,
                     consolidate_fee_rate,
-                    BTreeMap::new(),
+                    TxAdditionalInfo::new(),
                 )
             },
         )
@@ -584,7 +577,7 @@ where
             WithLocked::Unlocked,
         )?;
 
-        let (inputs, additional_utxo_infos) =
+        let (inputs, additional_info) =
             self.filter_out_utxos_with_frozen_tokens(selected_utxos).await?;
 
         let filtered_inputs = inputs
@@ -605,7 +598,7 @@ where
                     destination_address,
                     filtered_inputs,
                     current_fee_rate,
-                    additional_utxo_infos,
+                    additional_info,
                 )
             },
         )
@@ -694,7 +687,7 @@ where
                 [(Currency::Coin, change_address)].into(),
                 current_fee_rate,
                 consolidate_fee_rate,
-                BTreeMap::new(),
+                TxAdditionalInfo::new(),
             )
             .map_err(ControllerError::WalletError)?;
 
@@ -738,18 +731,18 @@ where
             ControllerError::<T>::ExpectingNonEmptyOutputs
         );
 
-        let (outputs, additional_utxo_infos) = {
+        let (outputs, additional_info) = {
             let mut result = Vec::new();
-            let mut additional_utxo_infos = BTreeMap::new();
+            let mut additional_info = TxAdditionalInfo::new();
 
             for (token_id, outputs_vec) in outputs {
                 let token_info = fetch_token_info(&self.rpc_client, token_id).await?;
-                additional_utxo_infos.insert(
-                    InfoId::TokenId(token_id),
-                    TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                additional_info.add_token_info(
+                    token_id,
+                    TokenAdditionalInfo {
                         num_decimals: token_info.token_number_of_decimals(),
                         ticker: token_info.token_ticker().to_vec(),
-                    }),
+                    },
                 );
 
                 match &token_info {
@@ -768,7 +761,7 @@ where
                 .map_err(ControllerError::InvalidTxOutput)?;
             }
 
-            (result, additional_utxo_infos)
+            (result, additional_info)
         };
 
         let (inputs, change_addresses) = {
@@ -846,7 +839,7 @@ where
             change_addresses,
             current_fee_rate,
             consolidate_fee_rate,
-            additional_utxo_infos,
+            additional_info,
         )?;
 
         let fees = into_balances(&self.rpc_client, self.chain_config, fees).await?;
@@ -899,7 +892,7 @@ where
                     BTreeMap::new(),
                     current_fee_rate,
                     consolidate_fee_rate,
-                    BTreeMap::new(),
+                    TxAdditionalInfo::new(),
                 )
             },
         )
@@ -960,13 +953,13 @@ where
                   account_index: U31,
                   token_info: &UnconfirmedTokenInfo| {
                 token_info.check_can_be_used()?;
-                let additional_info = BTreeMap::from_iter([(
-                    InfoId::TokenId(token_info.token_id()),
-                    TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                let additional_info = TxAdditionalInfo::with_token_info(
+                    token_info.token_id(),
+                    TokenAdditionalInfo {
                         num_decimals: token_info.num_decimals(),
                         ticker: token_info.token_ticker().to_vec(),
-                    }),
-                )]);
+                    },
+                );
                 wallet.create_transaction_to_addresses(
                     account_index,
                     [output],
@@ -998,13 +991,13 @@ where
                   account_index: U31,
                   token_info: &UnconfirmedTokenInfo| {
                 token_info.check_can_be_used()?;
-                let additional_info = BTreeMap::from_iter([(
-                    InfoId::TokenId(token_info.token_id()),
-                    TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                let additional_info = TxAdditionalInfo::with_token_info(
+                    token_info.token_id(),
+                    TokenAdditionalInfo {
                         num_decimals: token_info.num_decimals(),
                         ticker: token_info.token_ticker().to_vec(),
-                    }),
-                )]);
+                    },
+                );
                 wallet.create_transaction_to_addresses_with_intent(
                     account_index,
                     [output],
@@ -1113,7 +1106,7 @@ where
         &mut self,
         output_value: OutputValue,
         htlc: HashedTimelockContract,
-        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
+        additional_info: TxAdditionalInfo,
     ) -> Result<SignedTransaction, ControllerError<T>> {
         let (current_fee_rate, consolidate_fee_rate) =
             self.get_current_and_consolidation_fee_rate().await?;
@@ -1124,7 +1117,7 @@ where
             htlc,
             current_fee_rate,
             consolidate_fee_rate,
-            additional_utxo_infos,
+            additional_info,
         )?;
         Ok(result)
     }
@@ -1136,7 +1129,7 @@ where
         conclude_key: Address<Destination>,
         token_infos: Vec<RPCTokenInfo>,
     ) -> Result<(SignedTransaction, OrderId), ControllerError<T>> {
-        let additional_info = self.additional_token_infos(token_infos)?;
+        let additional_info = self.additional_token_info(token_infos)?;
 
         self.create_and_send_tx_with_id(
             move |current_fee_rate: FeeRate,
@@ -1164,7 +1157,7 @@ where
         output_address: Option<Destination>,
         token_infos: Vec<RPCTokenInfo>,
     ) -> Result<SignedTransaction, ControllerError<T>> {
-        let additional_info = self.additional_token_infos(token_infos)?;
+        let additional_info = self.additional_token_info(token_infos)?;
         self.create_and_send_tx(
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
@@ -1192,7 +1185,7 @@ where
         output_address: Option<Destination>,
         token_infos: Vec<RPCTokenInfo>,
     ) -> Result<SignedTransaction, ControllerError<T>> {
-        let additional_info = self.additional_token_infos(token_infos)?;
+        let additional_info = self.additional_token_info(token_infos)?;
         self.create_and_send_tx(
             move |current_fee_rate: FeeRate,
                   consolidate_fee_rate: FeeRate,
@@ -1213,24 +1206,25 @@ where
         .await
     }
 
-    fn additional_token_infos(
+    fn additional_token_info(
         &mut self,
         token_infos: Vec<RPCTokenInfo>,
-    ) -> Result<BTreeMap<InfoId, TxAdditionalInfo>, ControllerError<T>> {
+    ) -> Result<TxAdditionalInfo, ControllerError<T>> {
         token_infos
             .into_iter()
-            .map(|token_info| {
+            .try_fold(TxAdditionalInfo::new(), |mut acc, token_info| {
                 let token_info = self.unconfiremd_token_info(token_info)?;
 
-                Ok((
-                    InfoId::TokenId(token_info.token_id()),
-                    TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                acc.add_token_info(
+                    token_info.token_id(),
+                    TokenAdditionalInfo {
                         num_decimals: token_info.num_decimals(),
                         ticker: token_info.token_ticker().to_vec(),
-                    }),
-                ))
+                    },
+                );
+
+                Ok(acc)
             })
-            .try_collect()
     }
 
     /// Checks if the wallet has stake pools and marks this account for staking.

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -50,7 +50,7 @@ use wallet::{
     destination_getters::{get_tx_output_destination, HtlcSpendingCondition},
     send_request::{
         make_address_output, make_address_output_token, make_create_delegation_output,
-        make_data_deposit_output, PoolOrTokenId, SelectedInputs, StakePoolDataArguments,
+        make_data_deposit_output, SelectedInputs, StakePoolDataArguments,
     },
     wallet::WalletPoolsFilter,
     wallet_events::WalletEvents,
@@ -58,7 +58,7 @@ use wallet::{
 };
 use wallet_types::{
     partially_signed_transaction::{
-        PartiallySignedTransaction, TokenAdditionalInfo, UtxoAdditionalInfo,
+        InfoId, PartiallySignedTransaction, TokenAdditionalInfo, TxAdditionalInfo,
     },
     signature_status::SignatureStatus,
     utxo_types::{UtxoState, UtxoType},
@@ -161,7 +161,7 @@ where
     ) -> Result<
         (
             Vec<(UtxoOutPoint, TxOutput)>,
-            BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+            BTreeMap<InfoId, TxAdditionalInfo>,
         ),
         ControllerError<T>,
     > {
@@ -197,8 +197,8 @@ where
                     result.push(utxo);
                     for token_info in token_infos {
                         additional_utxo_infos.insert(
-                            PoolOrTokenId::TokenId(token_info.token_id()),
-                            UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                            InfoId::TokenId(token_info.token_id()),
+                            TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
                                 num_decimals: token_info.token_number_of_decimals(),
                                 ticker: token_info.token_ticker().to_vec(),
                             }),
@@ -531,7 +531,7 @@ where
                     BTreeMap::new(),
                     current_fee_rate,
                     consolidate_fee_rate,
-                    &BTreeMap::new(),
+                    BTreeMap::new(),
                 )
             },
         )
@@ -563,7 +563,7 @@ where
                     BTreeMap::new(),
                     current_fee_rate,
                     consolidate_fee_rate,
-                    &BTreeMap::new(),
+                    BTreeMap::new(),
                 )
             },
         )
@@ -694,7 +694,7 @@ where
                 [(Currency::Coin, change_address)].into(),
                 current_fee_rate,
                 consolidate_fee_rate,
-                &BTreeMap::new(),
+                BTreeMap::new(),
             )
             .map_err(ControllerError::WalletError)?;
 
@@ -745,8 +745,8 @@ where
             for (token_id, outputs_vec) in outputs {
                 let token_info = fetch_token_info(&self.rpc_client, token_id).await?;
                 additional_utxo_infos.insert(
-                    PoolOrTokenId::TokenId(token_id),
-                    UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                    InfoId::TokenId(token_id),
+                    TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
                         num_decimals: token_info.token_number_of_decimals(),
                         ticker: token_info.token_ticker().to_vec(),
                     }),
@@ -846,7 +846,7 @@ where
             change_addresses,
             current_fee_rate,
             consolidate_fee_rate,
-            &additional_utxo_infos,
+            additional_utxo_infos,
         )?;
 
         let fees = into_balances(&self.rpc_client, self.chain_config, fees).await?;
@@ -899,7 +899,7 @@ where
                     BTreeMap::new(),
                     current_fee_rate,
                     consolidate_fee_rate,
-                    &BTreeMap::new(),
+                    BTreeMap::new(),
                 )
             },
         )
@@ -961,8 +961,8 @@ where
                   token_info: &UnconfirmedTokenInfo| {
                 token_info.check_can_be_used()?;
                 let additional_info = BTreeMap::from_iter([(
-                    PoolOrTokenId::TokenId(token_info.token_id()),
-                    UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                    InfoId::TokenId(token_info.token_id()),
+                    TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
                         num_decimals: token_info.num_decimals(),
                         ticker: token_info.token_ticker().to_vec(),
                     }),
@@ -974,7 +974,7 @@ where
                     BTreeMap::new(),
                     current_fee_rate,
                     consolidate_fee_rate,
-                    &additional_info,
+                    additional_info,
                 )
             },
         )
@@ -999,8 +999,8 @@ where
                   token_info: &UnconfirmedTokenInfo| {
                 token_info.check_can_be_used()?;
                 let additional_info = BTreeMap::from_iter([(
-                    PoolOrTokenId::TokenId(token_info.token_id()),
-                    UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                    InfoId::TokenId(token_info.token_id()),
+                    TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
                         num_decimals: token_info.num_decimals(),
                         ticker: token_info.token_ticker().to_vec(),
                     }),
@@ -1013,7 +1013,7 @@ where
                     intent,
                     current_fee_rate,
                     consolidate_fee_rate,
-                    &additional_info,
+                    additional_info,
                 )
             },
         )
@@ -1113,7 +1113,7 @@ where
         &mut self,
         output_value: OutputValue,
         htlc: HashedTimelockContract,
-        additional_utxo_infos: &BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>,
+        additional_utxo_infos: BTreeMap<InfoId, TxAdditionalInfo>,
     ) -> Result<SignedTransaction, ControllerError<T>> {
         let (current_fee_rate, consolidate_fee_rate) =
             self.get_current_and_consolidation_fee_rate().await?;
@@ -1150,7 +1150,7 @@ where
                     conclude_key,
                     current_fee_rate,
                     consolidate_fee_rate,
-                    &additional_info,
+                    additional_info,
                 )
             },
         )
@@ -1177,7 +1177,7 @@ where
                     output_address,
                     current_fee_rate,
                     consolidate_fee_rate,
-                    &additional_info,
+                    additional_info,
                 )
             },
         )
@@ -1206,7 +1206,7 @@ where
                     output_address,
                     current_fee_rate,
                     consolidate_fee_rate,
-                    &additional_info,
+                    additional_info,
                 )
             },
         )
@@ -1216,15 +1216,15 @@ where
     fn additional_token_infos(
         &mut self,
         token_infos: Vec<RPCTokenInfo>,
-    ) -> Result<BTreeMap<PoolOrTokenId, UtxoAdditionalInfo>, ControllerError<T>> {
+    ) -> Result<BTreeMap<InfoId, TxAdditionalInfo>, ControllerError<T>> {
         token_infos
             .into_iter()
             .map(|token_info| {
                 let token_info = self.unconfiremd_token_info(token_info)?;
 
                 Ok((
-                    PoolOrTokenId::TokenId(token_info.token_id()),
-                    UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                    InfoId::TokenId(token_info.token_id()),
+                    TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
                         num_decimals: token_info.num_decimals(),
                         ticker: token_info.token_ticker().to_vec(),
                     }),

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -39,7 +39,6 @@ use utils::{ensure, shallow_clone::ShallowClone};
 use utils_networking::IpOrSocketAddress;
 use wallet::{
     account::{transaction_list::TransactionList, PoolData, TransactionToSign, TxInfo},
-    send_request::PoolOrTokenId,
     WalletError,
 };
 
@@ -79,7 +78,7 @@ use wallet_controller::{
 use wallet_types::{
     account_info::StandaloneAddressDetails,
     partially_signed_transaction::{
-        PartiallySignedTransaction, TokenAdditionalInfo, UtxoAdditionalInfo,
+        InfoId, PartiallySignedTransaction, TokenAdditionalInfo, TxAdditionalInfo,
     },
     signature_status::SignatureStatus,
     wallet_tx::TxData,
@@ -1509,8 +1508,8 @@ where
                                 .to_amount(token_info.token_number_of_decimals())
                                 .ok_or(RpcError::InvalidCoinAmount)?;
                             additional_utxo_infos.insert(
-                                PoolOrTokenId::TokenId(token_id),
-                                UtxoAdditionalInfo::TokenInfo(TokenAdditionalInfo {
+                                InfoId::TokenId(token_id),
+                                TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
                                     num_decimals: token_info.token_number_of_decimals(),
                                     ticker: token_info.token_ticker().to_vec(),
                                 }),
@@ -1528,7 +1527,7 @@ where
                     controller
                         .synced_controller(account_index, config)
                         .await?
-                        .create_htlc_tx(value, htlc, &additional_utxo_infos)
+                        .create_htlc_tx(value, htlc, additional_utxo_infos)
                         .await
                         .map_err(RpcError::Controller)
                 })

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -78,7 +78,7 @@ use wallet_controller::{
 use wallet_types::{
     account_info::StandaloneAddressDetails,
     partially_signed_transaction::{
-        InfoId, PartiallySignedTransaction, TokenAdditionalInfo, TxAdditionalInfo,
+        PartiallySignedTransaction, TokenAdditionalInfo, TxAdditionalInfo,
     },
     signature_status::SignatureStatus,
     wallet_tx::TxData,
@@ -1500,34 +1500,35 @@ where
         self.wallet
             .call_async(move |controller| {
                 Box::pin(async move {
-                    let mut additional_utxo_infos = BTreeMap::new();
-                    let value = match token_id {
+                    let (value, additional_info) = match token_id {
                         Some(token_id) => {
                             let token_info = controller.get_token_info(token_id).await?;
                             let amount = amount
                                 .to_amount(token_info.token_number_of_decimals())
                                 .ok_or(RpcError::InvalidCoinAmount)?;
-                            additional_utxo_infos.insert(
-                                InfoId::TokenId(token_id),
-                                TxAdditionalInfo::TokenInfo(TokenAdditionalInfo {
-                                    num_decimals: token_info.token_number_of_decimals(),
-                                    ticker: token_info.token_ticker().to_vec(),
-                                }),
-                            );
-                            OutputValue::TokenV1(token_id, amount)
+                            (
+                                OutputValue::TokenV1(token_id, amount),
+                                TxAdditionalInfo::with_token_info(
+                                    token_id,
+                                    TokenAdditionalInfo {
+                                        num_decimals: token_info.token_number_of_decimals(),
+                                        ticker: token_info.token_ticker().to_vec(),
+                                    },
+                                ),
+                            )
                         }
                         None => {
                             let amount = amount
                                 .to_amount(coin_decimals)
                                 .ok_or(RpcError::InvalidCoinAmount)?;
-                            OutputValue::Coin(amount)
+                            (OutputValue::Coin(amount), TxAdditionalInfo::new())
                         }
                     };
 
                     controller
                         .synced_controller(account_index, config)
                         .await?
-                        .create_htlc_tx(value, htlc, additional_utxo_infos)
+                        .create_htlc_tx(value, htlc, additional_info)
                         .await
                         .map_err(RpcError::Controller)
                 })


### PR DESCRIPTION
Changes made because additional tx info was required for Order input commands to be able to calculate the fees correctly on the hardware wallet side.
- Removed UTXO additional info and made it Tx additional info as it is no longer tied to UTXOs only
- added additional info for order inputs in the trezor messages