### PR TITLE
Minor cleanup of the docker compose example files

### DIFF
--- a/build-tools/docker/example-mainnet-dns-server/.env
+++ b/build-tools/docker/example-mainnet-dns-server/.env
@@ -4,10 +4,8 @@ COMPOSE_PROJECT_NAME=mintlayer-mainnet-dns-server
 
 # Dockerhub username, from which the docker images will be pulled.
 DOCKERHUB_USERNAME=mintlayer
-# The version of mintlayer binaries to use.
-# This will be used together with DOCKERHUB_USERNAME to form full names of docker images
-# (i.e. $DOCKERHUB_USERNAME/image_name:$ML_SOFTWARE_VERSION)
-ML_SOFTWARE_VERSION=0.5.1
+# The image tag to use, e.g. "v1.0.2" or "latest".
+IMAGE_TAG=latest
 
 # The user and group ids that will be used to run the software.
 ML_USER_ID=10001

--- a/build-tools/docker/example-mainnet-dns-server/docker-compose.yml
+++ b/build-tools/docker/example-mainnet-dns-server/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3'
-
 services:
   dns-server:
-    image: $DOCKERHUB_USERNAME/dns-server:$ML_SOFTWARE_VERSION
+    image: $DOCKERHUB_USERNAME/dns-server:$IMAGE_TAG
+    # Force pull the images on each invocation of docker compose.
+    pull_policy: always
     volumes:
       - ./mintlayer-data:/home/mintlayer
     command: dns-server

--- a/build-tools/docker/example-mainnet-dns-server/docker-compose.yml
+++ b/build-tools/docker/example-mainnet-dns-server/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   dns-server:
     image: $DOCKERHUB_USERNAME/dns-server:$IMAGE_TAG
-    # Force pull the images on each invocation of docker compose.
-    pull_policy: always
     volumes:
       - ./mintlayer-data:/home/mintlayer
     command: dns-server

--- a/build-tools/docker/example-mainnet/.env
+++ b/build-tools/docker/example-mainnet/.env
@@ -4,10 +4,8 @@ COMPOSE_PROJECT_NAME=mintlayer-mainnet
 
 # Dockerhub username, from which the docker images will be pulled.
 DOCKERHUB_USERNAME=mintlayer
-# The version of mintlayer binaries to use.
-# This will be used together with DOCKERHUB_USERNAME to form full names of docker images
-# (i.e. $DOCKERHUB_USERNAME/image_name:$ML_SOFTWARE_VERSION)
-ML_SOFTWARE_VERSION=0.5.1
+# The image tag to use, e.g. "v1.0.2" or "latest".
+IMAGE_TAG=latest
 
 # The user and group ids that will be used to run the software.
 ML_USER_ID=10001

--- a/build-tools/docker/example-mainnet/docker-compose.yml
+++ b/build-tools/docker/example-mainnet/docker-compose.yml
@@ -1,10 +1,6 @@
 x-common: &ml-common
   volumes:
     - ./mintlayer-data:/home/mintlayer
-  # Force pull the images on each invocation of docker compose.
-  # Note: this is mostly needed when IMAGE_TAG is set to "latest"; without it you may end up using
-  # an older version of an image if you happened to pull another "latest" version of it in the past.
-  pull_policy: always
 
 x-common-env: &ml-common-env
   RUST_LOG:
@@ -123,14 +119,14 @@ services:
   wallet-cli:
     <<: *ml-common
     image: $DOCKERHUB_USERNAME/wallet-cli:$IMAGE_TAG
-    command: wallet-cli mainnet
+    command: wallet-cli
     depends_on:
       - node-daemon
     environment:
       <<: *ml-common-env
