### PR TITLE
Add an IsEmpty derive macro and use it in pos-accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,6 +4347,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-empty"
+version = "1.4.0"
+dependencies = [
+ "is-empty-derive",
+]
+
+[[package]]
+name = "is-empty-derive"
+version = "1.4.0"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6635,6 +6650,7 @@ dependencies = [
  "accounting",
  "common",
  "crypto",
+ "is-empty",
  "parity-scale-codec",
  "randomness",
  "rstest",

--- a/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
+++ b/chainstate/test-suite/src/tests/chainstate_accounting_storage_tests.rs
@@ -32,7 +32,7 @@ use common::{
     primitives::{Amount, Idable, per_thousand::PerThousand},
 };
 use crypto::vrf::{VRFKeyKind, VRFPrivateKey};
-use pos_accounting::PoolData;
+use pos_accounting::{IsEmpty, PoolData};
 use randomness::{CryptoRng, RngExt as _};
 use rstest::rstest;
 use test_utils::random::{Seed, make_seedable_rng};

--- a/pos-accounting/Cargo.toml
+++ b/pos-accounting/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 accounting = { path = "../accounting" }
 common = { path = "../common" }
 crypto = { path = "../crypto" }
+is-empty = { path = "../utils/is-empty" }
 randomness = { path = "../randomness" }
 serialization = { path = "../serialization" }
 typename = { path = "../utils/typename" }

--- a/pos-accounting/src/data.rs
+++ b/pos-accounting/src/data.rs
@@ -19,11 +19,12 @@ use common::{
     chain::{DelegationId, PoolId},
     primitives::Amount,
 };
+use is_empty::IsEmpty;
 use serialization::{Decode, Encode};
 
 use crate::{DelegationData, PoolData};
 
-#[derive(Clone, Encode, Decode, Debug, PartialEq, Eq)]
+#[derive(Clone, Encode, Decode, Debug, PartialEq, Eq, IsEmpty)]
 pub struct PoSAccountingData {
     /// A collection of all the pools and their data.
     pub pool_data: BTreeMap<PoolId, PoolData>,
@@ -49,14 +50,5 @@ impl PoSAccountingData {
             delegation_balances: BTreeMap::new(),
             delegation_data: BTreeMap::new(),
         }
-    }
-
-    // TODO: avoid manual implementation (mintlayer/mintlayer-core#669)
-    pub fn is_empty(&self) -> bool {
-        self.pool_data.is_empty()
-            && self.pool_balances.is_empty()
-            && self.pool_delegation_shares.is_empty()
-            && self.delegation_balances.is_empty()
-            && self.delegation_data.is_empty()
     }
 }

--- a/pos-accounting/src/lib.rs
+++ b/pos-accounting/src/lib.rs
@@ -35,3 +35,6 @@ pub use crate::{
         in_memory::InMemoryPoSAccounting,
     },
 };
+
+// Re-exported so that users of `PoSAccountingData` (which derives it) have the trait in scope.
+pub use is_empty::IsEmpty;

--- a/utils/is-empty-derive/Cargo.toml
+++ b/utils/is-empty-derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "is-empty-derive"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn.workspace = true
+quote.workspace = true

