### PR TITLE
Improvements related to wallet-cli pagination mode

### DIFF
--- a/wallet/wallet-cli-lib/src/console.rs
+++ b/wallet/wallet-cli-lib/src/console.rs
@@ -16,6 +16,7 @@
 use std::{collections::VecDeque, path::PathBuf};
 
 use crossterm::tty::IsTty;
+
 use wallet_cli_commands::WalletCliCommandError;
 use wallet_rpc_lib::types::NodeInterface;
 

--- a/wallet/wallet-cli-lib/src/repl/interactive/log.rs
+++ b/wallet/wallet-cli-lib/src/repl/interactive/log.rs
@@ -67,7 +67,10 @@ impl InteractiveLogger {
         // Increase the buffer to prevent dropped log output.
         // Do not use very large buffers here, as this will increase
         // the amount of allocated memory (even if the buffer is not used).
-        let external_printer = reedline::ExternalPrinter::new(1024);
+        // Note that it shouldn't be too small either, because InteractiveLogger is also used
+        // to collect logs when displaying paginated output; 8k should be enough to collect
+        // relatively verbose debug logs for several minutes.
+        let external_printer = reedline::ExternalPrinter::new(8192);
 
         let print_directly = Arc::new(Mutex::new(true));
 


### PR DESCRIPTION
At the start of `paginate_output`:
1. Disable direct logging, so that the output is not polluted with logs (which will appear broken in the raw terminal mode anyway).
2. Enter the alternate terminal screen, so that the existing contents of the terminal window is preserved.