### PR TITLE
Some bridge-related changes

### DIFF
--- a/api-server/scanner-daemon/Cargo.toml
+++ b/api-server/scanner-daemon/Cargo.toml
@@ -10,7 +10,7 @@ api-server-common = { path = "../api-server-common" }
 api-blockchain-scanner-lib = { path = "../scanner-lib" }
 common = { path = "../../common" }
 logging = { path = "../../logging" }
-node-comm = { path = "../../wallet/wallet-node-client" }
+node-comm = { path = "../../wallet/wallet-node-client", default-features = false }
 node-lib = { path = "../../node-lib" }
 rpc = { path = "../../rpc" }
 utils = { path = "../../utils" }

--- a/api-server/scanner-lib/Cargo.toml
+++ b/api-server/scanner-lib/Cargo.toml
@@ -12,7 +12,7 @@ common = { path = "../../common" }
 constraints-value-accumulator = { path = "../../chainstate/constraints-value-accumulator" }
 logging = { path = "../../logging" }
 mempool = { path = "../../mempool" }
-node-comm = { path = "../../wallet/wallet-node-client" }
+node-comm = { path = "../../wallet/wallet-node-client", default-features = false }
 orders-accounting = { path = "../../orders-accounting" }
 pos-accounting = { path = "../../pos-accounting" }
 randomness = { path = "../../randomness" }

--- a/api-server/stack-test-suite/Cargo.toml
+++ b/api-server/stack-test-suite/Cargo.toml
@@ -19,7 +19,7 @@ serialization = { path = "../../serialization" }
 test-utils = { path = "../../test-utils" }
 utils = { path = "../../utils" }
 pos-accounting = { path = "../../pos-accounting" }
-node-comm = { path = "../../wallet/wallet-node-client" }
+node-comm = { path = "../../wallet/wallet-node-client", default-features = false }
 mempool = { path = "../../mempool" }
 
 async-trait.workspace = true

--- a/api-server/web-server/Cargo.toml
+++ b/api-server/web-server/Cargo.toml
@@ -14,7 +14,7 @@ serialization = { path = "../../serialization" }
 utils = { path = "../../utils" }
 utils-networking = { path = "../../utils/networking" }
 rpc = { path = "../../rpc" }
-node-comm = { path = "../../wallet/wallet-node-client" }
+node-comm = { path = "../../wallet/wallet-node-client", default-features = false }
 node-lib = { path = "../../node-lib" }
 mempool = { path = "../../mempool" }
 

--- a/node-gui/Cargo.toml
+++ b/node-gui/Cargo.toml
@@ -10,18 +10,18 @@ rust-version.workspace = true
 chainstate = { path = "../chainstate" }
 common = { path = "../common" }
 logging = { path = "../logging" }
-node-gui-backend = { path = "./backend" }
+node-comm = { path = "../wallet/wallet-node-client", default-features = false }
+node-gui-backend = { path = "./backend", default-features = false }
 node-lib = { path = "../node-lib" }
-node-comm = { path = "../wallet/wallet-node-client" }
 p2p = { path = "../p2p" }
 storage = { path = "../storage" }
 serialization = { path = "../serialization" }
 utils = { path = "../utils" }
-wallet = { path = "../wallet" }
-wallet-controller = { path = "../wallet/wallet-controller" }
-wallet-types = { path = "../wallet/types" }
-wallet-cli-commands = { path = "../wallet/wallet-cli-commands" }
-wallet-storage = { path = "../wallet/storage" }
+wallet = { path = "../wallet", default-features = false }
+wallet-cli-commands = { path = "../wallet/wallet-cli-commands", default-features = false }
+wallet-controller = { path = "../wallet/wallet-controller", default-features = false }
+wallet-types = { path = "../wallet/types", default-features = false }
+wallet-storage = { path = "../wallet/storage", default-features = false }
 
 anyhow.workspace = true
 chrono.workspace = true
@@ -41,15 +41,21 @@ winres = "0.1"
 [features]
 tokio-console = ["utils/tokio-console"]
 trezor = [
+  "node-comm/trezor",
+  "node-gui-backend/trezor",
+  "wallet/trezor",
+  "wallet-cli-commands/trezor",
   "wallet-controller/trezor",
   "wallet-types/trezor",
-  "wallet-cli-commands/trezor",
-  "node-gui-backend/trezor",
+  "wallet-storage/trezor",
 ]
 ledger = [
+  "node-comm/ledger",
+  "node-gui-backend/ledger",
+  "wallet/ledger",
+  "wallet-cli-commands/ledger",
   "wallet-controller/ledger",
   "wallet-types/ledger",
-  "wallet-cli-commands/ledger",
-  "node-gui-backend/ledger",
+  "wallet-storage/ledger",
 ]
 default = ["trezor", "ledger"]

--- a/node-gui/backend/Cargo.toml
+++ b/node-gui/backend/Cargo.toml
@@ -12,18 +12,18 @@ common = { path = "../../common" }
 crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
 mempool = { path = "../../mempool" }
+node-comm = { path = "../../wallet/wallet-node-client", default-features = false }
 node-lib = { path = "../../node-lib" }
-node-comm = { path = "../../wallet/wallet-node-client" }
 p2p = { path = "../../p2p" }
 serialization = { path = "../../serialization" }
 subsystem = { path = "../../subsystem" }
 utils = { path = "../../utils" }