--- a/utils/is-empty-derive/src/lib.rs
+++ b/utils/is-empty-derive/src/lib.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Index, parse_macro_input};
+
+/// Derive the `IsEmpty` trait for a struct.
+///
+/// The generated implementation considers the struct empty when all of its fields are empty. Each
+/// field's own `is_empty` method is used, so every field type must have one (for example the
+/// standard collections, `String`, or another type that implements `IsEmpty`). A struct with no
+/// fields is always empty.
+#[proc_macro_derive(IsEmpty)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let DeriveInput {
+        ident,
+        generics,
+        data,
+        ..
+    } = parse_macro_input!(input);
+
+    let fields = match data {
+        Data::Struct(data) => data.fields,
+        Data::Enum(_) | Data::Union(_) => {
+            return syn::Error::new_spanned(ident, "IsEmpty can only be derived for structs")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let checks: Vec<_> = match fields {
+        Fields::Named(fields) => fields
+            .named
+            .into_iter()
+            .map(|field| {
+                let name = field.ident.expect("a named field always has an identifier");
+                quote!(self.#name.is_empty())
+            })
+            .collect(),
+        Fields::Unnamed(fields) => (0..fields.unnamed.len())
+            .map(|i| {
+                let index = Index::from(i);
+                quote!(self.#index.is_empty())
+            })
+            .collect(),
+        Fields::Unit => Vec::new(),
+    };
+
+    let body = match checks.split_first() {
+        Some((first, rest)) => quote!(#first #(&& #rest)*),
+        None => quote!(true),
+    };
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics IsEmpty for #ident #ty_generics #where_clause {
+            fn is_empty(&self) -> bool {
+                #body
+            }
+        }
+    }
+    .into()
+}

--- a/utils/is-empty/Cargo.toml
+++ b/utils/is-empty/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "is-empty"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+is-empty-derive = { path = "../is-empty-derive" }

--- a/utils/is-empty/src/lib.rs
+++ b/utils/is-empty/src/lib.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-core/blob/master/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use is_empty_derive::IsEmpty;
+
+/// The interface for checking whether a value is "empty".
+///
+/// This is mainly meant to be derived for aggregate types (see the `IsEmpty` derive macro), where
+/// a value is empty when all of its fields are empty. Deriving it instead of writing `is_empty` by
+/// hand means a newly added field can't be silently left out of the check.
+pub trait IsEmpty {
+    /// Returns `true` if the value is empty.
+    fn is_empty(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[derive(IsEmpty)]
+    struct Aggregate {
+        a: BTreeMap<u32, u32>,
+        b: Vec<u32>,
+        c: String,
+    }
+
+    #[test]
+    fn empty_when_all_fields_are_empty() {
+        let value = Aggregate {
+            a: BTreeMap::new(),
+            b: Vec::new(),
+            c: String::new(),
+        };
+        assert!(value.is_empty());
+    }
+
+    #[test]
+    fn not_empty_when_any_field_is_not_empty() {
+        let with_map = Aggregate {
+            a: BTreeMap::from([(1, 1)]),
+            b: Vec::new(),
+            c: String::new(),
+        };
+        assert!(!with_map.is_empty());
+
+        let with_vec = Aggregate {
+            a: BTreeMap::new(),
+            b: vec![1],
+            c: String::new(),
+        };
+        assert!(!with_vec.is_empty());
+
+        let with_string = Aggregate {
+            a: BTreeMap::new(),
+            b: Vec::new(),
+            c: "x".to_owned(),
+        };
+        assert!(!with_string.is_empty());
+    }
+
+    #[test]
+    fn tuple_struct_is_empty_uses_all_fields() {
+        #[derive(IsEmpty)]
+        struct Pair(Vec<u32>, String);
+
+        assert!(Pair(Vec::new(), String::new()).is_empty());
+        assert!(!Pair(vec![1], String::new()).is_empty());
+    }
+
+    #[test]
+    fn unit_struct_is_always_empty() {
+        #[derive(IsEmpty)]
+        struct Unit;
+
+        assert!(Unit.is_empty());
+    }
+}


### PR DESCRIPTION
## Problem

`PoSAccountingData::is_empty` is written by hand as the conjunction of its five fields' `is_empty` calls, and carries a `// TODO: avoid manual implementation (mintlayer/mintlayer-core#669)`. As the issue notes, adding a field and forgetting to update such a method is an easy mistake.

## Change

Add an `IsEmpty` trait and a derive macro for it, as a new `is-empty` / `is-empty-derive` crate pair that mirrors the existing `typename` / `typename-derive` setup. The derive generates `is_empty` as the AND of each field's own `is_empty`, so a struct is empty exactly when all of its fields are empty (a field-less struct is always empty). Every field type therefore needs an `is_empty` method: the standard collections, `String`, or another `IsEmpty` type.

Apply the derive to `PoSAccountingData`, removing the manual implementation and the TODO. `pos-accounting` re-exports the trait so the existing callers only need it in scope.

## Tests

The `is-empty` crate has unit tests covering named-field, tuple and unit structs, and the empty and non-empty cases. The existing `pos-accounting` and `chainstate` tests still pass.

Closes #669
