### PR TITLE
Allow multiple FillOrder v1 txs to co-exist in the mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,6 +4560,7 @@ dependencies = [
  "chainstate-types",
  "common",
  "crypto",
+ "ctor",
  "hex",
  "jsonrpsee",
  "logging",

--- a/chainstate/test-framework/src/helpers.rs
+++ b/chainstate/test-framework/src/helpers.rs
@@ -1,0 +1,280 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate::BlockSource;
+use chainstate_storage::{BlockchainStorageRead, Transactional};
+use common::{
+    chain::{
+        make_token_id,
+        output_value::OutputValue,
+        signature::inputsig::InputWitness,
+        tokens::{IsTokenFreezable, TokenId, TokenIssuance, TokenIssuanceV1, TokenTotalSupply},
+        AccountCommand, AccountNonce, AccountType, Block, Destination, GenBlock, OrderId,
+        OrdersVersion, Transaction, TxInput, TxOutput, UtxoOutPoint,
+    },
+    primitives::{Amount, BlockHeight, Id, Idable},
+};
+use orders_accounting::OrdersAccountingDB;
+use randomness::{CryptoRng, Rng, SliceRandom as _};
+use test_utils::random_ascii_alphanumeric_string;
+
+use crate::{get_output_value, TestFramework, TransactionBuilder};
+
+// Note: this function will create 2 blocks
+pub fn issue_and_mint_random_token_from_best_block(
+    rng: &mut (impl Rng + CryptoRng),
+    tf: &mut TestFramework,
+    utxo_to_pay_fee: UtxoOutPoint,
+    amount_to_mint: Amount,
+    total_supply: TokenTotalSupply,
+    is_freezable: IsTokenFreezable,
+) -> (
+    TokenId,
+    /*tokens*/ UtxoOutPoint,
+    /*coins change*/ UtxoOutPoint,
+) {
+    let best_block_id = tf.best_block_id();
+    let issuance = {
+        let max_ticker_len = tf.chain_config().token_max_ticker_len();
+        let max_dec_count = tf.chain_config().token_max_dec_count();
+        let max_uri_len = tf.chain_config().token_max_uri_len();
+
+        let issuance = TokenIssuanceV1 {
+            token_ticker: random_ascii_alphanumeric_string(rng, 1..max_ticker_len)
+                .as_bytes()
+                .to_vec(),
+            number_of_decimals: rng.gen_range(1..max_dec_count),
+            metadata_uri: random_ascii_alphanumeric_string(rng, 1..max_uri_len).as_bytes().to_vec(),
+            total_supply,
+            is_freezable,
+            authority: Destination::AnyoneCanSpend,
+        };
+        TokenIssuance::V1(issuance)
+    };
+
+    let (token_id, _, utxo_with_change) =
+        issue_token_from_block(rng, tf, best_block_id, utxo_to_pay_fee, issuance);
+
+    let best_block_id = tf.best_block_id();
+    let (_, mint_tx_id) = mint_tokens_in_block(
+        rng,
+        tf,
+        best_block_id,
+        utxo_with_change,
+        token_id,
+        amount_to_mint,
+        true,
+    );
+
+    (
+        token_id,
+        UtxoOutPoint::new(mint_tx_id.into(), 0),
+        UtxoOutPoint::new(mint_tx_id.into(), 1),
+    )
+}
+
+pub fn issue_token_from_block(
+    rng: &mut (impl Rng + CryptoRng),
+    tf: &mut TestFramework,
+    parent_block_id: Id<GenBlock>,
+    utxo_to_pay_fee: UtxoOutPoint,
+    issuance: TokenIssuance,
+) -> (TokenId, Id<Block>, UtxoOutPoint) {
+    let token_issuance_fee = tf.chainstate.get_chain_config().fungible_token_issuance_fee();
+
+    let fee_utxo_coins =
+        get_output_value(tf.chainstate.utxo(&utxo_to_pay_fee).unwrap().unwrap().output())
+            .unwrap()
+            .coin_amount()
+            .unwrap();
+
+    let tx = TransactionBuilder::new()
+        .add_input(utxo_to_pay_fee.into(), InputWitness::NoSignature(None))
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin((fee_utxo_coins - token_issuance_fee).unwrap()),
+            Destination::AnyoneCanSpend,
+        ))
+        .add_output(TxOutput::IssueFungibleToken(Box::new(issuance.clone())))
+        .build();
+    let parent_block_height = tf.gen_block_index(&parent_block_id).block_height();
+    let token_id = make_token_id(
+        tf.chain_config(),
+        parent_block_height.next_height(),
+        tx.transaction().inputs(),
+    )
+    .unwrap();
+    let tx_id = tx.transaction().get_id();
+    let block = tf
+        .make_block_builder()
+        .add_transaction(tx)
+        .with_parent(parent_block_id)
+        .build(rng);
+    let block_id = block.get_id();
+    tf.process_block(block, BlockSource::Local).unwrap();
+
+    (token_id, block_id, UtxoOutPoint::new(tx_id.into(), 0))
+}
+
+pub fn mint_tokens_in_block(
+    rng: &mut (impl Rng + CryptoRng),
+    tf: &mut TestFramework,
+    parent_block_id: Id<GenBlock>,
+    utxo_to_pay_fee: UtxoOutPoint,
+    token_id: TokenId,
+    amount_to_mint: Amount,
+    produce_change: bool,
+) -> (Id<Block>, Id<Transaction>) {
+    let token_supply_change_fee =
+        tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
+
+    let nonce = BlockchainStorageRead::get_account_nonce_count(
+        &tf.storage.transaction_ro().unwrap(),
+        AccountType::Token(token_id),
+    )
+    .unwrap()
+    .map_or(AccountNonce::new(0), |n| n.increment().unwrap());
+
+    let tx_builder = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_command(nonce, AccountCommand::MintTokens(token_id, amount_to_mint)),
+            InputWitness::NoSignature(None),
+        )
+        .add_input(
+            utxo_to_pay_fee.clone().into(),
+            InputWitness::NoSignature(None),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::TokenV1(token_id, amount_to_mint),
+            Destination::AnyoneCanSpend,
+        ));
+
+    let tx_builder = if produce_change {
+        let fee_utxo_coins = tf.coin_amount_from_utxo(&utxo_to_pay_fee);
+
+        tx_builder.add_output(TxOutput::Transfer(
+            OutputValue::Coin((fee_utxo_coins - token_supply_change_fee).unwrap()),
+            Destination::AnyoneCanSpend,
+        ))
+    } else {
+        tx_builder
+    };
+
+    let tx = tx_builder.build();
+    let tx_id = tx.transaction().get_id();
+
+    let block = tf
+        .make_block_builder()
+        .add_transaction(tx)
+        .with_parent(parent_block_id)
+        .build(rng);
+    let block_id = block.get_id();
+    tf.process_block(block, BlockSource::Local).unwrap();
+
+    (block_id, tx_id)
+}
+
+/// Given the fill amount in the "ask" currency, return the filled amount in the "give" currency.
+pub fn calculate_fill_order(
+    tf: &TestFramework,
+    order_id: &OrderId,
+    fill_amount_in_ask_currency: Amount,
+    orders_version: OrdersVersion,
+) -> Amount {
+    let db_tx = tf.storage.transaction_ro().unwrap();
+    let orders_db = OrdersAccountingDB::new(&db_tx);
+    orders_accounting::calculate_fill_order(
+        &orders_db,
+        *order_id,
+        fill_amount_in_ask_currency,
+        orders_version,
+    )
+    .unwrap()
+}
+
+/// Split an u128 value into the specified number of "randomish" parts (the min part size is half
+/// the average part size).
+pub fn split_u128(rng: &mut (impl Rng + CryptoRng), amount: u128, parts_count: usize) -> Vec<u128> {
+    assert!(parts_count > 0);
+    let mut result = Vec::with_capacity(parts_count);
+    let parts_count = parts_count as u128;
+    let min_part_amount = amount / parts_count / 2;
+    let mut remaining_amount_above_min = amount - min_part_amount * parts_count;
+
+    for i in 0..parts_count {
+        let amount_part_above_min = if i == parts_count - 1 {
+            remaining_amount_above_min
+        } else {
+            rng.gen_range(0..remaining_amount_above_min / 2)
+        };
+
+        result.push(min_part_amount + amount_part_above_min);
+        remaining_amount_above_min -= amount_part_above_min;
+    }
+
+    assert_eq!(result.iter().sum::<u128>(), amount);
+
+    result.shuffle(rng);
+    result
+}
+
+/// Start building a tx that will "split" the specified outpoint into the specified number of outpoints.
+///
+/// The "fee" parameter only makes sense if the outpoint's currency is coins.
+pub fn make_tx_builder_to_split_utxo(
+    rng: &mut (impl Rng + CryptoRng),
+    tf: &mut TestFramework,
+    outpoint: UtxoOutPoint,
+    parts_count: usize,
+    fee: Amount,
+) -> TransactionBuilder {
+    let utxo_output_value = get_output_value(tf.utxo(&outpoint).output()).unwrap();
+    let utxo_amount = utxo_output_value.amount();
+
+    let output_amounts = split_u128(rng, (utxo_amount - fee).unwrap().into_atoms(), parts_count);
+
+    let mut tx_builder =
+        TransactionBuilder::new().add_input(outpoint.into(), InputWitness::NoSignature(None));
+    for output_amount in output_amounts {
+        tx_builder = tx_builder.add_output(TxOutput::Transfer(
+            output_value_with_amount(&utxo_output_value, Amount::from_atoms(output_amount)),
+            Destination::AnyoneCanSpend,
+        ))
+    }
+
+    tx_builder
+}
+
+pub fn split_utxo(
+    rng: &mut (impl Rng + CryptoRng),
+    tf: &mut TestFramework,
+    outpoint: UtxoOutPoint,
+    parts_count: usize,
+) -> Id<Transaction> {
+    let tx = make_tx_builder_to_split_utxo(rng, tf, outpoint, parts_count, Amount::ZERO).build();
+    let tx_id = tx.transaction().get_id();
+
+    tf.make_block_builder().add_transaction(tx).build_and_process(rng).unwrap();
+    tx_id
+}
+
+pub fn output_value_with_amount(output_value: &OutputValue, new_amount: Amount) -> OutputValue {
+    match output_value {
+        OutputValue::Coin(_) => OutputValue::Coin(new_amount),
+        OutputValue::TokenV0(_) => {
+            panic!("Unexpected token v0");
+        }
+        OutputValue::TokenV1(id, _) => OutputValue::TokenV1(*id, new_amount),
+    }
+}

