### PR TITLE
Mempool optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
       - Transactions are now announced in batches at irregular intervals (previously, a random delay was added
         before each individual transaction announcement).
 
+  - Mempool:
+    - Various optimizations were made.
+
 ### Fixed
   - Wallet:
     - Fixed handling of confirmed and unconfirmed conflicting order transactions in the wallet.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,6 +3056,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "font-types"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,7 +3574,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -3576,6 +3582,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -5015,6 +5032,7 @@ dependencies = [
  "common",
  "crypto",
  "ctor",
+ "hashbrown 0.17.1",
  "hex",
  "jsonrpsee",
  "logging",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ futures = { version = "0.3", default-features = false }
 # still use the 0.x version, so by upgrading to 1.x we'll end up using both versions of GenericArray
 # and will have to perform convertions between them.
 generic-array = "=0.14.7"
+hashbrown = "0.17"
 heck = "0.5"
 hex = "0.4"
 hex-literal = "0.4"

--- a/common/src/primitives/id/mod.rs
+++ b/common/src/primitives/id/mod.rs
@@ -179,6 +179,12 @@ impl<T: Eq> PartialOrd for Id<T> {
     }
 }
 
+impl<T> std::hash::Hash for Id<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.hash.hash(state);
+    }
+}
+
 impl<T: Eq> From<H256> for Id<T> {
     fn from(hash: H256) -> Self {
         Self::new(hash)

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -30,6 +30,7 @@ utxo = { path = "../utxo" }
 anyhow.workspace = true
 async-trait.workspace = true
 byte-unit.workspace = true
+hashbrown.workspace = true
 hex.workspace = true
 jsonrpsee = { workspace = true, features = ["macros"] }
 parking_lot.workspace = true

--- a/mempool/src/pool/tx_pool/collect_txs.rs
+++ b/mempool/src/pool/tx_pool/collect_txs.rs
@@ -147,7 +147,7 @@ pub fn collect_txs<M>(
         .filter_map(|tx_id| {
             // If the transaction with this ID has already been processed, skip it
             ensure!(processed.insert(tx_id));
-            let tx = mempool.store.txs_by_id.get(tx_id).expect("already checked").deref();
+            let tx = mempool.store.get_entry(tx_id).expect("already checked");
 
             tx_verifier::input_check::verify_timelocks(
                 tx.transaction(),
@@ -236,7 +236,9 @@ pub fn collect_txs<M>(
                     0 => panic!("pending with 0 missing parents"),
                     1 => {
                         // This was the last missing parent, put the tx into the ready queue
-                        ready.push(mempool.store.txs_by_id[c.key()].deref().into());
+                        let entry =
+                            mempool.store.get_entry(c.key()).expect("child must be present");
+                        ready.push(entry.into());
                         c.remove();
                     }
                     n => *n -= 1,
@@ -259,45 +261,59 @@ pub fn collect_txs<M>(
     }
 }
 
-/// Return at most `tx_count` tx ids from `tx_ids`, ordering them by score and ancestry
+/// Return at most `tx_count` tx ids from `selected_tx_ids`, ordering them by score and ancestry
 /// (txs with better score will come first, ancestors will come before their descendants).
 ///
-/// All txs in `tx_ids` must be present in the mempool.
+/// All txs in `selected_tx_ids` must be present in the mempool.
 ///
 /// Note: the ancestry is determined using TxMempoolEntry's `parents` and `children` collections,
 /// which at the moment only reflect utxo-based relationships, see the TODO inside `collect_txs`.
 pub fn get_best_tx_ids_by_score_and_ancestry<M>(
     mempool: &TxPool<M>,
-    tx_ids: &BTreeSet<Id<Transaction>>,
+    selected_tx_ids: &BTreeSet<Id<Transaction>>,
     tx_count: usize,
 ) -> Result<Vec<Id<Transaction>>, TxCollectionError> {
+    use get_best_tx_ids_by_score_and_ancestry_impl::*;
+
     if tx_count == 0 {
         return Ok(Vec::new());
     }
 
-    // Map from a tx id to all ancestors of the tx that are present in `tx_ids`.
+    // Map from a selected tx id to all its nearest selected ancestors (tx being "selected" means
+    // it's present in `selected_tx_ids`). E.g. if there is a chain TX <- A1 <- A2 and all of TX/A1/A2
+    // are selected, then selected_ancestors_map[TX] will contain A1, but not A2, selected_ancestors_map[A1]
+    // will contain A2 and selected_ancestors_map[A2] will be empty.
+    // (Technically, the map will also contain some keys that are not selected tx ids, due to how it's
+    // constructed, but they will be ignored).
     let mut selected_ancestors_map = BTreeMap::<Id<Transaction>, BTreeSet<Id<Transaction>>>::new();
-    // Map from a tx id to all descendants of the tx that are present in `tx_ids`.
+    // Map from a selected tx id to txs for which it is one of the nearest selected ancestors.
+    // In the example above, selected_descendants_map[A2] will contain A1, selected_descendants_map[A1]
+    // will contain TX and selected_descendants_map[TX] will be empty.
     let mut selected_descendants_map =
         BTreeMap::<Id<Transaction>, BTreeSet<Id<Transaction>>>::new();
-    // Map from a tx id to the number of its ancestors that haven't been emitted so far.
-    let mut missing_ancestors_count_map = BTreeMap::<Id<Transaction>, usize>::new();
-    // Heap of tx entries all of whose ancestors have already been emitted.
-    let mut ready_txs = BinaryHeap::<EntryByScore>::with_capacity(tx_ids.len());
+    // Map from a tx id to the number of its nearest selected ancestors that haven't been emitted so far.
+    let mut missing_selected_ancestors_count_map = BTreeMap::<Id<Transaction>, usize>::new();
+    // Heap of tx entries all of whose selected ancestors have already been emitted.
+    let mut ready_txs = BinaryHeap::<EntryByScore>::with_capacity(selected_tx_ids.len());
 
-    for tx_id in tx_ids {
+    for tx_id in selected_tx_ids {
         let entry = mempool
             .store
             .get_entry(tx_id)
             .ok_or(TxCollectionError::SpecifiedTxNotFound(*tx_id))?;
 
-        collect_selected_ancestors(mempool, entry, tx_ids, &mut selected_ancestors_map)?;
+        collect_nearest_selected_ancestors(
+            mempool,
+            entry,
+            selected_tx_ids,
+            &mut selected_ancestors_map,
+        )?;
         let selected_ancestors = selected_ancestors_map.get(tx_id).expect("must be present");
 
         if selected_ancestors.is_empty() {
             ready_txs.push(entry.into());
         } else {
-            missing_ancestors_count_map.insert(*tx_id, selected_ancestors.len());
+            missing_selected_ancestors_count_map.insert(*tx_id, selected_ancestors.len());
             for ancestor_id in selected_ancestors {
                 selected_descendants_map.entry(*ancestor_id).or_default().insert(*tx_id);
             }
@@ -307,7 +323,7 @@ pub fn get_best_tx_ids_by_score_and_ancestry<M>(
     let selected_descendants_map = selected_descendants_map;
     drop(selected_ancestors_map);
 
-    let mut result = Vec::with_capacity(std::cmp::min(tx_count, tx_ids.len()));
+    let mut result = Vec::with_capacity(std::cmp::min(tx_count, selected_tx_ids.len()));
 
     while result.len() < tx_count {
         let Some(tx_entry) = ready_txs.pop() else {
@@ -318,16 +334,16 @@ pub fn get_best_tx_ids_by_score_and_ancestry<M>(
 
         if let Some(child_ids) = selected_descendants_map.get(tx_id) {
             for child_id in child_ids {
-                match missing_ancestors_count_map.entry(*child_id) {
+                match missing_selected_ancestors_count_map.entry(*child_id) {
                     btree_map::Entry::Vacant(_) => {}
-                    btree_map::Entry::Occupied(mut missing_ancestors_count) => {
-                        match missing_ancestors_count.get_mut() {
+                    btree_map::Entry::Occupied(mut missing_selected_ancestors_count) => {
+                        match missing_selected_ancestors_count.get_mut() {
                             0 => {
                                 // Should not be possible by construction.
-                                panic!("Pending child with 0 missing parents");
+                                panic!("Pending child with 0 selected ancestors");
                             }
                             1 => {
-                                missing_ancestors_count.remove();
+                                missing_selected_ancestors_count.remove();
                                 let child = mempool.store.get_entry(child_id).ok_or(
                                     TxCollectionError::TxChildNotFound {
                                         tx_id: *tx_id,
@@ -347,50 +363,60 @@ pub fn get_best_tx_ids_by_score_and_ancestry<M>(
     Ok(result)
 }
 
-/// Collect all ancestors (both direct and indirect) of the specified tx that are present in `selected_tx_ids`.
-///
-/// After the call, `ancestors_map` is guaranteed to contain the id of the tx as a key, and the value
-/// will be the set of ancestors.
-///
-/// Note: it'd be better if the function returned a reference to the collected ancestors set instead
-/// of forcing the caller to do an additional lookup with `expect`, but the borrow checker throws
-/// a tantrum in this case and there doesn't seem to be a way to pacify it without doing extra lookups
-/// or cloning.
-fn collect_selected_ancestors<M>(
-    mempool: &TxPool<M>,
-    tx_entry: &TxMempoolEntry,
-    selected_tx_ids: &BTreeSet<Id<Transaction>>,
-    ancestors_map: &mut BTreeMap<Id<Transaction>, BTreeSet<Id<Transaction>>>,
-) -> Result<(), TxCollectionError> {
-    let tx_id = tx_entry.tx_id();
+mod get_best_tx_ids_by_score_and_ancestry_impl {
+    use super::*;
 
-    if !ancestors_map.contains_key(tx_id) {
-        let mut tx_ancestors = BTreeSet::new();
+    // For each ancestor path starting from the specified tx, take the nearest ancestor that is in `selected_tx_ids`
+    // and put it into a set. E.g. in
+    //  /--S1--**--S2
+    // T---**--S3--S4
+    //          \--**--S5
+    // where "S" means a tx in `selected_tx_ids` and "**" some other tx, S1 and S3 will be put into the set,
+    // while S2, S4 and S5 will not.
+    // After the call, `ancestors_map` is guaranteed to contain the id of the tx as a key, and the value
+    // will be the above-mentioned set.
+    //
+    // Note: it'd be better if the function returned a reference to the collected ancestors set instead
+    // of forcing the caller to do an additional lookup with `expect`, but the borrow checker throws
+    // a tantrum in this case and there doesn't seem to be a way to pacify it without doing extra lookups
+    // or cloning.
+    pub fn collect_nearest_selected_ancestors<M>(
+        mempool: &TxPool<M>,
+        tx_entry: &TxMempoolEntry,
+        selected_tx_ids: &BTreeSet<Id<Transaction>>,
+        ancestors_map: &mut BTreeMap<Id<Transaction>, BTreeSet<Id<Transaction>>>,
+    ) -> Result<(), TxCollectionError> {
+        let tx_id = tx_entry.tx_id();
 
-        for parent_id in tx_entry.parents() {
-            if selected_tx_ids.contains(parent_id) {
-                tx_ancestors.insert(*parent_id);
-            } else {
-                let parent_tx_entry = mempool.store.get_entry(parent_id).ok_or(
-                    TxCollectionError::TxParentNotFound {
-                        tx_id: *tx_id,
-                        parent_tx_id: *parent_id,
-                    },
-                )?;
-                collect_selected_ancestors(
-                    mempool,
-                    parent_tx_entry,
-                    selected_tx_ids,
-                    ancestors_map,
-                )?;
+        if !ancestors_map.contains_key(tx_id) {
+            let mut tx_ancestors = BTreeSet::new();
 
-                let parent_ancestors = ancestors_map.get(parent_id).expect("must be present");
-                tx_ancestors.extend(parent_ancestors);
+            for parent_id in tx_entry.parents() {
+                if selected_tx_ids.contains(parent_id) {
+                    // The nearest selected ancestor has been found, no need to go deeper.
+                    tx_ancestors.insert(*parent_id);
+                } else {
+                    let parent_tx_entry = mempool.store.get_entry(parent_id).ok_or(
+                        TxCollectionError::TxParentNotFound {
+                            tx_id: *tx_id,
+                            parent_tx_id: *parent_id,
+                        },
+                    )?;
+                    collect_nearest_selected_ancestors(
+                        mempool,
+                        parent_tx_entry,
+                        selected_tx_ids,
+                        ancestors_map,
+                    )?;
+
+                    let parent_ancestors = ancestors_map.get(parent_id).expect("must be present");
+                    tx_ancestors.extend(parent_ancestors);
+                }
             }
+
+            ancestors_map.insert(*tx_id, tx_ancestors);
         }
 
-        ancestors_map.insert(*tx_id, tx_ancestors);
+        Ok(())
     }
-
-    Ok(())
 }

--- a/mempool/src/pool/tx_pool/mod.rs
+++ b/mempool/src/pool/tx_pool/mod.rs
@@ -60,7 +60,9 @@ use crate::{
         entry::{TxEntry, TxEntryWithFee},
         fee::Fee,
         feerate::FeeRate,
-        tx_pool::store::{StrictDropPolicy, Tracked, TrackedMap, TrackedTxIdMultiMap},
+        tx_pool::store::{
+            StoreHashSet, StrictDropPolicy, Tracked, TrackedHashMap, TrackedTxIdMultiMap,
+        },
     },
     tx_accumulator::{PackingStrategy, TransactionAccumulator},
     tx_origin::RemoteTxOrigin,
@@ -288,7 +290,7 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
                 self.conflicting_tx_ids(entry.tx_entry()).next().is_none(),
                 MempoolConflictError::Irreplacable
             );
-            Ok(Conflicts::new(BTreeSet::new()))
+            Ok(Conflicts::new(StoreHashSet::default()))
         }
     }
 
@@ -364,7 +366,7 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
             .collect::<Vec<_>>();
 
         if conflicts.is_empty() {
-            Ok(BTreeSet::new().into())
+            Ok(StoreHashSet::default().into())
         } else {
             self.do_rbf_checks(tx, &conflicts)
         }
@@ -455,7 +457,7 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
     fn pays_more_than_conflicts_with_descendants(
         &self,
         tx: &TxEntryWithFee,
-        conflicts_with_descendants: &BTreeSet<Id<Transaction>>,
+        conflicts_with_descendants: &StoreHashSet<Id<Transaction>>,
     ) -> Result<Fee, MempoolPolicyError> {
         let conflicts_with_descendants = conflicts_with_descendants.iter().map(|conflict_id| {
             self.store.txs_by_id.get(conflict_id).expect("tx should exist in mempool")
@@ -535,10 +537,10 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
     fn replacements_with_descendants(
         &self,
         conflicts: &[&TxMempoolEntry],
-    ) -> BTreeSet<Id<Transaction>> {
+    ) -> StoreHashSet<Id<Transaction>> {
         conflicts
             .iter()
-            .flat_map(|conflict| BTreeSet::from(conflict.unconfirmed_descendants(&self.store)))
+            .flat_map(|conflict| conflict.unconfirmed_descendants(&self.store).take())
             .chain(conflicts.iter().map(|conflict| *conflict.tx_id()))
             .collect()
     }
@@ -586,26 +588,29 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
     }
 
     fn remove_expired_transactions(&mut self) {
-        let expired_ids: Vec<_> = self
+        let now = self.clock.get_time();
+
+        let expired_ids = self
             .store
             .txs_by_creation_time
             .iter()
-            .map(|(_time, id)| self.store.txs_by_id.get(id).expect("entry should exist"))
-            .filter(|entry| {
-                let now = self.clock.get_time();
-                let expired = now.saturating_sub(entry.creation_time()) > self.max_tx_age;
+            // Note: entries in txs_by_creation_time are sorted by the creation time in ascending order,
+            // so once we find a tx that is not expired, the rest will not be expired either.
+            .map_while(|&(creation_time, tx_id)| {
+                let expired = now.saturating_sub(creation_time) > self.max_tx_age;
                 if expired {
                     log::trace!(
                         "Evicting tx {} which was created at {:?}. It is now {:?}",
-                        entry.tx_id(),
-                        entry.creation_time(),
+                        tx_id,
+                        creation_time,
                         now
                     );
+                    Some(tx_id)
+                } else {
+                    None
                 }
-                expired
             })
-            .map(|entry| *entry.tx_id())
-            .collect();
+            .collect::<Vec<_>>();
 
         for tx_id in expired_ids.iter() {
             self.remove_tx_and_descendants(tx_id, MempoolRemovalReason::Expiry);
@@ -926,7 +931,7 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
         mempool_config: &MempoolConfig,
         rolling_fee_rate: &RollingFeeRate,
         txs_by_descendant_score: &TrackedTxIdMultiMap<DescendantScore>,
-        txs_by_id: &TrackedMap<Id<Transaction>, Tracked<TxMempoolEntry, StrictDropPolicy>>,
+        txs_by_id: &TrackedHashMap<Id<Transaction>, Tracked<Box<TxMempoolEntry>, StrictDropPolicy>>,
     ) -> FeeRate {
         let min_feerate = std::cmp::max(
             rolling_fee_rate.rolling_minimum_fee_rate(),
@@ -973,7 +978,7 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
         mempool_config: &MempoolConfig,
         rolling_fee_rate: &RollingFeeRate,
         txs_by_descendant_score: &TrackedTxIdMultiMap<DescendantScore>,
-        txs_by_id: &TrackedMap<Id<Transaction>, Tracked<TxMempoolEntry, StrictDropPolicy>>,
+        txs_by_id: &TrackedHashMap<Id<Transaction>, Tracked<Box<TxMempoolEntry>, StrictDropPolicy>>,
     ) -> Result<Vec<(usize, FeeRate)>, MempoolPolicyError> {
         let min_feerate = std::cmp::max(
             rolling_fee_rate.rolling_minimum_fee_rate(),

--- a/mempool/src/pool/tx_pool/store/mem_usage.rs
+++ b/mempool/src/pool/tx_pool/store/mem_usage.rs
@@ -15,7 +15,11 @@
 
 //! Estimate and track memory usage taken by data structures.
 
-use std::{cmp, mem};
+use std::{
+    cmp,
+    hash::{BuildHasher, Hash},
+    mem,
+};
 
 use common::chain::{
     SignedTransaction, TxInput, TxOutput,
@@ -26,7 +30,7 @@ use common::chain::{
 };
 use logging::log;
 
-use super::{TxDependency, TxMempoolEntry};
+use super::{StoreHashMap, StoreHashSet, TxDependency, TxMempoolEntry};
 
 /// Structure that stores the current memory usage and keeps track of its changes
 #[derive(Debug)]
@@ -287,6 +291,46 @@ impl<K> MemoryUsage for std::collections::BTreeSet<K> {
     }
 }
 
+impl<K, V, S> MemoryUsage for hashbrown::hash_map::HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    /// The mem usage for [HashMap].
+    ///
+    /// Same as for the "BTree" case, the return value doesn't include the indirect memory usage
+    /// that keys and values have.
+    fn indirect_memory_usage(&self) -> usize {
+        // Note: `allocation_size` is only exposed by hashbrown containers and not by the standard
+        // ones (even though they use hashbrown under the hood), and this is the reason why we use
+        // the former. Technically we could implement size estimation ourselves, similar to how
+        // it's done in the BTree case:
+        // 1) Determine the "group width" based on the platform, as it's done in
+        //    https://github.com/rust-lang/hashbrown/blob/v0.16.1/src/control/group/mod.rs
+        // 2) Determine the number of buckets given the capacity, like they do it in
+        //    https://github.com/rust-lang/hashbrown/blob/v0.16.1/src/raw/mod.rs#L105
+        // 3) Estimate the memory usage from the number of buckets, as in
+        //    https://github.com/rust-lang/hashbrown/blob/v0.16.1/src/raw/mod.rs#L218
+        // The problem is that the actual capacity of the container is unknown - hashbrown is
+        // a probing table where deleting an item leaves a tombstone, which may be re-used during
+        // insertion, but not always. Because of this, the value returned by `capacity()` doesn't
+        // include the number of slots with tombstones, only the occupied and truly empty ones
+        // are counted. `allocation_size`, on the other hand, uses the actual number of buckets.
+        self.allocation_size()
+    }
+}
+
+impl<K, S> MemoryUsage for hashbrown::hash_set::HashSet<K, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn indirect_memory_usage(&self) -> usize {
+        // Same note as in the HashMap case.
+        self.allocation_size()
+    }
+}
+
 impl<T: MemoryUsage> MemoryUsage for Option<T> {
     fn indirect_memory_usage(&self) -> usize {
         self.as_ref().map_or(0, |x| x.indirect_memory_usage())
@@ -379,6 +423,8 @@ pub trait ZeroUsageDefault: MemoryUsage + Default {}
 
 impl<K, V> ZeroUsageDefault for std::collections::BTreeMap<K, V> {}
 impl<K> ZeroUsageDefault for std::collections::BTreeSet<K> {}
+impl<K: Eq + Hash, V> ZeroUsageDefault for StoreHashMap<K, V> {}
+impl<K: Eq + Hash> ZeroUsageDefault for StoreHashSet<K> {}
 impl<T: MemoryUsage> ZeroUsageDefault for Vec<T> {}
 
 #[cfg(test)]

--- a/mempool/src/pool/tx_pool/store/mod.rs
+++ b/mempool/src/pool/tx_pool/store/mod.rs
@@ -27,17 +27,35 @@ use common::{
     primitives::Id,
 };
 use logging::log;
-use utils::newtype;
+use utils::{debug_assert_or_log, newtype};
 
 use super::{Fee, Time, TxEntry, TxEntryWithFee};
 
-use crate::{FeeRate, error::MempoolPolicyError, pool::entry::TxDependency};
+use crate::{
+    FeeRate,
+    error::MempoolPolicyError,
+    pool::{entry::TxDependency, tx_pool::store::mem_usage::MemUsageTracker},
+};
 
 pub use mem_usage::Tracked;
 
+// The HashMap and HashSet used by MempoolStore. We use those from hashbrown because it's easier
+// to estimate their memory usage, see the corresponding comment in mem_usage.
+// Note:
+// 1. The standard hash containers also use the hashbrown crate under the hood (e.g. std lib 1.95
+//    uses hashbrown 0.16.1), but hashbrown's default hasher is weaker compared to SipHash, which
+//    is used in the std lib. We want to continue using SipHash, so we parameterize the hashbrown
+//    containers with the std lib's `RandomState`.
+// 2. The hashbrown containers only define the `new` method in the `DefaultHashBuilder` case,
+//    so we can't use it. But `Default` is still implemented.
+//    Same for `with_capacity` (use `with_capacity_and_hasher(cap, Default::default())` instead).
+pub type StoreHashMap<K, V> =
+    hashbrown::hash_map::HashMap<K, V, std::collections::hash_map::RandomState>;
+pub type StoreHashSet<K> = hashbrown::hash_set::HashSet<K, std::collections::hash_map::RandomState>;
+
 newtype! {
     #[derive(Debug)]
-    pub struct Ancestors(BTreeSet<Id<Transaction>>);
+    pub struct Ancestors(StoreHashSet<Id<Transaction>>);
 }
 
 impl Ancestors {
@@ -48,12 +66,12 @@ impl Ancestors {
 
 newtype! {
     #[derive(Debug)]
-    pub struct Descendants(BTreeSet<Id<Transaction>>);
+    pub struct Descendants(StoreHashSet<Id<Transaction>>);
 }
 
 newtype! {
     #[derive(Debug)]
-    pub struct Conflicts(BTreeSet<Id<Transaction>>);
+    pub struct Conflicts(StoreHashSet<Id<Transaction>>);
 }
 
 newtype! {
@@ -79,6 +97,7 @@ pub type StrictDropPolicy = mem_usage::AssertDropPolicy;
 pub type StrictDropPolicy = mem_usage::NoOpDropPolicy;
 
 pub type TrackedMap<K, V> = Tracked<BTreeMap<K, V>>;
+pub type TrackedHashMap<K, V> = Tracked<StoreHashMap<K, V>>;
 pub type TrackedSet<K> = Tracked<BTreeSet<K>>;
 pub type TrackedTxIdMultiMap<K> = TrackedSet<(K, Id<Transaction>)>;
 
@@ -86,7 +105,11 @@ pub type TrackedTxIdMultiMap<K> = TrackedSet<(K, Id<Transaction>)>;
 pub struct MempoolStore {
     // This is the "main" data structure storing Mempool entries. All other structures in the
     // MempoolStore contain ids (hashes) of entries, sorted according to some order of interest.
-    pub txs_by_id: TrackedMap<Id<Transaction>, Tracked<TxMempoolEntry, StrictDropPolicy>>,
+    // (Note: TxMempoolEntry is boxed, because the hashbrown table stores items directly
+    // and doesn't free the memory when an item is removed - it's only replaced with a tombstone.
+    // Since TxMempoolEntry is relatively big (size_of = 350+ bytes), we'd waste a noticeable
+    // amount of memory without boxing.)
+    pub txs_by_id: TrackedHashMap<Id<Transaction>, Tracked<Box<TxMempoolEntry>, StrictDropPolicy>>,
 
     // Mempool entries sorted by descendant score.
     // We keep this index so that when the mempool grows full, we know which transactions are the
@@ -120,8 +143,8 @@ pub struct MempoolStore {
     // the same order after a reorg. We keep both mapping from transactions to sequence numbers and
     // the mapping from sequence number back to transaction. The sequence number to be allocated to
     // the next incoming transaction is kept separately.
-    txs_by_seq_no: Tracked<BTreeMap<usize, Id<Transaction>>>,
-    seq_nos_by_tx: Tracked<BTreeMap<Id<Transaction>, usize>>,
+    txs_by_seq_no: TrackedMap<usize, Id<Transaction>>,
+    seq_nos_by_tx: TrackedHashMap<Id<Transaction>, usize>,
     next_seq_no: usize,
 
     /// Memory usage accumulator
@@ -163,7 +186,7 @@ impl MempoolStore {
     }
 
     pub fn get_entry(&self, id: &Id<Transaction>) -> Option<&TxMempoolEntry> {
-        self.txs_by_id.get(id).map(|tx| tx.deref())
+        self.txs_by_id.get(id).map(|tx| tx.as_ref())
     }
 
     pub fn contains(&self, id: &Id<Transaction>) -> bool {
@@ -182,12 +205,14 @@ impl MempoolStore {
     #[cfg(test)]
     fn assert_valid_inner(&self) {
         use mem_usage::MemoryUsage;
-        fn map_size_deep<K, V: MemoryUsage, D>(map: &BTreeMap<K, Tracked<V, D>>) -> usize {
+        fn hash_map_size_deep<K: Eq + std::hash::Hash, V: MemoryUsage, D>(
+            map: &StoreHashMap<K, Tracked<V, D>>,
+        ) -> usize {
             let vals_size = map.values().map(|v| v.indirect_memory_usage()).sum::<usize>();
             map.indirect_memory_usage() + vals_size
         }
 
-        let expected_size = map_size_deep(&self.txs_by_id)
+        let expected_size = hash_map_size_deep(&self.txs_by_id)
             + self.txs_by_descendant_score.indirect_memory_usage()
             + self.txs_by_ancestor_score.indirect_memory_usage()
             + self.txs_by_creation_time.indirect_memory_usage()
@@ -251,13 +276,18 @@ impl MempoolStore {
 
     fn update_ancestor_state_for_add(
         &mut self,
-        entry: &TxMempoolEntry,
+        entry_with_ancestors: &TxMempoolEntryWithAncestors,
     ) -> Result<(), MempoolPolicyError> {
-        for ancestor_id in entry.unconfirmed_ancestors(self).0 {
+        let entry = entry_with_ancestors.entry();
+        let ancestors = entry_with_ancestors.ancestors();
+
+        for ancestor_id in &ancestors.0 {
             self.mem_tracker.modify(&mut self.txs_by_id, |txs_by_id, tracker| {
                 tracker.modify(
-                    txs_by_id.get_mut(&ancestor_id).expect("ancestor"),
-                    |ancestor, _| -> Result<(), MempoolPolicyError> {
+                    txs_by_id.get_mut(ancestor_id).expect("ancestor"),
+                    |ancestor, tracker| -> Result<(), MempoolPolicyError> {
+                        let old_descendant_score = ancestor.descendant_score();
+
                         let total_fee = (ancestor.fees_with_descendants + entry.fee)
                             .ok_or(MempoolPolicyError::AncestorFeeUpdateOverflow)?;
                         ancestor.fees_with_descendants = total_fee;
@@ -266,11 +296,23 @@ impl MempoolStore {
                             .checked_add(ancestor.size_with_descendants.get())
                             .expect("non-zero size");
                         ancestor.count_with_descendants += 1;
+
+                        let new_descendant_score = ancestor.descendant_score();
+
+                        Self::replace_in_descendant_score_index(
+                            tracker,
+                            &mut self.txs_by_descendant_score,
+                            *ancestor.tx_id(),
+                            old_descendant_score,
+                            new_descendant_score,
+                        );
+
                         Ok(())
                     },
                 )
             })?;
         }
+
         Ok(())
     }
 
@@ -279,7 +321,9 @@ impl MempoolStore {
             self.mem_tracker.modify(&mut self.txs_by_id, |txs_by_id, tracker| {
                 tracker.modify(
                     txs_by_id.get_mut(&ancestor).expect("ancestor"),
-                    |ancestor, _| {
+                    |ancestor, tracker| {
+                        let old_descendant_score = ancestor.descendant_score();
+
                         ancestor.fees_with_descendants = (ancestor.fees_with_descendants
                             - entry.fee)
                             .expect("fee with descendants");
@@ -287,6 +331,16 @@ impl MempoolStore {
                         ancestor.size_with_descendants =
                             NonZeroUsize::new(size_desc).expect("non-zero size");
                         ancestor.count_with_descendants -= 1;
+
+                        let new_descendant_score = ancestor.descendant_score();
+
+                        Self::replace_in_descendant_score_index(
+                            tracker,
+                            &mut self.txs_by_descendant_score,
+                            *ancestor.tx_id(),
+                            old_descendant_score,
+                            new_descendant_score,
+                        );
                     },
                 )
             })
@@ -309,41 +363,25 @@ impl MempoolStore {
     }
 
     pub fn add_transaction(&mut self, entry: TxEntryWithFee) -> Result<(), MempoolPolicyError> {
-        // Genesis transaction has no parent, hence the first filter_map
-        let parents = entry
-            .transaction()
-            .inputs()
-            .iter()
-            .filter_map(|input| match input {
-                TxInput::Utxo(outpoint) => outpoint.source_id().get_tx_id().cloned(),
-                TxInput::Account(..)
-                | TxInput::AccountCommand(..)
-                | TxInput::OrderAccountCommand(..) => None,
-            })
-            .filter(|id| self.txs_by_id.contains_key(id))
-            .collect::<BTreeSet<_>>();
-        let ancestor_ids = TxMempoolEntry::unconfirmed_ancestors_from_parents(&parents, self)?;
-        let ancestors = BTreeSet::from(ancestor_ids)
-            .into_iter()
-            .map(|id| self.get_entry(&id).expect("ancestors to exist"))
-            .cloned()
-            .collect();
-
-        let entry = TxMempoolEntry::new(entry, parents, ancestors)?;
-        self.add_tx_entry(entry)
+        let entry_with_ancestors = TxMempoolEntryWithAncestors::new(&*self, entry)?;
+        self.add_tx_entry(entry_with_ancestors)
     }
 
-    pub fn add_tx_entry(&mut self, entry: TxMempoolEntry) -> Result<(), MempoolPolicyError> {
-        self.append_to_parents(&entry);
-        self.update_ancestor_state_for_add(&entry)?;
-        self.mark_outpoints_as_spent(&entry);
+    pub fn add_tx_entry(
+        &mut self,
+        entry_with_ancestors: TxMempoolEntryWithAncestors,
+    ) -> Result<(), MempoolPolicyError> {
+        let entry = entry_with_ancestors.entry();
+        self.append_to_parents(entry);
+        self.update_ancestor_state_for_add(&entry_with_ancestors)?;
+        self.mark_outpoints_as_spent(entry);
 
         let tx_id = *entry.tx_id();
         let seq_no = self.next_seq_no;
         self.next_seq_no += 1;
 
-        self.add_to_descendant_score_index(&entry);
-        self.add_to_ancestor_score_index(&entry);
+        self.add_to_descendant_score_index(entry);
+        self.add_to_ancestor_score_index(entry);
         self.mem_tracker.modify(
             &mut self.txs_by_creation_time,
             |txs_by_creation_time, _tracker| {
@@ -354,14 +392,13 @@ impl MempoolStore {
         self.mem_tracker.modify(&mut self.txs_by_seq_no, |m, _| m.insert(seq_no, tx_id));
         self.mem_tracker.modify(&mut self.seq_nos_by_tx, |m, _| m.insert(tx_id, seq_no));
 
-        let entry = self.mem_tracker.track(entry);
+        let entry = self.mem_tracker.track(Box::new(entry_with_ancestors.take_entry()));
         let prev = self.mem_tracker.modify(&mut self.txs_by_id, |m, _| m.insert(tx_id, entry));
         assert!(prev.is_none(), "Entry already in store");
         Ok(())
     }
 
     fn add_to_descendant_score_index(&mut self, entry: &TxMempoolEntry) {
-        self.refresh_ancestors(entry);
         self.mem_tracker.modify(
             &mut self.txs_by_descendant_score,
             |by_desc_score, _tracker| {
@@ -371,42 +408,48 @@ impl MempoolStore {
     }
 
     fn add_to_ancestor_score_index(&mut self, entry: &TxMempoolEntry) {
-        // TODO in the normal case of a new transaction arriving, there can't be any children
-        // because such children would be orphans.
-        // When we implement disconnecting a block, we'll need to clean up the mess we're leaving
-        // here.
         self.mem_tracker
             .modify(&mut self.txs_by_ancestor_score, |by_anc_score, _tracker| {
                 by_anc_score.insert((entry.ancestor_score(), *entry.tx_id()));
             });
     }
 
-    fn refresh_ancestors(&mut self, entry: &TxMempoolEntry) {
-        // Since the ancestors of `entry` have had their descendant score modified, their ordering
-        // in txs_by_descendant_score may no longer be correct. We thus remove all ancestors and
-        // reinsert them, taking the new, updated fees into account
-        let ancestors = entry.unconfirmed_ancestors(self);
-        self.mem_tracker.modify(&mut self.txs_by_descendant_score, |by_ds, _tracker| {
-            by_ds.retain(|(_score, e)| !ancestors.contains(e));
-            for ancestor_id in ancestors.0 {
-                let ancestor =
-                    self.txs_by_id.get(&ancestor_id).expect("Inconsistent mempool state");
-                by_ds.insert((ancestor.descendant_score(), ancestor_id));
-            }
-        });
+    fn replace_in_descendant_score_index(
+        tracker: &mut MemUsageTracker,
+        txs_by_descendant_score: &mut TrackedTxIdMultiMap<DescendantScore>,
+        ancestor_id: Id<Transaction>,
+        old_score: DescendantScore,
+        new_score: DescendantScore,
+    ) {
+        if new_score != old_score {
+            tracker.modify(txs_by_descendant_score, |by_ds, _| {
+                let removed = by_ds.remove(&(old_score, ancestor_id));
+                debug_assert_or_log!(
+                    removed,
+                    "Ancestor with id {ancestor_id:x} was not present in txs_by_descendant_score",
+                );
+                by_ds.insert((new_score, ancestor_id));
+            });
+        }
     }
 
-    /// refresh descendants with new ancestor scores
-    fn refresh_descendants(&mut self, entry: &TxMempoolEntry) {
-        let descendants = entry.unconfirmed_descendants(self);
-        self.mem_tracker.modify(&mut self.txs_by_ancestor_score, |by_as, _tracker| {
-            by_as.retain(|(_score, e)| !descendants.contains(e));
-            for descendant_id in descendants.0 {
-                let descendant =
-                    self.txs_by_id.get(&descendant_id).expect("Inconsistent mempool state");
-                by_as.insert((descendant.ancestor_score(), descendant_id));
-            }
-        })
+    fn replace_in_ancestor_score_index(
+        tracker: &mut MemUsageTracker,
+        txs_by_ancestor_score: &mut TrackedTxIdMultiMap<AncestorScore>,
+        descendant_id: Id<Transaction>,
+        old_score: AncestorScore,
+        new_score: AncestorScore,
+    ) {
+        if new_score != old_score {
+            tracker.modify(txs_by_ancestor_score, |by_as, _| {
+                let removed = by_as.remove(&(old_score, descendant_id));
+                debug_assert_or_log!(
+                    removed,
+                    "Descendant with id {descendant_id:x} was not present in txs_by_ancestor_score",
+                );
+                by_as.insert((new_score, descendant_id));
+            });
+        }
     }
 
     fn update_descendant_state_for_drop(&mut self, entry: &TxMempoolEntry) {
@@ -414,7 +457,9 @@ impl MempoolStore {
             self.mem_tracker.modify(&mut self.txs_by_id, |by_id, tracker| {
                 tracker.modify(
                     by_id.get_mut(&descendant_id).expect("descendant"),
-                    |descendant, _| {
+                    |descendant, tracker| {
+                        let old_ancestor_score = descendant.ancestor_score();
+
                         descendant.fees_with_ancestors = (descendant.fees_with_ancestors
                             - entry.fee)
                             .expect("fee with descendants");
@@ -422,6 +467,16 @@ impl MempoolStore {
                         descendant.size_with_ancestors =
                             NonZeroUsize::new(size_anc).expect("non-zero size");
                         descendant.count_with_ancestors -= 1;
+
+                        let new_ancestor_score = descendant.ancestor_score();
+
+                        Self::replace_in_ancestor_score_index(
+                            tracker,
+                            &mut self.txs_by_ancestor_score,
+                            *descendant.tx_id(),
+                            old_ancestor_score,
+                            new_ancestor_score,
+                        );
                     },
                 )
             })
@@ -443,7 +498,7 @@ impl MempoolStore {
                 self.update_descendant_state_for_drop(&entry)
             }
             self.drop_tx(&entry);
-            Some(entry)
+            Some(*entry)
         } else {
             assert!(!self.txs_by_descendant_score.iter().any(|(_, id)| id == tx_id));
             assert!(!self.spender_txs.iter().any(|(_, id)| *id == *tx_id));
@@ -466,14 +521,12 @@ impl MempoolStore {
     }
 
     fn remove_from_ancestor_score_index(&mut self, entry: &TxMempoolEntry) {
-        self.refresh_descendants(entry);
         self.mem_tracker.modify(&mut self.txs_by_ancestor_score, |by_as, _tracker| {
             by_as.remove(&(entry.ancestor_score(), *entry.tx_id()));
         })
     }
 
     fn remove_from_descendant_score_index(&mut self, entry: &TxMempoolEntry) {
-        self.refresh_ancestors(entry);
         self.mem_tracker.modify(&mut self.txs_by_descendant_score, |by_ds, _tracker| {
             by_ds.remove(&(entry.descendant_score(), *entry.tx_id()));
         })
@@ -541,12 +594,13 @@ impl Drop for MempoolStore {
     }
 }
 
+// TODO: move TxMempoolEntry and TxMempoolEntryWithAncestors to a separate file.
 #[derive(Debug, Eq, Clone)]
 pub struct TxMempoolEntry {
     entry: TxEntry,
     fee: Fee,
-    parents: BTreeSet<Id<Transaction>>,
-    children: BTreeSet<Id<Transaction>>,
+    parents: StoreHashSet<Id<Transaction>>,
+    children: StoreHashSet<Id<Transaction>>,
     count_with_descendants: usize,
     count_with_ancestors: usize,
     fees_with_descendants: Fee,
@@ -556,32 +610,35 @@ pub struct TxMempoolEntry {
 }
 
 impl TxMempoolEntry {
-    pub fn new(
+    fn new<'a>(
         entry: TxEntryWithFee,
-        parents: BTreeSet<Id<Transaction>>,
-        ancestors: BTreeSet<TxMempoolEntry>,
+        parents: StoreHashSet<Id<Transaction>>,
+        ancestors: impl ExactSizeIterator<Item = &'a TxMempoolEntry>,
     ) -> Result<TxMempoolEntry, MempoolPolicyError> {
         let fee = entry.fee();
         let entry = entry.into_tx_entry();
         let size = entry.size();
-        let size_with_ancestors = size
-            .checked_add(ancestors.iter().map(|x| x.size().get()).sum())
-            .expect("Sizes should not overflow");
-        let ancestor_fees = ancestors
-            .iter()
-            .map(TxMempoolEntry::fee)
-            .sum::<Option<_>>()
-            .ok_or(MempoolPolicyError::AncestorFeeOverflow)?;
-        let fees_with_ancestors =
-            (fee + ancestor_fees).ok_or(MempoolPolicyError::AncestorFeeOverflow)?;
+        let ancestors_count = ancestors.len();
+
+        let mut size_with_ancestors = size;
+        let mut fees_with_ancestors = fee;
+
+        for ancestor in ancestors {
+            size_with_ancestors = size_with_ancestors
+                .checked_add(ancestor.size().get())
+                .expect("Sizes should not overflow");
+            fees_with_ancestors = (fees_with_ancestors + ancestor.fee())
+                .ok_or(MempoolPolicyError::AncestorFeeOverflow)?;
+        }
+
         Ok(Self {
             size_with_ancestors,
-            count_with_ancestors: 1 + ancestors.len(),
+            count_with_ancestors: 1 + ancestors_count,
             size_with_descendants: size,
             entry,
             fee,
             parents,
-            children: BTreeSet::default(),
+            children: StoreHashSet::default(),
             count_with_descendants: 1,
             fees_with_descendants: fee,
             fees_with_ancestors,
@@ -592,7 +649,7 @@ impl TxMempoolEntry {
     pub fn new_from_data(
         tx: SignedTransaction,
         fee: Fee,
-        parents: BTreeSet<Id<Transaction>>,
+        parents: StoreHashSet<Id<Transaction>>,
         ancestors: BTreeSet<TxMempoolEntry>,
         creation_time: Time,
     ) -> Result<TxMempoolEntry, MempoolPolicyError> {
@@ -600,7 +657,7 @@ impl TxMempoolEntry {
         let origin = LocalTxOrigin::Mempool.into();
         let options = crate::TxOptions::default_for(origin);
         let entry = TxEntry::new(tx, creation_time, origin, options);
-        Self::new(TxEntryWithFee::new(entry, fee), parents, ancestors)
+        Self::new(TxEntryWithFee::new(entry, fee), parents, ancestors.iter())
     }
 
     pub fn transaction(&self) -> &SignedTransaction {
@@ -675,11 +732,11 @@ impl TxMempoolEntry {
         self.children.iter()
     }
 
-    fn get_children_mut(&mut self) -> &mut BTreeSet<Id<Transaction>> {
+    fn get_children_mut(&mut self) -> &mut StoreHashSet<Id<Transaction>> {
         &mut self.children
     }
 
-    fn get_parents_mut(&mut self) -> &mut BTreeSet<Id<Transaction>> {
+    fn get_parents_mut(&mut self) -> &mut StoreHashSet<Id<Transaction>> {
         &mut self.parents
     }
 
@@ -691,13 +748,13 @@ impl TxMempoolEntry {
     }
 
     pub fn unconfirmed_ancestors(&self, store: &MempoolStore) -> Ancestors {
-        let mut visited = Ancestors(BTreeSet::new());
+        let mut visited = Ancestors(Default::default());
         self.unconfirmed_ancestors_inner(&mut visited, store);
         visited
     }
 
     pub fn unconfirmed_ancestors_from_parents(
-        parents: &BTreeSet<Id<Transaction>>,
+        parents: &StoreHashSet<Id<Transaction>>,
         store: &MempoolStore,
     ) -> Result<Ancestors, MempoolPolicyError> {
         let mut ancestors = parents.clone().into();
@@ -710,6 +767,7 @@ impl TxMempoolEntry {
 
     fn unconfirmed_ancestors_inner(&self, visited: &mut Ancestors, store: &MempoolStore) {
         // TODO: change this from recursive to iterative
+        visited.reserve(self.count_with_ancestors - 1);
         for parent in self.parents.iter() {
             if visited.insert(*parent) {
                 store
@@ -725,13 +783,16 @@ impl TxMempoolEntry {
         store: &'a MempoolStore,
     ) -> impl Iterator<Item = &'a TxMempoolEntry> {
         let children_fn = |entry: &&'a TxMempoolEntry| {
-            entry.children.iter().map(|id| store.txs_by_id[id].deref())
+            entry
+                .children
+                .iter()
+                .map(|id| store.get_entry(id).expect("child must be present"))
         };
         utils::graph_traversals::dag_depth_postorder(self, children_fn)
     }
 
     pub fn unconfirmed_descendants(&self, store: &MempoolStore) -> Descendants {
-        let mut visited = Descendants(BTreeSet::new());
+        let mut visited = Descendants(Default::default());
         self.unconfirmed_descendants_inner(&mut visited, store);
         visited
     }
@@ -764,5 +825,55 @@ impl PartialEq for TxMempoolEntry {
 impl Ord for TxMempoolEntry {
     fn cmp(&self, other: &Self) -> Ordering {
         other.tx_id().cmp(self.tx_id())
+    }
+}
+
+/// A helper struct that encapsulates a newly created `TxMempoolEntry` and its ancestors.
+pub struct TxMempoolEntryWithAncestors {
+    entry: TxMempoolEntry,
+    ancestors: Ancestors,
+}
+
+impl TxMempoolEntryWithAncestors {
+    pub fn new(store: &MempoolStore, entry: TxEntryWithFee) -> Result<Self, MempoolPolicyError> {
+        // Genesis transaction has no parent, hence the first filter_map
+        let parents = entry
+            .transaction()
+            .inputs()
+            .iter()
+            .filter_map(|input| match input {
+                TxInput::Utxo(outpoint) => outpoint.source_id().get_tx_id().cloned(),
+                TxInput::Account(..)
+                | TxInput::AccountCommand(..)
+                | TxInput::OrderAccountCommand(..) => None,
+            })
+            .filter(|id| store.txs_by_id.contains_key(id))
+            .collect::<StoreHashSet<_>>();
+        let ancestors = TxMempoolEntry::unconfirmed_ancestors_from_parents(&parents, store)?;
+        let ancestor_entries_iter = ancestors
+            .deref()
+            .iter()
+            .map(|id| store.get_entry(id).expect("ancestors to exist"));
+
+        let entry = TxMempoolEntry::new(entry, parents, ancestor_entries_iter)?;
+        Ok(Self { entry, ancestors })
+    }
+
+    #[cfg(test)]
+    pub fn new_from_existing_entry(store: &MempoolStore, entry: TxMempoolEntry) -> Self {
+        let ancestors = entry.unconfirmed_ancestors(store);
+        Self { entry, ancestors }
+    }
+
+    pub fn entry(&self) -> &TxMempoolEntry {
+        &self.entry
+    }
+
+    pub fn take_entry(self) -> TxMempoolEntry {
+        self.entry
+    }
+
+    pub fn ancestors(&self) -> &Ancestors {
+        &self.ancestors
     }
 }

--- a/mempool/src/pool/tx_pool/tests/basic.rs
+++ b/mempool/src/pool/tx_pool/tests/basic.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::pool::tx_pool::store::{StoreHashSet, TxMempoolEntryWithAncestors};
+
 use super::*;
 
 #[test]
@@ -376,7 +378,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
     let fee = Amount::from_atoms(1).into();
 
     // Generation 1
-    let tx1_parents = BTreeSet::default();
+    let tx1_parents = StoreHashSet::default();
     let entry_1_ancestors = BTreeSet::default();
     let entry1 = TxMempoolEntry::new_from_data(
         txs.first().unwrap().clone(),
@@ -386,7 +388,7 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
         time::get_time(),
     )
     .unwrap();
-    let tx2_parents = BTreeSet::default();
+    let tx2_parents = StoreHashSet::default();
     let entry_2_ancestors = BTreeSet::default();
     let entry2 = TxMempoolEntry::new_from_data(
         txs.get(1).unwrap().clone(),
@@ -450,7 +452,9 @@ async fn tx_mempool_entry() -> anyhow::Result<()> {
     let ids = entries.iter().map(|entry| *entry.tx_id()).collect::<Vec<_>>();
 
     for entry in entries.into_iter() {
-        mempool.store.add_tx_entry(entry)?;
+        let entry_with_ancestors =
+            TxMempoolEntryWithAncestors::new_from_existing_entry(&mempool.store, entry);
+        mempool.store.add_tx_entry(entry_with_ancestors)?;
     }
 
     #[allow(clippy::get_first)]
@@ -1090,8 +1094,8 @@ fn check_txs_sorted_by_ancestor_score<E>(tx_pool: &TxPool<E>) {
         log::debug!("i =  {}", i);
         let tx_id = txs_by_ancestor_score.get(i).unwrap();
         let next_tx_id = txs_by_ancestor_score.get(i + 1).unwrap();
-        let entry_score = tx_pool.store.txs_by_id.get(tx_id).unwrap().descendant_score();
-        let next_entry_score = tx_pool.store.txs_by_id.get(next_tx_id).unwrap().descendant_score();
+        let entry_score = tx_pool.store.txs_by_id.get(*tx_id).unwrap().descendant_score();
+        let next_entry_score = tx_pool.store.txs_by_id.get(*next_tx_id).unwrap().descendant_score();
         log::debug!("entry_score: {:?}", entry_score);
         log::debug!("next_entry_score: {:?}", next_entry_score);
         assert!(entry_score <= next_entry_score)
@@ -1210,8 +1214,8 @@ fn check_txs_sorted_by_descendant_sore<M>(tx_pool: &TxPool<M>) {
         log::debug!("i =  {}", i);
         let tx_id = txs_by_descendant_score.get(i).unwrap();
         let next_tx_id = txs_by_descendant_score.get(i + 1).unwrap();
-        let entry_score = tx_pool.store.txs_by_id.get(tx_id).unwrap().descendant_score();
-        let next_entry_score = tx_pool.store.txs_by_id.get(next_tx_id).unwrap().descendant_score();
+        let entry_score = tx_pool.store.txs_by_id.get(*tx_id).unwrap().descendant_score();
+        let next_entry_score = tx_pool.store.txs_by_id.get(*next_tx_id).unwrap().descendant_score();
         log::debug!("entry_score: {:?}", entry_score);
         log::debug!("next_entry_score: {:?}", next_entry_score);
         assert!(entry_score <= next_entry_score)

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -476,10 +476,6 @@ criteria = "safe-to-deploy"
 version = "5.4.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.expect-test]]
-version = "1.5.1"
-criteria = "safe-to-run"
-
 [[exemptions.fallible-streaming-iterator]]
 version = "0.1.9"
 criteria = "safe-to-deploy"
@@ -650,10 +646,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.impl-trait-for-tuples]]
 version = "0.2.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.instant]]
-version = "0.1.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.ipnet]]
@@ -1074,14 +1066,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rand]]
 version = "0.7.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand]]
-version = "0.8.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand]]
-version = "0.9.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand_chacha]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -691,6 +691,12 @@ when = "2025-11-20"
 user-id = 55123
 user-login = "rust-lang-owner"
 
+[[publisher.hashbrown]]
+version = "0.17.1"
+when = "2026-05-09"
+user-id = 55123
+user-login = "rust-lang-owner"
+
 [[publisher.hdrhistogram]]
 version = "7.5.4"
 when = "2023-11-18"
@@ -2933,6 +2939,18 @@ crate is broadly used throughout the ecosystem and does not contain anything
 suspicious.
 """
 
+[[audits.bytecode-alliance.audits.instant]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "0.1.12"
+notes = "Small crate wrapping platform primitives for time that uses `unsafe` only for FFI."
+
+[[audits.bytecode-alliance.audits.instant]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.12 -> 0.1.13"
+notes = "Nothing major changed in this update"
+
 [[audits.bytecode-alliance.audits.leb128fmt]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -3073,6 +3091,12 @@ change.
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.29 -> 0.3.32"
+
+[[audits.bytecode-alliance.audits.rand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.2 -> 0.9.4"
+notes = "Minor bugfix release"
 
 [[audits.bytecode-alliance.audits.rand]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -4443,7 +4467,7 @@ who = "Nicolas Silva <nical@fastmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1281 # Nicolas Silva (nical)
 start = "2020-11-12"
-end = "2025-06-01"
+end = "2027-04-23"
 notes = "I am the author of this crate."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -4461,7 +4485,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-11-06"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -4470,7 +4494,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-05-15"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -4488,7 +4512,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -4673,11 +4697,33 @@ version = "1.0.10"
 notes = "dtolnay crate that will generate diffs for testing purposes.  No IO or unsafe code."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.expect-test]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-run"
+version = "1.4.1"
+notes = """
+Expectation testing/management library.  This will read/write the Rust test files, but that's
+expected.  It should only change string literals and any changes will be visible in code review.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.expect-test]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-run"
+delta = "1.4.1 -> 1.5.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.fnv]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "1.0.7"
 notes = "Simple hasher implementation with no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.foldhash]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.5 -> 0.2.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.foreign-types]]
@@ -5145,6 +5191,16 @@ version = "0.2.0"
 notes = """
 A tiny bit of unsafe code to implement functionality that isn't in stable rust
 yet, but it's all valid. Otherwise it's a pretty simple crate.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rand]]
+who = "Henrik Skupin <mail@hskupin.info>"
+criteria = "safe-to-deploy"
+delta = "0.8.5 -> 0.8.6"
+notes = """
+Fixes RUSTSEC-2026-0097 by removing `log` dependency. Removes `simd_support`
+feature. No new dependencies or unsafe code.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 

--- a/utils/src/newtype.rs
+++ b/utils/src/newtype.rs
@@ -24,6 +24,21 @@ macro_rules! newtype {
             pub fn new(inner: $wrapped) -> Self {
                 Self(inner)
             }
+
+            #[allow(dead_code)]
+            pub fn inner(&self) -> &$wrapped {
+                &self.0
+            }
+
+            #[allow(dead_code)]
+            pub fn inner_mut(&mut self) -> &mut $wrapped {
+                &mut self.0
+            }
+
+            #[allow(dead_code)]
+            pub fn take(self) -> $wrapped {
+                self.0
+            }
         }
 
         impl From<$name> for $wrapped {
@@ -56,17 +71,19 @@ macro_rules! newtype {
 #[cfg(test)]
 mod tests {
     #[derive(Clone, Debug)]
-    struct OldInt {
+    struct Inner {
         val: u32,
     }
 
-    impl OldInt {
+    impl Inner {
         fn new() -> Self {
             Self { val: 0 }
         }
+
         fn set(&mut self, val: u32) {
             self.val = val
         }
+
         fn get(&self) -> u32 {
             self.val
         }
@@ -74,17 +91,31 @@ mod tests {
 
     newtype! {
         #[derive(Clone, Debug)]
-        struct NewInt(OldInt);
+        struct Wrapper(Inner);
     }
 
     #[test]
     fn test_new_type() {
-        let old = OldInt::new();
-        let mut new = NewInt::from(old);
+        let inner = Inner::new();
+        let mut wrapper = Wrapper::from(inner);
+
         let val = 7;
-        new.set(val);
-        assert_eq!(new.get(), val);
-        let old_again = OldInt::from(new);
-        assert_eq!(old_again.get(), val);
+        wrapper.set(val);
+        assert_eq!(wrapper.get(), val);
+        assert_eq!(wrapper.inner().get(), val);
+        assert_eq!(wrapper.inner_mut().get(), val);
+
+        let val = 8;
+        wrapper.inner_mut().set(val);
+        assert_eq!(wrapper.get(), val);
+        assert_eq!(wrapper.inner().get(), val);
+        assert_eq!(wrapper.inner_mut().get(), val);
+
+        let wrapper_clone = wrapper.clone();
+        let taken_inner = wrapper_clone.take();
+        assert_eq!(taken_inner.get(), val);
+
+        let inner_again = Inner::from(wrapper);
+        assert_eq!(inner_again.get(), val);
     }
 }


### PR DESCRIPTION
- Collections in `MempoolStore` that have tx id as the key were changed from btree-based to hash-based. Note that I decided to use `hashbrown`'s containers directly, instead of using the standard ones (which also use `hashbrown` under the hood), because the size estimation is more precise in this case.
- There were a few places where the whole mempool would be traversed when adding a new tx:
  - `TxPool::remove_expired_transactions` would iterate the entire `MempoolStore::txs_by_creation_time` even though only the first few txs need to be checked.
  - `MempoolStore` had methods `refresh_ancestors`/`refresh_descendants`, which were called from `add_to_descendant_score_index`/`remove_from_ancestor_score_index`/`remove_from_descendant_score_index` - they would remove all ancestors/descendants from `txs_by_ancestor_score` or `txs_by_descendant_score` and reinsert them with the new score. I removed these `refresh_` methods, and now `txs_by_ancestor_score`/`txs_by_descendant_score` are updated in the places where the score is modified - in `update_ancestor_state_for_add`/`update_ancestor_state_for_drop`/`update_descendant_state_for_drop`.
- New tx's ancestors were collected multiple times. I added the `TxMempoolEntryWithAncestors` struct, so that the collected ancestors can be re-used at least during the new entry initialization.

I also updated comments and did some renaming in `get_best_tx_ids_by_score_and_ancestry` and its helper function `collect_selected_ancestors` (which is now called `collect_nearest_selected_ancestors` and is in a separate module). The logic here wasn't changed, it's just that the old comments and naming were misleading.