### PR TITLE
Mempool: fix spuriouly failing test; shrink hash tables; some cleanup.

### DIFF
--- a/mempool/src/pool/tests/orphans.rs
+++ b/mempool/src/pool/tests/orphans.rs
@@ -258,9 +258,9 @@ async fn transaction_graph_subset_permutation(#[case] seed: Seed) {
 
         log::info!(
             "Stats: count {}, memory {}, encoded size {}",
-            mempool.tx_store().txs_by_id.len(),
+            mempool.tx_store().txs_by_id().len(),
             mempool.memory_usage(),
-            mempool.tx_store().txs_by_id.values().map(|e| e.size().get()).sum::<usize>(),
+            mempool.tx_store().txs_by_id().values().map(|e| e.size().get()).sum::<usize>(),
         );
 
         // Check the final state of each transaction in the original sequence

--- a/mempool/src/pool/tx_pool/collect_txs.rs
+++ b/mempool/src/pool/tx_pool/collect_txs.rs
@@ -133,7 +133,7 @@ pub fn collect_txs<M>(
     // Transaction IDs taken from mempool to fill in the rest of the block
     let mempool_txids = {
         // Get transactions from mempool by score
-        let txids = mempool.store.txs_by_ancestor_score.iter().map(|x| &x.1).rev();
+        let txids = mempool.store.txs_by_ancestor_score().iter().map(|x| &x.1).rev();
         // Take the appropriate amount of them as determined by the packing strategy
         txids.take(match packing_strategy {
             PackingStrategy::FillSpaceFromMempool => usize::MAX,

--- a/mempool/src/pool/tx_pool/mod.rs
+++ b/mempool/src/pool/tx_pool/mod.rs
@@ -172,7 +172,7 @@ impl<M> TxPool<M> {
 
     pub fn get_all(&self) -> Vec<SignedTransaction> {
         self.store
-            .txs_by_descendant_score
+            .txs_by_descendant_score()
             .iter()
             .map(|(_score, id)| self.store.get_entry(id).expect("entry").transaction().clone())
             .collect()
@@ -486,7 +486,7 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
         conflicts_with_descendants: &StoreHashSet<Id<Transaction>>,
     ) -> Result<Fee, MempoolPolicyError> {
         let conflicts_with_descendants = conflicts_with_descendants.iter().map(|conflict_id| {
-            self.store.txs_by_id.get(conflict_id).expect("tx should exist in mempool")
+            self.store.txs_by_id().get(conflict_id).expect("tx should exist in mempool")
         });
 
         let total_conflict_fees = conflicts_with_descendants
@@ -626,7 +626,7 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
 
         let expired_ids = self
             .store
-            .txs_by_creation_time
+            .txs_by_creation_time()
             .iter()
             // Note: entries in txs_by_creation_time are sorted by the creation time in ascending order,
             // so once we find a tx that is not expired, the rest will not be expired either.
@@ -663,12 +663,12 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
             // TODO sort by descendant score, not by fee
             let removed_id = self
                 .store
-                .txs_by_descendant_score
+                .txs_by_descendant_score()
                 .iter()
                 .map(|(_score, entry)| *entry)
                 .next()
                 .expect("pool not empty");
-            let removed = self.store.txs_by_id.get(&removed_id).expect("tx with id should exist");
+            let removed = self.store.txs_by_id().get(&removed_id).expect("tx with id should exist");
 
             log::debug!(
                 "Mempool trim: Evicting tx {:x} which has a descendant score of {:?} and has size {}",
@@ -953,8 +953,8 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
             in_top_x_mb,
             &self.mempool_config,
             &self.rolling_fee_rate.read(),
-            &self.store.txs_by_descendant_score,
-            &self.store.txs_by_id,
+            self.store.txs_by_descendant_score(),
+            self.store.txs_by_id(),
         )
     }
 
@@ -998,8 +998,8 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
             num_points,
             &self.mempool_config,
             &self.rolling_fee_rate.read(),
-            &self.store.txs_by_descendant_score,
-            &self.store.txs_by_id,
+            self.store.txs_by_descendant_score(),
+            self.store.txs_by_id(),
         )
     }
 

--- a/mempool/src/pool/tx_pool/mod.rs
+++ b/mempool/src/pool/tx_pool/mod.rs
@@ -653,7 +653,13 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
 
     fn trim(&mut self) -> Result<Vec<FeeRate>, MempoolPolicyError> {
         let mut removed_fees = Vec::new();
-        while !self.store.is_empty() && self.memory_usage() > self.max_size.as_bytes() {
+        loop {
+            self.store.shrink_capacity_if_needed();
+
+            if self.store.is_empty() || self.memory_usage() <= self.max_size.as_bytes() {
+                break;
+            }
+
             // TODO sort by descendant score, not by fee
             let removed_id = self
                 .store
@@ -673,6 +679,7 @@ impl<M: MemoryUsageEstimator> TxPool<M> {
             removed_fees.push(FeeRate::from_total_tx_fee(removed.fee(), removed.size())?);
             self.remove_tx_and_descendants(&removed_id, MempoolRemovalReason::SizeLimit);
         }
+
         Ok(removed_fees)
     }
 

--- a/mempool/src/pool/tx_pool/store/mod.rs
+++ b/mempool/src/pool/tx_pool/store/mod.rs
@@ -663,7 +663,86 @@ impl MempoolStore {
         let entry = self.get_existing_entry(tx_id)?;
         entry.collect_cluster(self)
     }
+
+    /// For internal containers that have capacity, check if the capacity is excessive; shrink
+    /// the container if it is.
+    pub fn shrink_capacity_if_needed(&mut self) {
+        // Note:
+        // * Hashbrown tables never shrink their capacity automatically.
+        // * According to the pseudo-test `estimate_max_tx_count_in_store`, the store with the default
+        //   size of 300Mb can fit over 230'000 txs of the smallest possible size. Due to how hashbrown
+        //   tables work (1/8 of all buckets should always be empty, and reallocation doubles the number
+        //   of buckets), `txs_by_id` and `seq_nos_by_tx` may end up with more than 500'000 buckets each.
+        //   Given that the bucket size in each table is 40 bytes (in non-test builds), this results in
+        //   roughly 20Mb of allocated memory per table, which will not go down even if the tables'
+        //   element counts become zero. Since table's entire allocation_size counts towards the
+        //   mempool size, this will effectively reduce the max mempool size by 40Mb.
+        // * On the other hand, the mempool re-creates its store completely every time a new block
+        //   arrives, so the situation described above can only exist for a few minutes. Still,
+        //   it's better for the store not to depend on such a behavior of its owner code and
+        //   manage the capacities explicitly.
+
+        // Implementation notes:
+        // * table's `capacity` doesn't count the tombstones, so in a degenerate case like the one
+        //   described above it's possible to have a table with a huge allocation size and small
+        //   capacity. So below we don't use capacity when deciding whether to shrink, and estimate
+        //   (roughly) the number of buckets instead.
+        // * even though `shrink_to` accepts capacity, it'll compare the estimated number of buckets
+        //   (from the passed capacity) with the current one and reallocate/rehash the table if the
+        //   latter is bigger.
+
+        fn maybe_shrink<K, V>(
+            table: &mut TrackedHashMap<K, V>,
+            mem_tracker: &mut MemUsageTracker,
+            table_name: &str,
+        ) where
+            K: Eq + std::hash::Hash,
+        {
+            let bucket_size = hash_map_bucket_size(table);
+            let bucket_count = hash_map_bucket_count_upper_bound(table);
+
+            let max_bucket_count = table.len() * HASH_TABLE_MAX_BUCKET_COUNT_FACTOR;
+            let adjusted_capacity = table.len() * HASH_TABLE_ADJUSTED_CAPACITY_FACTOR;
+
+            if bucket_count > max_bucket_count {
+                let potentially_reclaimable_mem_size =
+                    (bucket_count - adjusted_capacity) * bucket_size;
+
+                // Only bother shrinking if the win is noticeable.
+                if potentially_reclaimable_mem_size >= HASH_TABLE_MIN_RECLAIMABLE_MEM_SIZE {
+                    log::debug!("Shrinking {table_name} to {adjusted_capacity}");
+                    mem_tracker.modify(table, |table, _| table.shrink_to(adjusted_capacity));
+                }
+            }
+        }
+
+        maybe_shrink(&mut self.txs_by_id, &mut self.mem_tracker, "txs_by_id");
+        maybe_shrink(
+            &mut self.seq_nos_by_tx,
+            &mut self.mem_tracker,
+            "seq_nos_by_tx",
+        );
+    }
 }
+
+pub fn hash_map_bucket_size<K, V>(_: &StoreHashMap<K, V>) -> usize {
+    std::mem::size_of::<(K, V)>()
+}
+
+// Return the upper bound for the number of buckets in the map.
+pub fn hash_map_bucket_count_upper_bound<K, V>(map: &StoreHashMap<K, V>) -> usize
+where
+    K: Eq + std::hash::Hash,
+{
+    // Note: the actual number of buckets will be smaller than this, because `allocation_size` also
+    // includes control bytes and padding.
+    map.allocation_size() / hash_map_bucket_size(map)
+}
+
+// Constants that determine whether store's hash tables should be shrunk and, if yes, to what capacity.
+pub const HASH_TABLE_MAX_BUCKET_COUNT_FACTOR: usize = 5;
+pub const HASH_TABLE_ADJUSTED_CAPACITY_FACTOR: usize = 2;
+pub const HASH_TABLE_MIN_RECLAIMABLE_MEM_SIZE: usize = 10_000;
 
 #[cfg(test)]
 impl Drop for MempoolStore {

--- a/mempool/src/pool/tx_pool/store/mod.rs
+++ b/mempool/src/pool/tx_pool/store/mod.rs
@@ -124,7 +124,7 @@ pub struct MempoolStore {
     // and doesn't free the memory when an item is removed - it's only replaced with a tombstone.
     // Since TxMempoolEntry is relatively big (size_of = 350+ bytes), we'd waste a noticeable
     // amount of memory without boxing.)
-    pub txs_by_id: TrackedHashMap<Id<Transaction>, Tracked<Box<TxMempoolEntry>, StrictDropPolicy>>,
+    txs_by_id: TrackedHashMap<Id<Transaction>, Tracked<Box<TxMempoolEntry>, StrictDropPolicy>>,
 
     // Mempool entries sorted by descendant score.
     // We keep this index so that when the mempool grows full, we know which transactions are the
@@ -136,22 +136,22 @@ pub struct MempoolStore {
     //  max(fee/size of entry's tx, fee/size with all descendants).
     //  TODO if we wish to follow Bitcoin Core, "size" is not simply the encoded size, but
     // rather a value that takes into account witness and sigop data (see CTxMemPoolEntry::GetTxSize).
-    pub txs_by_descendant_score: TrackedTxIdMultiMap<DescendantScore>,
+    txs_by_descendant_score: TrackedTxIdMultiMap<DescendantScore>,
 
     // Mempool entries sorted by ancestor score.
     // This is used to select the most economically attractive transactions for block production.
     // The ancestor score of an entry is defined as
     //  min(fee/size of entry's tx, fee/size with all ancestors).
-    pub txs_by_ancestor_score: TrackedTxIdMultiMap<AncestorScore>,
+    txs_by_ancestor_score: TrackedTxIdMultiMap<AncestorScore>,
 
     // Entries that have remained in the mempool for a long time (see DEFAULT_MEMPOOL_EXPIRY) are
     // evicted. To efficiently know which entries to evict, we store the mempool entries sorted by
     // their creation time, from earliest to latest.
-    pub txs_by_creation_time: TrackedTxIdMultiMap<Time>,
+    txs_by_creation_time: TrackedTxIdMultiMap<Time>,
 
     // We keep the information of which inputs are spent by entries currently in the mempool.
     // This allows us to recognize conflicts (double-spends) and handle them
-    pub spender_txs: Tracked<BTreeMap<TxDependency, Id<Transaction>>>,
+    spender_txs: Tracked<BTreeMap<TxDependency, Id<Transaction>>>,
 
     // Track transactions by internal unique sequence number. This is used to recover the order in
     // which the transactions have been inserted into the mempool, so they can be re-inserted in
@@ -241,6 +241,29 @@ impl MempoolStore {
 
     pub fn memory_usage(&self) -> usize {
         self.mem_tracker.get_usage()
+    }
+
+    pub fn txs_by_id(
+        &self,
+    ) -> &TrackedHashMap<Id<Transaction>, Tracked<Box<TxMempoolEntry>, StrictDropPolicy>> {
+        &self.txs_by_id
+    }
+
+    pub fn txs_by_descendant_score(&self) -> &TrackedTxIdMultiMap<DescendantScore> {
+        &self.txs_by_descendant_score
+    }
+
+    pub fn txs_by_ancestor_score(&self) -> &TrackedTxIdMultiMap<AncestorScore> {
+        &self.txs_by_ancestor_score
+    }
+
+    pub fn txs_by_creation_time(&self) -> &TrackedTxIdMultiMap<Time> {
+        &self.txs_by_creation_time
+    }
+
+    #[cfg(test)]
+    pub fn seq_nos_by_tx(&self) -> &TrackedHashMap<Id<Transaction>, usize> {
+        &self.seq_nos_by_tx
     }
 
     pub fn assert_valid(&self) {

--- a/mempool/src/pool/tx_pool/tests/accumulator.rs
+++ b/mempool/src/pool/tx_pool/tests/accumulator.rs
@@ -259,7 +259,10 @@ async fn collect_transactions(#[case] seed: Seed) -> anyhow::Result<()> {
         .unwrap();
     let collected_txs = returned_accumulator.unwrap();
     let collected_txs = collected_txs.transactions();
-    log::debug!("ancestor index: {:?}", mempool.store.txs_by_ancestor_score);
+    log::debug!(
+        "ancestor index: {:?}",
+        mempool.store.txs_by_ancestor_score()
+    );
     let expected_num_txs_collected = 6;
     assert_eq!(collected_txs.len(), expected_num_txs_collected);
     let total_tx_size: usize = collected_txs.iter().map(|tx| tx.encoded_size()).sum();

--- a/mempool/src/pool/tx_pool/tests/basic.rs
+++ b/mempool/src/pool/tx_pool/tests/basic.rs
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chainstate_test_framework::helpers::split_utxo;
 use mempool_types::tx_origin::LocalTxOrigin;
+use test_utils::BasicTestTimeGetter;
 
 use crate::pool::tx_pool::store::{StoreHashSet, TxMempoolEntryWithAncestors};
 
@@ -583,7 +585,7 @@ async fn test_bip125_max_replacements(
         .await?;
         mempool.add_transaction_test(tx)?.assert_in_mempool();
     }
-    let mempool_size_before_replacement = mempool.store.txs_by_id.len();
+    let mempool_size_before_replacement = mempool.store.txs_by_id().len();
 
     let replacement_fee = (Amount::from_atoms(1_000_000_000_000_000) * fee).map(Fee::from);
     let replacement_tx = tx_spend_input(
@@ -595,7 +597,7 @@ async fn test_bip125_max_replacements(
     )
     .await?;
     mempool.add_transaction_test(replacement_tx)?.assert_in_mempool();
-    let mempool_size_after_replacement = mempool.store.txs_by_id.len();
+    let mempool_size_after_replacement = mempool.store.txs_by_id().len();
 
     assert_eq!(
         mempool_size_after_replacement,
@@ -726,7 +728,7 @@ async fn rolling_fee(#[case] seed: Seed) -> anyhow::Result<()> {
     tx_pool.add_transaction_test(child_1)?.assert_in_mempool();
     log::debug!("added child_1");
 
-    assert_eq!(tx_pool.store.txs_by_id.len(), 2);
+    assert_eq!(tx_pool.store.txs_by_id().len(), 2);
     assert!(tx_pool.contains_transaction(&child_1_id));
     assert!(!tx_pool.contains_transaction(&child_0_id));
     let rolling_fee = tx_pool.get_minimum_rolling_fee();
@@ -1070,17 +1072,17 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
     log::debug!("tx_c fee : {:?}", try_get_fee(&mempool, &tx_c).await);
     mempool.add_transaction_test(tx_c)?.assert_in_mempool();
 
-    let entry_tx = mempool.store.txs_by_id.get(&tx_id).expect("tx");
+    let entry_tx = mempool.store.txs_by_id().get(&tx_id).expect("tx");
     let entry_tx_id = *entry_tx.tx_id();
     log::debug!(
         "at first, entry tx has score {:?}",
         entry_tx.ancestor_score()
     );
-    let entry_a = mempool.store.txs_by_id.get(&tx_a_id).expect("tx_a").deref().clone();
+    let entry_a = mempool.store.txs_by_id().get(&tx_a_id).expect("tx_a").deref().clone();
     log::debug!("AT FIRST, entry a has score {:?}", entry_a.ancestor_score());
-    let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b").deref();
+    let entry_b = mempool.store.txs_by_id().get(&tx_b_id).expect("tx_b").deref();
     log::debug!("AT FIRST, entry b has score {:?}", entry_b.ancestor_score());
-    let entry_c = mempool.store.txs_by_id.get(&tx_c_id).expect("tx_c").deref().clone();
+    let entry_c = mempool.store.txs_by_id().get(&tx_c_id).expect("tx_c").deref().clone();
     log::debug!(
         "AT FIRST, entry c looks like {:?} and has score {:?}",
         entry_c,
@@ -1096,26 +1098,26 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
     );
     log::debug!(
         "BEFORE REMOVAL raw txs_by_ancestor_score {:?}",
-        mempool.store.txs_by_ancestor_score
+        mempool.store.txs_by_ancestor_score()
     );
     check_txs_sorted_by_ancestor_score(&mempool);
 
     mempool.store.remove_tx(&entry_tx_id, MempoolRemovalReason::Block);
     log::debug!(
         "AFTER REMOVAL raw txs_by_ancestor_score {:?}",
-        mempool.store.txs_by_ancestor_score
+        mempool.store.txs_by_ancestor_score()
     );
-    let entry_a = mempool.store.txs_by_id.get(&tx_a_id).expect("tx_a");
+    let entry_a = mempool.store.txs_by_id().get(&tx_a_id).expect("tx_a");
     log::debug!(
         "AFTER removing tx, entry a has score {:?}",
         entry_a.ancestor_score()
     );
-    let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b");
+    let entry_b = mempool.store.txs_by_id().get(&tx_b_id).expect("tx_b");
     log::debug!(
         "AFTER removing tx, entry b has score {:?}",
         entry_b.ancestor_score()
     );
-    let entry_c = mempool.store.txs_by_id.get(&tx_c_id).expect("tx_b");
+    let entry_c = mempool.store.txs_by_id().get(&tx_c_id).expect("tx_b");
     log::debug!(
         "AFTER removing tx, entry c looks like {:?} and has score {:?}",
         entry_c,
@@ -1131,7 +1133,7 @@ async fn ancestor_score(#[case] seed: Seed) -> anyhow::Result<()> {
 fn check_txs_sorted_by_ancestor_score<E>(tx_pool: &TxPool<E>) {
     let txs_by_ancestor_score = tx_pool
         .store
-        .txs_by_descendant_score
+        .txs_by_descendant_score()
         .iter()
         .map(|(_score, id)| id)
         .collect::<Vec<_>>();
@@ -1139,8 +1141,9 @@ fn check_txs_sorted_by_ancestor_score<E>(tx_pool: &TxPool<E>) {
         log::debug!("i =  {}", i);
         let tx_id = txs_by_ancestor_score.get(i).unwrap();
         let next_tx_id = txs_by_ancestor_score.get(i + 1).unwrap();
-        let entry_score = tx_pool.store.txs_by_id.get(*tx_id).unwrap().descendant_score();
-        let next_entry_score = tx_pool.store.txs_by_id.get(*next_tx_id).unwrap().descendant_score();
+        let entry_score = tx_pool.store.txs_by_id().get(*tx_id).unwrap().descendant_score();
+        let next_entry_score =
+            tx_pool.store.txs_by_id().get(*next_tx_id).unwrap().descendant_score();
         log::debug!("entry_score: {:?}", entry_score);
         log::debug!("next_entry_score: {:?}", next_entry_score);
         assert!(entry_score <= next_entry_score)
@@ -1221,11 +1224,11 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     log::debug!("tx_c fee : {:?}", try_get_fee(&mempool, &tx_c).await);
     mempool.add_transaction_test(tx_c)?.assert_in_mempool();
 
-    let entry_a = mempool.store.txs_by_id.get(&tx_a_id).expect("tx_a");
+    let entry_a = mempool.store.txs_by_id().get(&tx_a_id).expect("tx_a");
     log::debug!("entry a has score {:?}", entry_a.descendant_score());
-    let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b");
+    let entry_b = mempool.store.txs_by_id().get(&tx_b_id).expect("tx_b");
     log::debug!("entry b has score {:?}", entry_b.descendant_score());
-    let entry_c = mempool.store.txs_by_id.get(&tx_c_id).expect("tx_c").deref().clone();
+    let entry_c = mempool.store.txs_by_id().get(&tx_c_id).expect("tx_c").deref().clone();
     log::debug!("entry c has score {:?}", entry_c.descendant_score());
     assert_eq!(entry_a.fee(), entry_a.fees_with_descendants());
     assert_eq!(
@@ -1234,12 +1237,12 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
     );
     log::debug!(
         "raw_txs_by_descendant_score {:?}",
-        mempool.store.txs_by_descendant_score
+        mempool.store.txs_by_descendant_score()
     );
     check_txs_sorted_by_descendant_sore(&mempool);
 
     mempool.store.remove_tx(entry_c.tx_id(), MempoolRemovalReason::Block);
-    let entry_b = mempool.store.txs_by_id.get(&tx_b_id).expect("tx_b");
+    let entry_b = mempool.store.txs_by_id().get(&tx_b_id).expect("tx_b");
     assert_eq!(entry_b.fees_with_descendants(), entry_b.fee());
 
     check_txs_sorted_by_descendant_sore(&mempool);
@@ -1251,7 +1254,7 @@ async fn descendant_score(#[case] seed: Seed) -> anyhow::Result<()> {
 fn check_txs_sorted_by_descendant_sore<M>(tx_pool: &TxPool<M>) {
     let txs_by_descendant_score = tx_pool
         .store
-        .txs_by_descendant_score
+        .txs_by_descendant_score()
         .iter()
         .map(|(_score, id)| id)
         .collect::<Vec<_>>();
@@ -1259,8 +1262,9 @@ fn check_txs_sorted_by_descendant_sore<M>(tx_pool: &TxPool<M>) {
         log::debug!("i =  {}", i);
         let tx_id = txs_by_descendant_score.get(i).unwrap();
         let next_tx_id = txs_by_descendant_score.get(i + 1).unwrap();
-        let entry_score = tx_pool.store.txs_by_id.get(*tx_id).unwrap().descendant_score();
-        let next_entry_score = tx_pool.store.txs_by_id.get(*next_tx_id).unwrap().descendant_score();
+        let entry_score = tx_pool.store.txs_by_id().get(*tx_id).unwrap().descendant_score();
+        let next_entry_score =
+            tx_pool.store.txs_by_id().get(*next_tx_id).unwrap().descendant_score();
         log::debug!("entry_score: {:?}", entry_score);
         log::debug!("next_entry_score: {:?}", next_entry_score);
         assert!(entry_score <= next_entry_score)
@@ -1362,12 +1366,12 @@ async fn mempool_full_real(#[case] seed: Seed) {
         mempool.add_transaction_bare(tx.tx_entry().clone()).unwrap().assert_in_mempool();
         log::trace!("Mempool mem usage updated: {}", mempool.memory_usage());
     }
-    assert_eq!(mempool.store.txs_by_id.len(), num_txs - 1);
+    assert_eq!(mempool.store.txs_by_id().len(), num_txs - 1);
 
     // Add the last transaction, check the memory limit kicked in and the total number of
     // transactions has not increased.
     let _ = mempool.add_transaction_bare(last_tx.tx_entry().clone());
-    assert!(mempool.store.txs_by_id.len() < num_txs);
+    assert!(mempool.store.txs_by_id().len() < num_txs);
 
     // Bump the memory limit again, and re-insert the evicted transaction(s). Also reset the
     // rolling fee since recently evicted transactions bump it up.
@@ -1388,7 +1392,7 @@ async fn mempool_full_real(#[case] seed: Seed) {
         mempool.add_transaction_bare(tx.into_tx_entry()).unwrap().assert_in_mempool();
     }
 
-    assert_eq!(mempool.store.txs_by_id.len(), num_txs, "Some txs missing");
+    assert_eq!(mempool.store.txs_by_id().len(), num_txs, "Some txs missing");
 }
 
 #[rstest]
@@ -1453,8 +1457,8 @@ async fn no_empty_bags_in_indices(#[case] seed: Seed) -> anyhow::Result<()> {
     for id in ids {
         mempool.store.remove_tx(&id, MempoolRemovalReason::Block);
     }
-    assert!(mempool.store.txs_by_descendant_score.is_empty());
-    assert!(mempool.store.txs_by_creation_time.is_empty());
+    assert!(mempool.store.txs_by_descendant_score().is_empty());
+    assert!(mempool.store.txs_by_creation_time().is_empty());
     mempool.store.assert_valid();
     Ok(())
 }
@@ -1760,7 +1764,7 @@ async fn estimate_max_tx_count_in_store() {
     storage.disable_heavy_validity_checks();
 
     loop {
-        let tx_count = storage.txs_by_id.len();
+        let tx_count = storage.txs_by_id().len();
 
         let tx = make_minimal_tx(TxInput::from_utxo(fake_source.clone(), tx_count as u32));
         let entry = TxEntry::new(tx, time, origin, options.clone());
@@ -1772,13 +1776,13 @@ async fn estimate_max_tx_count_in_store() {
         }
     }
 
-    let tx_ids = storage.txs_by_id.keys().copied().collect::<Vec<_>>();
+    let tx_ids = storage.txs_by_id().keys().copied().collect::<Vec<_>>();
 
     for tx_id in tx_ids {
         storage.remove_tx(&tx_id, MempoolRemovalReason::Expiry);
     }
 
-    assert!(storage.txs_by_id.is_empty());
+    assert!(storage.txs_by_id().is_empty());
 
     // After all txs have been removed, the only thing that can occupy storage is allocated capacity
     // of containers that have it, which at the moment of writing this are the 2 hash tables -
@@ -1791,4 +1795,116 @@ async fn estimate_max_tx_count_in_store() {
         "memory usage after store cleanup: {}",
         storage.memory_usage()
     );
+}
+
+// Check that the mempool tries to shrink hash maps when a new tx is inserted.
+#[rstest]
+#[case(Seed::from_entropy())]
+#[trace]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn storage_capacity_shrinkage(#[case] seed: Seed) {
+    let mut rng = make_seedable_rng(seed);
+
+    let chain_config = chain::config::create_unit_test_config();
+    let time_getter = BasicTestTimeGetter::new();
+    let mut tf = TestFramework::builder(&mut rng)
+        .with_chain_config(chain_config)
+        .with_time_getter(time_getter.get_time_getter())
+        .build();
+    let genesis_id = tf.genesis().get_id();
+    let tx_id = split_utxo(
+        &mut rng,
+        &mut tf,
+        UtxoOutPoint::new(genesis_id.into(), 0),
+        2,
+    );
+
+    let min_tx_relay_fee_rate = FeeRate::from_atoms_per_kb(1);
+
+    let time = time_getter.get_time_getter().get_time();
+    let num_txs = 250;
+    let txs: Vec<_> = generate_transaction_graph_generic(
+        &mut rng,
+        time,
+        min_tx_relay_fee_rate,
+        UtxoOutPoint::new(tx_id.into(), 0),
+        Amount::from_atoms(100_000_000_000_000),
+    )
+    .take(num_txs)
+    .collect();
+
+    let mempool_config = MempoolConfig {
+        min_tx_relay_fee_rate: min_tx_relay_fee_rate.into(),
+        // Make sure we don't hit the max cluster tx count limit.
+        max_cluster_tx_count: txs.len().into(),
+        max_cluster_size_bytes: Default::default(),
+    };
+
+    let mut mempool = setup_with_chainstate_generic(
+        tf.chainstate(),
+        mempool_config,
+        time_getter.get_time_getter(),
+    );
+
+    for tx in &txs {
+        mempool.add_transaction_bare(tx.tx_entry().clone()).unwrap().assert_in_mempool();
+    }
+
+    let bucket_count1 = store::hash_map_bucket_count_upper_bound(mempool.store.txs_by_id());
+    let bucket_count2 = store::hash_map_bucket_count_upper_bound(mempool.store.seq_nos_by_tx());
+    let alloc_size1 = mempool.store.txs_by_id().allocation_size();
+    let alloc_size2 = mempool.store.seq_nos_by_tx().allocation_size();
+
+    log::debug!("bucket_count1 = {bucket_count1}, bucket_count2 = {bucket_count2}");
+    log::debug!("alloc_size1 = {alloc_size1}, alloc_size2 = {alloc_size2}");
+
+    // Some sanity checks
+    assert!(bucket_count1 >= txs.len());
+    assert!(bucket_count2 >= txs.len());
+
+    assert!(alloc_size1 > 3 * store::HASH_TABLE_MIN_RECLAIMABLE_MEM_SIZE / 2);
+    assert!(alloc_size2 > 3 * store::HASH_TABLE_MIN_RECLAIMABLE_MEM_SIZE / 2);
+
+    time_getter.advance_time(config::DEFAULT_MEMPOOL_EXPIRY + Duration::from_secs(1));
+
+    let new_time = time_getter.get_time_getter().get_time();
+    let new_tx = generate_transaction_graph_generic(
+        &mut rng,
+        new_time,
+        min_tx_relay_fee_rate,
+        UtxoOutPoint::new(tx_id.into(), 1),
+        Amount::from_atoms(100_000_000_000_000),
+    )
+    .next()
+    .unwrap();
+
+    mempool
+        .add_transaction_bare(new_tx.tx_entry().clone())
+        .unwrap()
+        .assert_in_mempool();
+
+    // Sanity check: the old txs have expired
+    assert_eq!(mempool.store.txs_by_id().len(), 1);
+    assert_eq!(mempool.store.seq_nos_by_tx().len(), 1);
+
+    let new_bucket_count1 = store::hash_map_bucket_count_upper_bound(mempool.store.txs_by_id());
+    let new_bucket_count2 = store::hash_map_bucket_count_upper_bound(mempool.store.seq_nos_by_tx());
+    let new_alloc_size1 = mempool.store.txs_by_id().allocation_size();
+    let new_alloc_size2 = mempool.store.seq_nos_by_tx().allocation_size();
+
+    log::debug!("new_bucket_count1 = {new_bucket_count1}, new_bucket_count2 = {new_bucket_count2}");
+    log::debug!("new_alloc_size1 = {new_alloc_size1}, new_alloc_size2 = {new_alloc_size2}");
+
+    // After inserting the new tx, the store should attempt to shrink the capacities to number of
+    // txs (which will be 1) times HASH_TABLE_ADJUSTED_CAPACITY_FACTOR. But the shrinkage is not
+    // guaranteed to be done to this exact value and also the bucket count estimate is bigger than
+    // the actual bucket count, so we can't simply assert that new bucket counts are no bigger than
+    // HASH_TABLE_ADJUSTED_CAPACITY_FACTOR. So we multiply the latter by some additional factor.
+    let new_bucket_counts_expected_max = store::HASH_TABLE_ADJUSTED_CAPACITY_FACTOR * 3;
+    assert!(new_bucket_count1 <= new_bucket_counts_expected_max);
+    assert!(new_bucket_count2 <= new_bucket_counts_expected_max);
+
+    // Sanity check: new_bucket_counts_expected_max is less than the original bucket counts.
+    assert!(new_bucket_counts_expected_max < bucket_count1);
+    assert!(new_bucket_counts_expected_max < bucket_count2);
 }

--- a/mempool/src/pool/tx_pool/tests/basic.rs
+++ b/mempool/src/pool/tx_pool/tests/basic.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use mempool_types::tx_origin::LocalTxOrigin;
+
 use crate::pool::tx_pool::store::{StoreHashSet, TxMempoolEntryWithAncestors};
 
 use super::*;
@@ -1314,7 +1316,6 @@ async fn mempool_full_mock(#[case] seed: Seed) -> anyhow::Result<()> {
 
 #[rstest]
 #[case(Seed::from_entropy())]
-#[case::fail(Seed(1))]
 #[trace]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mempool_full_real(#[case] seed: Seed) {
@@ -1370,7 +1371,14 @@ async fn mempool_full_real(#[case] seed: Seed) {
 
     // Bump the memory limit again, and re-insert the evicted transaction(s). Also reset the
     // rolling fee since recently evicted transactions bump it up.
-    mempool.max_size = MempoolMaxSize::from_bytes(memory_size);
+    // Note: since the switch to using hashbrown tables in the mempool store, simply resetting
+    // `mempool.max_size` back to `memory_size` may not be enough for the previously evicted
+    // txs to fit back in. This is because hashbrown tables are probing tables that leave tombstones
+    // during element removal and tombstones may not always be reused during insertion. In such a
+    // case insertion will eat up one additional capacity element, and if the capacity is already at
+    // the maximum, reallocation will occur, doubling the number of buckets, which will contribute
+    // to the current mempool size and will cause some of the previously fitting txs to be evicted.
+    mempool.max_size = MempoolMaxSize::from_bytes(memory_size * 2);
     mempool.drop_rolling_fee();
 
     for tx in txs {
@@ -1719,4 +1727,68 @@ fn stack_overflow_on_transaction_addition(
         .await
         .unwrap();
     });
+}
+
+// Note: this is not a real test; it's just a piece of code to estimate the maximum number
+// of transactions that can fit into a store of the default size. I.e. it fills the store
+// with txs of minimally possible size, stops when it's full and prints the count.
+// In the end, it removes all txs from the store and prints the resulting memory usage, which
+// will be the capacity overhead introduced by the 2 hashbrown tables.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore]
+async fn estimate_max_tx_count_in_store() {
+    let make_minimal_tx = |input| {
+        let tx = Transaction::new(
+            0,
+            vec![input],
+            vec![TxOutput::Transfer(OutputValue::Coin(Amount::ZERO), Destination::AnyoneCanSpend)],
+        )
+        .unwrap();
+        SignedTransaction::new(tx, vec![InputWitness::NoSignature(None)]).unwrap()
+    };
+
+    let fake_source = OutPointSourceId::Transaction(Id::new(common::primitives::H256::zero()));
+    let minimal_tx = make_minimal_tx(TxInput::from_utxo(fake_source.clone(), 0));
+    log::info!("minimal tx size = {}", minimal_tx.encoded_size());
+
+    let time = TimeGetter::default().get_time();
+    let origin = TxOrigin::Local(LocalTxOrigin::P2p);
+    let options = TxOptions::default_for(origin);
+    let fee = Amount::from_atoms(1_000_000).into();
+
+    let mut storage = MempoolStore::new(Default::default());
+    storage.disable_heavy_validity_checks();
+
+    loop {
+        let tx_count = storage.txs_by_id.len();
+
+        let tx = make_minimal_tx(TxInput::from_utxo(fake_source.clone(), tx_count as u32));
+        let entry = TxEntry::new(tx, time, origin, options.clone());
+        storage.add_transaction(TxEntryWithFee::new(entry, fee)).unwrap();
+
+        if storage.memory_usage() > MAX_MEMPOOL_SIZE_BYTES {
+            log::info!("max tx count: {tx_count}",);
+            break;
+        }
+    }
+
+    let tx_ids = storage.txs_by_id.keys().copied().collect::<Vec<_>>();
+
+    for tx_id in tx_ids {
+        storage.remove_tx(&tx_id, MempoolRemovalReason::Expiry);
+    }
+
+    assert!(storage.txs_by_id.is_empty());
+
+    // After all txs have been removed, the only thing that can occupy storage is allocated capacity
+    // of containers that have it, which at the moment of writing this are the 2 hash tables -
+    // `txs_by_id` and `seq_nos_by_tx`.
+    // Note though that this value will not exactly represent what will happen in the actual app,
+    // because in `cfg(test)` builds AssertDropPolicy is used as StrictDropPolicy, which contains
+    // an additional bool, which will turn into 8 extra bytes for each bucket of `txs_by_id`, due
+    // to alignment.
+    log::info!(
+        "memory usage after store cleanup: {}",
+        storage.memory_usage()
+    );
 }

--- a/mempool/src/pool/tx_pool/tests/utils.rs
+++ b/mempool/src/pool/tx_pool/tests/utils.rs
@@ -206,7 +206,7 @@ pub async fn try_get_fee<M>(tx_pool: &TxPool<M>, tx: &SignedTransaction) -> Fee 
 // unconfirmed means: The outpoint comes from a transaction in the mempool
 pub fn get_unconfirmed_outpoint_value(store: &MempoolStore, outpoint: &UtxoOutPoint) -> Amount {
     let tx_id = *outpoint.source_id().get_tx_id().expect("Not a transaction");
-    let entry = store.txs_by_id.get(&tx_id).expect("Entry not found");
+    let entry = store.txs_by_id().get(&tx_id).expect("Entry not found");
     let tx = entry.transaction().transaction();
     let output = tx.outputs().get(outpoint.output_index() as usize).expect("output not found");
     output_coin_amount(output)
@@ -235,21 +235,24 @@ pub fn make_tx(
 /// This produces an infinite iterator but taking too many items may not be valid:
 /// * The transaction fees may drop below minimum threshold.
 /// * In extreme, 0-value outputs may be generated.
-pub fn generate_transaction_graph(
+pub fn generate_transaction_graph_generic(
     rng: &mut impl CryptoRng,
     time: Time,
+    min_tx_relay_fee_rate: FeeRate,
+    initial_utxo: UtxoOutPoint,
+    initial_utxo_amount: Amount,
 ) -> impl Iterator<Item = TxEntryWithFee> + '_ {
-    let tf = TestFramework::builder(rng).build();
     let mut utxos = vec![(
-        TxInput::from_utxo(tf.genesis().get_id().into(), 0),
-        100_000_000_000_000_u128,
+        TxInput::Utxo(initial_utxo),
+        initial_utxo_amount.into_atoms(),
     )];
 
     std::iter::from_fn(move || {
         let n_inputs = rng.random_range(1..=std::cmp::min(3, utxos.len()));
         let n_outputs = rng.random_range(1..=3);
 
-        let estimated_fee = get_relay_fee_from_tx_size(estimate_tx_size(n_inputs, n_outputs));
+        let estimated_tx_size = estimate_tx_size(n_inputs, n_outputs);
+        let estimated_fee = min_tx_relay_fee_rate.compute_fee(estimated_tx_size).unwrap();
 
         let mut builder = TransactionBuilder::new();
         let mut total = 0u128;
@@ -297,6 +300,23 @@ pub fn generate_transaction_graph(
             Fee::new(Amount::from_atoms(total)),
         ))
     })
+}
+
+pub fn generate_transaction_graph(
+    rng: &mut impl CryptoRng,
+    time: Time,
+) -> impl Iterator<Item = TxEntryWithFee> + '_ {
+    let tf = TestFramework::builder(rng).build();
+    let initial_utxo = UtxoOutPoint::new(tf.genesis().get_id().into(), 0);
+    let initial_utxo_amount = Amount::from_atoms(100_000_000_000_000);
+
+    generate_transaction_graph_generic(
+        rng,
+        time,
+        TEST_MIN_TX_RELAY_FEE_RATE,
+        initial_utxo,
+        initial_utxo_amount,
+    )
 }
 
 pub fn make_test_block(

--- a/mempool/src/pool/tx_pool/tx_verifier/utxo_view.rs
+++ b/mempool/src/pool/tx_pool/tx_verifier/utxo_view.rs
@@ -54,7 +54,7 @@ impl<M, P: UtxosView> UtxosView for MempoolUtxoView<'_, M, P> {
             None => return Ok(self.parent.utxo(outpoint)?),
         };
 
-        self.mempool.store.txs_by_id.get(&tx_id).map_or_else(
+        self.mempool.store.txs_by_id().get(&tx_id).map_or_else(
             || Ok(self.parent.utxo(outpoint)?),
             |tx_entry| {
                 let tx = tx_entry.transaction();


### PR DESCRIPTION
* Since the switch to using hashbrown tables in mempool, the test `mempool_full_real` can fail spuriously, because now removing a tx from a full mempool and inserting one with the same size is not guaranteed to succeed (this is because hashbrown tables leave a tombstone instead of a removed element, which may not always be re-used during insertion). So the test had to be relaxed.

* Mempool will now try to shrink its hashtables' capacities from time to time.
  Note that I initially implemented this to handle a degenerate case where an attacker would fill the mempool with 200'000 small transactions, which may permanently occupy up to 40Mb worth of capacity in the hashtables, thus reducing the effective mempool size by the same 40Mb. But then I noticed that we actually recreate the whole mempool store each time the mempool reorgs to a new tip, so the degenerate case may exist for several minutes at best. But IMO it's better to keep the shrinkage logic, at least as a fail-safe.

* Small cleanup - MempoolStore's fields are now non-public.