### PR TITLE
Minor node GUI visual improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,17 +3597,17 @@ dependencies = [
 
 [[package]]
 name = "iced_aw"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e05df3019f20c6decea93d035b32a2afc7b329d89cc5a68cca097d0e0a1889"
+version = "0.12.2"
+source = "git+https://github.com/iced-rs/iced_aw?branch=main#def1db9aac1e58a47e0c3127d4d4e95d724ca8ad"
 dependencies = [
  "cfg-if",
  "chrono",
  "iced",
  "iced_fonts",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-format",
  "num-traits",
+ "web-time",
 ]
 
 [[package]]
@@ -3994,15 +3994,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,9 @@ hex = "0.4"
 hex-literal = "0.4"
 hmac = "0.12"
 iced = "0.13"
-iced_aw = "0.11"
+# Note: we need this fix - https://github.com/iced-rs/iced_aw/pull/329
+# TODO: switch back to a released version of iced_aw once the fix is released (need version > 0.12)
+iced_aw = { git = "https://github.com/iced-rs/iced_aw", branch = "main" }
 iced_fonts = "0.1"
 indoc = "2.0"
 itertools = "0.14"

--- a/common/src/chain/config/builder.rs
+++ b/common/src/chain/config/builder.rs
@@ -55,7 +55,8 @@ use super::{
 
 // The fork at which we:
 // * enable tokens v1;
-// * upgrade consensus to PoSConsensusVersion::V1 to dis-incentivize large pools.
+// * upgrade consensus to PoSConsensusVersion::V1 to dis-incentivize large pools;
+// * change the maturity block count to 7200.
 const TESTNET_FORK_HEIGHT_1_TOKENS_V1: BlockHeight = BlockHeight::new(78_440);
 
 // The fork at which we:

--- a/common/src/chain/config/checkpoints.rs
+++ b/common/src/chain/config/checkpoints.rs
@@ -83,8 +83,14 @@ impl Checkpoints {
             .checkpoints
             .range(..=height)
             .next_back()
-            .expect("Genesis must be there, at least.");
+            .expect("Genesis must be there, at least");
         (*cp.0, *cp.1)
+    }
+
+    pub fn last_checkpoint(&self) -> (BlockHeight, Id<GenBlock>) {
+        let (height, cp) =
+            self.checkpoints.last_key_value().expect("Genesis must be there, at least");
+        (*height, *cp)
     }
 
     #[cfg(test)]

--- a/node-gui/src/main_window/main_widget/tabs/wallet/left_panel.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/left_panel.rs
@@ -91,6 +91,10 @@ pub fn view_left_panel(
         WalletMessage::SelectAccount(item.account_id)
     });
 
+    let panel_button_row_padding = 8;
+    // The pick-list row looks a bit nicer when these values are equal.
+    let pick_list_row_spacing = panel_button_row_padding;
+
     let panel_button = |label, panel, selected_panel, tooltip_text| {
         let label = row![
             text(label).size(16).width(Length::Fill),
@@ -101,7 +105,7 @@ pub fn view_left_panel(
                 tooltip::Position::Bottom
             )
             .gap(10)
-            .style(iced::widget::container::bordered_box),
+            .style(iced::widget::container::bordered_box)
         ];
 
         button(label)
@@ -112,7 +116,7 @@ pub fn view_left_panel(
             })
             .width(Length::Fill)
             .on_press(WalletMessage::SelectPanel(panel))
-            .padding(8)
+            .padding(panel_button_row_padding)
     };
 
     // `next_height` is used to prevent flickering when a new block is found
@@ -159,7 +163,7 @@ pub fn view_left_panel(
         column![
             text(file_name).size(25),
             row![
-                pick_list,
+                pick_list.width(Length::Fill),
                 button(Text::new("+"))
                     .style(iced::widget::button::success)
                     .on_press(WalletMessage::NewAccount),
@@ -170,14 +174,17 @@ pub fn view_left_panel(
                     tooltip::Position::Bottom
                 )
                 .gap(10)
-                .style(iced::widget::container::bordered_box),
+                .style(iced::widget::container::bordered_box)
             ]
             .align_y(Alignment::Center)
-            .spacing(10)
+            .spacing(pick_list_row_spacing)
             .width(Length::Fill)
         ]
         .spacing(10)
-        .padding(10),
+        // Note: this specifies both vertical and horizontal padding; so if this value is different
+        // from the one used in `panel_button`, the tooltip's question mark will be misaligned with
+        // `panel_button's question marks.
+        .padding(panel_button_row_padding),
         match wallet_info.wallet_type {
             #[cfg(feature = "trezor")]
             WalletType::Trezor => {

--- a/node-gui/src/main_window/main_widget/tabs/wallet/transactions.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/transactions.rs
@@ -34,15 +34,26 @@ pub fn view_transactions(
     let mut transactions = Column::new();
 
     let current_transaction_list = &account.transaction_list;
-    let mut transaction_list = Grid::new().width(Length::Fill).push(
-        GridRow::new()
-            .push(field("#".into()))
-            .push(field("Transaction Id".into()))
-            .push(field("Timestamp (UTC)".into()))
-            .push(field("Type".into()))
-            .push(field("Amount".into()))
-            .push(field("State".into())),
-    );
+    let mut transaction_list = Grid::new()
+        .width(Length::Fill)
+        .push(
+            GridRow::new()
+                .push(field("#".into()))
+                .push(field("Transaction Id".into()))
+                .push(field("Timestamp (UTC)".into()))
+                .push(field("Type".into()))
+                .push(field("Amount".into()))
+                .push(field("State".into())),
+        )
+        .column_widths(&[
+            // Make the number column stretch just a little bit, compared to the other ones.
+            Length::FillPortion(1),
+            Length::FillPortion(5),
+            Length::FillPortion(5),
+            Length::FillPortion(5),
+            Length::FillPortion(5),
+            Length::FillPortion(5),
+        ]);
     for (index, tx) in current_transaction_list.txs.iter().enumerate() {
         let amount_str = tx
             .tx_type


### PR DESCRIPTION
1. In the left pane, the account selection row's layout was fixed.
    Before, expanded:
    ![before1](https://github.com/user-attachments/assets/8b1f400f-371f-4702-bed3-11191c96cd1c)
    and contracted:
    ![before2](https://github.com/user-attachments/assets/0f9bafbf-d5a0-4e62-82e3-1b6e4f2a598c)
    After, expanded:
    ![after1](https://github.com/user-attachments/assets/307951aa-4e67-43e4-907a-e347c0a96cb8)
    and contracted:
    ![after2](https://github.com/user-attachments/assets/ee99556d-42cc-4547-94b3-d24bcd30797e)

    Still not great, but better IMO.

2. In the "Delegations" panel, the delegations grid had weird spacing:
    Before:
    ![before3](https://github.com/user-attachments/assets/e06eb7fb-bcee-4758-87d1-ecf7f68cf979)
    After:
    ![after3](https://github.com/user-attachments/assets/2c12e9f8-6924-4e98-9e86-c2918ca33ba0)

    This was happening due to a bug in iced_aw, which was fixed in [this PR](https://www.github.com/iced-rs/iced_aw/pull/329) only a couple months ago. This is the reason for using an unreleased version of iced_aw.

    Note that for some reason the upgrade also changed how the grid in the "Transactions" panel is rendered, so I had to specify relative `column_widths` for it explicitly (it still looks a bit different than before though).

    Because of this I'm not sure whether this PR should be merged right away (but we should probably merge it before our next release anyway).

3. For testnet wallets, we used to print the legacy maturity period (2000 blocks) in the "Delegations" panel.