### PR TITLE
Group up Software and Trezor args in separate subcommands

### DIFF
--- a/node-gui/backend/src/backend_impl.rs
+++ b/node-gui/backend/src/backend_impl.rs
@@ -550,7 +550,7 @@ impl Backend {
                             handles_client,
                             file_path.clone(),
                             wallet_events,
-                            Some(HardwareWalletType::Trezor),
+                            Some(HardwareWalletType::Trezor { device_id: None }),
                         )
                         .await?;
 
@@ -626,7 +626,6 @@ impl Backend {
                 false,
                 ScanBlockchain::ScanNoWait,
                 hardware_wallet,
-                None,
             )
             .await
             .map_err(|err| BackendError::WalletError(err.to_string()))?;

--- a/test/functional/test_framework/wallet_cli_controller.py
+++ b/test/functional/test_framework/wallet_cli_controller.py
@@ -166,17 +166,17 @@ class WalletCliController(WalletCliControllerBase):
     async def create_wallet(self, name: str = "wallet", mnemonic: Optional[str] = None) -> str:
         wallet_file = os.path.join(self.node.datadir, name)
         mnemonic_str = "" if mnemonic is None else f'"{mnemonic}"'
-        return await self._write_command(f"wallet-create \"{wallet_file}\" store-seed-phrase {mnemonic_str}\n")
+        return await self._write_command(f"wallet-create software \"{wallet_file}\" store-seed-phrase {mnemonic_str}\n")
 
     async def open_wallet(self, name: str, password: Optional[str] = None, force_change_wallet_type: bool = False) -> str:
         password_str = password if password else ""
         force_change_wallet_type_str = "--force-change-wallet-type" if force_change_wallet_type else ""
         wallet_file = os.path.join(self.node.datadir, name)
-        return await self._write_command(f"wallet-open \"{wallet_file}\" {password_str} {force_change_wallet_type_str}\n")
+        return await self._write_command(f"wallet-open software \"{wallet_file}\" {password_str} {force_change_wallet_type_str}\n")
 
     async def recover_wallet(self, mnemonic: str, name: str = "recovered_wallet") -> str:
         wallet_file = os.path.join(self.node.datadir, name)
-        return await self._write_command(f"wallet-recover \"{wallet_file}\" store-seed-phrase \"{mnemonic}\"\n")
+        return await self._write_command(f"wallet-recover software \"{wallet_file}\" store-seed-phrase \"{mnemonic}\"\n")
 
     async def close_wallet(self) -> str:
         return await self._write_command("wallet-close\n")

