### PR TITLE
Bump min rust version to 1.91

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ utxo = { path = "utxo" }
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.91"
 version = "1.3.0"
 license = "MIT"
 


### PR DESCRIPTION
The latest `wasm-pack` (v0.15) needs rust 1.91 and the CI on master is currently broken because of this.