### PR TITLE
CI: use the same ledger app repo revision that is hardcoded in the root Cargo.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,11 +371,17 @@ jobs:
           submodules: recursive
           path: ./mintlayer-core
 
+      - name: Extract required info from Cargo.toml
+        id: extract_cargo_info
+        run: |
+          echo "LEDGER_REPO_REV=$(python ./build-tools/cargo-info-extractor/extract.py --ledger-repo-rev)" >> $GITHUB_OUTPUT
+        working-directory: ./mintlayer-core
+
       - name: Checkout mintlayer-ledger-app repository
         uses: actions/checkout@v5
         with:
           repository: mintlayer/mintlayer-ledger-app
-          ref: feature/mintlayer-app
+          ref: ${{ steps.extract_cargo_info.outputs.LEDGER_REPO_REV }}
           path: ./mintlayer-ledger-app
 
       - name: Download archived tests

--- a/build-tools/cargo-info-extractor/extract.py
+++ b/build-tools/cargo-info-extractor/extract.py
@@ -26,11 +26,16 @@ def get_trezor_repo_rev(workspace_settings):
     return workspace_settings["dependencies"]["trezor-client"]["rev"]
 
 
+def get_ledger_repo_rev(workspace_settings):
+    return workspace_settings["dependencies"]["mintlayer-ledger-messages"]["rev"]
+
+
 def main():
     parser = argparse.ArgumentParser()
     mutex_group = parser.add_mutually_exclusive_group(required=True)
     mutex_group.add_argument('--rust-version', action='store_true', help='extract Rust version')
     mutex_group.add_argument('--trezor-repo-rev', action='store_true', help='extract Trezor repo revision')
+    mutex_group.add_argument('--ledger-repo-rev', action='store_true', help='extract Ledger repo revision')
     args = parser.parse_args()
 
     with open(ROOT_CARGO_TOML, "rb") as file:
@@ -43,6 +48,9 @@ def main():
         print(result)
     elif args.trezor_repo_rev:
         result = get_trezor_repo_rev(workspace_settings)
+        print(result)
+    elif args.ledger_repo_rev:
+        result = get_ledger_repo_rev(workspace_settings)
         print(result)
 
 


### PR DESCRIPTION
Currently the CI always checks out the `feature/mintlayer-app` branch and the recent pushes to it broke the current tests.