--- a/wallet/wallet-cli-lib/tests/basic.rs
+++ b/wallet/wallet-cli-lib/tests/basic.rs
@@ -57,12 +57,14 @@ async fn wallet_cli_file(#[case] seed: Seed) {
         .to_owned();
 
     assert!(test
-        .exec(&format!("wallet-create \"{file_name}\" store-seed-phrase"))
+        .exec(&format!(
+            "wallet-create software \"{file_name}\" store-seed-phrase"
+        ))
         .starts_with("New wallet created successfully\n"));
     assert_eq!(test.exec("wallet-close"), "Successfully closed the wallet.");
 
     assert_eq!(
-        test.exec(&format!("wallet-open \"{file_name}\"")),
+        test.exec(&format!("wallet-open software \"{file_name}\"")),
         "Wallet loaded successfully"
     );
     assert_eq!(test.exec("wallet-close"), "Successfully closed the wallet.");

--- a/wallet/wallet-cli-lib/tests/cli_test_framework.rs
+++ b/wallet/wallet-cli-lib/tests/cli_test_framework.rs
@@ -202,7 +202,7 @@ impl CliTestFramework {
             .unwrap()
             .to_owned();
         let cmd = format!(
-            "wallet-recover \"{}\" store-seed-phrase \"{}\"",
+            "wallet-recover software \"{}\" store-seed-phrase \"{}\"",
             file_name, MNEMONIC
         );
         assert_eq!(self.exec(&cmd), "Wallet recovered successfully");
@@ -220,7 +220,7 @@ impl CliTestFramework {
             .unwrap()
             .to_owned();
         let cmd = format!(
-            "wallet-create \"{}\" store-seed-phrase \"{}\"",
+            "wallet-create software \"{}\" store-seed-phrase \"{}\"",
             file_name, COLD_WALLET_MENEMONIC,
         );
         assert_eq!(self.exec(&cmd), "New wallet created successfully");

--- a/wallet/wallet-rpc-client/src/handles_client/mod.rs
+++ b/wallet/wallet-rpc-client/src/handles_client/mod.rs
@@ -139,26 +139,14 @@ where
     async fn recover_wallet(
         &self,
         path: PathBuf,
-        store_seed_phrase: bool,
-        mnemonic: Option<String>,
-        passphrase: Option<String>,
-        hardware_wallet: Option<HardwareWalletType>,
-        device_id: Option<String>,
+        wallet_args: WalletTypeArgs,
     ) -> Result<CreatedWallet, Self::Error> {
-        let args = HardwareWalletType::into_wallet_args::<N>(
-            hardware_wallet,
-            store_seed_phrase,
-            mnemonic,
-            passphrase,
-            device_id,
-        )?;
-
         let options = WalletCreationOptions {
             overwrite_wallet_file: false,
             scan_blockchain: ScanBlockchain::ScanAndWait,
         };
         self.wallet_rpc
-            .create_wallet(path, args, options)
+            .create_wallet(path, wallet_args, options)
             .await
             .map(Into::into)
             .map_err(WalletRpcHandlesClientError::WalletRpcError)
@@ -170,7 +158,6 @@ where
         password: Option<String>,
         force_migrate_wallet_type: Option<bool>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_id: Option<String>,
     ) -> Result<OpenedWallet, Self::Error> {
         self.wallet_rpc
             .open_wallet(
@@ -179,7 +166,6 @@ where
                 force_migrate_wallet_type.unwrap_or(false),
                 ScanBlockchain::ScanAndWait,
                 hardware_wallet,
-                device_id,
             )
             .await
             .map(Into::into)

--- a/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
+++ b/wallet/wallet-rpc-client/src/wallet_rpc_traits.rs
@@ -79,11 +79,7 @@ pub trait WalletInterface {
     async fn recover_wallet(
         &self,
         path: PathBuf,
-        store_seed_phrase: bool,
-        mnemonic: Option<String>,
-        passphrase: Option<String>,
-        hardware_wallet: Option<HardwareWalletType>,
-        device_id: Option<String>,
+        wallet_args: WalletTypeArgs,
     ) -> Result<CreatedWallet, Self::Error>;
 
     async fn open_wallet(
@@ -92,7 +88,6 @@ pub trait WalletInterface {
         password: Option<String>,
         force_migrate_wallet_type: Option<bool>,
         hardware_wallet: Option<HardwareWalletType>,
-        device_id: Option<String>,
     ) -> Result<OpenedWallet, Self::Error>;
 
     async fn close_wallet(&self) -> Result<(), Self::Error>;

--- a/wallet/wallet-rpc-daemon/docs/RPC.md
+++ b/wallet/wallet-rpc-daemon/docs/RPC.md
@@ -2747,10 +2747,12 @@ Parameters:
          1) string
          2) null,
     "hardware_wallet": EITHER OF
-         1) "Trezor"
-         2) null,
-    "trezor_device_id": EITHER OF
-         1) string
+         1) {
+                "type": "Trezor",
+                "content": { "device_id": EITHER OF
+                     1) string
+                     2) null },
+            }
          2) null,
 }
 ```
@@ -2793,10 +2795,12 @@ Parameters:
          1) string
          2) null,
     "hardware_wallet": EITHER OF
-         1) "Trezor"
-         2) null,
-    "trezor_device_id": EITHER OF
-         1) string
+         1) {
+                "type": "Trezor",
+                "content": { "device_id": EITHER OF
+                     1) string
+                     2) null },
+            }
          2) null,
 }
 ```
@@ -2838,10 +2842,12 @@ Parameters:
          1) bool
          2) null,
     "hardware_wallet": EITHER OF
