### PR TITLE
Wallet handle txs with conflicting account nonces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8988,6 +8988,7 @@ version = "1.0.2"
 dependencies = [
  "bip39",
  "chainstate",
+ "chainstate-test-framework",
  "common",
  "consensus",
  "crypto",

--- a/chainstate/test-framework/src/block_builder.rs
+++ b/chainstate/test-framework/src/block_builder.rs
@@ -210,10 +210,10 @@ impl<'f> BlockBuilder<'f> {
                     }
                     TxInput::Account(outpoint) => {
                         self.account_nonce_tracker
-                            .insert(outpoint.account().clone().into(), outpoint.nonce());
+                            .insert(outpoint.account().into(), outpoint.nonce());
                     }
                     TxInput::AccountCommand(nonce, op) => {
-                        self.account_nonce_tracker.insert(op.clone().into(), *nonce);
+                        self.account_nonce_tracker.insert(op.into(), *nonce);
                     }
                     TxInput::OrderAccountCommand(..) => {}
                 };

--- a/chainstate/test-framework/src/pos_block_builder.rs
+++ b/chainstate/test-framework/src/pos_block_builder.rs
@@ -450,10 +450,10 @@ impl<'f> PoSBlockBuilder<'f> {
                     }
                     TxInput::Account(outpoint) => {
                         self.account_nonce_tracker
-                            .insert(outpoint.account().clone().into(), outpoint.nonce());
+                            .insert(outpoint.account().into(), outpoint.nonce());
                     }
                     TxInput::AccountCommand(nonce, op) => {
-                        self.account_nonce_tracker.insert(op.clone().into(), *nonce);
+                        self.account_nonce_tracker.insert(op.into(), *nonce);
                     }
                     TxInput::OrderAccountCommand(..) => {}
                 };

--- a/chainstate/tx-verifier/src/transaction_verifier/mod.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/mod.rs
@@ -367,7 +367,7 @@ where
                             let res = self
                                 .spend_input_from_account(
                                     outpoint.nonce(),
-                                    outpoint.account().clone().into(),
+                                    outpoint.account().into(),
                                 )
                                 .and_then(|_| {
                                     // If the input spends from delegation account, this means the user is
@@ -496,10 +496,10 @@ where
             match input {
                 TxInput::Utxo(_) | TxInput::OrderAccountCommand(_) => { /* do nothing */ }
                 TxInput::Account(outpoint) => {
-                    self.unspend_input_from_account(outpoint.account().clone().into())?;
+                    self.unspend_input_from_account(outpoint.account().into())?;
                 }
                 TxInput::AccountCommand(_, cmd) => {
-                    self.unspend_input_from_account(cmd.clone().into())?;
+                    self.unspend_input_from_account(cmd.into())?;
                 }
             };
         }
@@ -553,7 +553,7 @@ where
                 TxInput::AccountCommand(nonce, account_op) => match account_op {
                     AccountCommand::MintTokens(token_id, amount) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 self.tokens_accounting_cache
                                     .mint_tokens(*token_id, *amount)
@@ -563,7 +563,7 @@ where
                     }
                     AccountCommand::UnmintTokens(ref token_id) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 // actual amount to unmint is determined by the number of burned tokens in the outputs
                                 let total_burned =
@@ -582,7 +582,7 @@ where
                     }
                     AccountCommand::LockTokenSupply(token_id) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 self.tokens_accounting_cache
                                     .lock_circulating_supply(*token_id)
@@ -592,7 +592,7 @@ where
                     }
                     AccountCommand::FreezeToken(token_id, is_unfreezable) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 self.tokens_accounting_cache
                                     .freeze_token(*token_id, *is_unfreezable)
@@ -602,7 +602,7 @@ where
                     }
                     AccountCommand::UnfreezeToken(token_id) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 self.tokens_accounting_cache
                                     .unfreeze_token(*token_id)
@@ -612,7 +612,7 @@ where
                     }
                     AccountCommand::ChangeTokenAuthority(token_id, new_authority) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 self.tokens_accounting_cache
                                     .change_authority(*token_id, new_authority.clone())
@@ -622,7 +622,7 @@ where
                     }
                     AccountCommand::ChangeTokenMetadataUri(token_id, new_metadata_uri) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 self.tokens_accounting_cache
                                     .change_metadata_uri(*token_id, new_metadata_uri.clone())
