### PR TITLE
Tests checking that TrezorSigner produces the same signatures as SoftwareSigner

### DIFF
--- a/blockprod/src/detail/mod.rs
+++ b/blockprod/src/detail/mod.rs
@@ -242,7 +242,7 @@ impl BlockProduction {
                                         block_timestamp,
                                         block_height,
                                         make_ancestor_getter(cs),
-                                        randomness::make_true_rng(),
+                                        &mut randomness::make_true_rng(),
                                     )?;
                                 let consensus_data = ConsensusData::PoS(Box::new(consensus_data));
 
@@ -591,6 +591,7 @@ impl BlockProduction {
                     max_block_timestamp_for_pos,
                     stop_flag,
                     finalize_block_data,
+                    &mut randomness::make_true_rng(),
                 )
                 .map_err(BlockProductionError::FailedConsensusInitialization);
 

--- a/common/src/chain/transaction/signature/inputsig/arbitrary_message/tests.rs
+++ b/common/src/chain/transaction/signature/inputsig/arbitrary_message/tests.rs
@@ -92,7 +92,7 @@ fn produce_uniparty_signature_as_pub_key_hash_spending_matches_produce_uniparty_
         &private_key,
         &destination_addr,
         &message,
-        test_utils::random::make_seedable_rng(signer_rng_seed),
+        &mut test_utils::random::make_seedable_rng(signer_rng_seed),
     )
     .unwrap();
     sig1.verify_signature(&chain_config, &destination_addr, &message_challenge)
@@ -101,7 +101,7 @@ fn produce_uniparty_signature_as_pub_key_hash_spending_matches_produce_uniparty_
     let sig2 = ArbitraryMessageSignature::produce_uniparty_signature_as_pub_key_hash_spending(
         &private_key,
         &message,
-        test_utils::random::make_seedable_rng(signer_rng_seed),
+        &mut test_utils::random::make_seedable_rng(signer_rng_seed),
     )
     .unwrap();
 

