### PR TITLE
Force fontconfig-parser version to v0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,9 +2752,8 @@ dependencies = [
 
 [[package]]
 name = "fontconfig-parser"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+version = "0.5.7"
+source = "git+https://github.com/Riey/fontconfig-parser?rev=f7d13a779e6ee282ce75acbc00a1270c0350e0c2#f7d13a779e6ee282ce75acbc00a1270c0350e0c2"
 dependencies = [
  "roxmltree",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,3 +286,14 @@ opt-level = 2
 [features]
 trezor = []
 default = ["trezor"]
+
+[patch.crates-io]
+# Using fontconfig-parser v0.5.8 completely breaks UI in node-gui on Linux - most of the text disappears and the few
+# characters that remain have broken spacing, so we force the usage of v0.5.7 via "patch".
+# Note: the commit is called "Bump version" and it's where the version was bumped to "0.5.7"; it is the last "good"
+# revision. The following ("bad") revision belongs to the PR https://github.com/Riey/fontconfig-parser/pull/11 which
+# claims to fix certain issues. So it's possible that fontconfig-parser v0.5.8 is actually good, but a dependent crate
+# uses it incorrectly (so v0.5.7 works only because several bugs cancel each other out). The current dependency chain
+# is fontconfig-parser <- fontdb <- cosmic-text <- various "iced" crates.
+# TODO: investigate this further.
+fontconfig-parser = { git = "https://github.com/Riey/fontconfig-parser", rev = "f7d13a779e6ee282ce75acbc00a1270c0350e0c2" }


### PR DESCRIPTION
Today I discovered that when built from master, node-gui UI looks like this on my Ubuntu machine:

<img width="700" alt="node_gui_broken1" src="https://github.com/user-attachments/assets/b2b0a067-a7ac-4fdf-9837-0603805d7218" />
<img width="700" alt="node_gui_broken2" src="https://github.com/user-attachments/assets/8dfb2b64-7ab7-4dd8-a0d6-6fd86f779510" />
<img width="700" alt="node_gui_broken3" src="https://github.com/user-attachments/assets/45f2b59a-d519-4737-9a27-8186f30ef555" />

The first bad commit is 8dbc6b94a8243f4e3de13c0fcce64425f5065eb1 where the only significant changes are those in `Cargo.lock`. I managed to narrow it down to the `fontconfig-parser` crate which was updated from v0.5.7 to v0.5.8 in that commit.
So in this PR I forcibly set the version back to 0.5.7 via `[patch]`. This is a hacky fix though, ideally we should find the real culprit (which may not be `fontconfig-parser` itself) and at least file a bug report.

Update: it seems that the issue is specific to MATE desktop. I.e. I was able to reproduce it on a fresh install of Ubuntu MATE, but not on a fresh install of the vanilla Ubuntu.