### PR TITLE
Add selection of trezor device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8994,6 +8994,7 @@ dependencies = [
  "crossterm",
  "crypto",
  "directories",
+ "dyn-clone",
  "futures",
  "hex",
  "humantime",

--- a/node-gui/src/main_window/mod.rs
+++ b/node-gui/src/main_window/mod.rs
@@ -722,10 +722,7 @@ impl MainWindow {
                         }
                     }
                     #[cfg(feature = "trezor")]
-                    WalletArgs::Trezor => WalletTypeArgs::Trezor {
-                        device_name: None,
-                        device_id: None,
-                    },
+                    WalletArgs::Trezor => WalletTypeArgs::Trezor { device_id: None },
                 };
 
                 self.file_dialog_active = true;

--- a/node-gui/src/main_window/mod.rs
+++ b/node-gui/src/main_window/mod.rs
@@ -645,6 +645,20 @@ impl MainWindow {
                             backend_sender,
                         )
                         .map(MainWindowMessage::MainWidgetMessage),
+                    ConsoleCommand::ChoiceMenu(menu) => self
+                        .main_widget
+                        .update(
+                            MainWidgetMessage::TabsMessage(TabsMessage::WalletMessage(
+                                wallet_id,
+                                WalletMessage::ConsoleOutput(format!(
+                                    "{}\n{}",
+                                    menu.header(),
+                                    menu.completion_list().join("\n")
+                                )),
+                            )),
+                            backend_sender,
+                        )
+                        .map(MainWindowMessage::MainWidgetMessage),
                     ConsoleCommand::ClearScreen
                     | ConsoleCommand::ClearHistory
                     | ConsoleCommand::PrintHistory
@@ -708,7 +722,10 @@ impl MainWindow {
                         }
                     }
                     #[cfg(feature = "trezor")]
-                    WalletArgs::Trezor => WalletTypeArgs::Trezor,
+                    WalletArgs::Trezor => WalletTypeArgs::Trezor {
+                        device_name: None,
+                        device_id: None,
+                    },
                 };
 
                 self.file_dialog_active = true;

