### PR TITLE
Add a code structure overview to the p2p README

### DIFF
--- a/p2p/README.md
+++ b/p2p/README.md
@@ -1,6 +1,18 @@
 # P2P subsystem
 
-TODO: this document is very incomplete.
+The p2p subsystem is responsible for everything related to talking to other nodes on the network: finding peers, establishing and maintaining connections, and exchanging blocks, transactions and control messages with them. This document first describes how the crate is put together and then specifies the wire protocol that nodes use to communicate.
+
+## Code structure
+
+The crate is split into a handful of modules, each with a focused responsibility:
+
+* `net` is the networking backend. It defines the `NetworkingService` interface that abstracts the low-level transport and, under `default_backend`, provides the implementation that actually speaks the wire protocol described below.
+* `peer_manager` owns the set of peers. It handles peer discovery (including dns seeds), decides which nodes to connect to, accepts inbound connections, keeps the number of connections within the configured bounds, and bans or discourages misbehaving peers. The peer database and the eviction logic live here.
+* `sync` handles block synchronization. It drives the initial block download when the node starts, and afterwards reacts to block and transaction announcements from peers as well as announcing blocks produced by this node.
+* `message` defines the messages that peers exchange, which are described in the protocol specification below.
+* `protocol` deals with protocol versioning. When two nodes connect they exchange protocol versions and negotiate the lowest version that both of them support.
+* `interface` and `rpc` expose the subsystem to the rest of the node and over RPC, for example to query the connected peers, manage bans, or add and remove reserved nodes.
+* `config` and `ban_config` hold the tunable settings for the subsystem, while `error` and `disconnection_reason` define the error and disconnection types used throughout.
 
 ## Protocol specification
 


### PR DESCRIPTION
The p2p README documents the wire protocol but is marked as incomplete and does not describe how the crate itself is organised. This adds a short "Code structure" section that maps each module to its responsibility (the net backend, peer_manager, sync, message, protocol, the interface and rpc modules, and the config and error types), so a reader can get oriented before diving into the code. I also reworded the intro slightly and removed the old TODO line.

The descriptions are based on the module doc comments and the current layout of the crate. Addresses #1556.