--- a/chainstate/test-framework/src/lib.rs
+++ b/chainstate/test-framework/src/lib.rs
@@ -18,6 +18,7 @@
 mod block_builder;
 mod framework;
 mod framework_builder;
+pub mod helpers;
 mod key_manager;
 mod pos_block_builder;
 mod random_tx_maker;

--- a/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens_v1.rs
@@ -22,7 +22,10 @@ use chainstate::{
     ConnectTransactionError, IOPolicyError, TokensError,
 };
 use chainstate_storage::{BlockchainStorageRead, Transactional};
-use chainstate_test_framework::{TestFramework, TransactionBuilder};
+use chainstate_test_framework::{
+    helpers::{issue_token_from_block, mint_tokens_in_block},
+    TestFramework, TransactionBuilder,
+};
 use common::{
     chain::{
         make_token_id,
@@ -56,8 +59,6 @@ use tx_verifier::{
     transaction_verifier::error::TokenIssuanceError,
     CheckTransactionError,
 };
-
-use crate::tests::helpers::{issue_token_from_block, mint_tokens_in_block};
 
 fn make_issuance(
     rng: &mut impl Rng,

--- a/chainstate/test-suite/src/tests/helpers/mod.rs
+++ b/chainstate/test-suite/src/tests/helpers/mod.rs
@@ -13,26 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chainstate::BlockSource;
-use chainstate_storage::{BlockchainStorageRead, Transactional};
 use chainstate_test_framework::{anyonecanspend_address, TestFramework, TransactionBuilder};
 use common::{
     chain::{
-        block::timestamp::BlockTimestamp,
-        make_token_id,
-        output_value::OutputValue,
-        signature::inputsig::InputWitness,
-        timelock::OutputTimeLock,
-        tokens::{IsTokenFreezable, TokenId, TokenIssuance, TokenIssuanceV1, TokenTotalSupply},
-        AccountCommand, AccountNonce, AccountType, Block, Destination, GenBlock, OrderId,
-        OrdersVersion, Transaction, TxInput, TxOutput, UtxoOutPoint,
+        block::timestamp::BlockTimestamp, output_value::OutputValue,
+        signature::inputsig::InputWitness, timelock::OutputTimeLock, Destination, Transaction,
+        TxInput, TxOutput,
     },
-    primitives::{Amount, BlockDistance, BlockHeight, Id, Idable},
+    primitives::{Amount, BlockDistance, Id, Idable},
 };
 use crypto::key::{KeyKind, PrivateKey};
-use orders_accounting::OrdersAccountingDB;
 use randomness::{CryptoRng, Rng};
-use test_utils::random_ascii_alphanumeric_string;
 
 pub mod block_creation_helpers;
 pub mod block_index_handle_impl;
@@ -85,176 +76,4 @@ pub fn add_block_with_locked_output(
 pub fn new_pub_key_destination(rng: &mut (impl Rng + CryptoRng)) -> Destination {
     let (_, pub_key) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
     Destination::PublicKey(pub_key)
-}
-
-pub fn issue_token_from_block(
-    rng: &mut (impl Rng + CryptoRng),
-    tf: &mut TestFramework,
-    parent_block_id: Id<GenBlock>,
-    utxo_to_pay_fee: UtxoOutPoint,
-    issuance: TokenIssuance,
-) -> (TokenId, Id<Block>, UtxoOutPoint) {
-    let token_issuance_fee = tf.chainstate.get_chain_config().fungible_token_issuance_fee();
-
-    let fee_utxo_coins = chainstate_test_framework::get_output_value(
-        tf.chainstate.utxo(&utxo_to_pay_fee).unwrap().unwrap().output(),
-    )
-    .unwrap()
-    .coin_amount()
-    .unwrap();
-
-    let tx = TransactionBuilder::new()
-        .add_input(utxo_to_pay_fee.into(), InputWitness::NoSignature(None))
-        .add_output(TxOutput::Transfer(
-            OutputValue::Coin((fee_utxo_coins - token_issuance_fee).unwrap()),
-            Destination::AnyoneCanSpend,
-        ))
-        .add_output(TxOutput::IssueFungibleToken(Box::new(issuance.clone())))
-        .build();
-    let parent_block_height = tf.gen_block_index(&parent_block_id).block_height();
-    let token_id = make_token_id(
-        tf.chain_config(),
-        parent_block_height.next_height(),
-        tx.transaction().inputs(),
-    )
-    .unwrap();
-    let tx_id = tx.transaction().get_id();
-    let block = tf
-        .make_block_builder()
-        .add_transaction(tx)
-        .with_parent(parent_block_id)
-        .build(rng);
-    let block_id = block.get_id();
-    tf.process_block(block, BlockSource::Local).unwrap();
-
-    (token_id, block_id, UtxoOutPoint::new(tx_id.into(), 0))
-}
-
-pub fn mint_tokens_in_block(
-    rng: &mut (impl Rng + CryptoRng),
-    tf: &mut TestFramework,
-    parent_block_id: Id<GenBlock>,
-    utxo_to_pay_fee: UtxoOutPoint,
-    token_id: TokenId,
-    amount_to_mint: Amount,
-    produce_change: bool,
-) -> (Id<Block>, Id<Transaction>) {
-    let token_supply_change_fee =
-        tf.chainstate.get_chain_config().token_supply_change_fee(BlockHeight::zero());
-
-    let nonce = BlockchainStorageRead::get_account_nonce_count(
-        &tf.storage.transaction_ro().unwrap(),
-        AccountType::Token(token_id),
-    )
-    .unwrap()
-    .map_or(AccountNonce::new(0), |n| n.increment().unwrap());
-
-    let tx_builder = TransactionBuilder::new()
-        .add_input(
-            TxInput::from_command(nonce, AccountCommand::MintTokens(token_id, amount_to_mint)),
-            InputWitness::NoSignature(None),
-        )
-        .add_input(
-            utxo_to_pay_fee.clone().into(),
-            InputWitness::NoSignature(None),
-        )
-        .add_output(TxOutput::Transfer(
-            OutputValue::TokenV1(token_id, amount_to_mint),
-            Destination::AnyoneCanSpend,
-        ));
-
-    let tx_builder = if produce_change {
-        let fee_utxo_coins = tf.coin_amount_from_utxo(&utxo_to_pay_fee);
-
-        tx_builder.add_output(TxOutput::Transfer(
-            OutputValue::Coin((fee_utxo_coins - token_supply_change_fee).unwrap()),
-            Destination::AnyoneCanSpend,
-        ))
-    } else {
-        tx_builder
-    };
-
-    let tx = tx_builder.build();
-    let tx_id = tx.transaction().get_id();
-
-    let block = tf
-        .make_block_builder()
-        .add_transaction(tx)
-        .with_parent(parent_block_id)
-        .build(rng);
-    let block_id = block.get_id();
-    tf.process_block(block, BlockSource::Local).unwrap();
-
-    (block_id, tx_id)
-}
-
-// Note: this function will create 2 blocks
-pub fn issue_and_mint_random_token_from_best_block(
-    rng: &mut (impl Rng + CryptoRng),
-    tf: &mut TestFramework,
-    utxo_to_pay_fee: UtxoOutPoint,
-    amount_to_mint: Amount,
-    total_supply: TokenTotalSupply,
-    is_freezable: IsTokenFreezable,
-) -> (
-    TokenId,
-    /*tokens*/ UtxoOutPoint,
-    /*coins change*/ UtxoOutPoint,
-) {
-    let best_block_id = tf.best_block_id();
-    let issuance = {
-        let max_ticker_len = tf.chain_config().token_max_ticker_len();
-        let max_dec_count = tf.chain_config().token_max_dec_count();
-        let max_uri_len = tf.chain_config().token_max_uri_len();
-
-        let issuance = TokenIssuanceV1 {
-            token_ticker: random_ascii_alphanumeric_string(rng, 1..max_ticker_len)
-                .as_bytes()
-                .to_vec(),
-            number_of_decimals: rng.gen_range(1..max_dec_count),
-            metadata_uri: random_ascii_alphanumeric_string(rng, 1..max_uri_len).as_bytes().to_vec(),
-            total_supply,
-            is_freezable,
-            authority: Destination::AnyoneCanSpend,
-        };
-        TokenIssuance::V1(issuance)
-    };
-
-    let (token_id, _, utxo_with_change) =
-        issue_token_from_block(rng, tf, best_block_id, utxo_to_pay_fee, issuance);
-
-    let best_block_id = tf.best_block_id();
-    let (_, mint_tx_id) = mint_tokens_in_block(
-        rng,
-        tf,
-        best_block_id,
-        utxo_with_change,
-        token_id,
-        amount_to_mint,
-        true,
-    );
-
-    (
-        token_id,
-        UtxoOutPoint::new(mint_tx_id.into(), 0),
-        UtxoOutPoint::new(mint_tx_id.into(), 1),
-    )
-}
-
-/// Given the fill amount in the "ask" currency, return the filled amount in the "give" currency.
-pub fn calculate_fill_order(
-    tf: &TestFramework,
-    order_id: &OrderId,
-    fill_amount_in_ask_currency: Amount,
-    orders_version: OrdersVersion,
-) -> Amount {
-    let db_tx = tf.storage.transaction_ro().unwrap();
-    let orders_db = OrdersAccountingDB::new(&db_tx);
-    orders_accounting::calculate_fill_order(
-        &orders_db,
-        *order_id,
-        fill_amount_in_ask_currency,
-        orders_version,
-    )
-    .unwrap()
 }

--- a/chainstate/test-suite/src/tests/input_commitments.rs
+++ b/chainstate/test-suite/src/tests/input_commitments.rs
@@ -22,8 +22,9 @@ use chainstate::{
     chainstate_interface::ChainstateInterface, BlockError, ChainstateError, ConnectTransactionError,
 };
 use chainstate_test_framework::{
-    create_chain_config_with_staking_pool, empty_witness, PoSBlockBuilder, TestFramework,
-    TransactionBuilder,
+    create_chain_config_with_staking_pool, empty_witness,
+    helpers::{calculate_fill_order, issue_and_mint_random_token_from_best_block},
+    PoSBlockBuilder, TestFramework, TransactionBuilder,
 };
 use common::{
     chain::{
@@ -59,10 +60,6 @@ use tx_verifier::{
     error::{InputCheckError, ScriptError},
     input_check::InputCheckErrorPayload,
 };
-
-use crate::tests::helpers::calculate_fill_order;
-
-use super::helpers::issue_and_mint_random_token_from_best_block;
 
 #[rstest]
 #[trace]

--- a/chainstate/test-suite/src/tests/orders_tests.rs
+++ b/chainstate/test-suite/src/tests/orders_tests.rs
@@ -21,7 +21,10 @@ use chainstate::{
     BlockError, ChainstateError, CheckBlockError, CheckBlockTransactionsError,
     ConnectTransactionError,
 };
-use chainstate_test_framework::{output_value_amount, TestFramework, TransactionBuilder};
+use chainstate_test_framework::{
+    helpers::{calculate_fill_order, issue_and_mint_random_token_from_best_block},
+    output_value_amount, TestFramework, TransactionBuilder,
+};
 use common::{
     address::pubkeyhash::PublicKeyHash,
     chain::{
@@ -51,8 +54,6 @@ use tx_verifier::{
     input_check::signature_only_check::verify_tx_signature,
     CheckTransactionError,
 };
-
-use crate::tests::helpers::{calculate_fill_order, issue_and_mint_random_token_from_best_block};
 
 fn create_test_framework_with_orders(
     rng: &mut (impl Rng + CryptoRng),

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -48,5 +48,6 @@ chainstate-test-framework = { path = "../chainstate/test-framework" }
 crypto = { path = "../crypto" }
 test-utils = { path = "../test-utils" }
 
+ctor.workspace = true
 mockall.workspace = true
 rstest.workspace = true

--- a/mempool/src/pool/tests/mod.rs
+++ b/mempool/src/pool/tests/mod.rs
@@ -26,5 +26,11 @@ use common::{
 };
 
 mod basic;
+mod orders_v1;
 mod orphans;
 mod utils;
+
+#[ctor::ctor]
+fn init() {
+    logging::init_logging();
+}

--- a/mempool/src/pool/tests/orders_v1.rs
+++ b/mempool/src/pool/tests/orders_v1.rs
@@ -1,0 +1,986 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chainstate::{
+    constraints_value_accumulator, tx_verifier::error::InputCheckErrorPayload,
+    ConnectTransactionError,
+};
+use chainstate_test_framework::{
+    helpers::{
+        calculate_fill_order, issue_and_mint_random_token_from_best_block,
+        make_tx_builder_to_split_utxo, split_utxo,
+    },
+    TestFrameworkBuilder,
+};
+use common::chain::{
+    make_order_id,
+    tokens::{IsTokenFreezable, TokenId, TokenTotalSupply},
+    ChainstateUpgradeBuilder, OrderAccountCommand, OrderData, OrderId, OrdersVersion, UtxoOutPoint,
+};
+use mintscript::translate::TranslationError;
+use test_utils::{assert_matches, assert_matches_return_val};
+
+use super::*;
+
+use crate::error::TxValidationError;
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_orphans(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let mut tf = create_test_framework_builder_with_orders_v1(&mut rng).build();
+
+    let (token_id, tokens_outpoint, coins_outpoint) =
+        issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+
+    let tokens_src_id: OutPointSourceId = split_utxo(&mut rng, &mut tf, tokens_outpoint, 2).into();
+    let coins_src_id: OutPointSourceId = split_utxo(&mut rng, &mut tf, coins_outpoint, 10).into();
+
+    let initial_ask_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let initial_give_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let order_id = {
+        let order_data = OrderData::new(
+            Destination::AnyoneCanSpend,
+            OutputValue::Coin(initial_ask_amount),
+            OutputValue::TokenV1(token_id, initial_give_amount),
+        );
+
+        let tx = TransactionBuilder::new()
+            .add_input(
+                UtxoOutPoint::new(tokens_src_id.clone(), 0).into(),
+                InputWitness::NoSignature(None),
+            )
+            .add_output(TxOutput::CreateOrder(Box::new(order_data)))
+            .build();
+        let order_id = make_order_id(tx.inputs()).unwrap();
+        tf.make_block_builder().add_transaction(tx).build_and_process(&mut rng).unwrap();
+        order_id
+    };
+    let another_order_initial_ask_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let another_order_initial_give_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let another_order_id = {
+        let order_data = OrderData::new(
+            Destination::AnyoneCanSpend,
+            OutputValue::Coin(another_order_initial_ask_amount),
+            OutputValue::TokenV1(token_id, another_order_initial_give_amount),
+        );
+
+        let tx = TransactionBuilder::new()
+            .add_input(
+                UtxoOutPoint::new(tokens_src_id.clone(), 1).into(),
+                InputWitness::NoSignature(None),
+            )
+            .add_output(TxOutput::CreateOrder(Box::new(order_data)))
+            .build();
+        let order_id = make_order_id(tx.inputs()).unwrap();
+        tf.make_block_builder().add_transaction(tx).build_and_process(&mut rng).unwrap();
+        order_id
+    };
+
+    let fill_tx1 = make_fill_order_tx(
+        &mut tf,
+        order_id,
+        token_id,
+        Amount::from_atoms(rng.gen_range(10..initial_ask_amount.into_atoms() / 10)),
+        UtxoOutPoint::new(coins_src_id.clone(), 0),
+        None,
+    );
+    let fill_tx2 = make_fill_order_tx(
+        &mut tf,
+        order_id,
+        token_id,
+        Amount::from_atoms(rng.gen_range(10..initial_ask_amount.into_atoms() / 10)),
+        UtxoOutPoint::new(coins_src_id.clone(), 1),
+        None,
+    );
+    let fill_tx3 = make_fill_order_tx(
+        &mut tf,
+        order_id,
+        token_id,
+        Amount::from_atoms(rng.gen_range(10..initial_ask_amount.into_atoms() / 10)),
+        UtxoOutPoint::new(coins_src_id.clone(), 2),
+        None,
+    );
+    let freeze_tx1 = make_freeze_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 3),
+        None,
+    );
+    let freeze_tx2 = make_freeze_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 4),
+        None,
+    );
+    let conclude_tx1 = make_conclude_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 5),
+        None,
+    );
+    let conclude_tx2 = make_conclude_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 6),
+        None,
+    );
+    let another_order_fill_tx = make_fill_order_tx(
+        &mut tf,
+        another_order_id,
+        token_id,
+        Amount::from_atoms(rng.gen_range(10..another_order_initial_ask_amount.into_atoms() / 10)),
+        UtxoOutPoint::new(coins_src_id.clone(), 7),
+        None,
+    );
+    let another_order_freeze_tx = make_freeze_order_tx(
+        &mut tf,
+        another_order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 8),
+        None,
+    );
+    let another_order_conclude_tx = make_conclude_order_tx(
+        &mut tf,
+        another_order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 9),
+        None,
+    );
+
+    let chain_config = std::sync::Arc::clone(tf.chain_config());
+    let mempool_config = create_mempool_config();
+    let chainstate_handle = start_chainstate(tf.chainstate());
+    let create_mempool = || {
+        Mempool::new(
+            Arc::clone(&chain_config),
+            mempool_config.clone(),
+            chainstate_handle.clone(),
+            Default::default(),
+            StoreMemoryUsageEstimator,
+        )
+    };
+
+    {
+        let mut mempool = create_mempool();
+
+        // Can add another fill tx after a fill tx.
+        mempool.add_transaction_test(fill_tx1.clone()).unwrap().assert_in_mempool();
+        mempool.add_transaction_test(fill_tx2.clone()).unwrap().assert_in_mempool();
+
+        // Can add a freeze after the fills.
+        mempool.add_transaction_test(freeze_tx1.clone()).unwrap().assert_in_mempool();
+
+        // Cannot add another freeze.
+        let err = mempool.add_transaction_test(freeze_tx2.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::OrdersAccountingError(
+                    orders_accounting::Error::AttemptedFreezeAlreadyFrozenOrder(_)
+                )
+            ))
+        );
+
+        // Cannot add another fill after the freeze.
+        let err = mempool.add_transaction_test(fill_tx3.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::AttemptedFillFrozenOrder(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        // Can add a conclude tx.
+        mempool.add_transaction_test(conclude_tx1.clone()).unwrap().assert_in_mempool();
+
+        // Cannot add another conclude tx.
+        let err = mempool.add_transaction_test(conclude_tx2.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::OrderDataNotFound(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        // Still cannot add another freeze.
+        let err = mempool.add_transaction_test(freeze_tx2.clone()).unwrap_err();
+        let err_payload = assert_matches_return_val!(
+            &err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::InputCheck(err),
+            )),
+            err.error()
+        );
+        assert_matches!(
+            err_payload,
+            InputCheckErrorPayload::Translation(TranslationError::OrderNotFound(_))
+        );
+
+        // Still cannot add another fill.
+        let err = mempool.add_transaction_test(fill_tx3.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::OrderDataNotFound(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        // Can fill/freeze/conclude another order
+        mempool
+            .add_transaction_test(another_order_fill_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+        mempool
+            .add_transaction_test(another_order_freeze_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+        mempool
+            .add_transaction_test(another_order_conclude_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+    }
+
+    // Same as above, but we start with a freeze
+    {
+        let mut mempool = create_mempool();
+
+        // Can add the freeze.
+        mempool.add_transaction_test(freeze_tx1.clone()).unwrap().assert_in_mempool();
+
+        // Cannot add another freeze.
+        let err = mempool.add_transaction_test(freeze_tx2.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::OrdersAccountingError(
+                    orders_accounting::Error::AttemptedFreezeAlreadyFrozenOrder(_)
+                )
+            ))
+        );
+
+        // Cannot add a fill after the freeze.
+        let err = mempool.add_transaction_test(fill_tx1.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::AttemptedFillFrozenOrder(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        // Can add a conclude tx.
+        mempool.add_transaction_test(conclude_tx1.clone()).unwrap().assert_in_mempool();
+
+        // Cannot add another conclude tx.
+        let err = mempool.add_transaction_test(conclude_tx2.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::OrderDataNotFound(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        // Still cannot add another freeze.
+        let err = mempool.add_transaction_test(freeze_tx2.clone()).unwrap_err();
+        let err_payload = assert_matches_return_val!(
+            &err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::InputCheck(err),
+            )),
+            err.error()
+        );
+        assert_matches!(
+            err_payload,
+            InputCheckErrorPayload::Translation(TranslationError::OrderNotFound(_))
+        );
+
+        // Still cannot add another fill.
+        let err = mempool.add_transaction_test(fill_tx3.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::OrderDataNotFound(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        // Can fill/freeze/conclude another order
+        mempool
+            .add_transaction_test(another_order_fill_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+        mempool
+            .add_transaction_test(another_order_freeze_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+        mempool
+            .add_transaction_test(another_order_conclude_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+    }
+
+    // Same as above, but we start with a conclude.
+    {
+        let mut mempool = create_mempool();
+
+        // Can add the conclude tx.
+        mempool.add_transaction_test(conclude_tx1.clone()).unwrap().assert_in_mempool();
+
+        // Cannot add another conclude tx.
+        let err = mempool.add_transaction_test(conclude_tx2.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::OrderDataNotFound(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        // Cannot add a fill after the conclude.
+        let err = mempool.add_transaction_test(fill_tx1.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::OrderDataNotFound(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        // Cannot add a freeze after the conclude.
+        let err = mempool.add_transaction_test(freeze_tx1.clone()).unwrap_err();
+        let err_payload = assert_matches_return_val!(
+            &err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::InputCheck(err),
+            )),
+            err.error()
+        );
+        assert_matches!(
+            err_payload,
+            InputCheckErrorPayload::Translation(TranslationError::OrderNotFound(_))
+        );
+
+        // Can fill/freeze/conclude another order
+        mempool
+            .add_transaction_test(another_order_fill_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+        mempool
+            .add_transaction_test(another_order_freeze_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+        mempool
+            .add_transaction_test(another_order_conclude_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+    }
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn orphans_with_missing_utxo(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let mut tf = create_test_framework_builder_with_orders_v1(&mut rng).build();
+
+    let (token_id, tokens_outpoint, coins_outpoint) =
+        issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+
+    let coins_src_id: OutPointSourceId = split_utxo(&mut rng, &mut tf, coins_outpoint, 10).into();
+
+    let initial_ask_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let initial_give_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let order_id = {
+        let order_data = OrderData::new(
+            Destination::AnyoneCanSpend,
+            OutputValue::Coin(initial_ask_amount),
+            OutputValue::TokenV1(token_id, initial_give_amount),
+        );
+
+        let tx = TransactionBuilder::new()
+            .add_input(tokens_outpoint.into(), InputWitness::NoSignature(None))
+            .add_output(TxOutput::CreateOrder(Box::new(order_data)))
+            .build();
+        let order_id = make_order_id(tx.inputs()).unwrap();
+        tf.make_block_builder().add_transaction(tx).build_and_process(&mut rng).unwrap();
+        order_id
+    };
+
+    let missing_parent_tx = make_tx_builder_to_split_utxo(
+        &mut rng,
+        &mut tf,
+        UtxoOutPoint::new(coins_src_id.clone(), 0),
+        10,
+        Amount::from_atoms(TEST_MIN_TX_RELAY_FEE_RATE.atoms_per_kb()),
+    )
+    .build();
+    let missing_parent_tx_src_id: OutPointSourceId =
+        missing_parent_tx.transaction().get_id().into();
+
+    let fill_tx1 = make_fill_order_tx(
+        &mut tf,
+        order_id,
+        token_id,
+        Amount::from_atoms(rng.gen_range(10..initial_ask_amount.into_atoms() / 10)),
+        UtxoOutPoint::new(coins_src_id.clone(), 1),
+        Some(UtxoOutPoint::new(missing_parent_tx_src_id.clone(), 0).into()),
+    );
+    let fill_tx1_id = fill_tx1.transaction().get_id();
+    let fill_tx2 = make_fill_order_tx(
+        &mut tf,
+        order_id,
+        token_id,
+        Amount::from_atoms(rng.gen_range(10..initial_ask_amount.into_atoms() / 10)),
+        UtxoOutPoint::new(coins_src_id.clone(), 2),
+        Some(UtxoOutPoint::new(missing_parent_tx_src_id.clone(), 1).into()),
+    );
+    let fill_tx2_id = fill_tx2.transaction().get_id();
+    let freeze_tx1 = make_freeze_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 3),
+        Some(UtxoOutPoint::new(missing_parent_tx_src_id.clone(), 2).into()),
+    );
+    let freeze_tx1_id = freeze_tx1.transaction().get_id();
+    let freeze_tx2 = make_freeze_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 4),
+        Some(UtxoOutPoint::new(missing_parent_tx_src_id.clone(), 3).into()),
+    );
+    let freeze_tx2_id = freeze_tx2.transaction().get_id();
+    let conclude_tx1 = make_conclude_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 5),
+        Some(UtxoOutPoint::new(missing_parent_tx_src_id.clone(), 4).into()),
+    );
+    let conclude_tx1_id = conclude_tx1.transaction().get_id();
+    let conclude_tx2 = make_conclude_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 6),
+        Some(UtxoOutPoint::new(missing_parent_tx_src_id.clone(), 5).into()),
+    );
+    let conclude_tx2_id = conclude_tx2.transaction().get_id();
+
+    let unrelated_tx = TransactionBuilder::new()
+        .add_input(
+            UtxoOutPoint::new(coins_src_id.clone(), 7).into(),
+            InputWitness::NoSignature(None),
+        )
+        .add_output(TxOutput::Burn(OutputValue::Coin(Amount::from_atoms(1))))
+        .build();
+
+    let chain_config = std::sync::Arc::clone(tf.chain_config());
+    let mempool_config = create_mempool_config();
+    let chainstate_handle = start_chainstate(tf.chainstate());
+    let create_mempool = || {
+        Mempool::new(
+            Arc::clone(&chain_config),
+            mempool_config.clone(),
+            chainstate_handle.clone(),
+            Default::default(),
+            StoreMemoryUsageEstimator,
+        )
+    };
+
+    // Note:
+    // 1) Below we can add, say, a freeze before a fill and they both end up in the orphan pool.
+    // This is because currently the orphan pool has no way of knowing whether 2 order txs can
+    // conflict with each other.
+    // 2) In the above-mentioned scenario, after the missing tx has been added to the mempool
+    // (so that the orphan txs are no longer orphans), the fill tx may or may not end up in the
+    // "normal" mempool, depending on the order in which the orphans will be handled. However,
+    // in both cases it will no longer be in the orphan pool.
+
+    // Add 2 orphan fill txs. After the missing parent is also added, both fill txs should
+    // be in the mempool and none of them should be in the orphan pool.
+    {
+        let mut mempool = create_mempool();
+
+        mempool.add_transaction_test(fill_tx1.clone()).unwrap().assert_in_orphan_pool();
+        mempool.add_transaction_test(fill_tx2.clone()).unwrap().assert_in_orphan_pool();
+
+        assert!(!mempool.contains_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_transaction(&fill_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx2_id));
+
+        // Add an unrelated tx; this shouldn't affect the orphans.
+        mempool.add_transaction_test(unrelated_tx.clone()).unwrap().assert_in_mempool();
+        assert!(!mempool.contains_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_transaction(&fill_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx2_id));
+
+        // Now add the missing parent.
+        mempool
+            .add_transaction_test(missing_parent_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+
+        assert!(mempool.contains_transaction(&fill_tx1_id));
+        assert!(mempool.contains_transaction(&fill_tx2_id));
+        assert!(!mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_orphan_transaction(&fill_tx2_id));
+    }
+
+    // Add 2 orphan freeze and some fill txs. After the missing parent is also added, only
+    // one of the freeze txs should be in the mempool; none of the txs should be in the orphan pool.
+    {
+        let mut mempool = create_mempool();
+
+        mempool
+            .add_transaction_test(freeze_tx1.clone())
+            .unwrap()
+            .assert_in_orphan_pool();
+        mempool
+            .add_transaction_test(freeze_tx2.clone())
+            .unwrap()
+            .assert_in_orphan_pool();
+        mempool.add_transaction_test(fill_tx1.clone()).unwrap().assert_in_orphan_pool();
+        mempool.add_transaction_test(fill_tx2.clone()).unwrap().assert_in_orphan_pool();
+
+        assert!(!mempool.contains_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_transaction(&fill_tx2_id));
+        assert!(!mempool.contains_transaction(&freeze_tx1_id));
+        assert!(!mempool.contains_transaction(&freeze_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&freeze_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&freeze_tx2_id));
+
+        // Add an unrelated tx; this shouldn't affect the orphans.
+        mempool.add_transaction_test(unrelated_tx.clone()).unwrap().assert_in_mempool();
+        assert!(!mempool.contains_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_transaction(&fill_tx2_id));
+        assert!(!mempool.contains_transaction(&freeze_tx1_id));
+        assert!(!mempool.contains_transaction(&freeze_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&freeze_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&freeze_tx2_id));
+
+        // Now add the missing parent.
+        mempool
+            .add_transaction_test(missing_parent_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+
+        // Only one of the freeze txs should be in the mempool.
+        let freeze1_in_mempool = mempool.contains_transaction(&freeze_tx1_id);
+        let freeze2_in_mempool = mempool.contains_transaction(&freeze_tx2_id);
+        assert_ne!(freeze1_in_mempool, freeze2_in_mempool);
+
+        // None of the txs should be in the orphans pool.
+        assert!(!mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_orphan_transaction(&fill_tx2_id));
+        assert!(!mempool.contains_orphan_transaction(&freeze_tx1_id));
+        assert!(!mempool.contains_orphan_transaction(&freeze_tx2_id));
+    }
+
+    // Add 2 orphan conclude and some fill/freeze txs. After the missing parent is also added, only
+    // one of the conclude txs should be in the mempool; none of the txs should be in the orphan pool.
+    {
+        let mut mempool = create_mempool();
+
+        mempool
+            .add_transaction_test(conclude_tx1.clone())
+            .unwrap()
+            .assert_in_orphan_pool();
+        mempool
+            .add_transaction_test(conclude_tx2.clone())
+            .unwrap()
+            .assert_in_orphan_pool();
+        mempool
+            .add_transaction_test(freeze_tx1.clone())
+            .unwrap()
+            .assert_in_orphan_pool();
+        mempool
+            .add_transaction_test(freeze_tx2.clone())
+            .unwrap()
+            .assert_in_orphan_pool();
+        mempool.add_transaction_test(fill_tx1.clone()).unwrap().assert_in_orphan_pool();
+        mempool.add_transaction_test(fill_tx2.clone()).unwrap().assert_in_orphan_pool();
+
+        assert!(!mempool.contains_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_transaction(&fill_tx2_id));
+        assert!(!mempool.contains_transaction(&freeze_tx1_id));
+        assert!(!mempool.contains_transaction(&freeze_tx2_id));
+        assert!(!mempool.contains_transaction(&conclude_tx1_id));
+        assert!(!mempool.contains_transaction(&conclude_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&freeze_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&freeze_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&conclude_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&conclude_tx2_id));
+
+        // Add an unrelated tx; this shouldn't affect the orphans.
+        mempool.add_transaction_test(unrelated_tx.clone()).unwrap().assert_in_mempool();
+        assert!(!mempool.contains_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_transaction(&fill_tx2_id));
+        assert!(!mempool.contains_transaction(&freeze_tx1_id));
+        assert!(!mempool.contains_transaction(&freeze_tx2_id));
+        assert!(!mempool.contains_transaction(&conclude_tx1_id));
+        assert!(!mempool.contains_transaction(&conclude_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&fill_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&freeze_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&freeze_tx2_id));
+        assert!(mempool.contains_orphan_transaction(&conclude_tx1_id));
+        assert!(mempool.contains_orphan_transaction(&conclude_tx2_id));
+
+        // Now add the missing parent.
+        mempool
+            .add_transaction_test(missing_parent_tx.clone())
+            .unwrap()
+            .assert_in_mempool();
+
+        // Only one of the conclude txs should be in the mempool.
+        let conclude1_in_mempool = mempool.contains_transaction(&conclude_tx1_id);
+        let conclude2_in_mempool = mempool.contains_transaction(&conclude_tx2_id);
+        assert_ne!(conclude1_in_mempool, conclude2_in_mempool);
+
+        // None of the txs should be in the orphans pool.
+        assert!(!mempool.contains_orphan_transaction(&fill_tx1_id));
+        assert!(!mempool.contains_orphan_transaction(&fill_tx2_id));
+        assert!(!mempool.contains_orphan_transaction(&freeze_tx1_id));
+        assert!(!mempool.contains_orphan_transaction(&freeze_tx2_id));
+        assert!(!mempool.contains_orphan_transaction(&conclude_tx1_id));
+        assert!(!mempool.contains_orphan_transaction(&conclude_tx2_id));
+    }
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn orphans_with_missing_order(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let mut tf = create_test_framework_builder_with_orders_v1(&mut rng).build();
+
+    let (token_id, tokens_outpoint, coins_outpoint) =
+        issue_and_mint_token_from_genesis(&mut rng, &mut tf);
+
+    let coins_src_id: OutPointSourceId = split_utxo(&mut rng, &mut tf, coins_outpoint, 10).into();
+
+    let initial_ask_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let initial_give_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let order_creation_tx = {
+        let fee_input = UtxoOutPoint::new(coins_src_id.clone(), 0);
+        let coins_amount = tf.coin_amount_from_utxo(&fee_input);
+        let fee = TEST_MIN_TX_RELAY_FEE_RATE.atoms_per_kb(); // the tx is expected to be less than 1 kb
+        let change = (coins_amount - Amount::from_atoms(fee)).unwrap();
+
+        TransactionBuilder::new()
+            .add_input(fee_input.into(), InputWitness::NoSignature(None))
+            .add_input(tokens_outpoint.into(), InputWitness::NoSignature(None))
+            .add_output(TxOutput::CreateOrder(Box::new(OrderData::new(
+                Destination::AnyoneCanSpend,
+                OutputValue::Coin(initial_ask_amount),
+                OutputValue::TokenV1(token_id, initial_give_amount),
+            ))))
+            .add_output(TxOutput::Transfer(
+                OutputValue::Coin(change),
+                Destination::AnyoneCanSpend,
+            ))
+            .build()
+    };
+    let order_id = make_order_id(order_creation_tx.inputs()).unwrap();
+
+    let fill_tx = make_fill_order_tx_from_initial_amounts(
+        &mut tf,
+        order_id,
+        token_id,
+        initial_ask_amount,
+        initial_give_amount,
+        Amount::from_atoms(rng.gen_range(10..initial_ask_amount.into_atoms() / 10)),
+        UtxoOutPoint::new(coins_src_id.clone(), 1),
+        None,
+    );
+    let freeze_tx = make_freeze_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 2),
+        None,
+    );
+    let conclude_tx = make_conclude_order_tx(
+        &mut tf,
+        order_id,
+        UtxoOutPoint::new(coins_src_id.clone(), 3),
+        None,
+    );
+
+    let chain_config = std::sync::Arc::clone(tf.chain_config());
+    let mempool_config = create_mempool_config();
+    let chainstate_handle = start_chainstate(tf.chainstate());
+    let create_mempool = || {
+        Mempool::new(
+            Arc::clone(&chain_config),
+            mempool_config.clone(),
+            chainstate_handle.clone(),
+            Default::default(),
+            StoreMemoryUsageEstimator,
+        )
+    };
+
+    // Note: at this moment missing order is considered a hard error, so the txs will just be rejected.
+    {
+        let mut mempool = create_mempool();
+
+        let err = mempool.add_transaction_test(fill_tx.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::OrderDataNotFound(_)
+                    ),
+                    _
+                )
+            ))
+        );
+
+        let err = mempool.add_transaction_test(freeze_tx.clone()).unwrap_err();
+        let err_payload = assert_matches_return_val!(
+            &err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::InputCheck(err),
+            )),
+            err.error()
+        );
+        assert_matches!(
+            err_payload,
+            InputCheckErrorPayload::Translation(TranslationError::OrderNotFound(_))
+        );
+
+        let err = mempool.add_transaction_test(conclude_tx.clone()).unwrap_err();
+        assert_matches!(
+            err,
+            Error::Validity(TxValidationError::TxValidation(
+                ConnectTransactionError::ConstrainedValueAccumulatorError(
+                    constraints_value_accumulator::Error::OrdersAccountingError(
+                        orders_accounting::Error::OrderDataNotFound(_)
+                    ),
+                    _
+                )
+            ))
+        );
+    }
+}
+
+fn create_test_framework_builder_with_orders_v1(
+    rng: &mut (impl Rng + CryptoRng),
+) -> TestFrameworkBuilder {
+    TestFramework::builder(rng).with_chain_config(
+        common::chain::config::Builder::test_chain()
+            .chainstate_upgrades(
+                common::chain::NetUpgrades::initialize(vec![(
+                    BlockHeight::zero(),
+                    ChainstateUpgradeBuilder::latest().orders_version(OrdersVersion::V1).build(),
+                )])
+                .unwrap(),
+            )
+            .build(),
+    )
+}
+
+fn issue_and_mint_token_from_genesis(
+    rng: &mut (impl Rng + CryptoRng),
+    tf: &mut TestFramework,
+) -> (TokenId, UtxoOutPoint, UtxoOutPoint) {
+    let genesis_block_id = tf.genesis().get_id();
+    let utxo = UtxoOutPoint::new(genesis_block_id.into(), 0);
+    let to_mint = Amount::from_atoms(rng.gen_range(100..100_000_000));
+
+    issue_and_mint_random_token_from_best_block(
+        rng,
+        tf,
+        utxo,
+        to_mint,
+        TokenTotalSupply::Unlimited,
+        IsTokenFreezable::Yes,
+    )
+}
+
+fn make_fill_order_tx(
+    tf: &mut TestFramework,
+    order_id: OrderId,
+    token_id: TokenId,
+    fill_amount: Amount,
+    coins_outpoint: UtxoOutPoint,
+    additional_input: Option<TxInput>,
+) -> SignedTransaction {
+    let filled_amount = calculate_fill_order(tf, &order_id, fill_amount, OrdersVersion::V1);
+    make_fill_order_tx_impl(
+        tf,
+        order_id,
+        token_id,
+        fill_amount,
+        filled_amount,
+        coins_outpoint,
+        additional_input,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn make_fill_order_tx_from_initial_amounts(
+    tf: &mut TestFramework,
+    order_id: OrderId,
+    token_id: TokenId,
+    initially_asked: Amount,
+    initially_given: Amount,
+    fill_amount: Amount,
+    coins_outpoint: UtxoOutPoint,
+    additional_input: Option<TxInput>,
+) -> SignedTransaction {
+    let filled_amount =
+        orders_accounting::calculate_filled_amount(initially_asked, initially_given, fill_amount)
+            .unwrap();
+    make_fill_order_tx_impl(
+        tf,
+        order_id,
+        token_id,
+        fill_amount,
+        filled_amount,
+        coins_outpoint,
+        additional_input,
+    )
+}
+
+fn make_fill_order_tx_impl(
+    tf: &mut TestFramework,
+    order_id: OrderId,
+    token_id: TokenId,
+    fill_amount: Amount,
+    filled_amount: Amount,
+    coins_outpoint: UtxoOutPoint,
+    additional_input: Option<TxInput>,
+) -> SignedTransaction {
+    let fill_order_input =
+        TxInput::OrderAccountCommand(OrderAccountCommand::FillOrder(order_id, fill_amount));
+    let coins_amount = tf.coin_amount_from_utxo(&coins_outpoint);
+    let fee = TEST_MIN_TX_RELAY_FEE_RATE.atoms_per_kb(); // the tx is expected to be less than 1 kb
+    let change = ((coins_amount - fill_amount).unwrap() - Amount::from_atoms(fee)).unwrap();
+
+    let mut tx_builder = TransactionBuilder::new()
+        .add_input(coins_outpoint.into(), InputWitness::NoSignature(None))
+        .add_input(fill_order_input, InputWitness::NoSignature(None))
+        .add_output(TxOutput::Transfer(
+            OutputValue::TokenV1(token_id, filled_amount),
+            Destination::AnyoneCanSpend,
+        ))
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(change),
+            Destination::AnyoneCanSpend,
+        ));
+    if let Some(additional_input) = additional_input {
+        tx_builder = tx_builder.add_input(additional_input, InputWitness::NoSignature(None));
+    }
+
+    tx_builder.build()
+}
+
+fn make_freeze_order_tx(
+    tf: &mut TestFramework,
+    order_id: OrderId,
+    coins_outpoint: UtxoOutPoint,
+    additional_input: Option<TxInput>,
+) -> SignedTransaction {
+    let freeze_order_input =
+        TxInput::OrderAccountCommand(OrderAccountCommand::FreezeOrder(order_id));
+    let coins_amount = tf.coin_amount_from_utxo(&coins_outpoint);
+    let fee = TEST_MIN_TX_RELAY_FEE_RATE.atoms_per_kb(); // the tx is expected to be less than 1 kb
+    let change = (coins_amount - Amount::from_atoms(fee)).unwrap();
+
+    let mut tx_builder = TransactionBuilder::new()
+        .add_input(coins_outpoint.into(), InputWitness::NoSignature(None))
+        .add_input(freeze_order_input, InputWitness::NoSignature(None))
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(change),
+            Destination::AnyoneCanSpend,
+        ));
+    if let Some(additional_input) = additional_input {
+        tx_builder = tx_builder.add_input(additional_input, InputWitness::NoSignature(None));
+    }
+
+    tx_builder.build()
+}
+
+fn make_conclude_order_tx(
+    tf: &mut TestFramework,
+    order_id: OrderId,
+    coins_outpoint: UtxoOutPoint,
+    additional_input: Option<TxInput>,
+) -> SignedTransaction {
+    let conclude_order_input =
+        TxInput::OrderAccountCommand(OrderAccountCommand::ConcludeOrder(order_id));
+    let coins_amount = tf.coin_amount_from_utxo(&coins_outpoint);
+    let fee = TEST_MIN_TX_RELAY_FEE_RATE.atoms_per_kb(); // the tx is expected to be less than 1 kb
+    let change = (coins_amount - Amount::from_atoms(fee)).unwrap();
+
+    let mut tx_builder = TransactionBuilder::new()
+        .add_input(coins_outpoint.into(), InputWitness::NoSignature(None))
+        .add_input(conclude_order_input, InputWitness::NoSignature(None))
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(change),
+            Destination::AnyoneCanSpend,
+        ));
+    if let Some(additional_input) = additional_input {
+        tx_builder = tx_builder.add_input(additional_input, InputWitness::NoSignature(None));
+    }
+
+    tx_builder.build()
+}

