### PR TITLE
Cherry-pick "fix handling of conflicting order transactions in the wallet" into 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,12 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
     - `wallet-create`/`wallet-recover`/`wallet-open` support the `ledger` subcommand, in addition to the existing
       `software` and `trezor`, which specifies the type of the wallet to operate on.
 
-### Fixed
-  - Wallet:
-    - Fixed handling of confirmed and unconfirmed conflicting order transactions in the wallet.
-
 ## [1.3.1]
 
 ### Fixed
   - Wallet:
+    - Fixed wallet handling of V1 order command conflicts, allowing confirmed ConcludeOrder and FreezeOrder transactions
+      to replace conflicting unconfirmed order transactions correctly.
     - Fixed an issue where the wallet in cold mode would always use input commitments v0, thus producing signatures
       that may no longer be valid at the current height.
     - Fixed an issue where the wallet in cold mode would still try to access the mempool, which would cause `wallet-cli`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
     - `wallet-create`/`wallet-recover`/`wallet-open` support the `ledger` subcommand, in addition to the existing
       `software` and `trezor`, which specifies the type of the wallet to operate on.
 
+### Fixed
+  - Wallet:
+    - Fixed handling of confirmed and unconfirmed conflicting order transactions in the wallet.
+
 ## [1.3.1]
 
 ### Fixed

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -783,9 +783,11 @@ impl OutputCache {
         confirmed_tx: &Transaction,
         block_id: Id<GenBlock>,
     ) -> WalletResult<Vec<(Id<Transaction>, WalletTx)>> {
+        // TODO: maybe make it an enum
         struct ConflictCheck {
             frozen_token_id: Option<TokenId>,
             confirmed_account_nonce: Option<(AccountType, AccountNonce)>,
+            conflicting_order_command: Option<(OrderAccountCommandTag, OrderId)>,
         }
 
         let conflict_checks = confirmed_tx
@@ -804,6 +806,7 @@ impl OutputCache {
                             outpoint.account().into(),
                             outpoint.nonce(),
                         )),
+                        conflicting_order_command: None,
                     }),
                     TxInput::AccountCommand(nonce, cmd) => match cmd {
                         AccountCommand::MintTokens(_, _)
@@ -816,13 +819,34 @@ impl OutputCache {
                         | AccountCommand::FillOrder(_, _, _) => Some(ConflictCheck {
                             frozen_token_id: None,
                             confirmed_account_nonce: Some((cmd.into(), *nonce)),
+                            conflicting_order_command: None,
                         }),
                         | AccountCommand::FreezeToken(token_id, _) => Some(ConflictCheck {
                             frozen_token_id: Some(*token_id),
                             confirmed_account_nonce: Some((cmd.into(), *nonce)),
+                            conflicting_order_command: None,
                         }),
                     },
-                    TxInput::OrderAccountCommand(_) => None,
+                    TxInput::OrderAccountCommand(cmd) => {
+                        let order_id = match cmd {
+                            OrderAccountCommand::FillOrder(order_id, _)
+                            | OrderAccountCommand::FreezeOrder(order_id)
+                            | OrderAccountCommand::ConcludeOrder(order_id) => *order_id,
+                        };
+                        let cmd_tag: OrderAccountCommandTag = cmd.into();
+                        match cmd_tag {
+                            // ConcludeOrder and FreezeOrder are exclusive: only one tx can win.
+                            // Any unconfirmed tx with the same command for the same order conflicts.
+                            OrderAccountCommandTag::ConcludeOrder
+                            | OrderAccountCommandTag::FreezeOrder => Some(ConflictCheck {
+                                frozen_token_id: None,
+                                confirmed_account_nonce: None,
+                                conflicting_order_command: Some((cmd_tag, order_id)),
+                            }),
+                            // Multiple fills for the same order can coexist.
+                            OrderAccountCommandTag::FillOrder => None,
+                        }
+                    }
                 }
             })
             .collect::<Vec<_>>();
