### PR TITLE
Htlc refund via single sig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7248,7 +7248,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes 0.14.0",
  "rand 0.8.5",
  "secp256k1-sys",
 ]
@@ -9101,6 +9101,7 @@ dependencies = [
  "randomness",
  "rpc-description",
  "rstest",
+ "secp256k1",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ license = "MIT"
 [workspace.dependencies]
 addr = "0.15"
 anyhow = "1.0"
+argon2 = "0.5"
 arraytools = "0.1"
 assert_cmd = "2.0"
 async-trait = "0.1"
@@ -175,6 +176,8 @@ generic-array = "0.14"
 heck = "0.5"
 hex = "0.4"
 hex-literal = "0.4"
+hickory-client = "0.24"
+hickory-server = "0.24"
 hmac = "0.12"
 iced = "0.13"
 # Note: we need this fix - https://github.com/iced-rs/iced_aw/pull/329
@@ -189,6 +192,7 @@ libtest-mimic = "0.8"
 log = "0.4"
 loom = "0.7"
 merkletree-mintlayer = "0.1"
+merlin = { version = "3.0", default-features = false }
 mockall = "0.13"
 num = "0.4"
 num-derive = "0.4"
@@ -216,6 +220,7 @@ rlimit = "0.10"
 rstest = "0.24"
 rusqlite = "0.33"
 schnorrkel = "0.11"
+secp256k1 = { version = "0.29", default-features = false }
 semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"
@@ -248,8 +253,7 @@ tokio-util = { version = "0.7", default-features = false }
 toml = "0.8"
 tower = "0.4"
 tower-http-axum = { package = "tower-http", version = "0.5" }
-hickory-client = "0.24"
-hickory-server = "0.24"
+x25519-dalek = "2.0"
 zeroize = "1.5"
 
 [workspace.dependencies.trezor-client]

--- a/api-server/stack-test-suite/tests/v2/htlc.rs
+++ b/api-server/stack-test-suite/tests/v2/htlc.rs
@@ -23,8 +23,8 @@ use common::chain::{
         inputsig::{
             classical_multisig::authorize_classical_multisig::AuthorizedClassicalMultisigSpend,
             htlc::{
-                produce_classical_multisig_signature_for_htlc_input,
-                produce_uniparty_signature_for_htlc_input,
+                produce_classical_multisig_signature_for_htlc_refunding,
+                produce_uniparty_signature_for_htlc_spending,
             },
         },
         sighash::signature_hash,
@@ -123,7 +123,7 @@ async fn spend(#[case] seed: Seed) {
                     .take_transaction();
                 let tx_2_id = tx2.get_id();
 
-                let input_sign = produce_uniparty_signature_for_htlc_input(
+                let input_sign = produce_uniparty_signature_for_htlc_spending(
                     &bob_sk,
                     SigHashType::all(),
                     Destination::PublicKeyHash((&PublicKey::from_private_key(&bob_sk)).into()),
@@ -305,7 +305,7 @@ async fn refund(#[case] seed: Seed) {
                     authorization
                 };
 
-                let input_sign = produce_classical_multisig_signature_for_htlc_input(
+                let input_sign = produce_classical_multisig_signature_for_htlc_refunding(
                     &chain_config,
                     &authorization,
                     SigHashType::all(),

--- a/api-server/web-server/src/api/json_helpers.rs
+++ b/api-server/web-server/src/api/json_helpers.rs
@@ -224,10 +224,10 @@ fn opt_spent_utxo_to_json(
                         .expect("proper signature");
 
                 match htlc_sig {
-                    AuthorizedHashedTimelockContractSpend::Secret(secret, _) => {
+                    AuthorizedHashedTimelockContractSpend::Spend(secret, _) => {
                         Some(to_json_string(secret.secret()))
                     }
-                    AuthorizedHashedTimelockContractSpend::Multisig(_) => None,
+                    AuthorizedHashedTimelockContractSpend::Refund(_) => None,
                 }
             } else {
                 None

--- a/chainstate/test-framework/src/key_manager.rs
+++ b/chainstate/test-framework/src/key_manager.rs
@@ -26,7 +26,7 @@ use common::{
                     sign_classical_multisig_spending, AuthorizedClassicalMultisigSpend,
                     ClassicalMultisigCompletionStatus,
                 },
-                htlc::produce_classical_multisig_signature_for_htlc_input,
+                htlc::produce_classical_multisig_signature_for_htlc_refunding,
                 standard_signature::StandardInputSignature,
                 InputWitness,
             },
@@ -217,7 +217,7 @@ impl KeyManager {
                     match res {
                         ClassicalMultisigCompletionStatus::Complete(sigs) => {
                             let sig = if input_utxo.is_some_and(is_htlc_output) {
-                                produce_classical_multisig_signature_for_htlc_input(
+                                produce_classical_multisig_signature_for_htlc_refunding(
                                     chain_config,
                                     &sigs,
                                     sighash_type,

--- a/chainstate/test-suite/src/tests/htlc.rs
+++ b/chainstate/test-suite/src/tests/htlc.rs
@@ -454,7 +454,7 @@ fn refund_htlc_multisig(#[case] seed: Seed) {
                 let signature = test_fixture.alice_sk.sign_message(&sighash, &mut rng).unwrap();
                 authorization.add_signature(0, signature);
 
-                AuthorizedHashedTimelockContractSpend::Multisig(authorization.encode())
+                AuthorizedHashedTimelockContractSpend::Refund(authorization.encode())
             };
 
             let input_sign =
@@ -511,7 +511,7 @@ fn refund_htlc_multisig(#[case] seed: Seed) {
                 let signature = test_fixture.bob_sk.sign_message(&sighash, &mut rng).unwrap();
                 authorization.add_signature(1, signature);
 
-                AuthorizedHashedTimelockContractSpend::Multisig(authorization.encode())
+                AuthorizedHashedTimelockContractSpend::Refund(authorization.encode())
             };
 
             let input_sign =

--- a/common/src/chain/transaction/signature/inputsig/authorize_hashed_timelock_contract_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_hashed_timelock_contract_spend.rs
@@ -21,6 +21,7 @@ use crate::chain::{htlc::HtlcSecret, signature::DestinationSigError};
 
 #[derive(Debug, Encode, Decode, PartialEq, Eq, EnumDiscriminants)]
 #[strum_discriminants(name(AuthorizedHashedTimelockContractSpendTag))]
+// FIXME rename (also search after rename for comments etc)
 pub enum AuthorizedHashedTimelockContractSpend {
     Secret(HtlcSecret, Vec<u8>),
     Multisig(Vec<u8>),

--- a/common/src/chain/transaction/signature/inputsig/authorize_hashed_timelock_contract_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/authorize_hashed_timelock_contract_spend.rs
@@ -21,10 +21,9 @@ use crate::chain::{htlc::HtlcSecret, signature::DestinationSigError};
 
 #[derive(Debug, Encode, Decode, PartialEq, Eq, EnumDiscriminants)]
 #[strum_discriminants(name(AuthorizedHashedTimelockContractSpendTag))]
-// FIXME rename (also search after rename for comments etc)
 pub enum AuthorizedHashedTimelockContractSpend {
-    Secret(HtlcSecret, Vec<u8>),
-    Multisig(Vec<u8>),
+    Spend(HtlcSecret, Vec<u8>),
+    Refund(Vec<u8>),
 }
 
 impl AuthorizedHashedTimelockContractSpend {

--- a/common/src/chain/transaction/signature/inputsig/classical_multisig/encode_decode_multisig_spend.rs
+++ b/common/src/chain/transaction/signature/inputsig/classical_multisig/encode_decode_multisig_spend.rs
@@ -36,7 +36,7 @@ pub fn encode_multisig_spend(
     let raw_signature = match utxo {
         Some(utxo) => {
             if is_htlc_output(utxo) {
-                AuthorizedHashedTimelockContractSpend::Multisig(sig_component.encode()).encode()
+                AuthorizedHashedTimelockContractSpend::Refund(sig_component.encode()).encode()
             } else {
                 sig_component.encode()
             }
@@ -58,10 +58,10 @@ pub fn decode_multisig_spend(
                 let htlc_spend =
                     AuthorizedHashedTimelockContractSpend::from_data(sig.raw_signature())?;
                 match htlc_spend {
-                    AuthorizedHashedTimelockContractSpend::Secret(_, _) => {
+                    AuthorizedHashedTimelockContractSpend::Spend(_, _) => {
                         return Err(DestinationSigError::InvalidClassicalMultisigAuthorization);
                     }
-                    AuthorizedHashedTimelockContractSpend::Multisig(raw_signature) => {
+                    AuthorizedHashedTimelockContractSpend::Refund(raw_signature) => {
                         AuthorizedClassicalMultisigSpend::from_data(&raw_signature)?
                     }
                 }

--- a/common/src/chain/transaction/signature/inputsig/htlc.rs
+++ b/common/src/chain/transaction/signature/inputsig/htlc.rs
@@ -55,7 +55,7 @@ pub fn produce_uniparty_signature_for_htlc_spending<
     )?;
 
     let sig_with_secret =
-        AuthorizedHashedTimelockContractSpend::Secret(htlc_secret, sig.raw_signature().to_owned());
+        AuthorizedHashedTimelockContractSpend::Spend(htlc_secret, sig.raw_signature().to_owned());
     let serialized_sig = sig_with_secret.encode();
 
     Ok(StandardInputSignature::new(
@@ -82,7 +82,7 @@ pub fn produce_classical_multisig_signature_for_htlc_refunding(
     )?;
 
     let raw_signature =
-        AuthorizedHashedTimelockContractSpend::Multisig(sig.raw_signature().to_owned()).encode();
+        AuthorizedHashedTimelockContractSpend::Refund(sig.raw_signature().to_owned()).encode();
 
     Ok(StandardInputSignature::new(
         sig.sighash_type(),
@@ -113,7 +113,7 @@ pub fn produce_uniparty_signature_for_htlc_refunding<
     )?;
 
     let sig_with_secret =
-        AuthorizedHashedTimelockContractSpend::Multisig(sig.raw_signature().to_owned());
+        AuthorizedHashedTimelockContractSpend::Refund(sig.raw_signature().to_owned());
     let serialized_sig = sig_with_secret.encode();
 
     Ok(StandardInputSignature::new(

--- a/common/src/chain/transaction/signature/inputsig/htlc.rs
+++ b/common/src/chain/transaction/signature/inputsig/htlc.rs
@@ -31,7 +31,10 @@ use super::{
 };
 
 #[allow(clippy::too_many_arguments)]
-pub fn produce_uniparty_signature_for_htlc_spending<T: Signable, AuxP: SigAuxDataProvider + ?Sized>(
+pub fn produce_uniparty_signature_for_htlc_spending<
+    T: Signable,
+    AuxP: SigAuxDataProvider + ?Sized,
+>(
     private_key: &crypto::key::PrivateKey,
     sighash_type: SigHashType,
     outpoint_destination: Destination,
@@ -87,7 +90,10 @@ pub fn produce_classical_multisig_signature_for_htlc_refunding(
     ))
 }
 
-pub fn produce_uniparty_signature_for_htlc_refunding<T: Signable, AuxP: SigAuxDataProvider + ?Sized>(
+pub fn produce_uniparty_signature_for_htlc_refunding<
+    T: Signable,
+    AuxP: SigAuxDataProvider + ?Sized,
+>(
     private_key: &crypto::key::PrivateKey,
     sighash_type: SigHashType,
     outpoint_destination: Destination,

--- a/common/src/chain/transaction/signature/sighash/hashable.rs
+++ b/common/src/chain/transaction/signature/sighash/hashable.rs
@@ -113,8 +113,8 @@ impl SignatureHashableElement for SignatureHashableInputs<'_> {
                 {
                     // Commit the extra commitments
                     hash_encoded_to(&(self.input_commitments.len() as u32), stream);
-                    for input_info in self.input_commitments {
-                        hash_encoded_to(&input_info, stream);
+                    for input_commitment in self.input_commitments {
+                        hash_encoded_to(&input_commitment, stream);
                     }
                 }
             }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -14,30 +14,27 @@ rpc-description = { path = "../rpc/description" }
 randomness = { path = "../randomness" }
 serialization = { path = "../serialization" }
 
-# The following crates don't work well with "workspace.dependencies"
-argon2 = { version = "0.5", features = ["std"] }
-merlin = { version = "3.0", default-features = false }
-secp256k1 = { version = "0.29", default-features = false, features = ["rand-std", "std", "rand"] }
-
+argon2 = { workspace = true, features = ["std"] }
 bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }
 blake2.workspace = true
 chacha20poly1305.workspace = true
 generic-array.workspace = true
 hmac.workspace = true
+merlin = { workspace = true, default-features = false }
 num-derive.workspace = true
 num-traits.workspace = true
 num.workspace = true
 parity-scale-codec.workspace = true
 ripemd.workspace = true
 schnorrkel.workspace = true
+secp256k1 = { workspace = true, default-features = false, features = ["rand-std", "std", "rand"] }
 serde = { workspace = true, features = ["derive"] }
 sha-1.workspace = true
 sha2.workspace = true
 sha3.workspace = true
 thiserror.workspace = true
+x25519-dalek = { workspace = true, features = ["reusable_secrets", "zeroize"] }
 zeroize.workspace = true
-
-x25519-dalek = { version = "2.0", features = ["reusable_secrets", "zeroize"] }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/mempool/src/pool/tx_pool/tests/accumulator.rs
+++ b/mempool/src/pool/tx_pool/tests/accumulator.rs
@@ -23,7 +23,7 @@ use common::{
         signature::{
             inputsig::{
                 classical_multisig::authorize_classical_multisig::AuthorizedClassicalMultisigSpend,
-                htlc::produce_classical_multisig_signature_for_htlc_input,
+                htlc::produce_classical_multisig_signature_for_htlc_refunding,
             },
             sighash::{
                 input_commitments::SighashInputCommitment, sighashtype::SigHashType, signature_hash,
@@ -564,7 +564,7 @@ async fn timelocked_htlc_refund(
         authorization
     };
 
-    let input_sign = produce_classical_multisig_signature_for_htlc_input(
+    let input_sign = produce_classical_multisig_signature_for_htlc_refunding(
         &chain_config,
         &authorization,
         SigHashType::all(),

--- a/mintscript/src/tests/translate/mod.rs
+++ b/mintscript/src/tests/translate/mod.rs
@@ -191,7 +191,7 @@ fn htlc_spend_sig(byte: u8) -> InputWitness {
     let sht = SigHashType::default();
     let raw_sig = vec![byte; 2];
     let secret = HtlcSecret::new([6; 32]);
-    let sig_with_secret = AuthorizedHashedTimelockContractSpend::Secret(secret, raw_sig);
+    let sig_with_secret = AuthorizedHashedTimelockContractSpend::Spend(secret, raw_sig);
     let serialized_sig = sig_with_secret.encode();
 
     InputWitness::Standard(StandardInputSignature::new(sht, serialized_sig))
@@ -200,7 +200,7 @@ fn htlc_spend_sig(byte: u8) -> InputWitness {
 fn htlc_refund_sig(byte: u8) -> InputWitness {
     let sht = SigHashType::default();
     let raw_sig = vec![byte; 2];
-    let sig_with_secret = AuthorizedHashedTimelockContractSpend::Multisig(raw_sig);
+    let sig_with_secret = AuthorizedHashedTimelockContractSpend::Refund(raw_sig);
     let serialized_sig = sig_with_secret.encode();
 
     InputWitness::Standard(StandardInputSignature::new(sht, serialized_sig))

--- a/mintscript/src/tests/translate/mod.rs
+++ b/mintscript/src/tests/translate/mod.rs
@@ -187,7 +187,7 @@ fn stdsig(byte: u8) -> InputWitness {
     InputWitness::Standard(StandardInputSignature::new(sht, vec![byte; 2]))
 }
 
-fn htlc_stdsig(byte: u8) -> InputWitness {
+fn htlc_spend_sig(byte: u8) -> InputWitness {
     let sht = SigHashType::default();
     let raw_sig = vec![byte; 2];
     let secret = HtlcSecret::new([6; 32]);
@@ -197,7 +197,7 @@ fn htlc_stdsig(byte: u8) -> InputWitness {
     InputWitness::Standard(StandardInputSignature::new(sht, serialized_sig))
 }
 
-fn htlc_multisig(byte: u8) -> InputWitness {
+fn htlc_refund_sig(byte: u8) -> InputWitness {
     let sht = SigHashType::default();
     let raw_sig = vec![byte; 2];
     let sig_with_secret = AuthorizedHashedTimelockContractSpend::Multisig(raw_sig);
@@ -505,7 +505,7 @@ enum Mode {
     (Mode::TxTimelockOnly, "true"),
     (Mode::TxFull, "signature(0x020003745607a08b12634e402eec525ddaaaaab73cc3951cd232cb88ad934f4be717f6, 0x0000)"),
 ])]
-#[case(htlc(11, 12, tl_until_height(999_999)), htlc_stdsig(0x54), &[
+#[case(htlc(11, 12, tl_until_height(999_999)), htlc_spend_sig(0x54), &[
     (Mode::Reward, "ERROR: Illegal output spend"),
     (Mode::TxSigOnly, "signature(0x020003574c6b846c9a4c555ea75d771d5a40564b9ef37419682da12573e1d8ac27d71e, 0x0101085454)"),
     (Mode::TxTimelockOnly, "true"),
@@ -516,7 +516,7 @@ enum Mode {
         "])"
     )),
 ])]
-#[case(htlc(13, 14, tl_for_secs(1111)), htlc_stdsig(0x58), &[
+#[case(htlc(13, 14, tl_for_secs(1111)), htlc_spend_sig(0x58), &[
     (Mode::Reward, "ERROR: Illegal output spend"),
     (Mode::TxSigOnly, "signature(0x020002a3fe239606e407ea161143e42c7c3ef0059573466950a910b28289df247df7a3, 0x0101085858)"),
     (Mode::TxTimelockOnly, "true"),
@@ -527,7 +527,7 @@ enum Mode {
         "])"
     )),
 ])]
-#[case(htlc(15, 16, tl_until_time(99)), htlc_stdsig(0x53), &[
+#[case(htlc(15, 16, tl_until_time(99)), htlc_spend_sig(0x53), &[
     (Mode::Reward, "ERROR: Illegal output spend"),
     (Mode::TxSigOnly, "signature(0x0200039315c9da756f584d5a7fff618d230bf13115a43d63e7c7d464bb513ab6be7bbc, 0x0101085353)"),
     (Mode::TxTimelockOnly, "true"),
@@ -538,7 +538,7 @@ enum Mode {
         "])"
     )),
 ])]
-#[case(htlc(17, 18, tl_for_secs(124)), htlc_multisig(0x54), &[
+#[case(htlc(17, 18, tl_for_secs(124)), htlc_refund_sig(0x54), &[
     (Mode::Reward, "ERROR: Illegal output spend"),
     (Mode::TxSigOnly, "signature(0x041c9bb73a209c49363022813e7197ac80c761d80b, 0x0101085454)"),
     (Mode::TxTimelockOnly, "after_seconds(124)"),
@@ -549,7 +549,7 @@ enum Mode {
         "])"
     )),
 ])]
-#[case(htlc(19, 20, tl_for_blocks(1000)), htlc_multisig(0x55), &[
+#[case(htlc(19, 20, tl_for_blocks(1000)), htlc_refund_sig(0x55), &[
     (Mode::Reward, "ERROR: Illegal output spend"),
     (Mode::TxSigOnly, "signature(0x04d55789fd7dd4b58f8bdb889a0d31cac70e67df92, 0x0101085555)"),
     (Mode::TxTimelockOnly, "after_blocks(1000)"),

--- a/mintscript/src/translate.rs
+++ b/mintscript/src/translate.rs
@@ -156,7 +156,7 @@ impl<C: SignatureInfoProvider> TranslateInput<C> for SignedTransaction {
                                 sig.raw_signature(),
                             )?;
                             match htlc_spend {
-                                AuthorizedHashedTimelockContractSpend::Secret(
+                                AuthorizedHashedTimelockContractSpend::Spend(
                                     secret,
                                     raw_signature,
                                 ) => WitnessScript::satisfied_conjunction([
@@ -174,7 +174,7 @@ impl<C: SignatureInfoProvider> TranslateInput<C> for SignedTransaction {
                                         ),
                                     ),
                                 ]),
-                                AuthorizedHashedTimelockContractSpend::Multisig(raw_signature) => {
+                                AuthorizedHashedTimelockContractSpend::Refund(raw_signature) => {
                                     WitnessScript::satisfied_conjunction([
                                         WitnessScript::timelock(htlc.refund_timelock),
                                         WitnessScript::signature(
@@ -318,10 +318,10 @@ impl<C: InputInfoProvider> TranslateInput<C> for TimelockOnly {
                         let htlc_spend =
                             AuthorizedHashedTimelockContractSpend::from_data(sig.raw_signature())?;
                         match htlc_spend {
-                            AuthorizedHashedTimelockContractSpend::Secret(_, _) => {
+                            AuthorizedHashedTimelockContractSpend::Spend(_, _) => {
                                 Ok(WitnessScript::TRUE)
                             }
-                            AuthorizedHashedTimelockContractSpend::Multisig(_) => {
+                            AuthorizedHashedTimelockContractSpend::Refund(_) => {
                                 Ok(WitnessScript::timelock(htlc.refund_timelock))
                             }
                         }
@@ -397,7 +397,7 @@ impl<C: SignatureInfoProvider> TranslateInput<C> for SignatureOnlyTx {
                                 sig.raw_signature(),
                             )?;
                             match htlc_spend {
-                                AuthorizedHashedTimelockContractSpend::Secret(_, raw_signature) => {
+                                AuthorizedHashedTimelockContractSpend::Spend(_, raw_signature) => {
                                     WitnessScript::signature(
                                         htlc.spend_key.clone(),
                                         EvaluatedInputWitness::Standard(
@@ -408,7 +408,7 @@ impl<C: SignatureInfoProvider> TranslateInput<C> for SignatureOnlyTx {
                                         ),
                                     )
                                 }
-                                AuthorizedHashedTimelockContractSpend::Multisig(raw_signature) => {
+                                AuthorizedHashedTimelockContractSpend::Refund(raw_signature) => {
                                     WitnessScript::signature(
                                         htlc.refund_key.clone(),
                                         EvaluatedInputWitness::Standard(

--- a/p2p/src/sync/tests/no_discouragement_after_tx_reorg.rs
+++ b/p2p/src/sync/tests/no_discouragement_after_tx_reorg.rs
@@ -901,6 +901,7 @@ impl TestFixture {
             .build()
     }
 
+    // Note: here it doesn't matter what kind of refund key the htlc has - multi or single sig.
     fn make_htlc(&mut self) -> (HashedTimelockContract, ClassicMultisigChallenge) {
         let secret = HtlcSecret::new_from_rng(&mut self.rng);
 

--- a/test-rpc-functions/src/rpc.rs
+++ b/test-rpc-functions/src/rpc.rs
@@ -528,10 +528,10 @@ impl RpcTestFunctionsRpcServer for super::RpcTestFunctionsHandle {
                     let htlc_spend: AuthorizedHashedTimelockContractSpend =
                         rpc::handle_result(htlc_spend_result)?;
                     match htlc_spend {
-                        AuthorizedHashedTimelockContractSpend::Secret(secret, _) => {
+                        AuthorizedHashedTimelockContractSpend::Spend(secret, _) => {
                             Ok(Some(secret.hex_encode()))
                         }
-                        AuthorizedHashedTimelockContractSpend::Multisig(_) => Ok(None),
+                        AuthorizedHashedTimelockContractSpend::Refund(_) => Ok(None),
                     }
                 }
             },

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -47,6 +47,7 @@ test-utils = { path = "../test-utils" }
 ctor.workspace = true
 lazy_static.workspace = true
 rstest.workspace = true
+secp256k1 = { workspace = true, default-features = false }
 serde_json.workspace = true
 serial_test.workspace = true
 tempfile.workspace = true

--- a/wallet/src/account/utxo_selector/mod.rs
+++ b/wallet/src/account/utxo_selector/mod.rs
@@ -623,8 +623,9 @@ fn select_coins_bnb(
                 .last()
                 // Empty or
                 .is_none_or(
-                // The previous index is included and therefore not relevant for exclusion shortcut
-                    |idx| (utxo_pool_index - 1 == *idx))
+                    // The previous index is included and therefore not relevant for exclusion shortcut
+                    |idx| utxo_pool_index - 1 == *idx
+                )
                 // Avoid searching a branch if the previous UTXO has the same value and same waste and was excluded.
                 // Since the ratio of fee to long term fee is the same, we only need to check if one of those values match in order to know that the waste is the same.
                 || utxo.get_effective_value(pay_fees)

--- a/wallet/src/destination_getters.rs
+++ b/wallet/src/destination_getters.rs
@@ -17,6 +17,7 @@ use common::chain::{htlc::HtlcSecret, Destination, PoolId, TxOutput};
 
 use crate::account::PoolData;
 
+// FIXME rename
 #[derive(Clone, Copy, Debug)]
 pub enum HtlcSpendingCondition {
     WithSecret,

--- a/wallet/src/destination_getters.rs
+++ b/wallet/src/destination_getters.rs
@@ -17,11 +17,10 @@ use common::chain::{htlc::HtlcSecret, Destination, PoolId, TxOutput};
 
 use crate::account::PoolData;
 
-// FIXME rename
 #[derive(Clone, Copy, Debug)]
 pub enum HtlcSpendingCondition {
-    WithSecret,
-    WithMultisig,
+    WithSpend,
+    WithRefund,
     Skip,
 }
 
@@ -34,7 +33,7 @@ impl HtlcSpendingCondition {
             secrets
                 .get(index)
                 .and_then(Option::as_ref)
-                .map_or(Self::WithMultisig, |_: &HtlcSecret| Self::WithSecret)
+                .map_or(Self::WithRefund, |_: &HtlcSecret| Self::WithSpend)
         })
     }
 }
@@ -62,8 +61,8 @@ where
         | TxOutput::DataDeposit(_)
         | TxOutput::CreateOrder(_) => None,
         TxOutput::Htlc(_, htlc) => match htlc_spending {
-            HtlcSpendingCondition::WithSecret => Some(htlc.spend_key.clone()),
-            HtlcSpendingCondition::WithMultisig => Some(htlc.refund_key.clone()),
+            HtlcSpendingCondition::WithSpend => Some(htlc.spend_key.clone()),
+            HtlcSpendingCondition::WithRefund => Some(htlc.refund_key.clone()),
             HtlcSpendingCondition::Skip => None,
         },
     }

--- a/wallet/src/send_request/mod.rs
+++ b/wallet/src/send_request/mod.rs
@@ -279,8 +279,8 @@ impl SendRequest {
         for (outpoint, txo, secret) in utxos {
             self.inputs.push(outpoint);
             let htlc_spending_condition = match &secret {
-                Some(_) => HtlcSpendingCondition::WithSecret,
-                None => HtlcSpendingCondition::WithMultisig,
+                Some(_) => HtlcSpendingCondition::WithSpend,
+                None => HtlcSpendingCondition::WithRefund,
             };
 
             self.destinations.push(

--- a/wallet/src/signer/mod.rs
+++ b/wallet/src/signer/mod.rs
@@ -99,8 +99,8 @@ pub enum SignerError {
     AddressError(#[from] AddressError),
     #[error("Order was filled more than the available balance")]
     OrderFillUnderflow,
-    #[error("Multisig HTLC destination expected")]
-    HtlcMultisigDestinationExpected, // FIXME rename?
+    #[error("HTLC refund expected for a multisig destination")]
+    HtlcRefundExpectedForMultisig,
     #[error("Partially signed transaction error: {0}")]
     PartiallySignedTransactionError(#[from] PartiallySignedTransactionError),
     #[error("Duplicate UTXO input: {0:?}")]

--- a/wallet/src/signer/mod.rs
+++ b/wallet/src/signer/mod.rs
@@ -29,7 +29,7 @@ use common::{
             DestinationSigError,
         },
         ChainConfig, Destination, SignedTransactionIntent, SignedTransactionIntentError,
-        Transaction,
+        Transaction, UtxoOutPoint,
     },
     primitives::BlockHeight,
 };
@@ -54,6 +54,7 @@ use crate::{
 pub mod software_signer;
 #[cfg(feature = "trezor")]
 pub mod trezor_signer;
+pub mod utils;
 
 #[cfg(feature = "trezor")]
 use self::trezor_signer::TrezorError;
@@ -99,11 +100,12 @@ pub enum SignerError {
     #[error("Order was filled more than the available balance")]
     OrderFillUnderflow,
     #[error("Multisig HTLC destination expected")]
-    HtlcMultisigDestinationExpected,
+    HtlcMultisigDestinationExpected, // FIXME rename?
     #[error("Partially signed transaction error: {0}")]
     PartiallySignedTransactionError(#[from] PartiallySignedTransactionError),
+    #[error("Duplicate UTXO input: {0:?}")]
+    DuplicateUtxoInput(UtxoOutPoint),
 }
-
 type SignerResult<T> = Result<T, SignerError>;
 
 /// Signer trait responsible for signing transactions or challenges using a software or hardware

--- a/wallet/src/signer/software_signer/mod.rs
+++ b/wallet/src/signer/software_signer/mod.rs
@@ -31,8 +31,6 @@ use common::{
                     },
                     encode_decode_multisig_spend::{decode_multisig_spend, encode_multisig_spend},
                 },
-                htlc::produce_uniparty_signature_for_htlc_spending,
-                standard_signature::StandardInputSignature,
                 InputWitness,
             },
             sighash::{
@@ -67,10 +65,11 @@ use crate::{
         make_account_path, AccountKeyChainImplSoftware, AccountKeyChains, FoundPubKey,
         MasterKeyChain,
     },
+    signer::utils::produce_uniparty_signature_for_input,
     Account, WalletResult,
 };
 
-use super::{Signer, SignerError, SignerProvider, SignerResult};
+use super::{utils::is_htlc_utxo, Signer, SignerError, SignerProvider, SignerResult};
 
 pub struct SoftwareSigner {
     chain_config: Arc<ChainConfig>,
@@ -160,32 +159,18 @@ impl SoftwareSigner {
                 let sig = self
                     .get_private_key_for_destination(destination, key_chain, db_tx)?
                     .map(|private_key| {
-                        let sighash_type = SigHashType::all();
-                        match htlc_secret {
-                            Some(htlc_secret) => produce_uniparty_signature_for_htlc_spending(
-                                &private_key,
-                                sighash_type,
-                                destination.clone(),
-                                tx,
-                                input_commitments,
-                                input_index,
-                                htlc_secret.clone(),
-                                self.sig_aux_data_provider.lock().expect("poisoned mutex").as_mut(),
-                            )
-                            .map(InputWitness::Standard)
-                            .map_err(SignerError::SigningError),
-                            None => StandardInputSignature::produce_uniparty_signature_for_input(
-                                &private_key,
-                                sighash_type,
-                                destination.clone(),
-                                tx,
-                                input_commitments,
-                                input_index,
-                                self.sig_aux_data_provider.lock().expect("poisoned mutex").as_mut(),
-                            )
-                            .map(InputWitness::Standard)
-                            .map_err(SignerError::SigningError),
-                        }
+                        let is_htlc_input = input_utxo.is_some_and(is_htlc_utxo);
+
+                        produce_uniparty_signature_for_input(
+                            is_htlc_input,
+                            htlc_secret.clone(),
+                            &private_key,
+                            destination.clone(),
+                            tx,
+                            input_commitments,
+                            input_index,
+                            self.sig_aux_data_provider.lock().expect("poisoned mutex").as_mut(),
+                        )
                     })
                     .transpose()?;
 
@@ -209,6 +194,8 @@ impl SoftwareSigner {
                         db_tx,
                     )?;
 
+                    // Note: this will check whether the utxo is an htlc one and produce
+                    // AuthorizedHashedTimelockContractSpend if it is.
                     let signature = encode_multisig_spend(&sig, input_utxo);
 
                     return Ok((Some(InputWitness::Standard(signature)), status));
@@ -323,15 +310,15 @@ impl Signer for SoftwareSigner {
                         InputWitness::Standard(sig) => match destination {
                             Some(destination) => {
                                 let sig_verified =
-                                tx_verifier::input_check::signature_only_check::verify_tx_signature(
-                                    &self.chain_config,
-                                    destination,
-                                    &ptx,
-                                    &input_commitments,
-                                    i,
-                                    input_utxo.clone()
-                                )
-                                .is_ok();
+                                    tx_verifier::input_check::signature_only_check::verify_tx_signature(
+                                        &self.chain_config,
+                                        destination,
+                                        &ptx,
+                                        &input_commitments,
+                                        i,
+                                        input_utxo.clone()
+                                    )
+                                    .is_ok();
 
                                 if sig_verified {
                                     Ok((

--- a/wallet/src/signer/software_signer/mod.rs
+++ b/wallet/src/signer/software_signer/mod.rs
@@ -31,7 +31,7 @@ use common::{
                     },
                     encode_decode_multisig_spend::{decode_multisig_spend, encode_multisig_spend},
                 },
-                htlc::produce_uniparty_signature_for_htlc_input,
+                htlc::produce_uniparty_signature_for_htlc_spending,
                 standard_signature::StandardInputSignature,
                 InputWitness,
             },
@@ -162,7 +162,7 @@ impl SoftwareSigner {
                     .map(|private_key| {
                         let sighash_type = SigHashType::all();
                         match htlc_secret {
-                            Some(htlc_secret) => produce_uniparty_signature_for_htlc_input(
+                            Some(htlc_secret) => produce_uniparty_signature_for_htlc_spending(
                                 &private_key,
                                 sighash_type,
                                 destination.clone(),

--- a/wallet/src/signer/software_signer/tests.rs
+++ b/wallet/src/signer/software_signer/tests.rs
@@ -21,6 +21,7 @@ use test_utils::random::{make_seedable_rng, Seed};
 use crate::signer::tests::{
     generic_fixed_signature_tests::{
         test_fixed_signatures_generic, test_fixed_signatures_generic2,
+        test_fixed_signatures_generic_htlc_refunding,
     },
     generic_tests::{
         test_sign_message_generic, test_sign_transaction_generic,
@@ -92,6 +93,24 @@ fn test_fixed_signatures2(
     let mut rng = make_seedable_rng(seed);
 
     test_fixed_signatures_generic2(
+        &mut rng,
+        input_commitments_version,
+        make_deterministic_software_signer,
+    );
+}
+
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy(), SighashInputCommitmentVersion::V0)]
+#[trace]
+#[case(Seed::from_entropy(), SighashInputCommitmentVersion::V1)]
+fn test_fixed_signatures_htlc_refunding(
+    #[case] seed: Seed,
+    #[case] input_commitments_version: SighashInputCommitmentVersion,
+) {
+    let mut rng = make_seedable_rng(seed);
+
+    test_fixed_signatures_generic_htlc_refunding(
         &mut rng,
         input_commitments_version,
         make_deterministic_software_signer,

--- a/wallet/src/signer/tests/generic_fixed_signature_tests.rs
+++ b/wallet/src/signer/tests/generic_fixed_signature_tests.rs
@@ -1511,10 +1511,10 @@ fn log_witness(index: usize, witness: &InputWitness) {
                     }
                 }
                 PossibleSpend::Htlc(spend) => match spend {
-                    AuthorizedHashedTimelockContractSpend::Secret(_, inner_sig) => {
+                    AuthorizedHashedTimelockContractSpend::Spend(_, inner_sig) => {
                         let sig_hex = hex::encode(&inner_sig);
                         log::debug!(
-                            "sig #{index} is AuthorizedHashedTimelockContractSpend::Secret, entire sig = {sig_hex}"
+                            "sig #{index} is AuthorizedHashedTimelockContractSpend::Spend, entire sig = {sig_hex}"
                         );
 
                         let inner_spend = decode_sig(&inner_sig).unwrap_or_else(|| {
@@ -1541,9 +1541,9 @@ fn log_witness(index: usize, witness: &InputWitness) {
                             }
                         }
                     }
-                    AuthorizedHashedTimelockContractSpend::Multisig(inner_sig) => {
+                    AuthorizedHashedTimelockContractSpend::Refund(inner_sig) => {
                         log::debug!(
-                            "sig #{index} is AuthorizedHashedTimelockContractSpend::Multisig"
+                            "sig #{index} is AuthorizedHashedTimelockContractSpend::Refund"
                         );
 
                         let inner_spend = decode_sig(&inner_sig).unwrap_or_else(|| {
@@ -1645,7 +1645,7 @@ fn make_htlc_pub_key_spend_sig(secret: HtlcSecret, sig_hex: &str) -> StandardInp
     let sig = Signature::from_raw_data(&sig_bytes, SignatureKind::Secp256k1Schnorr).unwrap();
     let inner_spend = AuthorizedPublicKeySpend::new(sig);
 
-    let spend = AuthorizedHashedTimelockContractSpend::Secret(secret, inner_spend.encode());
+    let spend = AuthorizedHashedTimelockContractSpend::Spend(secret, inner_spend.encode());
     StandardInputSignature::new(SigHashType::ALL.try_into().unwrap(), spend.encode())
 }
 
@@ -1661,7 +1661,7 @@ fn make_htlc_multisig_refund_sig<'a>(
         multisig_spend.add_signature(idx as u8, sig);
     }
 
-    let spend = AuthorizedHashedTimelockContractSpend::Multisig(multisig_spend.encode());
+    let spend = AuthorizedHashedTimelockContractSpend::Refund(multisig_spend.encode());
     let sighash_type: SigHashType = SigHashType::ALL.try_into().unwrap();
     StandardInputSignature::new(sighash_type, spend.encode())
 }
@@ -1671,7 +1671,7 @@ fn make_htlc_uniparty_pub_key_refund_sig(sig_hex: &str) -> StandardInputSignatur
     let sig = Signature::from_raw_data(&sig_bytes, SignatureKind::Secp256k1Schnorr).unwrap();
     let inner_spend = AuthorizedPublicKeySpend::new(sig);
 
-    let spend = AuthorizedHashedTimelockContractSpend::Multisig(inner_spend.encode());
+    let spend = AuthorizedHashedTimelockContractSpend::Refund(inner_spend.encode());
     StandardInputSignature::new(SigHashType::ALL.try_into().unwrap(), spend.encode())
 }
 
@@ -1683,7 +1683,7 @@ fn make_htlc_uniparty_pub_key_hash_refund_sig(
     let sig = Signature::from_raw_data(&sig_bytes, SignatureKind::Secp256k1Schnorr).unwrap();
     let inner_spend = AuthorizedPublicKeyHashSpend::new(pub_key, sig);
 
-    let spend = AuthorizedHashedTimelockContractSpend::Multisig(inner_spend.encode());
+    let spend = AuthorizedHashedTimelockContractSpend::Refund(inner_spend.encode());
     StandardInputSignature::new(SigHashType::ALL.try_into().unwrap(), spend.encode())
 }
 

--- a/wallet/src/signer/tests/generic_tests.rs
+++ b/wallet/src/signer/tests/generic_tests.rs
@@ -813,7 +813,9 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
                 tx_block_height,
             )
             .unwrap();
-        assert!(another_ptx.all_signatures_available());
+        if first_account_can_sign_htlc {
+            assert!(another_ptx.all_signatures_available());
+        }
 
         assert_eq!(ptx, another_ptx);
     }

--- a/wallet/src/signer/tests/generic_tests.rs
+++ b/wallet/src/signer/tests/generic_tests.rs
@@ -29,7 +29,10 @@ use common::{
         config::{create_regtest, ChainType},
         htlc::{HashedTimelockContract, HtlcSecret},
         output_value::OutputValue,
-        signature::{inputsig::arbitrary_message::produce_message_challenge, DestinationSigError},
+        signature::{
+            inputsig::arbitrary_message::produce_message_challenge, DestinationSigError,
+            Transactable,
+        },
         stakelock::StakePoolData,
         timelock::OutputTimeLock,
         tokens::{
@@ -407,15 +410,15 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
         })
         .collect();
 
-    let (_, pub_key1) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
-    let pub_key2 = if let Destination::PublicKeyHash(pkh) =
+    let (_, unknown_pub_key) = PrivateKey::new_from_rng(rng, KeyKind::Secp256k1Schnorr);
+    let pub_key1 = if let Destination::PublicKeyHash(pkh) =
         account.get_new_address(&mut db_tx, KeyPurpose::Change).unwrap().1.into_object()
     {
         account.find_corresponding_pub_key(&pkh).unwrap()
     } else {
         panic!("not a public key hash")
     };
-    let pub_key3 = if let Destination::PublicKeyHash(pkh) = account2
+    let pub_key2 = if let Destination::PublicKeyHash(pkh) = account2
         .get_new_address(&mut db_tx, KeyPurpose::Change)
         .unwrap()
         .1
@@ -427,19 +430,21 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
     };
 
     let min_required_signatures = 3;
-    // The first account can sign the pub_key2 and the standalone key,
+    // The first account can sign the pub_key1 and the standalone key,
     // but it will not be fully signed, so we will need to sign it with the account2 which
-    // can complete the signing with the pub_key3.
+    // can complete the signing with the pub_key2.
     let challenge = ClassicMultisigChallenge::new(
         &chain_config,
         NonZeroU8::new(min_required_signatures).unwrap(),
-        vec![pub_key1.clone(), pub_key2.clone(), standalone_pk, pub_key3.clone()],
+        vec![unknown_pub_key.clone(), pub_key1.clone(), standalone_pk, pub_key2.clone()],
     )
     .unwrap();
-    account.add_standalone_multisig(&mut db_tx, challenge.clone(), None).unwrap();
-    let multisig_hash = account2.add_standalone_multisig(&mut db_tx, challenge, None).unwrap();
+    let multisig_hash1 =
+        account.add_standalone_multisig(&mut db_tx, challenge.clone(), None).unwrap();
+    let multisig_hash2 = account2.add_standalone_multisig(&mut db_tx, challenge, None).unwrap();
+    assert_eq!(multisig_hash1, multisig_hash2);
 
-    let multisig_dest = Destination::ClassicMultisig(multisig_hash);
+    let multisig_dest = Destination::ClassicMultisig(multisig_hash1);
 
     let source_id: OutPointSourceId = if rng.gen_bool(0.5) {
         Id::<Transaction>::new(H256::random_using(rng)).into()
@@ -452,18 +457,75 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
         multisig_dest.clone(),
     );
 
-    let secret = HtlcSecret::new_from_rng(rng);
-    let hash_lock = HashedTimelockContract {
-        secret_hash: secret.hash(),
-        spend_key: Destination::PublicKey(pub_key2.clone()),
+    let pub_key1_or_2 = if rng.gen_bool(0.5) {
+        log::debug!("pub_key1_or_2 is pub_key1");
+        pub_key1.clone()
+    } else {
+        log::debug!("pub_key1_or_2 is pub_key2");
+        pub_key2.clone()
+    };
+    let pub_key1_or_2_is_key1 = pub_key1_or_2 == pub_key1;
+    let dest1_or_2 = if rng.gen_bool(0.5) {
+        log::debug!("dest1_or_2 is pub key");
+        Destination::PublicKey(pub_key1_or_2)
+    } else {
+        log::debug!("dest1_or_2 is pub key hash");
+        Destination::PublicKeyHash((&pub_key1_or_2).into())
+    };
+
+    let spend_htlc = rng.gen_bool(0.5);
+    let htlc_secret = HtlcSecret::new_from_rng(rng);
+
+    // Note: in "first_account_can_sign_htlc", "sign" actually means "at least partially sign".
+    let (htlc_spend_dest, htlc_refund_dest, first_account_can_sign_htlc) = if spend_htlc {
+        log::debug!("htlc will be spent");
+
+        (
+            dest1_or_2,
+            Destination::PublicKey(unknown_pub_key),
+            pub_key1_or_2_is_key1,
+        )
+    } else {
+        let (refund_dest, first_account_can_sign_htlc) = if rng.gen_bool(0.5) {
+            log::debug!("htlc will be refunded, single sig");
+
+            (dest1_or_2, pub_key1_or_2_is_key1)
+        } else {
+            log::debug!("htlc will be refunded, multisig");
+
+            let challenge = ClassicMultisigChallenge::new(
+                &chain_config,
+                NonZeroU8::new(2).unwrap(),
+                vec![pub_key1, pub_key2],
+            )
+            .unwrap();
+            let multisig_hash1 =
+                account.add_standalone_multisig(&mut db_tx, challenge.clone(), None).unwrap();
+            let multisig_hash2 =
+                account2.add_standalone_multisig(&mut db_tx, challenge, None).unwrap();
+            assert_eq!(multisig_hash1, multisig_hash2);
+
+            (Destination::ClassicMultisig(multisig_hash1), true)
+        };
+
+        (
+            Destination::PublicKey(unknown_pub_key),
+            refund_dest,
+            first_account_can_sign_htlc,
+        )
+    };
+
+    let htlc = HashedTimelockContract {
+        secret_hash: htlc_secret.hash(),
+        spend_key: htlc_spend_dest,
         refund_timelock: OutputTimeLock::UntilHeight(BlockHeight::new(rng.gen_range(100..200))),
-        refund_key: Destination::PublicKey(pub_key1),
+        refund_key: htlc_refund_dest,
     };
 
     let htlc_input = TxInput::from_utxo(source_id, rng.next_u32());
     let htlc_utxo = TxOutput::Htlc(
         OutputValue::Coin(Amount::from_atoms(rng.gen::<u32>() as u128)),
-        Box::new(hash_lock.clone()),
+        Box::new(htlc.clone()),
     );
 
     let token_id = TokenId::new(H256::random_using(rng));
@@ -644,7 +706,7 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
             Destination::AnyoneCanSpend,
         ),
         TxOutput::DataDeposit(gen_random_bytes(rng, 10, 20)),
-        TxOutput::Htlc(OutputValue::Coin(htlc_transfer_amount), Box::new(hash_lock)),
+        TxOutput::Htlc(OutputValue::Coin(htlc_transfer_amount), Box::new(htlc)),
         TxOutput::CreateOrder(Box::new(created_order_data)),
     ];
 
@@ -658,17 +720,21 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
         )
         .unwrap()
         .with_inputs(
-            [(htlc_input.clone(), htlc_utxo.clone(), Some(secret))],
-            &|_| None,
-        )
-        .unwrap()
-        .with_inputs(
-            [(multisig_input.clone(), multisig_utxo.clone(), None)],
+            [
+                (
+                    htlc_input.clone(),
+                    htlc_utxo.clone(),
+                    spend_htlc.then_some(htlc_secret),
+                ),
+                (multisig_input.clone(), multisig_utxo.clone(), None),
+            ],
             &|_| None,
         )
         .unwrap()
         .with_inputs_and_destinations(acc_inputs.into_iter().zip(acc_dests.clone()))
         .with_outputs(outputs);
+    let htlc_input_index = inputs.len();
+    let multisig_input_index = htlc_input_index + 1;
     let destinations = req.destinations().to_vec();
 
     let ptx_additional_info = PtxAdditionalInfo::new()
@@ -732,7 +798,9 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
             tx_block_height,
         )
         .unwrap();
-    assert!(ptx.all_signatures_available());
+    if first_account_can_sign_htlc {
+        assert!(ptx.all_signatures_available());
+    }
 
     if let Some(make_another_signer) = &make_another_signer {
         let mut another_signer = make_another_signer(chain_config.clone(), account.account_index());
@@ -765,9 +833,8 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
         .collect::<Vec<_>>();
 
     for (i, dest) in destinations.iter().enumerate() {
-        // the multisig will not be fully signed
-        if dest == &multisig_dest {
-            let err = tx_verifier::input_check::signature_only_check::verify_tx_signature(
+        let verify = || {
+            tx_verifier::input_check::signature_only_check::verify_tx_signature(
                 &chain_config,
                 dest,
                 &ptx,
@@ -775,7 +842,10 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
                 i,
                 all_utxos[i].cloned(),
             )
-            .unwrap_err();
+        };
+        if i == multisig_input_index {
+            // The multisig will not be fully signed.
+            let err = verify().unwrap_err();
             assert_eq!(
                 err.error(),
                 &InputCheckErrorPayload::Verification(ScriptError::Signature(
@@ -785,16 +855,23 @@ pub fn test_sign_transaction_generic<MkS1, MkS2, S1, S2>(
                     )
                 )),
             )
+        } else if i == htlc_input_index {
+            if !first_account_can_sign_htlc {
+                assert!(ptx.signatures()[i].is_none());
+            } else if matches!(dest, Destination::ClassicMultisig(_)) {
+                // The multisig will not be fully signed.
+                let err = verify().unwrap_err();
+                assert_eq!(
+                    err.error(),
+                    &InputCheckErrorPayload::Verification(ScriptError::Signature(
+                        DestinationSigError::IncompleteClassicalMultisigSignature(2, 1)
+                    )),
+                )
+            } else {
+                verify().unwrap();
+            }
         } else {
-            tx_verifier::input_check::signature_only_check::verify_tx_signature(
-                &chain_config,
-                dest,
-                &ptx,
-                &input_commitments,
-                i,
-                all_utxos[i].cloned(),
-            )
-            .unwrap();
+            verify().unwrap();
         }
     }
 

--- a/wallet/src/signer/trezor_signer/mod.rs
+++ b/wallet/src/signer/trezor_signer/mod.rs
@@ -38,7 +38,7 @@ use common::{
                     },
                     multisig_partial_signature::{self, PartiallySignedMultisigChallenge},
                 },
-                htlc::produce_uniparty_signature_for_htlc_input,
+                htlc::produce_uniparty_signature_for_htlc_spending,
                 standard_signature::StandardInputSignature,
                 InputWitness,
             },
@@ -883,7 +883,7 @@ fn sign_input_with_standalone_key<AuxP: SigAuxDataProvider + ?Sized>(
 ) -> SignerResult<InputWitness> {
     let sighash_type = SigHashType::all();
     match secret {
-        Some(htlc_secret) => produce_uniparty_signature_for_htlc_input(
+        Some(htlc_secret) => produce_uniparty_signature_for_htlc_spending(
             &standalone.private_key,
             sighash_type,
             destination.clone(),

--- a/wallet/src/signer/trezor_signer/mod.rs
+++ b/wallet/src/signer/trezor_signer/mod.rs
@@ -578,12 +578,12 @@ impl Signer for TrezorSigner {
                     let sig = if is_htlc_input {
                         let sighash_type = sig.sighash_type();
                         let spend = if let Some(htlc_secret) = htlc_secret {
-                            AuthorizedHashedTimelockContractSpend::Secret(
+                            AuthorizedHashedTimelockContractSpend::Spend(
                                 htlc_secret.clone(),
                                 sig.into_raw_signature(),
                             )
                         } else {
-                            AuthorizedHashedTimelockContractSpend::Multisig(sig.into_raw_signature())
+                            AuthorizedHashedTimelockContractSpend::Refund(sig.into_raw_signature())
                         };
 
                         let serialized_spend = spend.encode();
@@ -646,10 +646,10 @@ impl Signer for TrezorSigner {
                                     let current_signatures = if is_htlc_input {
                                         let htlc_spend = AuthorizedHashedTimelockContractSpend::from_data(sig.raw_signature())?;
                                         match htlc_spend {
-                                            AuthorizedHashedTimelockContractSpend::Secret(_, _) => {
-                                                return Err(SignerError::HtlcMultisigDestinationExpected);
+                                            AuthorizedHashedTimelockContractSpend::Spend(_, _) => {
+                                                return Err(SignerError::HtlcRefundExpectedForMultisig);
                                             },
-                                            AuthorizedHashedTimelockContractSpend::Multisig(raw_sig) => {
+                                            AuthorizedHashedTimelockContractSpend::Refund(raw_sig) => {
                                                 AuthorizedClassicalMultisigSpend::from_data(&raw_sig)?
                                             },
                                         }

--- a/wallet/src/signer/trezor_signer/tests.rs
+++ b/wallet/src/signer/trezor_signer/tests.rs
@@ -27,6 +27,7 @@ use crate::signer::{
     tests::{
         generic_fixed_signature_tests::{
             test_fixed_signatures_generic, test_fixed_signatures_generic2,
+            test_fixed_signatures_generic_htlc_refunding,
         },
         generic_tests::{
             test_sign_message_generic, test_sign_transaction_generic,
@@ -170,6 +171,30 @@ fn test_fixed_signatures2(
     let mut rng = make_seedable_rng(seed);
 
     test_fixed_signatures_generic2(
+        &mut rng,
+        input_commitments_version,
+        make_deterministic_trezor_signer,
+    );
+}
+
+#[rstest]
+#[trace]
+#[serial]
+#[case(Seed::from_entropy(), SighashInputCommitmentVersion::V0)]
+#[trace]
+#[serial]
+#[case(Seed::from_entropy(), SighashInputCommitmentVersion::V1)]
+fn test_fixed_signatures_htlc_refunding(
+    #[case] seed: Seed,
+    #[case] input_commitments_version: SighashInputCommitmentVersion,
+) {
+    log::debug!("test_fixed_signatures_htlc_refunding, seed = {seed:?}, input_commitments_version = {input_commitments_version:?}");
+
+    let _join_guard = maybe_spawn_auto_confirmer();
+
+    let mut rng = make_seedable_rng(seed);
+
+    test_fixed_signatures_generic_htlc_refunding(
         &mut rng,
         input_commitments_version,
         make_deterministic_trezor_signer,

--- a/wallet/src/signer/utils.rs
+++ b/wallet/src/signer/utils.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common::chain::{
+    htlc::HtlcSecret,
+    signature::{
+        inputsig::{
+            htlc::{
+                produce_uniparty_signature_for_htlc_refunding,
+                produce_uniparty_signature_for_htlc_spending,
+            },
+            standard_signature::StandardInputSignature,
+            InputWitness,
+        },
+        sighash::{input_commitments::SighashInputCommitment, sighashtype::SigHashType},
+    },
+    Destination, Transaction, TxOutput,
+};
+use crypto::key::{PrivateKey, SigAuxDataProvider};
+
+use crate::signer::{SignerError, SignerResult};
+
+pub fn is_htlc_utxo(utxo: &TxOutput) -> bool {
+    match utxo {
+        TxOutput::Htlc(_, _) => true,
+
+        TxOutput::Transfer(_, _)
+        | TxOutput::LockThenTransfer(_, _, _)
+        | TxOutput::Burn(_)
+        | TxOutput::CreateStakePool(_, _)
+        | TxOutput::ProduceBlockFromStake(_, _)
+        | TxOutput::CreateDelegationId(_, _)
+        | TxOutput::DelegateStaking(_, _)
+        | TxOutput::IssueFungibleToken(_)
+        | TxOutput::IssueNft(_, _, _)
+        | TxOutput::DataDeposit(_)
+        | TxOutput::CreateOrder(_) => false,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn produce_uniparty_signature_for_input<AuxP: SigAuxDataProvider + ?Sized>(
+    is_htlc_input: bool,
+    htlc_secret: Option<HtlcSecret>,
+    private_key: &PrivateKey,
+    destination: Destination,
+    tx: &Transaction,
+    input_commitments: &[SighashInputCommitment],
+    input_index: usize,
+    sig_aux_data_provider: &mut AuxP,
+) -> SignerResult<InputWitness> {
+    let sighash_type = SigHashType::all();
+
+    if is_htlc_input {
+        match htlc_secret {
+            Some(htlc_secret) => produce_uniparty_signature_for_htlc_spending(
+                private_key,
+                sighash_type,
+                destination,
+                tx,
+                input_commitments,
+                input_index,
+                htlc_secret,
+                sig_aux_data_provider,
+            ),
+            None => produce_uniparty_signature_for_htlc_refunding(
+                private_key,
+                sighash_type,
+                destination,
+                tx,
+                input_commitments,
+                input_index,
+                sig_aux_data_provider,
+            ),
+        }
+    } else {
+        assert!(htlc_secret.is_none());
+
+        StandardInputSignature::produce_uniparty_signature_for_input(
+            private_key,
+            sighash_type,
+            destination,
+            tx,
+            input_commitments,
+            input_index,
+            sig_aux_data_provider,
+        )
+    }
+    .map(InputWitness::Standard)
+    .map_err(SignerError::SigningError)
+}

--- a/wallet/wallet-controller/src/helpers/mod.rs
+++ b/wallet/wallet-controller/src/helpers/mod.rs
@@ -114,7 +114,7 @@ pub async fn fetch_utxo<T: NodeInterface, B: storage::Backend>(
     // TODO: perhaps find_unspent_utxo_and_destination should return Option<Destination> for the cases when it's
     // not actually needed.
     if let Some(out) =
-        wallet.find_unspent_utxo_and_destination(input, HtlcSpendingCondition::WithMultisig)
+        wallet.find_unspent_utxo_and_destination(input, HtlcSpendingCondition::WithRefund)
     {
         return Ok(out.0);
     }

--- a/wasm-wrappers/WASM-API.md
+++ b/wasm-wrappers/WASM-API.md
@@ -241,10 +241,11 @@ Note:
   so if you only have `FillOrder` inputs, you can technically pass bogus values for the current balances and
   the resulting signature will still be valid; though it's better to avoid doing this).
 
-### Function: `encode_witness_htlc_secret`
+### Function: `encode_witness_htlc_spend`
 
-Given a private key, inputs and an input number to sign, and the destination that owns that output (through the utxo),
-and a network type (mainnet, testnet, etc), and an htlc secret this function returns a witness to be used in a signed transaction, as bytes.
+Sign the specified HTLC input of the transaction and encode the signature as InputWitness.
+
+This function must be used for HTLC spending.
 
 `input_utxos` and `additional_info` have the same format and requirements as in `encode_witness`.
 
@@ -257,13 +258,23 @@ the multisig challenge, as bytes.
 
 Produce a multisig address given a multisig challenge.
 
-### Function: `encode_witness_htlc_multisig`
+### Function: `encode_witness_htlc_refund_multisig`
 
-Given a private key, inputs and an input number to sign, and multisig challenge,
-and a network type (mainnet, testnet, etc), this function returns a witness to be used in a signed transaction, as bytes.
+Sign the specified HTLC input of the transaction and encode the signature as InputWitness.
 
-`key_index` parameter is an index of the public key in the challenge corresponding to the specified private key.
+This function must be used for HTLC refunding when the refund address is a multisig one.
+
+`key_index` parameter is an index of the public key in the multisig challenge corresponding to
+the specified private key.
 `input_witness` parameter can be either empty or a result of previous calls to this function.
+
+`input_utxos` and `additional_info` have the same format and requirements as in `encode_witness`.
+
+### Function: `encode_witness_htlc_refund_single_sig`
+
+Sign the specified HTLC input of the transaction and encode the signature as InputWitness.
+
+This function must be used for HTLC refunding when the refund address is a single-sig one.
 
 `input_utxos` and `additional_info` have the same format and requirements as in `encode_witness`.
 

--- a/wasm-wrappers/js-bindings-test/tests/test_encode_other_inputs.ts
+++ b/wasm-wrappers/js-bindings-test/tests/test_encode_other_inputs.ts
@@ -51,8 +51,9 @@ export const INPUTS = [
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4,
 ];
 
-// OutpointSourceId used in INPUTS.
-export const TX_OUTPOINT = new Uint8Array(33).fill(0)
+// OutpointSourceId and index used in INPUTS.
+export const TX_OUTPOINT_SOURCE_ID = new Uint8Array(33).fill(0);
+export const TX_OUTPOINT_INDEX = 1;
 
 export function test_encode_other_inputs() {
   run_one_test(predefined_inputs_test);
@@ -60,7 +61,7 @@ export function test_encode_other_inputs() {
 }
 
 function predefined_inputs_test() {
-  const tx_input = encode_input_for_utxo(TX_OUTPOINT, 1);
+  const tx_input = encode_input_for_utxo(TX_OUTPOINT_SOURCE_ID, TX_OUTPOINT_INDEX);
   const deleg_id =
     "mdelg1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqut3aj8";
   const tx_input2 = encode_input_for_withdraw_from_delegation(

--- a/wasm-wrappers/js-bindings-test/tests/test_htlc.ts
+++ b/wasm-wrappers/js-bindings-test/tests/test_htlc.ts
@@ -15,27 +15,32 @@
 
 import {
   Amount,
+  encode_input_for_utxo,
   encode_lock_until_height,
   encode_multisig_challenge,
   encode_output_htlc,
   encode_signed_transaction,
   encode_transaction,
-  encode_witness_htlc_multisig,
-  encode_witness_htlc_secret,
+  encode_witness_htlc_refund_multisig,
+  encode_witness_htlc_refund_single_sig,
+  encode_witness_htlc_spend,
   extract_htlc_secret,
+  internal_verify_witness,
   make_default_account_privkey,
   make_receiving_address,
+  multisig_challenge_to_address,
+  pubkey_to_pubkeyhash_address,
   public_key_from_private_key,
   Network,
   SignatureHashType,
 } from "../../pkg/wasm_wrappers.js";
 
 import {
-  assert_eq_arrays
+  assert_eq_arrays,
+  get_err_msg
 } from "./utils.js";
 
 import {
-  generate_prv_key,
   HTLC_SECRET,
   HTLC_SECRET_HASH,
   MNEMONIC,
@@ -43,11 +48,8 @@ import {
   TOKEN_ID,
 } from "./defs.js";
 import {
-  ADDRESS
-} from "./test_address_generation.js";
-import {
-  INPUTS,
-  TX_OUTPOINT,
+  TX_OUTPOINT_INDEX,
+  TX_OUTPOINT_SOURCE_ID,
 } from "./test_encode_other_inputs.js";
 import {
   OUTPUTS,
@@ -58,89 +60,163 @@ export function test_htlc() {
     MNEMONIC,
     Network.Testnet
   );
-  const receiving_privkey = make_receiving_address(account_privkey, 0);
+  const priv_key1 = make_receiving_address(account_privkey, 0);
+  const pub_key1 = public_key_from_private_key(priv_key1);
+  const addr1 = pubkey_to_pubkeyhash_address(pub_key1, Network.Testnet);
 
-  const htlc_coins_output = encode_output_htlc(
-    Amount.from_atoms("40000"),
-    undefined,
-    HTLC_SECRET_HASH,
-    ADDRESS,
-    ADDRESS,
-    encode_lock_until_height(BigInt(100)),
-    Network.Testnet
-  );
-  console.log("htlc with coins encoding ok");
+  const priv_key2 = make_receiving_address(account_privkey, 2);
+  const pub_key2 = public_key_from_private_key(priv_key2);
+  const addr2 = pubkey_to_pubkeyhash_address(pub_key2, Network.Testnet);
 
-  const htlc_tokens_output = encode_output_htlc(
-    Amount.from_atoms("40000"),
-    TOKEN_ID,
-    HTLC_SECRET_HASH,
-    ADDRESS,
-    ADDRESS,
-    encode_lock_until_height(BigInt(100)),
-    Network.Testnet
-  );
-  console.log("htlc with tokens encoding ok");
+  const multisig_challenge = encode_multisig_challenge(Uint8Array.from([...pub_key1, ...pub_key2]), 2, Network.Testnet);
+  const multisig_addr = multisig_challenge_to_address(multisig_challenge, Network.Testnet);
 
-  const opt_htlc_utxos = [1, ...htlc_coins_output, 1, ...htlc_tokens_output];
-  const tx = encode_transaction(Uint8Array.from(INPUTS), Uint8Array.from(OUTPUTS), BigInt(0));
-  // encode witness with secret
-  const witness_with_htlc_secret = encode_witness_htlc_secret(
-    SignatureHashType.ALL,
-    receiving_privkey,
-    ADDRESS,
-    tx,
-    Uint8Array.from(opt_htlc_utxos),
-    0,
-    Uint8Array.from(HTLC_SECRET),
-    { pool_info: {}, order_info: {} },
-    BigInt(RANDOM_HEIGHT),
-    Network.Testnet
-  );
-  console.log("Tested encode witness with htlc secret successfully");
+  const tx_input = encode_input_for_utxo(TX_OUTPOINT_SOURCE_ID, TX_OUTPOINT_INDEX);
+  const tx = encode_transaction(tx_input, Uint8Array.from(OUTPUTS), BigInt(0));
 
-  // encode multisig challenge
-  const alice_sk = generate_prv_key("alice_sk");
-  const alice_pk = public_key_from_private_key(alice_sk);
-  const bob_sk = generate_prv_key("bob_sk");
-  const bob_pk = public_key_from_private_key(bob_sk);
-  let challenge = encode_multisig_challenge(Uint8Array.from([...alice_pk, ...bob_pk]), 2, Network.Testnet);
-  console.log("Tested multisig challenge successfully");
+  for (const token of [null, TOKEN_ID]) {
+    for (const refund_to_multisig of [true, false]) {
+      console.log(`Testing htlc, token = ${token}, refund_to_multisig = ${refund_to_multisig}`);
 
-  // encode mutlisig witness
-  const witness_with_htlc_multisig_1 = encode_witness_htlc_multisig(
-    SignatureHashType.ALL,
-    alice_sk,
-    0,
-    new Uint8Array([]),
-    challenge,
-    tx,
-    Uint8Array.from(opt_htlc_utxos),
-    1,
-    { pool_info: {}, order_info: {} },
-    BigInt(RANDOM_HEIGHT),
-    Network.Testnet
-  );
-  console.log("Tested encode multisig witness 0 successfully");
+      const refund_addr = refund_to_multisig ? multisig_addr : addr2;
+      const htlc_output = encode_output_htlc(
+        Amount.from_atoms("40000"),
+        token,
+        HTLC_SECRET_HASH,
+        addr1,
+        refund_addr,
+        encode_lock_until_height(BigInt(100)),
+        Network.Testnet
+      );
 
-  const witness_with_htlc_multisig = encode_witness_htlc_multisig(
-    SignatureHashType.ALL,
-    bob_sk,
-    1,
-    witness_with_htlc_multisig_1,
-    challenge,
-    tx,
-    Uint8Array.from(opt_htlc_utxos),
-    1,
-    { pool_info: {}, order_info: {} },
-    BigInt(RANDOM_HEIGHT),
-    Network.Testnet
-  );
-  console.log("Tested encode multisig witness 1 successfully");
+      console.log("Htlc encoded successfully");
 
-  // encode signed tx with secret and multi
-  const htlc_signed_tx = encode_signed_transaction(tx, Uint8Array.from([...witness_with_htlc_secret, ...witness_with_htlc_multisig]));
-  // extract secret from signed tx
-  const secret_extracted = extract_htlc_secret(htlc_signed_tx, true, TX_OUTPOINT, 1);
-  assert_eq_arrays(HTLC_SECRET, secret_extracted);
+      const opt_utxos = Uint8Array.from([1, ...htlc_output]);
+
+      const witness_with_htlc_spend = encode_witness_htlc_spend(
+        SignatureHashType.ALL,
+        priv_key1,
+        addr1,
+        tx,
+        opt_utxos,
+        0,
+        Uint8Array.from(HTLC_SECRET),
+        { pool_info: {}, order_info: {} },
+        BigInt(RANDOM_HEIGHT),
+        Network.Testnet
+      );
+
+      console.log("Witness with htlc spend encoded successfully");
+
+      internal_verify_witness(
+        SignatureHashType.ALL,
+        null,
+        witness_with_htlc_spend,
+        tx,
+        opt_utxos,
+        0,
+        { pool_info: {}, order_info: {} },
+        BigInt(RANDOM_HEIGHT),
+        Network.Testnet
+      );
+
+      console.log("Witness with htlc spend verified successfully");
+
+      const htlc_signed_tx = encode_signed_transaction(tx, Uint8Array.from([...witness_with_htlc_spend]));
+
+      const secret_extracted = extract_htlc_secret(htlc_signed_tx, true, TX_OUTPOINT_SOURCE_ID, TX_OUTPOINT_INDEX);
+      assert_eq_arrays(HTLC_SECRET, secret_extracted);
+
+      console.log("Htlc secret extracted successfully");
+
+      try {
+        extract_htlc_secret(htlc_signed_tx, true, TX_OUTPOINT_SOURCE_ID, TX_OUTPOINT_INDEX + 1)
+        throw new Error("Extracting the Htlc secret using wrong utxo outpoint worked somehow!");
+      } catch (e) {
+        if (
+          !get_err_msg(e).includes("No input outpoint found in transaction")
+        ) {
+          throw e;
+        }
+      }
+
+      console.log("Invalid htlc secret extraction tested successfully");
+
+      if (refund_to_multisig) {
+        const partial_witness_with_htlc_refund = encode_witness_htlc_refund_multisig(
+          SignatureHashType.ALL,
+          priv_key1,
+          0,
+          new Uint8Array([]),
+          multisig_challenge,
+          tx,
+          opt_utxos,
+          0,
+          { pool_info: {}, order_info: {} },
+          BigInt(RANDOM_HEIGHT),
+          Network.Testnet
+        );
+
+        console.log("Partial witness with htlc refund encoded successfully");
+
+        const witness_with_htlc_refund = encode_witness_htlc_refund_multisig(
+          SignatureHashType.ALL,
+          priv_key2,
+          1,
+          partial_witness_with_htlc_refund,
+          multisig_challenge,
+          tx,
+          opt_utxos,
+          0,
+          { pool_info: {}, order_info: {} },
+          BigInt(RANDOM_HEIGHT),
+          Network.Testnet
+        );
+
+        console.log("Witness with htlc refund encoded successfully");
+
+        internal_verify_witness(
+          SignatureHashType.ALL,
+          null,
+          witness_with_htlc_refund,
+          tx,
+          opt_utxos,
+          0,
+          { pool_info: {}, order_info: {} },
+          BigInt(RANDOM_HEIGHT),
+          Network.Testnet
+        );
+
+        console.log("Witness with htlc refund verified successfully");
+      } else {
+        const witness_with_htlc_refund = encode_witness_htlc_refund_single_sig(
+          SignatureHashType.ALL,
+          priv_key2,
+          addr2,
+          tx,
+          opt_utxos,
+          0,
+          { pool_info: {}, order_info: {} },
+          BigInt(RANDOM_HEIGHT),
+          Network.Testnet
+        );
+
+        console.log("Witness with htlc refund encoded successfully");
+
+        internal_verify_witness(
+          SignatureHashType.ALL,
+          null,
+          witness_with_htlc_refund,
+          tx,
+          opt_utxos,
+          0,
+          { pool_info: {}, order_info: {} },
+          BigInt(RANDOM_HEIGHT),
+          Network.Testnet
+        );
+
+        console.log("Witness with htlc refund verified successfully");
+      }
+    }
+  }
 }

--- a/wasm-wrappers/src/internal.rs
+++ b/wasm-wrappers/src/internal.rs
@@ -122,10 +122,10 @@ pub fn internal_verify_witness(
         let (htlc_spend, sighash_type) = extract_htlc_spend(&witness)?;
 
         let (raw_sig, dest) = match htlc_spend {
-            AuthorizedHashedTimelockContractSpend::Secret(_, raw_sig) => {
+            AuthorizedHashedTimelockContractSpend::Spend(_, raw_sig) => {
                 (raw_sig, htlc.spend_key.clone())
             }
-            AuthorizedHashedTimelockContractSpend::Multisig(raw_sig) => {
+            AuthorizedHashedTimelockContractSpend::Refund(raw_sig) => {
                 (raw_sig, htlc.refund_key.clone())
             }
         };

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -56,7 +56,7 @@ use common::{
                 classical_multisig::authorize_classical_multisig::{
                     sign_classical_multisig_spending, AuthorizedClassicalMultisigSpend,
                 },
-                htlc::produce_uniparty_signature_for_htlc_input,
+                htlc::produce_uniparty_signature_for_htlc_spending,
                 standard_signature::StandardInputSignature,
                 InputWitness,
             },
@@ -826,7 +826,7 @@ pub fn encode_witness_htlc_secret(
     let secret =
         HtlcSecret::decode_all(&mut &secret[..]).map_err(Error::InvalidHtlcSecretEncoding)?;
 
-    let witness = produce_uniparty_signature_for_htlc_input(
+    let witness = produce_uniparty_signature_for_htlc_spending(
         &private_key,
         sighashtype.into(),
         destination,

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -56,7 +56,10 @@ use common::{
                 classical_multisig::authorize_classical_multisig::{
                     sign_classical_multisig_spending, AuthorizedClassicalMultisigSpend,
                 },
-                htlc::{produce_uniparty_signature_for_htlc_refunding, produce_uniparty_signature_for_htlc_spending},
+                htlc::{
+                    produce_uniparty_signature_for_htlc_refunding,
+                    produce_uniparty_signature_for_htlc_spending,
+                },
                 standard_signature::StandardInputSignature,
                 InputWitness,
             },
@@ -783,7 +786,7 @@ pub fn encode_witness(
 }
 
 /// Sign the specified HTLC input of the transaction and encode the signature as InputWitness.
-/// 
+///
 /// This function must be used for HTLC spending.
 ///
 /// `input_utxos` and `additional_info` have the same format and requirements as in `encode_witness`.
@@ -888,7 +891,7 @@ pub fn multisig_challenge_to_address(
 /// Sign the specified HTLC input of the transaction and encode the signature as InputWitness.
 ///
 /// This function must be used for HTLC refunding when the refund address is a multisig one.
-/// 
+///
 /// `key_index` parameter is an index of the public key in the multisig challenge corresponding to
 /// the specified private key.
 /// `input_witness` parameter can be either empty or a result of previous calls to this function.

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -640,9 +640,9 @@ pub fn extract_htlc_secret(
         extract_htlc_spend(tx.signatures().get(htlc_position).ok_or(Error::InvalidWitnessCount)?)?;
 
     match htlc_spend {
-        AuthorizedHashedTimelockContractSpend::Secret(secret, _) => Ok(secret.encode()),
-        AuthorizedHashedTimelockContractSpend::Multisig(_) => Err(Error::UnexpectedHtlcSpendType(
-            AuthorizedHashedTimelockContractSpendTag::Multisig,
+        AuthorizedHashedTimelockContractSpend::Spend(secret, _) => Ok(secret.encode()),
+        AuthorizedHashedTimelockContractSpend::Refund(_) => Err(Error::UnexpectedHtlcSpendType(
+            AuthorizedHashedTimelockContractSpendTag::Refund,
         )),
     }
 }
@@ -946,12 +946,12 @@ pub fn encode_witness_htlc_refund_multisig(
         let (htlc_spend, _) = extract_htlc_spend(&input_witness)?;
 
         match htlc_spend {
-            AuthorizedHashedTimelockContractSpend::Secret(_, _) => {
+            AuthorizedHashedTimelockContractSpend::Spend(_, _) => {
                 return Err(Error::UnexpectedHtlcSpendType(
-                    AuthorizedHashedTimelockContractSpendTag::Secret,
+                    AuthorizedHashedTimelockContractSpendTag::Spend,
                 ));
             }
-            AuthorizedHashedTimelockContractSpend::Multisig(raw_signature) => {
+            AuthorizedHashedTimelockContractSpend::Refund(raw_signature) => {
                 AuthorizedClassicalMultisigSpend::from_data(&raw_signature)
                     .map_err(Error::MultisigSpendCreationError)?
             }
@@ -973,7 +973,7 @@ pub fn encode_witness_htlc_refund_multisig(
     .take();
 
     let raw_signature =
-        AuthorizedHashedTimelockContractSpend::Multisig(authorization.encode()).encode();
+        AuthorizedHashedTimelockContractSpend::Refund(authorization.encode()).encode();
     let witness = InputWitness::Standard(StandardInputSignature::new(sighashtype, raw_signature));
 
     Ok(witness.encode())

--- a/wasm-wrappers/src/lib.rs
+++ b/wasm-wrappers/src/lib.rs
@@ -56,7 +56,7 @@ use common::{
                 classical_multisig::authorize_classical_multisig::{
                     sign_classical_multisig_spending, AuthorizedClassicalMultisigSpend,
                 },
-                htlc::produce_uniparty_signature_for_htlc_spending,
+                htlc::{produce_uniparty_signature_for_htlc_refunding, produce_uniparty_signature_for_htlc_spending},
                 standard_signature::StandardInputSignature,
                 InputWitness,
             },
@@ -782,13 +782,14 @@ pub fn encode_witness(
     Ok(witness.encode())
 }
 
-/// Given a private key, inputs and an input number to sign, and the destination that owns that output (through the utxo),
-/// and a network type (mainnet, testnet, etc), and an htlc secret this function returns a witness to be used in a signed transaction, as bytes.
+/// Sign the specified HTLC input of the transaction and encode the signature as InputWitness.
+/// 
+/// This function must be used for HTLC spending.
 ///
 /// `input_utxos` and `additional_info` have the same format and requirements as in `encode_witness`.
 #[allow(clippy::too_many_arguments)]
 #[wasm_bindgen]
-pub fn encode_witness_htlc_secret(
+pub fn encode_witness_htlc_spend(
     sighashtype: SignatureHashType,
     private_key: &[u8],
     input_owner_destination: &str,
@@ -884,16 +885,18 @@ pub fn multisig_challenge_to_address(
     Ok(address)
 }
 
-/// Given a private key, inputs and an input number to sign, and multisig challenge,
-/// and a network type (mainnet, testnet, etc), this function returns a witness to be used in a signed transaction, as bytes.
+/// Sign the specified HTLC input of the transaction and encode the signature as InputWitness.
 ///
-/// `key_index` parameter is an index of the public key in the challenge corresponding to the specified private key.
+/// This function must be used for HTLC refunding when the refund address is a multisig one.
+/// 
+/// `key_index` parameter is an index of the public key in the multisig challenge corresponding to
+/// the specified private key.
 /// `input_witness` parameter can be either empty or a result of previous calls to this function.
 ///
 /// `input_utxos` and `additional_info` have the same format and requirements as in `encode_witness`.
 #[allow(clippy::too_many_arguments)]
 #[wasm_bindgen]
-pub fn encode_witness_htlc_multisig(
+pub fn encode_witness_htlc_refund_multisig(
     sighashtype: SignatureHashType,
     private_key: &[u8],
     key_index: u8,
@@ -969,6 +972,62 @@ pub fn encode_witness_htlc_multisig(
     let raw_signature =
         AuthorizedHashedTimelockContractSpend::Multisig(authorization.encode()).encode();
     let witness = InputWitness::Standard(StandardInputSignature::new(sighashtype, raw_signature));
+
+    Ok(witness.encode())
+}
+
+/// Sign the specified HTLC input of the transaction and encode the signature as InputWitness.
+///
+/// This function must be used for HTLC refunding when the refund address is a single-sig one.
+///
+/// `input_utxos` and `additional_info` have the same format and requirements as in `encode_witness`.
+#[allow(clippy::too_many_arguments)]
+#[wasm_bindgen]
+pub fn encode_witness_htlc_refund_single_sig(
+    sighashtype: SignatureHashType,
+    private_key: &[u8],
+    input_owner_destination: &str,
+    transaction: &[u8],
+    input_utxos: &[u8],
+    input_index: u32,
+    additional_info: TxAdditionalInfo,
+    current_block_height: u64,
+    network: Network,
+) -> Result<Vec<u8>, Error> {
+    let chain_config = Builder::new(network.into()).build();
+
+    let private_key =
+        PrivateKey::decode_all(&mut &private_key[..]).map_err(Error::InvalidPrivateKeyEncoding)?;
+
+    let destination = parse_addressable(&chain_config, input_owner_destination)?;
+
+    let tx = Transaction::decode_all(&mut &transaction[..])
+        .map_err(Error::InvalidTransactionEncoding)?;
+
+    let input_utxos = decode_raw_array::<Option<TxOutput>>(input_utxos)
+        .map_err(Error::InvalidInputUtxoEncoding)?;
+
+    let ptx_additional_info = to_ptx_additional_info(&chain_config, &additional_info)?;
+
+    let input_commitments = make_sighash_input_commitments_at_height(
+        tx.inputs(),
+        &input_utxos,
+        &ptx_additional_info,
+        &chain_config,
+        BlockHeight::new(current_block_height),
+    )?;
+
+    let witness = produce_uniparty_signature_for_htlc_refunding(
+        &private_key,
+        sighashtype.into(),
+        destination,
+        &tx,
+        &input_commitments,
+        input_index as usize,
+        &mut randomness::make_true_rng(),
+    )
+    .map(InputWitness::Standard)
+    .map_err(Error::InputSigningError)?;
 
     Ok(witness.encode())
 }


### PR DESCRIPTION
In the wasm bindings, `encode_witness_htlc_secret` was renamed to `encode_witness_htlc_spend`, `encode_witness_htlc_multisig` was renamed to `encode_witness_htlc_refund_multisig` and a new functions was added - `encode_witness_htlc_refund_single_sig`.

I also added tests for single-sig htlc refund where appropriate and made the corresponding fixes in the wallet signers.

The variants of the `AuthorizedHashedTimelockContractSpend` enum are now called `Spend` and `Refund`. Some other things were renamed here and there too.

P.S. the test failures I was talking about during the daily were because I accidentally specified the same UtxoOutpoint twice in the same tx in tests. The signers didn't complain, but the trezor one would produce wrong signatures. I added a small check to fail earlier in such a case.