### PR TITLE
wallet: `node_traits::MempoolEvent` enum now also has the `NewTip` va…

### DIFF
--- a/wallet/wallet-controller/src/lib.rs
+++ b/wallet/wallet-controller/src/lib.rs
@@ -209,6 +209,12 @@ pub enum ControllerError<N: NodeInterface> {
 
     #[error("The number of htlc secrets does not match the number of inputs")]
     InvalidHtlcSecretsCount,
+
+    #[error("Mempool events channel closed unexpectedly")]
+    MempoolEventChannelClosedUnexpectedly,
+
+    #[error("Timeout reached while waiting for a mempool NewTip event with block {expected_tip:x}")]
+    MempoolTipEventWaitTimeout { expected_tip: Id<GenBlock> },
 }
 
 #[derive(Clone, Copy)]
@@ -773,12 +779,23 @@ where
 
     /// Try to generate the `block_count` number of blocks.
     /// The function may return an error early if some attempt fails.
+    ///
+    /// Note that this function is intended to be used on regtest/signet and it assumes that
+    /// no other blocks can enter chainstate during the call. E.g. it expects that each produced
+    /// block becomes a tip; if this is not the case (e.g. because a better block has been received
+    /// via p2p in the meantime), it will fail after a short timeout.
     pub async fn generate_blocks(
         &mut self,
         account_index: U31,
         block_count: u32,
     ) -> Result<(), ControllerError<N>> {
-        for _ in 0..block_count {
+        let mut mempool_events = self
+            .rpc_client
+            .mempool_subscribe_to_events()
+            .await
+            .map_err(ControllerError::NodeCallError)?;
+
+        for idx in 0..block_count {
             self.sync_once().await?;
             let block = self
                 .generate_block(
@@ -789,10 +806,41 @@ where
                 )
                 .await?;
 
+            let block_id = block.get_id();
+
             self.rpc_client
                 .submit_block(block)
                 .await
                 .map_err(ControllerError::NodeCallError)?;
+
+            if idx < block_count - 1 {
+                // Wait until the new tip reaches the mempool, otherwise producing the next block
+                // may fail with "Recoverable mempool error".
+                let mut event_wait_loop = async || -> Result<(), ControllerError<N>> {
+                    loop {
+                        let event = mempool_events
+                            .next()
+                            .await
+                            .ok_or(ControllerError::MempoolEventChannelClosedUnexpectedly)?;
+
+                        match event {
+                            MempoolEvent::NewTransaction { .. } => {}
+                            MempoolEvent::NewTip { tip_id } => {
+                                if tip_id == block_id {
+                                    break Ok(());
+                                }
+                            }
+                        }
+                    }
+                };
+
+                let timeout = Duration::from_secs(5);
+                tokio::time::timeout(timeout, event_wait_loop()).await.map_err(
+                    |_: tokio::time::error::Elapsed| ControllerError::MempoolTipEventWaitTimeout {
+                        expected_tip: block_id.into(),
+                    },
+                )??;
+            }
         }
 
         self.sync_once().await
@@ -1497,7 +1545,6 @@ where
                                 log::error!("Mempool notifications channel is closed.");
                                 tokio::time::sleep(ERROR_DELAY).await;
 
-
                                 match self.rpc_client
                                     .mempool_subscribe_to_events()
                                     .await {
@@ -1533,6 +1580,7 @@ where
                                     }
                                 }
                             }
+                            MempoolEvent::NewTip { .. } => {},
                         }
                     }
                 }

--- a/wallet/wallet-node-client/src/handles_client/mod.rs
+++ b/wallet/wallet-node-client/src/handles_client/mod.rs
@@ -465,7 +465,9 @@ impl NodeInterface for WalletHandlesClient {
         let subscription =
             res.into_stream().filter_map(|event| {
                 futures::future::ready(match event {
-                    MempoolEvent::NewTip { .. } => None,
+                    MempoolEvent::NewTip(tip) => Some(crate::node_traits::MempoolEvent::NewTip {
+                        tip_id: *tip.block_id(),
+                    }),
 
                     MempoolEvent::TransactionProcessed(tx) => tx.was_accepted().then_some(
                         crate::node_traits::MempoolEvent::NewTransaction { tx_id: *tx.tx_id() },

--- a/wallet/wallet-node-client/src/node_traits.rs
+++ b/wallet/wallet-node-client/src/node_traits.rs
@@ -161,5 +161,9 @@ pub trait NodeInterface {
 pub type MempoolEvents = Box<dyn Stream<Item = MempoolEvent> + Sync + Send + Unpin>;
 
 pub enum MempoolEvent {
+    /// Sent whenever a new transaction is added to the mempool.
     NewTransaction { tx_id: Id<Transaction> },
+
+    /// Sent whenever the mempool observes a new tip.
+    NewTip { tip_id: Id<GenBlock> },
 }

--- a/wallet/wallet-node-client/src/rpc_client/client_impl.rs
+++ b/wallet/wallet-node-client/src/rpc_client/client_impl.rs
@@ -433,7 +433,7 @@ impl NodeInterface for NodeRpcClient {
 
         let subscription = subscription.filter_map(|item| {
             futures::future::ready(item.ok().and_then(|event| match event {
-                RpcEvent::NewTip { .. } => None,
+                RpcEvent::NewTip { id, height: _ } => Some(MempoolEvent::NewTip { tip_id: id }),
 
                 RpcEvent::TransactionProcessed {
                     tx_id, successful, ..


### PR DESCRIPTION
Got this failure on CI - https://github.com/mintlayer/mintlayer-core/actions/runs/25721713754/job/75524264465:
```
2026-05-12T08:53:17.2986831Z thread 'produce_blocks::case_1' panicked at wallet/wallet-cli-lib/tests/basic.rs:87:5:
2026-05-12T08:53:17.2987256Z assertion `left == right` failed
2026-05-12T08:53:17.2987894Z   left: "Wallet controller error: Node call error: Response error: ErrorObject { code: ServerError(-32000), message: \"Recoverable mempool error\", data: None }"
2026-05-12T08:53:17.2988509Z  right: "Success"
```

In that commit, `basic.rs:87` corresponds to `assert_eq!(test.exec("node-generate-blocks 20"), "Success");` and "Recoverable mempool error" means that while blockprod was collecting txs from the mempool, mempool's current tip changed and the whole block production attempt was aborted. To prevent this, I added `NewTip` variant to `MempoolEvent` in `wallet/wallet-node-client/src/node_traits.rs`, and `Contoller::generate_blocks` now waits for the corresponding `NewTip` event from the mempool before attempting to produce the next block.