### PR TITLE
Fix a typo in transaction verifier

### DIFF
--- a/chainstate/test-suite/src/tests/orders_tests.rs
+++ b/chainstate/test-suite/src/tests/orders_tests.rs
@@ -5014,31 +5014,29 @@ fn token_v0_in_orders_test(
             .build_and_process(&mut rng)
             .unwrap_err();
 
-        if ask_for_token {
-            if switch_to_tokens_v1 {
-                assert_eq!(
-                    err,
-                    ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
-                        CheckBlockError::CheckTransactionFailed(
-                            CheckBlockTransactionsError::CheckTransactionError(
-                                tx_verifier::CheckTransactionError::DeprecatedTokenOperationVersion(
-                                    TokenIssuanceVersion::V0,
-                                    order_creation_tx_id
-                                )
+        if switch_to_tokens_v1 {
+            assert_eq!(
+                err,
+                ChainstateError::ProcessBlockError(BlockError::CheckBlockFailed(
+                    CheckBlockError::CheckTransactionFailed(
+                        CheckBlockTransactionsError::CheckTransactionError(
+                            tx_verifier::CheckTransactionError::DeprecatedTokenOperationVersion(
+                                TokenIssuanceVersion::V0,
+                                order_creation_tx_id
                             )
                         )
-                    ))
-                );
-            } else {
-                assert_eq!(
-                    err,
-                    ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
-                        ConnectTransactionError::OrdersAccountingError(
-                            orders_accounting::Error::UnsupportedTokenVersion,
-                        )
-                    ))
-                );
-            }
+                    )
+                ))
+            );
+        } else if ask_for_token {
+            assert_eq!(
+                err,
+                ChainstateError::ProcessBlockError(BlockError::StateUpdateFailed(
+                    ConnectTransactionError::OrdersAccountingError(
+                        orders_accounting::Error::UnsupportedTokenVersion,
+                    )
+                ))
+            );
         } else {
             assert_eq!(
                 err,

--- a/chainstate/tx-verifier/src/transaction_verifier/check_transaction.rs
+++ b/chainstate/tx-verifier/src/transaction_verifier/check_transaction.rs
@@ -175,7 +175,7 @@ fn check_tokens_tx(
                         OutputValue::Coin(_) | OutputValue::TokenV1(_, _) => false,
                         OutputValue::TokenV0(_) => true,
                     };
-                    let give_token_v0 = match data.ask() {
+                    let give_token_v0 = match data.give() {
                         OutputValue::Coin(_) | OutputValue::TokenV1(_, _) => false,
                         OutputValue::TokenV0(_) => true,
                     };


### PR DESCRIPTION
Fix for the typo in the transaction verifier mentioned in https://github.com/mintlayer/mintlayer-core/pull/2060.
As a result of the fix, the expected errors in `token_v0_in_orders_test` changed and now they're the same in the 'ask' and 'give' cases. This is enough to cover the fix, so I didn't add a new test for this.