### PR TITLE
refactor the use of SigHashType::ALL

### DIFF
--- a/api-server/stack-test-suite/tests/v2/address.rs
+++ b/api-server/stack-test-suite/tests/v2/address.rs
@@ -123,7 +123,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -195,7 +195,7 @@ async fn multiple_outputs_to_single_address(#[case] seed: Seed) {
                 previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -363,7 +363,7 @@ async fn test_unlocking_for_locked_utxos(#[case] seed: Seed) {
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -435,7 +435,7 @@ async fn test_unlocking_for_locked_utxos(#[case] seed: Seed) {
                 previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -611,7 +611,7 @@ async fn ok(#[case] seed: Seed) {
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -666,7 +666,7 @@ async fn ok(#[case] seed: Seed) {
                     previous_witness = InputWitness::Standard(
                         StandardInputSignature::produce_uniparty_signature_for_input(
                             &alice_sk,
-                            SigHashType::try_from(SigHashType::ALL).unwrap(),
+                            SigHashType::all(),
                             alice_destination.clone(),
                             &transaction,
                             &[Some(&previous_tx_out)],

--- a/api-server/stack-test-suite/tests/v2/address_all_utxos.rs
+++ b/api-server/stack-test-suite/tests/v2/address_all_utxos.rs
@@ -122,7 +122,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -198,7 +198,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
                 previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -372,7 +372,7 @@ async fn ok(#[case] seed: Seed) {
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -450,7 +450,7 @@ async fn ok(#[case] seed: Seed) {
                     previous_witness = InputWitness::Standard(
                         StandardInputSignature::produce_uniparty_signature_for_input(
                             &alice_sk,
-                            SigHashType::try_from(SigHashType::ALL).unwrap(),
+                            SigHashType::all(),
                             alice_destination.clone(),
                             &transaction,
                             &[Some(&previous_tx_out)],

--- a/api-server/stack-test-suite/tests/v2/address_spendable_utxos.rs
+++ b/api-server/stack-test-suite/tests/v2/address_spendable_utxos.rs
@@ -125,7 +125,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -200,7 +200,7 @@ async fn multiple_utxos_to_single_address(#[case] seed: Seed) {
                 previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -374,7 +374,7 @@ async fn ok(#[case] seed: Seed) {
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction,
                         &[Some(&previous_tx_out)],
@@ -442,7 +442,7 @@ async fn ok(#[case] seed: Seed) {
                     previous_witness = InputWitness::Standard(
                         StandardInputSignature::produce_uniparty_signature_for_input(
                             &alice_sk,
-                            SigHashType::try_from(SigHashType::ALL).unwrap(),
+                            SigHashType::all(),
                             alice_destination.clone(),
                             &transaction,
                             &[Some(&previous_tx_out)],

--- a/api-server/stack-test-suite/tests/v2/htlc.rs
+++ b/api-server/stack-test-suite/tests/v2/htlc.rs
@@ -126,7 +126,7 @@ async fn spend(#[case] seed: Seed) {
 
                 let input_sign = produce_uniparty_signature_for_htlc_input(
                     &bob_sk,
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     Destination::PublicKeyHash((&PublicKey::from_private_key(&bob_sk)).into()),
                     &tx2,
                     &[Some(&tx_1.transaction().outputs()[0])],
@@ -282,7 +282,7 @@ async fn refund(#[case] seed: Seed) {
                         AuthorizedClassicalMultisigSpend::new_empty(refund_challenge);
 
                     let sighash = signature_hash(
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         &tx2,
                         &[Some(&tx_1.transaction().outputs()[0])],
                         0,
@@ -301,7 +301,7 @@ async fn refund(#[case] seed: Seed) {
                 let input_sign = produce_classical_multisig_signature_for_htlc_input(
                     &chain_config,
                     &authorization,
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     &tx2,
                     &[Some(&tx_1.transaction().outputs()[0])],
                     0,

--- a/api-server/stack-test-suite/tests/v2/nft.rs
+++ b/api-server/stack-test-suite/tests/v2/nft.rs
@@ -124,7 +124,7 @@ async fn ok(#[case] seed: Seed) {
                     let sig = InputWitness::Standard(
                         StandardInputSignature::produce_uniparty_signature_for_input(
                             &alice_sk,
-                            SigHashType::try_from(SigHashType::ALL).unwrap(),
+                            SigHashType::all(),
                             alice_destination.clone(),
                             &tx,
                             &[issue_nft_tx.outputs().first()],

--- a/api-server/stack-test-suite/tests/v2/statistics.rs
+++ b/api-server/stack-test-suite/tests/v2/statistics.rs
@@ -161,7 +161,7 @@ async fn ok_tokens(#[case] seed: Seed) {
                 let token_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &mint_transaction,
                         &[Some(&issue_token_transaction.outputs()[0]), None],

--- a/api-server/stack-test-suite/tests/v2/transaction.rs
+++ b/api-server/stack-test-suite/tests/v2/transaction.rs
@@ -102,7 +102,7 @@ async fn multiple_tx_in_same_block(#[case] seed: Seed) {
                 let mut previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &signed_tx1,
                         &[Some(&previous_tx_out)],
@@ -149,7 +149,7 @@ async fn multiple_tx_in_same_block(#[case] seed: Seed) {
                 previous_witness = InputWitness::Standard(
                     StandardInputSignature::produce_uniparty_signature_for_input(
                         &alice_sk,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         alice_destination.clone(),
                         &transaction2,
                         &[Some(&previous_tx_out)],

--- a/chainstate/test-framework/src/key_manager.rs
+++ b/chainstate/test-framework/src/key_manager.rs
@@ -156,8 +156,7 @@ impl KeyManager {
             Destination::AnyoneCanSpend => Some(InputWitness::NoSignature(None)),
             Destination::PublicKey(pub_key) => {
                 let private_key = self.public_keys.get(pub_key).unwrap();
-                let sighash_type =
-                    SigHashType::try_from(SigHashType::ALL).expect("Should not fail");
+                let sighash_type = SigHashType::all();
 
                 let sig = StandardInputSignature::produce_uniparty_signature_for_input(
                     private_key,
@@ -174,8 +173,7 @@ impl KeyManager {
             }
             Destination::PublicKeyHash(pub_key) => {
                 let private_key = self.public_key_hashes.get(pub_key).unwrap();
-                let sighash_type =
-                    SigHashType::try_from(SigHashType::ALL).expect("Should not fail");
+                let sighash_type = SigHashType::all();
 
                 let sig = StandardInputSignature::produce_uniparty_signature_for_input(
                     private_key,
@@ -195,8 +193,7 @@ impl KeyManager {
                 let challenge = multisig.challenge(chain_config);
                 let mut current_signatures =
                     AuthorizedClassicalMultisigSpend::new_empty(challenge.clone());
-                let sighash_type =
-                    SigHashType::try_from(SigHashType::ALL).expect("Should not fail");
+                let sighash_type = SigHashType::all();
 
                 let sighash = signature_hash(sighash_type, tx, inputs_utxos, input_num).unwrap();
 

--- a/chainstate/test-suite/src/tests/htlc.rs
+++ b/chainstate/test-suite/src/tests/htlc.rs
@@ -144,7 +144,7 @@ fn spend_htlc_with_secret(#[case] seed: Seed) {
 
             let input_sign = produce_uniparty_signature_for_htlc_input(
                 &test_fixture.alice_sk,
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
+                SigHashType::all(),
                 Destination::PublicKeyHash(
                     (&PublicKey::from_private_key(&test_fixture.alice_sk)).into(),
                 ),
@@ -191,7 +191,7 @@ fn spend_htlc_with_secret(#[case] seed: Seed) {
 
             let input_sign = StandardInputSignature::produce_uniparty_signature_for_input(
                 &test_fixture.bob_sk,
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
+                SigHashType::all(),
                 Destination::PublicKeyHash(
                     (&PublicKey::from_private_key(&test_fixture.bob_sk)).into(),
                 ),
@@ -239,7 +239,7 @@ fn spend_htlc_with_secret(#[case] seed: Seed) {
 
             let input_sign = produce_uniparty_signature_for_htlc_input(
                 &test_fixture.bob_sk,
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
+                SigHashType::all(),
                 Destination::PublicKeyHash(
                     (&PublicKey::from_private_key(&test_fixture.bob_sk)).into(),
                 ),
@@ -283,7 +283,7 @@ fn spend_htlc_with_secret(#[case] seed: Seed) {
 
         let input_sign = produce_uniparty_signature_for_htlc_input(
             &test_fixture.bob_sk,
-            SigHashType::try_from(SigHashType::ALL).unwrap(),
+            SigHashType::all(),
             Destination::PublicKeyHash((&PublicKey::from_private_key(&test_fixture.bob_sk)).into()),
             &tx,
             &[Some(&tx_1.transaction().outputs()[0])],
@@ -352,7 +352,7 @@ fn refund_htlc(#[case] seed: Seed) {
                     AuthorizedClassicalMultisigSpend::new_empty(refund_challenge.clone());
 
                 let sighash = signature_hash(
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     &tx,
                     &[Some(&tx_1.transaction().outputs()[0])],
                     0,
@@ -371,7 +371,7 @@ fn refund_htlc(#[case] seed: Seed) {
             let input_sign = produce_classical_multisig_signature_for_htlc_input(
                 &chain_config,
                 &authorization,
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
+                SigHashType::all(),
                 &tx,
                 &[Some(&tx_1.transaction().outputs()[0])],
                 0,
@@ -423,7 +423,7 @@ fn refund_htlc(#[case] seed: Seed) {
                     AuthorizedClassicalMultisigSpend::new_empty(refund_challenge.clone());
 
                 let sighash = signature_hash(
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     &tx,
                     &[Some(&tx_1.transaction().outputs()[0])],
                     0,
@@ -437,10 +437,8 @@ fn refund_htlc(#[case] seed: Seed) {
                 AuthorizedHashedTimelockContractSpend::Multisig(authorization.encode())
             };
 
-            let input_sign = StandardInputSignature::new(
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
-                authorization.encode(),
-            );
+            let input_sign =
+                StandardInputSignature::new(SigHashType::all(), authorization.encode());
 
             let result = tf
                 .make_block_builder()
@@ -480,7 +478,7 @@ fn refund_htlc(#[case] seed: Seed) {
                     AuthorizedClassicalMultisigSpend::new_empty(refund_challenge.clone());
 
                 let sighash = signature_hash(
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     &tx,
                     &[Some(&tx_1.transaction().outputs()[0])],
                     0,
@@ -494,10 +492,8 @@ fn refund_htlc(#[case] seed: Seed) {
                 AuthorizedHashedTimelockContractSpend::Multisig(authorization.encode())
             };
 
-            let input_sign = StandardInputSignature::new(
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
-                authorization.encode(),
-            );
+            let input_sign =
+                StandardInputSignature::new(SigHashType::all(), authorization.encode());
 
             let result = tf
                 .make_block_builder()
@@ -535,7 +531,7 @@ fn refund_htlc(#[case] seed: Seed) {
             let mut authorization = AuthorizedClassicalMultisigSpend::new_empty(refund_challenge);
 
             let sighash = signature_hash(
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
+                SigHashType::all(),
                 &tx,
                 &[Some(&tx_1.transaction().outputs()[0])],
                 0,
@@ -554,7 +550,7 @@ fn refund_htlc(#[case] seed: Seed) {
         let input_sign = produce_classical_multisig_signature_for_htlc_input(
             &chain_config,
             &authorization,
-            SigHashType::try_from(SigHashType::ALL).unwrap(),
+            SigHashType::all(),
             &tx,
             &[Some(&tx_1.transaction().outputs()[0])],
             0,
@@ -843,7 +839,7 @@ fn spend_tokens(#[case] seed: Seed) {
 
         let input_sign = produce_uniparty_signature_for_htlc_input(
             &test_fixture.bob_sk,
-            SigHashType::try_from(SigHashType::ALL).unwrap(),
+            SigHashType::all(),
             Destination::PublicKeyHash((&PublicKey::from_private_key(&test_fixture.bob_sk)).into()),
             &tx,
             &[Some(&mint_token_v1_tx.transaction().outputs()[0])],

--- a/chainstate/test-suite/src/tests/pos_processing_tests.rs
+++ b/chainstate/test-suite/src/tests/pos_processing_tests.rs
@@ -2132,7 +2132,7 @@ fn pos_decommission_genesis_pool(#[case] seed: Seed) {
 
         let input_sign = StandardInputSignature::produce_uniparty_signature_for_input(
             &genesis_staking_sk,
-            SigHashType::try_from(SigHashType::ALL).unwrap(),
+            SigHashType::all(),
             Destination::PublicKey(genesis_staking_pk),
             &tx,
             &[Some(input_utxo.output())],

--- a/chainstate/test-suite/src/tests/processing_tests.rs
+++ b/chainstate/test-suite/src/tests/processing_tests.rs
@@ -1458,7 +1458,7 @@ fn spend_timelocked_signed_output(#[case] seed: Seed) {
             let tx = {
                 let input_sign = StandardInputSignature::produce_uniparty_signature_for_input(
                     &private_key,
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     Destination::PublicKey(public_key.clone()),
                     &tx_2,
                     &[Some(&tx_1.transaction().outputs()[0])],
@@ -1512,7 +1512,7 @@ fn spend_timelocked_signed_output(#[case] seed: Seed) {
                     PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
                 let input_sign = StandardInputSignature::produce_uniparty_signature_for_input(
                     &random_private_key,
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     Destination::PublicKey(random_public_key),
                     &tx_2,
                     &[Some(&tx_1.transaction().outputs()[0])],
@@ -1540,7 +1540,7 @@ fn spend_timelocked_signed_output(#[case] seed: Seed) {
         let tx = {
             let input_sign = StandardInputSignature::produce_uniparty_signature_for_input(
                 &private_key,
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
+                SigHashType::all(),
                 Destination::PublicKey(public_key),
                 &tx_2,
                 &[Some(&tx_1.transaction().outputs()[0])],

--- a/chainstate/test-suite/src/tests/signature_tests.rs
+++ b/chainstate/test-suite/src/tests/signature_tests.rs
@@ -124,7 +124,7 @@ fn signed_tx(#[case] seed: Seed) {
                 SignedTransaction::new(
                     tx.clone(),
                     vec![InputWitness::Standard(StandardInputSignature::new(
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         gen_random_bytes(&mut rng, 100, 200),
                     ))],
                 )
@@ -154,7 +154,7 @@ fn signed_tx(#[case] seed: Seed) {
             let tx_2 = {
                 let input_sign = StandardInputSignature::produce_uniparty_signature_for_input(
                     &private_key,
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     Destination::PublicKey(public_key),
                     &tx,
                     &[Some(&tx_1.transaction().outputs()[0])],
@@ -242,7 +242,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
             let mut authorization = AuthorizedClassicalMultisigSpend::new_empty(challenge);
 
             let sighash = signature_hash(
-                SigHashType::try_from(SigHashType::ALL).unwrap(),
+                SigHashType::all(),
                 &tx,
                 &[Some(&tx_1.transaction().outputs()[0])],
                 0,
@@ -291,7 +291,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
                 SignedTransaction::new(
                     tx.clone(),
                     vec![InputWitness::Standard(StandardInputSignature::new(
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         gen_random_bytes(&mut rng, 100, 200),
                     ))],
                 )
@@ -322,7 +322,7 @@ fn signed_classical_multisig_tx(#[case] seed: Seed) {
                     StandardInputSignature::produce_classical_multisig_signature_for_input(
                         &chain_config,
                         &authorization,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         &tx,
                         &[Some(&tx_1.transaction().outputs()[0])],
                         0,
@@ -411,7 +411,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
         let mut authrorizations = vec![authorization.clone()];
 
         let sighash = signature_hash(
-            SigHashType::try_from(SigHashType::ALL).unwrap(),
+            SigHashType::all(),
             &tx,
             &[Some(&tx_1.transaction().outputs()[0])],
             0,
@@ -433,7 +433,7 @@ fn signed_classical_multisig_tx_missing_sigs(#[case] seed: Seed) {
                     StandardInputSignature::produce_classical_multisig_signature_for_input(
                         &chain_config,
                         &authorization,
-                        SigHashType::try_from(SigHashType::ALL).unwrap(),
+                        SigHashType::all(),
                         &tx,
                         &[Some(&tx_1.transaction().outputs()[0])],
                         0,

--- a/common/src/chain/block/block_body/mod.rs
+++ b/common/src/chain/block/block_body/mod.rs
@@ -104,10 +104,7 @@ mod tests {
                 let witness_size = rng.next_u32();
                 let witness_size = 1 + witness_size % 1000;
                 let witness = generate_random_bytes(rng, witness_size as usize);
-                InputWitness::Standard(StandardInputSignature::new(
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
-                    witness,
-                ))
+                InputWitness::Standard(StandardInputSignature::new(SigHashType::all(), witness))
             })
             .collect::<Vec<_>>()
     }

--- a/common/src/chain/transaction/signature/inputsig/classical_multisig/encode_decode_multisig_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/classical_multisig/encode_decode_multisig_spend.rs
@@ -44,7 +44,7 @@ pub fn encode_multisig_spend(
         None => sig_component.encode(),
     };
 
-    let sighash_type = SigHashType::try_from(SigHashType::ALL).expect("Should not fail");
+    let sighash_type = SigHashType::all();
     StandardInputSignature::new(sighash_type, raw_signature)
 }
 

--- a/common/src/chain/transaction/signature/sighash/hashable.rs
+++ b/common/src/chain/transaction/signature/sighash/hashable.rs
@@ -205,7 +205,7 @@ mod tests {
             assert!(hashable_inputs
                 .signature_hash(
                     &mut stream,
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     &inputs[index_to_hash],
                     index_to_hash,
                 )
@@ -215,7 +215,7 @@ mod tests {
             assert_eq!(
                 hashable_inputs.signature_hash(
                     &mut stream,
-                    SigHashType::try_from(SigHashType::ALL).unwrap(),
+                    SigHashType::all(),
                     &inputs[index_to_hash],
                     inputs_count,
                 ),

--- a/common/src/chain/transaction/signature/sighash/sighashtype.rs
+++ b/common/src/chain/transaction/signature/sighash/sighashtype.rs
@@ -32,6 +32,10 @@ impl SigHashType {
     const MASK_OUT: u8 = 0x7f;
     const MASK_IN: u8 = 0x80;
 
+    pub fn all() -> Self {
+        Self(Self::ALL)
+    }
+
     pub fn inputs_mode(&self) -> InputsMode {
         match self.0 & Self::MASK_IN {
             Self::ANYONECANPAY => InputsMode::AnyoneCanPay,

--- a/common/src/chain/transaction/signature/tests/mod.rs
+++ b/common/src/chain/transaction/signature/tests/mod.rs
@@ -251,7 +251,7 @@ fn mutate_all(#[case] seed: Seed) {
 
     let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
     let outpoint_dest = Destination::PublicKey(public_key);
-    let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
+    let sighash_type = SigHashType::all();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
     let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
     let original_tx = sign_mutate_then_verify(

--- a/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
+++ b/common/src/chain/transaction/signature/tests/sign_and_mutate.rs
@@ -122,7 +122,7 @@ fn modify_and_verify(#[case] seed: Seed) {
     let destination = Destination::PublicKey(public_key);
 
     {
-        let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
+        let sighash_type = SigHashType::all();
         let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, 3);
         let inputs_utxos_refs = inputs_utxos.iter().map(|utxo| utxo.as_ref()).collect::<Vec<_>>();
         let tx = sign_mutate_then_verify(
@@ -371,7 +371,7 @@ fn mutate_all(#[case] seed: Seed) {
 
     let (private_key, public_key) = PrivateKey::new_from_rng(&mut rng, KeyKind::Secp256k1Schnorr);
     let destination = Destination::PublicKey(public_key);
-    let sighash_type = SigHashType::try_from(SigHashType::ALL).unwrap();
+    let sighash_type = SigHashType::all();
     let (inputs_utxos, _priv_keys) = generate_inputs_utxos(&mut rng, INPUTS);
     let tx = generate_and_sign_tx(
         &chain_config,

--- a/common/src/size_estimation/mod.rs
+++ b/common/src/size_estimation/mod.rs
@@ -91,10 +91,7 @@ mod multisig_signature_size_impl {
                 let raw_signature =
                     AuthorizedClassicalMultisigSpend::new(signatures, challenge).encode();
 
-                let standard = StandardInputSignature::new(
-                    SigHashType::try_from(SigHashType::ALL).expect("should not fail"),
-                    raw_signature,
-                );
+                let standard = StandardInputSignature::new(SigHashType::all(), raw_signature);
                 let size = InputWitness::Standard(standard).encoded_size();
                 *entry.insert(size)
             }
@@ -115,7 +112,7 @@ lazy_static::lazy_static! {
         let raw_signature =
             AuthorizedPublicKeySpend::new(BOGUS_KEY_PAIR_AND_SIGNATURE.2.clone()).encode();
         let standard = StandardInputSignature::new(
-            SigHashType::try_from(SigHashType::ALL).expect("should not fail"),
+            SigHashType::all(),
             raw_signature,
         );
         InputWitness::Standard(standard).encoded_size()
@@ -130,7 +127,7 @@ lazy_static::lazy_static! {
         )
         .encode();
         let standard = StandardInputSignature::new(
-            SigHashType::try_from(SigHashType::ALL).expect("should not fail"),
+            SigHashType::all(),
             raw_signature,
         );
         InputWitness::Standard(standard).encoded_size()

--- a/mempool/src/pool/tx_pool/tests/accumulator.rs
+++ b/mempool/src/pool/tx_pool/tests/accumulator.rs
@@ -544,7 +544,7 @@ async fn timelocked_htlc_refund(
         let mut authorization = AuthorizedClassicalMultisigSpend::new_empty(refund_challenge);
 
         let sighash = signature_hash(
-            SigHashType::try_from(SigHashType::ALL).unwrap(),
+            SigHashType::all(),
             &tx,
             &[Some(&tx0.transaction().outputs()[0])],
             0,
@@ -563,7 +563,7 @@ async fn timelocked_htlc_refund(
     let input_sign = produce_classical_multisig_signature_for_htlc_input(
         &chain_config,
         &authorization,
-        SigHashType::try_from(SigHashType::ALL).unwrap(),
+        SigHashType::all(),
         &tx,
         &[Some(&tx0.transaction().outputs()[0])],
         0,

--- a/wallet/src/signer/software_signer/mod.rs
+++ b/wallet/src/signer/software_signer/mod.rs
@@ -111,8 +111,7 @@ impl<'a, T: WalletStorageReadUnlocked> SoftwareSigner<'a, T> {
                 let sig = self
                     .get_private_key_for_destination(destination, key_chain)?
                     .map(|private_key| {
-                        let sighash_type =
-                            SigHashType::try_from(SigHashType::ALL).expect("Should not fail");
+                        let sighash_type = SigHashType::all();
                         match htlc_secret {
                             Some(htlc_secret) => produce_uniparty_signature_for_htlc_input(
                                 &private_key,
@@ -183,7 +182,7 @@ impl<'a, T: WalletStorageReadUnlocked> SoftwareSigner<'a, T> {
         SignatureStatus,
         SignatureStatus,
     )> {
-        let sighash_type = SigHashType::try_from(SigHashType::ALL).expect("Should not fail");
+        let sighash_type = SigHashType::all();
 
         let challenge = current_signatures.challenge().clone();
         let sighash = signature_hash(sighash_type, tx, input_utxos, input_index)?;


### PR DESCRIPTION
add a method all() to SigHasType to avoid the try_from + except or unwrap around the code