### PR TITLE
Tests for compose_transaction and tx_to_partially_signed_tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,6 +4911,7 @@ dependencies = [
 name = "node-comm"
 version = "1.0.2"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "blockprod",
@@ -4921,6 +4922,7 @@ dependencies = [
  "crypto",
  "logging",
  "mempool",
+ "mockall",
  "node-lib",
  "p2p",
  "rpc",
@@ -9261,6 +9263,8 @@ dependencies = [
  "common",
  "consensus",
  "crypto",
+ "ctor",
+ "derive_more",
  "futures",
  "itertools 0.14.0",
  "logging",
@@ -9269,11 +9273,13 @@ dependencies = [
  "node-comm",
  "p2p-types",
  "randomness",
+ "rpc",
  "rpc-description",
  "rstest",
  "serde",
  "serialization",
  "storage",
+ "strum",
  "test-utils",
  "thiserror 1.0.69",
  "tokio",

--- a/chainstate/test-framework/src/framework_builder.rs
+++ b/chainstate/test-framework/src/framework_builder.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
 
 use crate::{
     key_manager::KeyManager,
@@ -241,6 +244,10 @@ impl TestFrameworkBuilder {
 
     pub fn build(self) -> TestFramework {
         self.try_build().unwrap()
+    }
+
+    pub fn build_arc_mutex(self) -> Arc<Mutex<TestFramework>> {
+        Arc::new(Mutex::new(self.build()))
     }
 }
 

--- a/test/functional/wallet_decommission_request.py
+++ b/test/functional/wallet_decommission_request.py
@@ -105,7 +105,7 @@ class WalletDecommissionRequest(WalletPOSTestBase):
 
             # try decommission from hot wallet
             address = await wallet.new_address()
-            assert (await wallet.decommission_stake_pool(pools[0].pool_id, address)).startswith("Wallet error: Wallet error: Failed to completely sign")
+            assert (await wallet.decommission_stake_pool(pools[0].pool_id, address)).startswith("Wallet controller error: Wallet error: Failed to completely sign")
 
             # create decommission request
             decommission_req_output = await wallet.decommission_stake_pool_request(pools[0].pool_id, address)

--- a/test/functional/wallet_htlc_spend.py
+++ b/test/functional/wallet_htlc_spend.py
@@ -220,10 +220,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             # Bob can't spend it without secret
             result = await wallet.compose_transaction([tx_output], [UtxoOutpoint(alice_htlc_tx_id, 0)], [None])
             output = await wallet.sign_raw_transaction(result['result']['hex'])
-            assert_in("The transaction has been fully signed and is ready to be broadcast to network", output)
-            signed_tx = output.split('\n')[2]
-            output = await wallet.submit_transaction(signed_tx)
-            assert_in("Signature decoding failed", output)
+            assert_in("Not all transaction inputs have been signed", output)
             # Bob can't spend it with incorrect secret
             result = await wallet.compose_transaction([tx_output], [UtxoOutpoint(alice_htlc_tx_id, 0)], [random_secret_hex])
             output = await wallet.sign_raw_transaction(result['result']['hex'])
@@ -240,10 +237,7 @@ class WalletHtlcSpend(BitcoinTestFramework):
             tx_output = TransferTxOutput(bob_amount_to_swap * ATOMS_PER_COIN, alice_pub_key_hex, None)
             result = await wallet.compose_transaction([tx_output], [UtxoOutpoint(bob_htlc_tx_id, 0)], [None])
             output = await wallet.sign_raw_transaction(result['result']['hex'])
-            assert_in("The transaction has been fully signed and is ready to be broadcast to network", output)
-            signed_tx = output.split('\n')[2]
-            output = await wallet.submit_transaction(signed_tx)
-            assert_in("Signature decoding failed", output)
+            assert_in("Not all transaction inputs have been signed", output)
             # Alice can't spend it with incorrect secret
             result = await wallet.compose_transaction([tx_output], [UtxoOutpoint(bob_htlc_tx_id, 0)], [random_secret_hex])
             output = await wallet.sign_raw_transaction(result['result']['hex'])

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -103,6 +103,7 @@ pub struct CurrentFeeRate {
     pub consolidate_fee_rate: FeeRate,
 }
 
+#[derive(Debug)]
 pub enum TransactionToSign {
     Tx(Transaction),
     Partial(PartiallySignedTransaction),
@@ -1614,6 +1615,7 @@ impl<K: AccountKeyChains> Account<K> {
         &self,
         outpoint: &UtxoOutPoint,
         current_block_info: BlockInfo,
+        htlc_spending_condition: HtlcSpendingCondition,
     ) -> WalletResult<(TxOutput, Destination)> {
         let txo = self.output_cache.find_unspent_unlocked_utxo(outpoint, current_block_info)?;
 
@@ -1622,7 +1624,7 @@ impl<K: AccountKeyChains> Account<K> {
             get_tx_output_destination(
                 txo,
                 &|pool_id| self.output_cache.pool_data(*pool_id).ok(),
-                HtlcSpendingCondition::Skip,
+                htlc_spending_condition,
             )
             .ok_or(WalletError::InputCannotBeSpent(txo.clone()))?,
         ))

--- a/wallet/src/destination_getters.rs
+++ b/wallet/src/destination_getters.rs
@@ -13,14 +13,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common::chain::{Destination, PoolId, TxOutput};
+use common::chain::{htlc::HtlcSecret, Destination, PoolId, TxOutput};
 
 use crate::account::PoolData;
 
+#[derive(Clone, Copy, Debug)]
 pub enum HtlcSpendingCondition {
     WithSecret,
     WithMultisig,
     Skip,
+}
+
+impl HtlcSpendingCondition {
+    pub fn from_opt_secrets_array_item(
+        secrets: Option<&[Option<HtlcSecret>]>,
+        index: usize,
+    ) -> Self {
+        secrets.map_or(Self::Skip, |secrets| {
+            secrets
+                .get(index)
+                .and_then(Option::as_ref)
+                .map_or(Self::WithMultisig, |_: &HtlcSecret| Self::WithSecret)
+        })
+    }
 }
 
 pub fn get_tx_output_destination<'a, PoolDataGetter>(

--- a/wallet/src/signer/trezor_signer/mod.rs
+++ b/wallet/src/signer/trezor_signer/mod.rs
@@ -1724,9 +1724,8 @@ fn find_trezor_device(
     let mut devices = devices
         .into_iter()
         .filter(|device| {
-            device.model == Model::Trezor
-                || device.model == Model::TrezorEmulator
-                || device.model == Model::TrezorLegacy
+            // Note: we don't support `Model::TrezorLegacy` AKA Trezor Model One.
+            device.model == Model::Trezor || device.model == Model::TrezorEmulator
         })
         .filter_map(|d| {
             d.connect().ok().and_then(|mut c| {

--- a/wallet/src/signer/trezor_signer/test_utils/mod.rs
+++ b/wallet/src/signer/trezor_signer/test_utils/mod.rs
@@ -47,7 +47,8 @@ pub fn find_test_device(debug: bool) -> AvailableDevice {
         .into_iter()
         .filter(|device| {
             if use_real_device {
-                device.model == Model::Trezor || device.model == Model::TrezorLegacy
+                // Note: we don't support `Model::TrezorLegacy` AKA Trezor Model One.
+                device.model == Model::Trezor
             } else {
                 device.model == Model::TrezorEmulator
             }

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -21,6 +21,7 @@ use crate::account::{
     transaction_list::TransactionList, CoinSelectionAlgo, CurrentFeeRate, DelegationData,
     OrderData, PoolData, TxInfo, UnconfirmedTokenInfo, UtxoSelectorError,
 };
+use crate::destination_getters::HtlcSpendingCondition;
 use crate::key_chain::{
     make_account_path, make_path_to_vrf_key, AccountKeyChainImplSoftware, KeyChainError,
     MasterKeyChain, LOOKAHEAD_SIZE, VRF_INDEX,
@@ -1301,13 +1302,19 @@ where
     pub fn find_unspent_utxo_and_destination(
         &self,
         outpoint: &UtxoOutPoint,
+        htlc_spending_condition: HtlcSpendingCondition,
     ) -> Option<(TxOutput, Destination)> {
         self.accounts.values().find_map(|acc: &Account<P::K>| {
             let current_block_info = BlockInfo {
                 height: acc.best_block().1,
                 timestamp: self.latest_median_time,
             };
-            acc.find_unspent_utxo_and_destination(outpoint, current_block_info).ok()
+            acc.find_unspent_utxo_and_destination(
+                outpoint,
+                current_block_info,
+                htlc_spending_condition,
+            )
+            .ok()
         })
     }
 
@@ -2589,3 +2596,5 @@ where
 
 #[cfg(test)]
 mod tests;
+
+pub mod test_helpers;

--- a/wallet/src/wallet/test_helpers.rs
+++ b/wallet/src/wallet/test_helpers.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A module for test utilities that depend on this crate and that are supposed to be used both
+//! in this crate's unit tests and in some other crates.
+
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use common::{
+    chain::{Block, ChainConfig},
+    primitives::BlockHeight,
+};
+use wallet_types::{seed_phrase::StoreSeedPhrase, wallet_type::WalletType};
+
+use crate::{
+    signer::{software_signer::SoftwareSignerProvider, SignerProvider},
+    wallet::create_wallet_in_memory,
+    wallet_events::WalletEventsNoOp,
+    DefaultWallet, Wallet,
+};
+
+pub fn create_wallet_with_mnemonic(
+    chain_config: Arc<ChainConfig>,
+    mnemonic: &str,
+) -> DefaultWallet {
+    let db = create_wallet_in_memory().unwrap();
+    let genesis_block_id = chain_config.genesis_block_id();
+    Wallet::create_new_wallet(
+        chain_config.clone(),
+        db,
+        (BlockHeight::new(0), genesis_block_id),
+        WalletType::Hot,
+        |db_tx| {
+            Ok(SoftwareSignerProvider::new_from_mnemonic(
+                chain_config,
+                db_tx,
+                mnemonic,
+                None,
+                StoreSeedPhrase::DoNotStore,
+            )?)
+        },
+    )
+    .unwrap()
+    .wallet()
+    .unwrap()
+}
+
+pub fn scan_wallet<B, P>(wallet: &mut Wallet<B, P>, height: BlockHeight, blocks: Vec<Block>)
+where
+    B: storage::Backend + 'static,
+    P: SignerProvider,
+{
+    for account in wallet.get_best_block().keys() {
+        wallet
+            .scan_new_blocks(*account, height, blocks.clone(), &WalletEventsNoOp)
+            .unwrap();
+    }
+
+    wallet
+        .scan_new_blocks_unused_account(height, blocks, &WalletEventsNoOp)
+        .unwrap();
+}

--- a/wallet/src/wallet_events.rs
+++ b/wallet/src/wallet_events.rs
@@ -19,7 +19,7 @@ use wallet_types::WalletTx;
 
 /// Callbacks that are called when the database is updated and the UI should be re-rendered.
 /// For example, when a new wallet is imported and the wallet scan is in progress,
-/// the wallet balance and address/transaction lists should be updated after this callbacks.
+/// the wallet balance and address/transaction lists should be updated after these callbacks.
 pub trait WalletEvents {
     /// New block is scanned
     fn new_block(&self);

--- a/wallet/wallet-cli-lib/tests/staking.rs
+++ b/wallet/wallet-cli-lib/tests/staking.rs
@@ -39,7 +39,10 @@ async fn staking_locked_wallet(#[case] seed: Seed) {
         test.exec("wallet-lock-private-keys"),
         "Success. The wallet is now locked."
     );
-    assert_eq!(test.exec("staking-start"), "Wallet error: Wallet is locked");
+    assert_eq!(
+        test.exec("staking-start"),
+        "Wallet controller error: Wallet is locked"
+    );
 
     // It is possible to start staking after the wallet is unlocked
     assert_eq!(
@@ -51,7 +54,7 @@ async fn staking_locked_wallet(#[case] seed: Seed) {
     // It is not possible to lock the wallet while staking is running
     assert_eq!(
         test.exec("wallet-lock-private-keys"),
-        "Wallet error: Cannot lock wallet because staking is running"
+        "Wallet controller error: Cannot lock wallet because staking is running"
     );
 
     // It is possible to lock the wallet after staking is stopped

--- a/wallet/wallet-controller/Cargo.toml
+++ b/wallet/wallet-controller/Cargo.toml
@@ -29,9 +29,12 @@ wallet-types = { path = "../types" }
 
 async-trait.workspace = true
 bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
+ctor.workspace = true
+derive_more.workspace = true
 futures = { workspace = true, default-features = false }
 itertools.workspace = true
 serde.workspace = true
+strum.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }
 zeroize.workspace = true
@@ -39,7 +42,9 @@ zeroize.workspace = true
 [dev-dependencies]
 chainstate-test-framework = { path = "../../chainstate/test-framework" }
 p2p-types = { path = "../../p2p/types" }
+rpc = { path = "../../rpc" }
 test-utils = { path = "../../test-utils" }
+
 futures = { workspace = true, features = ["executor"] }
 
 anyhow.workspace = true

--- a/wallet/wallet-controller/src/helpers/tests.rs
+++ b/wallet/wallet-controller/src/helpers/tests.rs
@@ -1,0 +1,1034 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeMap, num::NonZeroU8, sync::Arc};
+
+use itertools::Itertools as _;
+use rstest::rstest;
+
+use chainstate::ChainInfo;
+use common::{
+    address::pubkeyhash::PublicKeyHash,
+    chain::{
+        block::{timestamp::BlockTimestamp, BlockReward, ConsensusData},
+        classic_multisig::ClassicMultisigChallenge,
+        config::create_regtest,
+        htlc::{HashedTimelockContract, HtlcSecret, HtlcSecretHash},
+        make_delegation_id, make_order_id, make_token_id,
+        output_value::{OutputValue, RpcOutputValue},
+        signature::inputsig::InputWitness,
+        stakelock::StakePoolData,
+        timelock::OutputTimeLock,
+        tokens::{
+            IsTokenFreezable, RPCFungibleTokenInfo, RPCTokenInfo, TokenId, TokenIssuance,
+            TokenIssuanceV1, TokenTotalSupply,
+        },
+        AccountCommand, AccountNonce, AccountOutPoint, AccountSpending, Block, ChainConfig,
+        DelegationId, Destination, OrderAccountCommand, OrderData, PoolId, RpcOrderInfo,
+        SignedTransaction, Transaction, TxInput, TxOutput, UtxoOutPoint,
+    },
+    primitives::{per_thousand::PerThousand, Amount, BlockHeight, Id, Idable},
+};
+use node_comm::node_traits::MockNodeInterface;
+use randomness::{Rng, SliceRandom as _};
+use test_utils::random::{gen_random_alnum_string, gen_random_bytes, make_seedable_rng, Seed};
+use wallet::{
+    wallet::test_helpers::{create_wallet_with_mnemonic, scan_wallet},
+    DefaultWallet,
+};
+use wallet_types::{
+    account_info::DEFAULT_ACCOUNT_INDEX,
+    partially_signed_transaction::{
+        OrderAdditionalInfo, PoolAdditionalInfo, TokenAdditionalInfo, TxAdditionalInfo,
+    },
+};
+
+use crate::{
+    tests::test_utils::{
+        create_block_scan_wallet, random_is_token_unfreezable, random_nft_issuance,
+        random_order_currencies_with_token, random_pub_key,
+        random_rpc_ft_info_with_id_ticker_decimals, random_rpc_is_token_frozen,
+        random_token_data_with_id_and_authority, random_vrf_pub_key, tx_with_outputs,
+        wallet_new_dest, OrderCurrencies, TestOrderData, TestTokenData, MNEMONIC,
+    },
+    {
+        helpers::{fetch_utxo, tx_to_partially_signed_tx},
+        runtime_wallet::RuntimeWallet,
+    },
+};
+
+mod tx_to_partially_signed_tx_general_test {
+    use super::*;
+
+    #[rstest]
+    #[trace]
+    #[case(Seed::from_entropy())]
+    #[tokio::test]
+    async fn test(#[case] seed: Seed) {
+        let mut rng = make_seedable_rng(seed);
+
+        let random_tokens_count = 15;
+        let random_tokens = (0..random_tokens_count)
+            .map(|_| {
+                use crate::tests::test_utils::random_token_data_with_id_and_authority;
+
+                random_token_data_with_id_and_authority(
+                    TokenId::random_using(&mut rng),
+                    Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                    &mut rng,
+                )
+            })
+            .collect_vec();
+
+        let chain_config = Arc::new(create_regtest());
+        let block_timestamp = chain_config.genesis_block().timestamp();
+        let mut wallet = create_wallet_with_mnemonic(Arc::clone(&chain_config), MNEMONIC);
+
+        // Transfer to a destination belonging to the wallet.
+        let token0_transfer_utxo_dest = wallet_new_dest(&mut wallet);
+        let token0_transfer_utxo = TxOutput::Transfer(
+            OutputValue::TokenV1(random_tokens[0].id, Amount::from_atoms(rng.gen())),
+            token0_transfer_utxo_dest.clone(),
+        );
+        let tx_with_token0_transfer = tx_with_outputs(vec![token0_transfer_utxo.clone()]);
+        let tx_with_token0_transfer_id = tx_with_token0_transfer.transaction().get_id();
+        let token0_transfer_outpoint = UtxoOutPoint::new(tx_with_token0_transfer_id.into(), 0);
+
+        // Transfer to a random destination.
+        let token1_transfer_utxo_dest =
+            Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+        let token1_transfer_utxo = TxOutput::Transfer(
+            OutputValue::TokenV1(random_tokens[1].id, Amount::from_atoms(rng.gen())),
+            token1_transfer_utxo_dest.clone(),
+        );
+        let token1_transfer_outpoint =
+            UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), rng.gen());
+
+        let lock_then_transfer_utxo_dest =
+            Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+        let lock_then_transfer_utxo = TxOutput::LockThenTransfer(
+            OutputValue::TokenV1(random_tokens[2].id, Amount::from_atoms(rng.gen())),
+            lock_then_transfer_utxo_dest.clone(),
+            OutputTimeLock::ForBlockCount(rng.gen()),
+        );
+        let lock_then_transfer_outpoint =
+            UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), rng.gen());
+
+        let delegation_dest = wallet_new_dest(&mut wallet);
+        let tx_with_delegation = SignedTransaction::new(
+            Transaction::new(
+                0,
+                vec![TxInput::Utxo(UtxoOutPoint::new(
+                    Id::<Transaction>::random_using(&mut rng).into(),
+                    rng.r#gen(),
+                ))],
+                vec![TxOutput::CreateDelegationId(
+                    delegation_dest.clone(),
+                    PoolId::random_using(&mut rng),
+                )],
+            )
+            .unwrap(),
+            vec![InputWitness::NoSignature(None)],
+        )
+        .unwrap();
+        let delegation_id = make_delegation_id(tx_with_delegation.transaction().inputs()).unwrap();
+
+        // This pool's info will be cached inside the wallet because the decommission destination
+        // belongs to it.
+        let known_pool_id = PoolId::random_using(&mut rng);
+        let known_pool_staker_balance = Amount::from_atoms(rng.gen());
+        let known_pool_decommission_dest = wallet_new_dest(&mut wallet);
+        let tx_with_pool_creation = tx_with_outputs(vec![TxOutput::CreateStakePool(
+            known_pool_id,
+            Box::new(StakePoolData::new(
+                Amount::from_atoms(rng.r#gen()),
+                Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                random_vrf_pub_key(&mut rng),
+                known_pool_decommission_dest.clone(),
+                PerThousand::new(rng.gen_range(0..=1000)).unwrap(),
+                Amount::from_atoms(rng.r#gen()),
+            )),
+        )]);
+
+        let mut blocks = Vec::new();
+
+        blocks.push(
+            Block::new(
+                vec![tx_with_token0_transfer, tx_with_delegation, tx_with_pool_creation],
+                chain_config.genesis_block_id(),
+                chain_config.genesis_block().timestamp(),
+                ConsensusData::None,
+                BlockReward::new(vec![]),
+            )
+            .unwrap(),
+        );
+
+        let wallet_tokens_count = 7;
+        let wallet_tokens = make_blocks_with_wallet_tokens(
+            &mut blocks,
+            &chain_config,
+            wallet_tokens_count,
+            &mut wallet,
+            &mut rng,
+        );
+        let wallet_orders = make_blocks_with_wallet_orders(
+            &mut blocks,
+            &chain_config,
+            &[
+                random_order_currencies_with_token(&mut rng, random_tokens[3].id),
+                random_order_currencies_with_token(&mut rng, random_tokens[4].id),
+                random_order_currencies_with_token(&mut rng, random_tokens[5].id),
+                random_order_currencies_with_token(&mut rng, random_tokens[6].id),
+                random_order_currencies_with_token(&mut rng, random_tokens[7].id),
+            ],
+            &mut wallet,
+            &mut rng,
+        );
+
+        // This utxo will be cached inside the wallet because the info about the pool has been cached.
+        let known_produce_block_from_stake_utxo = TxOutput::ProduceBlockFromStake(
+            Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+            known_pool_id,
+        );
+        let pool_id_for_known_create_pool_utxo = PoolId::random_using(&mut rng);
+        let pool_staker_balance_for_known_create_pool_utxo = Amount::from_atoms(rng.gen());
+        let pool_decommission_dest_for_known_create_pool_utxo = wallet_new_dest(&mut wallet);
+        // This utxo will be cached inside the wallet because the decommission destination
+        // belongs to it.
+        let known_create_pool_utxo = TxOutput::CreateStakePool(
+            pool_id_for_known_create_pool_utxo,
+            Box::new(StakePoolData::new(
+                Amount::from_atoms(rng.r#gen()),
+                Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                random_vrf_pub_key(&mut rng),
+                pool_decommission_dest_for_known_create_pool_utxo.clone(),
+                PerThousand::new(rng.gen_range(0..=1000)).unwrap(),
+                Amount::from_atoms(rng.r#gen()),
+            )),
+        );
+        blocks.push(
+            Block::new(
+                vec![],
+                blocks.last().unwrap().get_id().into(),
+                chain_config.genesis_block().timestamp(),
+                ConsensusData::None,
+                BlockReward::new(vec![
+                    known_produce_block_from_stake_utxo.clone(),
+                    known_create_pool_utxo.clone(),
+                ]),
+            )
+            .unwrap(),
+        );
+        let last_block_id = blocks.last().unwrap().get_id();
+        let known_produce_block_from_stake_outpoint = UtxoOutPoint::new(last_block_id.into(), 0);
+        let known_create_pool_outpoint = UtxoOutPoint::new(last_block_id.into(), 1);
+
+        let last_height = blocks.len() as u64 + 1;
+        scan_wallet(&mut wallet, BlockHeight::new(0), blocks);
+
+        let htlc_spend_key = Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+        let htlc_refund_key = Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+        // Note: the wallet doesn't check that the secret and the secret hash are consistent.
+        let htlc_secret = HtlcSecret::new_from_rng(&mut rng);
+        let create_htlc_utxo = TxOutput::Htlc(
+            OutputValue::TokenV1(random_tokens[8].id, Amount::from_atoms(rng.gen())),
+            Box::new(HashedTimelockContract {
+                secret_hash: HtlcSecretHash::random_using(&mut rng),
+                spend_key: htlc_spend_key.clone(),
+                refund_timelock: OutputTimeLock::ForBlockCount(rng.gen()),
+                refund_key: htlc_refund_key.clone(),
+            }),
+        );
+        let create_htlc_outpoint =
+            UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), rng.gen());
+
+        let coins_utxo_dest = Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+        let coins_utxo = TxOutput::Transfer(
+            OutputValue::Coin(Amount::from_atoms(rng.gen())),
+            coins_utxo_dest.clone(),
+        );
+        let coins_outpoint =
+            UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), rng.gen());
+
+        let pool_id_for_unknown_create_pool_utxo = PoolId::random_using(&mut rng);
+        let pool_decommission_dest_for_unknown_create_pool_utxo =
+            Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+        let unknown_create_pool_utxo = TxOutput::CreateStakePool(
+            pool_id_for_unknown_create_pool_utxo,
+            Box::new(StakePoolData::new(
+                Amount::from_atoms(rng.r#gen()),
+                Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                random_vrf_pub_key(&mut rng),
+                pool_decommission_dest_for_unknown_create_pool_utxo.clone(),
+                PerThousand::new(rng.gen_range(0..=1000)).unwrap(),
+                Amount::from_atoms(rng.r#gen()),
+            )),
+        );
+        let unknown_create_pool_outpoint =
+            UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), rng.gen());
+        let staker_balance_for_pool_for_unknown_create_pool_utxo = Amount::from_atoms(rng.gen());
+
+        let pool_id_for_unknown_produce_block_from_stake_utxo = PoolId::random_using(&mut rng);
+        let pool_decommission_dest_for_unknown_produce_block_from_stake_utxo =
+            Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+        let unknown_produce_block_from_stake_utxo = TxOutput::ProduceBlockFromStake(
+            Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+            pool_id_for_unknown_produce_block_from_stake_utxo,
+        );
+        let unknown_produce_block_from_stake_outpoint =
+            UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), rng.gen());
+        let staker_balance_for_pool_for_unknown_produce_block_from_stake_utxo =
+            Amount::from_atoms(rng.gen());
+
+        let use_htlc_secret = rng.gen_bool(0.5);
+        let expected_htlc_dest = if use_htlc_secret {
+            htlc_spend_key
+        } else {
+            htlc_refund_key
+        };
+        let fill_order_v0_dest = Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+        let mut inputs_utxos_destinations_htlc_secrets = vec![
+            (
+                TxInput::Utxo(coins_outpoint.clone()),
+                Some(coins_utxo.clone()),
+                Some(coins_utxo_dest),
+                None,
+            ),
+            (
+                TxInput::Utxo(token0_transfer_outpoint),
+                Some(token0_transfer_utxo),
+                Some(token0_transfer_utxo_dest),
+                None,
+            ),
+            (
+                TxInput::Utxo(token1_transfer_outpoint.clone()),
+                Some(token1_transfer_utxo.clone()),
+                Some(token1_transfer_utxo_dest),
+                None,
+            ),
+            (
+                TxInput::Utxo(lock_then_transfer_outpoint.clone()),
+                Some(lock_then_transfer_utxo.clone()),
+                Some(lock_then_transfer_utxo_dest),
+                None,
+            ),
+            (
+                TxInput::Utxo(create_htlc_outpoint.clone()),
+                Some(create_htlc_utxo.clone()),
+                Some(expected_htlc_dest),
+                use_htlc_secret.then_some(htlc_secret),
+            ),
+            (
+                TxInput::Utxo(known_produce_block_from_stake_outpoint),
+                Some(known_produce_block_from_stake_utxo),
+                Some(known_pool_decommission_dest),
+                None,
+            ),
+            (
+                TxInput::Utxo(known_create_pool_outpoint),
+                Some(known_create_pool_utxo),
+                Some(pool_decommission_dest_for_known_create_pool_utxo),
+                None,
+            ),
+            (
+                TxInput::Utxo(unknown_create_pool_outpoint.clone()),
+                Some(unknown_create_pool_utxo.clone()),
+                Some(pool_decommission_dest_for_unknown_create_pool_utxo.clone()),
+                None,
+            ),
+            (
+                TxInput::Utxo(unknown_produce_block_from_stake_outpoint.clone()),
+                Some(unknown_produce_block_from_stake_utxo.clone()),
+                Some(pool_decommission_dest_for_unknown_produce_block_from_stake_utxo.clone()),
+                None,
+            ),
+            (
+                TxInput::Account(AccountOutPoint::new(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountSpending::DelegationBalance(
+                        delegation_id,
+                        Amount::from_atoms(rng.r#gen()),
+                    ),
+                )),
+                None,
+                Some(delegation_dest),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::MintTokens(
+                        wallet_tokens[0].id,
+                        Amount::from_atoms(rng.r#gen()),
+                    ),
+                ),
+                None,
+                Some(wallet_tokens[0].authority.clone()),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::UnmintTokens(wallet_tokens[1].id),
+                ),
+                None,
+                Some(wallet_tokens[1].authority.clone()),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::LockTokenSupply(wallet_tokens[2].id),
+                ),
+                None,
+                Some(wallet_tokens[2].authority.clone()),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::FreezeToken(
+                        wallet_tokens[3].id,
+                        random_is_token_unfreezable(&mut rng),
+                    ),
+                ),
+                None,
+                Some(wallet_tokens[3].authority.clone()),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::UnfreezeToken(wallet_tokens[4].id),
+                ),
+                None,
+                Some(wallet_tokens[4].authority.clone()),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::ChangeTokenAuthority(
+                        wallet_tokens[5].id,
+                        Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                    ),
+                ),
+                None,
+                Some(wallet_tokens[5].authority.clone()),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::ChangeTokenMetadataUri(
+                        wallet_tokens[6].id,
+                        gen_random_alnum_string(&mut rng, 10, 20).into_bytes(),
+                    ),
+                ),
+                None,
+                Some(wallet_tokens[6].authority.clone()),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::ConcludeOrder(wallet_orders[0].id),
+                ),
+                None,
+                Some(wallet_orders[0].conclude_key.clone()),
+                None,
+            ),
+            (
+                TxInput::AccountCommand(
+                    AccountNonce::new(rng.r#gen()),
+                    AccountCommand::FillOrder(
+                        wallet_orders[1].id,
+                        Amount::from_atoms(rng.r#gen()),
+                        fill_order_v0_dest.clone(),
+                    ),
+                ),
+                None,
+                Some(fill_order_v0_dest),
+                None,
+            ),
+            (
+                TxInput::OrderAccountCommand(OrderAccountCommand::ConcludeOrder(
+                    wallet_orders[2].id,
+                )),
+                None,
+                Some(wallet_orders[2].conclude_key.clone()),
+                None,
+            ),
+            (
+                TxInput::OrderAccountCommand(OrderAccountCommand::FillOrder(
+                    wallet_orders[3].id,
+                    Amount::from_atoms(rng.r#gen()),
+                )),
+                None,
+                Some(Destination::AnyoneCanSpend),
+                None,
+            ),
+            (
+                TxInput::OrderAccountCommand(OrderAccountCommand::FreezeOrder(wallet_orders[4].id)),
+                None,
+                Some(wallet_orders[4].conclude_key.clone()),
+                None,
+            ),
+        ];
+        inputs_utxos_destinations_htlc_secrets.shuffle(&mut rng);
+        let (inputs, expected_inputs_utxos, expected_inputs_destinations, htlc_secrets) = {
+            let mut inputs = Vec::with_capacity(inputs_utxos_destinations_htlc_secrets.len());
+            let mut utxos = Vec::with_capacity(inputs_utxos_destinations_htlc_secrets.len());
+            let mut destinations = Vec::with_capacity(inputs_utxos_destinations_htlc_secrets.len());
+            let mut htlc_secrets = Vec::with_capacity(inputs_utxos_destinations_htlc_secrets.len());
+
+            for (input, utxo, dest, htlc_secret) in inputs_utxos_destinations_htlc_secrets {
+                inputs.push(input);
+                utxos.push(utxo);
+                destinations.push(dest);
+                htlc_secrets.push(htlc_secret);
+            }
+
+            (inputs, utxos, destinations, htlc_secrets)
+        };
+
+        let outputs = vec![
+            TxOutput::Transfer(
+                OutputValue::TokenV1(random_tokens[9].id, Amount::from_atoms(rng.r#gen())),
+                Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+            ),
+            TxOutput::LockThenTransfer(
+                OutputValue::TokenV1(random_tokens[10].id, Amount::from_atoms(rng.r#gen())),
+                Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                OutputTimeLock::ForBlockCount(rng.r#gen()),
+            ),
+            TxOutput::Burn(OutputValue::TokenV1(
+                random_tokens[11].id,
+                Amount::from_atoms(rng.r#gen()),
+            )),
+            TxOutput::CreateStakePool(
+                PoolId::random_using(&mut rng),
+                Box::new(StakePoolData::new(
+                    Amount::from_atoms(rng.r#gen()),
+                    Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                    random_vrf_pub_key(&mut rng),
+                    Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                    PerThousand::new(rng.gen_range(0..=1000)).unwrap(),
+                    Amount::from_atoms(rng.r#gen()),
+                )),
+            ),
+            TxOutput::CreateDelegationId(
+                Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                PoolId::random_using(&mut rng),
+            ),
+            TxOutput::DelegateStaking(
+                Amount::from_atoms(rng.r#gen()),
+                DelegationId::random_using(&mut rng),
+            ),
+            TxOutput::IssueFungibleToken(Box::new(TokenIssuance::V1(TokenIssuanceV1 {
+                token_ticker: gen_random_alnum_string(&mut rng, 10, 20).into_bytes(),
+                number_of_decimals: rng.r#gen(),
+                metadata_uri: gen_random_alnum_string(&mut rng, 10, 20).into_bytes(),
+                total_supply: TokenTotalSupply::Unlimited,
+                authority: Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                is_freezable: IsTokenFreezable::Yes,
+            }))),
+            TxOutput::IssueNft(
+                TokenId::random_using(&mut rng),
+                Box::new(random_nft_issuance(&mut rng)),
+                Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+            ),
+            TxOutput::DataDeposit(gen_random_bytes(&mut rng, 10, 20)),
+            TxOutput::Htlc(
+                OutputValue::TokenV1(random_tokens[12].id, Amount::from_atoms(rng.r#gen())),
+                Box::new(HashedTimelockContract {
+                    secret_hash: HtlcSecretHash::random_using(&mut rng),
+                    spend_key: Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                    refund_timelock: OutputTimeLock::ForBlockCount(rng.r#gen()),
+                    refund_key: Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                }),
+            ),
+            TxOutput::CreateOrder(Box::new(OrderData::new(
+                Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+                OutputValue::TokenV1(random_tokens[13].id, Amount::from_atoms(rng.r#gen())),
+                OutputValue::TokenV1(random_tokens[14].id, Amount::from_atoms(rng.r#gen())),
+            ))),
+        ];
+
+        let node_mock = {
+            let mut node_mock = MockNodeInterface::new();
+
+            let utxos_to_return = BTreeMap::from([
+                // Note: token0_tx_output should already be known to the wallet,
+                // since it should have seen it in a block and the address belonged to the wallet.
+                // Same for known_produce_block_from_stake_utxo and known_create_pool_utxo.
+                (token1_transfer_outpoint, token1_transfer_utxo),
+                (lock_then_transfer_outpoint, lock_then_transfer_utxo),
+                (coins_outpoint, coins_utxo),
+                (create_htlc_outpoint.clone(), create_htlc_utxo.clone()),
+                (
+                    unknown_create_pool_outpoint.clone(),
+                    unknown_create_pool_utxo.clone(),
+                ),
+                (
+                    unknown_produce_block_from_stake_outpoint.clone(),
+                    unknown_produce_block_from_stake_utxo.clone(),
+                ),
+            ]);
+
+            // Note: the "wallet" token infos won't be queried, because those tokens
+            // are only used by token-related AccountCommand's, for which we don't collect
+            // TokenAdditionalInfo's currently.
+            let token_infos_to_return = random_tokens
+                .iter()
+                .map(|token_data| (token_data.id, make_rpc_token_info(token_data, &mut rng)))
+                .collect::<BTreeMap<_, _>>();
+
+            let order_infos_to_return = wallet_orders
+                .iter()
+                .map(|order_data| (order_data.id, make_rpc_order_info(order_data, &mut rng)))
+                .collect::<BTreeMap<_, _>>();
+
+            let staker_balances_to_return = BTreeMap::from([
+                (known_pool_id, known_pool_staker_balance),
+                (
+                    pool_id_for_known_create_pool_utxo,
+                    pool_staker_balance_for_known_create_pool_utxo,
+                ),
+                (
+                    pool_id_for_unknown_create_pool_utxo,
+                    staker_balance_for_pool_for_unknown_create_pool_utxo,
+                ),
+                (
+                    pool_id_for_unknown_produce_block_from_stake_utxo,
+                    staker_balance_for_pool_for_unknown_produce_block_from_stake_utxo,
+                ),
+            ]);
+
+            let decommission_destinations_to_return = BTreeMap::from([
+                (
+                    pool_id_for_unknown_produce_block_from_stake_utxo,
+                    pool_decommission_dest_for_unknown_produce_block_from_stake_utxo,
+                ),
+                // Note: technically this shouldn't be needed, because the destination can be extracted
+                // from the utxo itself. But we do query it in this case currently.
+                (
+                    pool_id_for_unknown_create_pool_utxo,
+                    pool_decommission_dest_for_unknown_create_pool_utxo,
+                ),
+            ]);
+
+            let chain_info_to_return = ChainInfo {
+                best_block_height: BlockHeight::new(last_height),
+                best_block_id: last_block_id.into(),
+                best_block_timestamp: block_timestamp,
+                median_time: BlockTimestamp::from_int_seconds(rng.gen()),
+                is_initial_block_download: false,
+            };
+
+            node_mock.expect_get_utxo().returning(move |outpoint| {
+                Ok(Some(utxos_to_return.get(&outpoint).unwrap().clone()))
+            });
+
+            node_mock.expect_get_token_info().returning(move |token_id| {
+                Ok(Some(token_infos_to_return.get(&token_id).unwrap().clone()))
+            });
+
+            node_mock.expect_get_order_info().returning(move |token_id| {
+                Ok(Some(order_infos_to_return.get(&token_id).unwrap().clone()))
+            });
+
+            node_mock.expect_get_staker_balance().returning(move |pool_id| {
+                Ok(Some(*staker_balances_to_return.get(&pool_id).unwrap()))
+            });
+
+            node_mock.expect_get_pool_decommission_destination().returning(move |pool_id| {
+                Ok(Some(
+                    decommission_destinations_to_return.get(&pool_id).unwrap().clone(),
+                ))
+            });
+
+            node_mock
+                .expect_chainstate_info()
+                .returning(move || Ok(chain_info_to_return.clone()));
+
+            node_mock
+        };
+
+        let tx = Transaction::new(0, inputs, outputs).unwrap();
+        let wallet = RuntimeWallet::Software(wallet);
+        let ptx =
+            tx_to_partially_signed_tx(&node_mock, &wallet, tx.clone(), Some(htlc_secrets.clone()))
+                .await
+                .unwrap();
+
+        assert_eq!(ptx.tx(), &tx);
+
+        assert!(ptx.witnesses().iter().all(|w| w.is_none()));
+        assert_eq!(ptx.input_utxos(), &expected_inputs_utxos);
+        assert_eq!(ptx.destinations(), &expected_inputs_destinations);
+        assert_eq!(ptx.htlc_secrets(), &htlc_secrets);
+
+        let expected_tx_additional_info = {
+            let mut info = TxAdditionalInfo::new();
+
+            // Note: the "wallet" tokens are only used by token-related AccountCommand's, for which
+            // we don't collect TokenAdditionalInfo's currently. So we don't append them here.
+            for token in random_tokens {
+                info = info.with_token_info(
+                    token.id,
+                    TokenAdditionalInfo {
+                        num_decimals: token.num_decimals,
+                        ticker: token.ticker.into_bytes(),
+                    },
+                )
+            }
+
+            for order in wallet_orders {
+                info = info.with_order_info(
+                    order.id,
+                    OrderAdditionalInfo {
+                        initially_asked: order.initially_asked,
+                        initially_given: order.initially_given,
+                        ask_balance: order.ask_balance,
+                        give_balance: order.give_balance,
+                    },
+                )
+            }
+
+            // Note: the info for pool_id_for_known_create_pool_utxo is not returned (because it can be extracted
+            // from the utxo itself).
+            info.with_pool_info(
+                known_pool_id,
+                PoolAdditionalInfo {
+                    staker_balance: known_pool_staker_balance,
+                },
+            )
+            .with_pool_info(
+                pool_id_for_unknown_produce_block_from_stake_utxo,
+                PoolAdditionalInfo {
+                    staker_balance:
+                        staker_balance_for_pool_for_unknown_produce_block_from_stake_utxo,
+                },
+            )
+        };
+        assert_eq!(ptx.additional_info(), &expected_tx_additional_info);
+    }
+
+    // Make blocks with txs that issue tokens with authority destinations belonging to the wallet.
+    fn make_blocks_with_wallet_tokens(
+        blocks: &mut Vec<Block>,
+        chain_config: &ChainConfig,
+        tokens_count: usize,
+        wallet: &mut DefaultWallet,
+        rng: &mut impl Rng,
+    ) -> Vec<TestTokenData> {
+        let mut result = Vec::with_capacity(tokens_count);
+
+        for _ in 0..tokens_count {
+            let tx_inputs = vec![TxInput::Utxo(UtxoOutPoint::new(
+                Id::<Transaction>::random_using(rng).into(),
+                rng.r#gen(),
+            ))];
+            let id = make_token_id(chain_config, BlockHeight::new(0), &tx_inputs).unwrap();
+            let authority = wallet_new_dest(wallet);
+            let data = random_token_data_with_id_and_authority(id, authority, rng);
+
+            let issuance = TokenIssuanceV1 {
+                token_ticker: data.ticker.clone().into_bytes(),
+                number_of_decimals: data.num_decimals,
+                metadata_uri: data.metadata_uri.clone().into_bytes(),
+                total_supply: data.total_supply,
+                authority: data.authority.clone(),
+                is_freezable: data.is_freezable,
+            };
+
+            result.push(data);
+
+            let tx = SignedTransaction::new(
+                Transaction::new(
+                    0,
+                    tx_inputs,
+                    vec![TxOutput::IssueFungibleToken(Box::new(TokenIssuance::V1(issuance)))],
+                )
+                .unwrap(),
+                vec![InputWitness::NoSignature(None)],
+            )
+            .unwrap();
+
+            blocks.push(
+                Block::new(
+                    vec![tx],
+                    blocks.last().unwrap().get_id().into(),
+                    chain_config.genesis_block().timestamp(),
+                    ConsensusData::None,
+                    BlockReward::new(vec![]),
+                )
+                .unwrap(),
+            );
+        }
+
+        result
+    }
+
+    // Make blocks with txs that create orders with conclude keys belonging to the wallet.
+    fn make_blocks_with_wallet_orders(
+        blocks: &mut Vec<Block>,
+        chain_config: &ChainConfig,
+        curencies: &[OrderCurrencies],
+        wallet: &mut DefaultWallet,
+        rng: &mut impl Rng,
+    ) -> Vec<TestOrderData> {
+        let mut result = Vec::with_capacity(curencies.len());
+
+        for curencies in curencies {
+            let tx_inputs = vec![TxInput::Utxo(UtxoOutPoint::new(
+                Id::<Transaction>::random_using(rng).into(),
+                rng.r#gen(),
+            ))];
+            let id = make_order_id(&tx_inputs).unwrap();
+            let initially_asked = curencies.ask.into_output_value(Amount::from_atoms(rng.gen()));
+            let initially_given = curencies.give.into_output_value(Amount::from_atoms(rng.gen()));
+            let ask_balance = Amount::from_atoms(rng.gen());
+            let give_balance = Amount::from_atoms(rng.gen());
+            let conclude_key = wallet_new_dest(wallet);
+
+            result.push(TestOrderData {
+                id,
+                initially_asked: initially_asked.clone(),
+                initially_given: initially_given.clone(),
+                give_balance,
+                ask_balance,
+                conclude_key: conclude_key.clone(),
+            });
+
+            let tx = SignedTransaction::new(
+                Transaction::new(
+                    0,
+                    tx_inputs,
+                    vec![TxOutput::CreateOrder(Box::new(OrderData::new(
+                        conclude_key,
+                        initially_asked,
+                        initially_given,
+                    )))],
+                )
+                .unwrap(),
+                vec![InputWitness::NoSignature(None)],
+            )
+            .unwrap();
+
+            blocks.push(
+                Block::new(
+                    vec![tx],
+                    blocks.last().unwrap().get_id().into(),
+                    chain_config.genesis_block().timestamp(),
+                    ConsensusData::None,
+                    BlockReward::new(vec![]),
+                )
+                .unwrap(),
+            );
+        }
+
+        result
+    }
+
+    fn make_rpc_token_info(data: &TestTokenData, rng: &mut impl Rng) -> RPCTokenInfo {
+        RPCTokenInfo::FungibleToken(RPCFungibleTokenInfo {
+            token_id: data.id,
+            token_ticker: data.ticker.clone().into(),
+            number_of_decimals: data.num_decimals,
+            metadata_uri: data.metadata_uri.clone().into(),
+            circulating_supply: Amount::from_atoms(rng.gen()),
+            total_supply: data.total_supply.into(),
+            is_locked: rng.gen(),
+            frozen: random_rpc_is_token_frozen(rng),
+            authority: data.authority.clone(),
+        })
+    }
+
+    fn make_rpc_order_info(data: &TestOrderData, rng: &mut impl Rng) -> RpcOrderInfo {
+        RpcOrderInfo {
+            conclude_key: data.conclude_key.clone(),
+            initially_asked: RpcOutputValue::from_output_value(&data.initially_asked).unwrap(),
+            initially_given: RpcOutputValue::from_output_value(&data.initially_given).unwrap(),
+            give_balance: data.give_balance,
+            ask_balance: data.ask_balance,
+            nonce: Some(AccountNonce::new(rng.gen())),
+        }
+    }
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+#[trace]
+#[tokio::test]
+async fn tx_to_partially_signed_tx_htlc_input_with_known_utxo_test(
+    #[case] seed: Seed,
+    #[values(false, true)] use_htlc_secret: bool,
+    #[values(false, true)] spend_key_belongs_to_wallet: bool,
+    #[values(false, true)] refund_key_known_to_wallet: bool,
+    #[values(false, true)] utxo_known_to_wallet: bool,
+) {
+    let mut rng = make_seedable_rng(seed);
+
+    let chain_config = Arc::new(create_regtest());
+    let mut wallet = create_wallet_with_mnemonic(Arc::clone(&chain_config), MNEMONIC);
+
+    let token_id = TokenId::random_using(&mut rng);
+
+    let htlc_spend_key = if spend_key_belongs_to_wallet {
+        wallet_new_dest(&mut wallet)
+    } else {
+        Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng))
+    };
+    let htlc_refund_key = if refund_key_known_to_wallet {
+        let keys = vec![random_pub_key(&mut rng), random_pub_key(&mut rng)];
+        let pkh = wallet
+            .add_standalone_multisig(
+                DEFAULT_ACCOUNT_INDEX,
+                ClassicMultisigChallenge::new(&chain_config, NonZeroU8::new(2).unwrap(), keys)
+                    .unwrap(),
+                None,
+            )
+            .unwrap();
+        Destination::ClassicMultisig(pkh)
+    } else {
+        Destination::ClassicMultisig(PublicKeyHash::random_using(&mut rng))
+    };
+    // Note: the wallet doesn't check that the secret and the secret hash are consistent.
+    let htlc_secret = HtlcSecret::new_from_rng(&mut rng);
+    let create_htlc_output = TxOutput::Htlc(
+        OutputValue::TokenV1(token_id, Amount::from_atoms(rng.gen())),
+        Box::new(HashedTimelockContract {
+            secret_hash: HtlcSecretHash::random_using(&mut rng),
+            spend_key: htlc_spend_key.clone(),
+            refund_timelock: OutputTimeLock::ForBlockCount(rng.gen()),
+            refund_key: htlc_refund_key.clone(),
+        }),
+    );
+
+    let tx = tx_with_outputs(vec![create_htlc_output.clone()]);
+    let tx_id = tx.transaction().get_id();
+    let create_htlc_outpoint = UtxoOutPoint::new(tx_id.into(), 0);
+
+    let last_block = create_block_scan_wallet(
+        &chain_config,
+        &mut wallet,
+        if utxo_known_to_wallet {
+            vec![tx]
+        } else {
+            vec![]
+        },
+        Amount::from_atoms(rng.gen()),
+        Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+        0,
+    );
+    let last_height = 1;
+
+    let token_num_decimals = rng.gen_range(1..20);
+    let token_ticker = gen_random_alnum_string(&mut rng, 5, 10);
+
+    let node_mock = {
+        let mut node_mock = MockNodeInterface::new();
+
+        let utxos_to_return = if utxo_known_to_wallet
+            && (spend_key_belongs_to_wallet || refund_key_known_to_wallet)
+        {
+            // In this case the utxo will be cached inside the wallet; it must be able to both find
+            // the utxo and extract the destination from it by correctly propagating the proper
+            // HtlcSpendingCondition.
+            BTreeMap::new()
+        } else {
+            BTreeMap::from([(create_htlc_outpoint.clone(), create_htlc_output.clone())])
+        };
+
+        let token_infos_to_return = BTreeMap::from([(
+            token_id,
+            RPCTokenInfo::FungibleToken(random_rpc_ft_info_with_id_ticker_decimals(
+                token_id,
+                token_ticker.clone(),
+                token_num_decimals,
+                &mut rng,
+            )),
+        )]);
+
+        let chain_info_to_return = ChainInfo {
+            best_block_height: BlockHeight::new(last_height),
+            best_block_id: last_block.get_id().into(),
+            best_block_timestamp: last_block.timestamp(),
+            median_time: BlockTimestamp::from_int_seconds(rng.gen()),
+            is_initial_block_download: false,
+        };
+
+        node_mock
+            .expect_get_utxo()
+            .returning(move |outpoint| Ok(Some(utxos_to_return.get(&outpoint).unwrap().clone())));
+
+        node_mock.expect_get_token_info().returning(move |token_id| {
+            Ok(Some(token_infos_to_return.get(&token_id).unwrap().clone()))
+        });
+
+        node_mock
+            .expect_chainstate_info()
+            .returning(move || Ok(chain_info_to_return.clone()));
+
+        node_mock
+    };
+
+    let inputs = vec![create_htlc_outpoint.clone()];
+    let expected_inputs_utxos = vec![Some(create_htlc_output.clone())];
+    let expected_htlc_dest = if use_htlc_secret {
+        htlc_spend_key
+    } else {
+        htlc_refund_key
+    };
+    let expected_inputs_destinations = vec![Some(expected_htlc_dest)];
+    let outputs = vec![];
+    let htlc_secrets = vec![use_htlc_secret.then_some(htlc_secret)];
+
+    let tx = Transaction::new(
+        0,
+        inputs.into_iter().map(TxInput::Utxo).collect_vec(),
+        outputs,
+    )
+    .unwrap();
+    let wallet = RuntimeWallet::Software(wallet);
+    let ptx =
+        tx_to_partially_signed_tx(&node_mock, &wallet, tx.clone(), Some(htlc_secrets.clone()))
+            .await
+            .unwrap();
+
+    assert_eq!(ptx.tx(), &tx);
+    assert!(ptx.witnesses().iter().all(|w| w.is_none()));
+    assert_eq!(ptx.input_utxos(), &expected_inputs_utxos);
+    assert_eq!(ptx.destinations(), &expected_inputs_destinations);
+    assert_eq!(ptx.htlc_secrets(), &htlc_secrets);
+    assert_eq!(
+        ptx.additional_info(),
+        &TxAdditionalInfo::new().with_token_info(
+            token_id,
+            TokenAdditionalInfo {
+                num_decimals: token_num_decimals,
+                ticker: token_ticker.clone().into_bytes()
+            }
+        )
+    );
+
+    // Also call fetch_utxo for the same outpoint; the expectations are exactly the same:
+    // if the wallet has cached the utxo, node interface should not be queried.
+    let fetched_utxo = fetch_utxo(&node_mock, &wallet, &create_htlc_outpoint).await.unwrap();
+    assert_eq!(fetched_utxo, create_htlc_output);
+}

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -43,6 +43,7 @@ use wallet::{
         transaction_list::TransactionList, CoinSelectionAlgo, DelegationData, PoolData, TxInfo,
         UnconfirmedTokenInfo,
     },
+    destination_getters::HtlcSpendingCondition,
     send_request::{SelectedInputs, StakePoolCreationArguments},
     signer::software_signer::SoftwareSignerProvider,
     wallet::WalletPoolsFilter,
@@ -74,11 +75,16 @@ impl<B: storage::Backend + 'static> RuntimeWallet<B> {
     pub fn find_unspent_utxo_and_destination(
         &self,
         input: &UtxoOutPoint,
+        htlc_spending_condition: HtlcSpendingCondition,
     ) -> Option<(TxOutput, Destination)> {
         match self {
-            RuntimeWallet::Software(w) => w.find_unspent_utxo_and_destination(input),
+            RuntimeWallet::Software(w) => {
+                w.find_unspent_utxo_and_destination(input, htlc_spending_condition)
+            }
             #[cfg(feature = "trezor")]
-            RuntimeWallet::Trezor(w) => w.find_unspent_utxo_and_destination(input),
+            RuntimeWallet::Trezor(w) => {
+                w.find_unspent_utxo_and_destination(input, htlc_spending_condition)
+            }
         }
     }
 

--- a/wallet/wallet-controller/src/sync/tests/mod.rs
+++ b/wallet/wallet-controller/src/sync/tests/mod.rs
@@ -202,7 +202,7 @@ impl MockNode {
 impl NodeInterface for MockNode {
     type Error = NodeRpcError;
 
-    fn is_cold_wallet_node(&self) -> WalletControllerMode {
+    async fn is_cold_wallet_node(&self) -> WalletControllerMode {
         WalletControllerMode::Hot
     }
 

--- a/wallet/wallet-controller/src/tests/compose_transaction_tests.rs
+++ b/wallet/wallet-controller/src/tests/compose_transaction_tests.rs
@@ -1,0 +1,321 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use itertools::Itertools as _;
+use rstest::rstest;
+
+use chainstate::ChainInfo;
+use common::{
+    address::pubkeyhash::PublicKeyHash,
+    chain::{
+        block::timestamp::BlockTimestamp,
+        config::create_regtest,
+        htlc::{HashedTimelockContract, HtlcSecret, HtlcSecretHash},
+        output_value::OutputValue,
+        timelock::OutputTimeLock,
+        tokens::{RPCTokenInfo, TokenId},
+        Destination, OrderData, Transaction, TxInput, TxOutput, UtxoOutPoint,
+    },
+    primitives::{Amount, BlockHeight, Id, Idable},
+};
+use node_comm::{mock::ClonableMockNodeInterface, node_traits::MockNodeInterface};
+use randomness::Rng;
+use test_utils::{
+    assert_matches_return_val,
+    random::{gen_random_alnum_string, make_seedable_rng, Seed},
+};
+use wallet::{
+    account::TransactionToSign, wallet::test_helpers::create_wallet_with_mnemonic,
+    wallet_events::WalletEventsNoOp,
+};
+use wallet_types::partially_signed_transaction::{TokenAdditionalInfo, TxAdditionalInfo};
+
+use crate::{
+    runtime_wallet::RuntimeWallet,
+    tests::test_utils::{
+        assert_fees, create_block_scan_wallet, random_rpc_ft_info_with_id_ticker_decimals,
+        tx_with_outputs, wallet_new_dest, MNEMONIC,
+    },
+    Controller,
+};
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy(), false)]
+#[trace]
+#[case(Seed::from_entropy(), true)]
+#[tokio::test]
+async fn general_test(#[case] seed: Seed, #[case] use_htlc_secret: bool) {
+    let mut rng = make_seedable_rng(seed);
+
+    let chain_config = Arc::new(create_regtest());
+    let mut wallet = create_wallet_with_mnemonic(Arc::clone(&chain_config), MNEMONIC);
+
+    let token1_id = TokenId::random_using(&mut rng);
+    let token2_id = TokenId::random_using(&mut rng);
+    let token3_id = TokenId::random_using(&mut rng);
+    let token4_id = TokenId::random_using(&mut rng);
+
+    let token1_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let token2_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let block_reward_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+
+    let token1_tx_output_dest = wallet_new_dest(&mut wallet);
+    let token1_tx_output = TxOutput::Transfer(
+        OutputValue::TokenV1(token1_id, token1_amount),
+        token1_tx_output_dest.clone(),
+    );
+    let tx_with_token1 = tx_with_outputs(vec![token1_tx_output.clone()]);
+    let tx_with_token1_id = tx_with_token1.transaction().get_id();
+    let token2_tx_output_dest = Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+    let token2_tx_output = TxOutput::Transfer(
+        OutputValue::TokenV1(token2_id, token2_amount),
+        token2_tx_output_dest.clone(),
+    );
+
+    let last_block = create_block_scan_wallet(
+        &chain_config,
+        &mut wallet,
+        vec![tx_with_token1],
+        block_reward_amount,
+        Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+        0,
+    );
+    let last_height = 1;
+
+    let token1_outpoint = UtxoOutPoint::new(tx_with_token1_id.into(), 0);
+    let token2_outpoint =
+        UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), rng.gen());
+
+    let token1_num_decimals = rng.gen_range(1..20);
+    let token1_ticker = gen_random_alnum_string(&mut rng, 5, 10);
+    let token2_num_decimals = rng.gen_range(1..20);
+    let token2_ticker = gen_random_alnum_string(&mut rng, 5, 10);
+    let token3_num_decimals = rng.gen_range(1..20);
+    let token3_ticker = gen_random_alnum_string(&mut rng, 5, 10);
+    let token4_num_decimals = rng.gen_range(1..20);
+    let token4_ticker = gen_random_alnum_string(&mut rng, 5, 10);
+
+    let created_order_coin_give_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let create_order_output = TxOutput::CreateOrder(Box::new(OrderData::new(
+        Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+        OutputValue::TokenV1(token3_id, Amount::from_atoms(rng.gen())),
+        OutputValue::Coin(created_order_coin_give_amount),
+    )));
+    let htlc_amount = Amount::from_atoms(rng.gen_range(1000..2000));
+    let htlc_spend_key = Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+    let htlc_refund_key = Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+    // Note: the wallet doesn't check that the secret and the secret hash are consistent.
+    let htlc_secret = HtlcSecret::new_from_rng(&mut rng);
+    let create_htlc_output = TxOutput::Htlc(
+        OutputValue::TokenV1(token4_id, htlc_amount),
+        Box::new(HashedTimelockContract {
+            secret_hash: HtlcSecretHash::random_using(&mut rng),
+            spend_key: htlc_spend_key.clone(),
+            refund_timelock: OutputTimeLock::ForBlockCount(rng.gen()),
+            refund_key: htlc_refund_key.clone(),
+        }),
+    );
+    let create_htlc_outpoint =
+        UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), rng.gen());
+
+    let coins_outpoint = UtxoOutPoint::new(Id::<Transaction>::random_using(&mut rng).into(), 0);
+    let coins_outpoint_amount =
+        (created_order_coin_give_amount + Amount::from_atoms(rng.gen_range(1000..2000))).unwrap();
+    let coins_utxo_dest = Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng));
+    let coins_utxo = TxOutput::LockThenTransfer(
+        OutputValue::Coin(coins_outpoint_amount),
+        coins_utxo_dest.clone(),
+        OutputTimeLock::ForBlockCount(rng.gen()),
+    );
+
+    let node_mock = {
+        let mut node_mock = MockNodeInterface::new();
+
+        let utxos_to_return = BTreeMap::from([
+            // Note: token1_tx_output should already be known to the wallet,
+            // since it should have seen it in a block and the address belonged to the wallet.
+            (token2_outpoint.clone(), token2_tx_output.clone()),
+            (coins_outpoint.clone(), coins_utxo.clone()),
+            (create_htlc_outpoint.clone(), create_htlc_output.clone()),
+        ]);
+
+        let token_infos_to_return = BTreeMap::from([
+            (
+                token1_id,
+                RPCTokenInfo::FungibleToken(random_rpc_ft_info_with_id_ticker_decimals(
+                    token1_id,
+                    token1_ticker.clone(),
+                    token1_num_decimals,
+                    &mut rng,
+                )),
+            ),
+            (
+                token2_id,
+                RPCTokenInfo::FungibleToken(random_rpc_ft_info_with_id_ticker_decimals(
+                    token2_id,
+                    token2_ticker.clone(),
+                    token2_num_decimals,
+                    &mut rng,
+                )),
+            ),
+            (
+                token3_id,
+                RPCTokenInfo::FungibleToken(random_rpc_ft_info_with_id_ticker_decimals(
+                    token3_id,
+                    token3_ticker.clone(),
+                    token3_num_decimals,
+                    &mut rng,
+                )),
+            ),
+            (
+                token4_id,
+                RPCTokenInfo::FungibleToken(random_rpc_ft_info_with_id_ticker_decimals(
+                    token4_id,
+                    token4_ticker.clone(),
+                    token4_num_decimals,
+                    &mut rng,
+                )),
+            ),
+        ]);
+
+        let chain_info_to_return = ChainInfo {
+            best_block_height: BlockHeight::new(last_height),
+            best_block_id: last_block.get_id().into(),
+            best_block_timestamp: last_block.timestamp(),
+            median_time: BlockTimestamp::from_int_seconds(rng.gen()),
+            is_initial_block_download: false,
+        };
+
+        node_mock
+            .expect_get_utxo()
+            .returning(move |outpoint| Ok(Some(utxos_to_return.get(&outpoint).unwrap().clone())));
+
+        node_mock.expect_get_token_info().returning(move |token_id| {
+            Ok(Some(token_infos_to_return.get(&token_id).unwrap().clone()))
+        });
+
+        node_mock
+            .expect_chainstate_info()
+            .returning(move || Ok(chain_info_to_return.clone()));
+
+        node_mock
+    };
+
+    let controller = Controller::new(
+        Arc::clone(&chain_config),
+        ClonableMockNodeInterface::from_mock(node_mock),
+        RuntimeWallet::Software(wallet),
+        WalletEventsNoOp,
+    )
+    .await
+    .unwrap();
+
+    let inputs = vec![token1_outpoint, token2_outpoint, coins_outpoint, create_htlc_outpoint];
+    let inputs_utxos = vec![token1_tx_output, token2_tx_output, coins_utxo, create_htlc_output];
+    let expected_htlc_dest = if use_htlc_secret {
+        htlc_spend_key
+    } else {
+        htlc_refund_key
+    };
+    let expected_inputs_destinations = vec![
+        Some(token1_tx_output_dest),
+        Some(token2_tx_output_dest),
+        Some(coins_utxo_dest),
+        Some(expected_htlc_dest),
+    ];
+    let outputs = vec![
+        TxOutput::Transfer(
+            OutputValue::TokenV1(token1_id, token1_amount),
+            Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+        ),
+        TxOutput::Transfer(
+            OutputValue::TokenV1(token2_id, token2_amount),
+            Destination::PublicKeyHash(PublicKeyHash::random_using(&mut rng)),
+        ),
+        create_order_output,
+    ];
+    let htlc_secrets = vec![None, None, None, use_htlc_secret.then_some(htlc_secret)];
+    let (composed_tx, fees) = controller
+        .compose_transaction(
+            inputs.clone(),
+            outputs.clone(),
+            Some(htlc_secrets.clone()),
+            false,
+        )
+        .await
+        .unwrap();
+    let composed_tx = assert_matches_return_val!(composed_tx, TransactionToSign::Partial(tx), tx);
+
+    let expected_coins_fee = (coins_outpoint_amount - created_order_coin_give_amount).unwrap();
+    assert_fees(
+        &fees,
+        expected_coins_fee,
+        &BTreeMap::from([(token4_id, htlc_amount)]),
+        &BTreeMap::from([(token4_id, token4_num_decimals)]),
+        &chain_config,
+    );
+
+    assert_eq!(
+        composed_tx.tx(),
+        &Transaction::new(
+            0,
+            inputs.into_iter().map(TxInput::Utxo).collect_vec(),
+            outputs
+        )
+        .unwrap()
+    );
+    assert!(composed_tx.witnesses().iter().all(|w| w.is_none()));
+    assert_eq!(
+        composed_tx.input_utxos(),
+        inputs_utxos.into_iter().map(Some).collect_vec()
+    );
+    assert_eq!(composed_tx.destinations(), &expected_inputs_destinations);
+    assert_eq!(composed_tx.htlc_secrets(), &htlc_secrets);
+    assert_eq!(
+        composed_tx.additional_info(),
+        &TxAdditionalInfo::new()
+            .with_token_info(
+                token1_id,
+                TokenAdditionalInfo {
+                    num_decimals: token1_num_decimals,
+                    ticker: token1_ticker.into_bytes()
+                }
+            )
+            .with_token_info(
+                token2_id,
+                TokenAdditionalInfo {
+                    num_decimals: token2_num_decimals,
+                    ticker: token2_ticker.into_bytes()
+                }
+            )
+            .with_token_info(
+                token3_id,
+                TokenAdditionalInfo {
+                    num_decimals: token3_num_decimals,
+                    ticker: token3_ticker.into_bytes()
+                }
+            )
+            .with_token_info(
+                token4_id,
+                TokenAdditionalInfo {
+                    num_decimals: token4_num_decimals,
+                    ticker: token4_ticker.into_bytes()
+                }
+            )
+    );
+}

--- a/wallet/wallet-controller/src/tests/mod.rs
+++ b/wallet/wallet-controller/src/tests/mod.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod compose_transaction_tests;
+pub mod test_utils;
+
+#[ctor::ctor]
+fn init() {
+    logging::init_logging();
+}

--- a/wallet/wallet-controller/src/tests/test_utils.rs
+++ b/wallet/wallet-controller/src/tests/test_utils.rs
@@ -1,0 +1,251 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use common::{
+    address::pubkeyhash::PublicKeyHash,
+    chain::{
+        block::{BlockReward, ConsensusData},
+        output_value::OutputValue,
+        tokens::{
+            IsTokenFreezable, IsTokenUnfreezable, Metadata, NftIssuance, NftIssuanceV0,
+            RPCFungibleTokenInfo, RPCIsTokenFrozen, RPCTokenTotalSupply, TokenCreator, TokenId,
+            TokenTotalSupply,
+        },
+        Block, ChainConfig, Destination, OrderId, SignedTransaction, Transaction, TxOutput,
+    },
+    primitives::{amount::RpcAmountOut, Amount, BlockHeight},
+};
+use crypto::{
+    key::{KeyKind, PrivateKey, PublicKey},
+    vrf::{VRFKeyKind, VRFPrivateKey, VRFPublicKey},
+};
+use randomness::{CryptoRng, Rng};
+use test_utils::random::{gen_random_alnum_string, gen_random_bytes};
+use wallet::{signer::SignerProvider, wallet::test_helpers::scan_wallet, DefaultWallet, Wallet};
+use wallet_types::{account_info::DEFAULT_ACCOUNT_INDEX, Currency};
+
+use crate::types::Balances;
+
+pub fn assert_fees(
+    actual_fees: &Balances,
+    expected_coin_fee: Amount,
+    expected_token_fees: &BTreeMap<TokenId, Amount>,
+    token_decimals: &BTreeMap<TokenId, u8>,
+    chain_config: &ChainConfig,
+) {
+    assert_eq!(actual_fees.coins().amount(), expected_coin_fee);
+    assert_consistent_rpc_amount_out(actual_fees.coins(), chain_config.coin_decimals());
+
+    let actual_token_fees = actual_fees
+        .tokens()
+        .iter()
+        .map(|(token_id_addr, amount_out)| {
+            let token_id = token_id_addr.decode_object(chain_config).unwrap();
+            let token_decimals = token_decimals.get(&token_id);
+            assert!(
+                token_decimals.is_some(),
+                "decimals for token {token_id:x} not provided"
+            );
+            assert_consistent_rpc_amount_out(amount_out, *token_decimals.unwrap());
+            (token_id, amount_out.amount())
+        })
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(&actual_token_fees, expected_token_fees);
+}
+
+pub fn assert_consistent_rpc_amount_out(amount_out: &RpcAmountOut, decimals: u8) {
+    assert_eq!(
+        amount_out.decimal().to_amount(decimals).unwrap(),
+        amount_out.amount()
+    );
+}
+
+pub fn random_rpc_ft_info_with_id_ticker_decimals(
+    id: TokenId,
+    ticker: String,
+    num_decimals: u8,
+    rng: &mut impl Rng,
+) -> RPCFungibleTokenInfo {
+    RPCFungibleTokenInfo {
+        token_id: id,
+        token_ticker: ticker.into(),
+        number_of_decimals: num_decimals,
+        metadata_uri: gen_random_alnum_string(rng, 10, 20).into(),
+        circulating_supply: Amount::from_atoms(rng.gen()),
+        total_supply: RPCTokenTotalSupply::Unlimited,
+        is_locked: rng.gen_bool(0.5),
+        frozen: random_rpc_is_token_frozen(rng),
+        authority: Destination::PublicKeyHash(PublicKeyHash::random_using(rng)),
+    }
+}
+
+pub fn random_rpc_is_token_frozen(rng: &mut impl Rng) -> RPCIsTokenFrozen {
+    if rng.gen_bool(0.5) {
+        RPCIsTokenFrozen::NotFrozen {
+            freezable: rng.gen(),
+        }
+    } else {
+        RPCIsTokenFrozen::Frozen {
+            unfreezable: rng.gen(),
+        }
+    }
+}
+
+pub fn random_is_token_freezable(rng: &mut impl Rng) -> IsTokenFreezable {
+    if rng.gen_bool(0.5) {
+        IsTokenFreezable::Yes
+    } else {
+        IsTokenFreezable::No
+    }
+}
+
+pub fn random_is_token_unfreezable(rng: &mut impl Rng) -> IsTokenUnfreezable {
+    if rng.gen_bool(0.5) {
+        IsTokenUnfreezable::Yes
+    } else {
+        IsTokenUnfreezable::No
+    }
+}
+
+pub fn random_token_total_supply(rng: &mut impl Rng) -> TokenTotalSupply {
+    match rng.gen_range(0..3) {
+        0 => TokenTotalSupply::Fixed(Amount::from_atoms(rng.gen())),
+        1 => TokenTotalSupply::Lockable,
+        _ => TokenTotalSupply::Unlimited,
+    }
+}
+
+pub fn random_nft_issuance(rng: &mut (impl Rng + CryptoRng)) -> NftIssuance {
+    NftIssuance::V0(NftIssuanceV0 {
+        metadata: Metadata {
+            creator: Some(TokenCreator {
+                public_key: random_pub_key(rng),
+            }),
+            name: gen_random_alnum_string(rng, 10, 20).into_bytes(),
+            description: gen_random_alnum_string(rng, 10, 20).into_bytes(),
+            ticker: gen_random_alnum_string(rng, 10, 20).into_bytes(),
+            icon_uri: Some(gen_random_alnum_string(rng, 10, 20).into_bytes()).into(),
+            additional_metadata_uri: Some(gen_random_alnum_string(rng, 10, 20).into_bytes()).into(),
+            media_uri: Some(gen_random_alnum_string(rng, 10, 20).into_bytes()).into(),
+            media_hash: gen_random_bytes(rng, 10, 20),
+        },
+    })
+}
+
+pub fn wallet_new_dest(wallet: &mut DefaultWallet) -> Destination {
+    wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1.into_object()
+}
+
+pub fn random_pub_key(rng: &mut (impl Rng + CryptoRng)) -> PublicKey {
+    PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr).1
+}
+
+pub fn random_vrf_pub_key(rng: &mut (impl Rng + CryptoRng)) -> VRFPublicKey {
+    VRFPrivateKey::new_from_rng(rng, VRFKeyKind::Schnorrkel).1
+}
+
+pub fn tx_with_outputs(outputs: Vec<TxOutput>) -> SignedTransaction {
+    SignedTransaction::new(Transaction::new(0, vec![], outputs).unwrap(), Vec::new()).unwrap()
+}
+
+pub fn create_block_scan_wallet<B, P>(
+    chain_config: &ChainConfig,
+    wallet: &mut Wallet<B, P>,
+    transactions: Vec<SignedTransaction>,
+    reward: Amount,
+    reward_dest: Destination,
+    block_height: u64,
+) -> Block
+where
+    B: storage::Backend + 'static,
+    P: SignerProvider,
+{
+    let block = Block::new(
+        transactions,
+        chain_config.genesis_block_id(),
+        chain_config.genesis_block().timestamp(),
+        ConsensusData::None,
+        BlockReward::new(vec![TxOutput::Transfer(
+            OutputValue::Coin(reward),
+            reward_dest,
+        )]),
+    )
+    .unwrap();
+
+    scan_wallet(wallet, BlockHeight::new(block_height), vec![block.clone()]);
+    block
+}
+
+pub const MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+pub struct TestTokenData {
+    pub id: TokenId,
+    pub num_decimals: u8,
+    pub ticker: String,
+    pub metadata_uri: String,
+    pub total_supply: TokenTotalSupply,
+    pub authority: Destination,
+    pub is_freezable: IsTokenFreezable,
+}
+
+pub fn random_token_data_with_id_and_authority(
+    token_id: TokenId,
+    authority: Destination,
+    rng: &mut impl Rng,
+) -> TestTokenData {
+    TestTokenData {
+        id: token_id,
+        num_decimals: rng.gen_range(1..20),
+        ticker: gen_random_alnum_string(rng, 5, 10),
+        metadata_uri: gen_random_alnum_string(rng, 5, 10),
+        total_supply: random_token_total_supply(rng),
+        authority,
+        is_freezable: random_is_token_freezable(rng),
+    }
+}
+
+pub struct TestOrderData {
+    pub id: OrderId,
+    pub initially_asked: OutputValue,
+    pub initially_given: OutputValue,
+    pub ask_balance: Amount,
+    pub give_balance: Amount,
+    pub conclude_key: Destination,
+}
+
+pub struct OrderCurrencies {
+    pub ask: Currency,
+    pub give: Currency,
+}
+
+pub fn random_order_currencies_with_token(
+    rng: &mut impl Rng,
+    token_id: TokenId,
+) -> OrderCurrencies {
+    if rng.gen_bool(0.5) {
+        OrderCurrencies {
+            ask: Currency::Coin,
+            give: Currency::Token(token_id),
+        }
+    } else {
+        OrderCurrencies {
+            ask: Currency::Token(token_id),
+            give: Currency::Coin,
+        }
+    }
+}

--- a/wallet/wallet-node-client/Cargo.toml
+++ b/wallet/wallet-node-client/Cargo.toml
@@ -23,16 +23,17 @@ subsystem = { path = "../../subsystem" }
 utils-networking = { path = "../../utils/networking" }
 wallet-types = { path = "../types" }
 
+anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+mockall.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }
 tower.workspace = true
 
 [dev-dependencies]
 chainstate-storage = { path = "../../chainstate/storage" }
-
-tokio = { workspace = true, default-features = false, features = ["io-util", "macros", "net", "rt", "sync"] }
 
 [features]
 trezor = ["wallet-types/trezor"]

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -103,7 +103,7 @@ impl WalletHandlesClient {
 impl NodeInterface for WalletHandlesClient {
     type Error = WalletHandlesClientError;
 
-    fn is_cold_wallet_node(&self) -> WalletControllerMode {
+    async fn is_cold_wallet_node(&self) -> WalletControllerMode {
         WalletControllerMode::Hot
     }
 

--- a/wallet/wallet-node-client/src/lib.rs
+++ b/wallet/wallet-node-client/src/lib.rs
@@ -26,6 +26,7 @@ use rpc::RpcAuthData;
 use rpc_client::NodeRpcError;
 
 pub mod handles_client;
+pub mod mock;
 pub mod node_traits;
 pub mod rpc_client;
 

--- a/wallet/wallet-node-client/src/mock.rs
+++ b/wallet/wallet-node-client/src/mock.rs
@@ -1,0 +1,297 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+
+use chainstate::ChainInfo;
+use common::{
+    chain::{
+        tokens::{RPCTokenInfo, TokenId},
+        Block, DelegationId, Destination, GenBlock, OrderId, PoolId, RpcOrderInfo,
+        SignedTransaction, Transaction, TxOutput, UtxoOutPoint,
+    },
+    primitives::{time::Time, Amount, BlockHeight, Id},
+};
+use consensus::GenerateBlockInputData;
+use crypto::ephemeral_e2e::EndToEndPublicKey;
+use mempool::{tx_accumulator::PackingStrategy, tx_options::TxOptionsOverrides, FeeRate};
+use p2p::{
+    interface::types::ConnectedPeer,
+    types::{bannable_address::BannableAddress, socket_address::SocketAddress, PeerId},
+};
+use tokio::sync::{Mutex, MutexGuard};
+use utils_networking::IpOrSocketAddress;
+use wallet_types::wallet_type::WalletControllerMode;
+
+use crate::node_traits::{MockNodeInterface, NodeInterface};
+
+/// `Controller` requires the provided `impl NodeInterface` to also implement `Clone`.
+/// There is no way to make `MockNodeInterface` itself clonable, since `mockall::automock` doesn't
+/// support this, so this wrapper can be used as a workaround.
+#[derive(Clone)]
+pub struct ClonableMockNodeInterface(pub Arc<Mutex<MockNodeInterface>>);
+
+impl ClonableMockNodeInterface {
+    pub fn from_mock(mock: MockNodeInterface) -> Self {
+        Self(Arc::new(Mutex::new(mock)))
+    }
+
+    pub async fn lock(&self) -> MutexGuard<'_, MockNodeInterface> {
+        self.0.lock().await
+    }
+}
+
+#[async_trait::async_trait]
+impl NodeInterface for ClonableMockNodeInterface {
+    type Error = <MockNodeInterface as NodeInterface>::Error;
+
+    async fn is_cold_wallet_node(&self) -> WalletControllerMode {
+        self.lock().await.is_cold_wallet_node().await
+    }
+
+    async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error> {
+        self.lock().await.chainstate_info().await
+    }
+
+    async fn get_best_block_id(&self) -> Result<Id<GenBlock>, Self::Error> {
+        self.lock().await.get_best_block_id().await
+    }
+
+    async fn get_block(&self, block_id: Id<Block>) -> Result<Option<Block>, Self::Error> {
+        self.lock().await.get_block(block_id).await
+    }
+
+    async fn get_mainchain_blocks(
+        &self,
+        from: BlockHeight,
+        max_count: usize,
+    ) -> Result<Vec<Block>, Self::Error> {
+        self.lock().await.get_mainchain_blocks(from, max_count).await
+    }
+
+    async fn get_block_ids_as_checkpoints(
+        &self,
+        start_height: BlockHeight,
+        end_height: BlockHeight,
+        step: NonZeroUsize,
+    ) -> Result<Vec<(BlockHeight, Id<GenBlock>)>, Self::Error> {
+        self.0
+            .lock()
+            .await
+            .get_block_ids_as_checkpoints(start_height, end_height, step)
+            .await
+    }
+
+    async fn get_best_block_height(&self) -> Result<BlockHeight, Self::Error> {
+        self.lock().await.get_best_block_height().await
+    }
+
+    async fn get_block_id_at_height(
+        &self,
+        height: BlockHeight,
+    ) -> Result<Option<Id<GenBlock>>, Self::Error> {
+        self.lock().await.get_block_id_at_height(height).await
+    }
+
+    async fn get_last_common_ancestor(
+        &self,
+        first_block: Id<GenBlock>,
+        second_block: Id<GenBlock>,
+    ) -> Result<Option<(Id<GenBlock>, BlockHeight)>, Self::Error> {
+        self.lock().await.get_last_common_ancestor(first_block, second_block).await
+    }
+
+    async fn get_stake_pool_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {
+        self.lock().await.get_stake_pool_balance(pool_id).await
+    }
+
+    async fn get_staker_balance(&self, pool_id: PoolId) -> Result<Option<Amount>, Self::Error> {
+        self.lock().await.get_staker_balance(pool_id).await
+    }
+
+    async fn get_pool_decommission_destination(
+        &self,
+        pool_id: PoolId,
+    ) -> Result<Option<Destination>, Self::Error> {
+        self.lock().await.get_pool_decommission_destination(pool_id).await
+    }
+
+    async fn get_delegation_share(
+        &self,
+        pool_id: PoolId,
+        delegation_id: DelegationId,
+    ) -> Result<Option<Amount>, Self::Error> {
+        self.lock().await.get_delegation_share(pool_id, delegation_id).await
+    }
+
+    async fn get_token_info(&self, token_id: TokenId) -> Result<Option<RPCTokenInfo>, Self::Error> {
+        self.lock().await.get_token_info(token_id).await
+    }
+
+    async fn get_order_info(&self, order_id: OrderId) -> Result<Option<RpcOrderInfo>, Self::Error> {
+        self.lock().await.get_order_info(order_id).await
+    }
+
+    async fn blockprod_e2e_public_key(&self) -> Result<EndToEndPublicKey, Self::Error> {
+        self.lock().await.blockprod_e2e_public_key().await
+    }
+
+    async fn generate_block(
+        &self,
+        input_data: GenerateBlockInputData,
+        transactions: Vec<SignedTransaction>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
+    ) -> Result<Block, Self::Error> {
+        self.0
+            .lock()
+            .await
+            .generate_block(input_data, transactions, transaction_ids, packing_strategy)
+            .await
+    }
+
+    async fn generate_block_e2e(
+        &self,
+        encrypted_input_data: Vec<u8>,
+        public_key: EndToEndPublicKey,
+        transactions: Vec<SignedTransaction>,
+        transaction_ids: Vec<Id<Transaction>>,
+        packing_strategy: PackingStrategy,
+    ) -> Result<Block, Self::Error> {
+        self.0
+            .lock()
+            .await
+            .generate_block_e2e(
+                encrypted_input_data,
+                public_key,
+                transactions,
+                transaction_ids,
+                packing_strategy,
+            )
+            .await
+    }
+
+    async fn collect_timestamp_search_data(
+        &self,
+        pool_id: PoolId,
+        min_height: BlockHeight,
+        max_height: Option<BlockHeight>,
+        seconds_to_check_for_height: u64,
+        check_all_timestamps_between_blocks: bool,
+    ) -> Result<blockprod::TimestampSearchData, Self::Error> {
+        self.0
+            .lock()
+            .await
+            .collect_timestamp_search_data(
+                pool_id,
+                min_height,
+                max_height,
+                seconds_to_check_for_height,
+                check_all_timestamps_between_blocks,
+            )
+            .await
+    }
+
+    async fn submit_block(&self, block: Block) -> Result<(), Self::Error> {
+        self.lock().await.submit_block(block).await
+    }
+
+    async fn submit_transaction(
+        &self,
+        tx: SignedTransaction,
+        opts: TxOptionsOverrides,
+    ) -> Result<(), Self::Error> {
+        self.lock().await.submit_transaction(tx, opts).await
+    }
+
+    async fn node_shutdown(&self) -> Result<(), Self::Error> {
+        self.lock().await.node_shutdown().await
+    }
+
+    async fn node_enable_networking(&self, enable: bool) -> Result<(), Self::Error> {
+        self.lock().await.node_enable_networking(enable).await
+    }
+
+    async fn node_version(&self) -> Result<String, Self::Error> {
+        self.lock().await.node_version().await
+    }
+
+    async fn p2p_connect(&self, address: IpOrSocketAddress) -> Result<(), Self::Error> {
+        self.lock().await.p2p_connect(address).await
+    }
+
+    async fn p2p_disconnect(&self, peer_id: PeerId) -> Result<(), Self::Error> {
+        self.lock().await.p2p_disconnect(peer_id).await
+    }
+
+    async fn p2p_list_banned(&self) -> Result<Vec<(BannableAddress, Time)>, Self::Error> {
+        self.lock().await.p2p_list_banned().await
+    }
+
+    async fn p2p_ban(
+        &self,
+        address: BannableAddress,
+        duration: Duration,
+    ) -> Result<(), Self::Error> {
+        self.lock().await.p2p_ban(address, duration).await
+    }
+
+    async fn p2p_unban(&self, address: BannableAddress) -> Result<(), Self::Error> {
+        self.lock().await.p2p_unban(address).await
+    }
+
+    async fn p2p_list_discouraged(&self) -> Result<Vec<(BannableAddress, Time)>, Self::Error> {
+        self.lock().await.p2p_list_discouraged().await
+    }
+
+    async fn p2p_undiscourage(&self, address: BannableAddress) -> Result<(), Self::Error> {
+        self.lock().await.p2p_undiscourage(address).await
+    }
+
+    async fn p2p_get_peer_count(&self) -> Result<usize, Self::Error> {
+        self.lock().await.p2p_get_peer_count().await
+    }
+
+    async fn p2p_get_connected_peers(&self) -> Result<Vec<ConnectedPeer>, Self::Error> {
+        self.lock().await.p2p_get_connected_peers().await
+    }
+
+    async fn p2p_get_reserved_nodes(&self) -> Result<Vec<SocketAddress>, Self::Error> {
+        self.lock().await.p2p_get_reserved_nodes().await
+    }
+
+    async fn p2p_add_reserved_node(&self, address: IpOrSocketAddress) -> Result<(), Self::Error> {
+        self.lock().await.p2p_add_reserved_node(address).await
+    }
+
+    async fn p2p_remove_reserved_node(
+        &self,
+        address: IpOrSocketAddress,
+    ) -> Result<(), Self::Error> {
+        self.lock().await.p2p_remove_reserved_node(address).await
+    }
+
+    async fn mempool_get_fee_rate(&self, in_top_x_mb: usize) -> Result<FeeRate, Self::Error> {
+        self.lock().await.mempool_get_fee_rate(in_top_x_mb).await
+    }
+
+    async fn mempool_get_fee_rate_points(&self) -> Result<Vec<(usize, FeeRate)>, Self::Error> {
+        self.lock().await.mempool_get_fee_rate_points().await
+    }
+
+    async fn get_utxo(&self, outpoint: UtxoOutPoint) -> Result<Option<TxOutput>, Self::Error> {
+        self.lock().await.get_utxo(outpoint).await
+    }
+}

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -24,20 +24,22 @@ use common::{
     },
     primitives::{time::Time, Amount, BlockHeight, Id},
 };
-
 use consensus::GenerateBlockInputData;
 use crypto::ephemeral_e2e::EndToEndPublicKey;
 use mempool::{tx_accumulator::PackingStrategy, tx_options::TxOptionsOverrides, FeeRate};
 use p2p::types::{bannable_address::BannableAddress, socket_address::SocketAddress};
-pub use p2p::{interface::types::ConnectedPeer, types::peer_id::PeerId};
 use utils_networking::IpOrSocketAddress;
 use wallet_types::wallet_type::WalletControllerMode;
 
+pub use p2p::{interface::types::ConnectedPeer, types::peer_id::PeerId};
+
+#[mockall::automock(type Error = anyhow::Error;)]
 #[async_trait::async_trait]
 pub trait NodeInterface {
-    type Error: std::error::Error + Send + Sync + 'static;
+    // Note: not requiring the `Error` trait here so that `anyhow::Error` can be used.
+    type Error: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static;
 
-    fn is_cold_wallet_node(&self) -> WalletControllerMode;
+    async fn is_cold_wallet_node(&self) -> WalletControllerMode;
 
     async fn chainstate_info(&self) -> Result<ChainInfo, Self::Error>;
     async fn get_best_block_id(&self) -> Result<Id<GenBlock>, Self::Error>;

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -48,7 +48,7 @@ use super::{NodeRpcClient, NodeRpcError};
 impl NodeInterface for NodeRpcClient {
     type Error = NodeRpcError;
 
-    fn is_cold_wallet_node(&self) -> WalletControllerMode {
+    async fn is_cold_wallet_node(&self) -> WalletControllerMode {
         WalletControllerMode::Hot
     }
 

--- a/wallet/wallet-node-client/src/rpc_client/cold_wallet_client.rs
+++ b/wallet/wallet-node-client/src/rpc_client/cold_wallet_client.rs
@@ -49,7 +49,7 @@ pub enum ColdWalletRpcError {
 impl NodeInterface for ColdWalletClient {
     type Error = ColdWalletRpcError;
 
-    fn is_cold_wallet_node(&self) -> WalletControllerMode {
+    async fn is_cold_wallet_node(&self) -> WalletControllerMode {
         WalletControllerMode::Cold
     }
 

--- a/wallet/wallet-rpc-lib/Cargo.toml
+++ b/wallet/wallet-rpc-lib/Cargo.toml
@@ -31,12 +31,12 @@ async-trait.workspace = true
 clap.workspace = true
 enum-iterator.workspace = true
 futures.workspace = true
+hex.workspace = true
 jsonrpsee.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-hex.workspace = true
 
 [dev-dependencies]
 

--- a/wallet/wallet-rpc-lib/src/lib.rs
+++ b/wallet/wallet-rpc-lib/src/lib.rs
@@ -102,8 +102,9 @@ pub async fn start_services<N>(
 where
     N: NodeInterface + Clone + Sync + Send + 'static + Debug,
 {
+    let is_cold_wallet_node = node_rpc.is_cold_wallet_node().await;
     let wallet_type = wallet_config.hardware_wallet_type.map_or_else(
-        || node_rpc.is_cold_wallet_node().into(),
+        || is_cold_wallet_node.into(),
         |hw| match hw {
             #[cfg(feature = "trezor")]
             HardwareWalletType::Trezor { device_id: _ } => WalletType::Trezor,

--- a/wallet/wallet-rpc-lib/src/rpc/mod.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/mod.rs
@@ -155,13 +155,13 @@ where
         scan_blockchain: ScanBlockchain,
         open_as_hw_wallet: Option<HardwareWalletType>,
     ) -> WRpcResult<OpenedWallet, N> {
-        let (open_as_wallet_type, device_id) = open_as_hw_wallet.map_or(
-            (self.node.is_cold_wallet_node().into(), None),
-            |hw| match hw {
-                #[cfg(feature = "trezor")]
-                HardwareWalletType::Trezor { device_id } => (WalletType::Trezor, device_id),
-            },
-        );
+        let (open_as_wallet_type, device_id) =
+            open_as_hw_wallet.map_or((self.node.is_cold_wallet_node().await.into(), None), |hw| {
+                match hw {
+                    #[cfg(feature = "trezor")]
+                    HardwareWalletType::Trezor { device_id } => (WalletType::Trezor, device_id),
+                }
+            });
         Ok(self
             .wallet
             .manage_async(move |wallet_manager| {

--- a/wallet/wallet-rpc-lib/src/rpc/types.rs
+++ b/wallet/wallet-rpc-lib/src/rpc/types.rs
@@ -108,7 +108,7 @@ pub enum RpcError<N: NodeInterface> {
     #[error("Invalid block ID")]
     InvalidBlockId,
 
-    #[error("Wallet error: {0}")]
+    #[error("Wallet controller error: {0}")]
     Controller(#[from] wallet_controller::ControllerError<N>),
 
     #[error("RPC error: {0}")]

--- a/wallet/wallet-rpc-lib/src/service/mod.rs
+++ b/wallet/wallet-rpc-lib/src/service/mod.rs
@@ -73,7 +73,7 @@ where
                     chain_config.shallow_clone(),
                     wallet_file,
                     wallet_password,
-                    node_rpc.is_cold_wallet_node(),
+                    node_rpc.is_cold_wallet_node().await,
                     force_change_wallet_type,
                     *open_as_wallet_type,
                     None,

--- a/wallet/wallet-rpc-lib/src/service/worker.rs
+++ b/wallet/wallet-rpc-lib/src/service/worker.rs
@@ -168,7 +168,7 @@ where
             self.chain_config.clone(),
             wallet_path,
             password,
-            self.node_rpc.is_cold_wallet_node(),
+            self.node_rpc.is_cold_wallet_node().await,
             force_migrate_wallet_type,
             open_as_wallet_type,
             device_id,
@@ -213,7 +213,7 @@ where
             self.controller.is_none(),
             ControllerError::WalletFileAlreadyOpen
         );
-        let wallet_type = args.wallet_type(self.node_rpc.is_cold_wallet_node());
+        let wallet_type = args.wallet_type(self.node_rpc.is_cold_wallet_node().await);
         let (computed_args, wallet_created) =
             args.parse_or_generate_mnemonic_if_needed().map_err(RpcError::InvalidMnemonic)?;
 


### PR DESCRIPTION
1. Tests for `tx_to_partially_signed_tx` and `compose_transaction` were added in `wallet-controller`.
2. `tx_to_partially_signed_tx` now accepts a list of HTLC secrets (though it's only used in tests for now).
3. `compose_transaction` had a bug where `HtlcSpendingCondition::WithSecret` would always be used even if None's were passed for the htlc secrets; this is fixed now.
4. A few utility functions from wallet tests were moved to `wallet/src/wallet/test_helpers.rs`, which is a test-only module that lives in production code. This is ugly, but there is no good alternative when we want to re-use the same code in unit tests of other components (and we already use this approach in p2p).
5. Some minor cleanup here and there.
6. I also removed `Model::TrezorLegacy` from Trezor model lists when searching for a device, because we don't really support it.