### PR TITLE
Update trezor ref and docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ env:
 jobs:
   build_windows:
     runs-on: windows-latest
+    env:
+        # With the default CARGO_HOME the job will fail due to Windows path length limit when
+        # checking out the trezor firmware repo. E.g. one of the paths looks like this:
+        # C:/Users/runneradmin/.cargo/git/checkouts/mintlayer-trezor-firmware-04bdf62619936e0b/596b3eb/vendor/libtropic/scripts/tropic01_model/provisioning_data/2025-06-27T07-51-29Z__prod_C2S_T200__provisioning__lab_batch_package/cert_chain/tropicsquare_root_ca_certificate_sn_101.der
+        CARGO_HOME: C:\crg
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v5
@@ -218,6 +223,19 @@ jobs:
       TREZOR_TESTS_USE_REAL_DEVICE: false
       TREZOR_TESTS_AUTO_CONFIRM: true
     steps:
+      # Note: THP is the new protocol used by Safe 7, which we do not yet support, so we disable
+      # it by setting THP to 0. This means that we're not emulating the real Safe 7 here, i.e. it's
+      # just a hack to make the CI pass.
+      # TODO:
+      # 1) Remove this after THP support is implemented.
+      # 2) Another thing that is different about Safe 7 is the use of an additional secure element
+      #    called Tropic. Tests on the firmware side build the firmware with DISABLE_TROPIC=0, which
+      #    then requires a Tropic model server to be run alongside the emulator. We might want to do
+      #    the same here, to make the emulator behave more like the real device.
+      - name: Disable THP for T3W1
+        if: ${{ matrix.model == 'T3W1' }}
+        run: echo "THP=0" >> "$GITHUB_ENV"
+
       # Note: cargo-nextest requires the source code to be present when running archived test binaries.
       - name: Checkout the core repository
         uses: actions/checkout@v5
@@ -271,18 +289,18 @@ jobs:
         run: nix-shell --arg fullDeps false --run "true"
         working-directory: ./mintlayer-trezor-firmware
       - name: Setup trezor repo build dependencies, part 2
-        run: nix-shell --arg fullDeps false --run "poetry install"
+        run: nix-shell --arg fullDeps false --run "uv sync"
         working-directory: ./mintlayer-trezor-firmware
 
       - name: Build the firmware
-        run: nix-shell --run "poetry run make -C core build_unix"
+        run: nix-shell --run "uv run make -C core build_unix"
         working-directory: ./mintlayer-trezor-firmware
 
       # Note: since we haven't installed Cargo in this job, we have to execute "cargo-nextest nextest"
       # instead of "cargo nextest".
       - name: Run tests in the emulator
         run: nix-shell --run "
-          poetry run core/emu.py
+          uv run core/emu.py
           --headless --quiet --temporary-profile
           --mnemonic \"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about\"
           --command env --chdir ../mintlayer-core

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -54,6 +54,10 @@ jobs:
 
   static_checks_windows:
     runs-on: windows-latest
+    env:
+        # Same as in build_windows, using the default CARGO_HOME would make the job fail due to Windows
+        # path length limit.
+        CARGO_HOME: C:\crg
     steps:
       # This prevents git from changing line-endings to crlf, which messes cargo fmt checks
       - name: Set git to use LF

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -54,7 +54,7 @@ jobs:
         run: npm install typescript knip
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack --locked
 
       - name: Build the wasm module
         working-directory: ./wasm-wrappers
