### PR TITLE
Misc cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9500,6 +9500,8 @@ dependencies = [
  "getrandom 0.2.16",
  "gloo-utils",
  "hex",
+ "itertools 0.14.0",
+ "js-sys",
  "randomness",
  "rstest",
  "serialization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,10 +187,10 @@ merkletree-mintlayer = "0.1"
 mockall = "0.13"
 num = "0.4"
 num-derive = "0.4"
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 once_cell = "1.13"
 oneshot = "0.1"
-parity-scale-codec = "3.1"
+parity-scale-codec = { version = "3.7", default-features = false }
 parking_lot = "0.12"
 paste = "1.0"
 probabilistic-collections = "0.7"
@@ -227,7 +227,7 @@ snowstorm = "0.4"
 socket2 = "0.5"
 sscanf = "0.4"
 static_assertions = "1.1"
-strum = { version = "0.26", features = ["derive"] }
+strum = { version = "0.26", default-features = false, features = ["derive"] }
 syn = "2.0"
 tap = "1.0"
 tempfile = "3.3"

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -670,7 +670,7 @@ fn nft_invalid_description(#[case] seed: Seed) {
                     BlockError::CheckBlockFailed(CheckBlockError::CheckTransactionFailed(
                         CheckBlockTransactionsError::CheckTransactionError(
                             CheckTransactionError::TokensError(TokensError::IssueError(
-                                TokenIssuanceError::IssueErrorDescriptionHasNoneAlphaNumericChar,
+                                TokenIssuanceError::IssueErrorDescriptionHasNonAlphaNumericChar,
                                 _,
                             ))
                         )
@@ -1772,7 +1772,7 @@ fn only_ascii_alphanumeric_after_v1(#[case] seed: Seed) {
                 CheckBlockError::CheckTransactionFailed(
                     CheckBlockTransactionsError::CheckTransactionError(
                         CheckTransactionError::TokensError(TokensError::IssueError(
-                            TokenIssuanceError::IssueErrorDescriptionHasNoneAlphaNumericChar,
+                            TokenIssuanceError::IssueErrorDescriptionHasNonAlphaNumericChar,
                             tx_id,
                         ))
                     )

--- a/chainstate/tx-verifier/src/transaction_verifier/error.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/error.rs
@@ -180,7 +180,7 @@ pub enum TokenIssuanceError {
     #[error("Invalid character in token name")]
     IssueErrorNameHasNoneAlphaNumericChar,
     #[error("Invalid character in token description")]
-    IssueErrorDescriptionHasNoneAlphaNumericChar,
+    IssueErrorDescriptionHasNonAlphaNumericChar,
     #[error("Incorrect amount")]
     IssueAmountIsZero,
     #[error("Too many decimals")]

--- a/chainstate/tx-verifier/src/transaction_verifier/tokens_check/check_utils.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/tokens_check/check_utils.rs
@@ -93,7 +93,7 @@ pub fn check_nft_description(
     // Check if description has alphanumeric chars
     ensure!(
         check_is_text_ascii_alphanumeric(description),
-        TokenIssuanceError::IssueErrorDescriptionHasNoneAlphaNumericChar
+        TokenIssuanceError::IssueErrorDescriptionHasNonAlphaNumericChar
     );
 
     Ok(())

--- a/common/src/chain/order/mod.rs
+++ b/common/src/chain/order/mod.rs
@@ -28,7 +28,7 @@ pub use rpc::RpcOrderInfo;
 /// The fields represent currencies and amounts to be exchanged and the trading pair can be deducted from it.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize)]
 pub struct OrderData {
-    /// The key that can authorize conclusion of an order.
+    /// The key that can authorize conclusion or freezing of an order.
     /// Conclusion closes an order and withdraws available funds.
     conclude_key: Destination,
     /// `Ask` and `give` fields represent amounts of currencies

--- a/common/src/chain/transaction/output/mod.rs
+++ b/common/src/chain/transaction/output/mod.rs
@@ -103,7 +103,18 @@ impl Addressable for Destination {
 // TODO: `CreateDelegationId` sounds a bit strange, it's better to rename it to just `CreateDelegation`.
 // Same applies to certain functions throughout the code, e.g. `create_delegation_id`/`delete_delegation_id`
 // in `pos-accounting` should become `create_delegation`/`delete_delegation``.
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Encode,
+    Decode,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::EnumDiscriminants,
+)]
+#[strum_discriminants(name(TxOutputTag), derive(EnumIter))]
 pub enum TxOutput {
     /// Transfer an output, giving the provided Destination the authority to spend it (no conditions).
     #[codec(index = 0)]

--- a/common/src/chain/transaction/output/output_value.rs
+++ b/common/src/chain/transaction/output/output_value.rs
@@ -48,6 +48,21 @@ impl OutputValue {
             OutputValue::TokenV0(_) | OutputValue::TokenV1(_, _) => None,
         }
     }
+
+    pub fn amount(&self) -> Amount {
+        match self {
+            OutputValue::Coin(amount) => *amount,
+            OutputValue::TokenV0(token_data) => {
+                let token_data = token_data.as_ref();
+                match token_data {
+                    TokenData::TokenTransfer(transfer) => transfer.amount,
+                    TokenData::TokenIssuance(issuance) => issuance.amount_to_issue,
+                    TokenData::NftIssuance(_) => Amount::from_atoms(1),
+                }
+            }
+            OutputValue::TokenV1(_, amount) => *amount,
+        }
+    }
 }
 
 impl From<TokenData> for OutputValue {
@@ -107,10 +122,10 @@ impl RpcOutputValue {
         }
     }
 
-    pub fn token_id(&self) -> Option<TokenId> {
+    pub fn token_id(&self) -> Option<&TokenId> {
         match self {
             RpcOutputValue::Coin { amount: _ } => None,
-            RpcOutputValue::Token { id, amount: _ } => Some(*id),
+            RpcOutputValue::Token { id, amount: _ } => Some(id),
         }
     }
 }

--- a/test/functional/test_framework/__init__.py
+++ b/test/functional/test_framework/__init__.py
@@ -223,15 +223,6 @@ def init_mintlayer_types():
                 ]
             },
 
-            "InfoId": {
-                "type": "enum",
-                "type_mapping": [
-                    ["TokenId", "H256"],
-                    ["PoolId", "H256"],
-                    ["OrderId", "H256"],
-                ],
-            },
-
             "TxAdditionalInfo": {
                 "type": "struct",
                 "type_mapping": [

--- a/trezor-common/Cargo.toml
+++ b/trezor-common/Cargo.toml
@@ -9,9 +9,9 @@ rust-version.workspace = true
 
 [dependencies]
 num-derive.workspace = true
-num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-parity-scale-codec = { version = "3.1", default-features = false, features = ["derive", "chain-error"] }
-strum = { version = "0.26", default-features = false, features = ["derive"] }
+num-traits = { workspace = true, default-features = false, features = ["libm"] }
+parity-scale-codec = { workspace = true, default-features = false, features = ["derive", "chain-error"] }
+strum = { workspace = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -1186,8 +1186,8 @@ impl<K: AccountKeyChains> Account<K> {
         };
         tx_verifier::check_nft_issuance_data(&self.chain_config, &nft_issuance)?;
 
-        // the first UTXO is needed in advance to issue a new nft, so just make a dummy one
-        // and then replace it with when we can calculate the pool_id
+        // the first UTXO is needed to calculate the id, so just make a dummy id
+        // and then replace it with the actual one when we can calculate it
         let dummy_token_id = TokenId::new(H256::zero());
         let dummy_issuance_output = TxOutput::IssueNft(
             dummy_token_id,
@@ -1493,8 +1493,8 @@ impl<K: AccountKeyChains> Account<K> {
             ),
         };
 
-        // the first UTXO is needed in advance to calculate pool_id, so just make a dummy one
-        // and then replace it with when we can calculate the pool_id
+        // the first UTXO is needed to calculate the id, so just make a dummy id
+        // and then replace it with the actual one when we can calculate it
         let dummy_pool_id = PoolId::new(Uint256::from_u64(0).into());
         let dummy_stake_output = make_stake_output(
             dummy_pool_id,

--- a/wallet/src/account/utxo_selector/output_group.rs
+++ b/wallet/src/account/utxo_selector/output_group.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use common::{
-    chain::{output_value::OutputValue, tokens::TokenData, TxInput, TxOutput},
+    chain::{output_value::OutputValue, TxInput, TxOutput},
     primitives::Amount,
 };
 
@@ -74,18 +74,7 @@ impl OutputGroup {
                 )))
             }
         };
-        let value = match output_value {
-            OutputValue::Coin(output_amount) => output_amount,
-            OutputValue::TokenV0(token_data) => {
-                let token_data = token_data.as_ref();
-                match token_data {
-                    TokenData::TokenTransfer(token_transfer) => token_transfer.amount,
-                    TokenData::TokenIssuance(token_issuance) => token_issuance.amount_to_issue,
-                    TokenData::NftIssuance(_) => Amount::from_atoms(1),
-                }
-            }
-            OutputValue::TokenV1(_, output_amount) => output_amount,
-        };
+        let value = output_value.amount();
 
         Ok(Self {
             outputs: vec![output],

--- a/wallet/src/destination_getters.rs
+++ b/wallet/src/destination_getters.rs
@@ -52,6 +52,7 @@ where
         },
     }
 }
+
 pub fn get_all_tx_output_destinations<'a, PoolDataGetter>(
     txo: &TxOutput,
     pool_data_getter: &PoolDataGetter,

--- a/wallet/src/signer/trezor_signer/mod.rs
+++ b/wallet/src/signer/trezor_signer/mod.rs
@@ -145,7 +145,7 @@ pub enum TrezorError {
     MultisigSignatureReturned,
     #[error("The file being loaded is a software wallet and does not correspond to the connected hardware wallet")]
     HardwareWalletDifferentFile,
-    #[error("Public keys mismatch. Wrong device or passphrase:\nfile device id \"{file_device_id}\", connected device id \"{connected_device_id}\",\nfile label \"{file_label}\" and connected device label \"{connected_device_id}\"")]
+    #[error("Public keys mismatch. Wrong device or passphrase:\nfile device id \"{file_device_id}\", connected device id \"{connected_device_id}\",\nfile label \"{file_label}\" and connected device label \"{connected_device_label}\"")]
     HardwareWalletDifferentMnemonicOrPassphrase {
         file_device_id: String,
         connected_device_id: String,

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -54,7 +54,7 @@ use wallet_storage::{schema, WalletStorageEncryptionRead};
 use wallet_types::{
     account_info::DEFAULT_ACCOUNT_INDEX,
     partially_signed_transaction::{
-        PartiallySignedTransaction, PartiallySignedTransactionCreationError, TxAdditionalInfo,
+        PartiallySignedTransaction, PartiallySignedTransactionError, TxAdditionalInfo,
     },
     seed_phrase::{PassPhrase, StoreSeedPhrase},
     utxo_types::{UtxoState, UtxoType},
@@ -2874,7 +2874,7 @@ fn issue_and_transfer_tokens(#[case] seed: Seed) {
         Destination::PublicKeyHash(some_other_address),
     );
 
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         *token_id,
         TokenAdditionalInfo {
             num_decimals: number_of_decimals,
@@ -3230,7 +3230,7 @@ fn freeze_and_unfreeze_tokens(#[case] seed: Seed) {
         Destination::PublicKeyHash(some_other_address),
     );
 
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -4876,7 +4876,7 @@ fn decommission_pool_request_wrong_account(#[case] seed: Seed) {
     assert!(!decommission_partial_tx.all_signatures_available());
     matches!(
         decommission_partial_tx.into_signed_tx().unwrap_err(),
-        PartiallySignedTransactionCreationError::FailedToConvertPartiallySignedTx(_)
+        PartiallySignedTransactionError::FailedToConvertPartiallySignedTx(_)
     );
 }
 
@@ -5903,7 +5903,7 @@ fn create_order(#[case] seed: Seed) {
     // Create an order selling tokens for coins
     let ask_value = OutputValue::Coin(Amount::from_atoms(111));
     let give_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6032,7 +6032,7 @@ fn create_order_and_conclude(#[case] seed: Seed) {
     // Create an order selling tokens for coins
     let ask_value = OutputValue::Coin(Amount::from_atoms(111));
     let give_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6077,7 +6077,7 @@ fn create_order_and_conclude(#[case] seed: Seed) {
     assert_eq!(coin_balance, expected_balance);
     assert!(token_balances.is_empty());
 
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6225,7 +6225,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
     let ask_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
     let sell_amount = Amount::from_atoms(1000);
     let give_value = OutputValue::Coin(sell_amount);
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6284,7 +6284,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
             Some(&(issued_token_id, token_amount_to_mint))
         );
     }
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6351,7 +6351,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
         nonce: Some(AccountNonce::new(0)),
     };
 
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6409,7 +6409,7 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
         ask_balance: Amount::ZERO,
         nonce: Some(AccountNonce::new(1)),
     };
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6568,7 +6568,7 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
     let ask_value = OutputValue::TokenV1(issued_token_id, token_amount_to_mint);
     let sell_amount = Amount::from_atoms(1000);
     let give_value = OutputValue::Coin(sell_amount);
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6628,7 +6628,7 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
         );
     }
 
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -6694,7 +6694,7 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
         nonce: Some(AccountNonce::new(0)),
     };
 
-    let additional_info = TxAdditionalInfo::with_token_info(
+    let additional_info = TxAdditionalInfo::new().with_token_info(
         issued_token_id,
         TokenAdditionalInfo {
             num_decimals: unconfirmed_token_info.num_decimals(),
@@ -7451,18 +7451,10 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
         )
         .unwrap();
 
-    let order_info = RpcOrderInfo {
-        conclude_key: address2.clone().into_object(),
-        initially_given: RpcOutputValue::Token {
-            id: issued_token_id,
-            amount: buy_amount,
-        },
-        initially_asked: RpcOutputValue::Coin {
-            amount: sell_amount,
-        },
-        give_balance: sell_amount,
-        ask_balance: buy_amount,
-        nonce: Some(AccountNonce::new(0)),
+    let order_info = {
+        let mut order_info = order_info.clone();
+        order_info.nonce = Some(AccountNonce::new(0));
+        order_info
     };
 
     let spend_coins_2 = Amount::from_atoms(3);
@@ -7471,7 +7463,7 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
         .create_fill_order_tx(
             DEFAULT_ACCOUNT_INDEX,
             order_id,
-            order_info.clone(),
+            order_info,
             spend_coins_2,
             None,
             FeeRate::from_amount_per_kb(Amount::ZERO),

--- a/wallet/wallet-cli-commands/src/command_handler/mod.rs
+++ b/wallet/wallet-cli-commands/src/command_handler/mod.rs
@@ -1101,7 +1101,7 @@ where
                 token_ticker,
                 number_of_decimals,
                 metadata_uri,
-                destination_address,
+                authority_address,
                 token_supply,
                 is_freezable,
             } => {
@@ -1111,7 +1111,7 @@ where
                 let new_token = wallet
                     .issue_new_token(
                         selected_account,
-                        destination_address,
+                        authority_address,
                         TokenMetadata {
                             token_ticker: token_ticker.into(),
                             number_of_decimals,

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -536,8 +536,8 @@ pub enum WalletCommand {
         number_of_decimals: u8,
         /// URI for data related to the token (website, media, etc)
         metadata_uri: String,
-        /// The address of the receiver of this token
-        destination_address: String,
+        /// The address of the authority who will be able to manage this token
+        authority_address: String,
         /// The total supply of this token
         token_supply: String,
         /// Whether it's possible to centrally freeze this token for all users (due to migration requirements, for example)

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -1258,6 +1258,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
         order_info: RpcOrderInfo,
         current_fee_rate: FeeRate,
         consolidate_fee_rate: FeeRate,
+        additional_info: TxAdditionalInfo,
     ) -> WalletResult<SignedTxWithFees> {
         match self {
             RuntimeWallet::Software(w) => w.create_freeze_order_tx(
@@ -1266,6 +1267,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 order_info,
                 current_fee_rate,
                 consolidate_fee_rate,
+                additional_info,
             ),
             #[cfg(feature = "trezor")]
             RuntimeWallet::Trezor(w) => w.create_freeze_order_tx(
@@ -1274,6 +1276,7 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
                 order_info,
                 current_fee_rate,
                 consolidate_fee_rate,
+                additional_info,
             ),
         }
     }

--- a/wasm-wrappers/Cargo.toml
+++ b/wasm-wrappers/Cargo.toml
@@ -11,20 +11,22 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+common = { path = "../common" }
 consensus = { path = "../consensus" }
 crypto = { path = "../crypto" }
 randomness = { path = "../randomness" }
 serialization = { path = "../serialization" }
-common = { path = "../common" }
 tx-verifier = { path = "../chainstate/tx-verifier" }
 
 bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
 fixed-hash.workspace = true
+itertools.workspace = true
 thiserror.workspace = true
 
 # This crate is required for rand to work with wasm. See: https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 getrandom = { version = "0.2", features = ["js"] }
 gloo-utils = "0.2"
+js-sys = "0.3"
 wasm-bindgen = "0.2"
 # web-sys provides `console::log` and is useful during debugging.
 web-sys = { version = "0.3", features = ["console"] }

--- a/wasm-wrappers/README.md
+++ b/wasm-wrappers/README.md
@@ -28,6 +28,19 @@ Also, install TypeScript:
 npm install -g typescript
 ```
 
+### Build the wasm package
+
+In the wasm Cargo.toml directory, execute one of the following:
+  * for running the tests in a web browser:
+    ```
+    wasm-pack build --target web
+    ```
+
+  * for running the tests in Node.js:
+    ```
+    wasm-pack build --target nodejs
+    ```
+
 ### Compile the tests via `tsc`
 
 In the wasm Cargo.toml directory, run:
@@ -36,12 +49,6 @@ tsc --project js-bindings-test/tsconfig.json
 ```
 
 ### Run the tests in a web browser
-
-To build the wasm package from the crate, run (in the wasm Cargo.toml directory):
-
-```
-wasm-pack build --target web
-```
 
 To test the wasm binary, first install `http-server` web server (feel free to use any other web-server of your choosing):
 
@@ -61,20 +68,13 @@ If you're using a remote server, either tunnel to port 8080, or expose that port
 http-server --port 8080 --host 0.0.0.0
 ```
 
-To run test tests, choose the file `js-bindings-test/index.html` in the browser. Use browser's console to see the output.
+To run the tests, choose the file `js-bindings-test/index.html` in the browser. Use browser's console to see the output.
 
 ### Run the tests in Node.js
 
-To build the wasm package from the crate, run (in the wasm Cargo.toml directory):
-
+In the wasm Cargo.toml directory, execute the following:
 ```
-wasm-pack build --target nodejs
-```
-
-Finally, to run the tests, run:
-
-```
-node --enable-source-maps  js-bindings-test/node-entry.js
+node --enable-source-maps js-bindings-test/node-entry.js
 ```
 
 ### Run `knip`

--- a/wasm-wrappers/WASM-API.md
+++ b/wasm-wrappers/WASM-API.md
@@ -91,7 +91,7 @@ corresponding to each input of the transaction.
 
 Parameters:
 `signed_message` - this must have been produced by `make_transaction_intent_message_to_sign`.
-`signatures` - this should be an array of arrays of bytes, each of them representing an individual signature
+`signatures` - this should be an array of Uint8Array, each of them representing an individual signature
 of `signed_message` produced by `sign_challenge` using the private key for the corresponding input destination
 of the transaction. The number of signatures must be equal to the number of inputs in the transaction.
 
@@ -217,18 +217,27 @@ Encode an input witness of the variant that contains no signature.
 
 ### Function: `encode_witness`
 
-Given a private key, inputs and an input number to sign, and the destination that owns that output (through the utxo),
-and a network type (mainnet, testnet, etc), this function returns a witness to be used in a signed transaction, as bytes.
+Sign the specified input of the transaction and encode the signature as InputWitness.
+
+`input_utxos` must be formed as follows: for each transaction input, emit byte 0 if it's a non-UTXO input,
+otherwise emit 1 followed by the corresponding transaction output encoded via the appropriate "encode_output_"
+function.
 
 ### Function: `encode_witness_htlc_secret`
 
 Given a private key, inputs and an input number to sign, and the destination that owns that output (through the utxo),
 and a network type (mainnet, testnet, etc), and an htlc secret this function returns a witness to be used in a signed transaction, as bytes.
 
+`input_utxos` have the same format as in `encode_witness`.
+
 ### Function: `encode_multisig_challenge`
 
 Given an arbitrary number of public keys as bytes, number of minimum required signatures, and a network type, this function returns
 the multisig challenge, as bytes.
+
+### Function: `multisig_challenge_to_address`
+
+Produce a multisig address given a multisig challenge.
 
 ### Function: `encode_witness_htlc_multisig`
 
@@ -237,6 +246,8 @@ and a network type (mainnet, testnet, etc), this function returns a witness to b
 
 `key_index` parameter is an index of a public key in the challenge, against which is the signature produces from private key is to be verified.
 `input_witness` parameter can be either empty or a result of previous calls to this function.
+
+`input_utxos` have the same format as in `encode_witness`.
 
 ### Function: `encode_signed_transaction`
 
@@ -380,6 +391,17 @@ Given a pool id, staking data as bytes and the network type (mainnet, testnet, e
 this function returns an output that creates that staking pool.
 Note that the pool id is mandated to be taken from the hash of the first input.
 It is not arbitrary.
+
+Note: a UTXO of this kind is consumed when decommissioning a pool (provided that the pool
+never staked).
+
+### Function: `encode_output_produce_block_from_stake`
+
+Given a pool id and a staker address, this function returns an output that is emitted
+when producing a block via that pool.
+
+Note: a UTXO of this kind is consumed when decommissioning a pool (provided that the pool
+has staked at least once).
 
 ### Function: `encode_output_issue_fungible_token`
 

--- a/wasm-wrappers/js-bindings-test/tests/defs.ts
+++ b/wasm-wrappers/js-bindings-test/tests/defs.ts
@@ -30,7 +30,7 @@ export const MNEMONIC =
 // A random private key that is generated only once and printed to the console.
 // Note: simply putting `const PRIVATE_KEY = make_private_key()` to the global scope won't
 // work if the tests are run in the browser.
-export const get_predefined_prv_key = (function () {
+export const get_predefined_random_prv_key = (function () {
   let PRIVATE_KEY: Uint8Array | null = null;
   return function () {
     if (!PRIVATE_KEY) {
@@ -41,17 +41,23 @@ export const get_predefined_prv_key = (function () {
   }
 })();
 
-// The public key corresponding to get_predefined_prv_key().
-export const get_predefined_pub_key = (function () {
+// The public key corresponding to get_predefined_random_prv_key().
+export const get_predefined_random_pub_key = (function () {
   let PUBLIC_KEY: Uint8Array | null = null;
   return function () {
     if (!PUBLIC_KEY) {
-      PUBLIC_KEY = public_key_from_private_key(get_predefined_prv_key());
+      PUBLIC_KEY = public_key_from_private_key(get_predefined_random_prv_key());
       console.log(`PUBLIC_KEY = ${PUBLIC_KEY}`);
     }
     return PUBLIC_KEY;
   }
 })();
+
+export function generate_prv_key(description: string) {
+  const result = make_private_key();
+  console.log(`Generated ${description} private key: ${result}`);
+  return result;
+}
 
 // Some token id.
 export const TOKEN_ID = "tmltk15tgfrs49rv88v8utcllqh0nvpaqtgvn26vdxhuner5m6ewg9c3msn9fxns";
@@ -61,3 +67,31 @@ export const POOL_ID = "tpool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
 
 // Some order id
 export const ORDER_ID = "tordr1xxt0avjtt4flkq0tnlyphmdm4aaj9vmkx5r2m4g863nw3lgf7nzs7mlkqc";
+
+// Some HTLC secret and its hash
+export const HTLC_SECRET = [
+  0, 229, 233, 72, 110, 22, 64, 36, 69, 188, 238, 51, 130, 168, 185, 241,
+  73, 48, 120, 151, 140, 45, 46, 39, 50, 207, 18, 50, 243, 30, 115, 93
+]
+export const HTLC_SECRET_HASH = "b5a48c7780e597de8012346fb30761965248e3f2"
+
+// Some predefined key pairs (note that the prv keys are unused at the moment, so they are marked
+// with `/** @public */` to pacify knip).
+/** @public */
+export const PRV_KEY_A = [
+  0, 155, 37, 209, 155, 128, 40, 223, 139, 200, 13, 149, 126, 93, 4, 44,
+  190, 53, 102, 135, 246, 42, 84, 200, 61, 221, 125, 104, 135, 142, 0, 42, 12
+]
+export const PUB_KEY_A = [
+  0, 2, 204, 229, 50, 59, 113, 11, 253, 127, 50, 216, 85, 175, 139, 202,
+  118, 28, 122, 51, 91, 43, 137, 206, 188, 119, 57, 86, 49, 215, 37, 5, 134, 195
+]
+/** @public */
+export const PRV_KEY_B = [
+  0, 181, 124, 242, 82, 150, 38, 29, 109, 72, 118, 47, 37, 55, 218, 146,
+  84, 200, 134, 132, 108, 202, 174, 86, 48, 160, 159, 211, 78, 99, 66, 6, 173
+]
+export const PUB_KEY_B = [
+  0, 3, 68, 225, 99, 228, 45, 76, 242, 134, 151, 216, 99, 225, 215, 59,
+  77, 101, 3, 191, 248, 212, 205, 172, 178, 252, 65, 140, 255, 213, 205, 49, 234, 81
+]

--- a/wasm-wrappers/js-bindings-test/tests/test_encode_other_outputs.ts
+++ b/wasm-wrappers/js-bindings-test/tests/test_encode_other_outputs.ts
@@ -24,6 +24,7 @@ import {
   encode_output_issue_fungible_token,
   encode_output_issue_nft,
   encode_output_lock_then_transfer,
+  encode_output_produce_block_from_stake,
   encode_output_token_burn,
   encode_output_token_lock_then_transfer,
   encode_output_token_transfer,
@@ -70,6 +71,7 @@ export const OUTPUTS = [...OUTPUT_LOCK_THEN_TRANSFER, ...OUTPUT_CREATE_STAKE_POO
 export function test_encode_other_outputs() {
   run_one_test(create_stake_pool_test);
   run_one_test(stake_pool_data_test);
+  run_one_test(produce_block_from_stake_test);
   run_one_test(coin_burn_test);
   run_one_test(token_burn_test);
   run_one_test(lock_then_transfer_test);
@@ -156,6 +158,22 @@ function stake_pool_data_test() {
     }
     console.log("Tested invalid margin_ratio_per_thousand successfully");
   }
+}
+
+function produce_block_from_stake_test() {
+  const output = encode_output_produce_block_from_stake(
+    POOL_ID,
+    ADDRESS,
+    Network.Testnet
+  );
+  const expected_output = [
+    4, 1, 91, 58, 110, 176, 100, 207, 6, 194, 41, 193, 30, 91, 4, 195,
+    202, 103, 207, 80, 217, 178, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0
+  ];
+
+  assert_eq_arrays(output, expected_output);
 }
 
 function coin_burn_test() {

--- a/wasm-wrappers/js-bindings-test/tests/test_signed_transaction_intent.ts
+++ b/wasm-wrappers/js-bindings-test/tests/test_signed_transaction_intent.ts
@@ -44,16 +44,6 @@ export function test_signed_transaction_intent() {
     "<tx_id:dfc2bb0cc4c7f3ed3fe682a48ee9f78bcd4962e55e7bc239bd340ec22aff8657;intent:the intent>");
   assert_eq_arrays(message, expected_message);
 
-  try {
-    const invalid_signatures = "invalid signatures";
-    encode_signed_transaction_intent(message, invalid_signatures);
-    throw new Error("Invalid signatures worked somehow!");
-  } catch (e) {
-    if (!get_err_msg(e).includes("Error decoding a JsValue as an array of arrays of bytes")) {
-      throw e;
-    }
-  }
-
   {
     const prv_key1 = [
       0, 142, 11, 183, 83, 79, 207, 79, 18, 172, 116, 88, 251, 128, 146, 254, 82,
@@ -71,7 +61,7 @@ export function test_signed_transaction_intent() {
     const signature1 = sign_challenge(Uint8Array.from(prv_key1), message);
     const signature2 = sign_challenge(Uint8Array.from(prv_key2), message);
 
-    const signed_intent = encode_signed_transaction_intent(message, [Array.from(signature1), Array.from(signature2)]);
+    const signed_intent = encode_signed_transaction_intent(message, [signature1, signature2]);
 
     verify_transaction_intent(message, signed_intent, [pubkey_addr1, pubkeyhash_addr2], Network.Regtest);
     verify_transaction_intent(message, signed_intent, [pubkeyhash_addr1, pubkey_addr2], Network.Regtest);
@@ -86,7 +76,7 @@ export function test_signed_transaction_intent() {
     }
 
     const bad_signature1 = sign_challenge(Uint8Array.from(prv_key1), Uint8Array.from([...message, 123]));
-    const bad_signed_intent = encode_signed_transaction_intent(message, [Array.from(bad_signature1), Array.from(signature2)]);
+    const bad_signed_intent = encode_signed_transaction_intent(message, [bad_signature1, signature2]);
 
     try {
       verify_transaction_intent(message, bad_signed_intent, [pubkey_addr1, pubkey_addr2], Network.Regtest);
@@ -128,7 +118,7 @@ export function test_signed_transaction_intent() {
     ];
 
     const encoded_signed_intent =
-      encode_signed_transaction_intent(message, [signature1, signature2]);
+      encode_signed_transaction_intent(message, [Uint8Array.from(signature1), Uint8Array.from(signature2)]);
     assert_eq_arrays(encoded_signed_intent, expected_encoded_signed_intent);
   }
 }

--- a/wasm-wrappers/js-bindings-test/tests/utils.ts
+++ b/wasm-wrappers/js-bindings-test/tests/utils.ts
@@ -17,6 +17,10 @@ export const TEXT_ENCODER = new TextEncoder();
 
 type AnyArray = any[] | Uint8Array;
 
+export function assert_eq_vals(val1: any, val2: any) {
+  assert(val1 == val2, `val1 ${val1} differs from val2 ${val2}`)
+}
+
 export function assert_eq_arrays(arr1: AnyArray, arr2: AnyArray) {
   const equal = arr1.length == arr2.length && arr1.every((value, index) => value == arr2[index]);
 

--- a/wasm-wrappers/src/error.rs
+++ b/wasm-wrappers/src/error.rs
@@ -83,7 +83,7 @@ pub enum Error {
     MultisigSpendCreationError(DestinationSigError),
 
     #[error("Error creating HTLC spend: {0}")]
-    HtlcSpendCreationError(DestinationSigError),
+    HtlcSpendDecodingError(DestinationSigError),
 
     #[error("Error signing a message: {0}")]
     SignMessageError(crypto::key::SignatureError),
@@ -169,9 +169,6 @@ pub enum Error {
     // Note: IdCreationError already contains the info about which kind of id is being created.
     #[error("Id creation error: {0}")]
     IdCreationError(#[from] IdCreationError),
-
-    #[error("Error decoding a JsValue as an array of arrays of bytes: {error}")]
-    JsValueNotArrayOfArraysOfBytes { error: String },
 
     #[error("Signed transaction intent verification error: {0}")]
     SignedTransactionIntentVerificationError(SignedTransactionIntentError),

--- a/wasm-wrappers/src/types.rs
+++ b/wasm-wrappers/src/types.rs
@@ -26,11 +26,11 @@ use common::{
 
 use crate::{error::Error, utils::internal_amount_from_atoms_str};
 
-#[wasm_bindgen]
 /// Amount type abstraction. The amount type is stored in a string
 /// since JavaScript number type cannot fit 128-bit integers.
 /// The amount is given as an integer in units of "atoms".
 /// Atoms are the smallest, indivisible amount of a coin or token.
+#[wasm_bindgen]
 pub struct Amount {
     atoms: String,
 }
@@ -60,9 +60,9 @@ impl Amount {
     }
 }
 
+/// The network, for which an operation to be done. Mainnet, testnet, etc.
 #[wasm_bindgen]
 #[derive(Debug, Copy, Clone)]
-/// The network, for which an operation to be done. Mainnet, testnet, etc.
 pub enum Network {
     Mainnet,
     Testnet,


### PR DESCRIPTION
A bunch of smaller changes extracted from [pull/1910](https://github.com/mintlayer/mintlayer-core/pull/1910) to make the latter smaller.

* In wallet's `generic_tests.rs`, `test_sign_message_generic` was improved a bit - some data randomized, `ProduceBlockFromStake` input added.
* In `TxAdditionalInfo` the "with_" methods now accept `self`, so that it's possible to build `TxAdditionalInfo` repeatedly without calling `join`.
* `fetch_utxo_extra_info_for_hw_wallet` was renamed to `fetch_utxo_extra_info`.
* Some functions in `SyncedController` that used to receive `TxAdditionalInfo` or `RPCTokenInfo` from the caller now collect the infos themselves, to reduce the risk of the info getting out of sync with the other parameters.
* `Wallet::create_freeze_order_tx` now accepts `TxAdditionalInfo` and puts it into `PartialySignedTransaction`, same as other order-related functions do. The main reason is consistency (in this PR the presence of the data is not checked, but in [pull/1910](https://github.com/mintlayer/mintlayer-core/pull/1910) `PartialySignedTransaction` now requires that for any order input the corresponding order info is present in the `TxAdditionalInfo`).
* In wasm bindings, `verify_transaction_intent` was changed to accept an array of `Uint8Array` instead of array of arrays (it's just nicer this way; but note that it's a "breaking" change, i.e. the UI guys will have to update their code).
   I also added functions `encode_output_produce_block_from_stake` and `multisig_challenge_to_address` (needed by [pull/1910](https://github.com/mintlayer/mintlayer-core/pull/1910))
* `parity-scale-codec` version was updated to 3.7 (needed by a later PR)
* In `trezor-common` a couple missing tests were added, as well as a bunch of comments explaining the relationship between the enums in the crate and those generated by protobuf. I also added a TODO to reconsider the approach with the Tag enums, let me know if you agree.