@@ -842,7 +842,7 @@ where
                     | AccountCommand::ChangeTokenMetadataUri(..) => None,
                     AccountCommand::ConcludeOrder(order_id) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 self.orders_accounting_cache
                                     .conclude_order(*order_id)
@@ -852,7 +852,7 @@ where
                     }
                     AccountCommand::FillOrder(order_id, fill, _) => {
                         let res = self
-                            .spend_input_from_account(*nonce, account_op.clone().into())
+                            .spend_input_from_account(*nonce, account_op.into())
                             .and_then(|_| {
                                 self.orders_accounting_cache
                                     .fill_order(*order_id, *fill, OrdersVersion::V0)

--- a/common/src/chain/transaction/account_outpoint.rs
+++ b/common/src/chain/transaction/account_outpoint.rs
@@ -36,16 +36,16 @@ pub enum AccountType {
     Order(OrderId),
 }
 
-impl From<AccountSpending> for AccountType {
-    fn from(spending: AccountSpending) -> Self {
+impl From<&AccountSpending> for AccountType {
+    fn from(spending: &AccountSpending) -> Self {
         match spending {
-            AccountSpending::DelegationBalance(id, _) => AccountType::Delegation(id),
+            AccountSpending::DelegationBalance(id, _) => AccountType::Delegation(*id),
         }
     }
 }
 
-impl From<AccountCommand> for AccountType {
-    fn from(op: AccountCommand) -> Self {
+impl From<&AccountCommand> for AccountType {
+    fn from(op: &AccountCommand) -> Self {
         match op {
             AccountCommand::MintTokens(id, _)
             | AccountCommand::UnmintTokens(id)
@@ -53,9 +53,9 @@ impl From<AccountCommand> for AccountType {
             | AccountCommand::FreezeToken(id, _)
             | AccountCommand::UnfreezeToken(id)
             | AccountCommand::ChangeTokenAuthority(id, _)
-            | AccountCommand::ChangeTokenMetadataUri(id, _) => AccountType::Token(id),
+            | AccountCommand::ChangeTokenMetadataUri(id, _) => AccountType::Token(*id),
             AccountCommand::ConcludeOrder(id) | AccountCommand::FillOrder(id, _, _) => {
-                AccountType::Order(id)
+                AccountType::Order(*id)
             }
         }
     }

--- a/mempool/src/pool/entry.rs
+++ b/mempool/src/pool/entry.rs
@@ -63,7 +63,7 @@ impl TxDependency {
     fn from_account(account: &AccountSpending, nonce: AccountNonce) -> Self {
         match account {
             AccountSpending::DelegationBalance(_, _) => {
-                Self::DelegationAccount(TxAccountDependency::new(account.clone().into(), nonce))
+                Self::DelegationAccount(TxAccountDependency::new(account.into(), nonce))
             }
         }
     }
@@ -77,10 +77,10 @@ impl TxDependency {
             | AccountCommand::UnfreezeToken(_)
             | AccountCommand::ChangeTokenMetadataUri(_, _)
             | AccountCommand::ChangeTokenAuthority(_, _) => {
-                Self::TokenSupplyAccount(TxAccountDependency::new(cmd.clone().into(), nonce))
+                Self::TokenSupplyAccount(TxAccountDependency::new(cmd.into(), nonce))
             }
             AccountCommand::ConcludeOrder(_) | AccountCommand::FillOrder(_, _, _) => {
-                Self::OrderAccount(TxAccountDependency::new(cmd.clone().into(), nonce))
+                Self::OrderAccount(TxAccountDependency::new(cmd.into(), nonce))
             }
         }
     }

--- a/mempool/src/pool/mod.rs
+++ b/mempool/src/pool/mod.rs
@@ -378,7 +378,9 @@ impl<'a> TxFinalizer<'a> {
             TxAdditionOutcome::Rejected { transaction, error } => {
                 let tx_id = *transaction.tx_id();
                 let origin = transaction.origin();
-                log::trace!("Rejected transaction {tx_id}, checking orphan status");
+                log::trace!(
+                    "Rejected transaction {tx_id} with error {error}. Checking orphan status"
+                );
 
                 self.try_add_orphan(tx_pool, transaction, error)
                     .inspect_err(|err| match &mut self.events_mode {

--- a/node-gui/src/main_window/main_widget/tabs/wallet/delegation.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/delegation.rs
@@ -87,7 +87,7 @@ pub fn view_delegation(
                 .map(|(del_id, (pool_id, b))| (*del_id, *pool_id, *b))
             {
                 let delegation_address = Address::new(chain_config, delegation_id)
-                    .expect("Encoding pool id to address can't fail (GUI)");
+                    .expect("Encoding delegation id to address can't fail (GUI)");
                 let pool_address = Address::new(chain_config, pool_id)
                     .expect("Encoding pool id to address can't fail (GUI)");
                 let delegate_staking_amount =

--- a/test/functional/wallet_conflict.py
+++ b/test/functional/wallet_conflict.py
@@ -198,7 +198,7 @@ class WalletConflictTransaction(BitcoinTestFramework):
 
             # check we cannot abandon an already confirmed transaction
             assert_in("Success", await wallet.select_account(1))
-            assert_in("Cannot abandon a transaction in Confirmed at height 6", await wallet.abandon_transaction(new_transfer_tx_id))
+            assert_in("Cannot change a transaction's state from Confirmed", await wallet.abandon_transaction(new_transfer_tx_id))
 
 
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -37,7 +37,9 @@ thiserror.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
+chainstate-test-framework = { path = "../chainstate/test-framework" }
 test-utils = { path = "../test-utils" }
+
 serial_test = "3.2"
 
 rstest.workspace = true

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -2120,9 +2120,9 @@ impl<K: AccountKeyChains> Account<K> {
         let conflicting_txs =
             self.output_cache.update_conflicting_txs(confirmed_tx, block.get_id().into())?;
 
-        for tx_id in conflicting_txs {
-            let id = AccountWalletCreatedTxId::new(acc_id.clone(), tx_id);
-            db_tx.del_user_transaction(&id)?;
+        for (tx_id, tx) in conflicting_txs {
+            db_tx.set_transaction(&AccountWalletTxId::new(acc_id.clone(), tx.id()), &tx)?;
+            db_tx.del_user_transaction(&AccountWalletCreatedTxId::new(acc_id.clone(), tx_id))?;
         }
 
         Ok(())
@@ -2282,9 +2282,9 @@ impl<K: AccountKeyChains> Account<K> {
         let abandoned_txs = self.output_cache.abandon_transaction(tx_id)?;
         let acc_id = self.get_account_id();
 
-        for tx_id in abandoned_txs {
-            let id = AccountWalletCreatedTxId::new(acc_id.clone(), tx_id);
-            db_tx.del_user_transaction(&id)?;
+        for (tx_id, tx) in abandoned_txs {
+            db_tx.set_transaction(&AccountWalletTxId::new(acc_id.clone(), tx.id()), &tx)?;
+            db_tx.del_user_transaction(&AccountWalletCreatedTxId::new(acc_id.clone(), tx_id))?;
         }
 
         Ok(())

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -35,7 +35,6 @@ use common::size_estimation::{
 use common::Uint256;
 use crypto::key::hdkd::child_number::ChildNumber;
 use mempool::FeeRate;
-use output_cache::OrderData;
 use serialization::hex_encoded::HexEncoded;
 use utils::ensure;
 pub use utxo_selector::UtxoSelectorError;
@@ -89,7 +88,8 @@ use wallet_types::{
 };
 
 pub use self::output_cache::{
-    DelegationData, OwnFungibleTokenInfo, PoolData, TxInfo, UnconfirmedTokenInfo, UtxoWithTxOutput,
+    DelegationData, OrderData, OwnFungibleTokenInfo, PoolData, TxInfo, UnconfirmedTokenInfo,
+    UtxoWithTxOutput,
 };
 use self::output_cache::{OutputCache, TokenIssuanceData};
 use self::transaction_list::{get_transaction_list, TransactionList};
@@ -885,6 +885,12 @@ impl<K: AccountKeyChains> Account<K> {
             .token_data(token_id)
             .filter(|data| self.is_destination_mine(&data.authority))
             .ok_or(WalletError::UnknownTokenId(*token_id))
+    }
+
+    pub fn get_orders(&self) -> impl Iterator<Item = (&OrderId, &OrderData)> {
+        self.output_cache
+            .orders()
+            .filter(|(_, data)| self.is_destination_mine(&data.conclude_key))
     }
 
     pub fn find_order(&self, order_id: &OrderId) -> WalletResult<&OrderData> {

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -836,9 +836,17 @@ impl OutputCache {
                                 );
                                 Ok(())
                             }
-                            TxState::Abandoned
-                            | TxState::Confirmed(..)
-                            | TxState::Conflicted(..) => {
+                            TxState::Conflicted(..) => {
+                                // It's possible to try to mark descendant as conflicting twice
+                                // because unconfirmed_descendants contains a tx as child and as parent.
+                                // So it's not an error only if done during this function call.
+                                ensure!(
+                                    conflicting_txs_with_descendants.contains(&tx_id),
+                                    WalletError::CannotMarkTxAsConflictedIfInState(*tx.state())
+                                );
+                                Ok(())
+                            }
+                            TxState::Abandoned | TxState::Confirmed(..) => {
                                 Err(WalletError::CannotMarkTxAsConflictedIfInState(*tx.state()))
                             }
                         },

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -1563,7 +1563,7 @@ impl OutputCache {
                     | OrderAccountCommand::FreezeOrder(order_id)
                     | OrderAccountCommand::ConcludeOrder(order_id) => {
                         if let Some(data) = self.orders.get_mut(order_id) {
-                            data.last_parent = find_parent(&unconfirmed_descendants, tx_id.into());
+                            data.last_parent = find_parent(&self.unconfirmed_descendants, &tx_id);
                         }
                     }
                 },
@@ -1932,8 +1932,8 @@ fn uses_conflicting_nonce(
     confirmed_account_type: AccountType,
     confirmed_nonce: AccountNonce,
 ) -> bool {
-    unconfirmed_tx.inputs().iter().any(|inp| match inp {
-        TxInput::Utxo(_) => false,
+    unconfirmed_tx.inputs().iter().any(|input| match input {
+        TxInput::Utxo(_) | TxInput::OrderAccountCommand(_) => false,
         TxInput::AccountCommand(nonce, cmd) => {
             confirmed_account_type == cmd.into() && *nonce <= confirmed_nonce
         }

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -802,7 +802,9 @@ impl OutputCache {
                         confirmed_account_nonce,
                     ) {
                         if let WalletTx::Tx(tx) = unconfirmed_tx {
-                            conflicting_txs.insert(tx.get_transaction().get_id());
+                            if confirmed_tx.get_id() != tx.get_transaction().get_id() {
+                                conflicting_txs.insert(tx.get_transaction().get_id());
+                            }
                         }
                     }
                 }
@@ -813,14 +815,10 @@ impl OutputCache {
         let mut conflicting_txs_with_descendants = vec![];
 
         for conflicting_tx in conflicting_txs {
-            if conflicting_tx != confirmed_tx.get_id() {
-                let descendants = self.remove_descendants_and_mark_as(
-                    conflicting_tx,
-                    TxState::Conflicted(block_id),
-                )?;
+            let descendants =
+                self.remove_descendants_and_mark_as(conflicting_tx, TxState::Conflicted(block_id))?;
 
-                conflicting_txs_with_descendants.extend(descendants.into_iter());
-            }
+            conflicting_txs_with_descendants.extend(descendants.into_iter());
         }
 
         Ok(conflicting_txs_with_descendants)

--- a/wallet/src/account/output_cache/tests.rs
+++ b/wallet/src/account/output_cache/tests.rs
@@ -1,0 +1,247 @@
+// Copyright (c) 2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate_test_framework::{empty_witness, TransactionBuilder};
+use common::{chain::signature::inputsig::InputWitness, primitives::H256};
+use randomness::Rng;
+use rstest::rstest;
+use test_utils::random::{make_seedable_rng, Seed};
+
+use super::*;
+
+// Create a diamond shape dependant unconfirmed txs:
+//
+//  /-->B-->\
+// A         D
+//  \-->C-->/
+//
+// Check the cache.
+// Remove A from unconfirmed descendants. Check the result.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn diamond_unconfirmed_descendants(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let mut output_cache = OutputCache::empty();
+
+    // A
+    let genesis_tx_id = Id::<Transaction>::new(H256::random_using(&mut rng));
+    let tx_a = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(genesis_tx_id.into(), 0),
+            InputWitness::NoSignature(None),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(Amount::from_atoms(rng.gen())),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let tx_a_id = tx_a.transaction().get_id();
+    output_cache
+        .add_tx(
+            tx_a_id.into(),
+            WalletTx::Tx(TxData::new(tx_a, TxState::Inactive(0))),
+        )
+        .unwrap();
+
+    // B
+    let tx_b = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(tx_a_id.into(), 0),
+            empty_witness(&mut rng),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(Amount::from_atoms(rng.gen())),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let tx_b_id = tx_b.transaction().get_id();
+    output_cache
+        .add_tx(
+            tx_b_id.into(),
+            WalletTx::Tx(TxData::new(tx_b, TxState::Inactive(0))),
+        )
+        .unwrap();
+
+    // C
+    let tx_c = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(tx_a_id.into(), 0),
+            empty_witness(&mut rng),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(Amount::from_atoms(rng.gen())),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let tx_c_id = tx_c.transaction().get_id();
+    output_cache
+        .add_tx(
+            tx_c_id.into(),
+            WalletTx::Tx(TxData::new(tx_c, TxState::Inactive(0))),
+        )
+        .unwrap();
+
+    // D
+    let tx_d = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(tx_b_id.into(), 0),
+            empty_witness(&mut rng),
+        )
+        .add_input(
+            TxInput::from_utxo(tx_c_id.into(), 0),
+            empty_witness(&mut rng),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(Amount::from_atoms(rng.gen())),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let tx_d_id = tx_d.transaction().get_id();
+    output_cache
+        .add_tx(
+            tx_d_id.into(),
+            WalletTx::Tx(TxData::new(tx_d, TxState::Inactive(0))),
+        )
+        .unwrap();
+
+    let expected_unconfirmed_descendants = BTreeMap::from_iter([
+        (
+            tx_a_id.into(),
+            BTreeSet::from_iter([tx_b_id.into(), tx_c_id.into()]),
+        ),
+        (tx_b_id.into(), BTreeSet::from_iter([tx_d_id.into()])),
+        (tx_c_id.into(), BTreeSet::from_iter([tx_d_id.into()])),
+        (tx_d_id.into(), BTreeSet::new()),
+    ]);
+    assert_eq!(
+        expected_unconfirmed_descendants,
+        output_cache.unconfirmed_descendants
+    );
+
+    let result = output_cache.remove_from_unconfirmed_descendants(tx_a_id);
+    assert!(
+        (result == vec![tx_a_id, tx_b_id, tx_c_id, tx_d_id])
+            || (result == vec![tx_a_id, tx_c_id, tx_b_id, tx_d_id])
+    );
+    assert!(output_cache.unconfirmed_descendants.is_empty());
+}
+
+// Create 2 unconfirmed txs B and C that spends tokens:
+//
+//  /-->B-->C
+// A
+//  \-->D
+//
+// Freeze token in D.
+// Check that both B and C got marked as conflicted and function doesn't crash.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn conflict_parent_and_child(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let mut output_cache = OutputCache::empty();
+    let token_id = TokenId::random_using(&mut rng);
+
+    // A
+    let genesis_tx_id = Id::<Transaction>::new(H256::random_using(&mut rng));
+    let tx_a = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(genesis_tx_id.into(), 0),
+            InputWitness::NoSignature(None),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::TokenV1(token_id, Amount::from_atoms(rng.gen())),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let tx_a_id = tx_a.transaction().get_id();
+    output_cache
+        .add_tx(
+            tx_a_id.into(),
+            WalletTx::Tx(TxData::new(
+                tx_a,
+                TxState::Confirmed(BlockHeight::zero(), BlockTimestamp::from_int_seconds(0), 0),
+            )),
+        )
+        .unwrap();
+
+    // B
+    let tx_b = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(tx_a_id.into(), 0),
+            empty_witness(&mut rng),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::TokenV1(token_id, Amount::from_atoms(rng.gen())),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let tx_b_id = tx_b.transaction().get_id();
+    output_cache
+        .add_tx(
+            tx_b_id.into(),
+            WalletTx::Tx(TxData::new(tx_b.clone(), TxState::Inactive(0))),
+        )
+        .unwrap();
+
+    // C
+    let tx_c = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(tx_b_id.into(), 0),
+            empty_witness(&mut rng),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::TokenV1(token_id, Amount::from_atoms(rng.gen())),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let tx_c_id = tx_c.transaction().get_id();
+    output_cache
+        .add_tx(
+            tx_c_id.into(),
+            WalletTx::Tx(TxData::new(tx_c.clone(), TxState::Inactive(0))),
+        )
+        .unwrap();
+
+    // D
+    let tx_d = TransactionBuilder::new()
+        .add_input(
+            TxInput::AccountCommand(
+                AccountNonce::new(0),
+                AccountCommand::FreezeToken(token_id, IsTokenUnfreezable::No),
+            ),
+            empty_witness(&mut rng),
+        )
+        .build();
+
+    let block_id = Id::<GenBlock>::new(H256::random_using(&mut rng));
+    let result = output_cache.update_conflicting_txs(tx_d.transaction(), block_id).unwrap();
+    assert_eq!(
+        result,
+        vec![
+            (
+                tx_c_id,
+                WalletTx::Tx(TxData::new(tx_c, TxState::Conflicted(block_id)))
+            ),
+            (
+                tx_b_id,
+                WalletTx::Tx(TxData::new(tx_b, TxState::Conflicted(block_id)))
+            ),
+        ]
+    );
+}

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -18,8 +18,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::account::{
-    transaction_list::TransactionList, CoinSelectionAlgo, CurrentFeeRate, DelegationData, PoolData,
-    TxInfo, UnconfirmedTokenInfo, UtxoSelectorError,
+    transaction_list::TransactionList, CoinSelectionAlgo, CurrentFeeRate, DelegationData,
+    OrderData, PoolData, TxInfo, UnconfirmedTokenInfo, UtxoSelectorError,
 };
 use crate::key_chain::{
     make_account_path, make_path_to_vrf_key, AccountKeyChainImplSoftware, KeyChainError,
@@ -178,8 +178,8 @@ pub enum WalletError {
     NotUtxoInput,
     #[error("Coin selection error: {0}")]
     CoinSelectionError(#[from] UtxoSelectorError),
-    #[error("Cannot abandon a transaction in {0} state")]
-    CannotAbandonTransaction(TxState),
+    #[error("Cannot change a transaction's state from {0} to {1}")]
+    CannotChangeTransactionState(TxState, TxState),
     #[error("Transaction with Id {0} not found")]
     CannotFindTransactionWithId(Id<Transaction>),
     #[error("Address error: {0}")]
@@ -2050,6 +2050,14 @@ where
                 )
             },
         )
+    }
+
+    pub fn get_orders(
+        &self,
+        account_index: U31,
+    ) -> WalletResult<impl Iterator<Item = (&OrderId, &OrderData)>> {
+        let orders = self.get_account(account_index)?.get_orders();
+        Ok(orders)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -281,6 +281,8 @@ pub enum WalletError {
     MismatchedTokenAdditionalData(TokenId),
     #[error("Unsupported operation for a Hardware wallet")]
     UnsupportedHardwareWalletOperation,
+    #[error("Transaction from {0:?} is confirmed and among unconfirmed descendants")]
+    ConfirmedTxAmongUnconfirmedDescendants(OutPointSourceId),
 }
 
 /// Result type used for the wallet

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -180,8 +180,14 @@ pub enum WalletError {
     CoinSelectionError(#[from] UtxoSelectorError),
     #[error("Cannot change a transaction's state from {0} to {1}")]
     CannotChangeTransactionState(TxState, TxState),
+    #[error("Cannot mark as conflicted transaction in {0} state")]
+    CannotMarkTxAsConflictedIfInState(TxState),
     #[error("Transaction with Id {0} not found")]
     CannotFindTransactionWithId(Id<Transaction>),
+    #[error("Transaction with Id {0} cannot map to a block")]
+    TransactionIdCannotMapToBlock(Id<Transaction>),
+    #[error("Descendant transaction with Id {0} not found")]
+    CannotFindDescendantTransactionWithId(Id<Transaction>),
     #[error("Address error: {0}")]
     AddressError(#[from] AddressError),
     #[error("Unknown pool id {0}")]

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -7001,7 +7001,26 @@ fn conflicting_delegation_account_nonce_same_wallet(#[case] seed: Seed) {
 #[case(Seed::from_entropy())]
 fn conflicting_order_account_nonce(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
-    let chain_config = Arc::new(create_unit_test_config());
+    let chain_config = common::chain::config::create_unit_test_config_builder()
+        .chainstate_upgrades(
+            common::chain::NetUpgrades::initialize(vec![(
+                BlockHeight::zero(),
+                common::chain::ChainstateUpgrade::new(
+                    common::chain::TokenIssuanceVersion::V1,
+                    common::chain::RewardDistributionVersion::V1,
+                    common::chain::TokensFeeVersion::V1,
+                    common::chain::DataDepositFeeVersion::V1,
+                    common::chain::ChangeTokenMetadataUriActivated::Yes,
+                    common::chain::FrozenTokensValidationVersion::V1,
+                    common::chain::HtlcActivated::Yes,
+                    common::chain::OrdersActivated::Yes,
+                    common::chain::OrdersVersion::V0,
+                ),
+            )])
+            .expect("cannot fail"),
+        )
+        .build();
+    let chain_config = Arc::new(chain_config);
 
     let mut wallet = create_wallet(chain_config.clone());
 

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -3935,17 +3935,17 @@ fn lock_then_transfer(#[case] seed: Seed) {
     scan_wallet(&mut wallet, BlockHeight::new(1), vec![block2]);
 
     // check balance
-    let balance_without_locked_transer =
+    let balance_without_locked_transfer =
         ((block1_amount * 2).unwrap() - amount_to_lock_then_transfer).unwrap();
 
     let coin_balance = get_coin_balance(&wallet);
-    assert_eq!(coin_balance, balance_without_locked_transer);
+    assert_eq!(coin_balance, balance_without_locked_transfer);
 
     // check that for block_count_lock, the amount is not included
     for idx in 0..block_count_lock {
         let coin_balance = get_coin_balance(&wallet);
         // check that the amount is still not unlocked
-        assert_eq!(coin_balance, balance_without_locked_transer);
+        assert_eq!(coin_balance, balance_without_locked_transfer);
 
         let currency_balances = wallet
             .get_balance(
@@ -3978,7 +3978,7 @@ fn lock_then_transfer(#[case] seed: Seed) {
     let coin_balance = get_coin_balance(&wallet);
     assert_eq!(
         coin_balance,
-        (balance_without_locked_transer + amount_to_lock_then_transfer).unwrap()
+        (balance_without_locked_transfer + amount_to_lock_then_transfer).unwrap()
     );
 }
 
@@ -4327,15 +4327,15 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
 
     assert_eq!(abandonable_transactions.len(), transactions.len());
 
-    let txs_to_abandone = rng.gen_range(0..total_num_transactions) as usize;
-    let (txs_to_keep, txs_to_abandone) = transactions.split_at(txs_to_abandone);
+    let txs_to_abandon = rng.gen_range(0..total_num_transactions) as usize;
+    let (txs_to_keep, txs_to_abandon) = transactions.split_at(txs_to_abandon);
 
-    assert!(!txs_to_abandone.is_empty());
+    assert!(!txs_to_abandon.is_empty());
 
-    let transaction_id = txs_to_abandone.first().unwrap().0.transaction().get_id();
+    let transaction_id = txs_to_abandon.first().unwrap().0.transaction().get_id();
     wallet.abandon_transaction(DEFAULT_ACCOUNT_INDEX, transaction_id).unwrap();
 
-    let coins_after_abandon = txs_to_abandone.first().unwrap().1;
+    let coins_after_abandon = txs_to_abandon.first().unwrap().1;
 
     let coin_balance = get_coin_balance_with_inactive(&wallet);
     assert_eq!(coin_balance, coins_after_abandon);
@@ -4345,7 +4345,7 @@ fn wallet_abandone_transactions(#[case] seed: Seed) {
     let coin_balance = get_coin_balance_with_inactive(&wallet);
     assert_eq!(coin_balance, coins_after_abandon);
 
-    // Abandone the same tx again
+    // Abandon the same tx again
     let result = wallet.abandon_transaction(DEFAULT_ACCOUNT_INDEX, transaction_id);
     assert_eq!(
         result.unwrap_err(),
@@ -6728,7 +6728,7 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
         )
     );
 
-    // Abandone conflicting txs
+    // Abandon conflicting txs
     wallet
         .abandon_transaction(DEFAULT_ACCOUNT_INDEX, spend_from_delegation_tx_1_id)
         .unwrap();
@@ -6991,9 +6991,9 @@ fn conflicting_delegation_account_nonce_same_tx(#[case] seed: Seed) {
     );
 }
 
-// Issue and mint some tokens
-// Create an order selling tokens for coins
-// Create 2 fill order txs and add them to a wallet as unconfirmed
+// Issue and mint some tokens.
+// Create an order selling tokens for coins.
+// Create 2 fill order txs and add them to a wallet as unconfirmed.
 // Confirm the first tx in a block and check that it is accounted in confirmed balance
 // and also that unconfirmed balance has second tx.
 #[rstest]
@@ -7126,7 +7126,7 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
     };
 
     let spend_coins_1 = Amount::from_atoms(10);
-    let recieved_tokens_1 = spend_coins_1;
+    let received_tokens_1 = spend_coins_1;
     let fill_order_tx_1 = wallet
         .create_fill_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -7163,7 +7163,7 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
     };
 
     let spend_coins_2 = Amount::from_atoms(3);
-    let recieved_tokens_2 = spend_coins_2;
+    let received_tokens_2 = spend_coins_2;
     let fill_order_tx_2 = wallet
         .create_fill_order_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -7237,7 +7237,7 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
         UtxoState::Confirmed.into(),
         WithLocked::Any,
     );
-    assert_eq!(token_balance_confirmed, recieved_tokens_1);
+    assert_eq!(token_balance_confirmed, received_tokens_1);
 
     let token_balance_unconfirmed = get_balance_with(
         &wallet,
@@ -7247,6 +7247,6 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
     );
     assert_eq!(
         token_balance_unconfirmed,
-        (recieved_tokens_1 + recieved_tokens_2).unwrap()
+        (received_tokens_1 + received_tokens_2).unwrap()
     );
 }

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -6740,6 +6740,12 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
         TxState::Abandoned
     );
 
+    let mut delegations = wallet.get_delegations(DEFAULT_ACCOUNT_INDEX).unwrap().collect_vec();
+    assert_eq!(delegations.len(), 1);
+    let (deleg_id, deleg_data) = delegations.pop().unwrap();
+    assert_eq!(*deleg_id, delegation_id);
+    assert_eq!(deleg_data.last_nonce, Some(AccountNonce::new(0)));
+
     wallet
         .abandon_transaction(DEFAULT_ACCOUNT_INDEX, spend_from_delegation_tx_2_id)
         .unwrap();
@@ -6750,6 +6756,12 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
             .state(),
         TxState::Abandoned
     );
+
+    let mut delegations = wallet.get_delegations(DEFAULT_ACCOUNT_INDEX).unwrap().collect_vec();
+    assert_eq!(delegations.len(), 1);
+    let (deleg_id, deleg_data) = delegations.pop().unwrap();
+    assert_eq!(*deleg_id, delegation_id);
+    assert_eq!(deleg_data.last_nonce, Some(AccountNonce::new(0)));
 }
 
 // Create a pool and a delegation with some share.

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -7252,7 +7252,7 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
 }
 
 // Create a pool and a delegation with some share.
-// Create tx that spend from delegation account multiple times in a single tx. Add it as unconfirmed.
+// Create a tx that spends from delegation account multiple times. Add it as unconfirmed.
 // Check confirmed/unconfirmed balance and ensure that account nonce is incremented in OutputCache.
 // Create a tx via separate wallet that spends from the same delegation once.
 // Submit the second tx in a block.
@@ -7521,7 +7521,7 @@ fn conflicting_delegation_account_nonce_multiple_inputs(#[case] seed: Seed) {
 }
 
 // Create a pool and a delegation with some share.
-// Create tx that spend from delegation account and it as unconfirmed.
+// Create a tx that spends from delegation account and add it as unconfirmed.
 // Revert the latest block in the wallet.
 // Create a tx via separate wallet that spends from the same delegation once. Submit the second tx in a block.
 // Check that the first tx was not removed by reorg and is marked as conflicting and the state was properly reversed.

--- a/wallet/types/src/wallet_tx.rs
+++ b/wallet/types/src/wallet_tx.rs
@@ -84,16 +84,6 @@ impl TxState {
             TxState::Abandoned => "Abandoned",
         }
     }
-
-    pub fn is_abandoned(&self) -> bool {
-        match self {
-            TxState::Abandoned => true,
-            TxState::Confirmed(_, _, _)
-            | TxState::Conflicted(_)
-            | TxState::InMempool(_)
-            | TxState::Inactive(_) => false,
-        }
-    }
 }
 
 impl Display for TxState {


### PR DESCRIPTION
Unconfirmed txs in the wallet which uses outdated nonce are marked as conflicted now if confirmed tx is encountered on mainchain and the state of OutputCache is updated accordingly. 

The behaviour is similar to abandoning tx.

Besides tests I had a wallet with conflicting orders which I couldn't open previously because of `InconsistentOrderDuplicateNonce` which is now resolved.