### PR TITLE
Reset InMempool txs to Inactive before connecting to the node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
     - Fixed an issue where the mempool wouldn't track non-UTXO dependencies between transactions, which could
       prevent e.g. several token management transactions from being included in the same block.
 
+  - Wallet:
+    - Fixed an issue where wallet transactions would remain marked as in-mempool after reopening the wallet when they are
+      actually no longer in the mempool.
+
 ## [1.3.1] - 2026-06-03
 
 ### Fixed

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -2411,10 +2411,10 @@ impl<K: AccountKeyChains> Account<K> {
         let account_index = self.account_index();
 
         for tx in self.output_cache.reset_inmempool_txs_to_inactive() {
-            db_tx.set_transaction(&AccountWalletTxId::new(acc_id.clone(), tx.id()), &tx)?;
+            db_tx.set_transaction(&AccountWalletTxId::new(acc_id.clone(), tx.id()), tx)?;
 
             if let Some(wallet_events) = wallet_events {
-                wallet_events.set_transaction(account_index, &tx);
+                wallet_events.set_transaction(account_index, tx);
             }
         }
 

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -2402,8 +2402,23 @@ impl<K: AccountKeyChains> Account<K> {
     }
 
     /// Reset all transactions that are currently in-mempool to inactive state
-    pub fn reset_inmempool_txs_to_inactive(&mut self) {
-        self.output_cache.reset_inmempool_txs_to_inactive();
+    pub fn reset_inmempool_txs_to_inactive<B: storage::Backend>(
+        &mut self,
+        db_tx: &mut StoreTxRw<B>,
+        wallet_events: Option<&impl WalletEvents>,
+    ) -> WalletResult<()> {
+        let acc_id = self.get_account_id();
+        let account_index = self.account_index();
+
+        for tx in self.output_cache.reset_inmempool_txs_to_inactive() {
+            db_tx.set_transaction(&AccountWalletTxId::new(acc_id.clone(), tx.id()), &tx)?;
+
+            if let Some(wallet_events) = wallet_events {
+                wallet_events.set_transaction(account_index, &tx);
+            }
+        }
+
+        Ok(())
     }
 
     pub fn update_best_block(

--- a/wallet/src/account/mod.rs
+++ b/wallet/src/account/mod.rs
@@ -2401,6 +2401,11 @@ impl<K: AccountKeyChains> Account<K> {
         )
     }
 
+    /// Reset all transactions that are currently in-mempool to inactive state
+    pub fn reset_inmempool_txs_to_inactive(&mut self) {
+        self.output_cache.reset_inmempool_txs_to_inactive();
+    }
+
     pub fn update_best_block(
         &mut self,
         db_tx: &mut impl WalletStorageWriteLocked,

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -1431,6 +1431,11 @@ impl OutputCache {
         Ok(())
     }
 
+    /// Reset all transactions that are currently in-mempool to inactive state.
+    pub fn reset_inmempool_txs_to_inactive(&mut self) {
+        self.txs.values_mut().for_each(|tx| tx.reset_inmempool_to_inactive());
+    }
+
     fn is_consumed(&self, utxo_states: UtxoStates, outpoint: &UtxoOutPoint) -> bool {
         self.consumed
             .get(outpoint)

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -1433,11 +1433,16 @@ impl OutputCache {
     }
 
     /// Reset all transactions that are currently in-mempool to inactive state.
-    pub fn reset_inmempool_txs_to_inactive(&mut self) {
-        self.txs.values_mut().for_each(|tx| tx.reset_inmempool_to_inactive());
-        self.consumed
+    ///
+    /// Return an iterator of the transactions that were reset.
+    pub fn reset_inmempool_txs_to_inactive(&mut self) -> impl Iterator<Item = &WalletTx> {
+        self.consumed.values_mut().for_each(|tx_state| {
+            tx_state.reset_inmempool_to_inactive();
+        });
+
+        self.txs
             .values_mut()
-            .for_each(|tx_state| tx_state.reset_inmempool_to_inactive());
+            .filter_map(|tx| tx.reset_inmempool_to_inactive().then_some(&*tx))
     }
 
     fn is_consumed(&self, utxo_states: UtxoStates, outpoint: &UtxoOutPoint) -> bool {

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -600,6 +600,7 @@ pub struct OutputCache {
     //  - no confirmed txs are allowed;
     //  - confirmed tx cannot have unconfirmed parent.
     unconfirmed_descendants: BTreeMap<OutPointSourceId, BTreeSet<OutPointSourceId>>,
+    // Map of consumed utxos; the value is the state of the tx that consumed the corresponding utxo.
     consumed: BTreeMap<UtxoOutPoint, TxState>,
 
     pools: BTreeMap<PoolId, PoolData>,
@@ -1434,6 +1435,9 @@ impl OutputCache {
     /// Reset all transactions that are currently in-mempool to inactive state.
     pub fn reset_inmempool_txs_to_inactive(&mut self) {
         self.txs.values_mut().for_each(|tx| tx.reset_inmempool_to_inactive());
+        self.consumed
+            .values_mut()
+            .for_each(|tx_state| tx_state.reset_inmempool_to_inactive());
     }
 
     fn is_consumed(&self, utxo_states: UtxoStates, outpoint: &UtxoOutPoint) -> bool {

--- a/wallet/src/account/output_cache/tests.rs
+++ b/wallet/src/account/output_cache/tests.rs
@@ -1608,6 +1608,28 @@ fn update_conflicting_txs_order_v1_freeze(#[case] seed: Seed) {
     assert!(!output_cache.orders[&order_id].is_concluded);
 }
 
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn reset_inmempool_txs_to_inactive(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = create_unit_test_config();
+    let mut output_cache = OutputCache::empty();
+
+    // add 10 random txs
+    for _ in 0..10 {
+        add_random_transfer_tx(&mut output_cache, &chain_config, &mut rng);
+    }
+
+    // Reset
+    output_cache.reset_inmempool_txs_to_inactive();
+
+    // Check none of the txs are InMempool state
+    for tx in output_cache.txs.values() {
+        assert!(!matches!(tx.state(), TxState::InMempool(_)));
+    }
+}
+
 fn add_random_transfer_tx(
     output_cache: &mut OutputCache,
     chain_config: &ChainConfig,

--- a/wallet/src/account/output_cache/tests.rs
+++ b/wallet/src/account/output_cache/tests.rs
@@ -1618,7 +1618,12 @@ fn reset_inmempool_txs_to_inactive(#[case] seed: Seed) {
 
     // add 10 random txs
     for _ in 0..10 {
-        add_random_transfer_tx(&mut output_cache, &chain_config, &mut rng);
+        add_random_transfer_tx_with_state(
+            &mut output_cache,
+            &chain_config,
+            TxStateTag::InMempool,
+            &mut rng,
+        );
     }
 
     // Reset
@@ -1635,6 +1640,16 @@ fn add_random_transfer_tx(
     chain_config: &ChainConfig,
     mut rng: impl Rng,
 ) {
+    let state_tag = TxStateTag::iter().choose(&mut rng).unwrap();
+    add_random_transfer_tx_with_state(output_cache, chain_config, state_tag, rng);
+}
+
+fn add_random_transfer_tx_with_state(
+    output_cache: &mut OutputCache,
+    chain_config: &ChainConfig,
+    state_tag: TxStateTag,
+    mut rng: impl Rng,
+) {
     let random_tx_id = Id::<Transaction>::random_using(&mut rng);
     let random_block_id = Id::<GenBlock>::random_using(&mut rng);
     let tx = TransactionBuilder::new()
@@ -1649,7 +1664,7 @@ fn add_random_transfer_tx(
         .build();
     let tx_id = tx.transaction().get_id();
 
-    let tx_state = match TxStateTag::iter().choose(&mut rng).unwrap() {
+    let tx_state = match state_tag {
         TxStateTag::Confirmed => TxState::Confirmed(
             BlockHeight::new(rng.random_range(0..100)),
             BlockTimestamp::from_int_seconds(rng.random_range(0..100)),

--- a/wallet/src/account/output_cache/tests.rs
+++ b/wallet/src/account/output_cache/tests.rs
@@ -1626,12 +1626,24 @@ fn reset_inmempool_txs_to_inactive(#[case] seed: Seed) {
         );
     }
 
+    // Sanity check - the `consumed` collection is not empty and all the tx states are InMempool.
+    assert_eq!(output_cache.consumed.len(), 10);
+    for tx_state in output_cache.consumed.values() {
+        assert!(matches!(tx_state, TxState::InMempool(_)));
+    }
+
     // Reset
     output_cache.reset_inmempool_txs_to_inactive();
 
-    // Check none of the txs are InMempool state
+    // Check that all txs are now Inactive
     for tx in output_cache.txs.values() {
-        assert!(!matches!(tx.state(), TxState::InMempool(_)));
+        assert!(matches!(tx.state(), TxState::Inactive(_)));
+    }
+
+    // Check that inside `consumed` the state of the consuming tx has been updated as well.
+    assert_eq!(output_cache.consumed.len(), 10);
+    for tx_state in output_cache.consumed.values() {
+        assert!(matches!(tx_state, TxState::Inactive(_)));
     }
 }
 

--- a/wallet/src/account/output_cache/tests.rs
+++ b/wallet/src/account/output_cache/tests.rs
@@ -1632,8 +1632,15 @@ fn reset_inmempool_txs_to_inactive(#[case] seed: Seed) {
         assert!(matches!(tx_state, TxState::InMempool(_)));
     }
 
+    let all_tx_ids = output_cache.txs.values().map(|tx| tx.id()).collect::<BTreeSet<_>>();
+
     // Reset
-    output_cache.reset_inmempool_txs_to_inactive();
+    let reset_tx_ids = output_cache
+        .reset_inmempool_txs_to_inactive()
+        .map(|tx| tx.id())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(reset_tx_ids, all_tx_ids);
 
     // Check that all txs are now Inactive
     for tx in output_cache.txs.values() {

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -980,7 +980,7 @@ where
             .into_iter()
             .map(|account| (account.account_index(), account))
             .collect();
-        // reset all inmempool transactions to inactive so we can set them properly from the current node again
+        // reset all in-mempool transactions to inactive so we can set them properly from the current node again
         accounts.values_mut().for_each(|a| a.reset_inmempool_txs_to_inactive());
 
         let latest_median_time =

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -812,6 +812,13 @@ where
         Ok(())
     }
 
+    /// Resets all transactions in all accounts from in-mempool state to inactive.
+    pub fn reset_inmempool_txs_to_inactive(&mut self) {
+        self.accounts
+            .values_mut()
+            .for_each(|account| account.reset_inmempool_txs_to_inactive());
+    }
+
     fn reset_wallet_transactions(
         chain_config: Arc<ChainConfig>,
         db_tx: &mut impl WalletStorageWriteLocked,
@@ -973,6 +980,8 @@ where
             .into_iter()
             .map(|account| (account.account_index(), account))
             .collect();
+        // reset all inmempool transactions to inactive so we can set them properly from the current node again
+        accounts.values_mut().for_each(|a| a.reset_inmempool_txs_to_inactive());
 
         let latest_median_time =
             db_tx.get_median_time()?.unwrap_or(chain_config.genesis_block().timestamp());

--- a/wallet/src/wallet/mod.rs
+++ b/wallet/src/wallet/mod.rs
@@ -813,10 +813,19 @@ where
     }
 
     /// Resets all transactions in all accounts from in-mempool state to inactive.
-    pub fn reset_inmempool_txs_to_inactive(&mut self) {
-        self.accounts
-            .values_mut()
-            .for_each(|account| account.reset_inmempool_txs_to_inactive());
+    pub fn reset_inmempool_txs_to_inactive(
+        &mut self,
+        wallet_events: Option<&impl WalletEvents>,
+    ) -> WalletResult<()> {
+        let mut db_tx = self.db.transaction_rw(None)?;
+
+        for account in self.accounts.values_mut() {
+            account.reset_inmempool_txs_to_inactive(&mut db_tx, wallet_events)?;
+        }
+
+        db_tx.commit()?;
+
+        Ok(())
     }
 
     fn reset_wallet_transactions(
@@ -980,13 +989,26 @@ where
             .into_iter()
             .map(|account| (account.account_index(), account))
             .collect();
-        // reset all in-mempool transactions to inactive so we can set them properly from the current node again
-        accounts.values_mut().for_each(|a| a.reset_inmempool_txs_to_inactive());
 
         let latest_median_time =
             db_tx.get_median_time()?.unwrap_or(chain_config.genesis_block().timestamp());
 
         db_tx.close();
+
+        {
+            // Reset all in-mempool transactions to inactive so we can set them properly from the current node again.
+
+            let mut db_tx = db.transaction_rw(None)?;
+
+            for account in accounts.values_mut() {
+                account.reset_inmempool_txs_to_inactive(
+                    &mut db_tx,
+                    Option::<&WalletEventsNoOp>::None,
+                )?;
+            }
+
+            db_tx.commit()?;
+        }
 
         let next_unused_account = accounts.pop_last().ok_or(WalletError::WalletNotInitialized)?;
 

--- a/wallet/types/src/wallet_tx.rs
+++ b/wallet/types/src/wallet_tx.rs
@@ -164,6 +164,17 @@ impl WalletTx {
         }
     }
 
+    pub fn reset_inmempool_to_inactive(&mut self) {
+        match self {
+            WalletTx::Block(_) => {} // Blocks are never InMempool
+            WalletTx::Tx(tx) => {
+                if let TxState::InMempool(counter) = tx.state {
+                    tx.state = TxState::Inactive(counter);
+                }
+            }
+        }
+    }
+
     pub fn inputs(&self) -> &[TxInput] {
         match self {
             WalletTx::Block(block) => block.kernel_inputs(),

--- a/wallet/types/src/wallet_tx.rs
+++ b/wallet/types/src/wallet_tx.rs
@@ -92,16 +92,17 @@ impl TxState {
         }
     }
 
-    pub fn reset_inmempool_to_inactive(&mut self) {
+    pub fn reset_inmempool_to_inactive(&mut self) -> bool {
         match self {
             TxState::InMempool(unconfirmed_tx_counter) => {
                 *self = TxState::Inactive(*unconfirmed_tx_counter);
+                true
             }
 
             TxState::Confirmed(_, _, _)
             | TxState::Conflicted(_)
             | TxState::Inactive(_)
-            | TxState::Abandoned => {}
+            | TxState::Abandoned => false,
         }
     }
 }
@@ -177,12 +178,10 @@ impl WalletTx {
         }
     }
 
-    pub fn reset_inmempool_to_inactive(&mut self) {
+    pub fn reset_inmempool_to_inactive(&mut self) -> bool {
         match self {
-            WalletTx::Block(_) => {} // Blocks are never InMempool
-            WalletTx::Tx(tx) => {
-                tx.state.reset_inmempool_to_inactive();
-            }
+            WalletTx::Block(_) => false, // Blocks are never InMempool
+            WalletTx::Tx(tx) => tx.state.reset_inmempool_to_inactive(),
         }
     }
 

--- a/wallet/types/src/wallet_tx.rs
+++ b/wallet/types/src/wallet_tx.rs
@@ -91,6 +91,19 @@ impl TxState {
             TxState::Abandoned => "Abandoned",
         }
     }
+
+    pub fn reset_inmempool_to_inactive(&mut self) {
+        match self {
+            TxState::InMempool(unconfirmed_tx_counter) => {
+                *self = TxState::Inactive(*unconfirmed_tx_counter);
+            }
+
+            TxState::Confirmed(_, _, _)
+            | TxState::Conflicted(_)
+            | TxState::Inactive(_)
+            | TxState::Abandoned => {}
+        }
+    }
 }
 
 impl Display for TxState {
@@ -168,9 +181,7 @@ impl WalletTx {
         match self {
             WalletTx::Block(_) => {} // Blocks are never InMempool
             WalletTx::Tx(tx) => {
-                if let TxState::InMempool(counter) = tx.state {
-                    tx.state = TxState::Inactive(counter);
-                }
+                tx.state.reset_inmempool_to_inactive();
             }
         }
     }

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -1579,7 +1579,7 @@ where
 
             match self.wallet_mode {
                 WalletControllerMode::Hot => {
-                    // after the first successful sync to the tip fetch all mempool transactions
+                    // fetch all mempool transactions after a broken connection or after the initial sync
                     if self.should_resecan_mempool_txs {
                         let txs = self.rpc_client.mempool_get_transactions().await;
 

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -54,7 +54,6 @@ use types::{
     SeedWithPassPhrase, SignatureStats, TransactionToInspect, ValidatedSignatures, WalletInfo,
     WalletTypeArgsComputed,
 };
-use utils::set_flag::SetFlag;
 use wallet_storage::DefaultBackend;
 
 use read::ReadOnlyController;
@@ -238,7 +237,7 @@ pub struct Controller<T, W, B: storage::Backend + 'static> {
     wallet_events: W,
 
     mempool_events: MempoolEvents,
-    finished_initial_sync: SetFlag,
+    should_resecan_mempool_txs: bool,
 }
 
 impl<T, WalletEvents, B: storage::Backend> std::fmt::Debug for Controller<T, WalletEvents, B> {
@@ -261,8 +260,19 @@ where
         wallet: RuntimeWallet<B>,
         wallet_events: W,
     ) -> Result<Self, ControllerError<N>> {
-        let mut controller =
-            Self::new_unsynced(chain_config, rpc_client, wallet, wallet_events).await?;
+        let mempool_events = rpc_client
+            .mempool_subscribe_to_events()
+            .await
+            .map_err(ControllerError::NodeCallError)?;
+        let mut controller = Self {
+            chain_config,
+            rpc_client,
+            wallet,
+            staking_started: BTreeSet::new(),
+            wallet_events,
+            mempool_events,
+            should_resecan_mempool_txs: true,
+        };
 
         // In the cold mode, try_sync_once is a no-op, so it doesn't matter whether we call it.
         // We omit the call to avoid printing the "Syncing the wallet" log line, which looks
@@ -299,7 +309,7 @@ where
             staking_started: BTreeSet::new(),
             wallet_events,
             mempool_events,
-            finished_initial_sync: SetFlag::new(),
+            should_resecan_mempool_txs: true,
         })
     }
 
@@ -1570,7 +1580,7 @@ where
             match self.wallet_mode {
                 WalletControllerMode::Hot => {
                     // after the first successful sync to the tip fetch all mempool transactions
-                    if !self.finished_initial_sync.test() {
+                    if self.should_resecan_mempool_txs {
                         let txs = self.rpc_client.mempool_get_transactions().await;
 
                         match txs {
@@ -1580,7 +1590,7 @@ where
                                 {
                                     log::error!("Error adding mempool transactions: {err}");
                                 } else {
-                                    self.finished_initial_sync.set();
+                                    self.should_resecan_mempool_txs = false
                                 }
                             }
                             Err(err) => {
@@ -1609,8 +1619,11 @@ where
                             Some(e) => e,
                             None => {
                                 log::error!("Mempool notifications channel is closed");
-                                tokio::time::sleep(ERROR_DELAY).await;
+                                // reset in-mempool transactions to inactive so we can rescan them when we connect again
+                                self.wallet.reset_inmempool_txs_to_inactive();
+                                self.should_resecan_mempool_txs = true;
 
+                                tokio::time::sleep(ERROR_DELAY).await;
                                 match self.rpc_client
                                     .mempool_subscribe_to_events()
                                     .await {

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -237,7 +237,7 @@ pub struct Controller<T, W, B: storage::Backend + 'static> {
     wallet_events: W,
 
     mempool_events: MempoolEvents,
-    should_resecan_mempool_txs: bool,
+    should_rescan_mempool_txs: bool,
 }
 
 impl<T, WalletEvents, B: storage::Backend> std::fmt::Debug for Controller<T, WalletEvents, B> {
@@ -260,19 +260,8 @@ where
         wallet: RuntimeWallet<B>,
         wallet_events: W,
     ) -> Result<Self, ControllerError<N>> {
-        let mempool_events = rpc_client
-            .mempool_subscribe_to_events()
-            .await
-            .map_err(ControllerError::NodeCallError)?;
-        let mut controller = Self {
-            chain_config,
-            rpc_client,
-            wallet,
-            staking_started: BTreeSet::new(),
-            wallet_events,
-            mempool_events,
-            should_resecan_mempool_txs: true,
-        };
+        let mut controller =
+            Self::new_unsynced(chain_config, rpc_client, wallet, wallet_events).await?;
 
         // In the cold mode, try_sync_once is a no-op, so it doesn't matter whether we call it.
         // We omit the call to avoid printing the "Syncing the wallet" log line, which looks
@@ -309,7 +298,7 @@ where
             staking_started: BTreeSet::new(),
             wallet_events,
             mempool_events,
-            should_resecan_mempool_txs: true,
+            should_rescan_mempool_txs: true,
         })
     }
 
@@ -1580,7 +1569,7 @@ where
             match self.wallet_mode {
                 WalletControllerMode::Hot => {
                     // fetch all mempool transactions after a broken connection or after the initial sync
-                    if self.should_resecan_mempool_txs {
+                    if self.should_rescan_mempool_txs {
                         let txs = self.rpc_client.mempool_get_transactions().await;
 
                         match txs {
@@ -1590,7 +1579,7 @@ where
                                 {
                                     log::error!("Error adding mempool transactions: {err}");
                                 } else {
-                                    self.should_resecan_mempool_txs = false
+                                    self.should_rescan_mempool_txs = false
                                 }
                             }
                             Err(err) => {
@@ -1621,7 +1610,7 @@ where
                                 log::error!("Mempool notifications channel is closed");
                                 // reset in-mempool transactions to inactive so we can rescan them when we connect again
                                 self.wallet.reset_inmempool_txs_to_inactive();
-                                self.should_resecan_mempool_txs = true;
+                                self.should_rescan_mempool_txs = true;
 
                                 tokio::time::sleep(ERROR_DELAY).await;
                                 match self.rpc_client

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -1607,7 +1607,12 @@ where
                         let event = match maybe_event {
                             Some(e) => e,
                             None => {
+                                // Note: currently the wallet is unable to automatically reconnect to the node when
+                                // the connection is dropped, so for now this branch mostly handles a hypothetical
+                                // situation when the connection is still up, but the stream itself somehow got closed.
+
                                 log::error!("Mempool notifications channel is closed");
+
                                 // reset in-mempool transactions to inactive so we can rescan them when we connect again
                                 self.wallet.reset_inmempool_txs_to_inactive();
                                 self.should_rescan_mempool_txs = true;
@@ -1628,6 +1633,21 @@ where
                         };
 
                         match event {
+                            // TODO: mempool can evict transactions - there is a size limit for the entire mempool
+                            // (MAX_MEMPOOL_SIZE_BYTES by default, which is 300Mb) and an expiration time for each tx
+                            // (DEFAULT_MEMPOOL_EXPIRY, which is currently 2 weeks). The wallet must be aware of this
+                            // and mark all its in-mempool txs that have been evicted as inactive.
+                            // At this moment eviction happens when a new tx is being added to the mempool, but note
+                            // that a `NewTransaction` event is not guaranteed in this case (e.g. if the newly added
+                            // tx gets evicted too). Additionally, txs may be evicted after the mempool has been explicitly
+                            // trimmed via `set_max_size`.
+                            // So, the simpler (but not 100% reliable) solution would be to check all of the wallet's
+                            // in-mempool txs for whether they're still in mempool (preferably via a dedicated rpc method,
+                            // to avoid overhead) whenever a `NewTransaction` event arrives.
+                            // A better solution is to introduce a separate mempool event, `TransactionsRemoved`,
+                            // that would contain ids of all txs that have been evicted or removed due to other reasons
+                            // (plus maybe the reason for the eviction/removal).
+
                             MempoolEvent::NewTransaction { tx_id } => {
                                 let transaction = self.rpc_client
                                     .mempool_get_transaction(tx_id)

--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -1613,8 +1613,8 @@ where
 
                                 log::error!("Mempool notifications channel is closed");
 
-                                // reset in-mempool transactions to inactive so we can rescan them when we connect again
-                                self.wallet.reset_inmempool_txs_to_inactive();
+                                // Reset in-mempool transactions to inactive so we can rescan them when we connect again.
+                                self.wallet.reset_inmempool_txs_to_inactive(Some(&self.wallet_events))?;
                                 self.should_rescan_mempool_txs = true;
 
                                 tokio::time::sleep(ERROR_DELAY).await;

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -102,6 +102,16 @@ where
         }
     }
 
+    pub fn reset_inmempool_txs_to_inactive(&mut self) {
+        match self {
+            RuntimeWallet::Software(w) => w.reset_inmempool_txs_to_inactive(),
+            #[cfg(feature = "trezor")]
+            RuntimeWallet::Trezor(w) => w.reset_inmempool_txs_to_inactive(),
+            #[cfg(feature = "ledger")]
+            RuntimeWallet::Ledger(w) => w.reset_inmempool_txs_to_inactive(),
+        }
+    }
+
     pub fn find_account_destination(&self, acc_outpoint: &AccountOutPoint) -> Option<Destination> {
         match self {
             RuntimeWallet::Software(w) => w.find_account_destination(acc_outpoint),

--- a/wallet/wallet-controller/src/runtime_wallet.rs
+++ b/wallet/wallet-controller/src/runtime_wallet.rs
@@ -102,13 +102,16 @@ where
         }
     }
 
-    pub fn reset_inmempool_txs_to_inactive(&mut self) {
+    pub fn reset_inmempool_txs_to_inactive(
+        &mut self,
+        wallet_events: Option<&impl WalletEvents>,
+    ) -> WalletResult<()> {
         match self {
-            RuntimeWallet::Software(w) => w.reset_inmempool_txs_to_inactive(),
+            RuntimeWallet::Software(w) => w.reset_inmempool_txs_to_inactive(wallet_events),
             #[cfg(feature = "trezor")]
-            RuntimeWallet::Trezor(w) => w.reset_inmempool_txs_to_inactive(),
+            RuntimeWallet::Trezor(w) => w.reset_inmempool_txs_to_inactive(wallet_events),
             #[cfg(feature = "ledger")]
-            RuntimeWallet::Ledger(w) => w.reset_inmempool_txs_to_inactive(),
+            RuntimeWallet::Ledger(w) => w.reset_inmempool_txs_to_inactive(wallet_events),
         }
     }
 


### PR DESCRIPTION
We reset all InMempool transactions back to Inactive on 
1. wallet load, 
2. every time the mempool notifications channel is closed
so that we can rescan them from the node when we connect back.