-      ML_MAINNET_WALLET_NODE_RPC_ADDRESS: node-daemon:3030
-      ML_MAINNET_WALLET_NODE_RPC_USERNAME: $NODE_RPC_USERNAME
-      ML_MAINNET_WALLET_NODE_RPC_PASSWORD: $NODE_RPC_PASSWORD
+      ML_WALLET_REMOTE_RPC_WALLET_ADDRESS: wallet-rpc-daemon:3034
+      ML_WALLET_REMOTE_RPC_WALLET_USERNAME: $WALLET_RPC_DAEMON_USERNAME
+      ML_WALLET_REMOTE_RPC_WALLET_PASSWORD: $WALLET_RPC_DAEMON_PASSWORD
     profiles:
       # Put it in a separate profile, so that it's not started automatically by "docker compose up".
       - wallet_cli

--- a/build-tools/docker/example-mainnet/docker-compose.yml
+++ b/build-tools/docker/example-mainnet/docker-compose.yml
@@ -1,8 +1,10 @@
-version: '3'
-
 x-common: &ml-common
   volumes:
     - ./mintlayer-data:/home/mintlayer
+  # Force pull the images on each invocation of docker compose.
+  # Note: this is mostly needed when IMAGE_TAG is set to "latest"; without it you may end up using
+  # an older version of an image if you happened to pull another "latest" version of it in the past.
+  pull_policy: always
 
 x-common-env: &ml-common-env
   RUST_LOG:
@@ -12,7 +14,7 @@ x-common-env: &ml-common-env
 services:
   node-daemon:
     <<: *ml-common
-    image: $DOCKERHUB_USERNAME/node-daemon:$ML_SOFTWARE_VERSION
+    image: $DOCKERHUB_USERNAME/node-daemon:$IMAGE_TAG
     command: node-daemon mainnet
     environment:
       <<: *ml-common-env
@@ -60,7 +62,7 @@ services:
 
   api-blockchain-scanner-daemon:
     <<: *ml-common
-    image: $DOCKERHUB_USERNAME/api-blockchain-scanner-daemon:$ML_SOFTWARE_VERSION
+    image: $DOCKERHUB_USERNAME/api-blockchain-scanner-daemon:$IMAGE_TAG
     command: api-blockchain-scanner-daemon
     depends_on:
       - api-postgres-db
@@ -77,7 +79,7 @@ services:
 
   api-web-server:
     <<: *ml-common
-    image: $DOCKERHUB_USERNAME/api-web-server:$ML_SOFTWARE_VERSION
+    image: $DOCKERHUB_USERNAME/api-web-server:$IMAGE_TAG
     command: api-web-server
     depends_on:
       - api-postgres-db
@@ -99,7 +101,7 @@ services:
 
   wallet-rpc-daemon:
     <<: *ml-common
-    image: $DOCKERHUB_USERNAME/wallet-rpc-daemon:$ML_SOFTWARE_VERSION
+    image: $DOCKERHUB_USERNAME/wallet-rpc-daemon:$IMAGE_TAG
     command: wallet-rpc-daemon mainnet
     depends_on:
       - node-daemon
@@ -120,7 +122,7 @@ services:
   # to run it via "docker compose run"
   wallet-cli:
     <<: *ml-common
-    image: $DOCKERHUB_USERNAME/wallet-cli:$ML_SOFTWARE_VERSION
+    image: $DOCKERHUB_USERNAME/wallet-cli:$IMAGE_TAG
     command: wallet-cli mainnet
     depends_on:
       - node-daemon

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -917,7 +917,7 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
     ) -> WRpcResult<NewTransaction, N> {
         let delegation_id = delegation_id
             .decode_object(&self.chain_config)
-            .map_err(|_| RpcError::InvalidPoolId)?;
+            .map_err(|_| RpcError::InvalidDelegationId)?;
         let destination_address = destination_address
             .into_address(self.chain_config())
             .map_err(|_| RpcError::InvalidAddress)?;


### PR DESCRIPTION
* `ML_SOFTWARE_VERSION` was renamed to `IMAGE_TAG` and set to `latest` by default.
* The obsolete "version" property was removed.
* ~`pull_policy: always` was added to make sure that "latest" images are indeed the latest ones.~ I reverted this.
* wallet-cli now connects to wallet-rpc-daemon and not to the node directly.
* `sweep_delegation` in wallet-rpc-lib used to return a wrong error type on invalid delegation id, this is also fixed.