### PR TITLE
Run CI jobs on push to release (cherry-pick for v1.3.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release-*
   pull_request:
     branches:
       - "**" # target all branches

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release-*
   pull_request:
     branches:
       - "**" # target all branches

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release-*
   pull_request:
     branches:
       - "**" # target all branches

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release-*
   pull_request:
     branches:
       - "**" # target all branches

--- a/common/src/chain/partially_signed_transaction/mod.rs
+++ b/common/src/chain/partially_signed_transaction/mod.rs
@@ -64,7 +64,7 @@ pub enum PartiallySignedTransactionConsistencyCheck {
 /// Note: currently PartiallySignedTransaction's consistency checks require that the additional info
 /// is present even if the inputs that need it are already signed.
 ///
-/// Thought PartiallySignedTransaction is not part of the blockchain, it is still part of
+/// Though PartiallySignedTransaction is not part of the blockchain, it is still part of
 /// the core's public interface:
 /// 1) It is returned and consumed by the wallet CLI and RPC (in its encoded form).
 /// 2) Through the wallet RPC, it is used by the bridge, whose e2m master agent puts


### PR DESCRIPTION
Currently CI is not triggered on push to a release branch. This was fixed on master earlier and here I cherry-pick that commit.