### PR TITLE
Fix/ledger ping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "messages"
 version = "0.1.0"
-source = "git+https://github.com/mintlayer/mintlayer-ledger-app?rev=dbc41342564b2198037ed4ad41b4cf0c34617870#dbc41342564b2198037ed4ad41b4cf0c34617870"
+source = "git+https://github.com/mintlayer/mintlayer-ledger-app?rev=985e76c95105533436c144c19707556b7521f745#985e76c95105533436c144c19707556b7521f745"
 dependencies = [
  "derive_more 2.1.1",
  "mintlayer-core-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,8 +296,8 @@ rev = "035789ec436d47b938e8a3d2085ffb2fbf6f0559"
 
 [workspace.dependencies.mintlayer-ledger-messages]
 git = "https://github.com/mintlayer/mintlayer-ledger-app"
-# The commit "Move StatusWord to messages crate"
-rev = "dbc41342564b2198037ed4ad41b4cf0c34617870"
+# The commit "Add Ping command"
+rev = "985e76c95105533436c144c19707556b7521f745"
 package = "messages"
 
 [workspace.dependencies.trezor-client]

--- a/wallet/src/signer/ledger_signer/ledger_messages.rs
+++ b/wallet/src/signer/ledger_signer/ledger_messages.rs
@@ -161,23 +161,13 @@ pub async fn check_current_app<L: Exchange + Device + Send>(
     Ok(app_version)
 }
 
-pub async fn get_extended_public_key_raw<L: Exchange>(
-    ledger: &mut L,
-    coin_type: ledger_msg::CoinType,
-    derivation_path: &DerivationPath,
-) -> Result<Vec<u8>, LedgerMessagesError> {
-    let path = ledger_msg::Bip32Path(
-        derivation_path.as_slice().iter().map(|c| c.into_encoded_index()).collect(),
-    );
-    let req = ledger_msg::PublicKeyReq { coin_type, path };
-    let encoded_req = ledger_msg::encode(req);
-
+pub async fn ping<L: Exchange>(ledger: &mut L) -> Result<Vec<u8>, LedgerMessagesError> {
     let apdu = ledger_msg::Apdu::new_with_data(
-        ledger_msg::Ins::PUB_KEY,
-        ledger_msg::PubKeyP1::NoDisplayAddress.into(),
-        &encoded_req,
+        ledger_msg::Ins::PING,
+        ledger_msg::PingP1::Start.into(),
+        &[],
     )
-    .ok_or(LedgerMessagesError::DerivationPathTooLong)?;
+    .expect("empty message is always within the APDU limits");
 
     let mut msg_buf = Vec::with_capacity(apdu.bytes_count());
     apdu.write_bytes(&mut msg_buf);

--- a/wallet/src/signer/ledger_signer/mod.rs
+++ b/wallet/src/signer/ledger_signer/mod.rs
@@ -25,8 +25,8 @@ use crate::{
             StandaloneInput, StandaloneInputs,
         },
         ledger_signer::ledger_messages::{
-            check_current_app, get_extended_public_key, get_extended_public_key_raw,
-            sign_challenge, sign_tx, LedgerMessagesError,
+            check_current_app, get_extended_public_key, ping, sign_challenge, sign_tx,
+            LedgerMessagesError,
         },
         utils::{is_htlc_utxo, produce_uniparty_signature_for_input},
         Signer, SignerError, SignerProvider, SignerResult,
@@ -206,10 +206,8 @@ where
         let mut client = self.client.lock().await;
         // Try and wait around 50 * TIMEOUT_DUR for the screen to clear after a signing operation ends
         let mut num_tries = 50;
-        let derivation_path = make_account_path(&self.chain_config, key_chain.account_index());
-        let coin_type = to_ledger_chain_type(&self.chain_config);
         loop {
-            match get_extended_public_key_raw(&mut *client, coin_type, &derivation_path).await {
+            match ping(&mut *client).await {
                 Ok(_) => {
                     check_public_keys_against_key_chain(
                         db_tx,

--- a/wallet/src/signer/ledger_signer/tests/mod.rs
+++ b/wallet/src/signer/ledger_signer/tests/mod.rs
@@ -39,9 +39,7 @@ use tokio::{
 
 use crate::signer::{
     ledger_signer::{
-        ledger_messages::{
-            check_current_app, get_extended_public_key, get_extended_public_key_raw,
-        },
+        ledger_messages::{check_current_app, get_extended_public_key, ping},
         LedgerError, LedgerFinder, LedgerSigner,
     },
     tests::{
@@ -142,9 +140,8 @@ impl LedgerFinder for DummyProvider {
 
 async fn wait_for_valid_reponse(device: &mut TcpDevice) {
     let mut tries = 0;
-    let derivation_path = DerivationPath::from_str("m/44h/19788h/0h").unwrap();
     loop {
-        match get_extended_public_key_raw(device, CoinType::Mainnet, &derivation_path).await {
+        match ping(device).await {
             Ok(_) => break,
             Err(_) => {
                 tries += 1;

--- a/wallet/src/signer/tests/generic_tests.rs
+++ b/wallet/src/signer/tests/generic_tests.rs
@@ -91,7 +91,10 @@ pub fn sign_message_test_params(
         MessageToSign::Random,
         // Special case: an "overlong" utf-8 string (basically, the letter 'K' encoded with 2 bytes
         // instead of 1). Trezor firmware used to have troubles with this.
-        MessageToSign::Predefined(vec![193, 139])
+        MessageToSign::Predefined(vec![193, 139]),
+        // Special case: ASCII control characters not printable. Ledger was not handling it
+        // properly.
+        MessageToSign::Predefined(vec![0, 3])
     )]
     message_to_sign: MessageToSign,
 ) {


### PR DESCRIPTION
- Use the new ping command instead of the get public key
- Add a predefined message test with null and unprintable control characters