--- a/wallet/src/signer/trezor_signer/mod.rs
+++ b/wallet/src/signer/trezor_signer/mod.rs
@@ -116,22 +116,7 @@ pub struct FoundDevice {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SelectedDevice {
-    pub name: Option<String>,
-    pub device_id: Option<String>,
-}
-
-impl PartialEq<FoundDevice> for SelectedDevice {
-    fn eq(&self, other: &FoundDevice) -> bool {
-        self.name.as_ref().is_none_or(|name| name == &other.name)
-            && self.device_id.as_ref().is_none_or(|id| id == &other.device_id)
-    }
-}
-
-impl SelectedDevice {
-    const NONE: Self = SelectedDevice {
-        name: None,
-        device_id: None,
-    };
+    pub device_id: String,
 }
 
 /// Signer errors
@@ -139,6 +124,8 @@ impl SelectedDevice {
 pub enum TrezorError {
     #[error("No connected Trezor device found")]
     NoDeviceFound,
+    #[error("No compatible Trezor device found with Mintlayer compatibilities")]
+    NoCompatibleDeviceFound,
     #[error("There are multiple connected Trezor devices found {0:?}")]
     NoUniqueDeviceFound(Vec<FoundDevice>),
     #[error("Cannot get the supported features for the connected Trezor device")]
@@ -208,7 +195,7 @@ impl TrezorSigner {
             Err(trezor_client::Error::TransportSendMessage(
                 trezor_client::transport::error::Error::Usb(rusb::Error::Io),
             )) => {
-                let selected = SelectedDevice::NONE;
+                let selected = None;
                 let (mut new_client, data, session_id) = find_trezor_device(selected)?;
 
                 check_public_keys_against_key_chain(
@@ -1454,7 +1441,7 @@ impl std::fmt::Debug for TrezorSignerProvider {
 }
 
 impl TrezorSignerProvider {
-    pub fn new(selected: SelectedDevice) -> Result<Self, TrezorError> {
+    pub fn new(selected: Option<SelectedDevice>) -> Result<Self, TrezorError> {
         let (client, data, session_id) = find_trezor_device(selected)?;
 
         Ok(Self {
@@ -1468,17 +1455,16 @@ impl TrezorSignerProvider {
         chain_config: Arc<ChainConfig>,
         db_tx: &impl WalletStorageReadLocked,
     ) -> WalletResult<Self> {
-        let selected = SelectedDevice::NONE;
+        let selected = None;
         let (client, data, session_id) = match find_trezor_device(selected) {
             Ok(data) => (data.0, data.1, data.2),
             Err(TrezorError::NoUniqueDeviceFound(_)) => {
                 if let Some(HardwareWalletData::Trezor(data)) = db_tx.get_hardware_wallet_data()? {
                     let selected = SelectedDevice {
-                        device_id: Some(data.device_id),
-                        name: Some(data.label),
+                        device_id: data.device_id,
                     };
 
-                    find_trezor_device(selected).map_err(SignerError::TrezorError)?
+                    find_trezor_device(Some(selected)).map_err(SignerError::TrezorError)?
                 } else {
                     return Err(
                         SignerError::TrezorError(TrezorError::MissingHardwareWalletData).into(),
@@ -1611,45 +1597,58 @@ fn check_public_keys_against_db(
 }
 
 fn find_trezor_device(
-    selected: SelectedDevice,
+    selected: Option<SelectedDevice>,
 ) -> Result<(Trezor, TrezorData, Vec<u8>), TrezorError> {
-    let mut devices = find_devices(false)
+    let devices = find_devices(false);
+    ensure!(!devices.is_empty(), TrezorError::NoDeviceFound);
+
+    let mut devices = devices
         .into_iter()
         .filter(|device| device.model == Model::Trezor || device.model == Model::TrezorEmulator)
         .filter_map(|d| {
             d.connect().ok().and_then(|mut c| {
                 c.init_device(None).ok()?;
 
-                c.features()
-                    .map(|f| FoundDevice {
-                        name: f.label().to_owned(),
-                        device_id: f.device_id().to_owned(),
-                    })
-                    .filter(|d| selected == *d)
-                    .map(|found| (c, found))
+                c.features()?
+                    .capabilities
+                    .iter()
+                    .filter_map(|c| c.enum_value().ok())
+                    .contains(&Capability::Capability_Mintlayer)
+                    .then_some(c)
             })
         })
         .collect_vec();
 
-    let client = match devices.len() {
-        0 => return Err(TrezorError::NoDeviceFound),
-        1 => devices.remove(0).0,
-        _ => {
-            let devices = devices.into_iter().map(|(_, d)| d).collect();
-            return Err(TrezorError::NoUniqueDeviceFound(devices));
+    let client = if let Some(position) = devices.iter().position(|d| {
+        d.features()
+            .is_some_and(|f| selected.as_ref().is_none_or(|s| s.device_id == f.device_id()))
+    }) {
+        devices.remove(position)
+    } else {
+        match devices.len() {
+            0 => return Err(TrezorError::NoCompatibleDeviceFound),
+            1 => devices.remove(0),
+            _ => {
+                let devices = devices
+                    .into_iter()
+                    .filter_map(|c| {
+                        c.features().map(|f| FoundDevice {
+                            name: if !f.label().is_empty() {
+                                f.label()
+                            } else {
+                                f.model()
+                            }
+                            .to_owned(),
+                            device_id: f.device_id().to_owned(),
+                        })
+                    })
+                    .collect();
+                return Err(TrezorError::NoUniqueDeviceFound(devices));
+            }
         }
     };
 
     let features = client.features().ok_or(TrezorError::CannotGetDeviceFeatures)?;
-    ensure!(
-        features
-            .capabilities
-            .iter()
-            .filter_map(|c| c.enum_value().ok())
-            .contains(&Capability::Capability_Mintlayer),
-        TrezorError::MintlayerFeaturesNotSupported
-    );
-
     let data = TrezorData {
         label: features.label().to_owned(),
         device_id: features.device_id().to_owned(),

--- a/wallet/src/signer/trezor_signer/mod.rs
+++ b/wallet/src/signer/trezor_signer/mod.rs
@@ -108,13 +108,39 @@ use crate::{
 
 use super::{Signer, SignerError, SignerProvider, SignerResult};
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FoundDevice {
+    pub name: String,
+    pub device_id: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SelectedDevice {
+    pub name: Option<String>,
+    pub device_id: Option<String>,
+}
+
+impl PartialEq<FoundDevice> for SelectedDevice {
+    fn eq(&self, other: &FoundDevice) -> bool {
+        self.name.as_ref().is_none_or(|name| name == &other.name)
+            && self.device_id.as_ref().is_none_or(|id| id == &other.device_id)
+    }
+}
+
+impl SelectedDevice {
+    const NONE: Self = SelectedDevice {
+        name: None,
+        device_id: None,
+    };
+}
+
 /// Signer errors
 #[derive(thiserror::Error, Debug, Eq, PartialEq)]
 pub enum TrezorError {
     #[error("No connected Trezor device found")]
     NoDeviceFound,
-    #[error("There are multiple connected Trezor devices found")]
-    NoUniqueDeviceFound,
+    #[error("There are multiple connected Trezor devices found {0:?}")]
+    NoUniqueDeviceFound(Vec<FoundDevice>),
     #[error("Cannot get the supported features for the connected Trezor device")]
     CannotGetDeviceFeatures,
     #[error("The connected Trezor device does not support the Mintlayer capabilities, please install the correct firmware")]
@@ -142,6 +168,8 @@ pub enum TrezorError {
     },
     #[error("The file being loaded correspond to the connected hardware wallet, but public keys are different. Maybe a wrong passphrase was entered?")]
     HardwareWalletDifferentPassphrase,
+    #[error("Missing hardware wallet data in database")]
+    MissingHardwareWalletData,
 }
 
 pub struct TrezorSigner {
@@ -180,7 +208,8 @@ impl TrezorSigner {
             Err(trezor_client::Error::TransportSendMessage(
                 trezor_client::transport::error::Error::Usb(rusb::Error::Io),
             )) => {
-                let (mut new_client, data, session_id) = find_trezor_device()?;
+                let selected = SelectedDevice::NONE;
+                let (mut new_client, data, session_id) = find_trezor_device(selected)?;
 
                 check_public_keys_against_key_chain(
                     db_tx,
@@ -1425,9 +1454,8 @@ impl std::fmt::Debug for TrezorSignerProvider {
 }
 
 impl TrezorSignerProvider {
-    pub fn new() -> Result<Self, TrezorError> {
-        let (client, data, session_id) =
-            find_trezor_device().map_err(|err| TrezorError::DeviceError(err.to_string()))?;
+    pub fn new(selected: SelectedDevice) -> Result<Self, TrezorError> {
+        let (client, data, session_id) = find_trezor_device(selected)?;
 
         Ok(Self {
             client: Arc::new(Mutex::new(client)),
@@ -1440,7 +1468,25 @@ impl TrezorSignerProvider {
         chain_config: Arc<ChainConfig>,
         db_tx: &impl WalletStorageReadLocked,
     ) -> WalletResult<Self> {
-        let (client, data, session_id) = find_trezor_device().map_err(SignerError::TrezorError)?;
+        let selected = SelectedDevice::NONE;
+        let (client, data, session_id) = match find_trezor_device(selected) {
+            Ok(data) => (data.0, data.1, data.2),
+            Err(TrezorError::NoUniqueDeviceFound(_)) => {
+                if let Some(HardwareWalletData::Trezor(data)) = db_tx.get_hardware_wallet_data()? {
+                    let selected = SelectedDevice {
+                        device_id: Some(data.device_id),
+                        name: Some(data.label),
+                    };
+
+                    find_trezor_device(selected).map_err(SignerError::TrezorError)?
+                } else {
+                    return Err(
+                        SignerError::TrezorError(TrezorError::MissingHardwareWalletData).into(),
+                    );
+                }
+            }
+            Err(err) => return Err(SignerError::TrezorError(err).into()),
+        };
 
         let provider = Self {
             client: Arc::new(Mutex::new(client)),
@@ -1564,19 +1610,35 @@ fn check_public_keys_against_db(
     .map_err(WalletError::SignerError)
 }
 
-fn find_trezor_device() -> Result<(Trezor, TrezorData, Vec<u8>), TrezorError> {
+fn find_trezor_device(
+    selected: SelectedDevice,
+) -> Result<(Trezor, TrezorData, Vec<u8>), TrezorError> {
     let mut devices = find_devices(false)
         .into_iter()
         .filter(|device| device.model == Model::Trezor || device.model == Model::TrezorEmulator)
+        .filter_map(|d| {
+            d.connect().ok().and_then(|mut c| {
+                c.init_device(None).ok()?;
+
+                c.features()
+                    .map(|f| FoundDevice {
+                        name: f.label().to_owned(),
+                        device_id: f.device_id().to_owned(),
+                    })
+                    .filter(|d| selected == *d)
+                    .map(|found| (c, found))
+            })
+        })
         .collect_vec();
 
-    let device = match devices.len() {
+    let client = match devices.len() {
         0 => return Err(TrezorError::NoDeviceFound),
-        1 => devices.remove(0),
-        _ => return Err(TrezorError::NoUniqueDeviceFound),
+        1 => devices.remove(0).0,
+        _ => {
+            let devices = devices.into_iter().map(|(_, d)| d).collect();
+            return Err(TrezorError::NoUniqueDeviceFound(devices));
+        }
     };
-    let mut client = device.connect().map_err(|e| TrezorError::DeviceError(e.to_string()))?;
-    client.init_device(None).map_err(|e| TrezorError::DeviceError(e.to_string()))?;
 
     let features = client.features().ok_or(TrezorError::CannotGetDeviceFeatures)?;
     ensure!(

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -28,6 +28,9 @@ use crate::key_chain::{
 use crate::send_request::{
     make_issue_token_outputs, IssueNftArguments, SelectedInputs, StakePoolCreationArguments,
 };
+#[cfg(feature = "trezor")]
+use crate::signer::trezor_signer::{FoundDevice, TrezorError};
+
 use crate::signer::{Signer, SignerError, SignerProvider};
 use crate::wallet_events::{WalletEvents, WalletEventsNoOp};
 use crate::{Account, SendRequest};
@@ -306,6 +309,35 @@ pub fn create_wallet_in_memory() -> WalletResult<Store<DefaultBackend>> {
     Ok(Store::new(DefaultBackend::new_in_memory())?)
 }
 
+pub enum WalletCreation<W> {
+    Wallet(W),
+    #[cfg(feature = "trezor")]
+    MultipleAvalableTrezorDevices(Vec<FoundDevice>),
+}
+
+impl<W> WalletCreation<W> {
+    pub fn map_wallet<F, W2>(self, f: F) -> WalletCreation<W2>
+    where
+        F: Fn(W) -> W2,
+    {
+        match self {
+            Self::Wallet(w) => WalletCreation::Wallet(f(w)),
+            #[cfg(feature = "trezor")]
+            Self::MultipleAvalableTrezorDevices(devices) => {
+                WalletCreation::MultipleAvalableTrezorDevices(devices)
+            }
+        }
+    }
+
+    pub fn wallet(self) -> Option<W> {
+        match self {
+            WalletCreation::Wallet(w) => Some(w),
+            #[cfg(feature = "trezor")]
+            WalletCreation::MultipleAvalableTrezorDevices(_) => None,
+        }
+    }
+}
+
 impl<B, P> Wallet<B, P>
 where
     B: storage::Backend + 'static,
@@ -317,10 +349,12 @@ where
         best_block: (BlockHeight, Id<GenBlock>),
         wallet_type: WalletType,
         signer_provider: F,
-    ) -> WalletResult<Self> {
+    ) -> WalletResult<WalletCreation<Self>> {
         let mut wallet = Self::new_wallet(chain_config, db, wallet_type, signer_provider)?;
 
-        wallet.set_best_block(best_block.0, best_block.1)?;
+        if let WalletCreation::Wallet(ref mut w) = wallet {
+            w.set_best_block(best_block.0, best_block.1)?;
+        }
 
         Ok(wallet)
     }
@@ -330,7 +364,7 @@ where
         db: Store<B>,
         wallet_type: WalletType,
         signer_provider: F,
-    ) -> WalletResult<Self> {
+    ) -> WalletResult<WalletCreation<Self>> {
         Self::new_wallet(chain_config, db, wallet_type, signer_provider)
     }
 
@@ -339,14 +373,21 @@ where
         db: Store<B>,
         wallet_type: WalletType,
         signer_provider: F,
-    ) -> WalletResult<Self> {
+    ) -> WalletResult<WalletCreation<Self>> {
         let mut db_tx = db.transaction_rw_unlocked(None)?;
 
         db_tx.set_storage_version(CURRENT_WALLET_VERSION)?;
         db_tx.set_chain_info(&ChainInfo::new(chain_config.as_ref()))?;
         db_tx.set_lookahead_size(LOOKAHEAD_SIZE)?;
         db_tx.set_wallet_type(wallet_type)?;
-        let mut signer_provider = signer_provider(&mut db_tx)?;
+        let mut signer_provider = match signer_provider(&mut db_tx) {
+            Ok(x) => x,
+            #[cfg(feature = "trezor")]
+            Err(WalletError::SignerError(SignerError::TrezorError(
+                TrezorError::NoUniqueDeviceFound(devices),
+            ))) => return Ok(WalletCreation::MultipleAvalableTrezorDevices(devices)),
+            Err(err) => return Err(err),
+        };
 
         if let Some(data) = signer_provider.get_hardware_wallet_data() {
             db_tx.set_hardware_wallet_data(data)?;
@@ -380,7 +421,7 @@ where
             signer_provider,
         };
 
-        Ok(wallet)
+        Ok(WalletCreation::Wallet(wallet))
     }
 
     /// Migrate the wallet DB from version 1 to version 2

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -315,6 +315,8 @@ fn create_wallet_with_mnemonic(chain_config: Arc<ChainConfig>, mnemonic: &str) -
         },
     )
     .unwrap()
+    .wallet()
+    .unwrap()
 }
 
 #[track_caller]
@@ -436,7 +438,10 @@ fn wallet_migration_to_v2(#[case] seed: Seed) {
             )?)
         },
     )
+    .unwrap()
+    .wallet()
     .unwrap();
+
     verify_wallet_balance(&chain_config, &wallet, genesis_amount);
 
     let password = Some("password".into());
@@ -543,6 +548,8 @@ fn wallet_seed_phrase_retrieval(#[case] seed: Seed) {
             )?)
         },
     )
+    .unwrap()
+    .wallet()
     .unwrap();
 
     let wallet_passphrase = PassPhrase::new(zeroize::Zeroizing::new(wallet_passphrase));
@@ -638,6 +645,8 @@ fn wallet_seed_phrase_check_address() {
             )?)
         },
     )
+    .unwrap()
+    .wallet()
     .unwrap();
 
     let address = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap();
@@ -664,6 +673,8 @@ fn wallet_seed_phrase_check_address() {
             )?)
         },
     )
+    .unwrap()
+    .wallet()
     .unwrap();
 
     let address = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap();

--- a/wallet/wallet-cli-commands/Cargo.toml
+++ b/wallet/wallet-cli-commands/Cargo.toml
@@ -32,6 +32,7 @@ clap = { workspace = true, features = ["derive"] }
 async-trait.workspace = true
 crossterm.workspace = true
 directories.workspace = true
+dyn-clone.workspace = true
 humantime.workspace = true
 hex.workspace = true
 itertools.workspace = true

--- a/wallet/wallet-cli-commands/src/command_handler/mod.rs
+++ b/wallet/wallet-cli-commands/src/command_handler/mod.rs
@@ -155,7 +155,6 @@ where
                 whether_to_store_seed_phrase,
                 passphrase,
                 hardware_wallet,
-                trezor_device_name,
                 trezor_device_id,
             } => {
                 let store_seed_phrase =
@@ -166,7 +165,7 @@ where
                         passphrase,
                         store_seed_phrase,
                     },
-                    |h| h.into_wallet_args(trezor_device_name, trezor_device_id),
+                    |h| h.into_wallet_args(trezor_device_id),
                 );
                 let response =
                     self.wallet().await?.create_wallet(wallet_path.clone(), wallet_args).await?;
@@ -214,7 +213,6 @@ where
                 whether_to_store_seed_phrase,
                 passphrase,
                 hardware_wallet,
-                trezor_device_name,
                 trezor_device_id,
             } => {
                 let hardware_wallet = hardware_wallet.map(Into::into);
@@ -228,7 +226,6 @@ where
                         mnemonic,
                         passphrase,
                         hardware_wallet,
-                        trezor_device_name,
                         trezor_device_id,
                     )
                     .await?;

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -76,12 +76,6 @@ pub enum WalletManagementCommand {
         #[arg(long, conflicts_with_all(["mnemonic", "passphrase", "whether_to_store_seed_phrase"]))]
         hardware_wallet: Option<CliHardwareWalletType>,
 
-        /// Optionally specify the name for the trezor device to connect to in case there
-        /// are multiple trezor devices connected at the same time.
-        /// If not specified and there are multiple devices connected a choice will be presented
-        #[arg(long, conflicts_with_all(["mnemonic", "passphrase", "whether_to_store_seed_phrase"]))]
-        trezor_device_name: Option<String>,
-
         /// Optionally specify the ID for the trezor device to connect to in case there
         /// are multiple trezor devices connected at the same time.
         /// If not specified and there are multiple devices connected a choice will be presented
@@ -115,12 +109,6 @@ pub enum WalletManagementCommand {
         /// and the latter will have to be entered every time the device is connected to the host machine.
         #[arg(long, conflicts_with_all(["passphrase", "mnemonic", "whether_to_store_seed_phrase"]))]
         hardware_wallet: Option<CliHardwareWalletType>,
-
-        /// Optionally specify the name for the trezor device to connect to in case there
-        /// are multiple trezor devices connected at the same time.
-        /// If not specified and there are multiple devices connected a choice will be presented
-        #[arg(long, conflicts_with_all(["mnemonic", "passphrase", "whether_to_store_seed_phrase"]))]
-        trezor_device_name: Option<String>,
 
         /// Optionally specify the ID for the trezor device to connect to in case there
         /// are multiple trezor devices connected at the same time.
@@ -954,7 +942,6 @@ impl ChoiceMenu for CreateWalletDeviceSelectMenu {
                         mnemonic: None,
                         passphrase: None,
                         hardware_wallet: Some(self.hardware_wallet),
-                        trezor_device_name: Some(d.name.clone()),
                         trezor_device_id: Some(d.device_id.clone()),
                     },
                 )
@@ -965,7 +952,6 @@ impl ChoiceMenu for CreateWalletDeviceSelectMenu {
                     mnemonic: None,
                     passphrase: None,
                     hardware_wallet: Some(self.hardware_wallet),
-                    trezor_device_name: Some(d.name.clone()),
                     trezor_device_id: Some(d.device_id.clone()),
                 })
             }

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -18,12 +18,14 @@ mod errors;
 mod helper_types;
 
 pub use command_handler::CommandHandler;
+use dyn_clone::DynClone;
 pub use errors::WalletCliCommandError;
 use helper_types::YesNo;
 use rpc::description::{Described, Module};
 use wallet_rpc_lib::{
-    cmdline::CliHardwareWalletType, types::NodeInterface, ColdWalletRpcDescription,
-    WalletRpcDescription,
+    cmdline::CliHardwareWalletType,
+    types::{FoundDevice, NodeInterface},
+    ColdWalletRpcDescription, WalletRpcDescription,
 };
 
 use std::{fmt::Debug, num::NonZeroUsize, path::PathBuf, time::Duration};
@@ -73,6 +75,18 @@ pub enum WalletManagementCommand {
         /// and the latter will have to be entered every time the device is connected to the host machine.
         #[arg(long, conflicts_with_all(["mnemonic", "passphrase", "whether_to_store_seed_phrase"]))]
         hardware_wallet: Option<CliHardwareWalletType>,
+
+        /// Optionally specify the name for the trezor device to connect to in case there
+        /// are multiple trezor devices connected at the same time.
+        /// If not specified and there are multiple devices connected a choice will be presented
+        #[arg(long, conflicts_with_all(["mnemonic", "passphrase", "whether_to_store_seed_phrase"]))]
+        trezor_device_name: Option<String>,
+
+        /// Optionally specify the ID for the trezor device to connect to in case there
+        /// are multiple trezor devices connected at the same time.
+        /// If not specified and there are multiple devices connected a choice will be presented
+        #[arg(long, conflicts_with_all(["mnemonic", "passphrase", "whether_to_store_seed_phrase"]))]
+        trezor_device_id: Option<String>,
     },
 
     #[clap(name = "wallet-recover")]
@@ -101,6 +115,18 @@ pub enum WalletManagementCommand {
         /// and the latter will have to be entered every time the device is connected to the host machine.
         #[arg(long, conflicts_with_all(["passphrase", "mnemonic", "whether_to_store_seed_phrase"]))]
         hardware_wallet: Option<CliHardwareWalletType>,
+
+        /// Optionally specify the name for the trezor device to connect to in case there
+        /// are multiple trezor devices connected at the same time.
+        /// If not specified and there are multiple devices connected a choice will be presented
+        #[arg(long, conflicts_with_all(["mnemonic", "passphrase", "whether_to_store_seed_phrase"]))]
+        trezor_device_name: Option<String>,
+
+        /// Optionally specify the ID for the trezor device to connect to in case there
+        /// are multiple trezor devices connected at the same time.
+        /// If not specified and there are multiple devices connected a choice will be presented
+        #[arg(long, conflicts_with_all(["mnemonic", "passphrase", "whether_to_store_seed_phrase"]))]
+        trezor_device_id: Option<String>,
     },
 
     #[clap(name = "wallet-open")]
@@ -875,7 +901,79 @@ pub enum ManageableWalletCommand {
     WalletCommands(WalletCommand),
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+pub trait ChoiceMenu: DynClone + Debug {
+    fn header(&self) -> &str;
+
+    fn completion_list(&self) -> Vec<String>;
+
+    fn choose(&self, choice: &str) -> Option<ManageableWalletCommand>;
+}
+dyn_clone::clone_trait_object!(ChoiceMenu);
+
+#[derive(Debug, Clone)]
+pub struct CreateWalletDeviceSelectMenu {
+    available_devices: Vec<FoundDevice>,
+
+    wallet_path: PathBuf,
+    hardware_wallet: CliHardwareWalletType,
+    recover: bool,
+}
+
+impl CreateWalletDeviceSelectMenu {
+    pub fn new(
+        available_devices: Vec<FoundDevice>,
+        wallet_path: PathBuf,
+        hardware_wallet: CliHardwareWalletType,
+        recover: bool,
+    ) -> Self {
+        Self {
+            available_devices,
+            wallet_path,
+            hardware_wallet,
+            recover,
+        }
+    }
+}
+
+impl ChoiceMenu for CreateWalletDeviceSelectMenu {
+    fn header(&self) -> &str {
+        "Please chose one of the available Trezor devices:"
+    }
+
+    fn completion_list(&self) -> Vec<String> {
+        self.available_devices.iter().map(|d| d.to_string()).collect()
+    }
+
+    fn choose(&self, choice: &str) -> Option<ManageableWalletCommand> {
+        self.available_devices.iter().find(|d| d.to_string() == choice).map(|d| {
+            if self.recover {
+                ManageableWalletCommand::ManagementCommands(
+                    WalletManagementCommand::RecoverWallet {
+                        wallet_path: self.wallet_path.clone(),
+                        whether_to_store_seed_phrase: None,
+                        mnemonic: None,
+                        passphrase: None,
+                        hardware_wallet: Some(self.hardware_wallet),
+                        trezor_device_name: Some(d.name.clone()),
+                        trezor_device_id: Some(d.device_id.clone()),
+                    },
+                )
+            } else {
+                ManageableWalletCommand::ManagementCommands(WalletManagementCommand::CreateWallet {
+                    wallet_path: self.wallet_path.clone(),
+                    whether_to_store_seed_phrase: None,
+                    mnemonic: None,
+                    passphrase: None,
+                    hardware_wallet: Some(self.hardware_wallet),
+                    trezor_device_name: Some(d.name.clone()),
+                    trezor_device_id: Some(d.device_id.clone()),
+                })
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum ConsoleCommand {
     Print(String),
     ClearScreen,
@@ -885,6 +983,7 @@ pub enum ConsoleCommand {
         status: String,
         print_message: String,
     },
+    ChoiceMenu(Box<dyn ChoiceMenu + Sync + Send>),
     Exit,
 }
 

--- a/wallet/wallet-cli-lib/src/errors.rs
+++ b/wallet/wallet-cli-lib/src/errors.rs
@@ -38,4 +38,6 @@ pub enum WalletCliError<N: NodeInterface> {
     WalletClientRpcError(#[from] WalletRpcError),
     #[error("{0}")]
     WalletCommandError(#[from] WalletCliCommandError<N>),
+    #[error("Unexpected interaction on startup commands")]
+    UnexpectedInteraction,
 }

--- a/wallet/wallet-cli-lib/src/repl/interactive/mod.rs
+++ b/wallet/wallet-cli-lib/src/repl/interactive/mod.rs
@@ -23,11 +23,13 @@ use std::path::PathBuf;
 use clap::Command;
 use reedline::{
     default_emacs_keybindings, default_vi_insert_keybindings, default_vi_normal_keybindings,
-    ColumnarMenu, DefaultValidator, EditMode, Emacs, FileBackedHistory, ListMenu, MenuBuilder,
-    Reedline, ReedlineMenu, Signal, Vi,
+    ColumnarMenu, DefaultPrompt, DefaultValidator, EditMode, Emacs, FileBackedHistory, History,
+    ListMenu, MenuBuilder, Reedline, ReedlineMenu, Signal, Vi,
 };
 use tokio::sync::{mpsc, oneshot};
-use wallet_cli_commands::{get_repl_command, parse_input, ConsoleCommand};
+use wallet_cli_commands::{
+    get_repl_command, parse_input, ChoiceMenu, ConsoleCommand, ManageableWalletCommand,
+};
 use wallet_rpc_lib::types::NodeInterface;
 
 use crate::{
@@ -40,19 +42,12 @@ const HISTORY_MAX_LINES: usize = 1000;
 const HISTORY_MENU_NAME: &str = "history_menu";
 const COMPLETION_MENU_NAME: &str = "completion_menu";
 
-fn create_line_editor<N: NodeInterface>(
+fn create_line_editor(
     printer: reedline::ExternalPrinter<String>,
-    repl_command: super::Command,
-    history_file: Option<PathBuf>,
+    commands: Vec<String>,
+    history: Option<Box<dyn History>>,
     vi_mode: bool,
-) -> Result<Reedline, WalletCliError<N>> {
-    let commands = repl_command
-        .get_subcommands()
-        .filter(|command| !command.is_hide_set())
-        .map(|command| command.get_name().to_owned())
-        .chain(std::iter::once("help".to_owned()))
-        .collect::<Vec<_>>();
-
+) -> Reedline {
     let completer = Box::new(wallet_completions::WalletCompletions::new(commands));
 
     let mut line_editor = Reedline::create()
@@ -63,11 +58,7 @@ fn create_line_editor<N: NodeInterface>(
         .with_validator(Box::new(DefaultValidator))
         .with_ansi_colors(true);
 
-    if let Some(file_name) = history_file {
-        let history = Box::new(
-            FileBackedHistory::with_file(HISTORY_MAX_LINES, file_name.clone())
-                .map_err(|e| WalletCliError::FileError(file_name, e.to_string()))?,
-        );
+    if let Some(history) = history {
         line_editor = line_editor.with_history(history);
     }
 
@@ -95,9 +86,7 @@ fn create_line_editor<N: NodeInterface>(
         Box::new(Emacs::new(keybindings))
     };
 
-    line_editor = line_editor.with_edit_mode(edit_mode);
-
-    Ok(line_editor)
+    line_editor.with_edit_mode(edit_mode)
 }
 
 fn process_line<N: NodeInterface>(
@@ -139,26 +128,43 @@ pub fn run<N: NodeInterface>(
 ) -> Result<(), WalletCliError<N>> {
     let repl_command = get_repl_command(cold_wallet, true);
 
-    let mut line_editor = create_line_editor(
-        logger.printer().clone(),
-        repl_command.clone(),
-        history_file,
-        vi_mode,
-    )?;
+    let commands = repl_command
+        .get_subcommands()
+        .filter(|command| !command.is_hide_set())
+        .map(|command| command.get_name().to_owned())
+        .chain(std::iter::once("help".to_owned()))
+        .collect::<Vec<_>>();
+
+    let history = if let Some(file_name) = history_file {
+        let h: Box<dyn History> = Box::new(
+            FileBackedHistory::with_file(HISTORY_MAX_LINES, file_name.clone())
+                .map_err(|e| WalletCliError::FileError(file_name, e.to_string()))?,
+        );
+        Some(h)
+    } else {
+        None
+    };
+
+    let mut line_editor = create_line_editor(logger.printer().clone(), commands, history, vi_mode);
 
     let mut prompt = wallet_prompt::WalletPrompt::new();
 
     // first wait for the results of any startup command before processing the rest
     for res_rx in startup_command_futures {
         let res = res_rx.blocking_recv().expect("Channel must be open");
-        if let Some(value) = handle_response(
+        match handle_response(
             res.map(Some),
             &mut console,
             &mut prompt,
             &mut line_editor,
+            logger.printer(),
+            vi_mode,
             true,
         ) {
-            return value;
+            CommandResponse::Exit => return Ok(()),
+            CommandResponse::Error(err) => return Err(err),
+            CommandResponse::Command(_) => return Err(WalletCliError::UnexpectedInteraction),
+            CommandResponse::Continue => {}
         }
     }
 
@@ -167,23 +173,40 @@ pub fn run<N: NodeInterface>(
     console.print_line("Press TAB on your keyboard to auto-complete any command you write.");
     console.print_line("Use 'exit' or Ctrl-D to quit.");
 
+    let mut cmd = None;
     loop {
-        logger.set_print_directly(false);
-        let sig = line_editor.read_line(&prompt).expect("Should not fail normally");
-        logger.set_print_directly(true);
+        let res = if let Some(command) = cmd.take() {
+            super::run_command_blocking(&event_tx, command).map(Option::Some)
+        } else {
+            logger.set_print_directly(false);
+            let sig = line_editor.read_line(&prompt).expect("Should not fail normally");
+            logger.set_print_directly(true);
 
-        let res = process_line(&repl_command, &event_tx, sig);
+            process_line(&repl_command, &event_tx, sig)
+        };
 
-        if let Some(value) = handle_response(
+        match handle_response(
             res,
             &mut console,
             &mut prompt,
             &mut line_editor,
+            logger.printer(),
+            vi_mode,
             exit_on_error,
         ) {
-            return value;
+            CommandResponse::Exit => return Ok(()),
+            CommandResponse::Error(err) => return Err(err),
+            CommandResponse::Continue => {}
+            CommandResponse::Command(command) => cmd = Some(*command),
         }
     }
+}
+
+enum CommandResponse<N: NodeInterface> {
+    Exit,
+    Continue,
+    Error(WalletCliError<N>),
+    Command(Box<ManageableWalletCommand>),
 }
 
 fn handle_response<N: NodeInterface>(
@@ -191,8 +214,10 @@ fn handle_response<N: NodeInterface>(
     console: &mut impl ConsoleOutput,
     prompt: &mut wallet_prompt::WalletPrompt,
     line_editor: &mut Reedline,
+    printer: &reedline::ExternalPrinter<String>,
+    vi_mode: bool,
     exit_on_error: bool,
-) -> Option<Result<(), WalletCliError<N>>> {
+) -> CommandResponse<N> {
     match res {
         Ok(Some(ConsoleCommand::Print(text))) => {
             console.print_line(&text);
@@ -213,16 +238,68 @@ fn handle_response<N: NodeInterface>(
         Ok(Some(ConsoleCommand::PrintHistory)) => {
             line_editor.print_history().expect("Should not fail normally");
         }
-        Ok(Some(ConsoleCommand::Exit)) => return Some(Ok(())),
+        Ok(Some(ConsoleCommand::Exit)) => return CommandResponse::Exit,
+
+        Ok(Some(ConsoleCommand::ChoiceMenu(choice))) => {
+            let line_editor_helper = create_line_editor(printer.clone(), vec![], None, vi_mode);
+            let cmd = handle_choice_menu(choice.as_ref(), line_editor_helper);
+            if let Some(cmd) = cmd {
+                return CommandResponse::Command(Box::new(cmd));
+            }
+        }
 
         Ok(None) => {}
 
         Err(err) => {
             if exit_on_error {
-                return Some(Err(err));
+                return CommandResponse::Error(err);
             }
             console.print_error(err);
         }
     }
-    None
+
+    CommandResponse::Continue
+}
+
+fn handle_choice_menu(
+    choice_menu: &dyn ChoiceMenu,
+    mut line_editor: Reedline,
+) -> Option<ManageableWalletCommand> {
+    let completer = Box::new(wallet_completions::WalletCompletions::new(
+        choice_menu.completion_list(),
+    ));
+
+    line_editor = line_editor.with_completer(completer);
+
+    let prompt = DefaultPrompt::new(
+        reedline::DefaultPromptSegment::Empty,
+        reedline::DefaultPromptSegment::Empty,
+    );
+
+    loop {
+        println!("{}", choice_menu.header());
+        for choice in choice_menu.completion_list() {
+            println!("{}", choice);
+        }
+
+        match line_editor.read_line(&prompt).expect("Should not fail normally") {
+            Signal::Success(input) => {
+                let input = input.trim();
+
+                if input.eq_ignore_ascii_case("Exit") {
+                    return None;
+                }
+
+                if let Some(cmd) = choice_menu.choose(input) {
+                    println!("You selected: {}", input);
+                    return Some(cmd);
+                }
+
+                println!("Invalid choice! Please select a valid option.");
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                return None;
+            }
+        }
+    }
 }

--- a/wallet/wallet-cli-lib/src/repl/mod.rs
+++ b/wallet/wallet-cli-lib/src/repl/mod.rs
@@ -16,7 +16,6 @@
 pub mod interactive;
 pub mod non_interactive;
 
-use clap::Command;
 use tokio::sync::mpsc;
 use wallet_cli_commands::{ConsoleCommand, ManageableWalletCommand};
 use wallet_rpc_lib::types::NodeInterface;

--- a/wallet/wallet-cli-lib/src/repl/non_interactive/mod.rs
+++ b/wallet/wallet-cli-lib/src/repl/non_interactive/mod.rs
@@ -58,6 +58,7 @@ fn to_line_output<N: NodeInterface>(
         } => Ok(LineOutput::Print(print_message)),
         ConsoleCommand::ClearScreen
         | ConsoleCommand::PrintHistory
+        | ConsoleCommand::ChoiceMenu(_)
         | ConsoleCommand::ClearHistory => Err(WalletCliError::InvalidInput(format!(
             "Unsupported command in non-interactive mode: {}",
             line,

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -273,19 +273,15 @@ where
                 .map(|w| w.map_wallet(RuntimeWallet::Software))
             }
             #[cfg(feature = "trezor")]
-            WalletTypeArgsComputed::Trezor {
-                device_name,
-                device_id,
-            } => wallet::Wallet::create_new_wallet(
+            WalletTypeArgsComputed::Trezor { device_id } => wallet::Wallet::create_new_wallet(
                 Arc::clone(&chain_config),
                 db,
                 best_block,
                 wallet_type,
                 |_db_tx| {
-                    Ok(TrezorSignerProvider::new(SelectedDevice {
-                        name: device_name,
-                        device_id,
-                    })
+                    Ok(TrezorSignerProvider::new(
+                        device_id.map(|device_id| SelectedDevice { device_id }),
+                    )
                     .map_err(SignerError::TrezorError)?)
                 },
             )
@@ -346,19 +342,15 @@ where
                 Ok(wallet.map_wallet(RuntimeWallet::Software))
             }
             #[cfg(feature = "trezor")]
-            WalletTypeArgsComputed::Trezor {
-                device_name,
-                device_id,
-            } => {
+            WalletTypeArgsComputed::Trezor { device_id } => {
                 let wallet = wallet::Wallet::recover_wallet(
                     Arc::clone(&chain_config),
                     db,
                     wallet_type,
                     |_db_tx| {
-                        Ok(TrezorSignerProvider::new(SelectedDevice {
-                            name: device_name,
-                            device_id,
-                        })
+                        Ok(TrezorSignerProvider::new(
+                            device_id.map(|device_id| SelectedDevice { device_id }),
+                        )
                         .map_err(SignerError::TrezorError)?)
                     },
                 )

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -165,10 +165,7 @@ pub enum WalletTypeArgs {
         store_seed_phrase: StoreSeedPhrase,
     },
     #[cfg(feature = "trezor")]
-    Trezor {
-        device_name: Option<String>,
-        device_id: Option<String>,
-    },
+    Trezor { device_id: Option<String> },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -188,10 +185,7 @@ impl WalletTypeArgs {
                 store_seed_phrase: _,
             } => controller_mode.into(),
             #[cfg(feature = "trezor")]
-            Self::Trezor {
-                device_name: _,
-                device_id: _,
-            } => WalletType::Trezor,
+            Self::Trezor { device_id: _ } => WalletType::Trezor,
         }
     }
 
@@ -230,14 +224,8 @@ impl WalletTypeArgs {
             }
 
             #[cfg(feature = "trezor")]
-            Self::Trezor {
-                device_name,
-                device_id,
-            } => Ok((
-                WalletTypeArgsComputed::Trezor {
-                    device_name,
-                    device_id,
-                },
+            Self::Trezor { device_id } => Ok((
+                WalletTypeArgsComputed::Trezor { device_id },
                 CreatedWallet::UserProvidedMnemonic,
             )),
         }
@@ -251,8 +239,5 @@ pub enum WalletTypeArgsComputed {
         store_seed_phrase: StoreSeedPhrase,
     },
     #[cfg(feature = "trezor")]
-    Trezor {
-        device_name: Option<String>,
-        device_id: Option<String>,
-    },
+    Trezor { device_id: Option<String> },
 }

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -143,12 +143,16 @@ where
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
+        device_name: Option<String>,
+        device_id: Option<String>,
     ) -> Result<CreatedWallet, Self::Error> {
         let args = HardwareWalletType::into_wallet_args::<N>(
             hardware_wallet,
             store_seed_phrase,
             mnemonic,
             passphrase,
+            device_name,
+            device_id,
         )?;
 
         let options = WalletCreationOptions {

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -143,7 +143,6 @@ where
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_name: Option<String>,
         device_id: Option<String>,
     ) -> Result<CreatedWallet, Self::Error> {
         let args = HardwareWalletType::into_wallet_args::<N>(
@@ -151,7 +150,6 @@ where
             store_seed_phrase,
             mnemonic,
             passphrase,
-            device_name,
             device_id,
         )?;
 

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -88,15 +88,33 @@ impl WalletInterface for ClientWalletRpc {
         path: PathBuf,
         wallet_args: WalletTypeArgs,
     ) -> Result<CreatedWallet, Self::Error> {
-        let (mnemonic, passphrase, store_seed_phrase, hardware_wallet) = match wallet_args {
-            WalletTypeArgs::Software {
-                mnemonic,
-                passphrase,
-                store_seed_phrase,
-            } => (mnemonic, passphrase, store_seed_phrase.should_save(), None),
-            #[cfg(feature = "trezor")]
-            WalletTypeArgs::Trezor => (None, None, false, Some(HardwareWalletType::Trezor)),
-        };
+        let (mnemonic, passphrase, store_seed_phrase, hardware_wallet, device_name, device_id) =
+            match wallet_args {
+                WalletTypeArgs::Software {
+                    mnemonic,
+                    passphrase,
+                    store_seed_phrase,
+                } => (
+                    mnemonic,
+                    passphrase,
+                    store_seed_phrase.should_save(),
+                    None,
+                    None,
+                    None,
+                ),
+                #[cfg(feature = "trezor")]
+                WalletTypeArgs::Trezor {
+                    device_name,
+                    device_id,
+                } => (
+                    None,
+                    None,
+                    false,
+                    Some(HardwareWalletType::Trezor),
+                    device_name,
+                    device_id,
+                ),
+            };
 
         ColdWalletRpcClient::create_wallet(
             &self.http_client,
@@ -105,6 +123,8 @@ impl WalletInterface for ClientWalletRpc {
             mnemonic,
             passphrase,
             hardware_wallet,
+            device_name,
+            device_id,
         )
         .await
         .map_err(WalletRpcError::ResponseError)
@@ -117,6 +137,8 @@ impl WalletInterface for ClientWalletRpc {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
+        device_name: Option<String>,
+        device_id: Option<String>,
     ) -> Result<CreatedWallet, Self::Error> {
         ColdWalletRpcClient::recover_wallet(
             &self.http_client,
@@ -125,6 +147,8 @@ impl WalletInterface for ClientWalletRpc {
             mnemonic,
             passphrase,
             hardware_wallet,
+            device_name,
+            device_id,
         )
         .await
         .map_err(WalletRpcError::ResponseError)

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -88,7 +88,7 @@ impl WalletInterface for ClientWalletRpc {
         path: PathBuf,
         wallet_args: WalletTypeArgs,
     ) -> Result<CreatedWallet, Self::Error> {
-        let (mnemonic, passphrase, store_seed_phrase, hardware_wallet, device_name, device_id) =
+        let (mnemonic, passphrase, store_seed_phrase, hardware_wallet, device_id) =
             match wallet_args {
                 WalletTypeArgs::Software {
                     mnemonic,
@@ -100,18 +100,13 @@ impl WalletInterface for ClientWalletRpc {
                     store_seed_phrase.should_save(),
                     None,
                     None,
-                    None,
                 ),
                 #[cfg(feature = "trezor")]
-                WalletTypeArgs::Trezor {
-                    device_name,
-                    device_id,
-                } => (
+                WalletTypeArgs::Trezor { device_id } => (
                     None,
                     None,
                     false,
                     Some(HardwareWalletType::Trezor),
-                    device_name,
                     device_id,
                 ),
             };
@@ -123,7 +118,6 @@ impl WalletInterface for ClientWalletRpc {
             mnemonic,
             passphrase,
             hardware_wallet,
-            device_name,
             device_id,
         )
         .await
@@ -137,7 +131,6 @@ impl WalletInterface for ClientWalletRpc {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_name: Option<String>,
         device_id: Option<String>,
     ) -> Result<CreatedWallet, Self::Error> {
         ColdWalletRpcClient::recover_wallet(
@@ -147,7 +140,6 @@ impl WalletInterface for ClientWalletRpc {
             mnemonic,
             passphrase,
             hardware_wallet,
-            device_name,
             device_id,
         )
         .await

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -83,7 +83,6 @@ pub trait WalletInterface {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_name: Option<String>,
         device_id: Option<String>,
     ) -> Result<CreatedWallet, Self::Error>;
 

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -75,6 +75,7 @@ pub trait WalletInterface {
         wallet_args: WalletTypeArgs,
     ) -> Result<CreatedWallet, Self::Error>;
 
+    #[allow(clippy::too_many_arguments)]
     async fn recover_wallet(
         &self,
         path: PathBuf,
@@ -82,6 +83,8 @@ pub trait WalletInterface {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
+        device_name: Option<String>,
+        device_id: Option<String>,
     ) -> Result<CreatedWallet, Self::Error>;
 
     async fn open_wallet(

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -2727,17 +2727,34 @@ Parameters:
     "hardware_wallet": EITHER OF
          1) "Trezor"
          2) null,
+    "device_name": EITHER OF
+         1) string
+         2) null,
+    "device_id": EITHER OF
+         1) string
+         2) null,
 }
 ```
 
 Returns:
 ```
-{ "mnemonic": EITHER OF
-     1) { "type": "UserProvided" }
-     2) {
-            "type": "NewlyGenerated",
-            "content": { "mnemonic": string },
-        } }
+{
+    "mnemonic": EITHER OF
+         1) { "type": "UserProvided" }
+         2) {
+                "type": "NewlyGenerated",
+                "content": { "mnemonic": string },
+            },
+    "multiple_devices_available": EITHER OF
+         1) {
+                "type": "Trezor",
+                "content": { "devices": [ {
+                    "name": string,
+                    "device_id": string,
+                }, .. ] },
+            }
+         2) null,
+}
 ```
 
 ### Method `wallet_recover`
@@ -2759,17 +2776,34 @@ Parameters:
     "hardware_wallet": EITHER OF
          1) "Trezor"
          2) null,
+    "device_name": EITHER OF
+         1) string
+         2) null,
+    "device_id": EITHER OF
+         1) string
+         2) null,
 }
 ```
 
 Returns:
 ```
-{ "mnemonic": EITHER OF
-     1) { "type": "UserProvided" }
-     2) {
-            "type": "NewlyGenerated",
-            "content": { "mnemonic": string },
-        } }
+{
+    "mnemonic": EITHER OF
+         1) { "type": "UserProvided" }
+         2) {
+                "type": "NewlyGenerated",
+                "content": { "mnemonic": string },
+            },
+    "multiple_devices_available": EITHER OF
+         1) {
+                "type": "Trezor",
+                "content": { "devices": [ {
+                    "name": string,
+                    "device_id": string,
+                }, .. ] },
+            }
+         2) null,
+}
 ```
 
 ### Method `wallet_open`

--- a/wallet/wallet-rpc-lib/src/cmdline.rs
+++ b/wallet/wallet-rpc-lib/src/cmdline.rs
@@ -90,16 +90,9 @@ pub enum CliHardwareWalletType {
 }
 
 impl CliHardwareWalletType {
-    pub fn into_wallet_args(
-        &self,
-        device_name: Option<String>,
-        device_id: Option<String>,
-    ) -> WalletTypeArgs {
+    pub fn into_wallet_args(&self, device_id: Option<String>) -> WalletTypeArgs {
         match self {
-            Self::Trezor => WalletTypeArgs::Trezor {
-                device_name,
-                device_id,
-            },
+            Self::Trezor => WalletTypeArgs::Trezor { device_id },
         }
     }
 }

--- a/wallet/wallet-rpc-lib/src/cmdline.rs
+++ b/wallet/wallet-rpc-lib/src/cmdline.rs
@@ -89,16 +89,22 @@ pub enum CliHardwareWalletType {
     Trezor,
 }
 
-impl From<CliHardwareWalletType> for HardwareWalletType {
-    fn from(value: CliHardwareWalletType) -> Self {
-        match value {
-            #[cfg(feature = "trezor")]
-            CliHardwareWalletType::Trezor => Self::Trezor,
+impl CliHardwareWalletType {
+    pub fn into_wallet_args(
+        &self,
+        device_name: Option<String>,
+        device_id: Option<String>,
+    ) -> WalletTypeArgs {
+        match self {
+            Self::Trezor => WalletTypeArgs::Trezor {
+                device_name,
+                device_id,
+            },
         }
     }
 }
 
-impl From<CliHardwareWalletType> for WalletTypeArgs {
+impl From<CliHardwareWalletType> for HardwareWalletType {
     fn from(value: CliHardwareWalletType) -> Self {
         match value {
             #[cfg(feature = "trezor")]

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -80,6 +80,8 @@ trait ColdWalletRpc {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
+        device_name: Option<String>,
+        device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet>;
 
     /// Recover new wallet, this will rescan the blockchain upon creation
@@ -91,6 +93,8 @@ trait ColdWalletRpc {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
+        device_name: Option<String>,
+        device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet>;
 
     /// Open an exiting wallet by specifying the file location of the wallet file

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -80,7 +80,6 @@ trait ColdWalletRpc {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_name: Option<String>,
         device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet>;
 
@@ -93,7 +92,6 @@ trait ColdWalletRpc {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_name: Option<String>,
         device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet>;
 

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -94,12 +94,16 @@ where
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
+        device_name: Option<String>,
+        device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet> {
         let args = HardwareWalletType::into_wallet_args::<N>(
             hardware_wallet,
             store_seed_phrase,
             mnemonic,
             passphrase,
+            device_name,
+            device_id,
         )?;
 
         let options = WalletCreationOptions {
@@ -120,12 +124,16 @@ where
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
+        device_name: Option<String>,
+        device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet> {
         let args = HardwareWalletType::into_wallet_args::<N>(
             hardware_wallet,
             store_seed_phrase,
             mnemonic,
             passphrase,
+            device_name,
+            device_id,
         )?;
 
         let options = WalletCreationOptions {

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -94,7 +94,6 @@ where
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_name: Option<String>,
         device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet> {
         let args = HardwareWalletType::into_wallet_args::<N>(
@@ -102,7 +101,6 @@ where
             store_seed_phrase,
             mnemonic,
             passphrase,
-            device_name,
             device_id,
         )?;
 
@@ -124,7 +122,6 @@ where
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_name: Option<String>,
         device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet> {
         let args = HardwareWalletType::into_wallet_args::<N>(
@@ -132,7 +129,6 @@ where
             store_seed_phrase,
             mnemonic,
             passphrase,
-            device_name,
             device_id,
         )?;
 

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -655,6 +655,7 @@ pub struct FoundDevice {
     pub device_id: String,
 }
 
+#[cfg(feature = "trezor")]
 impl std::fmt::Display for FoundDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}-{}", self.name, self.device_id)
@@ -848,7 +849,6 @@ impl HardwareWalletType {
         store_seed_phrase: bool,
         mnemonic: Option<String>,
         passphrase: Option<String>,
-        device_name: Option<String>,
         device_id: Option<String>,
     ) -> Result<WalletTypeArgs, RpcError<N>> {
         let store_seed_phrase = if store_seed_phrase {
@@ -872,10 +872,7 @@ impl HardwareWalletType {
                 );
                 match hw_type {
                     #[cfg(feature = "trezor")]
-                    HardwareWalletType::Trezor => Ok(WalletTypeArgs::Trezor {
-                        device_name,
-                        device_id,
-                    }),
+                    HardwareWalletType::Trezor => Ok(WalletTypeArgs::Trezor { device_id }),
                 }
             }
         }

--- a/wallet/wallet-rpc-lib/src/service/worker.rs
+++ b/wallet/wallet-rpc-lib/src/service/worker.rs
@@ -225,6 +225,14 @@ where
         }
         .map_err(RpcError::Controller)?;
 
+        let wallet = match wallet {
+            wallet::wallet::WalletCreation::Wallet(w) => w,
+            #[cfg(feature = "trezor")]
+            wallet::wallet::WalletCreation::MultipleAvalableTrezorDevices(devices) => {
+                return Ok(CreatedWallet::TrezorDeviceSelection(devices));
+            }
+        };
+
         let controller = if options.scan_blockchain.should_wait_for_blockchain_scanning() {
             WalletController::new(
                 self.chain_config.clone(),


### PR DESCRIPTION
- add a choice menu for the CLI wallet to select a trezor device if there are multiple devices available 
- add optional parameters to the create and recover wallet commands to specify a trezor device name or device ID
- Fixed the leftover empty wallet when a create wallet command fails