### PR TITLE
Feature/wallet sweep all addresses

### DIFF
--- a/node-gui/backend/src/backend_impl.rs
+++ b/node-gui/backend/src/backend_impl.rs
@@ -819,7 +819,8 @@ impl Backend {
                 },
             )
             .await
-            .map_err(|e| BackendError::WalletError(e.to_string()))?;
+            .map_err(|e| BackendError::WalletError(e.to_string()))?
+            .tx;
 
         Ok(TransactionInfo {
             wallet_id,
@@ -872,7 +873,8 @@ impl Backend {
                 },
             )
             .await
-            .map_err(|e| BackendError::WalletError(e.to_string()))?;
+            .map_err(|e| BackendError::WalletError(e.to_string()))?
+            .tx;
 
         Ok(TransactionInfo {
             wallet_id,
@@ -904,7 +906,8 @@ impl Backend {
                 },
             )
             .await
-            .map_err(|e| BackendError::WalletError(e.to_string()))?;
+            .map_err(|e| BackendError::WalletError(e.to_string()))?
+            .tx;
 
         Ok(TransactionInfo {
             wallet_id,
@@ -940,7 +943,7 @@ impl Backend {
 
         Ok(TransactionInfo {
             wallet_id,
-            tx: SignedTransactionWrapper::new(tx),
+            tx: SignedTransactionWrapper::new(tx.tx),
         })
     }
 
@@ -975,7 +978,8 @@ impl Backend {
                 },
             )
             .await
-            .map_err(|e| BackendError::WalletError(e.to_string()))?;
+            .map_err(|e| BackendError::WalletError(e.to_string()))?
+            .tx;
 
         Ok(TransactionInfo {
             wallet_id,
@@ -1018,7 +1022,8 @@ impl Backend {
                 },
             )
             .await
-            .map_err(|e| BackendError::WalletError(e.to_string()))?;
+            .map_err(|e| BackendError::WalletError(e.to_string()))?
+            .tx;
 
         Ok(TransactionInfo {
             wallet_id,

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -301,8 +301,9 @@ class WalletCliController(WalletCliControllerBase):
         change_address_str = '' if change_address is None else f"--change {change_address}"
         return await self._write_command(f"transaction-create-from-cold-input {address} {amount} {str(selected_utxo)} {change_address_str}\n")
 
-    async def sweep_addresses(self, destination_address: str, from_addresses: List[str] = []) -> str:
-        return await self._write_command(f"address-sweep-spendable {destination_address} {' '.join(from_addresses)}\n")
+    async def sweep_addresses(self, destination_address: str, from_addresses: List[str] = [], all_addresses: bool = False) -> str:
+        all_addresses_str = "--all" if all_addresses else ""
+        return await self._write_command(f"address-sweep-spendable {destination_address} {' '.join(from_addresses)} {all_addresses_str}\n")
 
     async def sweep_delegation(self, destination_address: str, delegation_id: str) -> str:
         return await self._write_command(f"staking-sweep-delegation {destination_address} {delegation_id}\n")

--- a/test/functional/wallet_htlc_refund.py
+++ b/test/functional/wallet_htlc_refund.py
@@ -128,7 +128,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
             assert_equal(await wallet.get_best_block(), block_id)
 
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 151", balance)
+            assert_in("Coins amount: 151", balance)
             assert_not_in("Tokens", balance)
 
             # issue a valid token
@@ -142,7 +142,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
             self.generate_block()
             assert_in("Success", await wallet.sync())
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 50", balance)
+            assert_in("Coins amount: 50", balance)
             assert_not_in("Tokens", balance)
 
             amount_to_mint = random.randint(1, 10000)
@@ -153,7 +153,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
             assert_in("Success", await wallet.sync())
             balance = await wallet.get_balance()
             print(balance)
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_in(f"Token: {token_id} amount: {amount_to_mint}", balance)
 
             ########################################################################################
@@ -165,7 +165,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
 
             alice_amount_to_swap = amount_to_mint
             alice_htlc_tx = await wallet.create_htlc_transaction(alice_amount_to_swap, token_id, alice_secret_hash, bob_address, refund_address, 6)
-            alice_signed_tx_obj = signed_tx_obj.decode(ScaleBytes("0x" + alice_htlc_tx))
+            alice_signed_tx_obj = signed_tx_obj.decode(ScaleBytes("0x" + alice_htlc_tx['tx']))
             alice_htlc_outputs = alice_signed_tx_obj['transaction']['outputs']
             alice_htlc_change_dest = alice_htlc_outputs[1]['Transfer'][1]
             alice_htlc_tx_id = hash_object(base_tx_obj, alice_signed_tx_obj['transaction'])
@@ -200,7 +200,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
 
             bob_amount_to_swap = 150
             bob_htlc_tx = await wallet.create_htlc_transaction(bob_amount_to_swap, None, alice_secret_hash, alice_address, refund_address, 6)
-            bob_signed_tx_obj = signed_tx_obj.decode(ScaleBytes("0x" + bob_htlc_tx))
+            bob_signed_tx_obj = signed_tx_obj.decode(ScaleBytes("0x" + bob_htlc_tx['tx']))
             bob_htlc_outputs = bob_signed_tx_obj['transaction']['outputs']
             bob_htlc_change_dest = bob_htlc_outputs[1]['Transfer'][1]
             bob_htlc_tx_id = hash_object(base_tx_obj, bob_signed_tx_obj['transaction'])
@@ -227,7 +227,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
             alice_refund_ptx = output.split('\n')[2]
 
             # Alice's htlc tx can now be broadcasted
-            output = await wallet.submit_transaction(alice_htlc_tx)
+            output = await wallet.submit_transaction(alice_htlc_tx['tx'])
             assert_in("The transaction was submitted successfully", output)
 
             # Alice signs Bob's refund
@@ -238,7 +238,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
             bob_refund_ptx = output.split('\n')[2]
 
             # Bob's htlc tx can now be broadcasted
-            output = await wallet.submit_transaction(bob_htlc_tx)
+            output = await wallet.submit_transaction(bob_htlc_tx['tx'])
             assert_in("The transaction was submitted successfully", output)
 
             self.generate_block()
@@ -246,14 +246,14 @@ class WalletHtlcRefund(BitcoinTestFramework):
 
             # Check Alice's balance
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_not_in("Tokens", balance)
 
             # Check Bob's balance now
             await self.switch_to_wallet(wallet, 'bob_wallet')
             assert_in("Success", await wallet.sync())
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_not_in("Tokens", balance)
 
             ########################################################################################
@@ -270,7 +270,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
             assert_in("Spending at height 9, locked until height 10", output)
 
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_not_in("Tokens", balance)
 
             # Bob signs and spends the refund
@@ -286,7 +286,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
             assert_in("Spending at height 9, locked until height 10", output)
 
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_not_in("Tokens", balance)
 
             ########################################################################################
@@ -304,7 +304,7 @@ class WalletHtlcRefund(BitcoinTestFramework):
             self.generate_block()
             assert_in("Success", await wallet.sync())
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_not_in("Tokens", balance)
 
             self.generate_block()
@@ -316,13 +316,13 @@ class WalletHtlcRefund(BitcoinTestFramework):
             await self.switch_to_wallet(wallet, 'alice_wallet')
             assert_in("Success", await wallet.sync())
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_in(f"Token: {token_id} amount: {alice_amount_to_swap}", balance)
 
             await self.switch_to_wallet(wallet, 'bob_wallet')
             assert_in("Success", await wallet.sync())
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 150", balance)
+            assert_in(f"Coins amount: {bob_amount_to_swap}", balance)
             assert_not_in("Tokens", balance)
 
 

--- a/test/functional/wallet_htlc_spend.py
+++ b/test/functional/wallet_htlc_spend.py
@@ -131,7 +131,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             assert_equal(await wallet.get_best_block(), block_id)
 
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 151", balance)
+            assert_in("Coins amount: 151", balance)
             assert_not_in("Tokens", balance)
 
             # issue a valid token
@@ -142,7 +142,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             self.generate_block()
             assert_in("Success", await wallet.sync())
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 50", balance)
+            assert_in("Coins amount: 50", balance)
             assert_not_in("Tokens", balance)
 
             amount_to_mint = random.randint(1, 10000)
@@ -152,7 +152,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             self.generate_block()
             assert_in("Success", await wallet.sync())
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_in(f"Token: {token_id} amount: {amount_to_mint}", balance)
 
             ########################################################################################
@@ -164,7 +164,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             alice_amount_to_swap = amount_to_mint
             refund_address = await wallet.add_standalone_multisig_address(2, [alice_pub_key, bob_pub_key], None)
             alice_htlc_tx = await wallet.create_htlc_transaction(alice_amount_to_swap, token_id, alice_secret_hash, bob_address, refund_address, 2)
-            output = await wallet.submit_transaction(alice_htlc_tx)
+            output = await wallet.submit_transaction(alice_htlc_tx['tx'])
             alice_htlc_tx_id = output.split('\n')[2]
             self.generate_block()
             assert_in("Success", await wallet.sync())
@@ -175,7 +175,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
 
             bob_amount_to_swap = 150
             bob_htlc_tx = await wallet.create_htlc_transaction(bob_amount_to_swap, None, alice_secret_hash, alice_address, refund_address, 2)
-            output = await wallet.submit_transaction(bob_htlc_tx)
+            output = await wallet.submit_transaction(bob_htlc_tx['tx'])
             bob_htlc_tx_id = output.split('\n')[2]
             self.generate_block()
             assert_in("Success", await wallet.sync())
@@ -189,7 +189,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             random_secret_hex = random_secret.hex()
 
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_not_in("Tokens", balance)
 
             # Alice can't spend Alice's htlc without a secret
@@ -214,7 +214,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             assert_in("Success", await wallet.sync())
 
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_not_in("Tokens", balance)
 
             # Bob can't spend it without secret
@@ -264,7 +264,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             assert_in("Success", await wallet.sync())
 
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 150", balance)
+            assert_in(f"Coins amount: {bob_amount_to_swap}", balance)
             assert_not_in("Tokens", balance)
 
             ########################################################################################
@@ -283,7 +283,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             assert_in("Success", await wallet.sync())
 
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             assert_in(f"Token: {token_id} amount: {alice_amount_to_swap}", balance)
 
 

--- a/test/functional/wallet_multisig_address.py
+++ b/test/functional/wallet_multisig_address.py
@@ -180,7 +180,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             await wallet.open_wallet('wallet0')
             output = await wallet.send_to_address(multisig_address, 1)
             assert_in("The transaction was submitted successfully", output)
-            multisig_tx_id = output.splitlines()[1]
+            multisig_tx_id = output.splitlines()[-1]
             self.generate_block()
             assert not node.mempool_contains_tx(multisig_tx_id)
             assert_not_in("No transaction found", await wallet.get_raw_signed_transaction(multisig_tx_id))

--- a/test/functional/wallet_sweep_address.py
+++ b/test/functional/wallet_sweep_address.py
@@ -149,14 +149,14 @@ class WalletSweepAddresses(BitcoinTestFramework):
             acc1_address = await wallet.new_address()
 
             await wallet.select_account(0)
-            assert_in("The transaction was submitted successfully", await wallet.sweep_addresses(acc1_address, addresses))
+            assert_in("The transaction was submitted successfully", await wallet.sweep_addresses(acc1_address, all_addresses=True))
 
             block_id = self.generate_block()
             assert_in("Success", await wallet.sync())
 
             # check we sent all our coins
             balance = await wallet.get_balance()
-            assert_in(f"Coins amount: 0", balance)
+            assert_in("Coins amount: 0", balance)
             # check we still have the locked balance
 
             balance = await wallet.get_balance('locked')

--- a/test/functional/wallet_watch_address.py
+++ b/test/functional/wallet_watch_address.py
@@ -109,7 +109,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             if store_tx_in_wallet:
                 assert_in(f"Coins amount: {coins_to_send}", await wallet.get_balance(utxo_states=['inactive']))
             else:
-                assert_in(f"Coins amount: 0", await wallet.get_balance(utxo_states=['inactive']))
+                assert_in("Coins amount: 0", await wallet.get_balance(utxo_states=['inactive']))
 
             assert node.mempool_contains_tx(receive_coins_tx_id)
 
@@ -145,7 +145,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             # send coins to that address
             output = await wallet.send_to_address(address_from_wallet1, 1)
             assert_in("The transaction was submitted successfully", output)
-            receive_coins_tx_id = output.splitlines()[1]
+            receive_coins_tx_id = output.splitlines()[-1]
 
             # check in wallet2
             await wallet.close_wallet()
@@ -173,7 +173,7 @@ class WalletSubmitTransaction(BitcoinTestFramework):
             other_address = await wallet.new_address()
             output = await wallet.send_to_address(other_address, 0.1)
             assert_in("The transaction was submitted successfully", output)
-            send_coins_tx_id = output.splitlines()[1]
+            send_coins_tx_id = output.splitlines()[-1]
 
 
             # go back to wallet 2

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1446,7 +1446,7 @@ impl<K: AccountKeyChains> Account<K> {
         )
     }
 
-    pub fn create_stake_pool_tx_with_vrf_key(
+    pub fn create_stake_pool_with_vrf_key(
         &mut self,
         db_tx: &mut impl WalletStorageWriteUnlocked,
         mut stake_pool_arguments: StakePoolCreationArguments,
@@ -1457,7 +1457,7 @@ impl<K: AccountKeyChains> Account<K> {
             return Err(WalletError::VrfKeyMustBeProvided);
         };
 
-        self.create_stake_pool_tx_impl(
+        self.create_stake_pool_impl(
             stake_pool_arguments,
             db_tx,
             vrf_public_key,
@@ -1466,7 +1466,7 @@ impl<K: AccountKeyChains> Account<K> {
         )
     }
 
-    fn create_stake_pool_tx_impl(
+    fn create_stake_pool_impl(
         &mut self,
         stake_pool_arguments: StakePoolCreationArguments,
         db_tx: &mut impl WalletStorageWriteUnlocked,
@@ -2493,7 +2493,7 @@ impl<K: AccountKeyChains + VRFAccountKeyChains> Account<K> {
         Ok(data)
     }
 
-    pub fn create_stake_pool_tx(
+    pub fn create_stake_pool(
         &mut self,
         db_tx: &mut impl WalletStorageWriteUnlocked,
         mut stake_pool_arguments: StakePoolCreationArguments,
@@ -2504,7 +2504,7 @@ impl<K: AccountKeyChains + VRFAccountKeyChains> Account<K> {
             Some(vrf_public_key) => vrf_public_key,
             None => self.get_vrf_public_key(db_tx)?,
         };
-        self.create_stake_pool_tx_impl(
+        self.create_stake_pool_impl(
             stake_pool_arguments,
             db_tx,
             vrf_public_key,

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -532,7 +532,7 @@ impl<K: AccountKeyChains> Account<K> {
     pub fn sweep_addresses(
         &mut self,
         destination: Destination,
-        request: SendRequest,
+        mut request: SendRequest,
         current_fee_rate: FeeRate,
     ) -> WalletResult<SendRequest> {
         let mut grouped_inputs = group_preselected_inputs(
@@ -592,6 +592,7 @@ impl<K: AccountKeyChains> Account<K> {
             destination,
         );
         outputs.push(coin_output);
+        request.add_fee(Currency::Coin, total_fee)?;
 
         Ok(request.with_outputs(outputs))
     }

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -444,6 +444,7 @@ impl<K: AccountKeyChains> Account<K> {
             selection_result = selection_result.add_change(
                 (total_fees_not_paid - new_total_fees_not_paid).unwrap_or(Amount::ZERO),
             )?;
+            let change_amount = selection_result.get_change();
             let change_output = match pay_fee_with_currency {
                 Currency::Coin => make_address_output(change_address.clone(), change_amount),
                 Currency::Token(token_id) => {

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -2018,7 +2018,7 @@ where
         Ok((token_id, signed_transaction))
     }
 
-    pub fn create_stake_pool_tx_with_vrf_key(
+    pub fn create_stake_pool_with_vrf_key(
         &mut self,
         account_index: U31,
         current_fee_rate: FeeRate,
@@ -2030,7 +2030,7 @@ where
             account_index,
             TxAdditionalInfo::new(),
             |account, db_tx| {
-                account.create_stake_pool_tx_with_vrf_key(
+                account.create_stake_pool_with_vrf_key(
                     db_tx,
                     stake_pool_arguments,
                     latest_median_time,
@@ -2515,7 +2515,7 @@ where
         Ok(account.get_legacy_vrf_public_key())
     }
 
-    pub fn create_stake_pool_tx(
+    pub fn create_stake_pool(
         &mut self,
         account_index: U31,
         current_fee_rate: FeeRate,
@@ -2527,7 +2527,7 @@ where
             account_index,
             TxAdditionalInfo::new(),
             |account, db_tx| {
-                account.create_stake_pool_tx(
+                account.create_stake_pool(
                     db_tx,
                     stake_pool_arguments,
                     latest_median_time,

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -1178,23 +1178,6 @@ where
         )
     }
 
-    fn for_account_rw_unlocked_and_check_tx(
-        &mut self,
-        account_index: U31,
-        additional_info: TxAdditionalInfo,
-        f: impl FnOnce(&mut Account<P::K>, &mut StoreTxRwUnlocked<B>) -> WalletResult<SendRequest>,
-    ) -> WalletResult<SignedTransaction> {
-        Ok(self
-            .for_account_rw_unlocked_and_check_tx_generic(
-                account_index,
-                additional_info,
-                |account, db_tx| Ok((f(account, db_tx)?, ())),
-                |err| err,
-            )?
-            .0
-            .tx)
-    }
-
     fn for_account_rw_unlocked_and_check_tx_with_fees(
         &mut self,
         account_index: U31,
@@ -2134,9 +2117,9 @@ where
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         additional_info: TxAdditionalInfo,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         let latest_median_time = self.latest_median_time;
-        self.for_account_rw_unlocked_and_check_tx(
+        self.for_account_rw_unlocked_and_check_tx_with_fees(
             account_index,
             additional_info,
             |account, db_tx| {

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -5579,7 +5579,8 @@ fn create_htlc_and_spend(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let create_htlc_tx_id = create_htlc_tx.transaction().get_id();
     let (_, block2) = create_block(
         &chain_config,
@@ -5719,7 +5720,8 @@ fn create_htlc_and_refund(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let create_htlc_tx_id = create_htlc_tx.transaction().get_id();
 
     let refund_tx = Transaction::new(

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -1762,7 +1762,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
     let decommission_key = Destination::PublicKey(standalone_pk);
 
     let err = wallet
-        .create_stake_pool_tx_with_vrf_key(
+        .create_stake_pool_with_vrf_key(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -1779,7 +1779,7 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
     assert_eq!(err, WalletError::VrfKeyMustBeProvided);
 
     let stake_pool_transaction = wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -1967,7 +1967,7 @@ fn create_stake_pool_for_different_wallet_and_list_pool_ids(#[case] seed: Seed) 
 
     // First, try to create the pool using staker_key_hash_dest as the staker address; this should fail.
     let err = wallet1
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -1990,7 +1990,7 @@ fn create_stake_pool_for_different_wallet_and_list_pool_ids(#[case] seed: Seed) 
 
     // Now use staker_key_dest.
     let stake_pool_transaction = wallet1
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -2008,7 +2008,7 @@ fn create_stake_pool_for_different_wallet_and_list_pool_ids(#[case] seed: Seed) 
     let stake_pool_transaction_id = stake_pool_transaction.transaction().get_id();
 
     let stake_pool_transaction2 = wallet1
-        .create_stake_pool_tx_with_vrf_key(
+        .create_stake_pool_with_vrf_key(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -2211,7 +2211,7 @@ fn reset_keys_after_failed_transaction(#[case] seed: Seed) {
         .unwrap()
         .last_issued();
 
-    let result = wallet.create_stake_pool_tx(
+    let result = wallet.create_stake_pool(
         DEFAULT_ACCOUNT_INDEX,
         FeeRate::from_amount_per_kb(Amount::ZERO),
         FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -2426,7 +2426,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
     let pool_amount = chain_config.min_stake_pool_pledge();
 
     let stake_pool_transaction = wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -4727,7 +4727,7 @@ fn decommission_pool_wrong_account(#[case] seed: Seed) {
     let decommission_key = wallet.get_new_address(acc_1_index).unwrap().1;
 
     let stake_pool_transaction = wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             acc_0_index,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -4824,7 +4824,7 @@ fn decommission_pool_request_wrong_account(#[case] seed: Seed) {
     let decommission_key = wallet.get_new_address(acc_1_index).unwrap().1;
 
     let stake_pool_transaction = wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             acc_0_index,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -4914,7 +4914,7 @@ fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
     let decommission_key = wallet.get_new_address(acc_1_index).unwrap().1;
 
     let stake_pool_transaction = wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             acc_0_index,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -5029,7 +5029,7 @@ fn sign_decommission_pool_request_cold_wallet(#[case] seed: Seed) {
     assert_eq!(res, (U31::from_u32(1).unwrap(), Some("name".into())));
 
     let stake_pool_transaction = hot_wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -5127,7 +5127,7 @@ fn filter_pools(#[case] seed: Seed) {
     let pool_amount = block1_amount;
 
     let stake_pool_transaction = wallet1
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -6783,7 +6783,7 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
     let pool_amount = chain_config.min_stake_pool_pledge();
 
     let stake_pool_transaction = wallet1
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -7076,7 +7076,7 @@ fn conflicting_delegation_account_nonce_same_wallet(#[case] seed: Seed) {
     let pool_amount = chain_config.min_stake_pool_pledge();
 
     let stake_pool_transaction = wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -7590,7 +7590,7 @@ fn conflicting_delegation_account_nonce_multiple_inputs(#[case] seed: Seed) {
     let pool_amount = chain_config.min_stake_pool_pledge();
 
     let stake_pool_transaction = wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
@@ -7865,7 +7865,7 @@ fn conflicting_delegation_account_with_reorg(#[case] seed: Seed) {
     let pool_amount = chain_config.min_stake_pool_pledge();
 
     let stake_pool_transaction = wallet
-        .create_stake_pool_tx(
+        .create_stake_pool(
             DEFAULT_ACCOUNT_INDEX,
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -1063,7 +1063,8 @@ fn wallet_accounts_creation() {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     // even with an unconfirmed transaction we cannot create a new account
     wallet.add_unconfirmed_tx(tx.clone(), &WalletEventsNoOp).unwrap();
@@ -1299,7 +1300,8 @@ fn wallet_get_transaction(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let tx_id = tx.transaction().get_id();
 
@@ -1359,7 +1361,8 @@ fn wallet_list_mainchain_transactions(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let send_tx_id = tx.transaction().get_id();
 
@@ -1382,7 +1385,8 @@ fn wallet_list_mainchain_transactions(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let spend_from_tx_id = tx.transaction().get_id();
 
     let _ = create_block(
@@ -1490,7 +1494,8 @@ fn wallet_transactions_with_fees(#[case] seed: Seed) {
             feerate,
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let tx_size = serialization::Encode::encoded_size(&transaction);
 
@@ -1546,7 +1551,8 @@ fn wallet_transactions_with_fees(#[case] seed: Seed) {
             feerate,
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let tx_size = serialization::Encode::encoded_size(&transaction);
     let exact_fee = feerate.compute_fee(tx_size).unwrap();
@@ -1681,7 +1687,8 @@ fn spend_from_user_specified_utxos(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     // check that we only have the selected_utxo as inputs
     assert_eq!(tx.inputs().len(), selected_utxos.len());
@@ -1790,7 +1797,8 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let stake_pool_transaction_id = stake_pool_transaction.transaction().get_id();
     let (addr, block2) = create_block(
         &chain_config,
@@ -1888,7 +1896,8 @@ fn create_stake_pool_and_list_pool_ids(#[case] seed: Seed) {
             None,
             FeeRate::from_amount_per_kb(Amount::from_atoms(0)),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -1999,7 +2008,8 @@ fn create_stake_pool_for_different_wallet_and_list_pool_ids(#[case] seed: Seed) 
                 vrf_public_key: Some(staker_vrf_public_key.clone()),
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let stake_pool_transaction_id = stake_pool_transaction.transaction().get_id();
 
     let stake_pool_transaction2 = wallet1
@@ -2016,7 +2026,8 @@ fn create_stake_pool_for_different_wallet_and_list_pool_ids(#[case] seed: Seed) 
                 vrf_public_key: Some(staker_vrf_public_key.clone()),
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let stake_pool_transaction_id2 = stake_pool_transaction2.transaction().get_id();
     assert_eq!(stake_pool_transaction_id, stake_pool_transaction_id2);
 
@@ -2156,7 +2167,8 @@ fn create_stake_pool_for_different_wallet_and_list_pool_ids(#[case] seed: Seed) 
             None,
             FeeRate::from_amount_per_kb(Amount::from_atoms(0)),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block4) = create_block(
         &chain_config,
@@ -2296,6 +2308,7 @@ fn send_to_unknown_delegation(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block_height = 2;
@@ -2329,7 +2342,8 @@ fn send_to_unknown_delegation(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let block_height = 3;
     let (_, block) = create_block(
@@ -2369,6 +2383,7 @@ fn send_to_unknown_delegation(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let _ = create_block(
@@ -2429,7 +2444,8 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (address, _) = create_block(
         &chain_config,
@@ -2456,6 +2472,7 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let _ = create_block(
@@ -2485,7 +2502,8 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -2504,7 +2522,8 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             Amount::from_atoms(2),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet
         .add_account_unconfirmed_tx(
@@ -2536,7 +2555,8 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             Amount::from_atoms(1),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     wallet
         .add_account_unconfirmed_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -2607,7 +2627,8 @@ fn create_spend_from_delegations(#[case] seed: Seed) {
             Amount::from_atoms(1),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     wallet
         .add_account_unconfirmed_tx(DEFAULT_ACCOUNT_INDEX, delegation_tx3, &WalletEventsNoOp)
         .unwrap();
@@ -2707,6 +2728,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
             )
+            .map(|(id, tx)| (id, tx.tx))
             .unwrap();
 
         let freezable = token_issuance.is_freezable.as_bool();
@@ -2752,7 +2774,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 TxAdditionalInfo::new(),
             )
-            .unwrap();
+            .unwrap()
+            .tx;
         wallet
             .add_account_unconfirmed_tx(
                 DEFAULT_ACCOUNT_INDEX,
@@ -2773,7 +2796,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
             )
-            .unwrap();
+            .unwrap()
+            .tx;
 
         (
             issued_token_id,
@@ -2799,6 +2823,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
             )
+            .map(|(id, tx)| (id, tx.tx))
             .unwrap();
         random_issuing_wallet
             .add_unconfirmed_tx(nft_issuance_transaction.clone(), &WalletEventsNoOp)
@@ -2817,7 +2842,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 TxAdditionalInfo::new(),
             )
-            .unwrap();
+            .unwrap()
+            .tx;
         (issued_token_id, vec![nft_issuance_transaction, transfer_tx])
     };
 
@@ -2870,7 +2896,8 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info.clone(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     wallet
         .add_account_unconfirmed_tx(
             DEFAULT_ACCOUNT_INDEX,
@@ -2924,8 +2951,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
-        .err()
-        .unwrap();
+        .unwrap_err();
 
     let remaining_tokens = (token_amount_to_issue - tokens_to_transfer).unwrap();
     if remaining_tokens == Amount::ZERO {
@@ -3042,6 +3068,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -3080,7 +3107,8 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(&chain_config, &mut wallet, vec![mint_tx], block2_amount, 2);
 
@@ -3096,7 +3124,8 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet.add_unconfirmed_tx(freeze_tx.clone(), &WalletEventsNoOp).unwrap();
 
@@ -3124,7 +3153,8 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet.add_unconfirmed_tx(unfreeze_tx.clone(), &WalletEventsNoOp).unwrap();
 
@@ -3195,7 +3225,8 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let tokens_to_transfer = Amount::from_atoms(rng.gen_range(1..=amount_to_mint.into_atoms()));
     let some_other_address = PublicKeyHash::from_low_u64_be(1);
@@ -3221,7 +3252,8 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet
         .add_unconfirmed_tx(transfer_tokens_transaction.clone(), &WalletEventsNoOp)
@@ -3340,6 +3372,7 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -3393,7 +3426,8 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet.add_unconfirmed_tx(mint_transaction.clone(), &WalletEventsNoOp).unwrap();
 
@@ -3508,7 +3542,8 @@ fn change_token_supply_fixed(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet
         .add_unconfirmed_tx(unmint_transaction.clone(), &WalletEventsNoOp)
@@ -3593,6 +3628,7 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -3647,7 +3683,8 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet.add_unconfirmed_tx(mint_transaction.clone(), &WalletEventsNoOp).unwrap();
     let unconfirmed_token_info = wallet
@@ -3703,7 +3740,8 @@ fn change_token_supply_unlimited(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     wallet
         .add_unconfirmed_tx(unmint_transaction.clone(), &WalletEventsNoOp)
         .unwrap();
@@ -3787,6 +3825,7 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -3841,7 +3880,8 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     wallet.add_unconfirmed_tx(mint_transaction.clone(), &WalletEventsNoOp).unwrap();
     let unconfirmed_token_info = wallet
         .get_token_unconfirmed_info(DEFAULT_ACCOUNT_INDEX, token_info.clone())
@@ -3896,7 +3936,8 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet
         .add_unconfirmed_tx(unmint_transaction.clone(), &WalletEventsNoOp)
@@ -3936,7 +3977,8 @@ fn change_and_lock_token_supply_lockable(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -4072,7 +4114,8 @@ fn lock_then_transfer(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     wallet
         .add_unconfirmed_tx(lock_then_transfer_transaction.clone(), &WalletEventsNoOp)
         .unwrap();
@@ -4193,7 +4236,8 @@ fn wallet_multiple_transactions_in_single_block(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 TxAdditionalInfo::new(),
             )
-            .unwrap();
+            .unwrap()
+            .tx;
         wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
 
         for utxo in transaction.inputs().iter().map(|inp| inp.utxo_outpoint().unwrap()) {
@@ -4281,7 +4325,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 TxAdditionalInfo::new(),
             )
-            .unwrap();
+            .unwrap()
+            .tx;
 
         wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
 
@@ -4316,7 +4361,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
 
     for utxo in transaction.inputs().iter().map(|inp| inp.utxo_outpoint().unwrap()) {
@@ -4381,7 +4427,8 @@ fn wallet_scan_multiple_transactions_from_mempool(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     wallet.add_unconfirmed_tx(transaction.clone(), &WalletEventsNoOp).unwrap();
 
     let transaction_id = transaction.transaction().get_id();
@@ -4462,7 +4509,8 @@ fn wallet_abandon_transactions(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 TxAdditionalInfo::new(),
             )
-            .unwrap();
+            .unwrap()
+            .tx;
         wallet
             .add_account_unconfirmed_tx(
                 DEFAULT_ACCOUNT_INDEX,
@@ -4697,7 +4745,8 @@ fn decommission_pool_wrong_account(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let _ = create_block(
         &chain_config,
         &mut wallet,
@@ -4732,7 +4781,8 @@ fn decommission_pool_wrong_account(#[case] seed: Seed) {
             None,
             FeeRate::from_amount_per_kb(Amount::from_atoms(0)),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -4792,7 +4842,8 @@ fn decommission_pool_request_wrong_account(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let _ = create_block(
         &chain_config,
         &mut wallet,
@@ -4881,7 +4932,8 @@ fn sign_decommission_pool_request_between_accounts(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     // remove the signatures and try to sign it again
     let tx = stake_pool_transaction.transaction().clone();
@@ -4995,7 +5047,8 @@ fn sign_decommission_pool_request_cold_wallet(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let _ = create_block(
         &chain_config,
         &mut hot_wallet,
@@ -5092,7 +5145,8 @@ fn filter_pools(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     // sync for wallet1
     let _ = create_block(
         &chain_config,
@@ -5790,6 +5844,7 @@ fn create_order(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -5829,7 +5884,8 @@ fn create_order(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -5867,6 +5923,7 @@ fn create_order(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let _ = create_block(
@@ -5916,6 +5973,7 @@ fn create_order_and_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -5955,7 +6013,8 @@ fn create_order_and_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -5993,6 +6052,7 @@ fn create_order_and_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
     let order_info = RpcOrderInfo {
         conclude_key: address2.clone().into_object(),
@@ -6037,7 +6097,8 @@ fn create_order_and_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -6091,6 +6152,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -6133,7 +6195,8 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block3) = create_block(
         &chain_config,
@@ -6182,6 +6245,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
     let order_info = RpcOrderInfo {
         conclude_key: address1.clone().into_object(),
@@ -6243,7 +6307,8 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block5) = create_block(
         &chain_config,
@@ -6307,7 +6372,8 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block6) = create_block(
         &chain_config,
@@ -6363,7 +6429,8 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block7) = create_block(
         &chain_config,
@@ -6428,6 +6495,7 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -6470,7 +6538,8 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block3) = create_block(
         &chain_config,
@@ -6519,6 +6588,7 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
     let order_info = RpcOrderInfo {
         conclude_key: address1.clone().into_object(),
@@ -6580,7 +6650,8 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block5) = create_block(
         &chain_config,
@@ -6643,7 +6714,8 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             additional_info,
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block6) = create_block(
         &chain_config,
@@ -6727,7 +6799,8 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (address, block2) = create_block(
         &chain_config,
@@ -6756,6 +6829,7 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let (_, block3) = create_block(
@@ -6787,7 +6861,8 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block4) = create_block(
         &chain_config,
@@ -6815,7 +6890,8 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
             delegation_amount,
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let spend_from_delegation_tx_1_id = spend_from_delegation_tx_1.transaction().get_id();
 
     wallet1
@@ -6836,7 +6912,8 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
             delegation_amount,
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let spend_from_delegation_tx_2_id = spend_from_delegation_tx_2.transaction().get_id();
 
     wallet1
@@ -6865,7 +6942,8 @@ fn conflicting_delegation_account_nonce(#[case] seed: Seed) {
             delegation_amount,
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let spend_from_delegation_tx_3_id = spend_from_delegation_tx_3.transaction().get_id();
 
     let (_, block5) = create_block(
@@ -7014,7 +7092,8 @@ fn conflicting_delegation_account_nonce_same_wallet(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (address, _) = create_block(
         &chain_config,
@@ -7042,6 +7121,7 @@ fn conflicting_delegation_account_nonce_same_wallet(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let _ = create_block(
@@ -7072,7 +7152,8 @@ fn conflicting_delegation_account_nonce_same_wallet(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -7099,7 +7180,8 @@ fn conflicting_delegation_account_nonce_same_wallet(#[case] seed: Seed) {
             delegation_amount,
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet
         .add_account_unconfirmed_tx(
@@ -7120,7 +7202,8 @@ fn conflicting_delegation_account_nonce_same_wallet(#[case] seed: Seed) {
             delegation_amount,
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet
         .add_account_unconfirmed_tx(
@@ -7243,6 +7326,7 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let block2_amount = chain_config.token_supply_change_fee(BlockHeight::zero());
@@ -7282,7 +7366,8 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let _ = create_block(
         &chain_config,
@@ -7307,6 +7392,7 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let _ = create_block(
@@ -7357,7 +7443,8 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet
         .add_account_unconfirmed_tx(
@@ -7394,7 +7481,8 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     wallet
         .add_account_unconfirmed_tx(
@@ -7518,7 +7606,8 @@ fn conflicting_delegation_account_nonce_multiple_inputs(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (address, block2) = create_block(
         &chain_config,
@@ -7547,6 +7636,7 @@ fn conflicting_delegation_account_nonce_multiple_inputs(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let (_, block3) = create_block(
@@ -7579,7 +7669,8 @@ fn conflicting_delegation_account_nonce_multiple_inputs(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block4) = create_block(
         &chain_config,
@@ -7661,7 +7752,8 @@ fn conflicting_delegation_account_nonce_multiple_inputs(#[case] seed: Seed) {
             delegation_amount,
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let spend_from_delegation_confirmed_tx_id =
         spend_from_delegation_tx_confirmed.transaction().get_id();
 
@@ -7789,7 +7881,8 @@ fn conflicting_delegation_account_with_reorg(#[case] seed: Seed) {
                 vrf_public_key: None,
             },
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (address, block2) = create_block(
         &chain_config,
@@ -7818,6 +7911,7 @@ fn conflicting_delegation_account_with_reorg(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
+        .map(|(id, tx)| (id, tx.tx))
         .unwrap();
 
     let (_, block3) = create_block(
@@ -7849,7 +7943,8 @@ fn conflicting_delegation_account_with_reorg(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
 
     let (_, block4) = create_block(
         &chain_config,
@@ -7879,7 +7974,8 @@ fn conflicting_delegation_account_with_reorg(#[case] seed: Seed) {
             delegation_amount,
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let spend_from_delegation_tx_id_1 = spend_from_delegation_tx_1.transaction().get_id();
 
     wallet
@@ -7911,7 +8007,8 @@ fn conflicting_delegation_account_with_reorg(#[case] seed: Seed) {
             delegation_amount,
             FeeRate::from_amount_per_kb(Amount::ZERO),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let spend_from_delegation_tx_id_2 = spend_from_delegation_tx_2.transaction().get_id();
 
     let (_, block5) = create_block(
@@ -8035,7 +8132,8 @@ fn rollback_utxos_after_abandon(#[case] seed: Seed) {
             FeeRate::from_amount_per_kb(Amount::ZERO),
             TxAdditionalInfo::new(),
         )
-        .unwrap();
+        .unwrap()
+        .tx;
     let tx_id = tx.transaction().get_id();
 
     wallet
@@ -8176,6 +8274,7 @@ fn token_id_generation_v1_uses_first_tx_input(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
             )
+            .map(|(id, tx)| (id, tx.tx))
             .unwrap();
 
         let expected_token_id = TokenId::from_tx_input(&token_issuance_transaction.inputs()[0]);
@@ -8201,6 +8300,7 @@ fn token_id_generation_v1_uses_first_tx_input(#[case] seed: Seed) {
                 FeeRate::from_amount_per_kb(Amount::ZERO),
                 FeeRate::from_amount_per_kb(Amount::ZERO),
             )
+            .map(|(id, tx)| (id, tx.tx))
             .unwrap();
 
         let expected_token_id = TokenId::from_tx_input(&nft_issuance_transaction.inputs()[0]);

--- a/wallet/types/src/lib.rs
+++ b/wallet/types/src/lib.rs
@@ -28,20 +28,20 @@ pub mod wallet_tx;
 pub mod wallet_type;
 pub mod with_locked;
 
-use std::collections::BTreeMap;
-
 pub use account_id::{
     AccountDerivationPathId, AccountId, AccountKeyPurposeId, AccountWalletCreatedTxId,
     AccountWalletTxId,
 };
 pub use account_info::AccountInfo;
+pub use currency::Currency;
+pub use keys::{KeyPurpose, KeychainUsageState, RootKeys};
+pub use wallet_tx::{BlockInfo, WalletTx};
+
 use common::{
     chain::{SignedTransaction, Transaction},
     primitives::Amount,
 };
-pub use currency::Currency;
-pub use keys::{KeyPurpose, KeychainUsageState, RootKeys};
-pub use wallet_tx::{BlockInfo, WalletTx};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignedTxWithFees {

--- a/wallet/types/src/lib.rs
+++ b/wallet/types/src/lib.rs
@@ -37,11 +37,12 @@ pub use currency::Currency;
 pub use keys::{KeyPurpose, KeychainUsageState, RootKeys};
 pub use wallet_tx::{BlockInfo, WalletTx};
 
+use std::collections::BTreeMap;
+
 use common::{
     chain::{SignedTransaction, Transaction},
     primitives::Amount,
 };
-use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignedTxWithFees {

--- a/wallet/types/src/lib.rs
+++ b/wallet/types/src/lib.rs
@@ -28,11 +28,29 @@ pub mod wallet_tx;
 pub mod wallet_type;
 pub mod with_locked;
 
+use std::collections::BTreeMap;
+
 pub use account_id::{
     AccountDerivationPathId, AccountId, AccountKeyPurposeId, AccountWalletCreatedTxId,
     AccountWalletTxId,
 };
 pub use account_info::AccountInfo;
+use common::{
+    chain::{SignedTransaction, Transaction},
+    primitives::Amount,
+};
 pub use currency::Currency;
 pub use keys::{KeyPurpose, KeychainUsageState, RootKeys};
 pub use wallet_tx::{BlockInfo, WalletTx};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedTxWithFees {
+    pub tx: SignedTransaction,
+    pub fees: BTreeMap<Currency, Amount>,
+}
+
+impl SignedTxWithFees {
+    pub fn transaction(&self) -> &Transaction {
+        self.tx.transaction()
+    }
+}

--- a/wallet/wallet-cli-commands/src/command_handler/mod.rs
+++ b/wallet/wallet-cli-commands/src/command_handler/mod.rs
@@ -136,7 +136,7 @@ where
             let hex = new_tx.tx.to_string();
             let summary = new_tx.tx.take().transaction().text_summary(chain_config);
 
-            format!("{summary}\nThe transaction was created and ready to be submitted:\n{hex}",)
+            format!("{summary}\nThe transaction was created and is ready to be submitted:\n{hex}",)
         };
 
         ConsoleCommand::Print(status_text)

--- a/wallet/wallet-cli-commands/src/command_handler/mod.rs
+++ b/wallet/wallet-cli-commands/src/command_handler/mod.rs
@@ -774,6 +774,13 @@ where
                 self.handle_cold_wallet_command(command, chain_config).await
             }
 
+            WalletCommand::ConfigBroadcast { broadcast } => {
+                self.config.broadcast_to_mempool = broadcast;
+                Ok(ConsoleCommand::Print(format!(
+                    "Broadcast to Mempool set to: {broadcast:?}"
+                )))
+            }
+
             WalletCommand::ChainstateInfo => {
                 let info = self.wallet().await?.chainstate_info().await?;
                 Ok(ConsoleCommand::Print(format!("{info:#?}")))

--- a/wallet/wallet-cli-commands/src/command_handler/mod.rs
+++ b/wallet/wallet-cli-commands/src/command_handler/mod.rs
@@ -129,14 +129,14 @@ where
         let status_text = if new_tx.broadcasted {
             let summary = new_tx.tx.take().transaction().text_summary(chain_config);
             format!(
-                "The transaction:\n{summary}\nWas submitted successfully with ID:\n{}",
+                "{summary}\nThe transaction was submitted successfully with ID:\n{}",
                 id_to_hex_string(*new_tx.tx_id.as_hash())
             )
         } else {
             let hex = new_tx.tx.to_string();
             let summary = new_tx.tx.take().transaction().text_summary(chain_config);
 
-            format!("The transaction:\n{summary}\nWas created and ready to be submitted:\n{hex}",)
+            format!("{summary}\nThe transaction was created and ready to be submitted:\n{hex}",)
         };
 
         ConsoleCommand::Print(status_text)

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -394,6 +394,12 @@ pub enum WalletCommand {
     #[command(flatten)]
     ColdCommands(ColdWalletCommand),
 
+    /// Configure broadcasting to Mempool to true of false.
+    /// By default it is set to true. If set to false, any command that creates a transaction will
+    /// return it to the user and will need to be submitted manually with the command `node-submit-transaction`
+    #[clap(name = "config-broadcast")]
+    ConfigBroadcast { broadcast: bool },
+
     #[clap(name = "account-create")]
     CreateNewAccount { name: Option<String> },
 

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -394,9 +394,12 @@ pub enum WalletCommand {
     #[command(flatten)]
     ColdCommands(ColdWalletCommand),
 
-    /// Configure broadcasting to Mempool to true of false.
-    /// By default it is set to true. If set to false, any command that creates a transaction will
-    /// return it to the user and will need to be submitted manually with the command `node-submit-transaction`
+    /// Configure broadcasting to Mempool to true or false.
+    ///
+    /// If set to false, any command that creates a transaction will return it to the user and not submit it automatically.
+    /// The transaction will need to be submitted manually with the command `node-submit-transaction`.
+    ///
+    /// The effect of this is not preserved when the CLI wallet is closed.
     #[clap(name = "config-broadcast")]
     ConfigBroadcast { broadcast: bool },
 

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -401,7 +401,10 @@ pub enum WalletCommand {
     ///
     /// The effect of this is not preserved when the CLI wallet is closed.
     #[clap(name = "config-broadcast")]
-    ConfigBroadcast { broadcast: bool },
+    ConfigBroadcast {
+        #[arg(value_enum)]
+        broadcast: YesNo,
+    },
 
     #[clap(name = "account-create")]
     CreateNewAccount { name: Option<String> },

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -652,9 +652,9 @@ pub enum WalletCommand {
 
     #[clap(name = "address-sweep-spendable")]
     /// Sweep all spendable coins or tokens from an address or addresses specified in `addresses`
-    /// or all addresses from this account if all is set to true, to the given destination address.
-    /// Either 1 or more addresses need to be specified in `addresses` without `all` being set, or
-    /// `addresses` needs to be empty and --all being set.
+    /// or all addresses from this account if `--all` is specified, to the given destination address.
+    /// Either 1 or more addresses need to be specified in `addresses` without `--all` being set, or
+    /// `addresses` needs to be empty and `--all` being set.
     ///
     /// Spendable coins are any coins that are not locked, and tokens that are not frozen or locked.
     /// The wallet will automatically calculate the required fees

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -643,7 +643,11 @@ pub enum WalletCommand {
         /// The receiving address of the coins or tokens
         destination_address: String,
         /// The addresses to be swept
+        #[arg(required_unless_present("all"))]
         addresses: Vec<String>,
+        /// Sweep all addresses
+        #[arg(long = "all", default_value_t = false, conflicts_with_all(["addresses"]))]
+        all: bool,
     },
 
     #[clap(name = "staking-sweep-delegation")]

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -394,9 +394,9 @@ pub enum WalletCommand {
     #[command(flatten)]
     ColdCommands(ColdWalletCommand),
 
-    /// Configure broadcasting to Mempool to true or false.
+    /// Configure broadcasting to Mempool to yes or no.
     ///
-    /// If set to false, any command that creates a transaction will return it to the user and not submit it automatically.
+    /// If set to no, any command that creates a transaction will return it to the user and not submit it automatically.
     /// The transaction will need to be submitted manually with the command `node-submit-transaction`.
     ///
     /// The effect of this is not preserved when the CLI wallet is closed.
@@ -651,6 +651,13 @@ pub enum WalletCommand {
     },
 
     #[clap(name = "address-sweep-spendable")]
+    /// Sweep all spendable coins or tokens from an address or addresses specified in `addresses`
+    /// or all addresses from this account if all is set to true, to the given destination address.
+    /// Either 1 or more addresses need to be specified in `addresses` without `all` being set, or
+    /// `addresses` needs to be empty and --all being set.
+    ///
+    /// Spendable coins are any coins that are not locked, and tokens that are not frozen or locked.
+    /// The wallet will automatically calculate the required fees
     SweepFromAddress {
         /// The receiving address of the coins or tokens
         destination_address: String,
@@ -1175,20 +1182,23 @@ pub fn get_repl_command(cold_wallet: bool, mutable_wallet: bool) -> Command {
 
     // Customize the help template for all commands to make it more REPL friendly
     for subcommand in repl_command.get_subcommands_mut() {
-        if let Some(desc) =
-            COLD_WALLET_DESC.methods.iter().chain(WALLET_DESC.methods).find_map(|method| {
-                method
-                    .name
-                    .split('_')
-                    .zip(subcommand.get_name().split('-'))
-                    .all(|(x, y)| x == y)
-                    .then_some(method.description)
-            })
-        {
-            *subcommand = subcommand.clone().help_template(COMMAND_HELP_TEMPLATE).about(desc);
-        } else {
-            *subcommand = subcommand.clone().help_template(COMMAND_HELP_TEMPLATE);
+        let mut new_subcommand = subcommand.clone().help_template(COMMAND_HELP_TEMPLATE);
+        if new_subcommand.get_about().is_none() {
+            if let Some(desc) =
+                COLD_WALLET_DESC.methods.iter().chain(WALLET_DESC.methods).find_map(|method| {
+                    method
+                        .name
+                        .split('_')
+                        .zip(subcommand.get_name().split('-'))
+                        .all(|(x, y)| x == y)
+                        .then_some(method.description)
+                })
+            {
+                new_subcommand = new_subcommand.about(desc);
+            }
         }
+
+        *subcommand = new_subcommand;
     }
 
     repl_command

--- a/wallet/wallet-cli-lib/tests/basic.rs
+++ b/wallet/wallet-cli-lib/tests/basic.rs
@@ -109,7 +109,7 @@ async fn produce_blocks_decommission_genesis_pool(#[case] seed: Seed) {
             rng.gen_range(1..100),
             address,
         ),)
-        .starts_with("The transaction was submitted successfully with ID"));
+        .contains("The transaction was submitted successfully with ID"));
     // create some blocks
     assert_eq!(test.exec("node-generate-blocks 20"), "Success");
 
@@ -123,7 +123,7 @@ async fn produce_blocks_decommission_genesis_pool(#[case] seed: Seed) {
     assert_eq!(test.exec("account-select 0"), "Success");
     assert!(test
         .exec(&format!("address-send {} 50000", acc2_address))
-        .starts_with("The transaction was submitted successfully with ID"));
+        .contains("The transaction was submitted successfully with ID"));
     // create a block
     assert_eq!(test.exec("node-generate-blocks 1"), "Success");
 
@@ -135,7 +135,7 @@ async fn produce_blocks_decommission_genesis_pool(#[case] seed: Seed) {
             rng.gen_range(1..100),
             address,
         ),)
-        .starts_with("The transaction was submitted successfully with ID"));
+        .contains("The transaction was submitted successfully with ID"));
     assert_eq!(test.exec("account-select 0"), "Success");
 
     // create some blocks
@@ -167,7 +167,7 @@ async fn produce_blocks_decommission_genesis_pool(#[case] seed: Seed) {
     assert_eq!(test.exec("wallet-sync"), "Success");
     assert!(test
         .exec(&format!("node-submit-transaction {signed_tx}"))
-        .starts_with("The transaction was submitted successfully with ID"));
+        .contains("The transaction was submitted successfully with ID"));
 
     // stake with the other acc
     assert_eq!(test.exec("account-select 1"), "Success");

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -56,7 +56,7 @@ use wallet_types::{
     utxo_types::{UtxoState, UtxoStates, UtxoTypes},
     wallet_tx::TxData,
     with_locked::WithLocked,
-    Currency, KeyPurpose, KeychainUsageState,
+    Currency, KeyPurpose, KeychainUsageState, SignedTxWithFees,
 };
 
 #[cfg(feature = "trezor")]
@@ -615,7 +615,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         token_issuance: TokenIssuance,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> WalletResult<(TokenId, SignedTransaction)> {
+    ) -> WalletResult<(TokenId, SignedTxWithFees)> {
         match self {
             RuntimeWallet::Software(w) => w.issue_new_token(
                 account_index,
@@ -640,7 +640,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         metadata: Metadata,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> WalletResult<(TokenId, SignedTransaction)> {
+    ) -> WalletResult<(TokenId, SignedTxWithFees)> {
         match self {
             RuntimeWallet::Software(w) => w.issue_new_nft(
                 account_index,
@@ -668,7 +668,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         address: Address<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> Result<SignedTransaction, WalletError> {
+    ) -> Result<SignedTxWithFees, WalletError> {
         match self {
             RuntimeWallet::Software(w) => w.mint_tokens(
                 account_index,
@@ -697,7 +697,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         amount: Amount,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> Result<SignedTransaction, WalletError> {
+    ) -> Result<SignedTxWithFees, WalletError> {
         match self {
             RuntimeWallet::Software(w) => w.unmint_tokens(
                 account_index,
@@ -723,7 +723,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         token_info: &UnconfirmedTokenInfo,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> Result<SignedTransaction, WalletError> {
+    ) -> Result<SignedTxWithFees, WalletError> {
         match self {
             RuntimeWallet::Software(w) => w.lock_token_supply(
                 account_index,
@@ -748,7 +748,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         is_token_unfreezable: IsTokenUnfreezable,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> Result<SignedTransaction, WalletError> {
+    ) -> Result<SignedTxWithFees, WalletError> {
         match self {
             RuntimeWallet::Software(w) => w.freeze_token(
                 account_index,
@@ -774,7 +774,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         token_info: &UnconfirmedTokenInfo,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> Result<SignedTransaction, WalletError> {
+    ) -> Result<SignedTxWithFees, WalletError> {
         match self {
             RuntimeWallet::Software(w) => w.unfreeze_token(
                 account_index,
@@ -799,7 +799,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         address: Address<Destination>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> Result<SignedTransaction, WalletError> {
+    ) -> Result<SignedTxWithFees, WalletError> {
         match self {
             RuntimeWallet::Software(w) => w.change_token_authority(
                 account_index,
@@ -826,7 +826,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         metadata_uri: Vec<u8>,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> Result<SignedTransaction, WalletError> {
+    ) -> Result<SignedTxWithFees, WalletError> {
         match self {
             RuntimeWallet::Software(w) => w.change_token_metadata_uri(
                 account_index,
@@ -856,7 +856,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         additional_info: TxAdditionalInfo,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_transaction_to_addresses(
                 account_index,
@@ -887,7 +887,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         filtered_inputs: Vec<(UtxoOutPoint, TxOutput)>,
         current_fee_rate: FeeRate,
         additional_info: TxAdditionalInfo,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_sweep_transaction(
                 account_index,
@@ -926,7 +926,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         delegation_id: DelegationId,
         delegation_share: Amount,
         current_fee_rate: FeeRate,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_sweep_from_delegation_transaction(
                 account_index,
@@ -989,7 +989,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         output: TxOutput,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> WalletResult<(DelegationId, SignedTransaction)> {
+    ) -> WalletResult<(DelegationId, SignedTxWithFees)> {
         match self {
             RuntimeWallet::Software(w) => w.create_delegation(
                 account_index,
@@ -1015,7 +1015,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         delegation_id: DelegationId,
         delegation_share: Amount,
         current_fee_rate: FeeRate,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_transaction_to_addresses_from_delegation(
                 account_index,
@@ -1043,7 +1043,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         stake_pool_arguments: StakePoolCreationArguments,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_stake_pool_tx(
                 account_index,
@@ -1068,7 +1068,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         staker_balance: Amount,
         output_address: Option<Destination>,
         current_fee_rate: FeeRate,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.decommission_stake_pool(
                 account_index,
@@ -1155,7 +1155,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         additional_info: TxAdditionalInfo,
-    ) -> WalletResult<(OrderId, SignedTransaction)> {
+    ) -> WalletResult<(OrderId, SignedTxWithFees)> {
         match self {
             RuntimeWallet::Software(w) => w.create_order_tx(
                 account_index,
@@ -1189,7 +1189,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         additional_info: TxAdditionalInfo,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_conclude_order_tx(
                 account_index,
@@ -1224,7 +1224,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         additional_info: TxAdditionalInfo,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_fill_order_tx(
                 account_index,
@@ -1257,7 +1257,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         order_info: RpcOrderInfo,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_freeze_order_tx(
                 account_index,
@@ -1317,7 +1317,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         additional_info: TxAdditionalInfo,
-    ) -> WalletResult<(SignedTransaction, SignedTransactionIntent)> {
+    ) -> WalletResult<(SignedTxWithFees, SignedTransactionIntent)> {
         match self {
             RuntimeWallet::Software(w) => w.create_transaction_to_addresses_with_intent(
                 account_index,

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -1037,7 +1037,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         }
     }
 
-    pub fn create_stake_pool_tx(
+    pub fn create_stake_pool(
         &mut self,
         account_index: U31,
         current_fee_rate: FeeRate,
@@ -1045,14 +1045,14 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         stake_pool_arguments: StakePoolCreationArguments,
     ) -> WalletResult<SignedTxWithFees> {
         match self {
-            RuntimeWallet::Software(w) => w.create_stake_pool_tx(
+            RuntimeWallet::Software(w) => w.create_stake_pool(
                 account_index,
                 current_fee_rate,
                 consolidate_fee_rate,
                 stake_pool_arguments,
             ),
             #[cfg(feature = "trezor")]
-            RuntimeWallet::Trezor(w) => w.create_stake_pool_tx_with_vrf_key(
+            RuntimeWallet::Trezor(w) => w.create_stake_pool_with_vrf_key(
                 account_index,
                 current_fee_rate,
                 consolidate_fee_rate,

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -1123,7 +1123,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
         additional_info: TxAdditionalInfo,
-    ) -> WalletResult<SignedTransaction> {
+    ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_htlc_tx(
                 account_index,

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -584,7 +584,7 @@ where
             .into_iter()
             .filter(|(_, output)| {
                 get_tx_output_destination(output, &|_| None, HtlcSpendingCondition::Skip)
-                    .is_some_and(|dest| from_addresses.contains(&dest))
+                    .is_some_and(|dest| from_addresses.is_empty() || from_addresses.contains(&dest))
             })
             .collect::<Vec<_>>();
 

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -68,7 +68,9 @@ use wallet_types::{
 use crate::{
     helpers::{fetch_token_info, fetch_utxo, into_balances, tx_to_partially_signed_tx},
     runtime_wallet::RuntimeWallet,
-    types::{Balances, GenericCurrencyTransfer, NewTransaction, SweepFromAddresses},
+    types::{
+        Balances, GenericCurrencyTransfer, NewTransaction, PreparedTransaction, SweepFromAddresses,
+    },
     ControllerConfig, ControllerError,
 };
 
@@ -1016,7 +1018,7 @@ where
     }
 
     /// Creates a transaction that creates a new stake pool and broadcasts it to the mempool.
-    pub async fn create_stake_pool_tx(
+    pub async fn create_stake_pool(
         &mut self,
         amount: Amount,
         decommission_key: Destination,
@@ -1030,7 +1032,7 @@ where
                   consolidate_fee_rate: FeeRate,
                   wallet: &mut RuntimeWallet<B>,
                   account_index: U31| {
-                wallet.create_stake_pool_tx(
+                wallet.create_stake_pool(
                     account_index,
                     current_fee_rate,
                     consolidate_fee_rate,
@@ -1113,7 +1115,7 @@ where
         output_value: OutputValue,
         htlc: HashedTimelockContract,
         additional_info: TxAdditionalInfo,
-    ) -> Result<NewTransaction, ControllerError<T>> {
+    ) -> Result<PreparedTransaction, ControllerError<T>> {
         let (current_fee_rate, consolidate_fee_rate) =
             self.get_current_and_consolidation_fee_rate().await?;
 
@@ -1128,11 +1130,7 @@ where
 
         let fees = into_balances(&self.rpc_client, self.chain_config, fees).await?;
 
-        Ok(NewTransaction {
-            tx,
-            fees,
-            broadcasted: false,
-        })
+        Ok(PreparedTransaction { tx, fees })
     }
 
     pub async fn create_order(

--- a/wallet/wallet-controller/src/synced_controller.rs
+++ b/wallet/wallet-controller/src/synced_controller.rs
@@ -68,7 +68,7 @@ use wallet_types::{
 use crate::{
     helpers::{fetch_token_info, fetch_utxo, into_balances, tx_to_partially_signed_tx},
     runtime_wallet::RuntimeWallet,
-    types::{Balances, GenericCurrencyTransfer, NewTransaction},
+    types::{Balances, GenericCurrencyTransfer, NewTransaction, SweepFromAddresses},
     ControllerConfig, ControllerError,
 };
 
@@ -568,7 +568,7 @@ where
     pub async fn sweep_addresses(
         &mut self,
         destination_address: Destination,
-        from_addresses: BTreeSet<Destination>,
+        from_addresses: SweepFromAddresses,
     ) -> Result<NewTransaction, ControllerError<T>> {
         let selected_utxos = self.wallet.get_utxos(
             self.account_index,
@@ -584,7 +584,7 @@ where
             .into_iter()
             .filter(|(_, output)| {
                 get_tx_output_destination(output, &|_| None, HtlcSpendingCondition::Skip)
-                    .is_some_and(|dest| from_addresses.is_empty() || from_addresses.contains(&dest))
+                    .is_some_and(|dest| from_addresses.should_sweep_address(&dest))
             })
             .collect::<Vec<_>>();
 

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -21,6 +21,8 @@ mod seed_phrase;
 mod standalone_key;
 mod transaction;
 
+use std::collections::BTreeSet;
+
 pub use balances::Balances;
 use bip39::{Language, Mnemonic};
 pub use block_info::{BlockInfo, CreatedBlockInfo};
@@ -246,4 +248,18 @@ pub enum WalletTypeArgsComputed {
     },
     #[cfg(feature = "trezor")]
     Trezor { device_id: Option<String> },
+}
+
+pub enum SweepFromAddresses {
+    All,
+    SpecificAddresses(BTreeSet<Destination>),
+}
+
+impl SweepFromAddresses {
+    pub fn should_sweep_address(&self, dest: &Destination) -> bool {
+        match self {
+            Self::All => true,
+            Self::SpecificAddresses(destinations) => destinations.contains(dest),
+        }
+    }
 }

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -38,7 +38,8 @@ use common::{
 pub use seed_phrase::SeedWithPassPhrase;
 pub use standalone_key::AccountStandaloneKeyDetails;
 pub use transaction::{
-    InspectTransaction, NewTransaction, SignatureStats, TransactionToInspect, ValidatedSignatures,
+    InspectTransaction, NewTransaction, PreparedTransaction, SignatureStats, TransactionToInspect,
+    ValidatedSignatures,
 };
 use utils::ensure;
 use wallet::signer::trezor_signer::FoundDevice;

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -35,6 +35,7 @@ use common::{
 };
 pub use seed_phrase::SeedWithPassPhrase;
 pub use standalone_key::AccountStandaloneKeyDetails;
+pub use transaction::NewTransaction;
 pub use transaction::{
     InspectTransaction, SignatureStats, TransactionToInspect, ValidatedSignatures,
 };

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -35,9 +35,8 @@ use common::{
 };
 pub use seed_phrase::SeedWithPassPhrase;
 pub use standalone_key::AccountStandaloneKeyDetails;
-pub use transaction::NewTransaction;
 pub use transaction::{
-    InspectTransaction, SignatureStats, TransactionToInspect, ValidatedSignatures,
+    InspectTransaction, NewTransaction, SignatureStats, TransactionToInspect, ValidatedSignatures,
 };
 use utils::ensure;
 use wallet::signer::trezor_signer::FoundDevice;

--- a/wallet/wallet-controller/src/types/transaction.rs
+++ b/wallet/wallet-controller/src/types/transaction.rs
@@ -68,3 +68,10 @@ pub struct InspectTransaction {
     pub fees: Option<Balances>,
     pub stats: SignatureStats,
 }
+
+/// Newly signed transaction with fees that might have been broadcasted to the mempool
+pub struct NewTransaction {
+    pub tx: SignedTransaction,
+    pub fees: Balances,
+    pub broadcasted: bool,
+}

--- a/wallet/wallet-controller/src/types/transaction.rs
+++ b/wallet/wallet-controller/src/types/transaction.rs
@@ -75,3 +75,9 @@ pub struct NewTransaction {
     pub fees: Balances,
     pub broadcasted: bool,
 }
+
+/// Newly signed transaction with fees that is ready to be broadcasted to the mempool
+pub struct PreparedTransaction {
+    pub tx: SignedTransaction,
+    pub fees: Balances,
+}

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -1093,7 +1093,7 @@ where
         token_id: Option<String>,
         htlc: RpcHashedTimelockContract,
         config: ControllerConfig,
-    ) -> Result<HexEncoded<SignedTransaction>, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         self.wallet_rpc
             .create_htlc_transaction(
                 account_index,
@@ -1103,7 +1103,6 @@ where
                 config,
             )
             .await
-            .map(HexEncoded::new)
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
     }
 

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -607,6 +607,7 @@ where
         account_index: U31,
         destination_address: String,
         from_addresses: Vec<String>,
+        all: bool,
         config: ControllerConfig,
     ) -> Result<RpcNewTransaction, Self::Error> {
         self.wallet_rpc
@@ -614,6 +615,7 @@ where
                 account_index,
                 destination_address.into(),
                 from_addresses.into_iter().map(Into::into).collect(),
+                all,
                 config,
             )
             .await

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -45,9 +45,9 @@ use wallet_rpc_lib::{
         NewDelegationTransaction, NewOrderTransaction, NewSubmittedTransaction,
         NewTokenTransaction, NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo,
         RpcHashedTimelockContract, RpcInspectTransaction, RpcNewTransaction,
-        RpcStandaloneAddresses, SendTokensFromMultisigAddressResult, StakePoolBalance,
-        StakingStatus, StandaloneAddressWithDetails, TokenMetadata, TxOptionsOverrides, UtxoInfo,
-        VrfPublicKeyInfo,
+        RpcPreparedTransaction, RpcStandaloneAddresses, SendTokensFromMultisigAddressResult,
+        StakePoolBalance, StakingStatus, StandaloneAddressWithDetails, TokenMetadata,
+        TxOptionsOverrides, UtxoInfo, VrfPublicKeyInfo,
     },
     RpcError, WalletRpc,
 };
@@ -1095,7 +1095,7 @@ where
         token_id: Option<String>,
         htlc: RpcHashedTimelockContract,
         config: ControllerConfig,
-    ) -> Result<RpcNewTransaction, Self::Error> {
+    ) -> Result<RpcPreparedTransaction, Self::Error> {
         self.wallet_rpc
             .create_htlc_transaction(
                 account_index,

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -475,16 +475,16 @@ impl WalletInterface for ClientWalletRpc {
         account_index: U31,
         destination_address: String,
         from_addresses: Vec<String>,
+        all: bool,
         config: ControllerConfig,
     ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
-        let all = from_addresses.is_empty();
         WalletRpcClient::sweep_addresses(
             &self.http_client,
             account_index.into(),
             destination_address.into(),
             from_addresses.into_iter().map(Into::into).collect(),
-            Some(all),
+            all,
             options,
         )
         .await

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -477,11 +477,13 @@ impl WalletInterface for ClientWalletRpc {
         config: ControllerConfig,
     ) -> Result<NewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
+        let all = from_addresses.is_empty();
         WalletRpcClient::sweep_addresses(
             &self.http_client,
             account_index.into(),
             destination_address.into(),
             from_addresses.into_iter().map(Into::into).collect(),
+            Some(all),
             options,
         )
         .await

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -50,9 +50,10 @@ use wallet_rpc_lib::{
         NewDelegationTransaction, NewOrderTransaction, NewSubmittedTransaction,
         NewTokenTransaction, NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo,
         RpcHashedTimelockContract, RpcInspectTransaction, RpcNewTransaction,
-        RpcStandaloneAddresses, SendTokensFromMultisigAddressResult, StakePoolBalance,
-        StakingStatus, StandaloneAddressWithDetails, TokenMetadata, TransactionOptions,
-        TxOptionsOverrides, UtxoInfo, VrfPublicKeyInfo,
+        RpcPreparedTransaction, RpcStandaloneAddresses, SendTokensFromMultisigAddressResult,
+        StakePoolBalance, StakingStatus, StandaloneAddressWithDetails, TokenMetadata,
+        TransactionOptions, TransactionRequestOptions, TxOptionsOverrides, UtxoInfo,
+        VrfPublicKeyInfo,
     },
     ColdWalletRpcClient, WalletRpcClient,
 };
@@ -519,7 +520,7 @@ impl WalletInterface for ClientWalletRpc {
         change_address: Option<String>,
         config: ControllerConfig,
     ) -> Result<ComposedTransaction, Self::Error> {
-        let options = TransactionOptions::from_controller_config(&config);
+        let options = TransactionRequestOptions::from_controller_config(&config);
         WalletRpcClient::transaction_from_cold_input(
             &self.http_client,
             account_index.into(),
@@ -595,7 +596,7 @@ impl WalletInterface for ClientWalletRpc {
         output_address: Option<String>,
         config: ControllerConfig,
     ) -> Result<HexEncoded<PartiallySignedTransaction>, Self::Error> {
-        let options = TransactionOptions::from_controller_config(&config);
+        let options = TransactionRequestOptions::from_controller_config(&config);
         WalletRpcClient::decommission_stake_pool_request(
             &self.http_client,
             account_index.into(),
@@ -955,7 +956,7 @@ impl WalletInterface for ClientWalletRpc {
         ),
         Self::Error,
     > {
-        let options = TransactionOptions::from_controller_config(&config);
+        let options = TransactionRequestOptions::from_controller_config(&config);
         WalletRpcClient::make_tx_for_sending_tokens_with_intent(
             &self.http_client,
             account_index.into(),
@@ -977,7 +978,7 @@ impl WalletInterface for ClientWalletRpc {
         outputs: Vec<GenericTokenTransfer>,
         config: ControllerConfig,
     ) -> Result<SendTokensFromMultisigAddressResult, Self::Error> {
-        let options = TransactionOptions::from_controller_config(&config);
+        let options = TransactionRequestOptions::from_controller_config(&config);
         WalletRpcClient::make_tx_to_send_tokens_from_multisig_address(
             &self.http_client,
             account_index.into(),
@@ -1014,8 +1015,8 @@ impl WalletInterface for ClientWalletRpc {
         token_id: Option<String>,
         htlc: RpcHashedTimelockContract,
         config: ControllerConfig,
-    ) -> Result<RpcNewTransaction, Self::Error> {
-        let options = TransactionOptions::from_controller_config(&config);
+    ) -> Result<RpcPreparedTransaction, Self::Error> {
+        let options = TransactionRequestOptions::from_controller_config(&config);
         WalletRpcClient::create_htlc_transaction(
             &self.http_client,
             account_index.into(),
@@ -1303,7 +1304,7 @@ impl WalletInterface for ClientWalletRpc {
         raw_tx: String,
         config: ControllerConfig,
     ) -> Result<SignRawTransactionResult, Self::Error> {
-        let options = TransactionOptions::from_controller_config(&config);
+        let options = TransactionRequestOptions::from_controller_config(&config);
         ColdWalletRpcClient::sign_raw_transaction(
             &self.http_client,
             account_index.into(),

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -46,12 +46,13 @@ use wallet_controller::{
 use wallet_rpc_lib::{
     types::{
         AddressInfo, AddressWithUsageInfo, BlockInfo, ComposedTransaction, CreatedWallet,
-        DelegationInfo, HardwareWalletType, LegacyVrfPublicKeyInfo, NewAccountInfo, NewDelegation,
-        NewOrder, NewTransaction, NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo,
-        RpcHashedTimelockContract, RpcInspectTransaction, RpcStandaloneAddresses, RpcTokenId,
-        SendTokensFromMultisigAddressResult, StakePoolBalance, StakingStatus,
-        StandaloneAddressWithDetails, TokenMetadata, TransactionOptions, TxOptionsOverrides,
-        UtxoInfo, VrfPublicKeyInfo,
+        DelegationInfo, HardwareWalletType, LegacyVrfPublicKeyInfo, NewAccountInfo,
+        NewDelegationTransaction, NewOrderTransaction, NewSubmittedTransaction,
+        NewTokenTransaction, NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo,
+        RpcHashedTimelockContract, RpcInspectTransaction, RpcNewTransaction,
+        RpcStandaloneAddresses, SendTokensFromMultisigAddressResult, StakePoolBalance,
+        StakingStatus, StandaloneAddressWithDetails, TokenMetadata, TransactionOptions,
+        TxOptionsOverrides, UtxoInfo, VrfPublicKeyInfo,
     },
     ColdWalletRpcClient, WalletRpcClient,
 };
@@ -441,7 +442,7 @@ impl WalletInterface for ClientWalletRpc {
         tx: HexEncoded<SignedTransaction>,
         do_not_store: bool,
         options: TxOptionsOverrides,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<NewSubmittedTransaction, Self::Error> {
         WalletRpcClient::submit_raw_transaction(&self.http_client, tx, do_not_store, options)
             .await
             .map_err(WalletRpcError::ResponseError)
@@ -454,7 +455,7 @@ impl WalletInterface for ClientWalletRpc {
         amount: DecimalAmount,
         selected_utxos: Vec<UtxoOutPoint>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         let selected_utxos = selected_utxos.into_iter().map(Into::into).collect();
         WalletRpcClient::send_coins(
@@ -475,7 +476,7 @@ impl WalletInterface for ClientWalletRpc {
         destination_address: String,
         from_addresses: Vec<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         let all = from_addresses.is_empty();
         WalletRpcClient::sweep_addresses(
@@ -496,7 +497,7 @@ impl WalletInterface for ClientWalletRpc {
         destination_address: String,
         delegation_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::sweep_delegation(
             &self.http_client,
@@ -551,7 +552,7 @@ impl WalletInterface for ClientWalletRpc {
         staker_address: Option<String>,
         vrf_public_key: Option<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::create_stake_pool(
             &self.http_client,
@@ -574,7 +575,7 @@ impl WalletInterface for ClientWalletRpc {
         pool_id: String,
         output_address: Option<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::decommission_stake_pool(
             &self.http_client,
@@ -612,7 +613,7 @@ impl WalletInterface for ClientWalletRpc {
         address: String,
         pool_id: String,
         config: ControllerConfig,
-    ) -> Result<NewDelegation, Self::Error> {
+    ) -> Result<NewDelegationTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::create_delegation(
             &self.http_client,
@@ -631,7 +632,7 @@ impl WalletInterface for ClientWalletRpc {
         amount: DecimalAmount,
         delegation_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::delegate_staking(
             &self.http_client,
@@ -651,7 +652,7 @@ impl WalletInterface for ClientWalletRpc {
         amount: DecimalAmount,
         delegation_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::withdraw_from_delegation(
             &self.http_client,
@@ -755,7 +756,7 @@ impl WalletInterface for ClientWalletRpc {
         destination_address: String,
         metadata: NftMetadata,
         config: ControllerConfig,
-    ) -> Result<RpcTokenId, Self::Error> {
+    ) -> Result<NewTokenTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::issue_new_nft(
             &self.http_client,
@@ -774,7 +775,7 @@ impl WalletInterface for ClientWalletRpc {
         destination_address: String,
         metadata: TokenMetadata,
         config: ControllerConfig,
-    ) -> Result<RpcTokenId, Self::Error> {
+    ) -> Result<NewTokenTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::issue_new_token(
             &self.http_client,
@@ -793,7 +794,7 @@ impl WalletInterface for ClientWalletRpc {
         token_id: String,
         address: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::change_token_authority(
             &self.http_client,
@@ -812,7 +813,7 @@ impl WalletInterface for ClientWalletRpc {
         token_id: String,
         metadata_uri: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::change_token_metadata_uri(
             &self.http_client,
@@ -832,7 +833,7 @@ impl WalletInterface for ClientWalletRpc {
         address: String,
         amount: DecimalAmount,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::mint_tokens(
             &self.http_client,
@@ -852,7 +853,7 @@ impl WalletInterface for ClientWalletRpc {
         token_id: String,
         amount: DecimalAmount,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::unmint_tokens(
             &self.http_client,
@@ -870,7 +871,7 @@ impl WalletInterface for ClientWalletRpc {
         account_index: U31,
         token_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::lock_token_supply(
             &self.http_client,
@@ -888,7 +889,7 @@ impl WalletInterface for ClientWalletRpc {
         token_id: String,
         is_unfreezable: bool,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::freeze_token(
             &self.http_client,
@@ -906,7 +907,7 @@ impl WalletInterface for ClientWalletRpc {
         account_index: U31,
         token_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::unfreeze_token(
             &self.http_client,
@@ -925,7 +926,7 @@ impl WalletInterface for ClientWalletRpc {
         address: String,
         amount: DecimalAmount,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::send_tokens(
             &self.http_client,
@@ -994,7 +995,7 @@ impl WalletInterface for ClientWalletRpc {
         account_index: U31,
         data: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::deposit_data(
             &self.http_client,
@@ -1036,7 +1037,7 @@ impl WalletInterface for ClientWalletRpc {
         give_amount: DecimalAmount,
         conclude_address: String,
         config: ControllerConfig,
-    ) -> Result<NewOrder, Self::Error> {
+    ) -> Result<NewOrderTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::create_order(
             &self.http_client,
@@ -1056,7 +1057,7 @@ impl WalletInterface for ClientWalletRpc {
         order_id: String,
         output_address: Option<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::conclude_order(
             &self.http_client,
@@ -1076,7 +1077,7 @@ impl WalletInterface for ClientWalletRpc {
         fill_amount_in_ask_currency: DecimalAmount,
         output_address: Option<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::fill_order(
             &self.http_client,
@@ -1095,7 +1096,7 @@ impl WalletInterface for ClientWalletRpc {
         account_index: U31,
         order_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::freeze_order(
             &self.http_client,

--- a/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-rpc-client/src/rpc_client/client_impl.rs
@@ -1014,7 +1014,7 @@ impl WalletInterface for ClientWalletRpc {
         token_id: Option<String>,
         htlc: RpcHashedTimelockContract,
         config: ControllerConfig,
-    ) -> Result<HexEncoded<SignedTransaction>, Self::Error> {
+    ) -> Result<RpcNewTransaction, Self::Error> {
         let options = TransactionOptions::from_controller_config(&config);
         WalletRpcClient::create_htlc_transaction(
             &self.http_client,

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -39,8 +39,8 @@ use wallet_rpc_lib::types::{
     DelegationInfo, HardwareWalletType, LegacyVrfPublicKeyInfo, NewAccountInfo,
     NewDelegationTransaction, NewOrderTransaction, NewSubmittedTransaction, NewTokenTransaction,
     NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo, RpcHashedTimelockContract,
-    RpcInspectTransaction, RpcNewTransaction, RpcSignatureStatus, RpcStandaloneAddresses,
-    SendTokensFromMultisigAddressResult, StakePoolBalance, StakingStatus,
+    RpcInspectTransaction, RpcNewTransaction, RpcPreparedTransaction, RpcSignatureStatus,
+    RpcStandaloneAddresses, SendTokensFromMultisigAddressResult, StakePoolBalance, StakingStatus,
     StandaloneAddressWithDetails, TokenMetadata, TxOptionsOverrides, UtxoInfo, VrfPublicKeyInfo,
 };
 use wallet_types::{
@@ -502,7 +502,7 @@ pub trait WalletInterface {
         token_id: Option<String>,
         htlc: RpcHashedTimelockContract,
         config: ControllerConfig,
-    ) -> Result<RpcNewTransaction, Self::Error>;
+    ) -> Result<RpcPreparedTransaction, Self::Error>;
 
     #[allow(clippy::too_many_arguments)]
     async fn create_order(

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -501,7 +501,7 @@ pub trait WalletInterface {
         token_id: Option<String>,
         htlc: RpcHashedTimelockContract,
         config: ControllerConfig,
-    ) -> Result<HexEncoded<SignedTransaction>, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     #[allow(clippy::too_many_arguments)]
     async fn create_order(

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -264,6 +264,7 @@ pub trait WalletInterface {
         account_index: U31,
         destination_address: String,
         from_addresses: Vec<String>,
+        all: bool,
         config: ControllerConfig,
     ) -> Result<RpcNewTransaction, Self::Error>;
 

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -36,10 +36,11 @@ use wallet_controller::{
 };
 use wallet_rpc_lib::types::{
     AddressInfo, AddressWithUsageInfo, Balances, BlockInfo, ComposedTransaction, CreatedWallet,
-    DelegationInfo, HardwareWalletType, LegacyVrfPublicKeyInfo, NewAccountInfo, NewDelegation,
-    NewOrder, NewTransaction, NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo,
-    RpcHashedTimelockContract, RpcInspectTransaction, RpcSignatureStatus, RpcStandaloneAddresses,
-    RpcTokenId, SendTokensFromMultisigAddressResult, StakePoolBalance, StakingStatus,
+    DelegationInfo, HardwareWalletType, LegacyVrfPublicKeyInfo, NewAccountInfo,
+    NewDelegationTransaction, NewOrderTransaction, NewSubmittedTransaction, NewTokenTransaction,
+    NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo, RpcHashedTimelockContract,
+    RpcInspectTransaction, RpcNewTransaction, RpcSignatureStatus, RpcStandaloneAddresses,
+    SendTokensFromMultisigAddressResult, StakePoolBalance, StakingStatus,
     StandaloneAddressWithDetails, TokenMetadata, TxOptionsOverrides, UtxoInfo, VrfPublicKeyInfo,
 };
 use wallet_types::{
@@ -211,7 +212,7 @@ pub trait WalletInterface {
         tx: HexEncoded<SignedTransaction>,
         do_not_store: bool,
         options: TxOptionsOverrides,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<NewSubmittedTransaction, Self::Error>;
 
     async fn sign_challenge(
         &self,
@@ -256,7 +257,7 @@ pub trait WalletInterface {
         amount: DecimalAmount,
         selected_utxos: Vec<UtxoOutPoint>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn sweep_addresses(
         &self,
@@ -264,7 +265,7 @@ pub trait WalletInterface {
         destination_address: String,
         from_addresses: Vec<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn sweep_delegation(
         &self,
@@ -272,7 +273,7 @@ pub trait WalletInterface {
         destination_address: String,
         delegation_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn transaction_from_cold_input(
         &self,
@@ -300,7 +301,7 @@ pub trait WalletInterface {
         staker_address: Option<String>,
         vrf_public_key: Option<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn decommission_stake_pool(
         &self,
@@ -308,7 +309,7 @@ pub trait WalletInterface {
         pool_id: String,
         output_address: Option<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn decommission_stake_pool_request(
         &self,
@@ -324,7 +325,7 @@ pub trait WalletInterface {
         address: String,
         pool_id: String,
         config: ControllerConfig,
-    ) -> Result<NewDelegation, Self::Error>;
+    ) -> Result<NewDelegationTransaction, Self::Error>;
 
     async fn delegate_staking(
         &self,
@@ -332,7 +333,7 @@ pub trait WalletInterface {
         amount: DecimalAmount,
         delegation_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn withdraw_from_delegation(
         &self,
@@ -341,7 +342,7 @@ pub trait WalletInterface {
         amount: DecimalAmount,
         delegation_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn start_staking(&self, account_index: U31) -> Result<(), Self::Error>;
 
@@ -387,7 +388,7 @@ pub trait WalletInterface {
         destination_address: String,
         metadata: NftMetadata,
         config: ControllerConfig,
-    ) -> Result<RpcTokenId, Self::Error>;
+    ) -> Result<NewTokenTransaction, Self::Error>;
 
     async fn issue_new_token(
         &self,
@@ -395,7 +396,7 @@ pub trait WalletInterface {
         destination_address: String,
         metadata: TokenMetadata,
         config: ControllerConfig,
-    ) -> Result<RpcTokenId, Self::Error>;
+    ) -> Result<NewTokenTransaction, Self::Error>;
 
     async fn change_token_authority(
         &self,
@@ -403,7 +404,7 @@ pub trait WalletInterface {
         token_id: String,
         address: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn change_token_metadata_uri(
         &self,
@@ -411,7 +412,7 @@ pub trait WalletInterface {
         token_id: String,
         metadata_uri: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn mint_tokens(
         &self,
@@ -420,7 +421,7 @@ pub trait WalletInterface {
         address: String,
         amount: DecimalAmount,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn unmint_tokens(
         &self,
@@ -428,14 +429,14 @@ pub trait WalletInterface {
         token_id: String,
         amount: DecimalAmount,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn lock_token_supply(
         &self,
         account_index: U31,
         token_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn freeze_token(
         &self,
@@ -443,14 +444,14 @@ pub trait WalletInterface {
         token_id: String,
         is_unfreezable: bool,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn unfreeze_token(
         &self,
         account_index: U31,
         token_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn send_tokens(
         &self,
@@ -459,7 +460,7 @@ pub trait WalletInterface {
         address: String,
         amount: DecimalAmount,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn make_tx_for_sending_tokens_with_intent(
         &self,
@@ -491,7 +492,7 @@ pub trait WalletInterface {
         account_index: U31,
         data: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn create_htlc_transaction(
         &self,
@@ -512,7 +513,7 @@ pub trait WalletInterface {
         give_amount: DecimalAmount,
         conclude_address: String,
         config: ControllerConfig,
-    ) -> Result<NewOrder, Self::Error>;
+    ) -> Result<NewOrderTransaction, Self::Error>;
 
     async fn conclude_order(
         &self,
@@ -520,7 +521,7 @@ pub trait WalletInterface {
         order_id: String,
         output_address: Option<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn fill_order(
         &self,
@@ -529,14 +530,14 @@ pub trait WalletInterface {
         fill_amount_in_ask_currency: DecimalAmount,
         output_address: Option<String>,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn freeze_order(
         &self,
         account_index: U31,
         order_id: String,
         config: ControllerConfig,
-    ) -> Result<NewTransaction, Self::Error>;
+    ) -> Result<RpcNewTransaction, Self::Error>;
 
     async fn node_version(&self) -> Result<NodeVersion, Self::Error>;
 

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -972,9 +972,14 @@ Parameters:
                 },
         "index": number,
     }, .. ],
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1000,9 +1005,10 @@ Returns:
 ### Method `address_sweep_spendable`
 
 Sweep all spendable coins or tokens from an address or addresses specified in `from_addresses`
-or all addresses from this account if all is set to true, to a given destination address.
+or all addresses from this account if all is set to true, to the given destination address.
 Either 1 or more addresses need to be specified in `from_addresses` with all set to false, or
 `from_addresses` needs to be empty and all set to true.
+
 Spendable coins are any coins that are not locked, and tokens that are not frozen or locked.
 The wallet will automatically calculate the required fees
 
@@ -1014,9 +1020,14 @@ Parameters:
     "destination_address": bech32 string,
     "from_addresses": [ bech32 string, .. ],
     "all": bool,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1051,9 +1062,14 @@ Parameters:
     "account": number,
     "destination_address": bech32 string,
     "delegation_id": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1111,9 +1127,14 @@ Parameters:
     "change_address": EITHER OF
          1) bech32 string
          2) null,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1226,9 +1247,14 @@ Parameters:
     "vrf_public_key": EITHER OF
          1) bech32 string
          2) null,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1265,9 +1291,14 @@ Parameters:
     "output_address": EITHER OF
          1) bech32 string
          2) null,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1306,9 +1337,14 @@ Parameters:
     "output_address": EITHER OF
          1) bech32 string
          2) null,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1331,9 +1367,14 @@ Parameters:
     "account": number,
     "address": bech32 string,
     "pool_id": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1370,9 +1411,14 @@ Parameters:
          1) { "atoms": number string }
          2) { "decimal": decimal string },
     "delegation_id": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1410,9 +1456,14 @@ Parameters:
          1) { "atoms": number string }
          2) { "decimal": decimal string },
     "delegation_id": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1645,9 +1696,14 @@ Parameters:
              2) { "hex": hex string }
              3) null,
     },
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1702,9 +1758,14 @@ Parameters:
              3) { "type": "Unlimited" },
         "is_freezable": bool,
     },
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1739,9 +1800,14 @@ Parameters:
     "account": number,
     "token_id": bech32 string,
     "address": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1775,9 +1841,14 @@ Parameters:
     "account": number,
     "token_id": bech32 string,
     "metadata_uri": hex string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1814,9 +1885,14 @@ Parameters:
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1854,9 +1930,14 @@ Parameters:
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1891,9 +1972,14 @@ Parameters:
 {
     "account_index": number,
     "token_id": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1930,9 +2016,14 @@ Parameters:
     "account": number,
     "token_id": bech32 string,
     "is_unfreezable": bool,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -1968,9 +2059,14 @@ Parameters:
 {
     "account": number,
     "token_id": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2007,9 +2103,14 @@ Parameters:
     "amount": EITHER OF
          1) { "atoms": number string }
          2) { "decimal": decimal string },
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2056,9 +2157,14 @@ Parameters:
          1) { "atoms": number string }
          2) { "decimal": decimal string },
     "intent": string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2089,9 +2195,14 @@ Parameters:
          1) bech32 string
          2) null,
     "outputs": [ object, .. ],
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2135,9 +2246,14 @@ Parameters:
 {
     "account": number,
     "data": hex string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2198,9 +2314,14 @@ Parameters:
                     "content": number,
                 },
     },
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2268,9 +2389,14 @@ Parameters:
                 },
             },
     "conclude_address": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2309,9 +2435,14 @@ Parameters:
     "output_address": EITHER OF
          1) bech32 string
          2) null,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2351,9 +2482,14 @@ Parameters:
     "output_address": EITHER OF
          1) bech32 string
          2) null,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -2387,9 +2523,14 @@ Parameters:
 {
     "account": number,
     "order_id": bech32 string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 
@@ -3589,9 +3730,14 @@ Parameters:
 {
     "account": number,
     "raw_tx": hex string,
-    "options": { "in_top_x_mb": EITHER OF
-         1) number
-         2) null },
+    "options": {
+        "in_top_x_mb": EITHER OF
+             1) number
+             2) null,
+        "broadcast_to_mempool": EITHER OF
+             1) bool
+             2) null,
+    },
 }
 ```
 

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -1005,9 +1005,9 @@ Returns:
 ### Method `address_sweep_spendable`
 
 Sweep all spendable coins or tokens from an address or addresses specified in `from_addresses`
-or all addresses from this account if all is set to true, to the given destination address.
-Either 1 or more addresses need to be specified in `from_addresses` with all set to false, or
-`from_addresses` needs to be empty and all set to true.
+or all addresses from this account if `all` is set to true, to the given destination address.
+Either 1 or more addresses need to be specified in `from_addresses` with `all` set to false, or
+`from_addresses` needs to be empty and `all` set to true.
 
 Spendable coins are any coins that are not locked, and tokens that are not frozen or locked.
 The wallet will automatically calculate the required fees
@@ -1127,14 +1127,9 @@ Parameters:
     "change_address": EITHER OF
          1) bech32 string
          2) null,
-    "options": {
-        "in_top_x_mb": EITHER OF
-             1) number
-             2) null,
-        "broadcast_to_mempool": EITHER OF
-             1) bool
-             2) null,
-    },
+    "options": { "in_top_x_mb": EITHER OF
+         1) number
+         2) null },
 }
 ```
 
@@ -1337,14 +1332,9 @@ Parameters:
     "output_address": EITHER OF
          1) bech32 string
          2) null,
-    "options": {
-        "in_top_x_mb": EITHER OF
-             1) number
-             2) null,
-        "broadcast_to_mempool": EITHER OF
-             1) bool
-             2) null,
-    },
+    "options": { "in_top_x_mb": EITHER OF
+         1) number
+         2) null },
 }
 ```
 
@@ -2157,14 +2147,9 @@ Parameters:
          1) { "atoms": number string }
          2) { "decimal": decimal string },
     "intent": string,
-    "options": {
-        "in_top_x_mb": EITHER OF
-             1) number
-             2) null,
-        "broadcast_to_mempool": EITHER OF
-             1) bool
-             2) null,
-    },
+    "options": { "in_top_x_mb": EITHER OF
+         1) number
+         2) null },
 }
 ```
 
@@ -2195,14 +2180,9 @@ Parameters:
          1) bech32 string
          2) null,
     "outputs": [ object, .. ],
-    "options": {
-        "in_top_x_mb": EITHER OF
-             1) number
-             2) null,
-        "broadcast_to_mempool": EITHER OF
-             1) bool
-             2) null,
-    },
+    "options": { "in_top_x_mb": EITHER OF
+         1) number
+         2) null },
 }
 ```
 
@@ -2314,14 +2294,9 @@ Parameters:
                     "content": number,
                 },
     },
-    "options": {
-        "in_top_x_mb": EITHER OF
-             1) number
-             2) null,
-        "broadcast_to_mempool": EITHER OF
-             1) bool
-             2) null,
-    },
+    "options": { "in_top_x_mb": EITHER OF
+         1) number
+         2) null },
 }
 ```
 
@@ -2340,7 +2315,6 @@ Returns:
             "decimal": decimal string,
         }, .. },
     },
-    "broadcasted": bool,
 }
 ```
 
@@ -3730,14 +3704,9 @@ Parameters:
 {
     "account": number,
     "raw_tx": hex string,
-    "options": {
-        "in_top_x_mb": EITHER OF
-             1) number
-             2) null,
-        "broadcast_to_mempool": EITHER OF
-             1) bool
-             2) null,
-    },
+    "options": { "in_top_x_mb": EITHER OF
+         1) number
+         2) null },
 }
 ```
 

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -999,7 +999,10 @@ Returns:
 
 ### Method `address_sweep_spendable`
 
-Sweep all spendable coins or tokens from an address or addresses to a given address.
+Sweep all spendable coins or tokens from an address or addresses specified in `from_addresses`
+or all addresses from this account if all is set to true, to a given destination address.
+Either 1 or more addresses need to be specified in `from_addresses` with all set to false, or
+`from_addresses` needs to be empty and all set to true.
 Spendable coins are any coins that are not locked, and tokens that are not frozen or locked.
 The wallet will automatically calculate the required fees
 
@@ -1010,9 +1013,7 @@ Parameters:
     "account": number,
     "destination_address": bech32 string,
     "from_addresses": [ bech32 string, .. ],
-    "all": EITHER OF
-         1) bool
-         2) null,
+    "all": bool,
     "options": { "in_top_x_mb": EITHER OF
          1) number
          2) null },
@@ -2205,7 +2206,21 @@ Parameters:
 
 Returns:
 ```
-hex string
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `create_order`

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -2380,7 +2380,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `node_version`

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -980,7 +980,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `address_sweep_spendable`
@@ -996,6 +1010,9 @@ Parameters:
     "account": number,
     "destination_address": bech32 string,
     "from_addresses": [ bech32 string, .. ],
+    "all": EITHER OF
+         1) bool
+         2) null,
     "options": { "in_top_x_mb": EITHER OF
          1) number
          2) null },
@@ -1004,7 +1021,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `staking_sweep_delegation`
@@ -1027,7 +1058,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `transaction_create_from_cold_input`
@@ -1188,7 +1233,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `staking_decommission_pool`
@@ -1213,7 +1272,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `staking_decommission_pool_request`
@@ -1266,8 +1339,20 @@ Parameters:
 Returns:
 ```
 {
-    "tx_id": hex string,
     "delegation_id": bech32 string,
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
 }
 ```
 
@@ -1292,7 +1377,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `delegation_withdraw`
@@ -1318,7 +1417,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `staking_start`
@@ -1542,6 +1655,18 @@ Returns:
 {
     "token_id": bech32 string,
     "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
 }
 ```
 
@@ -1587,6 +1712,18 @@ Returns:
 {
     "token_id": bech32 string,
     "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
 }
 ```
 
@@ -1609,7 +1746,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `token_change_metadata_uri`
@@ -1631,7 +1782,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `token_mint`
@@ -1656,7 +1821,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `token_unmint`
@@ -1682,7 +1861,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `token_lock_supply`
@@ -1705,7 +1898,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `token_freeze`
@@ -1730,7 +1937,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `token_unfreeze`
@@ -1754,7 +1975,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `token_send`
@@ -1779,7 +2014,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `token_make_tx_for_sending_with_intent`
@@ -1893,7 +2142,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `create_htlc_transaction`
@@ -1999,8 +2262,20 @@ Parameters:
 Returns:
 ```
 {
-    "tx_id": hex string,
     "order_id": bech32 string,
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
 }
 ```
 
@@ -2027,7 +2302,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `fill_order`
@@ -2055,7 +2344,21 @@ Parameters:
 
 Returns:
 ```
-{ "tx_id": hex string }
+{
+    "tx_id": hex string,
+    "tx": hex string,
+    "fees": {
+        "coins": {
+            "atoms": number string,
+            "decimal": decimal string,
+        },
+        "tokens": { bech32 string: {
+            "atoms": number string,
+            "decimal": decimal string,
+        }, .. },
+    },
+    "broadcasted": bool,
+}
 ```
 
 ### Method `freeze_order`

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -382,9 +382,10 @@ trait WalletRpc {
     ) -> rpc::RpcResult<RpcNewTransaction>;
 
     /// Sweep all spendable coins or tokens from an address or addresses specified in `from_addresses`
-    /// or all addresses from this account if all is set to true, to a given destination address.
+    /// or all addresses from this account if all is set to true, to the given destination address.
     /// Either 1 or more addresses need to be specified in `from_addresses` with all set to false, or
     /// `from_addresses` needs to be empty and all set to true.
+    ///
     /// Spendable coins are any coins that are not locked, and tokens that are not frozen or locked.
     /// The wallet will automatically calculate the required fees
     #[method(name = "address_sweep_spendable")]

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -381,7 +381,10 @@ trait WalletRpc {
         options: TransactionOptions,
     ) -> rpc::RpcResult<RpcNewTransaction>;
 
-    /// Sweep all spendable coins or tokens from an address or addresses to a given address.
+    /// Sweep all spendable coins or tokens from an address or addresses specified in `from_addresses`
+    /// or all addresses from this account if all is set to true, to a given destination address.
+    /// Either 1 or more addresses need to be specified in `from_addresses` with all set to false, or
+    /// `from_addresses` needs to be empty and all set to true.
     /// Spendable coins are any coins that are not locked, and tokens that are not frozen or locked.
     /// The wallet will automatically calculate the required fees
     #[method(name = "address_sweep_spendable")]
@@ -390,7 +393,7 @@ trait WalletRpc {
         account: AccountArg,
         destination_address: RpcAddress<Destination>,
         from_addresses: Vec<RpcAddress<Destination>>,
-        all: Option<bool>,
+        all: bool,
         options: TransactionOptions,
     ) -> rpc::RpcResult<RpcNewTransaction>;
 

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -390,6 +390,7 @@ trait WalletRpc {
         account: AccountArg,
         destination_address: RpcAddress<Destination>,
         from_addresses: Vec<RpcAddress<Destination>>,
+        all: Option<bool>,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction>;
 

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -48,10 +48,10 @@ use crate::types::{
     MaybeSignedTransaction, NewAccountInfo, NewDelegationTransaction, NewOrderTransaction,
     NewSubmittedTransaction, NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo,
     RpcAmountIn, RpcHashedTimelockContract, RpcInspectTransaction, RpcNewTransaction,
-    RpcStandaloneAddresses, RpcUtxoOutpoint, RpcUtxoState, RpcUtxoType,
+    RpcPreparedTransaction, RpcStandaloneAddresses, RpcUtxoOutpoint, RpcUtxoState, RpcUtxoType,
     SendTokensFromMultisigAddressResult, StakePoolBalance, StakingStatus,
-    StandaloneAddressWithDetails, TokenMetadata, TransactionOptions, TxOptionsOverrides,
-    VrfPublicKeyInfo,
+    StandaloneAddressWithDetails, TokenMetadata, TransactionOptions, TransactionRequestOptions,
+    TxOptionsOverrides, VrfPublicKeyInfo,
 };
 
 #[rpc::rpc(server)]
@@ -225,7 +225,7 @@ trait ColdWalletRpc {
         &self,
         account: AccountArg,
         raw_tx: RpcHexString,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<MaybeSignedTransaction>;
 
     #[method(name = "challenge_sign_plain")]
@@ -382,9 +382,9 @@ trait WalletRpc {
     ) -> rpc::RpcResult<RpcNewTransaction>;
 
     /// Sweep all spendable coins or tokens from an address or addresses specified in `from_addresses`
-    /// or all addresses from this account if all is set to true, to the given destination address.
-    /// Either 1 or more addresses need to be specified in `from_addresses` with all set to false, or
-    /// `from_addresses` needs to be empty and all set to true.
+    /// or all addresses from this account if `all` is set to true, to the given destination address.
+    /// Either 1 or more addresses need to be specified in `from_addresses` with `all` set to false, or
+    /// `from_addresses` needs to be empty and `all` set to true.
     ///
     /// Spendable coins are any coins that are not locked, and tokens that are not frozen or locked.
     /// The wallet will automatically calculate the required fees
@@ -425,7 +425,7 @@ trait WalletRpc {
         amount: RpcAmountIn,
         selected_utxo: RpcUtxoOutpoint,
         change_address: Option<RpcAddress<Destination>>,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<ComposedTransaction>;
 
     /// Print the summary of the transaction
@@ -488,7 +488,7 @@ trait WalletRpc {
         account: AccountArg,
         pool_id: RpcAddress<PoolId>,
         output_address: Option<RpcAddress<Destination>>,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<HexEncoded<PartiallySignedTransaction>>;
 
     /// Create a delegation to a given pool id and the owner address/destination.
@@ -698,7 +698,7 @@ trait WalletRpc {
         address: RpcAddress<Destination>,
         amount: RpcAmountIn,
         intent: String,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<(
         HexEncoded<SignedTransaction>,
         HexEncoded<SignedTransactionIntent>,
@@ -717,7 +717,7 @@ trait WalletRpc {
         from_address: RpcAddress<Destination>,
         fee_change_address: Option<RpcAddress<Destination>>,
         outputs: Vec<GenericTokenTransfer>,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<SendTokensFromMultisigAddressResult>;
 
     /// Store data on the blockchain, the data is provided as hex encoded string.
@@ -739,8 +739,8 @@ trait WalletRpc {
         amount: RpcAmountIn,
         token_id: Option<RpcAddress<TokenId>>,
         htlc: RpcHashedTimelockContract,
-        options: TransactionOptions,
-    ) -> rpc::RpcResult<RpcNewTransaction>;
+        options: TransactionRequestOptions,
+    ) -> rpc::RpcResult<RpcPreparedTransaction>;
 
     /// Create an order for exchanging "given" amount of an arbitrary currency (coins or tokens) for
     /// an arbitrary amount of "asked" currency.

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -736,7 +736,7 @@ trait WalletRpc {
         token_id: Option<RpcAddress<TokenId>>,
         htlc: RpcHashedTimelockContract,
         options: TransactionOptions,
-    ) -> rpc::RpcResult<HexEncoded<SignedTransaction>>;
+    ) -> rpc::RpcResult<RpcNewTransaction>;
 
     /// Create an order for exchanging "given" amount of an arbitrary currency (coins or tokens) for
     /// an arbitrary amount of "asked" currency.

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -37,7 +37,10 @@ use mempool::tx_accumulator::PackingStrategy;
 use mempool_types::tx_options::TxOptionsOverrides;
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
 use serialization::{hex_encoded::HexEncoded, Decode, DecodeAll};
-use types::{NewOrder, RpcHashedTimelockContract};
+use types::{
+    NewOrderTransaction, NewSubmittedTransaction, NewTokenTransaction, RpcHashedTimelockContract,
+    RpcNewTransaction,
+};
 use utils::{ensure, shallow_clone::ShallowClone};
 use utils_networking::IpOrSocketAddress;
 use wallet::{
@@ -73,7 +76,7 @@ pub use rpc::{rpc_creds::RpcCreds, Rpc};
 use wallet_controller::{
     types::{
         Balances, BlockInfo, CreatedBlockInfo, CreatedWallet, GenericTokenTransfer,
-        InspectTransaction, OpenedWallet, SeedWithPassPhrase, TransactionToInspect,
+        InspectTransaction, NewTransaction, OpenedWallet, SeedWithPassPhrase, TransactionToInspect,
         WalletCreationOptions, WalletInfo, WalletTypeArgs,
     },
     ConnectedPeer, ControllerConfig, ControllerError, NodeInterface, UtxoState, UtxoStates,
@@ -88,7 +91,7 @@ use wallet_types::{
     signature_status::SignatureStatus,
     wallet_tx::TxData,
     with_locked::WithLocked,
-    Currency,
+    Currency, SignedTxWithFees,
 };
 
 use crate::{service::WalletController, WalletHandle, WalletRpcConfig};
@@ -99,10 +102,10 @@ use wallet_types::wallet_type::WalletType;
 pub use self::types::RpcError;
 use self::types::{
     AddressInfo, AddressWithUsageInfo, DelegationInfo, HardwareWalletType, LegacyVrfPublicKeyInfo,
-    NewAccountInfo, NewTransaction, PoolInfo, PublicKeyInfo, RpcAddress, RpcAmountIn, RpcHexString,
+    NewAccountInfo, PoolInfo, PublicKeyInfo, RpcAddress, RpcAmountIn, RpcHexString,
     RpcStandaloneAddress, RpcStandaloneAddressDetails, RpcStandaloneAddresses,
-    RpcStandalonePrivateKeyAddress, RpcTokenId, RpcUtxoOutpoint, StakingStatus,
-    StandaloneAddressWithDetails, VrfPublicKeyInfo,
+    RpcStandalonePrivateKeyAddress, RpcUtxoOutpoint, StakingStatus, StandaloneAddressWithDetails,
+    VrfPublicKeyInfo,
 };
 
 #[derive(Clone)]
@@ -797,7 +800,7 @@ where
         tx: HexEncoded<SignedTransaction>,
         do_not_store: bool,
         options: TxOptionsOverrides,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<NewSubmittedTransaction, N> {
         let tx = tx.take();
         let block_height = self.best_block().await?.height;
         check_transaction(&self.chain_config, block_height, &tx).map_err(|err| {
@@ -830,7 +833,7 @@ where
                 .await??;
         }
 
-        Ok(NewTransaction { tx_id })
+        Ok(NewSubmittedTransaction { tx_id })
     }
 
     pub async fn sign_raw_transaction(
@@ -921,7 +924,7 @@ where
         destination_address: RpcAddress<Destination>,
         from_addresses: Vec<RpcAddress<Destination>>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let destination_address = destination_address
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidAddress)?;
@@ -940,7 +943,7 @@ where
                         .sweep_addresses(destination_address, from_addresses)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -952,7 +955,7 @@ where
         destination_address: RpcAddress<Destination>,
         delegation_id: RpcAddress<DelegationId>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let delegation_id = delegation_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidDelegationId)?;
@@ -969,7 +972,7 @@ where
                         .sweep_delegation(destination_address, delegation_id)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -982,7 +985,7 @@ where
         amount: RpcAmountIn,
         selected_utxos: Vec<UtxoOutPoint>,
         config: ControllerConfig,
-    ) -> WRpcResult<SignedTransaction, N> {
+    ) -> WRpcResult<NewTransaction, N> {
         let decimals = self.chain_config.coin_decimals();
         let amount = amount.to_amount(decimals).ok_or(RpcError::InvalidCoinAmount)?;
         let address =
@@ -1071,7 +1074,7 @@ where
         address: RpcAddress<Destination>,
         amount: RpcAmountIn,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -1092,7 +1095,7 @@ where
                         .send_tokens_to_address(token_info, address, amount)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -1106,7 +1109,7 @@ where
         amount: RpcAmountIn,
         intent: String,
         config: ControllerConfig,
-    ) -> WRpcResult<(SignedTransaction, SignedTransactionIntent), N> {
+    ) -> WRpcResult<(SignedTxWithFees, SignedTransactionIntent), N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -1272,7 +1275,7 @@ where
         staker_address: Option<RpcAddress<Destination>>,
         vrf_public_key: Option<RpcAddress<VRFPublicKey>>,
         config: ControllerConfig,
-    ) -> WRpcResult<SignedTransaction, N> {
+    ) -> WRpcResult<NewTransaction, N> {
         let decimals = self.chain_config.coin_decimals();
         let amount = amount.to_amount(decimals).ok_or(RpcError::InvalidCoinAmount)?;
         let cost_per_block =
@@ -1326,7 +1329,7 @@ where
         pool_id: RpcAddress<PoolId>,
         output_address: Option<RpcAddress<Destination>>,
         config: ControllerConfig,
-    ) -> WRpcResult<SignedTransaction, N> {
+    ) -> WRpcResult<NewTransaction, N> {
         let pool_id =
             pool_id.decode_object(&self.chain_config).map_err(|_| RpcError::InvalidPoolId)?;
 
@@ -1382,7 +1385,7 @@ where
         address: RpcAddress<Destination>,
         pool_id: RpcAddress<PoolId>,
         config: ControllerConfig,
-    ) -> WRpcResult<(SignedTransaction, RpcAddress<DelegationId>), N> {
+    ) -> WRpcResult<(NewTransaction, RpcAddress<DelegationId>), N> {
         let address =
             address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
 
@@ -1416,7 +1419,7 @@ where
         amount: RpcAmountIn,
         delegation_id: RpcAddress<DelegationId>,
         config: ControllerConfig,
-    ) -> WRpcResult<SignedTransaction, N> {
+    ) -> WRpcResult<NewTransaction, N> {
         let decimals = self.chain_config.coin_decimals();
         let amount = amount.to_amount(decimals).ok_or(RpcError::InvalidCoinAmount)?;
 
@@ -1445,7 +1448,7 @@ where
         amount: RpcAmountIn,
         delegation_id: RpcAddress<DelegationId>,
         config: ControllerConfig,
-    ) -> WRpcResult<SignedTransaction, N> {
+    ) -> WRpcResult<NewTransaction, N> {
         let decimals = self.chain_config.coin_decimals();
         let amount = amount.to_amount(decimals).ok_or(RpcError::InvalidCoinAmount)?;
         let address =
@@ -1603,7 +1606,7 @@ where
         give: RpcOutputValueIn,
         conclude_address: RpcAddress<Destination>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewOrder, N> {
+    ) -> WRpcResult<NewOrderTransaction, N> {
         let coin_decimals = self.chain_config.coin_decimals();
 
         let convert_currency = |rpc_currency| -> Result<_, RpcError<N>> {
@@ -1654,10 +1657,11 @@ where
                 })
             })
             .await?
-            .map(|(tx, order_id)| NewOrder {
-                tx_id: tx.transaction().get_id(),
-                order_id: RpcAddress::new(&self.chain_config, order_id)
-                    .expect("addressable delegation id"),
+            .map(|(tx, order_id)| {
+                NewOrderTransaction::new(
+                    tx,
+                    RpcAddress::new(&self.chain_config, order_id).expect("addressable order id"),
+                )
             })
     }
 
@@ -1667,7 +1671,7 @@ where
         order_id: RpcAddress<OrderId>,
         output_address: Option<RpcAddress<Destination>>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let order_id = order_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -1699,7 +1703,7 @@ where
                         .conclude_order(order_id, order_info, output_address, token_infos)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -1712,7 +1716,7 @@ where
         fill_amount_in_ask_currency: RpcAmountIn,
         output_address: Option<RpcAddress<Destination>>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let coin_decimals = self.chain_config.coin_decimals();
         let order_id = order_id
             .decode_object(&self.chain_config)
@@ -1763,7 +1767,7 @@ where
                         )
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -1774,7 +1778,7 @@ where
         account_index: U31,
         order_id: RpcAddress<OrderId>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let order_id = order_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -1789,7 +1793,7 @@ where
                         .freeze_order(order_id, order_info)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -1857,7 +1861,7 @@ where
         account_index: U31,
         data: Vec<u8>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         self.wallet
             .call_async(move |controller| {
                 Box::pin(async move {
@@ -1867,7 +1871,7 @@ where
                         .deposit_data(data)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -1884,7 +1888,7 @@ where
         token_total_supply: TokenTotalSupply,
         is_freezable: IsTokenFreezable,
         config: ControllerConfig,
-    ) -> WRpcResult<RpcTokenId, N> {
+    ) -> WRpcResult<NewTokenTransaction, N> {
         ensure!(
             number_of_decimals <= self.chain_config.token_max_dec_count(),
             RpcError::Controller(ControllerError::WalletError(WalletError::TokenIssuance(
@@ -1913,10 +1917,12 @@ where
                 })
             })
             .await?
-            .map(|(tx, token_id)| RpcTokenId {
-                tx_id: tx.transaction().get_id(),
-                token_id: RpcAddress::new(&self.chain_config, token_id)
-                    .expect("Encoding token id should never fail"),
+            .map(|(tx, token_id)| {
+                NewTokenTransaction::new(
+                    tx,
+                    RpcAddress::new(&self.chain_config, token_id)
+                        .expect("Encoding token id should never fail"),
+                )
             })
     }
 
@@ -1926,7 +1932,7 @@ where
         address: RpcAddress<Destination>,
         metadata: Metadata,
         config: ControllerConfig,
-    ) -> WRpcResult<RpcTokenId, N> {
+    ) -> WRpcResult<NewTokenTransaction, N> {
         let address =
             address.into_address(&self.chain_config).map_err(|_| RpcError::InvalidAddress)?;
         self.wallet
@@ -1939,10 +1945,12 @@ where
                 })
             })
             .await?
-            .map(|(tx, token_id)| RpcTokenId {
-                tx_id: tx.transaction().get_id(),
-                token_id: RpcAddress::new(&self.chain_config, token_id)
-                    .expect("Encoding token id should never fail"),
+            .map(|(tx, token_id)| {
+                NewTokenTransaction::new(
+                    tx,
+                    RpcAddress::new(&self.chain_config, token_id)
+                        .expect("Encoding token id should never fail"),
+                )
             })
     }
 
@@ -1953,7 +1961,7 @@ where
         address: RpcAddress<Destination>,
         amount: RpcAmountIn,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -1974,7 +1982,7 @@ where
                         .mint_tokens(token_info, amount, address)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -1986,7 +1994,7 @@ where
         token_id: RpcAddress<TokenId>,
         amount: RpcAmountIn,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -2005,7 +2013,7 @@ where
                         .unmint_tokens(token_info, amount)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -2016,7 +2024,7 @@ where
         account_index: U31,
         token_id: RpcAddress<TokenId>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -2030,7 +2038,7 @@ where
                         .lock_token_supply(token_info)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -2042,7 +2050,7 @@ where
         token_id: RpcAddress<TokenId>,
         is_unfreezable: IsTokenUnfreezable,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -2056,7 +2064,7 @@ where
                         .freeze_token(token_info, is_unfreezable)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -2067,7 +2075,7 @@ where
         account_index: U31,
         token_id: RpcAddress<TokenId>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -2081,7 +2089,7 @@ where
                         .unfreeze_token(token_info)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -2093,7 +2101,7 @@ where
         token_id: RpcAddress<TokenId>,
         address: RpcAddress<Destination>,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -2109,7 +2117,7 @@ where
                         .change_token_authority(token_info, address)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?
@@ -2121,7 +2129,7 @@ where
         token_id: RpcAddress<TokenId>,
         metadata_uri: RpcHexString,
         config: ControllerConfig,
-    ) -> WRpcResult<NewTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let token_id = token_id
             .decode_object(&self.chain_config)
             .map_err(|_| RpcError::InvalidTokenId)?;
@@ -2135,7 +2143,7 @@ where
                         .change_token_metadata_uri(token_info, metadata_uri.into_bytes())
                         .await
                         .map_err(RpcError::Controller)
-                        .map(NewTransaction::new)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -39,7 +39,7 @@ use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress
 use serialization::{hex_encoded::HexEncoded, Decode, DecodeAll};
 use types::{
     NewOrderTransaction, NewSubmittedTransaction, NewTokenTransaction, RpcHashedTimelockContract,
-    RpcNewTransaction,
+    RpcNewTransaction, RpcPreparedTransaction,
 };
 use utils::{ensure, shallow_clone::ShallowClone};
 use utils_networking::IpOrSocketAddress;
@@ -1321,7 +1321,7 @@ where
                     controller
                         .synced_controller(account_index, config)
                         .await?
-                        .create_stake_pool_tx(
+                        .create_stake_pool(
                             amount,
                             decommission_destination,
                             margin_ratio_per_thousand,
@@ -1525,7 +1525,7 @@ where
         token_id: Option<RpcAddress<TokenId>>,
         htlc: RpcHashedTimelockContract,
         config: ControllerConfig,
-    ) -> WRpcResult<RpcNewTransaction, N> {
+    ) -> WRpcResult<RpcPreparedTransaction, N> {
         let secret_hash = HtlcSecretHash::decode_all(&mut htlc.secret_hash.as_bytes())
             .map_err(|_| RpcError::InvalidHtlcSecretHash)?;
 
@@ -1585,7 +1585,7 @@ where
                         .create_htlc_tx(value, htlc, additional_info)
                         .await
                         .map_err(RpcError::Controller)
-                        .map(RpcNewTransaction::new)
+                        .map(RpcPreparedTransaction::new)
                 })
             })
             .await?

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -1512,7 +1512,7 @@ where
         token_id: Option<RpcAddress<TokenId>>,
         htlc: RpcHashedTimelockContract,
         config: ControllerConfig,
-    ) -> WRpcResult<SignedTransaction, N> {
+    ) -> WRpcResult<RpcNewTransaction, N> {
         let secret_hash = HtlcSecretHash::decode_all(&mut htlc.secret_hash.as_bytes())
             .map_err(|_| RpcError::InvalidHtlcSecretHash)?;
 
@@ -1572,6 +1572,7 @@ where
                         .create_htlc_tx(value, htlc, additional_info)
                         .await
                         .map_err(RpcError::Controller)
+                        .map(RpcNewTransaction::new)
                 })
             })
             .await?

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -29,6 +29,7 @@ use common::{
 use crypto::{key::PrivateKey, vrf::VRFPublicKey};
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
 use serialization::{hex::HexEncode, json_encoded::JsonEncoded};
+use utils::ensure;
 use utils_networking::IpOrSocketAddress;
 use wallet::{account::TxInfo, version::get_version};
 use wallet_controller::{
@@ -555,12 +556,18 @@ where
         account: AccountArg,
         destination_address: RpcAddress<Destination>,
         from_addresses: Vec<RpcAddress<Destination>>,
+        all: Option<bool>,
         options: TransactionOptions,
     ) -> rpc::RpcResult<NewTransaction> {
         let config = ControllerConfig {
             in_top_x_mb: options.in_top_x_mb(),
             broadcast_to_mempool: true,
         };
+        let all = all.unwrap_or(false);
+        ensure!(
+            all && from_addresses.is_empty() || !all && !from_addresses.is_empty(),
+            RpcError::<N>::InvalidSweepParameters
+        );
         rpc::handle_result(
             self.sweep_addresses(
                 account.index::<N>()?,

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -29,7 +29,6 @@ use common::{
 use crypto::{key::PrivateKey, vrf::VRFPublicKey};
 use p2p_types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId};
 use serialization::{hex::HexEncode, json_encoded::JsonEncoded};
-use utils::ensure;
 use utils_networking::IpOrSocketAddress;
 use wallet::{account::TxInfo, version::get_version};
 use wallet_controller::{
@@ -558,23 +557,19 @@ where
         account: AccountArg,
         destination_address: RpcAddress<Destination>,
         from_addresses: Vec<RpcAddress<Destination>>,
-        all: Option<bool>,
+        all: bool,
         options: TransactionOptions,
     ) -> rpc::RpcResult<RpcNewTransaction> {
         let config = ControllerConfig {
             in_top_x_mb: options.in_top_x_mb(),
             broadcast_to_mempool: true,
         };
-        let all = all.unwrap_or(false);
-        ensure!(
-            all && from_addresses.is_empty() || !all && !from_addresses.is_empty(),
-            RpcError::<N>::InvalidSweepParameters
-        );
         rpc::handle_result(
             self.sweep_addresses(
                 account.index::<N>()?,
                 destination_address,
                 from_addresses,
+                all,
                 config,
             )
             .await,

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -52,14 +52,15 @@ use crate::{
         NftMetadata, NodeVersion, OpenedWallet, PoolInfo, PublicKeyInfo, RpcAddress, RpcAmountIn,
         RpcHexString, RpcInspectTransaction, RpcStandaloneAddresses, RpcUtxoOutpoint, RpcUtxoState,
         RpcUtxoType, SendTokensFromMultisigAddressResult, StakePoolBalance, StakingStatus,
-        StandaloneAddressWithDetails, TokenMetadata, TransactionOptions, TxOptionsOverrides,
-        UtxoInfo, VrfPublicKeyInfo,
+        StandaloneAddressWithDetails, TokenMetadata, TransactionOptions, TransactionRequestOptions,
+        TxOptionsOverrides, UtxoInfo, VrfPublicKeyInfo,
     },
     RpcError,
 };
 
 use super::types::{
     NewOrderTransaction, NewTokenTransaction, RpcHashedTimelockContract, RpcNewTransaction,
+    RpcPreparedTransaction,
 };
 
 #[async_trait::async_trait]
@@ -266,7 +267,7 @@ where
         &self,
         account_arg: AccountArg,
         raw_tx: RpcHexString,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<MaybeSignedTransaction> {
         rpc::handle_result(
             self.sign_raw_transaction(account_arg.index::<N>()?, raw_tx, options.into())
@@ -589,7 +590,7 @@ where
         amount: RpcAmountIn,
         selected_utxo: RpcUtxoOutpoint,
         change_address: Option<RpcAddress<Destination>>,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<ComposedTransaction> {
         rpc::handle_result(
             self.request_send_coins(
@@ -668,7 +669,7 @@ where
         account_arg: AccountArg,
         pool_id: RpcAddress<PoolId>,
         output_address: Option<RpcAddress<Destination>>,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<HexEncoded<PartiallySignedTransaction>> {
         rpc::handle_result(
             self.decommission_stake_pool_request(
@@ -958,7 +959,7 @@ where
         address: RpcAddress<Destination>,
         amount: RpcAmountIn,
         intent: String,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<(
         HexEncoded<SignedTransaction>,
         HexEncoded<SignedTransactionIntent>,
@@ -983,7 +984,7 @@ where
         from_address: RpcAddress<Destination>,
         fee_change_address: Option<RpcAddress<Destination>>,
         outputs: Vec<GenericTokenTransfer>,
-        options: TransactionOptions,
+        options: TransactionRequestOptions,
     ) -> rpc::RpcResult<SendTokensFromMultisigAddressResult> {
         rpc::handle_result(
             self.make_tx_to_send_tokens_from_multisig_address(
@@ -1022,8 +1023,8 @@ where
         amount: RpcAmountIn,
         token_id: Option<RpcAddress<TokenId>>,
         htlc: RpcHashedTimelockContract,
-        options: TransactionOptions,
-    ) -> rpc::RpcResult<RpcNewTransaction> {
+        options: TransactionRequestOptions,
+    ) -> rpc::RpcResult<RpcPreparedTransaction> {
         rpc::handle_result(
             self.create_htlc_transaction(
                 account_arg.index::<N>()?,

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -1104,7 +1104,7 @@ where
         token_id: Option<RpcAddress<TokenId>>,
         htlc: RpcHashedTimelockContract,
         options: TransactionOptions,
-    ) -> rpc::RpcResult<HexEncoded<SignedTransaction>> {
+    ) -> rpc::RpcResult<RpcNewTransaction> {
         let config = ControllerConfig {
             in_top_x_mb: options.in_top_x_mb(),
             broadcast_to_mempool: true,
@@ -1112,8 +1112,7 @@ where
 
         rpc::handle_result(
             self.create_htlc_transaction(account_arg.index::<N>()?, amount, token_id, htlc, config)
-                .await
-                .map(HexEncoded::new),
+                .await,
         )
     }
 

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -162,6 +162,9 @@ pub enum RpcError<N: NodeInterface> {
 
     #[error("Invalid HTLC secret hash")]
     InvalidHtlcSecretHash,
+
+    #[error("Either set `all` to sweep all addresses, or provide specific addresses — not both")]
+    InvalidSweepParameters,
 }
 
 impl<N: NodeInterface> From<RpcError<N>> for rpc::Error {

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -453,9 +453,27 @@ impl PoolInfo {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
-pub struct NewDelegation {
-    pub tx_id: Id<Transaction>,
+pub struct NewDelegationTransaction {
     pub delegation_id: RpcAddress<DelegationId>,
+    pub tx_id: Id<Transaction>,
+    pub tx: HexEncoded<SignedTransaction>,
+    pub fees: Balances,
+    pub broadcasted: bool,
+}
+
+impl NewDelegationTransaction {
+    pub fn new(
+        tx: wallet_controller::types::NewTransaction,
+        delegation_id: RpcAddress<DelegationId>,
+    ) -> Self {
+        Self {
+            delegation_id,
+            tx_id: tx.tx.transaction().get_id(),
+            tx: tx.tx.into(),
+            fees: tx.fees,
+            broadcasted: tx.broadcasted,
+        }
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
@@ -632,20 +650,57 @@ pub struct StakePoolBalance {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
-pub struct RpcTokenId {
+pub struct NewTokenTransaction {
     pub token_id: RpcAddress<TokenId>,
     pub tx_id: Id<Transaction>,
+    pub tx: HexEncoded<SignedTransaction>,
+    pub fees: Balances,
+    pub broadcasted: bool,
+}
+
+impl NewTokenTransaction {
+    pub fn new(
+        tx: wallet_controller::types::NewTransaction,
+        token_id: RpcAddress<TokenId>,
+    ) -> Self {
+        Self {
+            token_id,
+            tx_id: tx.tx.transaction().get_id(),
+            tx: tx.tx.into(),
+            fees: tx.fees,
+            broadcasted: tx.broadcasted,
+        }
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
-pub struct NewTransaction {
+pub struct NewSubmittedTransaction {
     pub tx_id: Id<Transaction>,
 }
 
-impl NewTransaction {
+impl NewSubmittedTransaction {
     pub fn new(tx: SignedTransaction) -> Self {
         Self {
             tx_id: tx.transaction().get_id(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
+pub struct RpcNewTransaction {
+    pub tx_id: Id<Transaction>,
+    pub tx: HexEncoded<SignedTransaction>,
+    pub fees: Balances,
+    pub broadcasted: bool,
+}
+
+impl RpcNewTransaction {
+    pub fn new(tx: wallet_controller::types::NewTransaction) -> Self {
+        Self {
+            tx_id: tx.tx.transaction().get_id(),
+            tx: tx.tx.into(),
+            fees: tx.fees,
+            broadcasted: tx.broadcasted,
         }
     }
 }
@@ -870,9 +925,27 @@ pub struct RpcHashedTimelockContract {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
-pub struct NewOrder {
-    pub tx_id: Id<Transaction>,
+pub struct NewOrderTransaction {
     pub order_id: RpcAddress<OrderId>,
+    pub tx_id: Id<Transaction>,
+    pub tx: HexEncoded<SignedTransaction>,
+    pub fees: Balances,
+    pub broadcasted: bool,
+}
+
+impl NewOrderTransaction {
+    pub fn new(
+        tx: wallet_controller::types::NewTransaction,
+        order_id: RpcAddress<OrderId>,
+    ) -> Self {
+        Self {
+            order_id,
+            tx_id: tx.tx.transaction().get_id(),
+            tx: tx.tx.into(),
+            fees: tx.fees,
+            broadcasted: tx.broadcasted,
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -391,18 +391,39 @@ impl NewAccountInfo {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
 pub struct TransactionOptions {
     pub in_top_x_mb: Option<usize>,
+    pub broadcast_to_mempool: Option<bool>,
 }
 
 impl TransactionOptions {
     const DEFAULT_IN_TOP_X_MB: usize = 5;
+    const DEFAULT_BROADCAST: bool = true;
 
     pub fn from_controller_config(config: &ControllerConfig) -> Self {
         let in_top_x_mb = Some(config.in_top_x_mb);
-        Self { in_top_x_mb }
+        let broadcast_to_mempool = Some(config.broadcast_to_mempool);
+        Self {
+            in_top_x_mb,
+            broadcast_to_mempool,
+        }
     }
 
     pub fn in_top_x_mb(&self) -> usize {
         self.in_top_x_mb.unwrap_or(Self::DEFAULT_IN_TOP_X_MB)
+    }
+
+    pub fn broadcast_to_mempool(&self) -> bool {
+        self.broadcast_to_mempool.unwrap_or(Self::DEFAULT_BROADCAST)
+    }
+}
+
+impl From<TransactionOptions> for ControllerConfig {
+    fn from(value: TransactionOptions) -> Self {
+        Self {
+            broadcast_to_mempool: value
+                .broadcast_to_mempool
+                .unwrap_or(TransactionOptions::DEFAULT_BROADCAST),
+            in_top_x_mb: value.in_top_x_mb.unwrap_or(TransactionOptions::DEFAULT_IN_TOP_X_MB),
+        }
     }
 }
 

--- a/wallet/wallet-rpc-lib/tests/basic.rs
+++ b/wallet/wallet-rpc-lib/tests/basic.rs
@@ -28,7 +28,7 @@ use utils::{
 };
 use wallet_rpc_lib::{
     types::{
-        AddressInfo, Balances, BlockInfo, NewAccountInfo, NewTransaction, RpcAmountIn,
+        AddressInfo, Balances, BlockInfo, NewAccountInfo, NewSubmittedTransaction, RpcAmountIn,
         RpcUtxoState, TransactionOptions,
     },
     TxState,
@@ -164,7 +164,7 @@ async fn stake_and_send_coins_to_acct1(#[case] seed: Seed) {
     assert_eq!(utxo_amount, coins_before.into_atoms());
 
     let to_send_amount = Amount::from_atoms(utxo_amount / 2);
-    let _: NewTransaction = {
+    let _: NewSubmittedTransaction = {
         let send_to_addr = acct1_addr.address;
         let options = TransactionOptions {
             in_top_x_mb: Some(3),

--- a/wallet/wallet-rpc-lib/tests/basic.rs
+++ b/wallet/wallet-rpc-lib/tests/basic.rs
@@ -168,6 +168,7 @@ async fn stake_and_send_coins_to_acct1(#[case] seed: Seed) {
         let send_to_addr = acct1_addr.address;
         let options = TransactionOptions {
             in_top_x_mb: Some(3),
+            broadcast_to_mempool: Some(true),
         };
         let params = (
             ACCOUNT0_ARG,


### PR DESCRIPTION
- add an --all flag to sweep address command that sweeps all addresses for an account
- add a new command for setting the CLI config for broadcasting to true or false
- update all RPC endpoints to return the hex encoded signed transaction, fees and a broadcasted status