--- a/common/src/chain/transaction/signature/inputsig/classical_multisig/multisig_partial_signature.rs
+++ b/common/src/chain/transaction/signature/inputsig/classical_multisig/multisig_partial_signature.rs
@@ -313,7 +313,7 @@ mod tests {
             let tampered_signature = priv_keys[tampered_index as usize]
                 .sign_message(
                     &H256::random_using(rng).encode(),
-                    randomness::make_true_rng(),
+                    &mut randomness::make_true_rng(),
                 )
                 .unwrap();
             // replace the signatures with a tampered one
@@ -368,7 +368,7 @@ mod tests {
                 .0
                 .sign_message(
                     &H256::random_using(rng).encode(),
-                    randomness::make_true_rng(),
+                    &mut randomness::make_true_rng(),
                 )
                 .unwrap();
             // replace the signatures with a tampered one

--- a/common/src/chain/transaction/signature/inputsig/htlc.rs
+++ b/common/src/chain/transaction/signature/inputsig/htlc.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use randomness::{CryptoRng, Rng};
+use crypto::key::SigAuxDataProvider;
 use serialization::Encode;
 
 use standard_signature::StandardInputSignature;
@@ -28,7 +28,7 @@ use super::{
 };
 
 #[allow(clippy::too_many_arguments)]
-pub fn produce_uniparty_signature_for_htlc_input<T: Signable, R: Rng + CryptoRng>(
+pub fn produce_uniparty_signature_for_htlc_input<T: Signable, AuxP: SigAuxDataProvider + ?Sized>(
     private_key: &crypto::key::PrivateKey,
     sighash_type: SigHashType,
     outpoint_destination: Destination,
@@ -36,7 +36,7 @@ pub fn produce_uniparty_signature_for_htlc_input<T: Signable, R: Rng + CryptoRng
     inputs_utxos: &[Option<&TxOutput>],
     input_num: usize,
     htlc_secret: HtlcSecret,
-    rng: R,
+    sig_aux_data_provider: &mut AuxP,
 ) -> Result<StandardInputSignature, DestinationSigError> {
     let sig = StandardInputSignature::produce_uniparty_signature_for_input(
         private_key,
@@ -45,7 +45,7 @@ pub fn produce_uniparty_signature_for_htlc_input<T: Signable, R: Rng + CryptoRng
         tx,
         inputs_utxos,
         input_num,
-        rng,
+        sig_aux_data_provider,
     )?;
 
     let sig_with_secret =

--- a/common/src/size_estimation/mod.rs
+++ b/common/src/size_estimation/mod.rs
@@ -18,7 +18,7 @@ use std::{
     num::{NonZeroU8, NonZeroUsize},
 };
 
-use crypto::key::{PrivateKey, PublicKey, Signature};
+use crypto::key::{PredefinedSigAuxDataProvider, PrivateKey, PublicKey, Signature};
 use serialization::{CompactLen, Encode};
 
 use crate::chain::{
@@ -63,7 +63,7 @@ lazy_static::lazy_static! {
         let (private_key, public_key) =
             PrivateKey::new_from_entropy(crypto::key::KeyKind::Secp256k1Schnorr);
         let signature = private_key
-            .sign_message(&[0; 32], randomness::make_true_rng())
+            .sign_message(&[0; 32], &mut PredefinedSigAuxDataProvider)
             .expect("should not fail");
         (private_key, public_key, signature)
     };

--- a/crypto/src/key/aux_data_provider.rs
+++ b/crypto/src/key/aux_data_provider.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use randomness::{CryptoRng, Rng};
+
+pub trait Secp256k1SchnorrAuxDataProvider {
+    /// Return BIP-340's "auxiliary random data" that will eventually be passed as the `data` parameter
+    /// to the `nonce_function_bip340` here:
+    /// https://github.com/bitcoin-core/secp256k1/blob/f24b838bedffe19643fafd817b82fc49472d4877/src/modules/schnorrsig/main_impl.h#L52
+    ///
+    /// Note: using all-zeros array is safe and it's what Bitcoin Core does. Also, we do the same for Mintlayer in
+    /// the Trezor firmware. But our software wallets use random aux data.
+    /// TODO: consider using fixed aux data in software wallets too, so that they also produce deterministic signatures.
+    fn get_secp256k1_schnorr_aux_data(&mut self) -> [u8; 32];
+}
+
+pub trait SigAuxDataProvider: Secp256k1SchnorrAuxDataProvider {}
+
+impl<T> SigAuxDataProvider for T where T: Secp256k1SchnorrAuxDataProvider {}
+
+impl<R> Secp256k1SchnorrAuxDataProvider for R
+where
+    R: Rng + CryptoRng,
+{
+    fn get_secp256k1_schnorr_aux_data(&mut self) -> [u8; 32] {
+        self.gen()
+    }
+}
+
+/// The aux data provider that returns all zeroes in its `get_secp256k1_schnorr_aux_data`.
+pub struct PredefinedSigAuxDataProvider;
+
+impl Secp256k1SchnorrAuxDataProvider for PredefinedSigAuxDataProvider {
+    fn get_secp256k1_schnorr_aux_data(&mut self) -> [u8; 32] {
+        [0; 32]
+    }
+}

--- a/test-rpc-functions/src/rpc.rs
+++ b/test-rpc-functions/src/rpc.rs
@@ -308,7 +308,7 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
         let message: Vec<u8> = rpc::handle_result(Vec::<u8>::hex_decode_all(message_hex))?;
 
         let signature = private_key
-            .sign_message(&message, randomness::make_true_rng())
+            .sign_message(&message, &mut randomness::make_true_rng())
             .map_err(RpcTestFunctionsError::from);
         let signature: Signature = rpc::handle_result(signature)?;
 

--- a/wallet/src/signer/software_signer/tests.rs
+++ b/wallet/src/signer/software_signer/tests.rs
@@ -13,49 +13,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use rstest::rstest;
 
-use common::chain::ChainConfig;
-use crypto::key::hdkd::u31::U31;
 use test_utils::random::{make_seedable_rng, Seed};
 
-use super::*;
+use crate::signer::tests::{
+    generic_fixed_signature_tests::test_fixed_signatures_generic,
+    generic_tests::{
+        test_sign_message_generic, test_sign_transaction_generic,
+        test_sign_transaction_intent_generic,
+    },
+    make_deterministic_software_signer, make_software_signer, no_another_signer,
+};
 
-fn software_signer(chain_config: Arc<ChainConfig>, account_index: U31) -> SoftwareSigner {
-    SoftwareSigner::new(chain_config, account_index)
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn test_sign_message(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    test_sign_message_generic(&mut rng, make_software_signer, no_another_signer());
 }
 
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn sign_message(#[case] seed: Seed) {
-    use crate::signer::tests::generic_tests::test_sign_message;
-
+fn test_sign_transaction_intent(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
 
-    test_sign_message(&mut rng, software_signer);
+    test_sign_transaction_intent_generic(&mut rng, make_software_signer, no_another_signer());
 }
 
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn sign_transaction_intent(#[case] seed: Seed) {
-    use crate::signer::tests::generic_tests::test_sign_transaction_intent;
-
+fn test_sign_transaction(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
 
-    test_sign_transaction_intent(&mut rng, software_signer);
+    test_sign_transaction_generic(&mut rng, make_software_signer, no_another_signer());
 }
 
 #[rstest]
 #[trace]
 #[case(Seed::from_entropy())]
-fn sign_transaction(#[case] seed: Seed) {
-    use crate::signer::tests::generic_tests::test_sign_transaction;
-
+fn test_fixed_signatures(#[case] seed: Seed) {
     let mut rng = make_seedable_rng(seed);
 
-    test_sign_transaction(&mut rng, software_signer);
+    test_fixed_signatures_generic(&mut rng, make_deterministic_software_signer);
 }

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -244,7 +244,7 @@ pub fn sign_message_for_spending(private_key: &[u8], message: &[u8]) -> Result<V
     let private_key =
         PrivateKey::decode_all(&mut &private_key[..]).map_err(Error::InvalidPrivateKeyEncoding)?;
     let signature = private_key
-        .sign_message(message, randomness::make_true_rng())
+        .sign_message(message, &mut randomness::make_true_rng())
         .map_err(Error::SignMessageError)?;
     Ok(signature.encode())
 }
@@ -278,7 +278,7 @@ pub fn sign_challenge(private_key: &[u8], message: &[u8]) -> Result<Vec<u8>, Err
     let signature = ArbitraryMessageSignature::produce_uniparty_signature_as_pub_key_hash_spending(
         &private_key,
         message,
-        randomness::make_true_rng(),
+        &mut randomness::make_true_rng(),
     )
     .map_err(Error::ArbitraryMessageSigningError)?;
     Ok(signature.into_raw())
@@ -696,7 +696,7 @@ pub fn encode_witness(
         &tx,
         &utxos,
         input_index as usize,
-        randomness::make_true_rng(),
+        &mut randomness::make_true_rng(),
     )
     .map(InputWitness::Standard)
     .map_err(Error::InputSigningError)?;
@@ -743,7 +743,7 @@ pub fn encode_witness_htlc_secret(
         &utxos,
         input_index as usize,
         secret,
-        randomness::make_true_rng(),
+        &mut randomness::make_true_rng(),
     )
     .map(InputWitness::Standard)
     .map_err(Error::InputSigningError)?;


### PR DESCRIPTION
Instead of accepting `impl Rng + CryptoRng` directly, signing functions now accept a more specific `SigAuxDataProvider`, which returns auxiliary data for bip-340 nonce generation:
1) using random auxiliary data is what we did before and still do in the production code;
2) using all zeros for the data is what we do in the Trezor firmware.

So, `SoftwareSigner` can now be parameterized with a `SigAuxDataProvider`, which allows the tests to force it to produce trezor-like signatures, so that `TrezorSigner`'s signatures can be compared against them.