-wallet = { path = "../../wallet" }
-wallet-controller = { path = "../../wallet/wallet-controller" }
-wallet-types = { path = "../../wallet/types" }
-wallet-rpc-lib = { path = "../../wallet/wallet-rpc-lib" }
-wallet-rpc-client = { path = "../../wallet/wallet-rpc-client" }
-wallet-cli-commands = { path = "../../wallet/wallet-cli-commands" }
+wallet = { path = "../../wallet", default-features = false }
+wallet-cli-commands = { path = "../../wallet/wallet-cli-commands", default-features = false }
+wallet-controller = { path = "../../wallet/wallet-controller", default-features = false }
+wallet-rpc-client = { path = "../../wallet/wallet-rpc-client", default-features = false }
+wallet-rpc-lib = { path = "../../wallet/wallet-rpc-lib", default-features = false }
+wallet-types = { path = "../../wallet/types", default-features = false }
 
 anyhow.workspace = true
 chrono.workspace = true
@@ -43,19 +43,21 @@ rstest.workspace = true
 
 [features]
 trezor = [
+  "node-comm/trezor",
   "wallet/trezor",
-  "wallet-controller/trezor",
-  "wallet-types/trezor",
-  "wallet-rpc-lib/trezor",
-  "wallet-rpc-client/trezor",
   "wallet-cli-commands/trezor",
+  "wallet-controller/trezor",
+  "wallet-rpc-client/trezor",
+  "wallet-rpc-lib/trezor",
+  "wallet-types/trezor",
 ]
 ledger = [
+  "node-comm/ledger",
   "wallet/ledger",
-  "wallet-controller/ledger",
-  "wallet-types/ledger",
-  "wallet-rpc-lib/ledger",
-  "wallet-rpc-client/ledger",
   "wallet-cli-commands/ledger",
+  "wallet-controller/ledger",
+  "wallet-rpc-client/ledger",
+  "wallet-rpc-lib/ledger",
+  "wallet-types/ledger",
 ]
 default = ["trezor", "ledger"]

--- a/node-gui/backend/src/error.rs
+++ b/node-gui/backend/src/error.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use itertools::Itertools as _;
-
 #[cfg(feature = "trezor")]
 use wallet::signer::trezor_signer;
 
@@ -61,7 +59,10 @@ pub enum BackendError {
     MultipleTrezorDevicesFound(Vec<trezor_signer::FoundDevice>),
 }
 