@@ -92,7 +92,7 @@ jobs:
             --default-toolchain $(python ./build-tools/cargo-info-extractor/extract.py --rust-version)
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack  --locked
 
       - name: Build the wasm module for nodejs - release
         working-directory: ./wasm-wrappers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ dependencies = [
  "lazy_static",
  "logging",
  "merkletree-mintlayer",
- "mintlayer-core-primitives",
+ "mintlayer-core-primitives 1.0.0 (git+https://github.com/mintlayer/mintlayer-core-primitives?rev=13b10dbc88efdf3b5aa31ece8e34278bc69a5a9b)",
  "num",
  "num-traits",
  "once_cell",
@@ -5027,7 +5027,7 @@ version = "0.1.0"
 source = "git+https://github.com/mintlayer/mintlayer-ledger-app?rev=dbc41342564b2198037ed4ad41b4cf0c34617870#dbc41342564b2198037ed4ad41b4cf0c34617870"
 dependencies = [
  "derive_more 2.1.1",
- "mintlayer-core-primitives",
+ "mintlayer-core-primitives 1.0.0 (git+https://github.com/mintlayer/mintlayer-core-primitives?rev=13b10dbc88efdf3b5aa31ece8e34278bc69a5a9b)",
  "num_enum",
  "parity-scale-codec",
 ]
@@ -5100,11 +5100,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintlayer-core-primitives"
+version = "1.0.0"
+source = "git+https://github.com/mintlayer/mintlayer-core-primitives?rev=d5089aea20c6120e91667a29870dfeb496eff9ec#d5089aea20c6120e91667a29870dfeb496eff9ec"
+dependencies = [
+ "derive_more 2.1.1",
+ "fixed-hash",
+ "parity-scale-codec",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "mintlayer-firmware-deps"
 version = "0.0.0"
-source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=a2e67f6cf804dd905791ec36bff1981871f5321c#a2e67f6cf804dd905791ec36bff1981871f5321c"
+source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=fda0c12fc408ab96d4bd0fc3e796e00c622642db#fda0c12fc408ab96d4bd0fc3e796e00c622642db"
 dependencies = [
- "mintlayer-core-primitives",
+ "mintlayer-core-primitives 1.0.0 (git+https://github.com/mintlayer/mintlayer-core-primitives?rev=d5089aea20c6120e91667a29870dfeb496eff9ec)",
 ]
 
 [[package]]
@@ -9363,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.1.5"
-source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=a2e67f6cf804dd905791ec36bff1981871f5321c#a2e67f6cf804dd905791ec36bff1981871f5321c"
+source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=fda0c12fc408ab96d4bd0fc3e796e00c622642db#fda0c12fc408ab96d4bd0fc3e796e00c622642db"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "messages"
 version = "0.1.0"
-source = "git+https://github.com/mintlayer/mintlayer-ledger-app?rev=ffe0d6256877c1b4b18b2e4a27bdeeaa7fc5a2ff#ffe0d6256877c1b4b18b2e4a27bdeeaa7fc5a2ff"
+source = "git+https://github.com/mintlayer/mintlayer-ledger-app?rev=a544449d0c649c7c6b27ec0bd8e03f43861f60a7#a544449d0c649c7c6b27ec0bd8e03f43861f60a7"
 dependencies = [
  "derive_more 2.1.1",
  "mintlayer-core-primitives",
@@ -5102,7 +5102,7 @@ dependencies = [
 [[package]]
 name = "mintlayer-firmware-deps"
 version = "0.0.0"
-source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=596b3ebf536b438156132406d2e3a3f4dde53ebc#596b3ebf536b438156132406d2e3a3f4dde53ebc"
+source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=0e6c4d46ff75a94164f07c9bf0bd95cdba81fea3#0e6c4d46ff75a94164f07c9bf0bd95cdba81fea3"
 dependencies = [
  "mintlayer-core-primitives",
 ]
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.1.5"
-source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=596b3ebf536b438156132406d2e3a3f4dde53ebc#596b3ebf536b438156132406d2e3a3f4dde53ebc"
+source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=0e6c4d46ff75a94164f07c9bf0bd95cdba81fea3#0e6c4d46ff75a94164f07c9bf0bd95cdba81fea3"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ dependencies = [
  "lazy_static",
  "logging",
  "merkletree-mintlayer",
- "mintlayer-core-primitives 1.0.0 (git+https://github.com/mintlayer/mintlayer-core-primitives?rev=13b10dbc88efdf3b5aa31ece8e34278bc69a5a9b)",
+ "mintlayer-core-primitives",
  "num",
  "num-traits",
  "once_cell",
@@ -4606,7 +4606,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "ledger-lib"
 version = "0.1.0"
-source = "git+https://github.com/ImplOfAnImpl/rust-ledger.git?rev=035789ec436d47b938e8a3d2085ffb2fbf6f0559#035789ec436d47b938e8a3d2085ffb2fbf6f0559"
+source = "git+https://github.com/ledger-community/rust-ledger.git?rev=c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89#c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89"
 dependencies = [
  "async-trait",
  "btleplug",
@@ -4628,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "ledger-proto"
 version = "0.1.0"
-source = "git+https://github.com/ImplOfAnImpl/rust-ledger.git?rev=035789ec436d47b938e8a3d2085ffb2fbf6f0559#035789ec436d47b938e8a3d2085ffb2fbf6f0559"
+source = "git+https://github.com/ledger-community/rust-ledger.git?rev=c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89#c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89"
 dependencies = [
  "bitflags 2.10.0",
  "displaydoc",
@@ -5024,10 +5024,10 @@ dependencies = [
 [[package]]
 name = "messages"
 version = "0.1.0"
-source = "git+https://github.com/mintlayer/mintlayer-ledger-app?rev=dbc41342564b2198037ed4ad41b4cf0c34617870#dbc41342564b2198037ed4ad41b4cf0c34617870"
+source = "git+https://github.com/mintlayer/mintlayer-ledger-app?rev=ffe0d6256877c1b4b18b2e4a27bdeeaa7fc5a2ff#ffe0d6256877c1b4b18b2e4a27bdeeaa7fc5a2ff"
 dependencies = [
  "derive_more 2.1.1",
- "mintlayer-core-primitives 1.0.0 (git+https://github.com/mintlayer/mintlayer-core-primitives?rev=13b10dbc88efdf3b5aa31ece8e34278bc69a5a9b)",
+ "mintlayer-core-primitives",
  "num_enum",
  "parity-scale-codec",
 ]
@@ -5091,18 +5091,7 @@ dependencies = [
 [[package]]
 name = "mintlayer-core-primitives"
 version = "1.0.0"
-source = "git+https://github.com/mintlayer/mintlayer-core-primitives?rev=13b10dbc88efdf3b5aa31ece8e34278bc69a5a9b#13b10dbc88efdf3b5aa31ece8e34278bc69a5a9b"
-dependencies = [
- "derive_more 2.1.1",
- "fixed-hash",
- "parity-scale-codec",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "mintlayer-core-primitives"
-version = "1.0.0"
-source = "git+https://github.com/mintlayer/mintlayer-core-primitives?rev=d5089aea20c6120e91667a29870dfeb496eff9ec#d5089aea20c6120e91667a29870dfeb496eff9ec"
+source = "git+https://github.com/mintlayer/mintlayer-core-primitives?rev=8644bfe06d932d687075939d2d175183ba1c369d#8644bfe06d932d687075939d2d175183ba1c369d"
 dependencies = [
  "derive_more 2.1.1",
  "fixed-hash",
@@ -5113,9 +5102,9 @@ dependencies = [
 [[package]]
 name = "mintlayer-firmware-deps"
 version = "0.0.0"
-source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=fda0c12fc408ab96d4bd0fc3e796e00c622642db#fda0c12fc408ab96d4bd0fc3e796e00c622642db"
+source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=596b3ebf536b438156132406d2e3a3f4dde53ebc#596b3ebf536b438156132406d2e3a3f4dde53ebc"
 dependencies = [
- "mintlayer-core-primitives 1.0.0 (git+https://github.com/mintlayer/mintlayer-core-primitives?rev=d5089aea20c6120e91667a29870dfeb496eff9ec)",
+ "mintlayer-core-primitives",
 ]
 
 [[package]]
@@ -7607,9 +7596,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -9374,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.1.5"
-source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=fda0c12fc408ab96d4bd0fc3e796e00c622642db#fda0c12fc408ab96d4bd0fc3e796e00c622642db"
+source = "git+https://github.com/mintlayer/mintlayer-trezor-firmware?rev=596b3ebf536b438156132406d2e3a3f4dde53ebc#596b3ebf536b438156132406d2e3a3f4dde53ebc"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,8 +300,8 @@ package = "messages"
 
 [workspace.dependencies.trezor-client]
 git = "https://github.com/mintlayer/mintlayer-trezor-firmware"
-# The commit "Bump ml_primitives and parity scale codec deps"
-rev = "a2e67f6cf804dd905791ec36bff1981871f5321c"
+# The commit "Fix Mintlayer code after merge with v2.11.0"
+rev = "fda0c12fc408ab96d4bd0fc3e796e00c622642db"
 features = ["bitcoin", "mintlayer"]
 
 [workspace.metadata.dist.dependencies.apt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,14 +296,14 @@ rev = "c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89"
 
 [workspace.dependencies.mintlayer-ledger-messages]
 git = "https://github.com/mintlayer/mintlayer-ledger-app"
-# The commit "Update mintlayer-core-primitives repo revision. Enable disabled CI workflows. ..."
-rev = "ffe0d6256877c1b4b18b2e4a27bdeeaa7fc5a2ff"
+# The commit "Merge pull request #3 from mintlayer/update_ml_primitives_rev"
+rev = "a544449d0c649c7c6b27ec0bd8e03f43861f60a7"
 package = "messages"
 
 [workspace.dependencies.trezor-client]
 git = "https://github.com/mintlayer/mintlayer-trezor-firmware"
-# The commit "Fix Mintlayer code after merge with v2.11.0. Update revisions of mintlayer-core-primitives and parity-scale-codec."
-rev = "596b3ebf536b438156132406d2e3a3f4dde53ebc"
+# The commit "Merge pull request #25 from mintlayer/merge_with_v2.11.0_from_upstream"
+rev = "0e6c4d46ff75a94164f07c9bf0bd95cdba81fea3"
 features = ["bitcoin", "mintlayer"]
 
 [workspace.metadata.dist.dependencies.apt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,28 +280,30 @@ zeroize = "1.5"
 
 [workspace.dependencies.ml_primitives]
 git = "https://github.com/mintlayer/mintlayer-core-primitives"
-# The commit "Add CoinType used for Ledger and encode/decode utils".
-rev = "13b10dbc88efdf3b5aa31ece8e34278bc69a5a9b"
+# The commit "Merge pull request #4 from mintlayer/fix_typo".
+rev = "8644bfe06d932d687075939d2d175183ba1c369d"
 package = "mintlayer-core-primitives"
 
 [workspace.dependencies.ledger-lib]
-git = "https://github.com/ImplOfAnImpl/rust-ledger.git"
-rev = "035789ec436d47b938e8a3d2085ffb2fbf6f0559"
+git = "https://github.com/ledger-community/rust-ledger.git"
+# Note: we need this PR - https://github.com/ledger-community/rust-ledger/pull/14
+rev = "c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89"
 
 [workspace.dependencies.ledger-proto]
-git = "https://github.com/ImplOfAnImpl/rust-ledger.git"
-rev = "035789ec436d47b938e8a3d2085ffb2fbf6f0559"
+git = "https://github.com/ledger-community/rust-ledger.git"
+# The revision must be the same as for ledger-lib.
+rev = "c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89"
 
 [workspace.dependencies.mintlayer-ledger-messages]
 git = "https://github.com/mintlayer/mintlayer-ledger-app"
-# The commit "Move StatusWord to messages crate"
-rev = "dbc41342564b2198037ed4ad41b4cf0c34617870"
+# The commit "Update mintlayer-core-primitives repo revision. Enable disabled CI workflows. ..."
+rev = "ffe0d6256877c1b4b18b2e4a27bdeeaa7fc5a2ff"
 package = "messages"
 
 [workspace.dependencies.trezor-client]
 git = "https://github.com/mintlayer/mintlayer-trezor-firmware"
-# The commit "Fix Mintlayer code after merge with v2.11.0"
-rev = "fda0c12fc408ab96d4bd0fc3e796e00c622642db"
+# The commit "Fix Mintlayer code after merge with v2.11.0. Update revisions of mintlayer-core-primitives and parity-scale-codec."
+rev = "596b3ebf536b438156132406d2e3a3f4dde53ebc"
 features = ["bitcoin", "mintlayer"]
 
 [workspace.metadata.dist.dependencies.apt]
@@ -346,10 +348,13 @@ opt-level = 2
 # TODO: investigate this further.
 fontconfig-parser = { git = "https://github.com/Riey/fontconfig-parser", rev = "f7d13a779e6ee282ce75acbc00a1270c0350e0c2" }
 
-# This patch is needed because there is no release of the library and because ledger-lib depends on ledger-proto, so this is the only way to make the former find the latter.
-# Note that the revision specified here must be the same as the one used in the workspace.dependencies section
-ledger-proto = { git = "https://github.com/ImplOfAnImpl/rust-ledger.git", rev = "035789ec436d47b938e8a3d2085ffb2fbf6f0559" }
-# The specific commit is chosen because it contains a fix for the Ledger NanoX,
-# and we use the same version across all Trezor, Ledger and Mintlayerr core primitives repos
-# If a different version is used the tests in Mintlayer core will stop compiling
+# This patch is needed because there is no release of the library and because ledger-lib depends on ledger-proto, so this
+# is the only way to make the former find the latter.
+# Note that the revision specified here must be the same as the one used in the workspace.dependencies section.
+ledger-proto = { git = "https://github.com/ledger-community/rust-ledger.git", rev = "c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89" }
+
+# Use a specific commit because we need a fix (github.com/paritytech/parity-scale-codec/pull/751)
+# that has not been released yet (should be part of the release coming after v3.7.5).
+# Note that the fix is needed for the Ledger app, but we have to use the same version of parity-scale-codec
+# across Trezor, Ledger, mintlayer-core and mintlayer-core-primitives repos.
 parity-scale-codec = { git = "https://github.com/paritytech/parity-scale-codec.git", rev = "5021525697edc0661591ebc71392c48d950a10b0" }

--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,14 @@ db-path = "~/.cargo/advisory-dbs"
 db-urls = ["https://github.com/RustSec/advisory-db"]
 yanked = "warn"
 ignore = [
-    "RUSTSEC-2024-0436", # "paste" is no longer maintained
-    "RUSTSEC-2025-0141", # "bincode" is no longer maintained
+    # "paste" is no longer maintained.
+    "RUSTSEC-2024-0436",
+
+    # "bincode" is no longer maintained.
+    "RUSTSEC-2025-0141",
+
+    # `rand` is unsound.
+    # Note: to fix the error we need to upgrade `rand` to either 0.9.3 or 0.10.1, which is non-trivial
+    # because some of our dependencies still use 0.8.x and earlier versions.
+    "RUSTSEC-2026-0097"
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -713,11 +713,11 @@ version = "0.10.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.ledger-lib]]
-version = "0.1.0@git:035789ec436d47b938e8a3d2085ffb2fbf6f0559"
+version = "0.1.0@git:c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89"
 criteria = "safe-to-deploy"
 
 [[exemptions.ledger-proto]]
-version = "0.1.0@git:035789ec436d47b938e8a3d2085ffb2fbf6f0559"
+version = "0.1.0@git:c8ed12e89788e78d77cdc0dc9fb8a4bd4dc24b89"
 criteria = "safe-to-deploy"
 
 [[exemptions.libdbus-sys]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1430,8 +1430,8 @@ user-login = "cpu"
 user-name = "Daniel McCarney"
 
 [[publisher.rustls-webpki]]
-version = "0.103.10"
-when = "2026-03-20"
+version = "0.103.12"
+when = "2026-04-14"
 user-id = 2751
 user-login = "ctz"
 user-name = "Joe Birr-Pixton"

--- a/wallet/TREZOR_SUPPORT.md
+++ b/wallet/TREZOR_SUPPORT.md
@@ -52,17 +52,14 @@ Instead, you'll have to build it from `mintlayer-master`.
 
 If you are interested in a particular release, you may just go to [the firmware releases page](https://github.com/mintlayer/mintlayer-trezor-firmware/releases),
 download the `.bin` file corresponding to your device model and install it via Trezor Suite:
-- If you are installing the Mintlayer firmware over the official one, enter the bootloader mode on the device first,
-  otherwise Trezor Suite may refuse to install it, complaining about "different firmware vendor". To do so,
-  hold down both buttons while connecting a Safe 3, or swipe across the screen while connecting a Safe 5
-  or Model T. After that, select the "Install firmware" option (it can be named differently depending on
-  the device, e.g. it's called "INSTALL FW" on Safe 3).\
-  Note that if you're installing the Mintlayer firmware over another custom firmware (Mintlayer or not), this step is optional,
-  because Trezor Suite will automatically restart the device and put it in the bootloader mode on the next step.
 - Inside Trezor Suite go to "Settings" -> "Device" -> "Danger area" -> "Install custom firmware" and click "Install".
 - Follow the instructions that will appear on your screen.
 
-Note:
+Note that when installing the Mintlayer firmware over the official one, some versions of Trezor Suite may refuse to do it
+complaining about "different firmware vendor". In such a case you may need to enter the bootloader mode on the device first,
+as described in [Flash the built firmware](#flash-the-built-firmware), and try again.
+
+Also note:
 - Trezor Safe 3 comes in two revisions, A and B, that look identical but require different firmware.\
   Determining the revision of your particular device is non-trivial, unfortunately:
   * If you have `trezorctl` installed, which is the Trezor command line tool, you may run `trezorctl get-features`[^1]
@@ -83,24 +80,31 @@ In either case, you'll first need to clone the repository and checkout the requi
 - If you want a particular release, checkout the tag corresponding to that release. The list of tags
   can be found [here](https://github.com/mintlayer/mintlayer-trezor-firmware/tags).
 
-In the examples below we'll be assuming that you want the release 1.0.0, whose tag is `mintlayer-v1.0.0`.
+In the examples below we'll be assuming that you want the latest version from the `mintlayer-master` branch.
 
 #### Building the firmware using `Nix`
 
 ##### Get the source code
 
-Clone the repository, `cd` into the directory and checkout the required revision:
 ```sh
-git clone --recurse-submodules https://github.com/mintlayer/mintlayer-trezor-firmware
+# Clone the repository
+git clone https://github.com/mintlayer/mintlayer-trezor-firmware
+
+# `cd` into the source directory
 cd mintlayer-trezor-firmware
-git checkout --recurse-submodules mintlayer-v1.0.0
+
+# Checkout the required revision (redundant in the case of mintlayer-master, which is the default branch)
+git checkout mintlayer-master
+
+# Init repository submodules
+git submodule update --init --recursive
 ```
 
 ##### Install `Nix`
 
 On a Debian-based system you can do this via `sudo apt install nix-bin`.
 
-Check that `Nix` works by running `nix-shell -p hello --run hello`
+Check that `Nix` works by running `nix-shell -p hello --run hello`.
 
 If you're getting the error `getting status of /nix/var/nix/daemon-socket/socket: Permission denied`
 on your Linux machine, you may need to add the current user to the `nix-users` group:
@@ -112,16 +116,16 @@ You'll also need to re-login after that.
 If you're getting the error `file 'nixpkgs' was not found in the Nix search path`, add
 the `nixpkgs` channel by running:
 ```sh
-nix-channel --add https://nixos.org/channels/nixos-25.05 nixpkgs
+nix-channel --add https://nixos.org/channels/nixos-25.11 nixpkgs
 nix-channel --update
 ```
 
 Run `nix-shell -p hello --run hello` again. If everything is ok, it should print `Hello, world!`.
 
-##### Install required Python dependencies via `Poetry`
+##### Install required Python dependencies via `uv` [^2]
 
 ```sh
-nix-shell --run "poetry install"
+nix-shell --run "uv sync"
 ```
 
 ##### Build the firmware
@@ -129,7 +133,7 @@ nix-shell --run "poetry install"
 Run:
 
 ```sh
-TREZOR_MODEL=T3T1 nix-shell --run "poetry run make -C core vendor build_firmware"
+TREZOR_MODEL=T3T1 nix-shell --run "uv run make -C core vendor build_firmware"
 ```
 
 The value of the `TREZOR_MODEL` env variable determines the target device which the firmware will be built for.
@@ -143,7 +147,10 @@ The possible values are:
 
 So in the example above we're building it for Safe 5.
 
-##### Flash the firmware
+Note: Trezor Safe 7 (TREZOR_MODEL=T3W1) is not currently supported by the Core wallets. I.e. you can build
+the Mintlayer firmware for Safe 7, but the wallets won't be able to communicate with the device.
+
+##### Flash the built firmware
 
 The file `core/build/firmware/firmware.bin` in the source directory will be the firmware that you've just built,
 so you can go ahead and install it via Trezor Suite.
@@ -152,18 +159,19 @@ However you can also do it via the command line:
 
 First you need to put your device into bootloader mode. To do so
 - On Safe 3, hold the left button when connecting the USB cable.
-- On Model T and Safe 5, swipe across the screen when connecting the USB cable.
+- On touchscreen models, swipe across the screen when connecting the USB cable.
 
-After that the device will present you with an option to install firmware, select that option.
+After that the device will present you with an option to install firmware (which can be named differently depending
+on the model, e.g. it's called "INSTALL FW" on Safe 3); select that option.
 
-Now you can flash the firmware by running[^2]:
+Now you can flash the firmware by running[^3]:
 ```sh
-nix-shell --run "poetry run make -C core upload"
+nix-shell --run "uv run make -C core upload"
 ```
 
 Note: after having installed the firmware you may use Mintlayer-specific commands of `trezorctl`. Run
 ```sh
-nix-shell --run "poetry run trezorctl mintlayer --help"
+nix-shell --run "uv run trezorctl mintlayer --help"
 ```
 to see what commands are available.
 
@@ -177,17 +185,17 @@ Clone the repository, `cd` into the directory and checkout the required revision
 ```sh
 git clone https://github.com/mintlayer/mintlayer-trezor-firmware
 cd mintlayer-trezor-firmware
-git checkout mintlayer-v1.0.0
+git checkout mintlayer-master
 ```
 
-Note that the `--recurse-submodules` parameter is not needed in this case. This is because the build script will
-do the cloning again, so this initial clone is mainly to get the correct build script.
+Note that the `git submodule update` command is not needed in this case. This is because the build script will
+do the cloning again, so this initial clone is only needed to get the correct build script.
 
 ##### Build the firmware
 
 Run:
 ```sh
-PRODUCTION=0 ./build-docker.sh --models T3T1 --skip-bitcoinonly --targets firmware mintlayer-v1.0.0
+PRODUCTION=0 ./build-docker.sh --models T3T1 --skip-bitcoinonly --targets firmware mintlayer-master
 ```
 
 Note:
@@ -205,12 +213,25 @@ that you've specified via the `--models` parameter
 (i.e. in this particular example the path will be `build/core-T3T1/firmware/firmware.bin`).\
 Install it via Trezor Suite.
 
+### Passphrase
+
+Since late 2025, Trezor Suite disables passphrase wallets by default during the initial device setup.
+If you want to use a passphrase wallet (which is a good idea, but make sure you understand what it means),
+there are two ways to enable them:
+* via Trezor Suite: go to "Settings" -> "Device" -> "Passphrase" and turn the "Use Passphrase wallets" switch on;
+* via `trezorctl`: run `nix-shell --run "uv run trezorctl set passphrase on"` in the firmware source directory.
+
+When passphrase wallets are enabled on the device, `node-gui` and `wallet-cli` will ask you for the passphrase
+whenever you create a new wallet or open/recover an existing one.
+
 [^1]: If you instead decide to build the firmware from source using the `Nix` approach,
 you'll be able to run `trezorctl` directly from the source directory like this:
-`nix-shell --run "poetry run trezorctl get-features"`.\
+`nix-shell --run "uv run trezorctl get-features"`.\
 I.e. you won't have to install it separately in this case.
 
-[^2]: instead of executing `nix-shell --run "poetry run YOUR_COMMAND"` every time,
-you can enter the nix-shell by running `nix-shell`
-and then inside the nix-shell enter poetry shell by running `poetry shell`.\
-After this, you can run `YOUR_COMMAND` directly, e.g. `make -C core upload` or `trezorctl get-features`.
+[^2]: At the time of the `mintlayer-v1.0.0` release, Trezor firmware used `poetry` instead of `uv`
+for Python package management. So, if you're building `mintlayer-v1.0.0`, then a) instead of `uv sync` do `poetry install`, b) in all other commands just replace `uv` with `poetry`.
+
+[^3]: nix-shell is somewhat slow to start, so instead of executing `nix-shell --run "uv run YOUR_COMMAND_1"`,
+`nix-shell --run "uv run YOUR_COMMAND_2"` you may want to enter the shell once by executing `nix-shell`
+and then execute `uv run YOUR_COMMAND_1`, `uv run YOUR_COMMAND_2` inside it.

--- a/wallet/src/signer/ledger_signer/tests/mod.rs
+++ b/wallet/src/signer/ledger_signer/tests/mod.rs
@@ -86,7 +86,7 @@ fn emulator_apdu_port() -> u16 {
 }
 
 fn should_auto_confirm() -> bool {
-    bool_from_env("LEDGER_TESTS_AUTO_CONFIRM").unwrap().unwrap_or(false)
+    bool_from_env("LEDGER_TESTS_AUTO_CONFIRM").unwrap().unwrap_or(true)
 }
 
 async fn auto_confirmer(mut control_msg_rx: mpsc::Receiver<ControlMessage>, handle: Handle) {


### PR DESCRIPTION
The main purpose of this PR is to update the trezor repo commit hash after it was merged with upstream and update the documentation.

There are some additional changes though:
* `ledger-lib` and `ledger-proto` now point to `github.com/ledger-community` instead of a custom fork.
* The revisions of `mintlayer-core-primitives` and `mintlayer-ledger-messages` were updated.
* `LEDGER_TESTS_AUTO_CONFIRM` is now true by default, to match the corresponding behavior of Trezor tests.
* `rustls-webpki` was updated to pacify `cargo-deny` (fixes a vulnerability).
* cargo-deny error about `rand` being unsound was silenced (upgrading `rand` is not trivial).

P.S. with firmware v2.11.0 comes the potential Safe 7 support, but we won't get it for free, because the new device uses a new host communication protocol called THP. Trezor-lib doesn't seem to abstract it away, so we'll have to implement its support on the wallet side.