@@ -851,6 +875,21 @@ impl OutputCache {
                                     unconfirmed_tx,
                                     confirmed_account,
                                     confirmed_account_nonce,
+                                )
+                            {
+                                conflicting_txs.insert(tx.get_transaction().get_id());
+                                continue;
+                            }
+                        }
+
+                        if let Some((confirmed_cmd_tag, confirmed_order_id)) =
+                            conflict_check.conflicting_order_command
+                        {
+                            if confirmed_tx.get_id() != tx.get_transaction().get_id()
+                                && uses_conflicting_order_command(
+                                    unconfirmed_tx,
+                                    confirmed_cmd_tag,
+                                    confirmed_order_id,
                                 )
                             {
                                 conflicting_txs.insert(tx.get_transaction().get_id());
@@ -2059,6 +2098,41 @@ fn uses_conflicting_nonce(
             confirmed_account_type == outpoint.account().into()
                 && outpoint.nonce() <= confirmed_nonce
         }
+    })
+}
+
+fn uses_conflicting_order_command(
+    unconfirmed_tx: &WalletTx,
+    cmd_tag: OrderAccountCommandTag,
+    order_id: OrderId,
+) -> bool {
+    unconfirmed_tx.inputs().iter().any(|input| match input {
+        TxInput::OrderAccountCommand(cmd) => {
+            let unconfirmed_order_id = match cmd {
+                OrderAccountCommand::FillOrder(id, _)
+                | OrderAccountCommand::FreezeOrder(id)
+                | OrderAccountCommand::ConcludeOrder(id) => *id,
+            };
+            // It is only a conflict if it is the same order id
+            if unconfirmed_order_id != order_id {
+                return false;
+            }
+
+            let unconfirmed_cmd_tag: OrderAccountCommandTag = cmd.into();
+            match cmd_tag {
+                // Confirmed fill orders do not conflict with anything
+                OrderAccountCommandTag::FillOrder => false,
+                // Confirmed conclude order conflict with any other unconfirmed operation on the
+                // order
+                OrderAccountCommandTag::ConcludeOrder => true,
+                // Confirmed Freeze order conflicts with any unconfirmed Fill or Freeze order
+                OrderAccountCommandTag::FreezeOrder => match unconfirmed_cmd_tag {
+                    OrderAccountCommandTag::FillOrder | OrderAccountCommandTag::FreezeOrder => true,
+                    OrderAccountCommandTag::ConcludeOrder => false,
+                },
+            }
+        }
+        TxInput::Utxo(_) | TxInput::Account(_) | TxInput::AccountCommand(_, _) => false,
     })
 }
 