+#[cfg(feature = "trezor")]
 fn format_multiple_trezor_devices_err(devices: &[trezor_signer::FoundDevice]) -> String {
+    use itertools::Itertools as _;
+
     devices
         .iter()
         .map(|device| format!("{} (device id = {})", device.device_name, device.device_id))

--- a/node-gui/src/main_window/main_widget/tabs/wallet/left_panel.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/left_panel.rs
@@ -127,6 +127,7 @@ pub fn view_left_panel(
         wallet_info.best_block.1.next_height() < node_state.chain_info.best_block_height
     };
 
+    #[cfg(any(feature = "trezor", feature = "ledger"))]
     let hardware_wallet_panels = || {
         column![
             panel_button(

--- a/node-gui/src/main_window/main_widget/tabs/wallet/status_bar.rs
+++ b/node-gui/src/main_window/main_widget/tabs/wallet/status_bar.rs
@@ -13,20 +13,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use iced::Element;
 #[cfg(any(feature = "trezor", feature = "ledger"))]
-use iced::widget::{rich_text, span};
 use iced::{
     font,
-    widget::{container, row, Container},
-    Alignment, Element, Font, Length, Padding, Theme,
+    widget::{container, rich_text, row, span, Container, Row},
+    Alignment, Font, Length, Padding, Theme,
 };
 
 use wallet_controller::types::WalletExtraInfo;
 
 use super::WalletMessage;
 
+#[cfg(any(feature = "trezor", feature = "ledger"))]
 const TEXT_SIZE: f32 = 16.;
+#[cfg(any(feature = "trezor", feature = "ledger"))]
 const VERTICAL_PADDING: f32 = 5.;
+#[cfg(any(feature = "trezor", feature = "ledger"))]
 const HORIZONTAL_PADDING: f32 = 10.;
 
 #[allow(clippy::float_arithmetic)]
@@ -46,22 +49,44 @@ pub fn estimate_status_bar_height(wallet_info: &WalletExtraInfo) -> f32 {
 }
 
 pub fn view_status_bar(wallet_info: &WalletExtraInfo) -> Option<Element<'static, WalletMessage>> {
+    #[cfg(any(feature = "trezor", feature = "ledger"))]
+    let make_status_bar = |row: Row<'static, WalletMessage>| {
+        Container::new(
+            row.width(Length::Fill)
+                .padding(Padding {
+                    top: VERTICAL_PADDING,
+                    right: HORIZONTAL_PADDING,
+                    bottom: VERTICAL_PADDING,
+                    left: HORIZONTAL_PADDING,
+                })
+                .spacing(HORIZONTAL_PADDING)
+                .align_y(Alignment::Center),
+        )
+        .style(|theme: &Theme| {
+            let palette = theme.extended_palette();
+
+            container::Style {
+                background: Some(palette.background.weak.color.into()),
+                ..container::Style::default()
+            }
+        })
+    };
+
+    #[cfg(any(feature = "trezor", feature = "ledger"))]
     let bold_font = Font {
         weight: font::Weight::Bold,
         ..Font::default()
     };
 
-    let row = match wallet_info {
-        WalletExtraInfo::SoftwareWallet => {
-            return None;
-        }
+    match wallet_info {
+        WalletExtraInfo::SoftwareWallet => None,
         #[cfg(feature = "trezor")]
         WalletExtraInfo::TrezorWallet {
             device_id: _,
             device_name,
             firmware_version,
         } => {
-            row![
+            let row = row![
                 rich_text([span("Device name: ").font(bold_font), span(device_name.clone())])
                     .size(TEXT_SIZE),
                 rich_text([
@@ -69,39 +94,20 @@ pub fn view_status_bar(wallet_info: &WalletExtraInfo) -> Option<Element<'static,
                     span(firmware_version.clone())
                 ])
                 .size(TEXT_SIZE),
-            ]
+            ];
+
+            Some(make_status_bar(row).into())
         }
         #[cfg(feature = "ledger")]
         WalletExtraInfo::LedgerWallet { app_version, model } => {
-            row![
+            let row = row![
                 rich_text([span("Model name: ").font(bold_font), span(model.clone())])
                     .size(TEXT_SIZE),
                 rich_text([span("App version: ").font(bold_font), span(app_version.clone())])
                     .size(TEXT_SIZE),
-            ]
+            ];
+
+            Some(make_status_bar(row).into())
         }
-    };
-
-    let status_bar = Container::new(
-        row.width(Length::Fill)
-            .padding(Padding {
-                top: VERTICAL_PADDING,
-                right: HORIZONTAL_PADDING,
-                bottom: VERTICAL_PADDING,
-                left: HORIZONTAL_PADDING,
-            })
-            .spacing(HORIZONTAL_PADDING)
-            .align_y(Alignment::Center),
-    )
-    .style(|theme: &Theme| {
-        let palette = theme.extended_palette();
-
-        container::Style {
-            background: Some(palette.background.weak.color.into()),
-            ..container::Style::default()
-        }
-    })
-    .into();
-
-    Some(status_bar)
+    }
 }

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -13,9 +13,9 @@ dist = false
 utils = { path = "../utils" }
 node-lib = { path = "../node-lib" }
 logging = { path = "../logging" }
-wallet-cli-lib = { path = "../wallet/wallet-cli-lib" }
 wallet-address-generator-lib = { path = "../wallet/wallet-address-generator-lib" }
-wallet-rpc-lib = { path = "../wallet/wallet-rpc-lib" }
+wallet-cli-lib = { path = "../wallet/wallet-cli-lib", default-features = false }
+wallet-rpc-lib = { path = "../wallet/wallet-rpc-lib", default-features = false }
 
 clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ['full'] }
@@ -28,3 +28,14 @@ thiserror.workspace = true
 name = "functional"
 path = "runner/functional.rs"
 harness = false
+
+[features]
+trezor = [
+  "wallet-cli-lib/trezor",
+  "wallet-rpc-lib/trezor",
+]
+ledger = [
+  "wallet-cli-lib/ledger",
+  "wallet-rpc-lib/ledger",
+]
+default = ["trezor", "ledger"]

--- a/utils/src/fixed_hash.rs
+++ b/utils/src/fixed_hash.rs
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use fixed_hash::construct_fixed_hash as construct_fixed_hash_orig;
+pub mod orig {
+    pub use fixed_hash::*;
+}
 
 /// A macro that wraps the namesake one from `fixed_hash` (which is compiled with its `rand` feature
 /// disabled) and adds custom RNG-related methods to the generated type.
@@ -23,7 +25,7 @@ pub use fixed_hash::construct_fixed_hash as construct_fixed_hash_orig;
 #[macro_export]
 macro_rules! construct_fixed_hash {
     ( $(#[$attr:meta])* $visibility:vis struct $name:ident ( $n_bytes:expr ); ) => {
-        $crate::fixed_hash::construct_fixed_hash_orig! {
+        $crate::fixed_hash::orig::construct_fixed_hash! {
             $(#[$attr])*
             $visibility struct $name($n_bytes);
         }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -22,8 +22,8 @@ tx-verifier = { path = "../chainstate/tx-verifier" }
 utils = { path = "../utils" }
 utils-networking = { path = "../utils/networking" }
 utxo = { path = "../utxo" }
-wallet-storage = { path = "./storage" }
-wallet-types = { path = "./types" }
+wallet-storage = { path = "./storage", default-features = false }
+wallet-types = { path = "./types", default-features = false }
 
 async-trait.workspace = true
 bip39 = { workspace = true, default-features = false, features = [
@@ -75,12 +75,17 @@ tokio = { workspace = true, default-features = false, features = [
 tracing = { workspace = true }
 
 [features]
-trezor = ["dep:trezor-client", "wallet-types/trezor"]
+trezor = [
+  "dep:trezor-client",
+  "wallet-storage/trezor",
+  "wallet-types/trezor"
+]
 enable-trezor-device-tests = ["trezor"]
 
 ledger = [
   "dep:ledger-lib",
   "dep:mintlayer-ledger-messages",
+  "wallet-storage/ledger",
   "wallet-types/ledger",
 ]
 enable-ledger-device-tests = ["ledger"]

--- a/wallet/src/signer/tests/generic_tests.rs
+++ b/wallet/src/signer/tests/generic_tests.rs
@@ -85,6 +85,10 @@ pub enum MessageToSign {
     Predefined(Vec<u8>),
 }
 
+#[cfg(any(
+    feature = "enable-trezor-device-tests",
+    feature = "enable-ledger-device-tests"
+))]
 #[rstest_reuse::template]
 pub fn sign_message_test_params(
     #[values(

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -387,8 +387,12 @@ where
     ) -> WalletResult<WalletCreation<Self>> {
         let mut wallet = Self::new_wallet(chain_config, db, wallet_type, signer_provider).await?;
 
-        if let WalletCreation::Wallet(ref mut w) = wallet {
-            w.set_best_block(best_block.0, best_block.1)?;
+        match &mut wallet {
+            WalletCreation::Wallet(w) => {
+                w.set_best_block(best_block.0, best_block.1)?;
+            }
+            #[cfg(feature = "trezor")]
+            WalletCreation::MultipleAvailableTrezorDevices(_) => {}
         }
 
         Ok(wallet)

--- a/wallet/src/wallet/tests.rs
+++ b/wallet/src/wallet/tests.rs
@@ -428,7 +428,7 @@ async fn wallet_creation_in_memory() {
     let initialized_db = wallet.db;
 
     // successfully load a wallet from initialized db
-    let mut wallet = Wallet::load_wallet(
+    let _wallet = Wallet::load_wallet(
         chain_config.clone(),
         initialized_db,
         None,
@@ -444,6 +444,7 @@ async fn wallet_creation_in_memory() {
 
     #[cfg(any(feature = "trezor", feature = "ledger"))]
     {
+        let mut wallet = _wallet;
         let mut db_tx = wallet.db.transaction_rw(None).unwrap();
 
         #[cfg(feature = "trezor")]

--- a/wallet/storage/Cargo.toml
+++ b/wallet/storage/Cargo.toml
@@ -12,9 +12,9 @@ randomness = { path = "../../randomness" }
 serialization = { path = "../../serialization" }
 storage = { path = "../../storage" }
 storage-sqlite = { path = "../../storage/sqlite" }
+utils = { path = "../../utils" }
 utxo = { path = "../../utxo" }
 wallet-types = { path = "../types", default-features = false }
-utils = { path = "../../utils" }
 
 thiserror.workspace = true
 bip39 = { workspace = true, default-features = false, features = ["std", "zeroize"] }

--- a/wallet/storage/Cargo.toml
+++ b/wallet/storage/Cargo.toml
@@ -13,7 +13,7 @@ serialization = { path = "../../serialization" }
 storage = { path = "../../storage" }
 storage-sqlite = { path = "../../storage/sqlite" }
 utxo = { path = "../../utxo" }
-wallet-types = { path = "../types" }
+wallet-types = { path = "../types", default-features = false }
 utils = { path = "../../utils" }
 
 thiserror.workspace = true

--- a/wallet/wallet-address-generator-lib/Cargo.toml
+++ b/wallet/wallet-address-generator-lib/Cargo.toml
@@ -7,11 +7,11 @@ rust-version.workspace = true
 
 [dependencies]
 common = { path = "../../common" }
-utils = { path = "../../utils" }
-wallet-controller = { path = "../wallet-controller" }
-wallet-types = { path = "../types" }
-wallet = { path = "../../wallet" }
 crypto = { path = "../../crypto" }
+utils = { path = "../../utils" }
+wallet = { path = "../../wallet", default-features = false }
+wallet-controller = { path = "../wallet-controller", default-features = false }
+wallet-types = { path = "../types", default-features = false }
 
 clap = { workspace = true, features = ["derive"] }
 thiserror.workspace = true

--- a/wallet/wallet-address-generator/Cargo.toml
+++ b/wallet/wallet-address-generator/Cargo.toml
@@ -7,13 +7,12 @@ rust-version.workspace = true
 
 [dependencies]
 common = { path = "../../common" }
-utils = { path = "../../utils" }
-wallet-controller = { path = "../wallet-controller" }
-wallet-address-generator-lib = { path = "../wallet-address-generator-lib" }
-wallet-types = { path = "../types" }
-wallet = { path = "../../wallet" }
 crypto = { path = "../../crypto" }
+utils = { path = "../../utils" }
+wallet = { path = "../../wallet", default-features = false }
+wallet-address-generator-lib = { path = "../wallet-address-generator-lib", default-features = false }
+wallet-controller = { path = "../wallet-controller", default-features = false }
+wallet-types = { path = "../types", default-features = false }
 
 clap = { workspace = true, features = ["derive"] }
-
 thiserror.workspace = true

--- a/wallet/wallet-cli-commands/Cargo.toml
+++ b/wallet/wallet-cli-commands/Cargo.toml
@@ -12,19 +12,19 @@ consensus = { path = "../../consensus" }
 crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
 mempool = { path = "../../mempool" }
-node-comm = { path = "../wallet-node-client" }
+node-comm = { path = "../wallet-node-client", default-features = false }
 p2p-types = { path = "../../p2p/types" }
 randomness = { path = "../../randomness" }
 rpc = { path = "../../rpc" }
 serialization = { path = "../../serialization" }
 utils = { path = "../../utils" }
 utils-networking = { path = "../../utils/networking" }
-wallet = { path = ".." }
-wallet-controller = { path = "../wallet-controller" }
-wallet-rpc-lib = { path = "../wallet-rpc-lib" }
-wallet-rpc-client = { path = "../wallet-rpc-client" }
-wallet-storage = { path = "../storage" }
-wallet-types = { path = "../types" }
+wallet = { path = "..", default-features = false }
+wallet-controller = { path = "../wallet-controller", default-features = false }
+wallet-rpc-client = { path = "../wallet-rpc-client", default-features = false }
+wallet-rpc-lib = { path = "../wallet-rpc-lib", default-features = false }
+wallet-storage = { path = "../storage", default-features = false }
+wallet-types = { path = "../types", default-features = false }
 
 async-trait.workspace = true
 bigdecimal.workspace = true
@@ -73,6 +73,22 @@ rstest.workspace = true
 build_utils = { path = "../../utils/build_utils" }
 
 [features]
-trezor = ["wallet-types/trezor", "wallet-rpc-lib/trezor"]
-ledger = ["wallet-types/ledger", "wallet-rpc-lib/ledger"]
+trezor = [
+  "node-comm/trezor",
+  "wallet/trezor",
+  "wallet-controller/trezor",
+  "wallet-rpc-client/trezor",
+  "wallet-rpc-lib/trezor",
+  "wallet-storage/trezor",
+  "wallet-types/trezor",
+]
+ledger = [
+  "node-comm/ledger",
+  "wallet/ledger",
+  "wallet-controller/ledger",
+  "wallet-rpc-client/ledger",
+  "wallet-rpc-lib/ledger",
+  "wallet-storage/ledger",
+  "wallet-types/ledger",
+]
 default = ["trezor", "ledger"]

--- a/wallet/wallet-cli-commands/src/command_handler/mod.rs
+++ b/wallet/wallet-cli-commands/src/command_handler/mod.rs
@@ -43,21 +43,25 @@ use utils::{
 };
 use wallet_controller::types::WalletExtraInfo;
 use wallet_rpc_client::wallet_rpc_traits::{PartialOrSignedTx, WalletInterface};
+#[cfg(any(feature = "trezor", feature = "ledger"))]
+use wallet_rpc_lib::types::HardwareWalletType;
 use wallet_rpc_lib::types::{
-    Balances, ComposedTransaction, ControllerConfig, HardwareWalletType, MnemonicInfo,
-    NewOrderTransaction, NewSubmittedTransaction, NftMetadata, RpcHashedTimelockContract,
-    RpcInspectTransaction, RpcNewTransaction, RpcPreparedTransaction, RpcSignatureStats,
-    RpcSignatureStatus, RpcStandaloneAddressDetails, RpcValidatedSignatures, TokenMetadata,
+    Balances, ComposedTransaction, ControllerConfig, MnemonicInfo, NewOrderTransaction,
+    NewSubmittedTransaction, NftMetadata, RpcHashedTimelockContract, RpcInspectTransaction,
+    RpcNewTransaction, RpcPreparedTransaction, RpcSignatureStats, RpcSignatureStatus,
+    RpcStandaloneAddressDetails, RpcValidatedSignatures, TokenMetadata,
 };
 use wallet_types::partially_signed_transaction::PartiallySignedTransaction;
+
+#[cfg(feature = "trezor")]
+use crate::{CreateWalletDeviceSelectMenu, OpenWalletDeviceSelectMenu};
 
 use crate::{
     errors::WalletCliCommandError,
     helper_types::{
         active_order_infos_header, format_token_name, token_ticker_from_rpc_token_info, CliCurrency,
     },
-    CreateWalletDeviceSelectMenu, ManageableWalletCommand, OpenWalletDeviceSelectMenu,
-    OpenWalletSubCommand, WalletManagementCommand,
+    ManageableWalletCommand, OpenWalletSubCommand, WalletManagementCommand,
 };
 
 use self::local_state::WalletWithState;
@@ -211,6 +215,7 @@ where
 
                 if let Some(devices) = response.multiple_devices_available {
                     match devices {
+                        #[cfg(feature = "trezor")]
                         wallet_rpc_lib::types::MultipleDevicesAvailable::Trezor { devices } => {
                             let choices =
                                 CreateWalletDeviceSelectMenu::new(devices, wallet_path, false);
@@ -250,6 +255,7 @@ where
 
                 if let Some(devices) = response.multiple_devices_available {
                     match devices {
+                        #[cfg(feature = "trezor")]
                         wallet_rpc_lib::types::MultipleDevicesAvailable::Trezor { devices } => {
                             let choices =
                                 CreateWalletDeviceSelectMenu::new(devices, wallet_path, true);
@@ -323,6 +329,7 @@ where
                     response
                 {
                     match available {
+                        #[cfg(feature = "trezor")]
                         wallet_rpc_lib::types::MultipleDevicesAvailable::Trezor { devices } => {
                             let choices = OpenWalletDeviceSelectMenu::new(
                                 devices,

--- a/wallet/wallet-cli-commands/src/lib.rs
+++ b/wallet/wallet-cli-commands/src/lib.rs
@@ -35,10 +35,9 @@ use rpc::description::{Described, Module};
 use serialization::hex_encoded::HexEncoded;
 use utils_networking::IpOrSocketAddress;
 use wallet_controller::types::WalletTypeArgs;
-use wallet_rpc_lib::{
-    types::{FoundDevice, NodeInterface},
-    ColdWalletRpcDescription, WalletRpcDescription,
-};
+#[cfg(feature = "trezor")]
+use wallet_rpc_lib::types::FoundDevice;
+use wallet_rpc_lib::{types::NodeInterface, ColdWalletRpcDescription, WalletRpcDescription};
 
 use crate::helper_types::{
     CliCurrency, CliOutputTimeLock, CliTokenTotalSupply, CliUnspecifiedCurrencyTransfer,
@@ -1312,6 +1311,7 @@ pub trait ChoiceMenu: DynClone + Debug {
 dyn_clone::clone_trait_object!(ChoiceMenu);
 
 // TODO: this is Trezor-specific, so it should be either renamed or generalized.
+#[cfg(feature = "trezor")]
 #[derive(Debug, Clone)]
 pub struct CreateWalletDeviceSelectMenu {
     available_devices: Vec<FoundDevice>,
@@ -1320,6 +1320,7 @@ pub struct CreateWalletDeviceSelectMenu {
     recover: bool,
 }
 
+#[cfg(feature = "trezor")]
 impl CreateWalletDeviceSelectMenu {
     pub fn new(available_devices: Vec<FoundDevice>, wallet_path: PathBuf, recover: bool) -> Self {
         Self {
@@ -1330,6 +1331,7 @@ impl CreateWalletDeviceSelectMenu {
     }
 }
 
+#[cfg(feature = "trezor")]
 impl ChoiceMenu for CreateWalletDeviceSelectMenu {
     fn header(&self) -> &str {
         "Please choose one of the available Trezor devices:"
@@ -1366,6 +1368,7 @@ impl ChoiceMenu for CreateWalletDeviceSelectMenu {
 }
 
 // TODO: this is Trezor-specific, so it should be either renamed or generalized.
+#[cfg(feature = "trezor")]
 #[derive(Debug, Clone)]
 pub struct OpenWalletDeviceSelectMenu {
     available_devices: Vec<FoundDevice>,
@@ -1374,6 +1377,7 @@ pub struct OpenWalletDeviceSelectMenu {
     encryption_password: Option<String>,
 }
 
+#[cfg(feature = "trezor")]
 impl OpenWalletDeviceSelectMenu {
     pub fn new(
         available_devices: Vec<FoundDevice>,
@@ -1388,6 +1392,7 @@ impl OpenWalletDeviceSelectMenu {
     }
 }
 
+#[cfg(feature = "trezor")]
 impl ChoiceMenu for OpenWalletDeviceSelectMenu {
     fn header(&self) -> &str {
         "Please choose one of the available Trezor devices:"

--- a/wallet/wallet-cli-lib/Cargo.toml
+++ b/wallet/wallet-cli-lib/Cargo.toml
@@ -13,18 +13,18 @@ crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
 mempool = { path = "../../mempool" }
 p2p-types = { path = "../../p2p/types" }
-node-comm = { path = "../wallet-node-client" }
+node-comm = { path = "../wallet-node-client", default-features = false }
 rpc = { path = "../../rpc" }
 randomness = { path = "../../randomness" }
 serialization = { path = "../../serialization" }
 utils = { path = "../../utils" }
 utils-networking = { path = "../../utils/networking" }
-wallet = { path = ".." }
-wallet-storage = { path = "../storage" }
-wallet-types = { path = "../types" }
-wallet-rpc-lib = { path = "../wallet-rpc-lib" }
-wallet-rpc-client = { path = "../wallet-rpc-client" }
-wallet-cli-commands = { path = "../wallet-cli-commands" }
+wallet = { path = "..", default-features = false }
+wallet-cli-commands = { path = "../wallet-cli-commands", default-features = false }
+wallet-rpc-client = { path = "../wallet-rpc-client", default-features = false }
+wallet-rpc-lib = { path = "../wallet-rpc-lib", default-features = false }
+wallet-storage = { path = "../storage", default-features = false }
+wallet-types = { path = "../types", default-features = false }
 
 clap = { workspace = true, features = ["derive"] }
 async-trait.workspace = true
@@ -68,17 +68,21 @@ build_utils = { path = "../../utils/build_utils" }
 
 [features]
 trezor = [
+  "node-comm/trezor",
   "wallet/trezor",
   "wallet-cli-commands/trezor",
-  "wallet-types/trezor",
-  "wallet-rpc-lib/trezor",
   "wallet-rpc-client/trezor",
+  "wallet-rpc-lib/trezor",
+  "wallet-storage/trezor",
+  "wallet-types/trezor",
 ]
 ledger = [
+  "node-comm/ledger",
   "wallet/ledger",
   "wallet-cli-commands/ledger",
-  "wallet-types/ledger",
-  "wallet-rpc-lib/ledger",
   "wallet-rpc-client/ledger",
+  "wallet-rpc-lib/ledger",
+  "wallet-storage/ledger",
+  "wallet-types/ledger",
 ]
 default = ["trezor", "ledger"]

--- a/wallet/wallet-cli/Cargo.toml
+++ b/wallet/wallet-cli/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 utils = { path = "../../utils" }
-wallet-cli-lib = { path = "../wallet-cli-lib" }
+wallet-cli-lib = { path = "../wallet-cli-lib", default-features = false }
 
 clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, default-features = false, features = [

--- a/wallet/wallet-controller/Cargo.toml
+++ b/wallet/wallet-controller/Cargo.toml
@@ -58,6 +58,6 @@ anyhow.workspace = true
 rstest.workspace = true
 
 [features]
-trezor = ["wallet/trezor", "wallet-storage/trezor", "wallet-types/trezor"]
-ledger = ["wallet/ledger", "wallet-storage/ledger", "wallet-types/ledger"]
+trezor = ["node-comm/trezor", "wallet/trezor", "wallet-storage/trezor", "wallet-types/trezor"]
+ledger = ["node-comm/ledger", "wallet/ledger", "wallet-storage/ledger", "wallet-types/ledger"]
 default = ["trezor", "ledger"]

--- a/wallet/wallet-controller/Cargo.toml
+++ b/wallet/wallet-controller/Cargo.toml
@@ -14,16 +14,16 @@ crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
 mempool-types = { path = "../../mempool/types" }
 mempool = { path = "../../mempool" }
-node-comm = { path = "../wallet-node-client" }
+node-comm = { path = "../wallet-node-client", default-features = false }
 rpc-description = { path = "../../rpc/description" }
 randomness = { path = "../../randomness" }
 serialization = { path = "../../serialization" }
 storage = { path = "../../storage" }
 utils = { path = "../../utils" }
 utils-networking = { path = "../../utils/networking" }
-wallet = { path = ".." }
-wallet-storage = { path = "../storage" }
-wallet-types = { path = "../types" }
+wallet = { path = "..", default-features = false }
+wallet-storage = { path = "../storage", default-features = false }
+wallet-types = { path = "../types", default-features = false }
 
 async-trait.workspace = true
 bip39 = { workspace = true, default-features = false, features = [
@@ -58,6 +58,6 @@ anyhow.workspace = true
 rstest.workspace = true
 
 [features]
-trezor = ["wallet-types/trezor"]
-ledger = ["wallet-types/ledger"]
+trezor = ["wallet/trezor", "wallet-storage/trezor", "wallet-types/trezor"]
+ledger = ["wallet/ledger", "wallet-storage/ledger", "wallet-types/ledger"]
 default = ["trezor", "ledger"]

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -470,6 +470,7 @@ where
                 WalletCreation::Wallet(_) => false,
                 // Wallet was not created successfully. The caller will need to handle this result
                 // and either fail or try again.
+                #[cfg(feature = "trezor")]
                 WalletCreation::MultipleAvailableTrezorDevices(_) => true,
             },
         };

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -112,8 +112,10 @@ pub use wallet_types::{
     account_info::DEFAULT_ACCOUNT_INDEX,
     utxo_types::{UtxoState, UtxoStates, UtxoType, UtxoTypes},
 };
+
+#[cfg(any(feature = "trezor", feature = "ledger"))]
+use wallet_types::hw_data::HardwareWalletFullInfo;
 use wallet_types::{
-    hw_data::HardwareWalletFullInfo,
     partially_signed_transaction::{
         make_sighash_input_commitments, PartiallySignedTransaction,
         PartiallySignedTransactionError, PartiallySignedTransactionWalletExt as _,
@@ -514,7 +516,7 @@ where
         current_controller_mode: WalletControllerMode,
         force_change_wallet_type: bool,
         open_as_wallet_type: WalletType,
-        device_id: Option<String>,
+        #[cfg_attr(not(feature = "trezor"), allow(unused_variables))] device_id: Option<String>,
     ) -> Result<WalletCreation<RuntimeWallet<DefaultBackend>>, ControllerError<N>> {
         utils::ensure!(
             file_path.as_ref().exists(),

--- a/wallet/wallet-controller/src/types/mod.rs
+++ b/wallet/wallet-controller/src/types/mod.rs
@@ -34,6 +34,7 @@ use common::{
     primitives::{amount::decimal::DecimalAmountWithIsSameComparison, DecimalAmount, H256},
 };
 use utils::ensure;
+#[cfg(feature = "trezor")]
 use wallet::signer::trezor_signer::FoundDevice;
 use wallet_types::{
     scan_blockchain::ScanBlockchain,

--- a/wallet/wallet-node-client/Cargo.toml
+++ b/wallet/wallet-node-client/Cargo.toml
@@ -20,7 +20,7 @@ serialization = { path = "../../serialization" }
 subsystem = { path = "../../subsystem" }
 utils = { path = "../../utils" }
 utils-networking = { path = "../../utils/networking" }
-wallet-types = { path = "../types" }
+wallet-types = { path = "../types", default-features = false }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/wallet/wallet-rpc-client/Cargo.toml
+++ b/wallet/wallet-rpc-client/Cargo.toml
@@ -10,7 +10,7 @@ chainstate = { path = "../../chainstate" }
 common = { path = "../../common" }
 crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
-node-comm = { path = "../wallet-node-client" }
+node-comm = { path = "../wallet-node-client", default-features = false }
 node-lib = { path = "../../node-lib" }
 p2p-types = { path = "../../p2p/types" }
 rpc = { path = "../../rpc" }
@@ -18,10 +18,10 @@ serialization = { path = "../../serialization" }
 subsystem = { path = "../../subsystem" }
 utils = { path = "../../utils" }
 utils-networking = { path = "../../utils/networking" }
-wallet = { path = ".." }
-wallet-controller = { path = "../wallet-controller" }
-wallet-rpc-lib = { path = "../wallet-rpc-lib" }
-wallet-types = { path = "../types" }
+wallet = { path = "..", default-features = false }
+wallet-controller = { path = "../wallet-controller", default-features = false }
+wallet-rpc-lib = { path = "../wallet-rpc-lib", default-features = false }
+wallet-types = { path = "../types", default-features = false }
 
 async-trait.workspace = true
 base64.workspace = true
@@ -47,15 +47,17 @@ build_utils = { path = "../../utils/build_utils" }
 
 [features]
 trezor = [
+  "node-comm/trezor",
   "wallet/trezor",
-  "wallet-types/trezor",
-  "wallet-rpc-lib/trezor",
   "wallet-controller/trezor",
+  "wallet-rpc-lib/trezor",
+  "wallet-types/trezor",
 ]
 ledger = [
+  "node-comm/ledger",
   "wallet/ledger",
-  "wallet-types/ledger",
-  "wallet-rpc-lib/ledger",
   "wallet-controller/ledger",
+  "wallet-rpc-lib/ledger",
+  "wallet-types/ledger",
 ]
 default = ["trezor", "ledger"]

--- a/wallet/wallet-rpc-daemon/Cargo.toml
+++ b/wallet/wallet-rpc-daemon/Cargo.toml
@@ -11,7 +11,7 @@ common = { path = "../../common" }
 logging = { path = "../../logging" }
 rpc = { path = "../../rpc" }
 utils = { path = "../../utils" }
-wallet-rpc-lib = { path = "../wallet-rpc-lib" }
+wallet-rpc-lib = { path = "../wallet-rpc-lib", default-features = false }
 
 clap.workspace = true
 thiserror.workspace = true

--- a/wallet/wallet-rpc-lib/Cargo.toml
+++ b/wallet/wallet-rpc-lib/Cargo.toml
@@ -48,7 +48,6 @@ rpc = { path = "../../rpc", features = ["test-support"] }
 subsystem = { path = "../../subsystem" }
 test-utils = { path = "../../test-utils" }
 wallet-test-node = { path = "../wallet-test-node" }
-wallet-types = { path = "../types" }
 
 rstest.workspace = true
 

--- a/wallet/wallet-rpc-lib/Cargo.toml
+++ b/wallet/wallet-rpc-lib/Cargo.toml
@@ -13,18 +13,18 @@ crypto = { path = "../../crypto" }
 logging = { path = "../../logging" }
 mempool-types = { path = "../../mempool/types" }
 mempool = { path = "../../mempool" }
-node-comm = { path = "../wallet-node-client" }
+node-comm = { path = "../wallet-node-client", default-features = false }
+p2p-types = { path = "../../p2p/types" }
 randomness = { path = "../../randomness" }
 rpc = { path = "../../rpc" }
 rpc-description = { path = "../../rpc/description" }
 serialization = { path = "../../serialization" }
 utils = { path = "../../utils" }
 utils-networking = { path = "../../utils/networking" }
-wallet = { path = ".." }
-wallet-controller = { path = "../wallet-controller" }
-wallet-storage = { path = "../storage" }
-wallet-types = { path = "../types" }
-p2p-types = { path = "../../p2p/types" }
+wallet = { path = "..", default-features = false }
+wallet-controller = { path = "../wallet-controller", default-features = false }
+wallet-storage = { path = "../storage", default-features = false }
+wallet-types = { path = "../types", default-features = false }
 
 anyhow.workspace = true
 async-trait.workspace = true
@@ -56,6 +56,18 @@ rstest.workspace = true
 build_utils = { path = "../../utils/build_utils" }
 
 [features]
-trezor = ["wallet-types/trezor", "wallet/trezor", "wallet-controller/trezor"]
-ledger = ["wallet-types/ledger", "wallet/ledger", "wallet-controller/ledger"]
+trezor = [
+    "node-comm/trezor",
+    "wallet/trezor",
+    "wallet-controller/trezor",
+    "wallet-storage/trezor",
+    "wallet-types/trezor",
+]
+ledger = [
+     "node-comm/ledger",
+    "wallet/ledger",
+    "wallet-controller/ledger",
+    "wallet-storage/ledger",
+    "wallet-types/ledger",
+]
 default = ["trezor", "ledger"]

--- a/wallet/wallet-rpc-lib/Cargo.toml
+++ b/wallet/wallet-rpc-lib/Cargo.toml
@@ -57,17 +57,17 @@ build_utils = { path = "../../utils/build_utils" }
 
 [features]
 trezor = [
-    "node-comm/trezor",
-    "wallet/trezor",
-    "wallet-controller/trezor",
-    "wallet-storage/trezor",
-    "wallet-types/trezor",
+  "node-comm/trezor",
+  "wallet/trezor",
+  "wallet-controller/trezor",
+  "wallet-storage/trezor",
+  "wallet-types/trezor",
 ]
 ledger = [
-     "node-comm/ledger",
-    "wallet/ledger",
-    "wallet-controller/ledger",
-    "wallet-storage/ledger",
-    "wallet-types/ledger",
+  "node-comm/ledger",
+  "wallet/ledger",
+  "wallet-controller/ledger",
+  "wallet-storage/ledger",
+  "wallet-types/ledger",
 ]
 default = ["trezor", "ledger"]


### PR DESCRIPTION
1. Fix project build when either one or both of "trezor"/"ledger" features are disabled.

    In the bridge I need to be able to build `wallet-rpc-client` without those features, otherwise it would require the particular versions of `parity-scale-codec` and `ledger-proto` that the core uses to be explicitly specified in the bridge as well (and it's not something the bridge should know about). But for consistency I decided to fix it for the entire project, including the case when the entire workspace is built, e.g. `cargo build --no-default-features --workspace`.

    The end result is not super nice, as I had to add `default-features = false` to all dependencies that have `default = ["trezor", "ledger"]` in their `[features]` - without it the features would be enabled for some of the crates due to cargo's feature unification. E.g. if `api-blockchain-scanner-daemon` had simply `node-comm = { path = "../../wallet/wallet-node-client" }`, then during `cargo build --no-default-features --workspace` both features would be enabled for `wallet-node-client`, which would propagate them to `wallet-types`, but other packages, like `wallet` itself, would still be built without it, producing compilation errors.

    For consistency I also added "trezor"/"ledger" features and `default = ["trezor", "ledger"]` to `test/Cargo.toml` (functional tests don't care about those features, but potentially they could).

    But perhaps the better approach would be to remove `default = ["trezor", "ledger"]` from all libraries and only have it in the apps. Though I'm not sure.

2. In `utils/src/fixed_hash.rs` the original `fixed_hash` entities are now exposed via a submodule, so that the bridge doesn't need a direct dependency on `fixed_hash`.