--- a/mempool/src/pool/tests/utils.rs
+++ b/mempool/src/pool/tests/utils.rs
@@ -28,7 +28,6 @@ use super::{Error, MemoryUsageEstimator, Mempool, TxEntry};
 pub fn setup_with_chainstate(
     chainstate: Box<dyn ChainstateInterface>,
 ) -> Mempool<StoreMemoryUsageEstimator> {
-    logging::init_logging();
     let chain_config = std::sync::Arc::clone(chainstate.get_chain_config());
     let mempool_config = create_mempool_config();
     let chainstate_handle = start_chainstate(chainstate);

--- a/mempool/src/pool/tx_pool/reorg.rs
+++ b/mempool/src/pool/tx_pool/reorg.rs
@@ -92,7 +92,7 @@ impl ReorgData {
             })
             .collect();
 
-        // The transactions are returned in the order of them being disconnected which is the
+        // The blocks are returned in the order of them being disconnected which is the
         // opposite of what we want for connecting, so we need to reverse the iterator here.
         self.disconnected
             .into_iter()
@@ -169,6 +169,9 @@ pub fn handle_new_tip<M: MemoryUsageEstimator>(
         }
         return Ok(());
     }
+
+    // TODO: also check whether any of the existing txs in the orphan pool are no longer orphans
+    // due to the newly mined txs.
 
     match fetch_disconnected_txs(tx_pool, new_tip) {
         Ok(to_insert) => reorg_mempool_transactions(tx_pool, to_insert, finalizer),

--- a/mempool/src/pool/tx_pool/store/mod.rs
+++ b/mempool/src/pool/tx_pool/store/mod.rs
@@ -664,6 +664,7 @@ impl TxMempoolEntry {
         self.entry.creation_time()
     }
 
+    // Note: only the parents that are currently in the mempool are included here.
     pub fn parents(&self) -> impl Iterator<Item = &Id<Transaction>> {
         self.parents.iter()
     }

--- a/mempool/src/pool/tx_pool/tests/basic.rs
+++ b/mempool/src/pool/tx_pool/tests/basic.rs
@@ -17,7 +17,6 @@ use super::*;
 
 #[test]
 fn dummy_size() {
-    logging::init_logging();
     log::debug!("1, 1: {}", estimate_tx_size(1, 1));
     log::debug!("1, 2: {}", estimate_tx_size(1, 2));
     log::debug!("1, 400: {}", estimate_tx_size(1, 400));
@@ -590,7 +589,6 @@ async fn not_too_many_conflicts(#[case] seed: Seed) -> anyhow::Result<()> {
 #[case(Seed::from_entropy())]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
-    logging::init_logging();
     let mock_time = Arc::new(SeqCstAtomicU64::new(0));
     let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
     let mut mock_usage = MockMemoryUsageEstimator::new();
@@ -1221,8 +1219,6 @@ fn check_txs_sorted_by_descendant_sore<M>(tx_pool: &TxPool<M>) {
 #[case(Seed::from_entropy())]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mempool_full_mock(#[case] seed: Seed) -> anyhow::Result<()> {
-    logging::init_logging();
-
     let mut rng = make_seedable_rng(seed);
     let tf = TestFramework::builder(&mut rng).build();
     let genesis = tf.genesis();
@@ -1271,7 +1267,6 @@ async fn mempool_full_mock(#[case] seed: Seed) -> anyhow::Result<()> {
 #[case::fail(Seed(1))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mempool_full_real(#[case] seed: Seed) {
-    logging::init_logging();
     let mut rng = make_seedable_rng(seed);
 
     let num_txs = rng.gen_range(5..20);

--- a/mempool/src/pool/tx_pool/tests/expiry.rs
+++ b/mempool/src/pool/tx_pool/tests/expiry.rs
@@ -25,7 +25,6 @@ use ::utils::atomics::SeqCstAtomicU64;
 async fn descendant_of_expired_entry(#[case] seed: Seed) -> anyhow::Result<()> {
     let mock_time = Arc::new(SeqCstAtomicU64::new(0));
     let mock_clock = mocked_time_getter_seconds(Arc::clone(&mock_time));
-    logging::init_logging();
 
     let mut rng = make_seedable_rng(seed);
     let tf = TestFramework::builder(&mut rng).build();

--- a/mempool/src/pool/tx_pool/tests/utils.rs
+++ b/mempool/src/pool/tx_pool/tests/utils.rs
@@ -339,7 +339,6 @@ pub fn make_test_block(
 }
 
 pub fn setup() -> TxPool<StoreMemoryUsageEstimator> {
-    logging::init_logging();
     let chain_config = Arc::new(common::chain::config::create_unit_test_config());
     let chainstate_interface = start_chainstate_with_config(Arc::clone(&chain_config));
     TxPool::new(
@@ -352,7 +351,6 @@ pub fn setup() -> TxPool<StoreMemoryUsageEstimator> {
 }
 
 pub fn setup_with_min_tx_relay_fee_rate(fee_rate: FeeRate) -> TxPool<StoreMemoryUsageEstimator> {
-    logging::init_logging();
     let chain_config = Arc::new(common::chain::config::create_unit_test_config());
     let mempool_config = MempoolConfig {
         min_tx_relay_fee_rate: fee_rate.into(),
@@ -370,7 +368,6 @@ pub fn setup_with_min_tx_relay_fee_rate(fee_rate: FeeRate) -> TxPool<StoreMemory
 pub fn setup_with_chainstate(
     chainstate: Box<dyn ChainstateInterface>,
 ) -> TxPool<StoreMemoryUsageEstimator> {
-    logging::init_logging();
     let chain_config = Arc::clone(chainstate.get_chain_config());
     let chainstate_handle = start_chainstate(chainstate);
     TxPool::new(

--- a/mempool/src/pool/work_queue/test.rs
+++ b/mempool/src/pool/work_queue/test.rs
@@ -118,7 +118,6 @@ impl PeerIdSupply {
 #[trace]
 #[case(Seed::from_entropy())]
 fn simulation(#[case] seed: Seed) {
-    logging::init_logging();
     let mut rng = make_seedable_rng(seed);
     let mut peer_supply = PeerIdSupply::new();
 
@@ -198,7 +197,6 @@ fn scheduling_fairness_full_queues(#[case] seed: Seed) {
     // Minimum number of work items in each peer's queue at the start
     const MIN_WORK: usize = 100;
 
-    logging::init_logging();
     let mut rng = make_seedable_rng(seed);
     let num_peers: usize = rng.gen_range(2..=8);
     let peer1 = PeerId::from_u64(1);


### PR DESCRIPTION
Previously, mempool's `enum TxDependency`'s `OrderV1Account` variant only contained the order id (through `AccountType::Order`), which would make all transactions with order v1 inputs for the same order conflict with each other.

The fix that I've ended up with is that I've just removed the `OrderV1Account` variant from `TxDependency`.
This is OK because we rely on the tx verifier to check for conflicts anyway.

I also cleaned up `TxDependency` a little, removing the redundant `struct TxAccountDependency`.