--- a/wallet/src/account/output_cache/mod.rs
+++ b/wallet/src/account/output_cache/mod.rs
@@ -2103,8 +2103,8 @@ fn uses_conflicting_nonce(
 
 fn uses_conflicting_order_command(
     unconfirmed_tx: &WalletTx,
-    cmd_tag: OrderAccountCommandTag,
-    order_id: OrderId,
+    confirmed_cmd_tag: OrderAccountCommandTag,
+    confirmed_order_id: OrderId,
 ) -> bool {
     unconfirmed_tx.inputs().iter().any(|input| match input {
         TxInput::OrderAccountCommand(cmd) => {
@@ -2114,12 +2114,12 @@ fn uses_conflicting_order_command(
                 | OrderAccountCommand::ConcludeOrder(id) => *id,
             };
             // It is only a conflict if it is the same order id
-            if unconfirmed_order_id != order_id {
+            if unconfirmed_order_id != confirmed_order_id {
                 return false;
             }
 
             let unconfirmed_cmd_tag: OrderAccountCommandTag = cmd.into();
-            match cmd_tag {
+            match confirmed_cmd_tag {
                 // Confirmed fill orders do not conflict with anything
                 OrderAccountCommandTag::FillOrder => false,
                 // Confirmed conclude order conflict with any other unconfirmed operation on the

--- a/wallet/src/account/output_cache/tests.rs
+++ b/wallet/src/account/output_cache/tests.rs
@@ -1267,6 +1267,333 @@ fn orders_state_update(#[case] seed: Seed) {
     );
 }
 
+// Regression test: when a confirmed V1 ConcludeOrder arrives and an unconfirmed ConcludeOrder,
+// FreezeOrder or FillOrder for the same order is already in the cache,
+// the unconfirmed one must be marked Conflicted and the confirmed one must be accepted without error.
+// Previously, update_conflicting_txs returned None for OrderAccountCommand, so the unconfirmed
+// conclude was never rolled back, causing add_tx to fail with OrderAlreadyConcluded.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn update_conflicting_txs_order_v1_conclude(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = create_unit_test_config();
+    let mut output_cache = OutputCache::empty();
+
+    // Create the order (confirmed).
+    let parent_tx_id = Id::<Transaction>::random_using(&mut rng);
+    let creation_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(parent_tx_id.into(), 0),
+            InputWitness::NoSignature(None),
+        )
+        .add_output(TxOutput::CreateOrder(Box::new(OrderData::new(
+            Destination::AnyoneCanSpend,
+            OutputValue::Coin(Amount::from_atoms(1000)),
+            OutputValue::Coin(Amount::from_atoms(2000)),
+        ))))
+        .build();
+    let order_id = make_order_id(creation_tx.inputs()).unwrap();
+    let creation_tx_id = creation_tx.transaction().get_id();
+
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(1),
+            creation_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                creation_tx,
+                TxState::Confirmed(BlockHeight::new(1), BlockTimestamp::from_int_seconds(1), 0),
+            )),
+        )
+        .unwrap();
+
+    // Add an unconfirmed fill order tx
+    let unconfirmed_fill_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::OrderAccountCommand(OrderAccountCommand::FillOrder(
+                order_id,
+                Amount::from_atoms(rng.gen_range(100..200)),
+            )),
+            InputWitness::NoSignature(None),
+        )
+        .build();
+    let unconfirmed_fill_tx_id = unconfirmed_fill_tx.transaction().get_id();
+
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(2),
+            unconfirmed_fill_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                unconfirmed_fill_tx.clone(),
+                TxState::InMempool(1),
+            )),
+        )
+        .unwrap();
+
+    // Add an unconfirmed freeze tx — sets is_frozen = true.
+    let unconfirmed_freeze_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::OrderAccountCommand(OrderAccountCommand::FreezeOrder(order_id)),
+            InputWitness::NoSignature(None),
+        )
+        .build();
+    let unconfirmed_freeze_tx_id = unconfirmed_freeze_tx.transaction().get_id();
+
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(2),
+            unconfirmed_freeze_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                unconfirmed_freeze_tx.clone(),
+                TxState::InMempool(1),
+            )),
+        )
+        .unwrap();
+
+    assert!(output_cache.orders[&order_id].is_frozen);
+
+    // Add an unconfirmed conclude tx — sets is_concluded = true.
+    let unconfirmed_conclude_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::OrderAccountCommand(OrderAccountCommand::ConcludeOrder(order_id)),
+            InputWitness::NoSignature(None),
+        )
+        .build();
+    let unconfirmed_conclude_tx_id = unconfirmed_conclude_tx.transaction().get_id();
+
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(2),
+            unconfirmed_conclude_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                unconfirmed_conclude_tx.clone(),
+                TxState::InMempool(2),
+            )),
+        )
+        .unwrap();
+
+    assert!(output_cache.orders[&order_id].is_concluded);
+
+    // A *different* confirmed conclude tx for the same order arrives.
+    // update_conflicting_txs must mark the unconfirmed one as Conflicted.
+    let confirmed_conclude_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::OrderAccountCommand(OrderAccountCommand::ConcludeOrder(order_id)),
+            InputWitness::NoSignature(None),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(Amount::from_atoms(1)),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let confirmed_conclude_tx_id = confirmed_conclude_tx.transaction().get_id();
+    assert_ne!(confirmed_conclude_tx_id, unconfirmed_conclude_tx_id);
+
+    let block_id = Id::<GenBlock>::random_using(&mut rng);
+    let mut conflicted = output_cache
+        .update_conflicting_txs(&chain_config, confirmed_conclude_tx.transaction(), block_id)
+        .unwrap();
+
+    // sort conflicted by tx id
+    conflicted.sort_by_key(|(tx_id, _)| *tx_id);
+
+    let mut expected_conflicted = vec![
+        (
+            unconfirmed_fill_tx_id,
+            WalletTx::Tx(TxData::new(
+                unconfirmed_fill_tx,
+                TxState::Conflicted(block_id),
+            )),
+        ),
+        (
+            unconfirmed_freeze_tx_id,
+            WalletTx::Tx(TxData::new(
+                unconfirmed_freeze_tx,
+                TxState::Conflicted(block_id),
+            )),
+        ),
+        (
+            unconfirmed_conclude_tx_id,
+            WalletTx::Tx(TxData::new(
+                unconfirmed_conclude_tx,
+                TxState::Conflicted(block_id),
+            )),
+        ),
+    ];
+    expected_conflicted.sort_by_key(|(tx_id, _)| *tx_id);
+
+    assert_eq!(conflicted, expected_conflicted);
+
+    // is_concluded and is_frozen must be rolled back after the conflict.
+    assert!(!output_cache.orders[&order_id].is_concluded);
+    assert!(!output_cache.orders[&order_id].is_frozen);
+
+    // The confirmed conclude tx must now be addable without error.
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(2),
+            confirmed_conclude_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                confirmed_conclude_tx,
+                TxState::Confirmed(BlockHeight::new(2), BlockTimestamp::from_int_seconds(2), 0),
+            )),
+        )
+        .unwrap();
+
+    assert!(output_cache.orders[&order_id].is_concluded);
+}
+
+// Regression test: same as above but for FreezeOrder.
+#[rstest]
+#[trace]
+#[case(Seed::from_entropy())]
+fn update_conflicting_txs_order_v1_freeze(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+    let chain_config = create_unit_test_config();
+    let mut output_cache = OutputCache::empty();
+
+    // Create the order (confirmed).
+    let parent_tx_id = Id::<Transaction>::random_using(&mut rng);
+    let creation_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::from_utxo(parent_tx_id.into(), 0),
+            InputWitness::NoSignature(None),
+        )
+        .add_output(TxOutput::CreateOrder(Box::new(OrderData::new(
+            Destination::AnyoneCanSpend,
+            OutputValue::Coin(Amount::from_atoms(1000)),
+            OutputValue::Coin(Amount::from_atoms(2000)),
+        ))))
+        .build();
+    let order_id = make_order_id(creation_tx.inputs()).unwrap();
+    let creation_tx_id = creation_tx.transaction().get_id();
+
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(1),
+            creation_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                creation_tx,
+                TxState::Confirmed(BlockHeight::new(1), BlockTimestamp::from_int_seconds(1), 0),
+            )),
+        )
+        .unwrap();
+
+    // Add an unconfirmed fill order tx
+    let unconfirmed_fill_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::OrderAccountCommand(OrderAccountCommand::FillOrder(
+                order_id,
+                Amount::from_atoms(rng.gen_range(100..200)),
+            )),
+            InputWitness::NoSignature(None),
+        )
+        .build();
+    let unconfirmed_fill_tx_id = unconfirmed_fill_tx.transaction().get_id();
+
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(2),
+            unconfirmed_fill_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                unconfirmed_fill_tx.clone(),
+                TxState::InMempool(0),
+            )),
+        )
+        .unwrap();
+
+    // Add an unconfirmed freeze tx — sets is_frozen = true.
+    let unconfirmed_freeze_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::OrderAccountCommand(OrderAccountCommand::FreezeOrder(order_id)),
+            InputWitness::NoSignature(None),
+        )
+        .build();
+    let unconfirmed_freeze_tx_id = unconfirmed_freeze_tx.transaction().get_id();
+
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(2),
+            unconfirmed_freeze_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                unconfirmed_freeze_tx.clone(),
+                TxState::InMempool(1),
+            )),
+        )
+        .unwrap();
+
+    assert!(output_cache.orders[&order_id].is_frozen);
+
+    // A *different* confirmed freeze tx for the same order arrives.
+    // update_conflicting_txs must mark the unconfirmed one as Conflicted.
+    let confirmed_freeze_tx = TransactionBuilder::new()
+        .add_input(
+            TxInput::OrderAccountCommand(OrderAccountCommand::FreezeOrder(order_id)),
+            InputWitness::NoSignature(None),
+        )
+        .add_output(TxOutput::Transfer(
+            OutputValue::Coin(Amount::from_atoms(1)),
+            Destination::AnyoneCanSpend,
+        ))
+        .build();
+    let confirmed_freeze_tx_id = confirmed_freeze_tx.transaction().get_id();
+    assert_ne!(confirmed_freeze_tx_id, unconfirmed_freeze_tx_id);
+
+    let block_id = Id::<GenBlock>::random_using(&mut rng);
+    let mut conflicted = output_cache
+        .update_conflicting_txs(&chain_config, confirmed_freeze_tx.transaction(), block_id)
+        .unwrap();
+
+    let mut expected_conflicted = vec![
+        (
+            unconfirmed_fill_tx_id,
+            WalletTx::Tx(TxData::new(
+                unconfirmed_fill_tx,
+                TxState::Conflicted(block_id),
+            )),
+        ),
+        (
+            unconfirmed_freeze_tx_id,
+            WalletTx::Tx(TxData::new(
+                unconfirmed_freeze_tx,
+                TxState::Conflicted(block_id),
+            )),
+        ),
+    ];
+
+    // Sort by tx id
+    conflicted.sort_by_key(|(tx_id, _)| *tx_id);
+    expected_conflicted.sort_by_key(|(tx_id, _)| *tx_id);
+
+    assert_eq!(conflicted, expected_conflicted);
+
+    // is_frozen must be rolled back after the conflict.
+    assert!(!output_cache.orders[&order_id].is_frozen);
+
+    // The confirmed freeze tx must now be addable without error.
+    output_cache
+        .add_tx(
+            &chain_config,
+            BlockHeight::new(2),
+            confirmed_freeze_tx_id.into(),
+            WalletTx::Tx(TxData::new(
+                confirmed_freeze_tx,
+                TxState::Confirmed(BlockHeight::new(2), BlockTimestamp::from_int_seconds(2), 0),
+            )),
+        )
+        .unwrap();
+
+    assert!(output_cache.orders[&order_id].is_frozen);
+}
+
 fn add_random_transfer_tx(
     output_cache: &mut OutputCache,
     chain_config: &ChainConfig,

--- a/wallet/src/account/output_cache/tests.rs
+++ b/wallet/src/account/output_cache/tests.rs
@@ -1379,7 +1379,7 @@ fn update_conflicting_txs_order_v1_conclude(#[case] seed: Seed) {
     assert!(output_cache.orders[&order_id].is_concluded);
 
     // A *different* confirmed conclude tx for the same order arrives.
-    // update_conflicting_txs must mark the unconfirmed one as Conflicted.
+    // update_conflicting_txs must mark the unconfirmed ones as Conflicted.
     let confirmed_conclude_tx = TransactionBuilder::new()
         .add_input(
             TxInput::OrderAccountCommand(OrderAccountCommand::ConcludeOrder(order_id)),
@@ -1446,6 +1446,7 @@ fn update_conflicting_txs_order_v1_conclude(#[case] seed: Seed) {
         .unwrap();
 
     assert!(output_cache.orders[&order_id].is_concluded);
+    assert!(!output_cache.orders[&order_id].is_frozen);
 }
 
 // Regression test: same as above but for FreezeOrder.
@@ -1531,6 +1532,8 @@ fn update_conflicting_txs_order_v1_freeze(#[case] seed: Seed) {
         .unwrap();
 
     assert!(output_cache.orders[&order_id].is_frozen);
+    // concluded is still false
+    assert!(!output_cache.orders[&order_id].is_concluded);
 
     // A *different* confirmed freeze tx for the same order arrives.
     // update_conflicting_txs must mark the unconfirmed one as Conflicted.
@@ -1577,6 +1580,7 @@ fn update_conflicting_txs_order_v1_freeze(#[case] seed: Seed) {
 
     // is_frozen must be rolled back after the conflict.
     assert!(!output_cache.orders[&order_id].is_frozen);
+    assert!(!output_cache.orders[&order_id].is_concluded);
 
     // The confirmed freeze tx must now be addable without error.
     output_cache
@@ -1592,6 +1596,7 @@ fn update_conflicting_txs_order_v1_freeze(#[case] seed: Seed) {
         .unwrap();
 
     assert!(output_cache.orders[&order_id].is_frozen);
+    assert!(!output_cache.orders[&order_id].is_concluded);
 }
 
 fn add_random_transfer_tx(


### PR DESCRIPTION
The essential commits come from https://github.com/mintlayer/mintlayer-core/pull/2045, I only updated the changelog, moving the corresponding entry to 1.3.1 and rewording it.