### PR TITLE
Fix some spurious test failures

### DIFF
--- a/api-server/stack-test-suite/tests/v2/htlc.rs
+++ b/api-server/stack-test-suite/tests/v2/htlc.rs
@@ -88,8 +88,9 @@ async fn spend(#[case] seed: Seed) {
                     .build();
 
                 // Issue and mint some tokens to lock in htlc
+                let tokens_amount = Amount::from_atoms(100);
                 let issue_and_mint_result =
-                    helpers::issue_and_mint_tokens_from_genesis(&mut rng, &mut tf);
+                    helpers::issue_and_mint_tokens_from_genesis(tokens_amount, &mut rng, &mut tf);
 
                 // Create htlc
                 let (htlc, _) = create_htlc(&chain_config, &alice_pk, &bob_pk, secret.hash());
@@ -99,10 +100,7 @@ async fn spend(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Htlc(
-                        OutputValue::TokenV1(
-                            issue_and_mint_result.token_id,
-                            Amount::from_atoms(100),
-                        ),
+                        OutputValue::TokenV1(issue_and_mint_result.token_id, tokens_amount),
                         Box::new(htlc),
                     ))
                     .build();
@@ -118,10 +116,7 @@ async fn spend(#[case] seed: Seed) {
                         InputWitness::NoSignature(None),
                     )
                     .add_output(TxOutput::Transfer(
-                        OutputValue::TokenV1(
-                            issue_and_mint_result.token_id,
-                            Amount::from_atoms(100),
-                        ),
+                        OutputValue::TokenV1(issue_and_mint_result.token_id, tokens_amount),
                         Destination::AnyoneCanSpend,
                     ))
                     .build()

--- a/api-server/stack-test-suite/tests/v2/orders.rs
+++ b/api-server/stack-test-suite/tests/v2/orders.rs
@@ -54,14 +54,15 @@ async fn create_fill_conclude_order(#[case] seed: Seed, #[case] version: OrdersV
                     .build();
 
                 // Issue and mint some tokens to create an order with different currencies
+                let tokens_amount = Amount::from_atoms(10);
                 let issue_and_mint_result =
-                    helpers::issue_and_mint_tokens_from_genesis(&mut rng, &mut tf);
+                    helpers::issue_and_mint_tokens_from_genesis(tokens_amount, &mut rng, &mut tf);
 
                 // Create order
                 let order_data = OrderData::new(
                     Destination::AnyoneCanSpend,
                     OutputValue::Coin(Amount::from_atoms(10)),
-                    OutputValue::TokenV1(issue_and_mint_result.token_id, Amount::from_atoms(10)),
+                    OutputValue::TokenV1(issue_and_mint_result.token_id, tokens_amount),
                 );
                 let tx_1 = TransactionBuilder::new()
                     .add_input(
@@ -223,14 +224,15 @@ async fn order_pairs(#[case] seed: Seed) {
                     .build();
 
                 // Issue and mint some tokens to create an order with different currencies
+                let tokens_amount = Amount::from_atoms(10);
                 let issue_and_mint_result =
-                    helpers::issue_and_mint_tokens_from_genesis(&mut rng, &mut tf);
+                    helpers::issue_and_mint_tokens_from_genesis(tokens_amount, &mut rng, &mut tf);
 
                 // Create order
                 let order_data = OrderData::new(
                     Destination::AnyoneCanSpend,
                     OutputValue::Coin(Amount::from_atoms(10)),
-                    OutputValue::TokenV1(issue_and_mint_result.token_id, Amount::from_atoms(10)),
+                    OutputValue::TokenV1(issue_and_mint_result.token_id, tokens_amount),
                 );
                 let tx_1 = TransactionBuilder::new()
                     .add_input(


### PR DESCRIPTION
I've got a spurious failure in the htlc test in the api server due to the token's consumed amount being bigger than the minted amount.
Another failure was in order tests in chainstate where the fill amount was not big enough to produce 1 atom in the given currency (such amounts are not allowed in orders v1).
I also looked through other similar tests and tried to fix them all.