### PR TITLE
Fix a spurious test failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8173,6 +8173,7 @@ dependencies = [
  "regex",
  "rstest",
  "serialization",
+ "strum",
  "utils",
 ]
 

--- a/api-server/stack-test-suite/tests/v2/helpers.rs
+++ b/api-server/stack-test-suite/tests/v2/helpers.rs
@@ -159,7 +159,7 @@ pub fn issue_and_mint_tokens_from_genesis(
 ) -> IssueAndMintTokensResult {
     let token_issuance_fee = tf.chainstate.get_chain_config().fungible_token_issuance_fee();
 
-    let issuance = test_utils::nft_utils::random_token_issuance_v1(
+    let issuance = test_utils::token_utils::random_token_issuance_v1(
         tf.chain_config(),
         Destination::AnyoneCanSpend,
         rng,

--- a/api-server/stack-test-suite/tests/v2/nft.rs
+++ b/api-server/stack-test-suite/tests/v2/nft.rs
@@ -93,7 +93,7 @@ async fn ok(#[case] seed: Seed) {
 
                 let alice_destination = Destination::PublicKeyHash(PublicKeyHash::from(&alice_pk));
 
-                let nft = test_utils::nft_utils::random_nft_issuance(&chain_config, &mut rng);
+                let nft = test_utils::token_utils::random_nft_issuance(&chain_config, &mut rng);
 
                 let input = TxInput::from_utxo(
                     OutPointSourceId::BlockReward(tf.genesis().get_id().into()),

--- a/api-server/stack-test-suite/tests/v2/token_ids.rs
+++ b/api-server/stack-test-suite/tests/v2/token_ids.rs
@@ -144,7 +144,7 @@ async fn ok(#[case] seed: Seed) {
 
                 let mut nft_ids = vec![];
                 for _ in 0..10 {
-                    let nft = test_utils::nft_utils::random_nft_issuance(&chain_config, &mut rng);
+                    let nft = test_utils::token_utils::random_nft_issuance(&chain_config, &mut rng);
                     let token_id =
                         make_token_id(&chain_config, tf.next_block_height(), &[input.clone()])
                             .unwrap();

--- a/api-server/stack-test-suite/tests/v2/token_ticker.rs
+++ b/api-server/stack-test-suite/tests/v2/token_ticker.rs
@@ -147,7 +147,7 @@ async fn ok(#[case] seed: Seed) {
                 let mut nft_ids = vec![];
                 for _ in 0..10 {
                     let mut nft =
-                        test_utils::nft_utils::random_nft_issuance(&chain_config, &mut rng);
+                        test_utils::token_utils::random_nft_issuance(&chain_config, &mut rng);
                     nft.metadata.ticker = token_ticker.as_bytes().to_vec();
                     let token_id =
                         make_token_id(&chain_config, tf.next_block_height(), &[input.clone()])

--- a/api-server/stack-test-suite/tests/v2/transaction.rs
+++ b/api-server/stack-test-suite/tests/v2/transaction.rs
@@ -467,7 +467,7 @@ async fn mint_tokens(#[case] seed: Seed) {
                 let token_issuance_fee =
                     tf.chainstate.get_chain_config().fungible_token_issuance_fee();
 
-                let issuance = test_utils::nft_utils::random_token_issuance_v1(
+                let issuance = test_utils::token_utils::random_token_issuance_v1(
                     tf.chain_config(),
                     Destination::AnyoneCanSpend,
                     &mut rng,

--- a/chainstate/constraints-value-accumulator/src/tests/constraints_tests.rs
+++ b/chainstate/constraints-value-accumulator/src/tests/constraints_tests.rs
@@ -37,8 +37,8 @@ use pos_accounting::{DelegationData, InMemoryPoSAccounting, PoSAccountingDB, Poo
 use randomness::{CryptoRng, Rng};
 use rstest::rstest;
 use test_utils::{
-    nft_utils::random_nft_issuance,
     random::{make_seedable_rng, Seed},
+    token_utils::random_nft_issuance,
 };
 
 use crate::{ConstrainedValueAccumulator, Error};
@@ -755,7 +755,7 @@ fn calculate_fee_for_token_issuance(#[case] seed: Seed) {
     ))];
 
     let outputs = vec![TxOutput::IssueFungibleToken(Box::new(TokenIssuance::V1(
-        test_utils::nft_utils::random_token_issuance_v1(
+        test_utils::token_utils::random_token_issuance_v1(
             &chain_config,
             Destination::AnyoneCanSpend,
             &mut rng,
@@ -805,7 +805,7 @@ fn calculate_token_supply_change_fee(#[case] seed: Seed) {
     let orders_db = OrdersAccountingDB::new(&orders_store);
 
     let token_data = tokens_accounting::TokenData::FungibleToken(
-        TokenIssuance::V1(test_utils::nft_utils::random_token_issuance_v1(
+        TokenIssuance::V1(test_utils::token_utils::random_token_issuance_v1(
             &chain_config,
             Destination::AnyoneCanSpend,
             &mut rng,
@@ -978,7 +978,7 @@ fn calculate_token_fee_freeze(#[case] seed: Seed) {
     let orders_db = OrdersAccountingDB::new(&orders_store);
 
     let token_data = tokens_accounting::TokenData::FungibleToken(
-        TokenIssuance::V1(test_utils::nft_utils::random_token_issuance_v1(
+        TokenIssuance::V1(test_utils::token_utils::random_token_issuance_v1(
             &chain_config,
             Destination::AnyoneCanSpend,
             &mut rng,
@@ -1110,7 +1110,7 @@ fn calculate_token_fee_change_authority(#[case] seed: Seed) {
     let orders_db = OrdersAccountingDB::new(&orders_store);
 
     let token_data = tokens_accounting::TokenData::FungibleToken(
-        TokenIssuance::V1(test_utils::nft_utils::random_token_issuance_v1(
+        TokenIssuance::V1(test_utils::token_utils::random_token_issuance_v1(
             &chain_config,
             Destination::AnyoneCanSpend,
             &mut rng,
@@ -1305,7 +1305,7 @@ fn calculate_token_fee_change_metadata_uri(#[case] seed: Seed) {
     let orders_db = OrdersAccountingDB::new(&orders_store);
 
     let token_data = tokens_accounting::TokenData::FungibleToken(
-        TokenIssuance::V1(test_utils::nft_utils::random_token_issuance_v1(
+        TokenIssuance::V1(test_utils::token_utils::random_token_issuance_v1(
             &chain_config,
             Destination::AnyoneCanSpend,
             &mut rng,

--- a/chainstate/test-framework/src/random_tx_maker.rs
+++ b/chainstate/test-framework/src/random_tx_maker.rs
@@ -50,7 +50,7 @@ use pos_accounting::{
     PoolData,
 };
 use randomness::{seq::IteratorRandom, CryptoRng, Rng, SliceRandom};
-use test_utils::{nft_utils::*, random_ascii_alphanumeric_string};
+use test_utils::{random_ascii_alphanumeric_string, token_utils::*};
 use tokens_accounting::{
     InMemoryTokensAccounting, TokensAccountingCache, TokensAccountingDB, TokensAccountingDeltaData,
     TokensAccountingOperations, TokensAccountingView,

--- a/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_storage_tests.rs
@@ -29,7 +29,7 @@ use common::{
     },
     primitives::{Amount, Id, Idable},
 };
-use test_utils::nft_utils::random_nft_issuance;
+use test_utils::token_utils::random_nft_issuance;
 use utxo::{Utxo, UtxosStorageRead, UtxosTxUndo};
 
 use super::*;

--- a/chainstate/test-suite/src/tests/fungible_tokens.rs
+++ b/chainstate/test-suite/src/tests/fungible_tokens.rs
@@ -38,9 +38,9 @@ use crypto::hash::StreamHasher;
 use randomness::{CryptoRng, Rng};
 use serialization::extras::non_empty_vec::DataOrNoVec;
 use test_utils::{
-    nft_utils::random_token_issuance,
     random::{make_seedable_rng, Seed},
     random_ascii_alphanumeric_string,
+    token_utils::random_token_issuance,
 };
 use tx_verifier::CheckTransactionError;
 

--- a/chainstate/test-suite/src/tests/homomorphism.rs
+++ b/chainstate/test-suite/src/tests/homomorphism.rs
@@ -28,7 +28,7 @@ use common::{
     primitives::{Amount, Idable},
 };
 use crypto::vrf::{VRFKeyKind, VRFPrivateKey};
-use test_utils::nft_utils::random_token_issuance_v1;
+use test_utils::token_utils::random_token_issuance_v1;
 
 // These tests prove that TransactionVerifiers hierarchy has homomorphic property: f(ab) == f(a)f(b)
 // Meaning that multiple operations done via a single verifier give the same result as using one

--- a/chainstate/test-suite/src/tests/htlc.rs
+++ b/chainstate/test-suite/src/tests/htlc.rs
@@ -50,7 +50,7 @@ use common::{
 use crypto::key::{KeyKind, PrivateKey, PublicKey};
 use randomness::CryptoRng;
 use serialization::Encode;
-use test_utils::nft_utils::{random_token_issuance, random_token_issuance_v1};
+use test_utils::token_utils::{random_token_issuance, random_token_issuance_v1};
 use tx_verifier::{
     error::{InputCheckError, TranslationError},
     input_check::HashlockError,

--- a/chainstate/test-suite/src/tests/nft_burn.rs
+++ b/chainstate/test-suite/src/tests/nft_burn.rs
@@ -27,8 +27,8 @@ use common::{
 };
 use randomness::Rng;
 use test_utils::{
-    nft_utils::random_nft_issuance,
     random::{make_seedable_rng, Seed},
+    token_utils::random_nft_issuance,
 };
 
 #[rstest]

--- a/chainstate/test-suite/src/tests/nft_issuance.rs
+++ b/chainstate/test-suite/src/tests/nft_issuance.rs
@@ -35,9 +35,9 @@ use randomness::{CryptoRng, Rng};
 use serialization::extras::non_empty_vec::DataOrNoVec;
 use test_utils::{
     gen_text_with_non_ascii,
-    nft_utils::{random_creator, random_nft_issuance, random_token_issuance_v1},
     random::{make_seedable_rng, Seed},
     random_ascii_alphanumeric_string,
+    token_utils::{random_creator, random_nft_issuance, random_token_issuance_v1},
 };
 use tx_verifier::{error::TokenIssuanceError, CheckTransactionError};
 

--- a/chainstate/test-suite/src/tests/nft_reorgs.rs
+++ b/chainstate/test-suite/src/tests/nft_reorgs.rs
@@ -26,8 +26,8 @@ use common::{
 };
 use rstest::rstest;
 use test_utils::{
-    nft_utils::random_nft_issuance,
     random::{make_seedable_rng, Seed},
+    token_utils::random_nft_issuance,
 };
 
 #[rstest]

--- a/chainstate/test-suite/src/tests/nft_transfer.rs
+++ b/chainstate/test-suite/src/tests/nft_transfer.rs
@@ -29,8 +29,8 @@ use common::{
 };
 use randomness::Rng;
 use test_utils::{
-    nft_utils::random_nft_issuance,
     random::{make_seedable_rng, Seed},
+    token_utils::random_nft_issuance,
 };
 
 #[rstest]

--- a/chainstate/test-suite/src/tests/orders_tests.rs
+++ b/chainstate/test-suite/src/tests/orders_tests.rs
@@ -46,8 +46,8 @@ use crypto::key::{KeyKind, PrivateKey};
 use logging::log;
 use randomness::{CryptoRng, Rng, SliceRandom};
 use test_utils::{
-    nft_utils::random_nft_issuance,
     random::{gen_random_bytes, make_seedable_rng, Seed},
+    token_utils::random_nft_issuance,
 };
 use tx_verifier::{
     error::{InputCheckError, InputCheckErrorPayload, ScriptError, TranslationError},

--- a/chainstate/test-suite/src/tests/stake_pool_tests.rs
+++ b/chainstate/test-suite/src/tests/stake_pool_tests.rs
@@ -46,8 +46,8 @@ use crypto::{
 use pos_accounting::PoSAccountingStorageRead;
 use randomness::Rng;
 use test_utils::{
-    nft_utils::random_token_issuance_v1,
     random::{make_seedable_rng, Seed},
+    token_utils::random_token_issuance_v1,
 };
 use tx_verifier::error::{InputCheckError, ScriptError};
 

--- a/common/src/chain/tokens/issuance.rs
+++ b/common/src/chain/tokens/issuance.rs
@@ -29,7 +29,9 @@ use serialization::{Decode, Encode};
     Decode,
     serde::Serialize,
     serde::Deserialize,
+    strum::EnumDiscriminants,
 )]
+#[strum_discriminants(name(TokenTotalSupplyTag), derive(strum::EnumIter))]
 pub enum TokenTotalSupply {
     #[codec(index = 0)]
     Fixed(Amount), // fixed to a certain amount

--- a/p2p/src/sync/tests/no_discouragement_after_tx_reorg.rs
+++ b/p2p/src/sync/tests/no_discouragement_after_tx_reorg.rs
@@ -51,9 +51,10 @@ use p2p_types::PeerId;
 use randomness::Rng;
 use test_utils::{
     assert_matches,
-    nft_utils::random_nft_issuance,
     random::{gen_random_bytes, Seed},
-    random_ascii_alphanumeric_string, BasicTestTimeGetter,
+    random_ascii_alphanumeric_string,
+    token_utils::random_nft_issuance,
+    BasicTestTimeGetter,
 };
 
 use crate::{

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -21,3 +21,4 @@ itertools.workspace = true
 rand_chacha.workspace = true
 regex.workspace = true
 rstest.workspace = true
+strum.workspace = true

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -15,10 +15,10 @@
 
 mod basic_test_time_getter;
 pub mod mock_time_getter;
-pub mod nft_utils;
 pub mod random;
 pub mod test_dir;
 pub mod threading;
+pub mod token_utils;
 
 use std::collections::BTreeMap;
 

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -47,8 +47,8 @@ use serialization::{extras::non_empty_vec::DataOrNoVec, hex::HexEncode, Encode};
 use storage::raw::DbMapId;
 use test_utils::{
     assert_matches, assert_matches_return_val,
-    nft_utils::random_token_issuance_v1,
     random::{make_seedable_rng, Seed},
+    token_utils::random_token_issuance_v1_with_min_supply,
 };
 use wallet_storage::{schema, WalletStorageEncryptionRead};
 use wallet_types::{
@@ -5808,8 +5808,12 @@ fn create_order(#[case] seed: Seed) {
     // Issue a token
     let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
 
-    let token_issuance =
-        random_token_issuance_v1(&chain_config, address2.as_object().clone(), &mut rng);
+    let token_issuance = random_token_issuance_v1_with_min_supply(
+        &chain_config,
+        address2.as_object().clone(),
+        100,
+        &mut rng,
+    );
     let (issued_token_id, token_issuance_transaction) = wallet
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,
@@ -5937,8 +5941,12 @@ fn create_order_and_conclude(#[case] seed: Seed) {
     // Issue a token
     let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
 
-    let token_issuance =
-        random_token_issuance_v1(&chain_config, address2.as_object().clone(), &mut rng);
+    let token_issuance = random_token_issuance_v1_with_min_supply(
+        &chain_config,
+        address2.as_object().clone(),
+        100,
+        &mut rng,
+    );
     let (issued_token_id, token_issuance_transaction) = wallet
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,
@@ -6126,8 +6134,12 @@ fn create_order_fill_completely_conclude(#[case] seed: Seed) {
     // Issue a token
     let address1 = wallet1.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
 
-    let token_issuance =
-        random_token_issuance_v1(&chain_config, address1.as_object().clone(), &mut rng);
+    let token_issuance = random_token_issuance_v1_with_min_supply(
+        &chain_config,
+        address1.as_object().clone(),
+        100,
+        &mut rng,
+    );
     let (issued_token_id, token_issuance_transaction) = wallet1
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,
@@ -6499,8 +6511,12 @@ fn create_order_fill_partially_conclude(#[case] seed: Seed) {
     // Issue a token
     let address1 = wallet1.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
 
-    let token_issuance =
-        random_token_issuance_v1(&chain_config, address1.as_object().clone(), &mut rng);
+    let token_issuance = random_token_issuance_v1_with_min_supply(
+        &chain_config,
+        address1.as_object().clone(),
+        100,
+        &mut rng,
+    );
     let (issued_token_id, token_issuance_transaction) = wallet1
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,
@@ -7350,8 +7366,12 @@ fn conflicting_order_account_nonce(#[case] seed: Seed) {
     // Issue a token
     let address2 = wallet.get_new_address(DEFAULT_ACCOUNT_INDEX).unwrap().1;
 
-    let token_issuance =
-        random_token_issuance_v1(&chain_config, address2.as_object().clone(), &mut rng);
+    let token_issuance = random_token_issuance_v1_with_min_supply(
+        &chain_config,
+        address2.as_object().clone(),
+        100,
+        &mut rng,
+    );
     let (issued_token_id, token_issuance_transaction) = wallet
         .issue_new_token(
             DEFAULT_ACCOUNT_INDEX,


### PR DESCRIPTION
The test `conflicting_order_account_nonce` failed because it tried to mint more tokens than the available total supply; I fixed it and similar tests by specifying a minimum supply amount during token issuance.

I also renamed `test_utils::nft_utils` to `token_utils`