### PR TITLE
A few fixes in node gui related to the `iced` upgrade 

### DIFF
--- a/node-gui/src/widgets/esc_handler.rs
+++ b/node-gui/src/widgets/esc_handler.rs
@@ -1,0 +1,172 @@
+// Copyright (c) 2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use iced::{
+    advanced::{
+        layout, renderer,
+        widget::{tree, Operation, Tree},
+        Clipboard, Layout, Shell, Widget,
+    },
+    event, keyboard,
+    mouse::{self},
+    overlay, Element, Event, Length, Rectangle, Size, Vector,
+};
+
+/// Wrap an element, capturing Esc key press events and optionally emitting the specified message
+/// on each key press.
+///
+/// Note: the Esc key press events will be consumed even if msg_to_emit is None.
+pub fn esc_handler<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+    msg_to_emit: Option<Message>,
+) -> Element<'a, Message, Theme, Renderer>
+where
+    Message: Clone + 'a,
+    Theme: 'a,
+    Renderer: iced::advanced::Renderer + 'a,
+{
+    Element::new(EscHandler {
+        content: content.into(),
+        msg_to_emit,
+    })
+}
+
+struct EscHandler<'a, Message, Theme, Renderer> {
+    content: Element<'a, Message, Theme, Renderer>,
+    msg_to_emit: Option<Message>,
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for EscHandler<'_, Message, Theme, Renderer>
+where
+    Renderer: iced::advanced::Renderer,
+    Message: Clone,
+{
+    fn tag(&self) -> tree::Tag {
+        self.content.as_widget().tag()
+    }
+
+    fn state(&self) -> tree::State {
+        self.content.as_widget().state()
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        self.content.as_widget().children()
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        self.content.as_widget().diff(tree);
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
+    }
+
+    fn size_hint(&self) -> Size<Length> {
+        self.content.as_widget().size_hint()
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.content.as_widget().layout(tree, renderer, limits)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.content
+            .as_widget()
+            .draw(tree, renderer, theme, style, layout, cursor, viewport);
+    }
+
+    fn operate(
+        &self,
+        state: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        self.content.as_widget().operate(state, layout, renderer, operation);
+    }
+
+    fn on_event(
+        &mut self,
+        state: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        let event_captured = match &event {
+            Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
+                if *key == keyboard::Key::Named(keyboard::key::Named::Escape) {
+                    if let Some(msg) = &self.msg_to_emit {
+                        shell.publish(msg.clone());
+                    }
+
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+
+        if event_captured {
+            event::Status::Captured
+        } else {
+            self.content.as_widget_mut().on_event(
+                state, event, layout, cursor, renderer, clipboard, shell, viewport,
+            )
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content
+            .as_widget()
+            .mouse_interaction(state, layout, cursor, viewport, renderer)
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        state: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content.as_widget_mut().overlay(state, layout, renderer, translation)
+    }
+}

--- a/node-gui/src/widgets/mod.rs
+++ b/node-gui/src/widgets/mod.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 pub mod confirm_broadcast;
+pub mod esc_handler;
 pub mod new_wallet_account;
+pub mod opaque;
 pub mod popup_dialog;
 pub mod wallet_mnemonic;
 pub mod wallet_set_password;

--- a/node-gui/src/widgets/opaque.rs
+++ b/node-gui/src/widgets/opaque.rs
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use iced::{
+    advanced::{
+        layout, renderer,
+        widget::{tree, Operation, Tree},
+        Clipboard, Layout, Shell, Widget,
+    },
+    event,
+    mouse::{self},
+    overlay, Element, Event, Length, Rectangle, Size, Vector,
+};
+
+/// Wrap the given widget and capture any mouse events inside its bounds, effectively making it 'opaque'.
+///
+/// This helper is meant to be used to mark elements in a `Stack` to avoid mouse
+/// events from passing through layers.
+///
+/// Note: iced already has `opaque`, but their version only captures mouse presses. So e.g. tooltips
+/// under an "opaque" element would still receive mouse hover events. Our version of `opaque` captures
+/// all mouse events.
+pub fn opaque<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: iced::advanced::Renderer + 'a,
+{
+    Element::new(Opaque {
+        content: content.into(),
+    })
+}
+
+struct Opaque<'a, Message, Theme, Renderer> {
+    content: Element<'a, Message, Theme, Renderer>,
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Opaque<'_, Message, Theme, Renderer>
+where
+    Renderer: iced::advanced::Renderer,
+{
+    fn tag(&self) -> tree::Tag {
+        self.content.as_widget().tag()
+    }
+
+    fn state(&self) -> tree::State {
+        self.content.as_widget().state()
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        self.content.as_widget().children()
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        self.content.as_widget().diff(tree);
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.content.as_widget().size()
+    }
+
+    fn size_hint(&self) -> Size<Length> {
+        self.content.as_widget().size_hint()
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        self.content.as_widget().layout(tree, renderer, limits)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.content
+            .as_widget()
+            .draw(tree, renderer, theme, style, layout, cursor, viewport);
+    }
+
+    fn operate(
+        &self,
+        state: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        self.content.as_widget().operate(state, layout, renderer, operation);
+    }
+
+    fn on_event(
+        &mut self,
+        state: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        if let event::Status::Captured = self.content.as_widget_mut().on_event(
+            state, event, layout, cursor, renderer, clipboard, shell, viewport,
+        ) {
+            return event::Status::Captured;
+        }
+
+        if cursor.is_over(layout.bounds()) {
+            event::Status::Captured
+        } else {
+            event::Status::Ignored
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        let interaction = self
+            .content
+            .as_widget()
+            .mouse_interaction(state, layout, cursor, viewport, renderer);
+
+        if interaction == mouse::Interaction::None && cursor.is_over(layout.bounds()) {
+            mouse::Interaction::Idle
+        } else {
+            interaction
+        }
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        state: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content.as_widget_mut().overlay(state, layout, renderer, translation)
+    }
+}

--- a/node-gui/src/widgets/wallet_mnemonic.rs
+++ b/node-gui/src/widgets/wallet_mnemonic.rs
@@ -114,7 +114,7 @@ impl<Message> Component<Message, Theme, iced::Renderer> for WalletMnemonicDialog
                     .into()
             } else {
                 Row::new()
-                    .push(text(mnemonic.clone()))
+                    .push(text(mnemonic.clone()).width(Length::Fill).center())
                     .push(
                         Button::new(
                             Text::new(iced_fonts::Bootstrap::ClipboardCheck.to_string())


### PR DESCRIPTION
1) Add `esc_handler`, which creates a wrapper for an `Element` that captures Esc key presses.

2) Use an `opaque` wrapper instead of the separate Button-based element on the stack to prevent mouse events from reaching elements under a dialog.
(the problem with the button was that it would change the mouse cursor to a "finger", which looked strange.)
The `opaque` wrapper that comes with `iced` didn't work well enough though, because it only captures mouse clicks but not hovering (the button-based solution had the same problem btw). So e.g. main window tooltips would still respond to mouse movement when a dialog was opened. So I had to add a custom variant of `opaque` that captures all mouse events.

3) Use semi-transparent white color as the background for the `opaque` element, to make the ui under an opened dialog look blurred, like it was before the `iced` upgrade.

4) Fix a minor issue with the "new mnemonic" dialog, where the "copy to clipboard" button would not be laid out properly.
E.g. before:
![new_mnemonic_bad_layout](https://github.com/user-attachments/assets/4850ed16-e0f8-4ad1-aa4e-42625146f777)
And after:
![new_mnemonic_fixed_layout](https://github.com/user-attachments/assets/c84651e8-a794-49c5-9102-e566b9ac873a)

5) Add background to the "File dialog..." element.
Before:
![file_dialog_old_no_bg](https://github.com/user-attachments/assets/e87d618d-8945-4560-91d5-83e14d60a21a)
After (here the dialog is also blurred because a file dialog is open):
![file_dialog_new_with_bg](https://github.com/user-attachments/assets/feb9d6d3-4ad3-4881-8bf6-b027e0de7db1)

6) I also got rid of the useless element `Text::new("Nothing to show")`, which wasn't supposed to be shown anyway.