### PR TITLE
Show possible values and defaults in the node help

### DIFF
--- a/node-lib/src/options.rs
+++ b/node-lib/src/options.rs
@@ -265,10 +265,14 @@ pub struct RunOptions {
     pub blockprod_use_current_time_if_non_pos: Option<bool>,
 
     /// Storage backend to use.
+    ///
+    /// Possible values: `lmdb`, `inmemory`. Defaults to `lmdb`.
     #[clap(long)]
     pub storage_backend: Option<StorageBackendConfigFile>,
 
     /// The node type.
+    ///
+    /// Possible values: `full-node`, `blocks-only-node`. Defaults to `full-node`.
     #[clap(long)]
     pub node_type: Option<NodeTypeConfigFile>,
 
@@ -402,10 +406,14 @@ pub struct RunOptions {
     pub max_tip_age: Option<u64>,
 
     /// Address to bind RPC to.
+    ///
+    /// Defaults to `127.0.0.1` with the chain's default RPC port.
     #[clap(long, value_name = "ADDR")]
     pub rpc_bind_address: Option<SocketAddr>,
 
     /// Enable/Disable http RPC.
+    ///
+    /// Defaults to `true`.
     #[clap(long, value_name = "VAL")]
     pub rpc_enabled: Option<bool>,
 


### PR DESCRIPTION
The node help does not show which values the constrained options accept or what they default to, so you currently have to read the source to find out (#548).

This makes a start on it by documenting the following in the help text:

- `--storage-backend`: possible values `lmdb`, `inmemory`, defaults to `lmdb`.
- `--node-type`: possible values `full-node`, `blocks-only-node`, defaults to `full-node`.
- `--rpc-bind-address`: defaults to `127.0.0.1` with the chain's default RPC port.
- `--rpc-enabled`: defaults to `true`.

I focused on the options where the default has a single clear source in the code. Many of the numeric run options get their defaults deeper in the individual subsystems, so I left those out for now rather than risk documenting a value that might drift out of date. I am happy to extend this to more options if that is a welcome direction.

Verified with `node-daemon mainnet --help`. Addresses part of #548.
