### PR TITLE
Don't wait for wallet syncing when opening in GUI

### DIFF
--- a/node-gui/backend/src/backend_impl.rs
+++ b/node-gui/backend/src/backend_impl.rs
@@ -42,7 +42,8 @@ use wallet_controller::{
 use wallet_rpc_client::handles_client::WalletRpcHandlesClient;
 use wallet_rpc_lib::{EventStream, WalletRpc, WalletService};
 use wallet_types::{
-    seed_phrase::StoreSeedPhrase, wallet_type::WalletType, with_locked::WithLocked,
+    scan_blockchain::ScanBlockchain, seed_phrase::StoreSeedPhrase, wallet_type::WalletType,
+    with_locked::WithLocked,
 };
 
 use super::{
@@ -527,7 +528,7 @@ impl Backend {
         let chain_config = wallet_service.chain_config().clone();
         let wallet_rpc = WalletRpc::new(wallet_handle, node_rpc.clone(), chain_config.clone());
         wallet_rpc
-            .open_wallet(file_path, None, false)
+            .open_wallet(file_path, None, false, ScanBlockchain::ScanNoWait)
             .await
             .map_err(|err| BackendError::WalletError(err.to_string()))?;
         tokio::spawn(forward_events(

--- a/test/functional/wallet_orders.py
+++ b/test/functional/wallet_orders.py
@@ -70,6 +70,7 @@ class WalletOrders(BitcoinTestFramework):
     async def switch_to_wallet(self, wallet, wallet_name):
         await wallet.close_wallet()
         await wallet.open_wallet(wallet_name)
+        await wallet.sync()
 
     def run_test(self):
         if 'win32' in sys.platform:

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -146,7 +146,12 @@ impl<N: NodeInterface + Clone + Send + Sync + Debug + 'static> WalletInterface
         force_migrate_wallet_type: Option<bool>,
     ) -> Result<(), Self::Error> {
         self.wallet_rpc
-            .open_wallet(path, password, force_migrate_wallet_type.unwrap_or(false))
+            .open_wallet(
+                path,
+                password,
+                force_migrate_wallet_type.unwrap_or(false),
+                ScanBlockchain::ScanAndWait,
+            )
             .await
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -154,13 +154,19 @@ impl<N: NodeInterface + Clone + Send + Sync + 'static> WalletRpc<N> {
         wallet_path: PathBuf,
         password: Option<String>,
         force_migrate_wallet_type: bool,
+        scan_blockchain: ScanBlockchain,
     ) -> WRpcResult<(), N> {
         Ok(self
             .wallet
             .manage_async(move |wallet_manager| {
                 Box::pin(async move {
                     wallet_manager
-                        .open_wallet(wallet_path, password, force_migrate_wallet_type)
+                        .open_wallet(
+                            wallet_path,
+                            password,
+                            force_migrate_wallet_type,
+                            scan_blockchain,
+                        )
                         .await
                 })
             })

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -101,7 +101,7 @@ impl<N: NodeInterface + Clone + Send + Sync + Debug + 'static> ColdWalletRpcServ
                 whether_to_store_seed_phrase,
                 mnemonic,
                 passphrase,
-                ScanBlockchain::ScanAndWait,
+                ScanBlockchain::ScanNoWait,
             )
             .await
             .map(Into::<CreatedWallet>::into),
@@ -119,6 +119,7 @@ impl<N: NodeInterface + Clone + Send + Sync + Debug + 'static> ColdWalletRpcServ
                 path.into(),
                 password,
                 force_migrate_wallet_type.unwrap_or(false),
+                ScanBlockchain::ScanNoWait,
             )
             .await,
         )


### PR DESCRIPTION
We no longer wait for the wallet to sync with the blokchain if opened through the GUI or RPC.

Closes #1877 