### PR TITLE
Add option to not show QR code in Wallet CLI

### DIFF
--- a/node-gui/backend/src/backend_impl.rs
+++ b/node-gui/backend/src/backend_impl.rs
@@ -387,6 +387,7 @@ impl Backend {
                 broadcast_to_mempool: true,
             },
             WalletRpcHandlesClient::new(wallet_rpc.clone(), None),
+            None,
         )
         .await;
         let best_block = wallet_rpc
@@ -545,6 +546,7 @@ impl Backend {
                 broadcast_to_mempool: true,
             },
             WalletRpcHandlesClient::new(wallet_rpc.clone(), None),
+            None,
         )
         .await;
         let encryption_state = match wallet_rpc.remove_private_key_encryption().await {

--- a/wallet/wallet-cli-lib/src/cli_event_loop.rs
+++ b/wallet/wallet-cli-lib/src/cli_event_loop.rs
@@ -52,6 +52,7 @@ pub async fn run<N: NodeInterface + Clone + Send + Sync + Debug + 'static>(
     in_top_x_mb: usize,
     wallet_type: WalletType<N>,
     cold_wallet: bool,
+    no_qr: bool,
 ) -> Result<(), WalletCliError<N>> {
     match wallet_type {
         WalletType::Local {
@@ -95,6 +96,7 @@ pub async fn run<N: NodeInterface + Clone + Send + Sync + Debug + 'static>(
                     broadcast_to_mempool: true,
                 },
                 wallet,
+                Some(no_qr),
             )
             .await;
 
@@ -126,6 +128,7 @@ pub async fn run<N: NodeInterface + Clone + Send + Sync + Debug + 'static>(
                     broadcast_to_mempool: true,
                 },
                 wallet,
+                Some(no_qr),
             )
             .await;
 

--- a/wallet/wallet-cli-lib/src/config.rs
+++ b/wallet/wallet-cli-lib/src/config.rs
@@ -182,6 +182,10 @@ pub struct CliArgs {
     /// For a remote RPC wallet, this will not use any authentication
     #[arg(long, conflicts_with_all(["remote_rpc_wallet_password", "remote_rpc_wallet_username", "remote_rpc_wallet_cookie_file"]))]
     pub remote_rpc_wallet_no_authentication: bool,
+
+    /// Disable QR code output for wallet commands
+    #[arg(long)]
+    pub no_qr: bool,
 }
 
 impl From<&Network> for ChainType {

--- a/wallet/wallet-cli-lib/src/lib.rs
+++ b/wallet/wallet-cli-lib/src/lib.rs
@@ -155,6 +155,7 @@ async fn start_hot_wallet(
         cli_args.node_rpc_address.clone().unwrap_or(default_addr)
     };
 
+    let no_qr = cli_args.no_qr;
     let (repl_handle, wallet_rpc_config) =
         setup_events_and_repl(cli_args, mode, output, input, event_tx, chain_type)?;
 
@@ -168,6 +169,7 @@ async fn start_hot_wallet(
             wallet_rpc_config,
         },
         false,
+        no_qr,
     )
     .await?;
     Ok(repl_handle.join().expect("Should not panic")?)
@@ -183,6 +185,7 @@ async fn start_cold_wallet(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (event_tx, event_rx) = mpsc::unbounded_channel();
 
+    let no_qr = cli_args.no_qr;
     let (repl_handle, wallet_rpc_config) = setup_events_and_repl(
         cli_args,
         mode,
@@ -201,6 +204,7 @@ async fn start_cold_wallet(
             wallet_rpc_config,
         },
         true,
+        no_qr,
     )
     .await?;
     Ok(repl_handle.join().expect("Should not panic")?)
@@ -241,6 +245,7 @@ async fn connect_to_rpc_wallet(
         _ => panic!("Should not happen due to arg constraints"),
     };
 
+    let no_qr = cli_args.no_qr;
     let remote_socket_address = cli_args.remote_rpc_wallet_address.clone().expect("checked");
     let (repl_handle, _wallet_rpc_config) =
         setup_events_and_repl(cli_args, mode, output, input, event_tx, chain_type)?;
@@ -254,6 +259,7 @@ async fn connect_to_rpc_wallet(
             rpc_auth,
         },
         false,
+        no_qr,
     )
     .await?;
     Ok(repl_handle.join().expect("Should not panic")?)

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -121,6 +121,7 @@ impl CliTestFramework {
                     remote_rpc_wallet_password: None,
                     remote_rpc_wallet_cookie_file: None,
                     remote_rpc_wallet_no_authentication: true,
+                    no_qr: false,
                 },
             }))),
             run_options: wallet_cli_lib::config::CliArgs {
@@ -150,6 +151,7 @@ impl CliTestFramework {
                 remote_rpc_wallet_password: None,
                 remote_rpc_wallet_cookie_file: None,
                 remote_rpc_wallet_no_authentication: true,
+                no_qr: false,
             },
         };
 


### PR DESCRIPTION
Add a startup option for Wallet CLI to disable the output of QR codes in responses.

Closes #1859 