-         1) "Trezor"
-         2) null,
-    "trezor_device_id": EITHER OF
-         1) string
+         1) {
+                "type": "Trezor",
+                "content": { "device_id": EITHER OF
+                     1) string
+                     2) null },
+            }
          2) null,
 }
 ```

--- a/wallet/wallet-rpc-lib/src/cmdline.rs
+++ b/wallet/wallet-rpc-lib/src/cmdline.rs
@@ -26,7 +26,6 @@ use utils::{
     clap_utils, cookie::COOKIE_FILENAME, default_data_dir::default_data_dir_for_chain, ensure,
 };
 use utils_networking::NetworkAddressWithPort;
-use wallet_controller::types::WalletTypeArgs;
 
 use crate::{
     config::{WalletRpcConfig, WalletServiceConfig},
@@ -89,19 +88,11 @@ pub enum CliHardwareWalletType {
     Trezor,
 }
 
-impl CliHardwareWalletType {
-    pub fn into_wallet_args(&self, device_id: Option<String>) -> WalletTypeArgs {
-        match self {
-            Self::Trezor => WalletTypeArgs::Trezor { device_id },
-        }
-    }
-}
-
 impl From<CliHardwareWalletType> for HardwareWalletType {
     fn from(value: CliHardwareWalletType) -> Self {
         match value {
             #[cfg(feature = "trezor")]
-            CliHardwareWalletType::Trezor => Self::Trezor,
+            CliHardwareWalletType::Trezor => Self::Trezor { device_id: None },
         }
     }
 }

--- a/wallet/wallet-rpc-lib/src/lib.rs
+++ b/wallet/wallet-rpc-lib/src/lib.rs
@@ -106,7 +106,7 @@ where
         || node_rpc.is_cold_wallet_node().into(),
         |hw| match hw {
             #[cfg(feature = "trezor")]
-            HardwareWalletType::Trezor => WalletType::Trezor,
+            HardwareWalletType::Trezor { device_id: _ } => WalletType::Trezor,
         },
     );
     // Start the wallet service

--- a/wallet/wallet-rpc-lib/src/rpc/interface.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/interface.rs
@@ -80,7 +80,6 @@ trait ColdWalletRpc {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        trezor_device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet>;
 
     /// Recover new wallet, this will rescan the blockchain upon creation
@@ -92,7 +91,6 @@ trait ColdWalletRpc {
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        trezor_device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet>;
 
     /// Open an exiting wallet by specifying the file location of the wallet file
@@ -103,7 +101,6 @@ trait ColdWalletRpc {
         password: Option<String>,
         force_migrate_wallet_type: Option<bool>,
         hardware_wallet: Option<HardwareWalletType>,
-        trezor_device_id: Option<String>,
     ) -> rpc::RpcResult<OpenedWallet>;
 
     /// Close the currently open wallet file

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -158,13 +158,14 @@ where
         force_migrate_wallet_type: bool,
         scan_blockchain: ScanBlockchain,
         open_as_hw_wallet: Option<HardwareWalletType>,
-        device_id: Option<String>,
     ) -> WRpcResult<OpenedWallet, N> {
-        let open_as_wallet_type =
-            open_as_hw_wallet.map_or(self.node.is_cold_wallet_node().into(), |hw| match hw {
+        let (open_as_wallet_type, device_id) = open_as_hw_wallet.map_or(
+            (self.node.is_cold_wallet_node().into(), None),
+            |hw| match hw {
                 #[cfg(feature = "trezor")]
-                HardwareWalletType::Trezor => WalletType::Trezor,
-            });
+                HardwareWalletType::Trezor { device_id } => (WalletType::Trezor, device_id),
+            },
+        );
         Ok(self
             .wallet
             .manage_async(move |wallet_manager| {

--- a/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/server_impl.rs
@@ -94,14 +94,12 @@ where
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        trezor_device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet> {
         let args = HardwareWalletType::into_wallet_args::<N>(
             hardware_wallet,
             store_seed_phrase,
             mnemonic,
             passphrase,
-            trezor_device_id,
         )?;
 
         let options = WalletCreationOptions {
@@ -122,14 +120,12 @@ where
         mnemonic: Option<String>,
         passphrase: Option<String>,
         hardware_wallet: Option<HardwareWalletType>,
-        trezor_device_id: Option<String>,
     ) -> rpc::RpcResult<CreatedWallet> {
         let args = HardwareWalletType::into_wallet_args::<N>(
             hardware_wallet,
             store_seed_phrase,
             mnemonic,
             passphrase,
-            trezor_device_id,
         )?;
 
         let options = WalletCreationOptions {
@@ -149,7 +145,6 @@ where
         password: Option<String>,
         force_migrate_wallet_type: Option<bool>,
         open_as_hw_wallet: Option<HardwareWalletType>,
-        trezor_device_id: Option<String>,
     ) -> rpc::RpcResult<OpenedWallet> {
         rpc::handle_result(
             self.open_wallet(
@@ -158,7 +153,6 @@ where
                 force_migrate_wallet_type.unwrap_or(false),
                 ScanBlockchain::ScanNoWait,
                 open_as_hw_wallet,
-                trezor_device_id,
             )
             .await
             .map(Into::<OpenedWallet>::into),

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -879,10 +879,11 @@ pub enum RpcCurrency {
     Token { token_id: RpcAddress<TokenId> },
 }
 
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, HasValueHint)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, HasValueHint)]
+#[serde(tag = "type", content = "content")]
 pub enum HardwareWalletType {
     #[cfg(feature = "trezor")]
-    Trezor,
+    Trezor { device_id: Option<String> },
 }
 
 impl HardwareWalletType {
@@ -891,7 +892,6 @@ impl HardwareWalletType {
         store_seed_phrase: bool,
         mnemonic: Option<String>,
         passphrase: Option<String>,
-        device_id: Option<String>,
     ) -> Result<WalletTypeArgs, RpcError<N>> {
         let store_seed_phrase = if store_seed_phrase {
             StoreSeedPhrase::Store
@@ -914,7 +914,9 @@ impl HardwareWalletType {
                 );
                 match hw_type {
                     #[cfg(feature = "trezor")]
-                    HardwareWalletType::Trezor => Ok(WalletTypeArgs::Trezor { device_id }),
+                    HardwareWalletType::Trezor { device_id } => {
+                        Ok(WalletTypeArgs::Trezor { device_id })
+                    }
                 }
             }
         }


### PR DESCRIPTION
- CLI commands Create, Recover and Open wallet are now grouped up into subcommands for Software vs Trezor