### PR TITLE
Misc improvements in node gui.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4828,6 +4828,7 @@ dependencies = [
  "chrono",
  "common",
  "futures",
+ "heck 0.5.0",
  "iced",
  "iced_aw",
  "iced_fonts",

--- a/common/src/chain/config/regtest_options.rs
+++ b/common/src/chain/config/regtest_options.rs
@@ -36,7 +36,7 @@ use super::{regtest::GenesisStakingSettings, ChainConfig};
 use anyhow::{anyhow, ensure, Result};
 use paste::paste;
 
-#[derive(Args, Clone, Debug)]
+#[derive(Args, Clone, Debug, Default)]
 pub struct ChainConfigOptions {
     /// Magic bytes.
     #[clap(long)]

--- a/dns-server/src/main.rs
+++ b/dns-server/src/main.rs
@@ -108,7 +108,7 @@ async fn run(options: DnsServerRunOptions) -> anyhow::Result<Never> {
 
     let data_dir = prepare_data_dir(
         || default_data_dir_for_chain(chain_type.name()),
-        &config.datadir,
+        config.datadir.as_ref(),
         None,
     )
     .expect("Failed to prepare data directory");

--- a/node-daemon/src/main.rs
+++ b/node-daemon/src/main.rs
@@ -15,7 +15,7 @@
 
 pub async fn run() -> anyhow::Result<()> {
     let opts = node_lib::Options::from_args(std::env::args_os());
-    let setup_result = node_lib::setup(opts).await?;
+    let setup_result = node_lib::setup(opts.with_resolved_command()).await?;
     match setup_result {
         node_lib::NodeSetupResult::Node(node) => {
             node.main().await;

--- a/node-gui/Cargo.toml
+++ b/node-gui/Cargo.toml
@@ -27,6 +27,7 @@ wallet-cli-commands = { path = "../wallet/wallet-cli-commands"}
 anyhow.workspace = true
 chrono.workspace = true
 futures.workspace = true
+heck.workspace = true
 iced = { workspace = true, features = ["canvas", "debug", "tokio", "lazy"] }
 iced_aw = { workspace = true }
 iced_fonts = { workspace = true, features = ["bootstrap"] }

--- a/node-lib/src/lib.rs
+++ b/node-lib/src/lib.rs
@@ -25,10 +25,11 @@ mod runner;
 pub type Error = anyhow::Error;
 
 use chainstate_launcher::ChainConfig;
+
 pub use config_files::{
     NodeConfigFile, NodeTypeConfigFile, RpcConfigFile, StorageBackendConfigFile,
 };
-pub use options::{Command, Options, RunOptions};
+pub use options::{Command, Options, OptionsWithResolvedCommand, RunOptions, TopLevelOptions};
 pub use runner::{setup, NodeSetupResult};
 
 pub fn default_rpc_config(chain_config: &ChainConfig) -> RpcConfigFile {

--- a/node-lib/tests/cli.rs
+++ b/node-lib/tests/cli.rs
@@ -161,7 +161,6 @@ fn read_config_override_values() {
         min_tx_relay_fee_rate: Some(min_tx_relay_fee_rate),
         force_allow_run_as_root_outer: Default::default(),
         enable_chainstate_heavy_checks: Some(enable_chainstate_heavy_checks),
-        log_to_file: Some(false),
     };
     let config = NodeConfigFile::read(&chain_config, &config_path, &options).unwrap();
 

--- a/test/src/bin/test_node.rs
+++ b/test/src/bin/test_node.rs
@@ -18,7 +18,7 @@ use std::env;
 #[tokio::main]
 async fn main() -> Result<(), node_lib::Error> {
     let opts = node_lib::Options::from_args(env::args_os());
-    let setup_result = node_lib::setup(opts).await?;
+    let setup_result = node_lib::setup(opts.with_resolved_command()).await?;
     let node = match setup_result {
         node_lib::NodeSetupResult::Node(node) => node,
         node_lib::NodeSetupResult::DataDirCleanedUp => {

--- a/utils/src/default_data_dir.rs
+++ b/utils/src/default_data_dir.rs
@@ -59,7 +59,7 @@ pub enum PrepareDataDirError {
 /// Additionally, `create_data_dir_if_missing` allows to override the default behavior.
 pub fn prepare_data_dir<F: Fn() -> PathBuf>(
     default_data_dir_getter: F,
-    datadir_path_opt: &Option<PathBuf>,
+    datadir_path_opt: Option<&PathBuf>,
     create_data_dir_if_missing: Option<bool>,
 ) -> Result<PathBuf, PrepareDataDirError> {
     let (data_dir, create_if_missing_default) = match datadir_path_opt {
@@ -109,12 +109,12 @@ mod test {
         assert!(!supposed_default_dir.is_dir());
 
         // The call must fail if create_data_dir_if_missing is explicitly set to false.
-        let _err = prepare_data_dir(default_data_dir_getter, &None, Some(false)).unwrap_err();
+        let _err = prepare_data_dir(default_data_dir_getter, None, Some(false)).unwrap_err();
 
         // With create_data_dir_if_missing equal to None or true, the call must succeed.
-        let returned_data_dir1 = prepare_data_dir(default_data_dir_getter, &None, None).unwrap();
+        let returned_data_dir1 = prepare_data_dir(default_data_dir_getter, None, None).unwrap();
         let returned_data_dir2 =
-            prepare_data_dir(default_data_dir_getter, &None, Some(true)).unwrap();
+            prepare_data_dir(default_data_dir_getter, None, Some(true)).unwrap();
         assert_eq!(returned_data_dir1, returned_data_dir2);
 
         // The default directory must be returned.
@@ -137,11 +137,11 @@ mod test {
         test_file_data(&file_path, &file_data);
 
         // Now we prepare again, and ensure that our file is unchanged
-        let returned_data_dir1 = prepare_data_dir(default_data_dir_getter, &None, None).unwrap();
+        let returned_data_dir1 = prepare_data_dir(default_data_dir_getter, None, None).unwrap();
         let returned_data_dir2 =
-            prepare_data_dir(default_data_dir_getter, &None, Some(true)).unwrap();
+            prepare_data_dir(default_data_dir_getter, None, Some(true)).unwrap();
         let returned_data_dir3 =
-            prepare_data_dir(default_data_dir_getter, &None, Some(false)).unwrap();
+            prepare_data_dir(default_data_dir_getter, None, Some(false)).unwrap();
         assert_eq!(returned_data_dir1, returned_data_dir2);
         assert_eq!(returned_data_dir1, returned_data_dir3);
 
@@ -167,15 +167,11 @@ mod test {
         assert!(!supposed_custom_dir.is_dir());
 
         // The calls fail because the directory doesn't exist
+        let _err = prepare_data_dir(default_data_dir_getter, Some(&supposed_custom_dir), None)
+            .unwrap_err();
         let _err = prepare_data_dir(
             default_data_dir_getter,
-            &Some(supposed_custom_dir.clone()),
-            None,
-        )
-        .unwrap_err();
-        let _err = prepare_data_dir(
-            default_data_dir_getter,
-            &Some(supposed_custom_dir.clone()),
+            Some(&supposed_custom_dir),
             Some(false),
         )
         .unwrap_err();
@@ -187,7 +183,7 @@ mod test {
         // Now set create_data_dir_if_missing to true, the directory should be created.
         let returned_data_dir = prepare_data_dir(
             default_data_dir_getter,
-            &Some(supposed_custom_dir.clone()),
+            Some(&supposed_custom_dir),
             Some(true),
         )
         .unwrap();
@@ -204,15 +200,11 @@ mod test {
 
         // Passing None or false for create_data_dir_if_missing now also works, because the directory
         // already exists.
-        let returned_data_dir1 = prepare_data_dir(
-            default_data_dir_getter,
-            &Some(supposed_custom_dir.clone()),
-            None,
-        )
-        .unwrap();
+        let returned_data_dir1 =
+            prepare_data_dir(default_data_dir_getter, Some(&supposed_custom_dir), None).unwrap();
         let returned_data_dir2 = prepare_data_dir(
             default_data_dir_getter,
-            &Some(supposed_custom_dir.clone()),
+            Some(&supposed_custom_dir),
             Some(false),
         )
         .unwrap();
@@ -239,21 +231,17 @@ mod test {
         test_file_data(&file_path, &file_data);
 
         // Now we prepare again, and ensure that our file is unchanged
-        let returned_data_dir1 = prepare_data_dir(
-            default_data_dir_getter,
-            &Some(supposed_custom_dir.clone()),
-            None,
-        )
-        .unwrap();
+        let returned_data_dir1 =
+            prepare_data_dir(default_data_dir_getter, Some(&supposed_custom_dir), None).unwrap();
         let returned_data_dir2 = prepare_data_dir(
             default_data_dir_getter,
-            &Some(supposed_custom_dir.clone()),
+            Some(&supposed_custom_dir),
             Some(false),
         )
         .unwrap();
         let returned_data_dir3 = prepare_data_dir(
             default_data_dir_getter,
-            &Some(supposed_custom_dir.clone()),
+            Some(&supposed_custom_dir),
             Some(true),
         )
         .unwrap();


### PR DESCRIPTION
A bunch of minor improvements in node-gui:
* When the network type is passed from the command line, the app will actually use it, without asking the user.
* Some `expect`s were replaced with errors to avoid crashes, e.g. when a second node is started with a separate data directory but the same p2p listening port.
I also tried improving the error messages a bit, though they're still not very specific (e.g. if the port is busy, it'll say "Error subscribing to P2P events: Callee subsystem did not respond").
* Logging is now initialized in the cold mode too (only the console logging is enabled though). The app will also print a warning to the log when the log-to-file or clean-data options are specified in the cold mode.
* The message "Data directory is now clean ... Please restart the node" is no longer shown as an error.
* The log-to-file option was moved from `RunOptions` to the top-level options, as we discussed. (The clean-data option is still in `RunOptions`)
* I also prettified `MintlayerNodeGUI` a bit and renamed it to GuiState.